### PR TITLE
Dofmap builder simplifications

### DIFF
--- a/cpp/dolfin/fem/DofMapBuilder.h
+++ b/cpp/dolfin/fem/DofMapBuilder.h
@@ -107,9 +107,9 @@ private:
   // degrees of freedom
   static void
   _compute_global_dofs(std::set<std::size_t>& global_dofs,
-                      std::size_t& offset_local,
-                      std::shared_ptr<const ufc_dofmap> ufc_dofmap,
-                      const std::vector<int64_t>& num_mesh_entities_local);
+                       std::size_t& offset_local,
+                       std::shared_ptr<const ufc_dofmap> ufc_dofmap,
+                       const std::vector<int64_t>& num_mesh_entities_local);
 
   // Recursively extract UFC sub-dofmap and compute offset
   static std::shared_ptr<ufc_dofmap>
@@ -121,11 +121,12 @@ private:
   static std::size_t compute_blocksize(const ufc_dofmap& ufc_dofmap,
                                        std::size_t tdim);
 
-  static std::shared_ptr<const ufc_dofmap>
-  build_ufc_node_graph(std::vector<std::vector<la_index_t>>& node_dofmap,
-                       std::vector<std::size_t>& node_local_to_global,
-                       std::vector<int64_t>& num_mesh_entities_global,
-                       std::shared_ptr<const ufc_dofmap> ufc_dofmap,
+  // Build graph from UFC 'node' dofmap. Returns (ufc_dofmap,
+  // node_dofmap, node_local_to_global, num_mesh_entities_global)
+  static std::tuple<std::shared_ptr<const ufc_dofmap>,
+                    std::vector<std::vector<la_index_t>>,
+                    std::vector<std::size_t>, std::vector<int64_t>>
+  build_ufc_node_graph(std::shared_ptr<const ufc_dofmap> ufc_dofmap,
                        const mesh::Mesh& mesh, const std::size_t block_size);
 
   // Mark shared nodes. Boundary nodes are assigned a random

--- a/cpp/dolfin/fem/DofMapBuilder.h
+++ b/cpp/dolfin/fem/DofMapBuilder.h
@@ -8,9 +8,9 @@
 
 #include <dolfin/common/MPI.h>
 #include <dolfin/common/types.h>
-#include <map>
 #include <memory>
 #include <set>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -76,11 +76,12 @@ private:
   //
   // Also computes map from shared node to sharing processes and a
   // set of process that share dofs on this process.
-  // Returns: number of locally owned nodes
-  static int compute_node_ownership(
-      std::vector<short int>& node_ownership,
-      std::unordered_map<int, std::vector<int>>& shared_node_to_processes,
-      std::set<int>& neighbours,
+  // Returns: (number of locally owned nodes, node_ownership,
+  // shared_node_to_processes, neighbours)
+
+  static std::tuple<int, std::vector<short int>,
+                    std::unordered_map<int, std::vector<int>>, std::set<int>>
+  compute_node_ownership(
       const std::vector<std::vector<la_index_t>>& node_dofmap,
       const std::vector<int>& boundary_nodes,
       const std::set<std::size_t>& global_nodes,
@@ -150,13 +151,13 @@ private:
       const std::set<std::size_t>& global_nodes, const MPI_Comm mpi_comm);
 
   static void
-  get_cell_entities_local(const mesh::Cell& cell,
-                          std::vector<std::vector<int64_t>>& entity_indices,
+  get_cell_entities_local(std::vector<std::vector<int64_t>>& entity_indices,
+                          const mesh::Cell& cell,
                           const std::vector<bool>& needs_mesh_entities);
 
   static void
-  get_cell_entities_global(const mesh::Cell& cell,
-                           std::vector<std::vector<int64_t>>& entity_indices,
+  get_cell_entities_global(std::vector<std::vector<int64_t>>& entity_indices,
+                           const mesh::Cell& cell,
                            const std::vector<bool>& needs_mesh_entities);
 
   // Compute number of mesh entities for dimensions required by

--- a/cpp/dolfin/fem/DofMapBuilder.h
+++ b/cpp/dolfin/fem/DofMapBuilder.h
@@ -63,9 +63,8 @@ public:
 
 private:
   // Build simple local UFC-based dofmap data structure
-  static void
-  build_local_ufc_dofmap(std::vector<std::vector<dolfin::la_index_t>>& dofmap,
-                         const ufc_dofmap& ufc_dofmap, const mesh::Mesh& mesh);
+  static std::vector<std::vector<dolfin::la_index_t>>
+  build_local_ufc_dofmap(const ufc_dofmap& ufc_dofmap, const mesh::Mesh& mesh);
 
   // Compute which process 'owns' each node (point at which dofs live)
   //   - node_ownership = -1 -> dof shared but not 'owned' by this
@@ -89,9 +88,8 @@ private:
       const mesh::Mesh& mesh, const std::size_t global_dim);
 
   // Build dofmap based on re-ordered nodes
-  static void
-  build_dofmap(std::vector<std::vector<la_index_t>>& dofmap,
-               const std::vector<std::vector<la_index_t>>& node_dofmap,
+  static std::vector<std::vector<la_index_t>>
+  build_dofmap(const std::vector<std::vector<la_index_t>>& node_dofmap,
                const std::vector<int>& old_to_new_node_local,
                const std::size_t block_size);
 

--- a/cpp/dolfin/fem/DofMapBuilder.h
+++ b/cpp/dolfin/fem/DofMapBuilder.h
@@ -101,10 +101,12 @@ private:
   compute_global_dofs(std::shared_ptr<const ufc_dofmap> ufc_dofmap,
                       const std::vector<int64_t>& num_mesh_entities_local);
 
+  // FIXME: Try to simplify this function to make pure. Needs some care
+  //        because it's called recursively.
   // Iterate recursively over all sub-dof maps to find global
   // degrees of freedom
   static void
-  compute_global_dofs(std::set<std::size_t>& global_dofs,
+  _compute_global_dofs(std::set<std::size_t>& global_dofs,
                       std::size_t& offset_local,
                       std::shared_ptr<const ufc_dofmap> ufc_dofmap,
                       const std::vector<int64_t>& num_mesh_entities_local);
@@ -130,14 +132,15 @@ private:
   // positive integer, interior nodes are marked as -1, interior
   // nodes in ghost layer of other processes are marked -2, and
   // ghost nodes are marked as -3
-  static void
-  compute_shared_nodes(std::vector<int>& boundary_nodes,
-                       const std::vector<std::vector<la_index_t>>& node_dofmap,
+  static std::vector<int>
+  compute_shared_nodes(const std::vector<std::vector<la_index_t>>& node_dofmap,
                        const std::size_t num_nodes_local,
                        const ufc_dofmap& ufc_dofmap, const mesh::Mesh& mesh);
 
-  static void compute_node_reordering(
-      common::IndexMap& index_map, std::vector<int>& old_to_new_local,
+  // FIXME: document better
+  // Return (old-to-new_local, local_to_global_unowned) maps
+  static std::pair<std::vector<int>, std::vector<std::size_t>>
+  compute_node_reordering(
       const std::unordered_map<int, std::vector<int>>&
           node_to_sharing_processes,
       const std::vector<std::size_t>& old_local_to_global,

--- a/python/test/unit/function/test_function_space.py
+++ b/python/test/unit/function/test_function_space.py
@@ -1,4 +1,4 @@
-b"""Unit tests for the FunctionSpace class"""
+"""Unit tests for the FunctionSpace class"""
 
 # Copyright (C) 2011 Johan Hake
 #


### PR DESCRIPTION
Make most functions 'pure', i.e. `const` arguments and return pairs, tuples, etc (using move constructors).