### PR TITLE
Re-enable ghost shared vertex

### DIFF
--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -65,7 +65,7 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
     else
     {
       throw std::runtime_error(
-          "Mistmach between cell type and number of vertices per cell");
+          "Mismatch between cell type and number of vertices per cell");
     }
   }
 

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -89,6 +89,18 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
                                                 cell_permutation);
   _coordinate_dofs.init(tdim, coordinate_dofs, cell_permutation);
 
+  std::stringstream s;
+
+  s << MPI::rank(comm) << " = ";
+
+  s << "cells = " << cells << "\n";
+
+  for (auto& q : global_point_indices)
+    s << q << " ";
+  s << "\n";
+
+  std::cout << s.str();
+
   // Distribute the points across processes and calculate shared points
   EigenRowArrayXXd distributed_points;
   std::map<std::int32_t, std::set<std::uint32_t>> shared_points;

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -89,18 +89,6 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
                                                 cell_permutation);
   _coordinate_dofs.init(tdim, coordinate_dofs, cell_permutation);
 
-  std::stringstream s;
-
-  s << MPI::rank(comm) << " = ";
-
-  s << "cells = " << cells << "\n";
-
-  for (auto& q : global_point_indices)
-    s << q << " ";
-  s << "\n";
-
-  std::cout << s.str();
-
   // Distribute the points across processes and calculate shared points
   EigenRowArrayXXd distributed_points;
   std::map<std::int32_t, std::set<std::uint32_t>> shared_points;

--- a/cpp/dolfin/mesh/MeshPartitioning.cpp
+++ b/cpp/dolfin/mesh/MeshPartitioning.cpp
@@ -182,8 +182,9 @@ mesh::Mesh MeshPartitioning::build(
   timer.stop();
 
   // Build mesh from points and distributed cells
+  const std::int32_t num_ghosts = new_cell_vertices.rows() - num_regular_cells;
   mesh::Mesh mesh(comm, type, points, new_cell_vertices,
-                  new_global_cell_indices, ghost_mode);
+                  new_global_cell_indices, ghost_mode, num_ghosts);
 
   if (ghost_mode == mesh::GhostMode::none)
     return mesh;

