### PR TITLE
Add dolfin version to JIT hash

### DIFF
--- a/python/dolfin/jit/jit.py
+++ b/python/dolfin/jit/jit.py
@@ -167,7 +167,7 @@ def compile_class(cpp_data):
         if hasattr(v, '_cpp_object') and isinstance(v._cpp_object, cpp.function.GenericFunction):
             property_str += '*'
 
-    hash_str = str(statements) + str(property_str)
+    hash_str = str(statements) + str(property_str) + cpp.__version__
     module_hash = hashlib.md5(hash_str.encode('utf-8')).hexdigest()
     module_name = "dolfin_" + name + "_" + module_hash
 

--- a/python/dolfin/jit/pybind11jit.py
+++ b/python/dolfin/jit/pybind11jit.py
@@ -11,7 +11,7 @@ import re
 
 from dolfin.cpp.log import log, LogLevel
 from . import get_pybind_include
-
+import dolfin.cpp as cpp
 from dolfin.jit.jit import dijitso_jit, dolfin_pc
 
 
@@ -66,7 +66,8 @@ def compile_cpp_code(cpp_code):
 
     params['build']['cxxflags'] += tuple(dmacros)
 
-    module_hash = hashlib.md5(cpp_code.encode('utf-8')).hexdigest()
+    hash_str = cpp_code + cpp.__version__
+    module_hash = hashlib.md5(hash_str.encode('utf-8')).hexdigest()
     module_name = "dolfin_cpp_module_" + module_hash
 
     module, signature = dijitso_jit(cpp_code, module_name, params,


### PR DESCRIPTION
This is a backport of DOLFIN old commit [1211d17cbf1d35727a57b01c61127bc904becaf1](https://bitbucket.org/fenics-project/dolfin/commits/1211d17cbf1d35727a57b01c61127bc904becaf1)
where it fixed [problems on Bamboo](http://magpie.bpi.cam.ac.uk:8085/browse/DOL-DODO-PUTPY3-802).