### PR TITLE
Expression::restrict fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             pip3 install git+https://bitbucket.org/fenics-project/fiat.git --upgrade
             pip3 install git+https://bitbucket.org/fenics-project/ufl.git --upgrade
             pip3 install git+https://bitbucket.org/fenics-project/dijitso.git --upgrade
-            pip3 install git+https://github.com/fenics/ffcx.git@chris/simplify-ufc-dofmap --upgrade
+            pip3 install git+https://github.com/fenics/ffcx.git --upgrade
             rm -rf /usr/local/include/dolfin /usr/local/include/dolfin.h
       - run:
           name: Flake8 checks on Python code

--- a/cpp/dolfin/function/Expression.cpp
+++ b/cpp/dolfin/function/Expression.cpp
@@ -128,10 +128,6 @@ void Expression::restrict(
   // Evaluate all points in one call
   eval(eval_values, eval_points, cell);
 
-  // Transpose for vector values
-  // FIXME: remove need for this - needs work in ffc
-  eval_values.transposeInPlace();
-
   // FIXME: *do not* use UFC directly
   // Apply a mapping to the reference element.
   // FIXME: not needed for Lagrange elements, eliminate.

--- a/python/demo/documented/stokes-taylor-hood/demo_stokes-taylor-hood.py.rst
+++ b/python/demo/documented/stokes-taylor-hood/demo_stokes-taylor-hood.py.rst
@@ -174,7 +174,7 @@ We can calculate the :math:`L^2` norms of u and p as follows::
     # Check pressure norm
     pnorm = p.vector().norm(dolfin.cpp.la.Norm.l2)
     import numpy as np
-    assert np.isclose(pnorm, 4116.91298427)
+    assert np.isclose(pnorm, 4147.69457577)
 
 Finally, we can save and plot the solutions::
 

--- a/python/dolfin/function/function.py
+++ b/python/dolfin/function/function.py
@@ -281,6 +281,11 @@ class Function(ufl.Coefficient):
         # Assume all args are x argument
         x = np.array(args)
 
+        dim = self.ufl_domain().geometric_dimension()
+        if x.shape[-1] != dim:
+            raise TypeError("expected the geometry argument to be of "
+                            "length %d" % dim)
+
         value_size = ufl.product(self.ufl_element().value_shape())
         values = np.empty((1, value_size))
 

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -150,7 +150,7 @@ def test_assign(V, W):
 
 
 def test_call(R, V, W, Q, mesh):
-    from numpy import all
+    from numpy import all, allclose
     u0 = Function(R)
     u1 = Function(V)
     u2 = Function(W)
@@ -182,7 +182,7 @@ def test_call(R, V, W, Q, mesh):
 
     assert all(u2(x0) == u2(x0))
     assert all(u2(x0) == u2(p0))
-    assert all(u3(x0)[0][:3] == u2(x0))
+    assert allclose(u3(x0)[0][:3], u2(x0)[0], rtol=1e-15, atol=1e-15)
 
     with pytest.raises(TypeError):
         u0([0, 0, 0, 0])

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -7,7 +7,9 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import pytest
-from dolfin import (UnitCubeMesh, FunctionSpace, VectorFunctionSpace, Constant, MPI, Point, Function,
+from dolfin import (UnitCubeMesh,
+                    FunctionSpace, VectorFunctionSpace, TensorFunctionSpace,
+                    Constant, MPI, Point, Function,
                     UserExpression, interpolate, Expression, DOLFIN_EPS, Vertex, lt, cpp)
 from math import sqrt
 import numpy
@@ -34,6 +36,11 @@ def V(mesh):
 @fixture
 def W(mesh):
     return VectorFunctionSpace(mesh, 'CG', 1)
+
+
+@fixture
+def Q(mesh):
+    return TensorFunctionSpace(mesh, 'CG', 1)
 
 
 def test_name_argument(W):
@@ -142,19 +149,27 @@ def test_assign(V, W):
                 uu.assign(4 * u * u1)
 
 
-def test_call(R, V, W, mesh):
+def test_call(R, V, W, Q, mesh):
     from numpy import zeros, all
     u0 = Function(R)
     u1 = Function(V)
     u2 = Function(W)
+    u3 = Function(Q)
+
     e0 = Expression("x[0] + x[1] + x[2]", degree=1)
     e1 = Expression(
         ("x[0] + x[1] + x[2]", "x[0] - x[1] - x[2]", "x[0] + x[1] + x[2]"),
+        degree=1)
+    e2 = Expression(
+        (("x[0] + x[1] + x[2]", "x[0] - x[1] - x[2]", "x[0] + x[1] + x[2]"),
+         ("x[0]", "x[1]", "x[2]"),
+         ("-x[0]", "-x[1]", "-x[2]")),
         degree=1)
 
     u0.vector()[:] = 1.0
     u1.interpolate(e0)
     u2.interpolate(e1)
+    u3.interpolate(e2)
 
     p0 = ((Vertex(mesh, 0).point() + Vertex(mesh, 1).point()) / 2.0).array()
     x0 = (mesh.geometry.x(0) + mesh.geometry.x(1)) / 2.0
@@ -167,6 +182,7 @@ def test_call(R, V, W, mesh):
 
     assert all(u2(x0) == u2(x0))
     assert all(u2(x0) == u2(p0))
+    assert all(u3(x0)[0][:3] == u2(x0))
 
     with pytest.raises(TypeError):
         u0([0, 0, 0, 0])

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -150,7 +150,7 @@ def test_assign(V, W):
 
 
 def test_call(R, V, W, Q, mesh):
-    from numpy import zeros, all
+    from numpy import all
     u0 = Function(R)
     u1 = Function(V)
     u2 = Function(W)

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -142,7 +142,6 @@ def test_assign(V, W):
                 uu.assign(4 * u * u1)
 
 
-@pytest.mark.skip
 def test_call(R, V, W, mesh):
     from numpy import zeros, all
     u0 = Function(R)
@@ -157,22 +156,17 @@ def test_call(R, V, W, mesh):
     u1.interpolate(e0)
     u2.interpolate(e1)
 
-    p0 = (Vertex(mesh, 0).point() + Vertex(mesh, 1).point()) / 2.0
-    x0 = (mesh.geometry.x()[0] + mesh.geometry.x()[1]) / 2.0
-    x1 = tuple(x0)
+    p0 = ((Vertex(mesh, 0).point() + Vertex(mesh, 1).point()) / 2.0).array()
+    x0 = (mesh.geometry.x(0) + mesh.geometry.x(1)) / 2.0
 
-    assert round(u0(*x1) - u0(x0), 7) == 0
-    assert round(u0(x1) - u0(p0), 7) == 0
-    assert round(u1(x1) - u1(x0), 7) == 0
-    assert round(u1(*x1) - u1(p0), 7) == 0
-    assert round(u2(x1)[0] - u1(p0), 7) == 0
+    assert round(u0(x0)[0] - u0(x0)[0], 7) == 0
+    assert round(u0(x0)[0] - u0(p0)[0], 7) == 0
+    assert round(u1(x0)[0] - u1(x0)[0], 7) == 0
+    assert round(u1(x0)[0] - u1(p0)[0], 7) == 0
+    assert round(u2(x0)[0][0] - u1(p0)[0], 7) == 0
 
-    assert all(u2(*x1) == u2(x0))
-    assert all(u2(*x1) == u2(p0))
-
-    values = zeros(mesh.geometry.dim, dtype='d')
-    u2(p0, values=values)
-    assert all(values == u2(x0))
+    assert all(u2(x0) == u2(x0))
+    assert all(u2(x0) == u2(p0))
 
     with pytest.raises(TypeError):
         u0([0, 0, 0, 0])


### PR DESCRIPTION
Related to issue #98 

`Expression::restrict` had erroneous code transposing the evaluated values at DoFs. This affected any function spaces whose rank is greater than 0.

The changes here are:
- Remove an erroneous transpose operation
- Add back some `Function::interpolate` of `Expression` tests 
- Revert the assertion of the pressure norm value to the value computed using old DOLFIN