--- a/cpp/dolfin/mesh/MeshPartitioning.cpp
+++ b/cpp/dolfin/mesh/MeshPartitioning.cpp
@@ -296,14 +296,16 @@ void MeshPartitioning::distribute_cell_layer(
   const int mpi_size = MPI::size(mpi_comm);
   const int mpi_rank = MPI::rank(mpi_comm);
 
-  // Get set of vertices in ghost cells
+  // Map from shared vertex to the set of cells containing it
   std::map<std::int64_t, std::vector<std::int64_t>> sh_vert_to_cell;
 
-  // Make global-to-local map of shared cells
+  // Global to local mapping of cell indices
   std::map<std::int64_t, int> cell_global_to_local;
+
+  // Iterate only over ghost cells
   for (Eigen::Index i = num_regular_cells; i < cell_vertices.rows(); ++i)
   {
-    // Add map entry for each vertex
+    // Add map entry for each vertex of ghost cells
     for (Eigen::Index p = 0; p < cell_vertices.cols(); ++p)
     {
       sh_vert_to_cell.insert(
@@ -313,17 +315,12 @@ void MeshPartitioning::distribute_cell_layer(
     cell_global_to_local.insert({global_cell_indices[i], i});
   }
 
-  // Reduce vertex set to those which also appear in local cells
-  // giving the effective boundary vertices.  Make a map from these
-  // vertices to the set of connected cells (but only adding locally
-  // owned cells)
-
-  // Go through all regular cells to add any previously unshared
-  // cells.
+  // Iterate only over regular (non-ghost) cells
   for (int i = 0; i < num_regular_cells; ++i)
   {
     for (Eigen::Index j = 0; j != cell_vertices.cols(); ++j)
     {
+      // If vertex already in map, append local cell index to set
       auto vc_it = sh_vert_to_cell.find(cell_vertices(i, j));
       if (vc_it != sh_vert_to_cell.end())
       {
@@ -333,12 +330,16 @@ void MeshPartitioning::distribute_cell_layer(
     }
   }
 
-  // Send lists of cells/owners to "owner" of vertex,
+  // sh_vert_to_cell now contains a mapping from the vertices of
+  // ghost cells to any regular cells which they are also incident with.
+
+  // Send lists of cells/owners to "index owner" of vertex,
   // collating and sending back out...
   std::vector<std::vector<std::int64_t>> send_vertcells(mpi_size);
   std::vector<std::vector<std::int64_t>> recv_vertcells(mpi_size);
   for (const auto& vc_it : sh_vert_to_cell)
   {
+    // Generate unique destination "index owner" based on vertex index
     const int dest = (vc_it.first) % mpi_size;
 
     std::vector<std::int64_t>& sendv = send_vertcells[dest];
@@ -364,16 +365,17 @@ void MeshPartitioning::distribute_cell_layer(
 
   // Reset map
   sh_vert_to_cell.clear();
+  std::vector<std::int64_t> cell_set;
   for (int i = 0; i < mpi_size; ++i)
   {
     const std::vector<std::int64_t>& recv_i = recv_vertcells[i];
     for (auto q = recv_i.begin(); q != recv_i.end(); q += num_cell_vertices + 1)
     {
       const std::size_t vertex_index = *(q + 1);
-      std::vector<std::int64_t> cell_set = {i};
+      // Packing: [owner, cell_index, this_vertex, [other_vertices]]
+      cell_set = {i};
       cell_set.insert(cell_set.end(), q, q + num_cell_vertices + 1);
 
-      // Packing: [owner, cell_index, this_vertex, [other_vertices]]
       // Look for vertex in map, and add the attached cell
       auto it = sh_vert_to_cell.insert({vertex_index, cell_set});
       if (!it.second)
@@ -410,10 +412,10 @@ void MeshPartitioning::distribute_cell_layer(
     {
       const std::int64_t owner = *q;
       const std::int64_t cell_index = *(q + 1);
-      auto cell_it = cell_global_to_local.find(cell_index);
-      if (cell_it == cell_global_to_local.end())
+
+      auto cell_insert = cell_global_to_local.insert({cell_index, count});
+      if (cell_insert.second)
       {
-        cell_global_to_local.insert({cell_index, count});
         shared_cells.insert({count, std::set<std::uint32_t>()});
         global_cell_indices.push_back(cell_index);
         cell_partition.push_back(owner);
@@ -424,8 +426,11 @@ void MeshPartitioning::distribute_cell_layer(
 
   // Add received cells and update sharing information for cells
   cell_vertices.conservativeResize(count, num_cell_vertices);
+
+  // Set of processes and cells sharing the same vertex
   std::set<std::uint32_t> sharing_procs;
   std::vector<std::size_t> sharing_cells;
+
   std::size_t last_vertex = std::numeric_limits<std::size_t>::max();
   for (const auto& p : recv_vertcells)
   {

--- a/cpp/dolfin/mesh/MeshPartitioning.cpp
+++ b/cpp/dolfin/mesh/MeshPartitioning.cpp
@@ -143,14 +143,11 @@ mesh::Mesh MeshPartitioning::build(
 
   if (ghost_mode == mesh::GhostMode::shared_vertex)
   {
-    log::dolfin_error("MeshPartitioning.cpp", "use shared_vertex mode",
-                      "Needs fixing");
-
     // Send/receive additional cells defined by connectivity to the shared
     // vertices.
-    //    distribute_cell_layer(comm, num_regular_cells, num_global_vertices,
-    //                          shared_cells, new_cell_vertices,
-    //                          new_global_cell_indices, new_cell_partition);
+    distribute_cell_layer(comm, num_regular_cells, shared_cells,
+                          new_cell_vertices, new_global_cell_indices,
+                          new_cell_partition);
   }
   else if (ghost_mode == mesh::GhostMode::none)
   {
@@ -287,209 +284,199 @@ MeshPartitioning::reorder_cells_gps(
                          std::move(reordered_global_cell_indices));
 }
 //-----------------------------------------------------------------------------
-// void MeshPartitioning::distribute_cell_layer(
-//     MPI_Comm mpi_comm, const int num_regular_cells,
-//     const std::int64_t num_global_vertices,
-//     std::map<std::int32_t, std::set<std::uint32_t>>& shared_cells,
-//     EigenRowArrayXXi64& cell_vertices,
-//     std::vector<std::int64_t>& global_cell_indices,
-//     std::vector<int>& cell_partition)
-// {
-//   common::Timer timer("Distribute cell layer");
+void MeshPartitioning::distribute_cell_layer(
+    MPI_Comm mpi_comm, const int num_regular_cells,
+    std::map<std::int32_t, std::set<std::uint32_t>>& shared_cells,
+    EigenRowArrayXXi64& cell_vertices,
+    std::vector<std::int64_t>& global_cell_indices,
+    std::vector<int>& cell_partition)
+{
+  common::Timer timer("Distribute cell layer");
 
-//   const int mpi_size = MPI::size(mpi_comm);
-//   const int mpi_rank = MPI::rank(mpi_comm);
+  const int mpi_size = MPI::size(mpi_comm);
+  const int mpi_rank = MPI::rank(mpi_comm);
 
-//   // Get set of vertices in ghost cells
-//   std::map<std::int64_t, std::vector<std::int64_t>> sh_vert_to_cell;
+  // Get set of vertices in ghost cells
+  std::map<std::int64_t, std::vector<std::int64_t>> sh_vert_to_cell;
 
-//   // Make global-to-local map of shared cells
-//   std::map<std::int64_t, int> cell_global_to_local;
-//   for (Eigen::Index i = num_regular_cells; i < cell_vertices.rows(); ++i)
-//   {
-//     // Add map entry for each vertex
-//     for (Eigen::Index p = 0; p < cell_vertices.cols(); ++p)
-//     {
-//       sh_vert_to_cell.insert(
-//           {cell_vertices(i, p), std::vector<std::int64_t>()});
-//     }
+  // Make global-to-local map of shared cells
+  std::map<std::int64_t, int> cell_global_to_local;
+  for (Eigen::Index i = num_regular_cells; i < cell_vertices.rows(); ++i)
+  {
+    // Add map entry for each vertex
+    for (Eigen::Index p = 0; p < cell_vertices.cols(); ++p)
+    {
+      sh_vert_to_cell.insert(
+          {cell_vertices(i, p), std::vector<std::int64_t>()});
+    }
 
-//     cell_global_to_local.insert({global_cell_indices[i], i});
-//   }
+    cell_global_to_local.insert({global_cell_indices[i], i});
+  }
 
-//   // Reduce vertex set to those which also appear in local cells
-//   // giving the effective boundary vertices.  Make a map from these
-//   // vertices to the set of connected cells (but only adding locally
-//   // owned cells)
+  // Reduce vertex set to those which also appear in local cells
+  // giving the effective boundary vertices.  Make a map from these
+  // vertices to the set of connected cells (but only adding locally
+  // owned cells)
 
-//   // Go through all regular cells to add any previously unshared
-//   // cells.
-//   for (int i = 0; i < num_regular_cells; ++i)
-//   {
-//     for (Eigen::Index j = 0; j != cell_vertices.cols(); ++j)
-//     {
-//       auto vc_it = sh_vert_to_cell.find(cell_vertices(i, j));
-//       if (vc_it != sh_vert_to_cell.end())
-//       {
-//         cell_global_to_local.insert({global_cell_indices[i], i});
-//         vc_it->second.push_back(i);
-//       }
-//     }
-//   }
+  // Go through all regular cells to add any previously unshared
+  // cells.
+  for (int i = 0; i < num_regular_cells; ++i)
+  {
+    for (Eigen::Index j = 0; j != cell_vertices.cols(); ++j)
+    {
+      auto vc_it = sh_vert_to_cell.find(cell_vertices(i, j));
+      if (vc_it != sh_vert_to_cell.end())
+      {
+        cell_global_to_local.insert({global_cell_indices[i], i});
+        vc_it->second.push_back(i);
+      }
+    }
+  }
 
-//   // Send lists of cells/owners to MPI::index_owner of vertex,
-//   // collating and sending back out...
-//   std::vector<std::vector<std::int64_t>> send_vertcells(mpi_size);
-//   std::vector<std::vector<std::int64_t>> recv_vertcells(mpi_size);
-//   for (auto vc_it = sh_vert_to_cell.begin(); vc_it != sh_vert_to_cell.end();
-//        ++vc_it)
-//   {
-//     const int dest
-//         = MPI::index_owner(mpi_comm, vc_it->first, num_global_vertices);
+  // Send lists of cells/owners to "owner" of vertex,
+  // collating and sending back out...
+  std::vector<std::vector<std::int64_t>> send_vertcells(mpi_size);
+  std::vector<std::vector<std::int64_t>> recv_vertcells(mpi_size);
+  for (const auto& vc_it : sh_vert_to_cell)
+  {
+    const int dest = (vc_it.first) % mpi_size;
 
-//     std::vector<std::int64_t>& sendv = send_vertcells[dest];
+    std::vector<std::int64_t>& sendv = send_vertcells[dest];
 
-//     // Pack as [cell_global_index, this_vertex, [other_vertices]]
-//     for (auto q = vc_it->second.begin(); q != vc_it->second.end(); ++q)
-//     {
-//       sendv.push_back(global_cell_indices[*q]);
-//       sendv.push_back(vc_it->first);
-//       for (Eigen::Index v = 0; v < cell_vertices.cols(); ++v)
-//       {
-//         if (cell_vertices(*q, v) != vc_it->first)
-//           sendv.push_back(cell_vertices(*q, v));
-//       }
-//     }
-//   }
+    // Pack as [cell_global_index, this_vertex, [other_vertices]]
+    for (const auto& q : vc_it.second)
+    {
+      sendv.push_back(global_cell_indices[q]);
+      sendv.push_back(vc_it.first);
+      for (Eigen::Index v = 0; v < cell_vertices.cols(); ++v)
+      {
+        if (cell_vertices(q, v) != vc_it.first)
+          sendv.push_back(cell_vertices(q, v));
+      }
+    }
+  }
 
-//   MPI::all_to_all(mpi_comm, send_vertcells, recv_vertcells);
+  MPI::all_to_all(mpi_comm, send_vertcells, recv_vertcells);
 
-//   const std::uint32_t num_cell_vertices = cell_vertices.cols();
+  const std::uint32_t num_cell_vertices = cell_vertices.cols();
 
-//   // Collect up cells on common vertices
+  // Collect up cells on common vertices
 
-//   // Reset map
-//   sh_vert_to_cell.clear();
-//   for (int i = 0; i < mpi_size; ++i)
-//   {
-//     const std::vector<std::int64_t>& recv_i = recv_vertcells[i];
-//     for (auto q = recv_i.begin(); q != recv_i.end(); q += num_cell_vertices +
-//     1)
-//     {
-//       const std::size_t vertex_index = *(q + 1);
-//       std::vector<std::int64_t> cell_set = {i};
-//       cell_set.insert(cell_set.end(), q, q + num_cell_vertices + 1);
+  // Reset map
+  sh_vert_to_cell.clear();
+  for (int i = 0; i < mpi_size; ++i)
+  {
+    const std::vector<std::int64_t>& recv_i = recv_vertcells[i];
+    for (auto q = recv_i.begin(); q != recv_i.end(); q += num_cell_vertices + 1)
+    {
+      const std::size_t vertex_index = *(q + 1);
+      std::vector<std::int64_t> cell_set = {i};
+      cell_set.insert(cell_set.end(), q, q + num_cell_vertices + 1);
 
-//       // Packing: [owner, cell_index, this_vertex, [other_vertices]]
-//       // Look for vertex in map, and add the attached cell
-//       auto it = sh_vert_to_cell.find(vertex_index);
-//       if (it == sh_vert_to_cell.end())
-//         sh_vert_to_cell.insert({vertex_index, cell_set});
-//       else
-//         it->second.insert(it->second.end(), cell_set.begin(),
-//         cell_set.end());
-//     }
-//   }
+      // Packing: [owner, cell_index, this_vertex, [other_vertices]]
+      // Look for vertex in map, and add the attached cell
+      auto it = sh_vert_to_cell.insert({vertex_index, cell_set});
+      if (!it.second)
+        it.first->second.insert(it.first->second.end(), cell_set.begin(),
+                                cell_set.end());
+    }
+  }
 
-//   // Clear sending arrays
-//   send_vertcells = std::vector<std::vector<std::int64_t>>(mpi_size);
+  // Clear sending arrays
+  send_vertcells = std::vector<std::vector<std::int64_t>>(mpi_size);
 
-//   // Send back out to all processes which share the same vertex
-//   // FIXME: avoid sending back own cells to owner?
-//   for (auto p = sh_vert_to_cell.begin(); p != sh_vert_to_cell.end(); ++p)
-//   {
-//     for (auto q = p->second.begin(); q != p->second.end();
-//          q += (num_cell_vertices + 2))
-//     {
-//       send_vertcells[*q].insert(send_vertcells[*q].end(), p->second.begin(),
-//                                 p->second.end());
-//     }
-//   }
+  // Send back out to all processes which share the same vertex
+  for (const auto& p : sh_vert_to_cell)
+  {
+    for (auto q = p.second.begin(); q != p.second.end();
+         q += (num_cell_vertices + 2))
+    {
+      send_vertcells[*q].insert(send_vertcells[*q].end(), p.second.begin(),
+                                p.second.end());
+    }
+  }
 
-//   MPI::all_to_all(mpi_comm, send_vertcells, recv_vertcells);
+  MPI::all_to_all(mpi_comm, send_vertcells, recv_vertcells);
 
-//   // Count up new cells, assign local index, set owner
-//   // and initialise shared_cells
+  // Count up new cells, assign local index, set owner
+  // and initialise shared_cells
 
-//   const std::uint32_t num_cells = cell_vertices.rows();
-//   std::uint32_t count = num_cells;
+  const std::uint32_t num_cells = cell_vertices.rows();
+  std::uint32_t count = num_cells;
 
-//   for (auto p = recv_vertcells.begin(); p != recv_vertcells.end(); ++p)
-//   {
-//     for (auto q = p->begin(); q != p->end(); q += num_cell_vertices + 2)
-//     {
-//       const std::int64_t owner = *q;
-//       const std::int64_t cell_index = *(q + 1);
-//       auto cell_it = cell_global_to_local.find(cell_index);
-//       if (cell_it == cell_global_to_local.end())
-//       {
-//         cell_global_to_local.insert({cell_index, count});
-//         shared_cells.insert({count, std::set<std::uint32_t>()});
-//         global_cell_indices.push_back(cell_index);
-//         cell_partition.push_back(owner);
-//         ++count;
-//       }
-//     }
-//   }
+  for (const auto& p : recv_vertcells)
+  {
+    for (auto q = p.begin(); q != p.end(); q += num_cell_vertices + 2)
+    {
+      const std::int64_t owner = *q;
+      const std::int64_t cell_index = *(q + 1);
+      auto cell_it = cell_global_to_local.find(cell_index);
+      if (cell_it == cell_global_to_local.end())
+      {
+        cell_global_to_local.insert({cell_index, count});
+        shared_cells.insert({count, std::set<std::uint32_t>()});
+        global_cell_indices.push_back(cell_index);
+        cell_partition.push_back(owner);
+        ++count;
+      }
+    }
+  }
 
-//   cell_vertices.resize(count, num_cell_vertices);
-//   std::set<std::uint32_t> sharing_procs;
-//   std::vector<std::size_t> sharing_cells;
-//   std::size_t last_vertex = std::numeric_limits<std::size_t>::max();
-//   for (auto p = recv_vertcells.begin(); p != recv_vertcells.end(); ++p)
-//   {
-//     for (auto q = p->begin(); q != p->end(); q += num_cell_vertices + 2)
-//     {
-//       const std::size_t shared_vertex = *(q + 2);
-//       const int owner = *q;
-//       const std::size_t cell_index = *(q + 1);
-//       const std::size_t local_index
-//           = cell_global_to_local.find(cell_index)->second;
+  cell_vertices.conservativeResize(count, num_cell_vertices);
+  std::set<std::uint32_t> sharing_procs;
+  std::vector<std::size_t> sharing_cells;
+  std::size_t last_vertex = std::numeric_limits<std::size_t>::max();
+  for (const auto& p : recv_vertcells)
+  {
+    for (auto q = p.begin(); q != p.end(); q += num_cell_vertices + 2)
+    {
+      const std::size_t shared_vertex = *(q + 2);
+      const int owner = *q;
+      const std::size_t cell_index = *(q + 1);
+      const std::size_t local_index
+          = cell_global_to_local.find(cell_index)->second;
 
-//       // Add vertices to new cells
-//       if (local_index >= num_cells)
-//       {
-//         for (std::uint32_t j = 0; j != num_cell_vertices; ++j)
-//           cell_vertices(local_index, j) = *(q + j + 2);
-//       }
+      // Add vertices to new cells
+      if (local_index >= num_cells)
+      {
+        for (std::uint32_t j = 0; j != num_cell_vertices; ++j)
+          cell_vertices(local_index, j) = *(q + j + 2);
+      }
 
-//       // If starting on a new shared vertex, dump old data into
-//       // shared_cells
-//       if (shared_vertex != last_vertex)
-//       {
-//         last_vertex = shared_vertex;
-//         for (auto c = sharing_cells.begin(); c != sharing_cells.end(); ++c)
-//         {
-//           auto it = shared_cells.find(*c);
-//           if (it == shared_cells.end())
-//             shared_cells.insert({*c, sharing_procs});
-//           else
-//             it->second.insert(sharing_procs.begin(), sharing_procs.end());
-//         }
-//         sharing_procs.clear();
-//         sharing_cells.clear();
-//       }
+      // If starting on a new shared vertex, dump old data into
+      // shared_cells
+      if (shared_vertex != last_vertex)
+      {
+        last_vertex = shared_vertex;
+        for (auto c = sharing_cells.begin(); c != sharing_cells.end(); ++c)
+        {
+          auto it = shared_cells.find(*c);
+          if (it == shared_cells.end())
+            shared_cells.insert({*c, sharing_procs});
+          else
+            it->second.insert(sharing_procs.begin(), sharing_procs.end());
+        }
+        sharing_procs.clear();
+        sharing_cells.clear();
+      }
 
-//       // Don't include self in sharing processes
-//       if (owner != mpi_rank)
-//         sharing_procs.insert(owner);
-//       sharing_cells.push_back(local_index);
-//     }
-//   }
+      // Don't include self in sharing processes
+      if (owner != mpi_rank)
+        sharing_procs.insert(owner);
+      sharing_cells.push_back(local_index);
+    }
+  }
 
-//   for (auto c = sharing_cells.begin(); c != sharing_cells.end(); ++c)
-//   {
-//     auto it = shared_cells.find(*c);
-//     if (it == shared_cells.end())
-//       shared_cells.insert({*c, sharing_procs});
-//     else
-//       it->second.insert(sharing_procs.begin(), sharing_procs.end());
-//   }
-
-//   // Shrink
-//   global_cell_indices.shrink_to_fit();
-//   cell_partition.shrink_to_fit();
-// }
+  // FIXME: is this correct? Seems to be applying same sharing to all cells
+  for (auto c = sharing_cells.begin(); c != sharing_cells.end(); ++c)
+  {
+    auto it = shared_cells.find(*c);
+    if (it == shared_cells.end())
+      shared_cells.insert({*c, sharing_procs});
+    else
+      it->second.insert(sharing_procs.begin(), sharing_procs.end());
+  }
+}
 //-----------------------------------------------------------------------------
 std::tuple<EigenRowArrayXXi64, std::vector<std::int64_t>, std::vector<int>,
            std::map<std::int32_t, std::set<std::uint32_t>>, std::int32_t>

--- a/cpp/dolfin/mesh/MeshPartitioning.h
+++ b/cpp/dolfin/mesh/MeshPartitioning.h
@@ -107,10 +107,9 @@ public:
   ///   topology in local indexing (EigenRowArrayXXi32)
   static std::tuple<std::uint64_t, std::vector<std::int64_t>,
                     EigenRowArrayXXi32>
-  compute_point_mapping(
-      std::uint32_t num_cell_vertices,
-      const Eigen::Ref<const EigenRowArrayXXi64>& cell_points,
-      const std::vector<std::uint8_t>& cell_permutation);
+  compute_point_mapping(std::uint32_t num_cell_vertices,
+                        const Eigen::Ref<const EigenRowArrayXXi64>& cell_points,
+                        const std::vector<std::uint8_t>& cell_permutation);
 
   // Utility to create global vertex indices, needed for higher
   // order meshes, where there are geometric points which are not
@@ -146,13 +145,12 @@ private:
   // FIXME: Improve this docstring
   // Distribute a layer of cells attached by vertex to boundary updating
   // new_mesh_data and shared_cells. Used when ghosting by vertex.
-  //   static void distribute_cell_layer(
-  //       MPI_Comm mpi_comm, const int num_regular_cells,
-  //       const std::int64_t num_global_vertices,
-  //       std::map<std::int32_t, std::set<std::uint32_t>>& shared_cells,
-  //       EigenRowArrayXXi64& cell_vertices,
-  //       std::vector<std::int64_t>& global_cell_indices,
-  //       std::vector<int>& cell_partition);
+  static void distribute_cell_layer(
+      MPI_Comm mpi_comm, const int num_regular_cells,
+      std::map<std::int32_t, std::set<std::uint32_t>>& shared_cells,
+      EigenRowArrayXXi64& cell_vertices,
+      std::vector<std::int64_t>& global_cell_indices,
+      std::vector<int>& cell_partition);
 
   // FIXME: make clearer what goes in and what comes out
   // Reorder cells by Gibbs-Poole-Stockmeyer algorithm (via SCOTCH). Returns

--- a/cpp/dolfin/mesh/MeshPartitioning.h
+++ b/cpp/dolfin/mesh/MeshPartitioning.h
@@ -139,12 +139,11 @@ private:
                           const mesh::GhostMode ghost_mode,
                           const PartitionData& mp);
 
-  // FIXME: The code for this function is really bad. For example, it seems that
-  // cell_vertices carries data in which is used, and is then also modified
-  // (bad!)
-  // FIXME: Improve this docstring
-  // Distribute a layer of cells attached by vertex to boundary updating
-  // new_mesh_data and shared_cells. Used when ghosting by vertex.
+  // Distribute additional cells implied by connectivity via vertex. The input
+  // cell_vertices, shared_cells, global_cell_indices and cell_partition must
+  // already be distributed with a ghost layer by shared_facet.
+  // FIXME: shared_cells, cell_vertices, global_cell_indices and cell_partition
+  // are all modified by this function.
   static void distribute_cell_layer(
       MPI_Comm mpi_comm, const int num_regular_cells,
       std::map<std::int32_t, std::set<std::uint32_t>>& shared_cells,


### PR DESCRIPTION
This re-enables the 'ghost via shared vertex' ghost method.

*  fixes a bug where the global number of cells was incorrect for ghosted meshes.

* also improves ghost mesh tests

