### PR TITLE
Move tabulate_tensor to Form

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             apt-get -y install python3-tk
       - run:
           name: Install/update Python dependencies
-          command: pip3 install decorator flake8 matplotlib pytest pytest-xdist sphinx sphinx_rtd_theme --upgrade
+          command: pip3 install decorator flake8 numba matplotlib pytest pytest-xdist sphinx sphinx_rtd_theme --upgrade
       - run:
           name: Install FEniCS Python components
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ ENV SLEPC_DIR=/usr/local/slepc-32 \
 # Install Python packages (via pip)
 ARG PETSC4PY_VERSION=3.9.1
 ARG SLEPC4PY_VERSION=3.9.0
-RUN pip3 install --no-cache-dir mpi4py numpy scipy && \
+RUN pip3 install --no-cache-dir mpi4py numpy scipy numba && \
     pip3 install --no-cache-dir https://bitbucket.org/petsc/petsc4py/downloads/petsc4py-${PETSC4PY_VERSION}.tar.gz && \
     pip3 install --no-cache-dir https://bitbucket.org/slepc/slepc4py/downloads/slepc4py-${SLEPC4PY_VERSION}.tar.gz
 

--- a/cpp/dolfin/fem/Assembler.cpp
+++ b/cpp/dolfin/fem/Assembler.cpp
@@ -544,7 +544,6 @@ void Assembler::assemble(la::PETScMatrix& A, const Form& a,
   assert(a.mesh());
   const mesh::Mesh& mesh = *a.mesh();
 
-  const std::size_t gdim = mesh.geometry().dim();
   const std::size_t tdim = mesh.topology().dim();
   mesh.init(tdim);
 
@@ -598,7 +597,6 @@ void Assembler::assemble(la::PETScMatrix& A, const Form& a,
     assert(!cell.is_ghost());
 
     // Get cell vertex coordinates
-    coordinate_dofs.resize(cell.num_vertices(), gdim);
     cell.get_coordinate_dofs(coordinate_dofs);
 
     // Get dof maps for cell
@@ -695,7 +693,6 @@ void Assembler::assemble(Eigen::Ref<EigenVectorXd> b, const Form& L)
   assert(L.mesh());
   const mesh::Mesh& mesh = *L.mesh();
 
-  const std::size_t gdim = mesh.geometry().dim();
   const std::size_t tdim = mesh.topology().dim();
   mesh.init(tdim);
 
@@ -713,7 +710,6 @@ void Assembler::assemble(Eigen::Ref<EigenVectorXd> b, const Form& L)
     assert(!cell.is_ghost());
 
     // Get cell vertex coordinates
-    coordinate_dofs.resize(cell.num_vertices(), gdim);
     cell.get_coordinate_dofs(coordinate_dofs);
 
     // Get dof maps for cell
@@ -739,8 +735,6 @@ void Assembler::apply_bc(la::PETScVector& b, const Form& a,
   // Get mesh from form
   assert(a.mesh());
   const mesh::Mesh& mesh = *a.mesh();
-
-  const std::size_t gdim = mesh.geometry().dim();
 
   // Get bcs
   DirichletBC::Map boundary_values;
@@ -797,7 +791,6 @@ void Assembler::apply_bc(la::PETScVector& b, const Form& a,
     // std::cout << "  has bc" << std::endl;
 
     // Get cell vertex coordinates
-    coordinate_dofs.resize(cell.num_vertices(), gdim);
     cell.get_coordinate_dofs(coordinate_dofs);
 
     // Size data structure for assembly

--- a/cpp/dolfin/fem/Assembler.cpp
+++ b/cpp/dolfin/fem/Assembler.cpp
@@ -9,7 +9,6 @@
 #include "Form.h"
 #include "GenericDofMap.h"
 #include "SparsityPatternBuilder.h"
-#include "UFC.h"
 #include "utils.h"
 #include <dolfin/common/types.h>
 #include <dolfin/function/FunctionSpace.h>
@@ -545,10 +544,6 @@ void Assembler::assemble(la::PETScMatrix& A, const Form& a,
   assert(a.mesh());
   const mesh::Mesh& mesh = *a.mesh();
 
-  // FIXME: Remove UFC
-  // Create data structures for local assembly data
-  UFC ufc(a);
-
   const std::size_t gdim = mesh.geometry().dim();
   const std::size_t tdim = mesh.topology().dim();
   mesh.init(tdim);
@@ -595,9 +590,6 @@ void Assembler::assemble(la::PETScMatrix& A, const Form& a,
   EigenRowArrayXXd coordinate_dofs;
   EigenRowMatrixXd Ae;
 
-  // Get cell integral
-  auto cell_integral = a.integrals().cell_integral();
-
   // Iterate over all cells
   for (auto& cell : mesh::MeshRange<mesh::Cell>(mesh))
   {
@@ -609,9 +601,6 @@ void Assembler::assemble(la::PETScMatrix& A, const Form& a,
     coordinate_dofs.resize(cell.num_vertices(), gdim);
     cell.get_coordinate_dofs(coordinate_dofs);
 
-    // Update UFC data to current cell
-    ufc.update(cell, coordinate_dofs, cell_integral->enabled_coefficients);
-
     // Get dof maps for cell
     auto dmap0 = dofmaps[0]->cell_dofs(cell.index());
     auto dmap1 = dofmaps[1]->cell_dofs(cell.index());
@@ -620,9 +609,7 @@ void Assembler::assemble(la::PETScMatrix& A, const Form& a,
     Ae.resize(dmap0.size(), dmap1.size());
     Ae.setZero();
 
-    // Compute cell matrix
-    cell_integral->tabulate_tensor(Ae.data(), ufc.w(), coordinate_dofs.data(),
-                                   1);
+    a.tabulate_tensor(Ae.data(), cell, coordinate_dofs);
 
     // FIXME: Pass in list  of cells, and list of local dofs, with
     // Dirichlet conditions
@@ -708,10 +695,6 @@ void Assembler::assemble(Eigen::Ref<EigenVectorXd> b, const Form& L)
   assert(L.mesh());
   const mesh::Mesh& mesh = *L.mesh();
 
-  // FIXME: Remove UFC
-  // Create data structures for local assembly data
-  UFC ufc(L);
-
   const std::size_t gdim = mesh.geometry().dim();
   const std::size_t tdim = mesh.topology().dim();
   mesh.init(tdim);
@@ -723,9 +706,6 @@ void Assembler::assemble(Eigen::Ref<EigenVectorXd> b, const Form& L)
   EigenRowArrayXXd coordinate_dofs;
   EigenVectorXd be;
 
-  // Get cell integral
-  auto cell_integral = L.integrals().cell_integral();
-
   // Iterate over all cells
   for (auto& cell : mesh::MeshRange<mesh::Cell>(mesh))
   {
@@ -736,9 +716,6 @@ void Assembler::assemble(Eigen::Ref<EigenVectorXd> b, const Form& L)
     coordinate_dofs.resize(cell.num_vertices(), gdim);
     cell.get_coordinate_dofs(coordinate_dofs);
 
-    // Update UFC data to current cell
-    ufc.update(cell, coordinate_dofs, cell_integral->enabled_coefficients);
-
     // Get dof maps for cell
     auto dmap = dofmap->cell_dofs(cell.index());
     // auto dmap1 = dofmaps[1]->cell_dofs(cell.index());
@@ -748,8 +725,7 @@ void Assembler::assemble(Eigen::Ref<EigenVectorXd> b, const Form& L)
     be.setZero();
 
     // Compute cell matrix
-    cell_integral->tabulate_tensor(be.data(), ufc.w(), coordinate_dofs.data(),
-                                   1);
+    L.tabulate_tensor(be.data(), cell, coordinate_dofs);
 
     // Add to vector
     for (Eigen::Index i = 0; i < dmap.size(); ++i)
@@ -794,12 +770,6 @@ void Assembler::apply_bc(la::PETScVector& b, const Form& a,
   EigenVectorXd be;
   EigenRowArrayXXd coordinate_dofs;
 
-  // Create data structures for local assembly data
-  UFC ufc(a);
-
-  // Get cell integral
-  auto cell_integral = a.integrals().cell_integral();
-
   // Iterate over all cells
   for (auto& cell : mesh::MeshRange<mesh::Cell>(mesh))
   {
@@ -830,15 +800,11 @@ void Assembler::apply_bc(la::PETScVector& b, const Form& a,
     coordinate_dofs.resize(cell.num_vertices(), gdim);
     cell.get_coordinate_dofs(coordinate_dofs);
 
-    // Update UFC data to current cell
-    ufc.update(cell, coordinate_dofs, cell_integral->enabled_coefficients);
-
     // Size data structure for assembly
     auto dmap0 = dofmap1->cell_dofs(cell.index());
     Ae.resize(dmap0.size(), dmap1.size());
     Ae.setZero();
-    cell_integral->tabulate_tensor(Ae.data(), ufc.w(), coordinate_dofs.data(),
-                                   1);
+    a.tabulate_tensor(Ae.data(), cell, coordinate_dofs);
 
     // FIXME: Is this required?
     // Zero Dirichlet rows in Ae

--- a/cpp/dolfin/fem/Form.cpp
+++ b/cpp/dolfin/fem/Form.cpp
@@ -250,7 +250,6 @@ void Form::tabulate_tensor(
     double* A, mesh::Cell cell,
     Eigen::Ref<const EigenRowArrayXXd> coordinate_dofs) const
 {
-
   // Switch integral based on domain from dx MeshFunction
   std::uint32_t idx = 0;
   if (dx)

--- a/cpp/dolfin/fem/Form.cpp
+++ b/cpp/dolfin/fem/Form.cpp
@@ -242,14 +242,14 @@ void Form::tabulate_tensor(
   // Switch integral based on domain from dx MeshFunction
   std::shared_ptr<const ufc_cell_integral> integral;
 
-  std::uint32_t i = 0;
+  std::uint32_t idx = 0;
   if (!dx)
     integral = _integrals.cell_integral();
   else
   {
-    // FIXME: range checks on cell and i
-    i = (*dx)[cell];
-    integral = _integrals.cell_integral(i);
+    // FIXME: range checks on cell and idx
+    idx = (*dx)[cell];
+    integral = _integrals.cell_integral(idx);
   }
 
   // Restrict coefficients to cell
@@ -263,22 +263,22 @@ void Form::tabulate_tensor(
   }
 
   // Compute cell matrix
-  auto tab_fn = _integrals.cell_tabulate_tensor(i);
+  auto tab_fn = _integrals.cell_tabulate_tensor(idx);
   tab_fn(A, _wpointer.data(), coordinate_dofs.data(), 1);
 }
 //-----------------------------------------------------------------------------
 void Form::initialise_w()
 {
   const std::size_t num_coeffs = _coefficients.size();
-  std::vector<std::size_t> n = {0};
-  for (std::size_t i = 0; i < num_coeffs; ++i)
+  std::vector<std::uint32_t> n = {0};
+  for (std::uint32_t i = 0; i < num_coeffs; ++i)
   {
     const auto& element = _coefficients.element(i);
     n.push_back(n.back() + element.space_dimension());
   }
   _w.resize(n.back());
   _wpointer.resize(num_coeffs);
-  for (std::size_t i = 0; i < num_coeffs; ++i)
+  for (std::uint32_t i = 0; i < num_coeffs; ++i)
     _wpointer[i] = _w.data() + n[i];
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/fem/Form.cpp
+++ b/cpp/dolfin/fem/Form.cpp
@@ -65,10 +65,8 @@ Form::Form(std::shared_ptr<const ufc_form> ufc_form,
 }
 //-----------------------------------------------------------------------------
 Form::Form(const std::vector<std::shared_ptr<const function::FunctionSpace>>
-               function_spaces,
-           std::shared_ptr<const fem::CoordinateMapping> coordinate_mapping)
-    : _coefficients({}), _function_spaces(function_spaces),
-      _coord_mapping(coordinate_mapping)
+               function_spaces)
+    : _coefficients({}), _function_spaces(function_spaces)
 {
   // Set _mesh from function::FunctionSpace and check they are the same
   if (!function_spaces.empty())
@@ -284,15 +282,11 @@ void Form::initialise_w()
   for (std::uint32_t i = 0; i < num_coeffs; ++i)
   {
     const auto& element = _coefficients.element(i);
-    n.push_back(n.back() + element.space_dimension());
+    n.push_back(n.back() + element.space_dimension() * 2);
   }
-  _w.resize(n.back() * 2);
+  _w.resize(n.back());
   _wpointer.resize(num_coeffs);
-  _macro_wpointer.resize(num_coeffs);
   for (std::uint32_t i = 0; i < num_coeffs; ++i)
-  {
     _wpointer[i] = _w.data() + n[i];
-    _macro_wpointer[i] = _w.data() + 2 * n[i];
-  }
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/fem/Form.cpp
+++ b/cpp/dolfin/fem/Form.cpp
@@ -240,22 +240,19 @@ void Form::tabulate_tensor(
     Eigen::Ref<const EigenRowArrayXXd> coordinate_dofs) const
 {
   // Switch integral based on domain from dx MeshFunction
-  std::shared_ptr<const ufc_cell_integral> integral;
 
   std::uint32_t idx = 0;
-  if (!dx)
-    integral = _integrals.cell_integral();
-  else
+  if (dx)
   {
     // FIXME: range checks on cell and idx
     idx = (*dx)[cell];
-    integral = _integrals.cell_integral(idx);
   }
 
+  const bool* enabled_coefficients = _integrals.cell_enabled_coefficients(idx);
   // Restrict coefficients to cell
   for (std::size_t i = 0; i < _coefficients.size(); ++i)
   {
-    if (!integral->enabled_coefficients[i])
+    if (!enabled_coefficients[i])
       continue;
     const auto coefficient = _coefficients.get(i);
     const auto& element = _coefficients.element(i);

--- a/cpp/dolfin/fem/Form.h
+++ b/cpp/dolfin/fem/Form.h
@@ -8,6 +8,7 @@
 
 #include "FormCoefficients.h"
 #include "FormIntegrals.h"
+#include "UFC.h"
 #include <dolfin/common/types.h>
 #include <functional>
 #include <map>
@@ -36,6 +37,7 @@ namespace mesh
 class Mesh;
 template <typename T>
 class MeshFunction;
+class Cell;
 } // namespace mesh
 
 namespace fem
@@ -88,6 +90,10 @@ public:
   /// @return std::size_t
   ///         The rank of the form.
   std::size_t rank() const;
+
+  void
+  tabulate_tensor(double* A, mesh::Cell cell,
+                  Eigen::Ref<const EigenRowArrayXXd> coordinate_dofs) const;
 
   /// Get the coefficient index for a named coefficient
   int get_coefficient_index(std::string name) const;
@@ -276,6 +282,8 @@ private:
 
   std::function<int(const char*)> _coefficient_index_map;
   std::function<const char*(int)> _coefficient_name_map;
+
+  mutable UFC _ufc;
 };
 } // namespace fem
 } // namespace dolfin

--- a/cpp/dolfin/fem/Form.h
+++ b/cpp/dolfin/fem/Form.h
@@ -81,6 +81,15 @@ public:
        const std::vector<std::shared_ptr<const function::FunctionSpace>>
            function_spaces);
 
+  /// Create form (no UFC integrals)
+  ///
+  /// @param[in] function_spaces (std::vector<_function::FunctionSpace_>)
+  ///         Vector of function spaces.
+  /// @param[in] coordinate_map
+  Form(const std::vector<std::shared_ptr<const function::FunctionSpace>>
+           function_spaces,
+       std::shared_ptr<const fem::CoordinateMapping> coordinate_map);
+
   /// Destructor
   virtual ~Form();
 
@@ -239,6 +248,9 @@ public:
   /// Access coefficients (const)
   const FormCoefficients& coeffs() const { return _coefficients; }
 
+  /// Access form integrals (non-const)
+  FormIntegrals& integrals() { return _integrals; }
+
   /// Access form integrals (const)
   const FormIntegrals& integrals() const { return _integrals; }
 
@@ -278,15 +290,18 @@ private:
   std::shared_ptr<const mesh::MeshFunction<std::size_t>> dP;
 
   // Coordinate_mapping
-  std::shared_ptr<fem::CoordinateMapping> _coord_mapping;
+  std::shared_ptr<const fem::CoordinateMapping> _coord_mapping;
 
   std::function<int(const char*)> _coefficient_index_map;
   std::function<const char*(int)> _coefficient_name_map;
 
+  // Initialise temporary storage for coefficient values
   void initialise_w();
+
+  // Temporary storage for coefficient values
   std::vector<double> _w;
   std::vector<double*> _wpointer;
-  //  mutable UFC _ufc;
+  std::vector<double*> _macro_wpointer;
 };
 } // namespace fem
 } // namespace dolfin

--- a/cpp/dolfin/fem/Form.h
+++ b/cpp/dolfin/fem/Form.h
@@ -238,10 +238,10 @@ public:
       std::shared_ptr<const mesh::MeshFunction<std::size_t>> vertex_domains);
 
   /// Access coefficients (non-const)
-  FormCoefficients& coeffs() { return _coefficents; }
+  FormCoefficients& coeffs() { return _coefficients; }
 
   /// Access coefficients (const)
-  const FormCoefficients& coeffs() const { return _coefficents; }
+  const FormCoefficients& coeffs() const { return _coefficients; }
 
   /// Access form integrals (const)
   const FormIntegrals& integrals() const { return _integrals; }
@@ -257,7 +257,7 @@ private:
   FormIntegrals _integrals;
 
   // Coefficients associated with the Form
-  FormCoefficients _coefficents;
+  FormCoefficients _coefficients;
 
   // Function spaces (one for each argument)
   std::vector<std::shared_ptr<const function::FunctionSpace>> _function_spaces;
@@ -283,7 +283,10 @@ private:
   std::function<int(const char*)> _coefficient_index_map;
   std::function<const char*(int)> _coefficient_name_map;
 
-  mutable UFC _ufc;
+  void initialise_w();
+  std::vector<double> _w;
+  std::vector<double*> _wpointer;
+  //  mutable UFC _ufc;
 };
 } // namespace fem
 } // namespace dolfin

--- a/cpp/dolfin/fem/Form.h
+++ b/cpp/dolfin/fem/Form.h
@@ -81,7 +81,8 @@ public:
        const std::vector<std::shared_ptr<const function::FunctionSpace>>
            function_spaces);
 
-  /// Create form (no UFC integrals)
+  /// Create form (no UFC integrals). Integrals can be attached later
+  /// using FormIntegrals::set_cell_tabulate_tensor. Experimental.
   ///
   /// @param[in] function_spaces (std::vector<_function::FunctionSpace_>)
   ///         Vector of function spaces.
@@ -302,7 +303,8 @@ private:
   std::function<const char*(int)> _coefficient_name_map;
 
   // Initialise temporary storage for coefficient values
-  void initialise_w();
+  // needed for interface with UFC integrals
+  void init_coeff_scratch_space();
 
   // Temporary storage for coefficient values
   std::vector<double> _w;

--- a/cpp/dolfin/fem/Form.h
+++ b/cpp/dolfin/fem/Form.h
@@ -307,6 +307,7 @@ private:
   // Temporary storage for coefficient values
   std::vector<double> _w;
   std::vector<double*> _wpointer;
+
 };
 } // namespace fem
 } // namespace dolfin

--- a/cpp/dolfin/fem/Form.h
+++ b/cpp/dolfin/fem/Form.h
@@ -85,10 +85,8 @@ public:
   ///
   /// @param[in] function_spaces (std::vector<_function::FunctionSpace_>)
   ///         Vector of function spaces.
-  /// @param[in] coordinate_map
   Form(const std::vector<std::shared_ptr<const function::FunctionSpace>>
-           function_spaces,
-       std::shared_ptr<const fem::CoordinateMapping> coordinate_map);
+           function_spaces);
 
   /// Destructor
   virtual ~Form();
