### PR TITLE
Update MPI::all_to_all to use MPI_Put and MPI_Get

### DIFF
--- a/cpp/dolfin/common/MPI.h
+++ b/cpp/dolfin/common/MPI.h
@@ -336,7 +336,7 @@ void dolfin::MPI::broadcast(MPI_Comm comm, T& value, std::uint32_t broadcaster)
 #endif
 }
 //---------------------------------------------------------------------------
-#ifdef MPI_ALLTOALL_USE_PUT_GET
+#ifdef DOLFIN_MPI_USE_PUT_GET
 template <typename T>
 void dolfin::MPI::all_to_all_common(
     MPI_Comm comm, const std::vector<std::vector<T>>& in_values,


### PR DESCRIPTION
Makes a switchable implementation of alltoall available, which uses MPI-2 MPI_Put and MPI_Get.
Can be switched by setting `-DMPI_ALLTOALL_USE_PUT_GET`.