### PR TITLE
Add complex suppport to la::SLEPcEigenSolver

### DIFF
--- a/cpp/dolfin/la/SLEPcEigenSolver.cpp
+++ b/cpp/dolfin/la/SLEPcEigenSolver.cpp
@@ -138,7 +138,7 @@ void SLEPcEigenSolver::solve(std::int64_t n)
            eps_type, num_iterations);
 }
 //-----------------------------------------------------------------------------
-void SLEPcEigenSolver::get_eigenvalue(double& lr, double& lc,
+void SLEPcEigenSolver::get_eigenvalue(PetscScalar& lr, PetscScalar& lc,
                                       std::size_t i) const
 {
   assert(_eps);
@@ -158,8 +158,9 @@ void SLEPcEigenSolver::get_eigenvalue(double& lr, double& lc,
   }
 }
 //-----------------------------------------------------------------------------
-void SLEPcEigenSolver::get_eigenpair(double& lr, double& lc, PETScVector& r,
-                                     PETScVector& c, std::size_t i) const
+void SLEPcEigenSolver::get_eigenpair(PetscScalar& lr, PetscScalar& lc,
+                                     PETScVector& r, PETScVector& c,
+                                     std::size_t i) const
 {
   assert(_eps);
   const PetscInt ii = static_cast<PetscInt>(i);
@@ -378,19 +379,28 @@ void SLEPcEigenSolver::set_spectrum(std::string spectrum)
   {
     EPSSetWhichEigenpairs(_eps, EPS_TARGET_MAGNITUDE);
     if (parameters["spectral_shift"].is_set())
-      EPSSetTarget(_eps, parameters["spectral_shift"]);
+    {
+      PetscScalar shift = (double)parameters["spectral_shift"];
+      EPSSetTarget(_eps, shift);
+    }
   }
   else if (spectrum == "target real")
   {
     EPSSetWhichEigenpairs(_eps, EPS_TARGET_REAL);
     if (parameters["spectral_shift"].is_set())
-      EPSSetTarget(_eps, parameters["spectral_shift"]);
+    {
+      PetscScalar shift = (double)parameters["spectral_shift"];
+      EPSSetTarget(_eps, shift);
+    }
   }
   else if (spectrum == "target imaginary")
   {
     EPSSetWhichEigenpairs(_eps, EPS_TARGET_IMAGINARY);
     if (parameters["spectral_shift"].is_set())
-      EPSSetTarget(_eps, parameters["spectral_shift"]);
+    {
+      PetscScalar shift = (double)parameters["spectral_shift"];
+      EPSSetTarget(_eps, shift);
+    }
   }
   else
   {

--- a/cpp/dolfin/la/SLEPcEigenSolver.cpp
+++ b/cpp/dolfin/la/SLEPcEigenSolver.cpp
@@ -152,9 +152,8 @@ void SLEPcEigenSolver::get_eigenvalue(PetscScalar& lr, PetscScalar& lc,
     EPSGetEigenvalue(_eps, ii, &lr, &lc);
   else
   {
-    log::dolfin_error("SLEPcEigenSolver.cpp",
-                      "extract eigenvalue from SLEPc eigenvalue solver",
-                      "Requested eigenvalue (%d) has not been computed", i);
+    throw std::runtime_error("Requested eigenvalue (%d) has not been computed",
+                             i);
   }
 }
 //-----------------------------------------------------------------------------
@@ -186,9 +185,8 @@ void SLEPcEigenSolver::get_eigenpair(PetscScalar& lr, PetscScalar& lc,
   }
   else
   {
-    log::dolfin_error("SLEPcEigenSolver.cpp",
-                      "extract eigenpair from SLEPc eigenvalue solver",
-                      "Requested eigenpair (%d) has not been computed", i);
+    throw std::runtime_error("Requested eigenpair (%d) has not been computed",
+                             i);
   }
 }
 //-----------------------------------------------------------------------------
@@ -300,10 +298,8 @@ void SLEPcEigenSolver::read_parameters()
     }
     else
     {
-      log::dolfin_error(
-          "SLEPcEigenSolver.cpp", "set spectral transform",
-          "For an spectral transform, the spectral shift parameter "
-          "must be set");
+      throw std::runtime_error("For an spectral transform, the spectral shift "
+                         "parameter must be set");
     }
   }
 }
@@ -327,9 +323,7 @@ void SLEPcEigenSolver::set_problem_type(std::string type)
     EPSSetProblemType(_eps, EPS_PGNHEP);
   else
   {
-    log::dolfin_error("SLEPcEigenSolver.cpp",
-                      "set problem type for SLEPc eigensolver",
-                      "Unknown problem type (\"%s\")", type.c_str());
+    throw std::runtime_error("Unknown problem type (\"%s\")", type.c_str());
   }
 }
 //-----------------------------------------------------------------------------