@@ -260,6 +258,14 @@ public:
     return _coord_mapping;
   }
 
+  /// Call tabulate_tensor on a cell, returning the local element matrix
+  /// @param A
+  ///    Local element tensor (to be calculated)
+  /// @param cell
+  ///    Cell on which to calculate
+  /// @param coordinate_dofs
+  ///    Coordinates of the cell
+  ///
   void
   tabulate_tensor(double* A, mesh::Cell cell,
                   Eigen::Ref<const EigenRowArrayXXd> coordinate_dofs) const;
@@ -301,7 +307,6 @@ private:
   // Temporary storage for coefficient values
   std::vector<double> _w;
   std::vector<double*> _wpointer;
-  std::vector<double*> _macro_wpointer;
 };
 } // namespace fem
 } // namespace dolfin

--- a/cpp/dolfin/fem/Form.h
+++ b/cpp/dolfin/fem/Form.h
@@ -91,10 +91,6 @@ public:
   ///         The rank of the form.
   std::size_t rank() const;
 
-  void
-  tabulate_tensor(double* A, mesh::Cell cell,
-                  Eigen::Ref<const EigenRowArrayXXd> coordinate_dofs) const;
-
   /// Get the coefficient index for a named coefficient
   int get_coefficient_index(std::string name) const;
 
