### PR TITLE
Define ufc_scalar for a complex UFC interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             pip3 install git+https://bitbucket.org/fenics-project/fiat.git --upgrade
             pip3 install git+https://bitbucket.org/fenics-project/ufl.git --upgrade
             pip3 install git+https://bitbucket.org/fenics-project/dijitso.git --upgrade
-            pip3 install git+https://github.com/IgorBaratta/ffcx.git --upgrade
+            pip3 install git+https://github.com/fenics/ffcx.git --upgrade
             rm -rf /usr/local/include/dolfin /usr/local/include/dolfin.h
       - run:
           name: Flake8 checks on Python code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             pip3 install git+https://bitbucket.org/fenics-project/fiat.git --upgrade
             pip3 install git+https://bitbucket.org/fenics-project/ufl.git --upgrade
             pip3 install git+https://bitbucket.org/fenics-project/dijitso.git --upgrade
-            pip3 install git+https://github.com/fenics/ffcx.git --upgrade
+            pip3 install git+https://github.com/IgorBaratta/ffcx.git --upgrade
             rm -rf /usr/local/include/dolfin /usr/local/include/dolfin.h
       - run:
           name: Flake8 checks on Python code

--- a/cpp/dolfin/common/types.h
+++ b/cpp/dolfin/common/types.h
@@ -13,9 +13,9 @@
 
 // Typedefs for ufc_scalar - to be used in UFC.h
 #ifdef PETSC_USE_SCALAR
-using ufc_scalar = std::complex<double>;
+using ufc_scalar_t = std::complex<double>;
 #else
-using ufc_scalar = double;
+using ufc_scalar_t = double;
 #endif
 
 namespace dolfin

--- a/cpp/dolfin/common/types.h
+++ b/cpp/dolfin/common/types.h
@@ -7,8 +7,16 @@
 #pragma once
 
 #include <Eigen/Dense>
+#include <complex>
 #include <cstdint>
 #include <petscsys.h>
+
+// Typedefs for ufc_scalar - to be used in UFC.h
+#ifdef PETSC_USE_SCALAR
+using ufc_scalar = std::complex<double>;
+#else
+using ufc_scalar = double;
+#endif
 
 namespace dolfin
 {

--- a/cpp/dolfin/fem/FormIntegrals.h
+++ b/cpp/dolfin/fem/FormIntegrals.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Eigen/Dense>
+#include <dolfin/common/types.h>
 #include <functional>
 #include <memory>
 #include <vector>


### PR DESCRIPTION
Define `ufc_scalar` for use in _ufc.h_.
This PR should be considered together with FFC [PR #31](https://github.com/FEniCS/ffcx/pull/31).