@@ -349,9 +343,7 @@ void SLEPcEigenSolver::set_spectral_transform(std::string transform,
   }
   else
   {
-    log::dolfin_error("SLEPcEigenSolver.cpp",
-                      "set spectral transform for SLEPc eigensolver",
-                      "Unknown transform (\"%s\")", transform.c_str());
+    throw std::runtime_error("Unknown transform (\"%s\")", transform.c_str());
   }
 }
 //-----------------------------------------------------------------------------
@@ -404,9 +396,7 @@ void SLEPcEigenSolver::set_spectrum(std::string spectrum)
   }
   else
   {
-    log::dolfin_error("SLEPcEigenSolver.cpp",
-                      "set spectrum for SLEPc eigensolver",
-                      "Unknown spectrum type (\"%s\")", spectrum.c_str());
+    throw std::runtime_error("Unknown spectrum type (\"%s\")", spectrum.c_str());
   }
 
   // FIXME: Need to add some test here as most algorithms only compute
@@ -442,9 +432,7 @@ void SLEPcEigenSolver::set_solver(std::string solver)
     EPSSetType(_eps, EPSGD);
   else
   {
-    log::dolfin_error("SLEPcEigenSolver.cpp",
-                      "set solver for SLEPc eigensolver",
-                      "Unknown solver type (\"%s\")", solver.c_str());
+    throw std::runtime_error("Unknown solver type (\"%s\")", solver.c_str());
   }
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/la/SLEPcEigenSolver.cpp
+++ b/cpp/dolfin/la/SLEPcEigenSolver.cpp
@@ -138,8 +138,7 @@ void SLEPcEigenSolver::solve(std::int64_t n)
            eps_type, num_iterations);
 }
 //-----------------------------------------------------------------------------
-void SLEPcEigenSolver::get_eigenvalue(PetscScalar& lr, PetscScalar& lc,
-                                      std::size_t i) const
+std::complex<PetscReal> SLEPcEigenSolver::get_eigenvalue(std::size_t i) const
 {
   assert(_eps);
   const PetscInt ii = static_cast<PetscInt>(i);
@@ -149,7 +148,17 @@ void SLEPcEigenSolver::get_eigenvalue(PetscScalar& lr, PetscScalar& lc,
   EPSGetConverged(_eps, &num_computed_eigenvalues);
 
   if (ii < num_computed_eigenvalues)
-    EPSGetEigenvalue(_eps, ii, &lr, &lc);
+  {
+#ifdef PETSC_USE_COMPLEX
+    PetscScalar l;
+    EPSGetEigenvalue(_eps, ii, &l, NULL);
+    return l;
+#else
+    PetscScalar lr, li;
+    EPSGetEigenvalue(_eps, ii, &lr, &li);
+    return std::complex<PetscReal>(lr, li);
+#endif
+  }
   else
   {
     throw std::runtime_error("Requested eigenvalue (" + std::to_string(i)

--- a/cpp/dolfin/la/SLEPcEigenSolver.cpp
+++ b/cpp/dolfin/la/SLEPcEigenSolver.cpp
@@ -152,8 +152,8 @@ void SLEPcEigenSolver::get_eigenvalue(PetscScalar& lr, PetscScalar& lc,
     EPSGetEigenvalue(_eps, ii, &lr, &lc);
   else
   {
-    throw std::runtime_error("Requested eigenvalue (%d) has not been computed",
-                             i);
+    throw std::runtime_error("Requested eigenvalue (" + std::to_string(i)
+                             + ") has not been computed");
   }
 }
 //-----------------------------------------------------------------------------
@@ -185,8 +185,8 @@ void SLEPcEigenSolver::get_eigenpair(PetscScalar& lr, PetscScalar& lc,
   }
   else
   {
-    throw std::runtime_error("Requested eigenpair (%d) has not been computed",
-                             i);
+    throw std::runtime_error("Requested eigenpair (" + std::to_string(i)
+                             + ") has not been computed");
   }
 }
 //-----------------------------------------------------------------------------
@@ -299,7 +299,7 @@ void SLEPcEigenSolver::read_parameters()
     else
     {
       throw std::runtime_error("For an spectral transform, the spectral shift "
-                         "parameter must be set");
+                               "parameter must be set");
     }
   }
 }
@@ -323,7 +323,7 @@ void SLEPcEigenSolver::set_problem_type(std::string type)
     EPSSetProblemType(_eps, EPS_PGNHEP);
   else
   {
-    throw std::runtime_error("Unknown problem type (\"%s\")", type.c_str());
+    throw std::runtime_error("Unknown problem type (" + type + ")");
   }
 }
 //-----------------------------------------------------------------------------