@@ -251,6 +247,10 @@ public:
   {
     return _coord_mapping;
   }
+
+  void
+  tabulate_tensor(double* A, mesh::Cell cell,
+                  Eigen::Ref<const EigenRowArrayXXd> coordinate_dofs) const;
 
 private:
   // Integrals associated with the Form

--- a/cpp/dolfin/fem/FormCoefficients.cpp
+++ b/cpp/dolfin/fem/FormCoefficients.cpp
@@ -30,6 +30,13 @@ FormCoefficients::FormCoefficients(const ufc_form& ufc_form)
   }
 }
 //-----------------------------------------------------------------------------
+FormCoefficients::FormCoefficients(
+    std::vector<fem::FiniteElement>& coefficient_elements)
+    : _elements(coefficient_elements),
+      _coefficients(coefficient_elements.size())
+{
+}
+//-----------------------------------------------------------------------------
 std::size_t FormCoefficients::size() const { return _coefficients.size(); }
 //-----------------------------------------------------------------------------
 void FormCoefficients::set(

--- a/cpp/dolfin/fem/FormCoefficients.h
+++ b/cpp/dolfin/fem/FormCoefficients.h
@@ -21,7 +21,7 @@ class GenericFunction;
 
 namespace fem
 {
-  class FiniteElement;
+class FiniteElement;
 
 /// Storage for the coefficients of a Form consisting of GenericFunctions and
 /// the Elements they are defined on
@@ -31,6 +31,9 @@ public:
   /// Initialise the FormCoefficients from a ufc_form, instantiating all the
   /// required elements
   FormCoefficients(const ufc_form& ufc_form);
+
+  /// Initialise the FormCoefficients with their elements only
+  FormCoefficients(std::vector<fem::FiniteElement>& coefficient_elements);
 
   /// Get number of coefficients
   std::size_t size() const;

--- a/cpp/dolfin/fem/FormIntegrals.cpp
+++ b/cpp/dolfin/fem/FormIntegrals.cpp
@@ -141,6 +141,11 @@ FormIntegrals::cell_tabulate_tensor(int i) const
   return _cell_tabulate_tensor[i];
 }
 //-----------------------------------------------------------------------------
+const bool* FormIntegrals::cell_enabled_coefficients(int i) const
+{
+  return _enabled_coefficients.row(i).data();
+}
+//-----------------------------------------------------------------------------
 void FormIntegrals::set_cell_tabulate_tensor(
     int i, void (*fn)(double*, const double* const*, const double*, int))
 {

--- a/cpp/dolfin/fem/FormIntegrals.cpp
+++ b/cpp/dolfin/fem/FormIntegrals.cpp
@@ -151,6 +151,10 @@ void FormIntegrals::set_cell_tabulate_tensor(
 {
   _cell_tabulate_tensor.resize(i + 1);
   _cell_tabulate_tensor[i] = fn;
+
+  // Enable all coefficients for this integral
+  _enabled_coefficients.conservativeResize(i + 1, Eigen::NoChange);
+  _enabled_coefficients.row(i) = true;
 }
 //-----------------------------------------------------------------------------
 int FormIntegrals::count(FormIntegrals::Type t) const
@@ -158,7 +162,7 @@ int FormIntegrals::count(FormIntegrals::Type t) const
   switch (t)
   {
   case Type::cell:
-    return _cell_integrals.size();
+    return _cell_tabulate_tensor.size();
   case Type::interior_facet:
     return _interior_facet_integrals.size();
   case Type::exterior_facet:
@@ -170,7 +174,10 @@ int FormIntegrals::count(FormIntegrals::Type t) const
   return 0;
 }
 //-----------------------------------------------------------------------------
-int FormIntegrals::num_cell_integrals() const { return _cell_integrals.size(); }
+int FormIntegrals::num_cell_integrals() const
+{
+  return _cell_tabulate_tensor.size();
+}
 //-----------------------------------------------------------------------------
 std::shared_ptr<const ufc_exterior_facet_integral>
 FormIntegrals::exterior_facet_integral() const

--- a/cpp/dolfin/fem/FormIntegrals.cpp
+++ b/cpp/dolfin/fem/FormIntegrals.cpp
@@ -34,9 +34,18 @@ FormIntegrals::FormIntegrals(const ufc_form& ufc_form)
     }
   }
 
+  _enabled_coefficients.resize(_cell_integrals.size(),
+                               ufc_form.num_coefficients);
+
   // Experimental function pointers for tabulate_tensor cell integral
-  for (auto& ci : _cell_integrals)
+  for (unsigned int i = 0; i != _cell_integrals.size(); ++i)
+  {
+    const auto ci = _cell_integrals[i];
     _cell_tabulate_tensor.push_back(ci->tabulate_tensor);
+    std::copy(ci->enabled_coefficients,
+              ci->enabled_coefficients + ufc_form.num_coefficients,
+              _enabled_coefficients.row(i).data());
+  }
 
   // Exterior facet integrals
   ufc_exterior_facet_integral* _default_exterior_facet_integral

--- a/cpp/dolfin/fem/FormIntegrals.h
+++ b/cpp/dolfin/fem/FormIntegrals.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <Eigen/Dense>
 #include <functional>
 #include <memory>
 #include <vector>
-#include <Eigen/Dense>
 
 struct ufc_cell_integral;
 struct ufc_exterior_facet_integral;
@@ -49,6 +49,8 @@ public:
   /// Get the function for 'tabulate_tensor' for cell integral i
   const std::function<void(double*, const double* const*, const double*, int)>&
   cell_tabulate_tensor(int i) const;
+
+  const bool* cell_enabled_coefficients(int i) const;
 
   /// Set the function for 'tabulate_tensor' for cell integral i
   void set_cell_tabulate_tensor(int i, void (*fn)(double*, const double* const*,
@@ -103,7 +105,7 @@ private:
 
   // Storage for enabled coefficients, to match the functions
   Eigen::Array<bool, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
-    _enabled_coefficients;
+      _enabled_coefficients;
 
   // Exterior facet integrals
   std::vector<std::shared_ptr<ufc_exterior_facet_integral>>

--- a/cpp/dolfin/fem/FormIntegrals.h
+++ b/cpp/dolfin/fem/FormIntegrals.h
@@ -40,6 +40,9 @@ public:
   /// the required integrals
   FormIntegrals(const ufc_form& ufc_form);
 
+  /// Initialise the FormIntegrals as empty
+  FormIntegrals() {}
+
   /// Default cell integral
   std::shared_ptr<const ufc_cell_integral> cell_integral() const;
 

--- a/cpp/dolfin/fem/FormIntegrals.h
+++ b/cpp/dolfin/fem/FormIntegrals.h
@@ -50,9 +50,18 @@ public:
   std::shared_ptr<const ufc_cell_integral> cell_integral(unsigned int i) const;
 
   /// Get the function for 'tabulate_tensor' for cell integral i
+  /// @param i
+  ///    Integral number
+  /// @returns std::function
+  ///    Function to call for tabulate_tensor on a cell
   const std::function<void(double*, const double* const*, const double*, int)>&
   cell_tabulate_tensor(int i) const;
 
+  /// Get the enabled coefficients on cell integral i
+  /// @param i
+  ///    Integral number
+  /// @returns bool*
+  ///    Pointer to list of enabled coefficients for this integral
   const bool* cell_enabled_coefficients(int i) const;
 
   /// Set the function for 'tabulate_tensor' for cell integral i

--- a/cpp/dolfin/fem/FormIntegrals.h
+++ b/cpp/dolfin/fem/FormIntegrals.h
@@ -9,6 +9,7 @@
 #include <functional>
 #include <memory>
 #include <vector>
+#include <Eigen/Dense>
 
 struct ufc_cell_integral;
 struct ufc_exterior_facet_integral;
@@ -99,6 +100,10 @@ private:
   std::vector<
       std::function<void(double*, const double* const*, const double*, int)>>
       _cell_tabulate_tensor;
+
+  // Storage for enabled coefficients, to match the functions
+  Eigen::Array<bool, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+    _enabled_coefficients;
 
   // Exterior facet integrals
   std::vector<std::shared_ptr<ufc_exterior_facet_integral>>

--- a/python/src/fem.cpp
+++ b/python/src/fem.cpp
@@ -333,9 +333,8 @@ void fem(py::module& m)
       .def(py::init<std::shared_ptr<const ufc_form>,
                     std::vector<std::shared_ptr<
                         const dolfin::function::FunctionSpace>>>())
-      .def(py::init<
-           std::vector<std::shared_ptr<const dolfin::function::FunctionSpace>>,
-           std::shared_ptr<const dolfin::fem::CoordinateMapping>>())
+      .def(py::init<std::vector<
+               std::shared_ptr<const dolfin::function::FunctionSpace>>>())
       .def("num_coefficients",
            [](const dolfin::fem::Form& self) { return self.coeffs().size(); },
            "Return number of coefficients in form")

--- a/python/src/fem.cpp
+++ b/python/src/fem.cpp
@@ -333,6 +333,9 @@ void fem(py::module& m)
       .def(py::init<std::shared_ptr<const ufc_form>,
                     std::vector<std::shared_ptr<
                         const dolfin::function::FunctionSpace>>>())
+      .def(py::init<
+           std::vector<std::shared_ptr<const dolfin::function::FunctionSpace>>,
+           std::shared_ptr<const dolfin::fem::CoordinateMapping>>())
       .def("num_coefficients",
            [](const dolfin::fem::Form& self) { return self.coeffs().size(); },
            "Return number of coefficients in form")
@@ -350,6 +353,12 @@ void fem(py::module& m)
       .def("set_interior_facet_domains",
            &dolfin::fem::Form::set_interior_facet_domains)
       .def("set_vertex_domains", &dolfin::fem::Form::set_vertex_domains)
+      .def("set_cell_tabulate",
+           [](dolfin::fem::Form& self, unsigned int i, std::size_t addr) {
+             auto tabulate_tensor_ptr = (void (*)(double*, const double* const*,
+                                                  const double*, int))addr;
+             self.integrals().set_cell_tabulate_tensor(i, tabulate_tensor_ptr);
+           })
       .def("rank", &dolfin::fem::Form::rank)
       .def("mesh", &dolfin::fem::Form::mesh)
       .def("coordinate_mapping", &dolfin::fem::Form::coordinate_mapping);

--- a/python/test/unit/fem/test_numba_assembly.py
+++ b/python/test/unit/fem/test_numba_assembly.py
@@ -1,0 +1,92 @@
+"""Unit tests for assembly with a numba kernel"""
+
+# Copyright (C) 2018 Chris N. Richardson
+#
+# This file is part of DOLFIN (https://www.fenicsproject.org)
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+
+import pytest
+import dolfin
+from dolfin import *
+from dolfin.la import PETScMatrix, PETScVector
+from dolfin.cpp.fem import SystemAssembler
+from numba import cfunc, types, carray
+import numpy as np
+import ctypes
+
+from dolfin.jit.jit import dolfin_pc, ffc_jit
+
+def tabulate_tensor_A(A_, w_, coords_, cell_orientation):
+    A = carray(A_, (3, 3), dtype=np.float64)
+    coordinate_dofs = carray(coords_, (3, 2), dtype=np.float64)
+
+    # Ke=∫Ωe BTe Be dΩ
+    x0, y0 = coordinate_dofs[0, :]
+    x1, y1 = coordinate_dofs[1, :]
+    x2, y2 = coordinate_dofs[2, :]
+
+    # 2x Element area Ae
+    Ae = abs((x0 - x1)*(y2 - y1) - (y0 - y1)*(x2 - x1))
+
+    B = np.array([y1 - y2, y2 - y0, y0 - y1,
+                  x2 - x1, x0 - x2, x1 - x0],
+                  dtype=np.float64).reshape(2, 3)
+
+    A[:,:] = np.dot(B.T, B)/(2*Ae)
+
+
+def tabulate_tensor_b(b_, w_, coords_, cell_orientation):
+    b = carray(b_, (3), dtype=np.float64)
+    coordinate_dofs = carray(coords_, (3, 2), dtype=np.float64)
+    x0, y0 = coordinate_dofs[0, :]
+    x1, y1 = coordinate_dofs[1, :]
+    x2, y2 = coordinate_dofs[2, :]
+
+    # 2x Element area Ae
+    Ae = abs((x0 - x1)*(y2 - y1) - (y0 - y1)*(x2 - x1))
+    b[:] = Ae/6.0
+
+def test_numba_assembly():
+    mesh = UnitSquareMesh(MPI.comm_world, 13, 13)
+    Q = FunctionSpace(mesh, "CG", 1)
+
+    u = TrialFunction(Q)
+    v = TestFunction(Q)
+
+    a = dolfin.cpp.fem.Form([Q._cpp_object, Q._cpp_object], mesh.geometry.coord_mapping)
+    L = dolfin.cpp.fem.Form([Q._cpp_object], mesh.geometry.coord_mapping)
+
+    sig = types.void(types.CPointer(types.double), types.CPointer(types.CPointer(types.double)),
+                     types.CPointer(types.double), types.intc)
+
+    fnA = cfunc(sig, cache=True)(tabulate_tensor_A)
+    a.set_cell_tabulate(0, fnA.address)
+
+    fnb = cfunc(sig, cache=True)(tabulate_tensor_b)
+    L.set_cell_tabulate(0, fnb.address)
+
+    if (False):
+        ufc_form = ffc_jit(dot(grad(u), grad(v))*dx)
+        ufc_form = cpp.fem.make_ufc_form(ufc_form[0])
+        a = cpp.fem.Form(ufc_form, [Q._cpp_object, Q._cpp_object])
+        ufc_form = ffc_jit(v*dx)
+        ufc_form = cpp.fem.make_ufc_form(ufc_form[0])
+        L = cpp.fem.Form(ufc_form, [Q._cpp_object])
+
+    assembler = cpp.fem.Assembler([[a]], [L], [])
+    A = PETScMatrix(MPI.comm_world)
+    b = PETScVector(MPI.comm_world)
+    assembler.assemble(A, cpp.fem.Assembler.BlockType.monolithic)
+    assembler.assemble(b, cpp.fem.Assembler.BlockType.monolithic)
+
+    Anorm = A.norm('frobenius')
+    bnorm = b.norm('l2')
+
+    print(Anorm, bnorm)
+
+    assert (np.isclose(Anorm, 56.124860801609124))
+    assert (np.isclose(bnorm, 0.0739710713711999))
+
+
+    list_timings([TimingType.wall])

--- a/python/test/unit/fem/test_numba_assembly.py
+++ b/python/test/unit/fem/test_numba_assembly.py
@@ -54,8 +54,8 @@ def test_numba_assembly():
     u = TrialFunction(Q)
     v = TestFunction(Q)
 
-    a = dolfin.cpp.fem.Form([Q._cpp_object, Q._cpp_object], mesh.geometry.coord_mapping)
-    L = dolfin.cpp.fem.Form([Q._cpp_object], mesh.geometry.coord_mapping)
+    a = dolfin.cpp.fem.Form([Q._cpp_object, Q._cpp_object])
+    L = dolfin.cpp.fem.Form([Q._cpp_object])
 
     sig = types.void(types.CPointer(types.double), types.CPointer(types.CPointer(types.double)),
                      types.CPointer(types.double), types.intc)


### PR DESCRIPTION
Move tabulate_tensor to `Form` and relieves the assembler for the responsibility of updating
coefficients, or choosing which integral to use based on cell index.

* add a constructor to `Form` without any UFC integrals
* allow user-defined cell integrals (e.g. with numba) to be attached to `Form`
* add test for user-defined numba kernel

Obviously there is more to do, and much to clean up when we get rid of `SystemAssembler`.

