### PR TITLE
Sort out naming in XDMFFile methods

### DIFF
--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -122,9 +122,9 @@ void XDMFFile::write(const mesh::Mesh& mesh, const Encoding encoding)
     _xml_doc->save_file(_filename.c_str(), "  ");
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write_checkpoint(const function::Function& u,
-                                std::string function_name, double time_step,
-                                const Encoding encoding)
+void XDMFFile::write(const function::Function& u,
+                     std::string function_name, double time_step,
+                     const Encoding encoding)
 {
   // Check that encoding
   if (encoding == Encoding::HDF5 and !has_hdf5())
@@ -303,7 +303,8 @@ void XDMFFile::write_checkpoint(const function::Function& u,
 #endif
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write(const function::Function& u, const Encoding encoding)
+void XDMFFile::write_vertex_values(const function::Function& u,
+                                   const Encoding encoding)
 {
   // Check that encoding
   if (encoding == Encoding::HDF5 and !has_hdf5())
@@ -395,8 +396,10 @@ void XDMFFile::write(const function::Function& u, const Encoding encoding)
     _xml_doc->save_file(_filename.c_str(), "  ");
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write(const function::Function& u, double time_step,
-                     const Encoding encoding)
+void XDMFFile::write_vertex_values(
+    const function::Function& u,
+    double time_step,
+    const Encoding encoding)
 {
   // Check that encoding
   if (encoding == Encoding::HDF5 and !has_hdf5())
@@ -1482,8 +1485,8 @@ mesh::Mesh XDMFFile::read_mesh(MPI_Comm comm) const
 }
 //----------------------------------------------------------------------------
 function::Function
-XDMFFile::read_checkpoint(std::shared_ptr<const function::FunctionSpace> V,
-                          std::string func_name, std::int64_t counter) const
+XDMFFile::read(std::shared_ptr<const function::FunctionSpace> V,
+               std::string func_name, std::int64_t counter) const
 {
   if (!name_same_on_all_procs(func_name))
   {

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -122,9 +122,8 @@ void XDMFFile::write(const mesh::Mesh& mesh, const Encoding encoding)
     _xml_doc->save_file(_filename.c_str(), "  ");
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write(const function::Function& u,
-                     std::string function_name, double time_step,
-                     const Encoding encoding)
+void XDMFFile::write(const function::Function& u, std::string function_name,
+                     double time_step, const Encoding encoding)
 {
   // Check that encoding
   if (encoding == Encoding::HDF5 and !has_hdf5())
@@ -396,10 +395,8 @@ void XDMFFile::write_vertex_values(const function::Function& u,
     _xml_doc->save_file(_filename.c_str(), "  ");
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write_vertex_values(
-    const function::Function& u,
-    double time_step,
-    const Encoding encoding)
+void XDMFFile::write_vertex_values(const function::Function& u,
+                                   double time_step, const Encoding encoding)
 {
   // Check that encoding
   if (encoding == Encoding::HDF5 and !has_hdf5())
@@ -1486,8 +1483,7 @@ mesh::Mesh XDMFFile::read_mesh(MPI_Comm comm) const
 //----------------------------------------------------------------------------
 function::Function
 XDMFFile::read_function(std::shared_ptr<const function::FunctionSpace> V,
-                        std::string func_name,
-                        std::int64_t counter) const
+                        std::string func_name, std::int64_t counter) const
 {
   if (!name_same_on_all_procs(func_name))
   {

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -1485,8 +1485,9 @@ mesh::Mesh XDMFFile::read_mesh(MPI_Comm comm) const
 }
 //----------------------------------------------------------------------------
 function::Function
-XDMFFile::read(std::shared_ptr<const function::FunctionSpace> V,
-               std::string func_name, std::int64_t counter) const
+XDMFFile::read_function(std::shared_ptr<const function::FunctionSpace> V,
+                        std::string func_name,
+                        std::int64_t counter) const
 {
   if (!name_same_on_all_procs(func_name))
   {

--- a/cpp/dolfin/io/XDMFFile.h
+++ b/cpp/dolfin/io/XDMFFile.h
@@ -158,8 +158,7 @@ public:
   ///         Encoding to use: HDF5 or ASCII
   ///
   void write(const function::Function& u, std::string function_name,
-             double time_step = 0.0,
-             Encoding encoding = default_encoding);
+             double time_step = 0.0, Encoding encoding = default_encoding);
 
   /// Save a function::Function to XDMF file for visualisation, using an
   /// associated HDF5 file, or storing the data inline as XML.
@@ -341,10 +340,9 @@ public:
   ///         function before the last one.
   /// @returns function::Function
   ///         Function
-  function::Function read_function(
-      std::shared_ptr<const function::FunctionSpace> V,
-      std::string func_name,
-      std::int64_t counter = -1) const;
+  function::Function
+  read_function(std::shared_ptr<const function::FunctionSpace> V,
+                std::string func_name, std::int64_t counter = -1) const;
 
   /// Read first mesh::MeshFunction from file
   /// @param meshfunction (_MeshFunction<bool>_)

--- a/cpp/dolfin/io/XDMFFile.h
+++ b/cpp/dolfin/io/XDMFFile.h
@@ -157,9 +157,9 @@ public:
   /// @param    encoding (_Encoding_)
   ///         Encoding to use: HDF5 or ASCII
   ///
-  void write_checkpoint(const function::Function& u, std::string function_name,
-                        double time_step = 0.0,
-                        Encoding encoding = default_encoding);
+  void write(const function::Function& u, std::string function_name,
+             double time_step = 0.0,
+             Encoding encoding = default_encoding);
 
   /// Save a function::Function to XDMF file for visualisation, using an
   /// associated HDF5 file, or storing the data inline as XML.
@@ -169,7 +169,8 @@ public:
   /// @param    encoding (_Encoding_)
   ///         Encoding to use: HDF5 or ASCII
   ///
-  void write(const function::Function& u, Encoding encoding = default_encoding);
+  void write_vertex_values(const function::Function& u,
+                           Encoding encoding = default_encoding);
 
   /// Save a function::Function with timestamp to XDMF file for visualisation,
   /// using an associated HDF5 file, or storing the data inline as
@@ -195,8 +196,8 @@ public:
   /// @param   encoding (_Encoding_)
   ///         Encoding to use: HDF5 or ASCII
   ///
-  void write(const function::Function& u, double t,
-             Encoding encoding = default_encoding);
+  void write_vertex_values(const function::Function& u, double t,
+                           Encoding encoding = default_encoding);
 
   /// Save mesh::MeshFunction to file using an associated HDF5 file, or
   /// storing the data inline as XML.
@@ -340,9 +341,9 @@ public:
   ///         function before the last one.
   /// @returns function::Function
   ///         Function
-  function::Function
-  read_checkpoint(std::shared_ptr<const function::FunctionSpace> V,
-                  std::string func_name, std::int64_t counter = -1) const;
+  function::Function read(std::shared_ptr<const function::FunctionSpace> V,
+                          std::string func_name,
+                          std::int64_t counter = -1) const;
 
   /// Read first mesh::MeshFunction from file
   /// @param meshfunction (_MeshFunction<bool>_)

--- a/cpp/dolfin/io/XDMFFile.h
+++ b/cpp/dolfin/io/XDMFFile.h
@@ -341,9 +341,10 @@ public:
   ///         function before the last one.
   /// @returns function::Function
   ///         Function
-  function::Function read(std::shared_ptr<const function::FunctionSpace> V,
-                          std::string func_name,
-                          std::int64_t counter = -1) const;
+  function::Function read_function(
+      std::shared_ptr<const function::FunctionSpace> V,
+      std::string func_name,
+      std::int64_t counter = -1) const;
 
   /// Read first mesh::MeshFunction from file
   /// @param meshfunction (_MeshFunction<bool>_)

--- a/python/demo/documented/biharmonic/demo_biharmonic.py.rst
+++ b/python/demo/documented/biharmonic/demo_biharmonic.py.rst
@@ -188,7 +188,7 @@ the screen. ::
 
     # Save solution to file
     with XDMFFile(mesh.mpi_comm(), "biharmonic.xdmf") as file:
-        file.write(u)
+        file.write_vertex_values(u)
 
     # Plot solution
     plot(u)

--- a/python/demo/documented/poisson/demo_poisson.py.rst
+++ b/python/demo/documented/poisson/demo_poisson.py.rst
@@ -187,7 +187,7 @@ the :py:func:`plot <dolfin.common.plot.plot>` command: ::
 
     # Save solution in XDMF format
     file = XDMFFile(MPI.comm_world, "poisson.xdmf")
-    file.write(u, XDMFFile.Encoding.HDF5)
+    file.write_vertex_values(u, XDMFFile.Encoding.HDF5)
 
     # Plot solution
     import matplotlib.pyplot as plt

--- a/python/demo/documented/stokes-iterative/demo_stokes-iterative.py.rst
+++ b/python/demo/documented/stokes-iterative/demo_stokes-iterative.py.rst
@@ -204,6 +204,6 @@ Finally, we can play with the result in different ways: ::
 
     # Save solution in VTK format
     with XDMFFile(mesh.mpi_comm(), "velocity.xdmf") as ufile_xdmf:
-        ufile_xdmf.write(u)
+        ufile_xdmf.write_vertex_values(u)
     with XDMFFile(mesh.mpi_comm(), "pressure.xdmf") as pfile_xdmf:
-        pfile_xdmf.write(p)
+        pfile_xdmf.write_vertex_values(p)

--- a/python/demo/documented/stokes-taylor-hood/demo_stokes-taylor-hood.py.rst
+++ b/python/demo/documented/stokes-taylor-hood/demo_stokes-taylor-hood.py.rst
@@ -179,10 +179,10 @@ Finally, we can save and plot the solutions::
 
     # Save solution in XDMF format
     with XDMFFile(MPI.comm_world, "velocity.xdmf") as ufile_xdmf:
-        ufile_xdmf.write(u)
+        ufile_xdmf.write_vertex_values(u)
 
     with XDMFFile(MPI.comm_world, "pressure.xdmf") as pfile_xdmf:
-        pfile_xdmf.write(p)
+        pfile_xdmf.write_vertex_values(p)
 
     # Plot solution
     import matplotlib.pyplot as plt

--- a/python/demo/undocumented/buckling-tao/demo_buckling-tao.py
+++ b/python/demo/undocumented/buckling-tao/demo_buckling-tao.py
@@ -118,10 +118,10 @@ solver.solve(BucklingProblem(), u.vector(), u_min.vector(), u_max.vector())
 # Save solution in XDMF format if available
 out = XDMFFile(mesh.mpi_comm(), "u.xdmf")
 if has_hdf5():
-    out.write(u)
+    out.write_vertex_values(u)
 elif MPI.size(mesh.mpi_comm()) == 1:
     encoding = XDMFFile.Encoding.ASCII
-    out.write(u, encoding)
+    out.write_vertex_values(u, encoding)
 else:
     # Save solution in vtk format
     out = File("u.pvd")

--- a/python/demo/undocumented/contact-vi-tao/demo_contact-vi-tao.py
+++ b/python/demo/undocumented/contact-vi-tao/demo_contact-vi-tao.py
@@ -114,10 +114,10 @@ solver.solve(ContactProblem(), u.vector(), u_min.vector(), u_max.vector())
 # Save solution in XDMF format if available
 out = XDMFFile(mesh.mpi_comm(), "u.xdmf")
 if has_hdf5():
-    out.write(u)
+    out.write_vertex_values(u)
 elif MPI.size(mesh.mpi_comm()) == 1:
     encoding = XDMFFile.Encoding.ASCII
-    out.write(u, encoding)
+    out.write_vertex_values(u, encoding)
 else:
     # Save solution in vtk format
     out = File("u.pvd")

--- a/python/demo/undocumented/elasticity/demo_elasticity.py
+++ b/python/demo/undocumented/elasticity/demo_elasticity.py
@@ -148,7 +148,7 @@ solver.solve(u.vector(), b)
 
 # Save solution to XDMF format
 file = XDMFFile(MPI.comm_world, "elasticity.xdmf")
-file.write(u, XDMFFile.Encoding.ASCII)
+file.write_vertex_values(u, XDMFFile.Encoding.ASCII)
 
 unorm = u.vector().norm("l2")
 if MPI.rank(mesh.mpi_comm()) == 0:

--- a/python/demo/undocumented/ghost-mesh/demo_ghost-mesh.py
+++ b/python/demo/undocumented/ghost-mesh/demo_ghost-mesh.py
@@ -143,10 +143,10 @@ for note in facet_note:
 # # Save solution in XDMF format if available
 # xdmf = XDMFFile(mesh.mpi_comm(), "Q.xdmf")
 # if has_hdf5():
-#     xdmf.write(Q)
+#     xdmf.write_vertex_values(Q)
 # elif MPI.size(mesh.mpi_comm()) == 1:
 #     encoding = XDMFFile.Encoding.ASCII
-#     xdmf.write(Q, encoding)
+#     xdmf.write_vertex_values(Q, encoding)
 # else:
 #     # Save solution in vtk format
 #     xdmf = File("Q.pvd")

--- a/python/demo/undocumented/poisson-disc/demo_poisson-disc.py
+++ b/python/demo/undocumented/poisson-disc/demo_poisson-disc.py
@@ -91,6 +91,6 @@ def compute_rates():
                 if MPI.size(MPI.comm_world) > 1 and encoding == XDMFFile.Encoding.ASCII:
                     print("XDMF file output not supported in parallel without HDF5")
                 else:
-                    ufile.write(u, encoding)
+                    ufile.write_vertex_values(u, encoding)
 
 compute_rates()

--- a/python/dolfin/io.py
+++ b/python/dolfin/io.py
@@ -21,12 +21,11 @@ cpp.io.HDF5File.read_function = read_function
 del read_function
 
 
-def read_checkpoint(self, V, name, counter=-1):
+def read_function(self, V, name, counter=-1):
     # Read cpp function
-    u_cpp = self._read_checkpoint(V._cpp_object, name, counter)
+    u_cpp = self._read_function(V._cpp_object, name, counter)
     return dolfin.function.function.Function(V, u_cpp.vector())
 
 
-cpp.io.XDMFFile.read_checkpoint = read_checkpoint
-
-del read_checkpoint
+cpp.io.XDMFFile.read_function = read_function
+del read_function

--- a/python/src/io.cpp
+++ b/python/src/io.cpp
@@ -391,7 +391,7 @@ void io(py::module& m)
       .def("read_mvc_double", &dolfin::io::XDMFFile::read_mvc_double,
            py::arg("mesh"), py::arg("name") = "")
       // Checkpointing
-      .def("read", &dolfin::io::XDMFFile::read,
+      .def("_read_function", &dolfin::io::XDMFFile::read_function,
            py::arg("V"), py::arg("name"), py::arg("counter") = -1);
 }
 } // namespace dolfin_wrappers

--- a/python/src/io.cpp
+++ b/python/src/io.cpp
@@ -285,9 +285,9 @@ void io(py::module& m)
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
       // MeshValueCollection size_t
       .def("write",
-           py::overload_cast<const dolfin::mesh::MeshValueCollection<std::size_t>&,
-                             dolfin::io::XDMFFile::Encoding>(
-               &dolfin::io::XDMFFile::write),
+           py::overload_cast<
+               const dolfin::mesh::MeshValueCollection<std::size_t>&,
+               dolfin::io::XDMFFile::Encoding>(&dolfin::io::XDMFFile::write),
            py::arg("mvc"),
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
       // MeshValueCollection int
@@ -297,11 +297,11 @@ void io(py::module& m)
                &dolfin::io::XDMFFile::write),
            py::arg("mvc"),
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+      // MeshValueCollection double
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshValueCollection<double>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
+           py::overload_cast<const dolfin::mesh::MeshValueCollection<double>&,
+                             dolfin::io::XDMFFile::Encoding>(
+               &dolfin::io::XDMFFile::write),
            py::arg("mvc"),
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
       // Points

--- a/python/src/io.cpp
+++ b/python/src/io.cpp
@@ -230,74 +230,71 @@ void io(py::module& m)
   xdmf_file
       // Function
       .def("write_vertex_values",
-           (void (dolfin::io::XDMFFile::*)(const dolfin::function::Function&,
-                                           dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write_vertex_values,
+           py::overload_cast<const dolfin::function::Function&,
+                             dolfin::io::XDMFFile::Encoding>(
+               &dolfin::io::XDMFFile::write_vertex_values),
            py::arg("u"),
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
       .def("write_vertex_values",
-           (void (dolfin::io::XDMFFile::*)(const dolfin::function::Function&,
-                                           double,
-                                           dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write_vertex_values,
+           py::overload_cast<const dolfin::function::Function&, double,
+                             dolfin::io::XDMFFile::Encoding>(
+               &dolfin::io::XDMFFile::write_vertex_values),
            py::arg("u"), py::arg("t"),
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
       // Mesh
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(const dolfin::mesh::Mesh&,
-                                           dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
+           py::overload_cast<const dolfin::mesh::Mesh&,
+                             dolfin::io::XDMFFile::Encoding>(
+               &dolfin::io::XDMFFile::write),
            py::arg("mesh"),
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
-      // MeshFunction
+      // MeshFunction bool
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshFunction<bool>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
+           py::overload_cast<const dolfin::mesh::MeshFunction<bool>&,
+                             dolfin::io::XDMFFile::Encoding>(
+               &dolfin::io::XDMFFile::write),
+           py::arg("mesh_function"),
+           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+      // MeshFunction size_t
+      .def("write",
+           py::overload_cast<const dolfin::mesh::MeshFunction<std::size_t>&,
+                             dolfin::io::XDMFFile::Encoding>(
+               &dolfin::io::XDMFFile::write),
+           py::arg("mesh_function"),
+           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+      // MeshFunction int
+      .def("write",
+           py::overload_cast<const dolfin::mesh::MeshFunction<int>&,
+                             dolfin::io::XDMFFile::Encoding>(
+               &dolfin::io::XDMFFile::write),
+           py::arg("mesh_function"),
+           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+      // MeshFunction double
+      .def("write",
+           py::overload_cast<const dolfin::mesh::MeshFunction<double>&,
+                             dolfin::io::XDMFFile::Encoding>(
+               &dolfin::io::XDMFFile::write),
+           py::arg("mesh_function"),
+           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+      // MeshValueCollection bool
+      .def("write",
+           py::overload_cast<const dolfin::mesh::MeshValueCollection<bool>&,
+                             dolfin::io::XDMFFile::Encoding>(
+               &dolfin::io::XDMFFile::write),
            py::arg("mvc"),
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+      // MeshValueCollection size_t
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshFunction<std::size_t>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
+           py::overload_cast<const dolfin::mesh::MeshValueCollection<std::size_t>&,
+                             dolfin::io::XDMFFile::Encoding>(
+               &dolfin::io::XDMFFile::write),
            py::arg("mvc"),
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+      // MeshValueCollection int
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshFunction<int>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
-           py::arg("mvc"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
-      .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshFunction<double>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
-           py::arg("mvc"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
-      // MeshValueCollection
-      .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshValueCollection<bool>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
-           py::arg("mvc"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
-      .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshValueCollection<std::size_t>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
-           py::arg("mvc"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
-      .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshValueCollection<int>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
+           py::overload_cast<const dolfin::mesh::MeshValueCollection<int>&,
+                             dolfin::io::XDMFFile::Encoding>(
+               &dolfin::io::XDMFFile::write),
            py::arg("mvc"),
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
       .def("write",
@@ -391,7 +388,7 @@ void io(py::module& m)
       .def("read_mvc_double", &dolfin::io::XDMFFile::read_mvc_double,
            py::arg("mesh"), py::arg("name") = "")
       // Checkpointing
-      .def("_read_function", &dolfin::io::XDMFFile::read_function,
-           py::arg("V"), py::arg("name"), py::arg("counter") = -1);
+      .def("_read_function", &dolfin::io::XDMFFile::read_function, py::arg("V"),
+           py::arg("name"), py::arg("counter") = -1);
 }
 } // namespace dolfin_wrappers

--- a/python/src/io.cpp
+++ b/python/src/io.cpp
@@ -229,17 +229,17 @@ void io(py::module& m)
   // dolfin::io::XDMFFile::write
   xdmf_file
       // Function
-      .def("write",
+      .def("write_vertex_values",
            (void (dolfin::io::XDMFFile::*)(const dolfin::function::Function&,
                                            dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
+               & dolfin::io::XDMFFile::write_vertex_values,
            py::arg("u"),
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
-      .def("write",
+      .def("write_vertex_values",
            (void (dolfin::io::XDMFFile::*)(const dolfin::function::Function&,
                                            double,
                                            dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
+               & dolfin::io::XDMFFile::write_vertex_values,
            py::arg("u"), py::arg("t"),
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
       // Mesh
@@ -327,40 +327,40 @@ void io(py::module& m)
            py::arg("points"), py::arg("values"),
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
       // py:object / dolfin.function.function.Function
-      .def("write",
+      .def("write_vertex_values",
            [](dolfin::io::XDMFFile& instance, const py::object u,
               dolfin::io::XDMFFile::Encoding encoding) {
              auto _u
                  = u.attr("_cpp_object").cast<dolfin::function::Function*>();
-             instance.write(*_u, encoding);
+             instance.write_vertex_values(*_u, encoding);
            },
            py::arg("u"),
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
-      .def("write",
+      .def("write_vertex_values",
            [](dolfin::io::XDMFFile& instance, const py::object u, double t,
               dolfin::io::XDMFFile::Encoding encoding) {
              auto _u
                  = u.attr("_cpp_object").cast<dolfin::function::Function*>();
-             instance.write(*_u, t, encoding);
+             instance.write_vertex_values(*_u, t, encoding);
            },
            py::arg("u"), py::arg("t"),
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
-      // Check points
-      .def("write_checkpoint",
+      // Write for checkpointing
+      .def("write",
            [](dolfin::io::XDMFFile& instance,
               const dolfin::function::Function& u, std::string function_name,
               double time_step, dolfin::io::XDMFFile::Encoding encoding) {
-             instance.write_checkpoint(u, function_name, time_step, encoding);
+             instance.write(u, function_name, time_step, encoding);
            },
            py::arg("u"), py::arg("function_name"), py::arg("time_step") = 0.0,
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
-      .def("write_checkpoint",
+      .def("write",
            [](dolfin::io::XDMFFile& instance, const py::object u,
               std::string function_name, double time_step,
               dolfin::io::XDMFFile::Encoding encoding) {
              auto _u
                  = u.attr("_cpp_object").cast<dolfin::function::Function*>();
-             instance.write_checkpoint(*_u, function_name, time_step, encoding);
+             instance.write(*_u, function_name, time_step, encoding);
            },
            py::arg("u"), py::arg("function_name"), py::arg("time_step") = 0.0,
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5);
@@ -391,7 +391,7 @@ void io(py::module& m)
       .def("read_mvc_double", &dolfin::io::XDMFFile::read_mvc_double,
            py::arg("mesh"), py::arg("name") = "")
       // Checkpointing
-      .def("_read_checkpoint", &dolfin::io::XDMFFile::read_checkpoint,
+      .def("read", &dolfin::io::XDMFFile::read,
            py::arg("V"), py::arg("name"), py::arg("counter") = -1);
 }
 } // namespace dolfin_wrappers

--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -194,7 +194,7 @@ def test_save_and_checkpoint_scalar(tempdir, encoding, fe_degree, fe_family,
         file.write(u_out, "u_out", 0, encoding)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        u_in = file.read(V, "u_out", 0)
+        u_in = file.read_function(V, "u_out", 0)
 
     result = u_in.vector() - u_out.vector()
     assert all([np.isclose(x, 0.0) for x in result.get_local()])
@@ -231,7 +231,7 @@ def test_save_and_checkpoint_vector(tempdir, encoding, fe_degree, fe_family,
         file.write(u_out, "u_out", 0, encoding)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        u_in = file.read(V, "u_out", 0)
+        u_in = file.read_function(V, "u_out", 0)
 
     result = u_in.vector() - u_out.vector()
     assert all([np.isclose(x, 0.0) for x in result.get_local()])
@@ -258,7 +258,7 @@ def test_save_and_checkpoint_timeseries(tempdir, encoding):
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
         for i, p in enumerate(times):
-            u_in[i] = file.read(V, "u_out", i)
+            u_in[i] = file.read_function(V, "u_out", i)
 
     for i, p in enumerate(times):
         result = u_in[i].vector() - u_out[i].vector()
@@ -266,7 +266,7 @@ def test_save_and_checkpoint_timeseries(tempdir, encoding):
 
     # test reading last
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        u_in_last = file.read(V, "u_out", -1)
+        u_in_last = file.read_function(V, "u_out", -1)
 
     result = u_out[-1].vector() - u_in_last.vector()
     assert all([np.isclose(x, 0.0) for x in result.get_local()])

--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -165,7 +165,7 @@ def test_save_1d_scalar(tempdir, encoding):
     u.vector()[:] = 1.0
 
     with XDMFFile(mesh.mpi_comm(), filename2) as file:
-        file.write(u, encoding)
+        file.write_vertex_values(u, encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -191,10 +191,10 @@ def test_save_and_checkpoint_scalar(tempdir, encoding, fe_degree, fe_family,
     u_out.interpolate(Expression("x[0]", degree=1))
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write_checkpoint(u_out, "u_out", 0, encoding)
+        file.write(u_out, "u_out", 0, encoding)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        u_in = file.read_checkpoint(V, "u_out", 0)
+        u_in = file.read(V, "u_out", 0)
 
     result = u_in.vector() - u_out.vector()
     assert all([np.isclose(x, 0.0) for x in result.get_local()])
@@ -228,10 +228,10 @@ def test_save_and_checkpoint_vector(tempdir, encoding, fe_degree, fe_family,
         u_out.interpolate(Expression(("x[0]*x[1]", "x[0]", "x[2]"), degree=2))
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write_checkpoint(u_out, "u_out", 0, encoding)
+        file.write(u_out, "u_out", 0, encoding)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        u_in = file.read_checkpoint(V, "u_out", 0)
+        u_in = file.read(V, "u_out", 0)
 
     result = u_in.vector() - u_out.vector()
     assert all([np.isclose(x, 0.0) for x in result.get_local()])
@@ -254,11 +254,11 @@ def test_save_and_checkpoint_timeseries(tempdir, encoding):
     with XDMFFile(mesh.mpi_comm(), filename) as file:
         for i, p in enumerate(times):
             u_out[i] = interpolate(Expression("x[0]*p", p=p, degree=1), V)
-            file.write_checkpoint(u_out[i], "u_out", p, encoding)
+            file.write(u_out[i], "u_out", p, encoding)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
         for i, p in enumerate(times):
-            u_in[i] = file.read_checkpoint(V, "u_out", i)
+            u_in[i] = file.read(V, "u_out", i)
 
     for i, p in enumerate(times):
         result = u_in[i].vector() - u_out[i].vector()
@@ -266,7 +266,7 @@ def test_save_and_checkpoint_timeseries(tempdir, encoding):
 
     # test reading last
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        u_in_last = file.read_checkpoint(V, "u_out", -1)
+        u_in_last = file.read(V, "u_out", -1)
 
     result = u_out[-1].vector() - u_in_last.vector()
     assert all([np.isclose(x, 0.0) for x in result.get_local()])
@@ -284,7 +284,7 @@ def test_save_2d_scalar(tempdir, encoding):
     u.vector()[:] = 1.0
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding)
+        file.write_vertex_values(u, encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -298,7 +298,7 @@ def test_save_3d_scalar(tempdir, encoding):
     u.vector()[:] = 1.0
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding)
+        file.write_vertex_values(u, encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -313,7 +313,7 @@ def test_save_2d_vector(tempdir, encoding):
     u.interpolate(c)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding)
+        file.write_vertex_values(u, encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -327,7 +327,7 @@ def test_save_3d_vector(tempdir, encoding):
     u.interpolate(c)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding)
+        file.write_vertex_values(u, encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -340,13 +340,13 @@ def test_save_3d_vector_series(tempdir, encoding):
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
         u.vector()[:] = 1.0
-        file.write(u, 0.1, encoding)
+        file.write_vertex_values(u, 0.1, encoding)
 
         u.vector()[:] = 2.0
-        file.write(u, 0.2, encoding)
+        file.write_vertex_values(u, 0.2, encoding)
 
         u.vector()[:] = 3.0
-        file.write(u, 0.3, encoding)
+        file.write_vertex_values(u, 0.3, encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -359,7 +359,7 @@ def test_save_2d_tensor(tempdir, encoding):
     u.vector()[:] = 1.0
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding)
+        file.write_vertex_values(u, encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -372,7 +372,7 @@ def test_save_3d_tensor(tempdir, encoding):
     u.vector()[:] = 1.0
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding)
+        file.write_vertex_values(u, encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)

--- a/python/test/unit/io/test_XDMF_P2.py
+++ b/python/test/unit/io/test_XDMF_P2.py
@@ -34,4 +34,4 @@ def test_read_write_p2_function(tempdir):
 
     filename = os.path.join(tempdir, "tri6_function.xdmf")
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-        xdmf.write(F, XDMFFile.Encoding.HDF5)
+        xdmf.write_vertex_values(F, XDMFFile.Encoding.HDF5)

--- a/python/test/unit/io/test_XDMF_cell_output.py
+++ b/python/test/unit/io/test_XDMF_cell_output.py
@@ -28,7 +28,7 @@ def test_xdmf_cell_scalar_ghost(cd_tempdir, ghost_mode):
     # F.interpolate(E)
 
     # with XDMFFile(mesh.mpi_comm(), "dg0.xdmf") as xdmf:
-    #    xdmf.write(F)
+    #    xdmf.write_vertex_values(F)
 
     # with HDF5File(mesh.mpi_comm(), "dg0.h5", "r") as hdf:
     #     vec = PETScVector(mesh.mpi_comm())


### PR DESCRIPTION
Solves issue #20 . 

But there is still a thing to be discussed. New proposed name `write_vertex_values` is used also for `DG0` functions (and in future could be used also for VTKish XDMF for `P2` functions). Might be a bit misleading what vertex values for DG0 are... 