@@ -343,7 +343,7 @@ void SLEPcEigenSolver::set_spectral_transform(std::string transform,
   }
   else
   {
-    throw std::runtime_error("Unknown transform (\"%s\")", transform.c_str());
+    throw std::runtime_error("Unknown transform (" + transform + ")");
   }
 }
 //-----------------------------------------------------------------------------
@@ -396,7 +396,7 @@ void SLEPcEigenSolver::set_spectrum(std::string spectrum)
   }
   else
   {
-    throw std::runtime_error("Unknown spectrum type (\"%s\")", spectrum.c_str());
+    throw std::runtime_error("Unknown spectrum type (" + spectrum + ")");
   }
 
   // FIXME: Need to add some test here as most algorithms only compute
@@ -432,7 +432,7 @@ void SLEPcEigenSolver::set_solver(std::string solver)
     EPSSetType(_eps, EPSGD);
   else
   {
-    throw std::runtime_error("Unknown solver type (\"%s\")", solver.c_str());
+    throw std::runtime_error("Unknown solver type (" + solver + ")");
   }
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/la/SLEPcEigenSolver.h
+++ b/cpp/dolfin/la/SLEPcEigenSolver.h
@@ -126,7 +126,7 @@ public:
   void solve(std::int64_t n);
 
   /// Get ith eigenvalue
-  void get_eigenvalue(PetscScalar& lr, PetscScalar& lc, std::size_t i) const;
+  std::complex<PetscReal> get_eigenvalue(std::size_t i) const;
 
   /// Get ith eigenpair
   void get_eigenpair(PetscScalar& lr, PetscScalar& lc, PETScVector& r,

--- a/cpp/dolfin/la/SLEPcEigenSolver.h
+++ b/cpp/dolfin/la/SLEPcEigenSolver.h
@@ -126,11 +126,11 @@ public:
   void solve(std::int64_t n);
 
   /// Get ith eigenvalue
-  void get_eigenvalue(double& lr, double& lc, std::size_t i) const;
+  void get_eigenvalue(PetscScalar& lr, PetscScalar& lc, std::size_t i) const;
 
   /// Get ith eigenpair
-  void get_eigenpair(double& lr, double& lc, PETScVector& r, PETScVector& c,
-                     std::size_t i) const;
+  void get_eigenpair(PetscScalar& lr, PetscScalar& lc, PETScVector& r,
+                     PETScVector& c, std::size_t i) const;
 
   /// Get the number of iterations used by the solver
   std::size_t get_iteration_number() const;
@@ -201,6 +201,6 @@ private:
   // SLEPc solver pointer
   EPS _eps;
 };
-}
-}
+} // namespace la
+} // namespace dolfin
 #endif

--- a/python/src/la.cpp
+++ b/python/src/la.cpp
@@ -812,10 +812,7 @@ void la(py::module& m)
                         & dolfin::la::SLEPcEigenSolver::solve)
       .def("solve", (void (dolfin::la::SLEPcEigenSolver::*)(std::int64_t))
                         & dolfin::la::SLEPcEigenSolver::solve)
-      .def("get_eigenvalue",
-           [](dolfin::la::SLEPcEigenSolver& self, std::size_t i) {
-             return self.get_eigenvalue(i);
-           })
+      .def("get_eigenvalue", &dolfin::la::SLEPcEigenSolver::get_eigenpair)
       .def("get_eigenpair",
            [](dolfin::la::SLEPcEigenSolver& self, std::size_t i) {
              double lr, lc;

--- a/python/src/la.cpp
+++ b/python/src/la.cpp
@@ -814,9 +814,7 @@ void la(py::module& m)
                         & dolfin::la::SLEPcEigenSolver::solve)
       .def("get_eigenvalue",
            [](dolfin::la::SLEPcEigenSolver& self, std::size_t i) {
-             double lr, lc;
-             self.get_eigenvalue(lr, lc, i);
-             return py::make_tuple(lr, lc);
+             return self.get_eigenvalue(i);
            })
       .def("get_eigenpair",
            [](dolfin::la::SLEPcEigenSolver& self, std::size_t i) {


### PR DESCRIPTION
Although SLEPc separates the real and imaginary part of eigenvalues and eigenvectors, the scalar type is complex (with zero imaginary part) when PETSc is compiled with complex support.   

Changes:
* Set eigenvalues scalars to PetscScalar
* Convert spectral_shift to PetscScalar before calling EPSSetTarget

Note: The parameter "spectral_shift" is still real. For complex spectral shift: use complex parameters or a parameter for real and imaginary parts?




