### PR TITLE
Remove remnants of MPI and PETSc being optional

### DIFF
--- a/cpp/demo/documented/singular-poisson/main.cpp
+++ b/cpp/demo/documented/singular-poisson/main.cpp
@@ -63,7 +63,6 @@ class Flux : public Expression
 
 int main()
 {
-  #ifdef HAS_PETSC
   // Create mesh and function space
   auto mesh = std::make_shared<UnitSquareMesh>(128, 128);
   auto V = std::make_shared<Poisson::FunctionSpace>(mesh);
@@ -132,10 +131,6 @@ int main()
 
   // Write out solution to XDMF file.
   XDMFFile("u.xdmf").write(u);
-
-  #else
-  cout << "This demo requires DOLFIN to be confugured with PETSc." << endl;
-  #endif
 
   return 0;
 }

--- a/cpp/demo/undocumented/contact-vi-snes/main.cpp
+++ b/cpp/demo/undocumented/contact-vi-snes/main.cpp
@@ -67,8 +67,6 @@ public:
 
 int main()
 {
-#ifdef HAS_PETSC
-
   // Read mesh and create function space
   auto mesh = std::make_shared<Mesh>("../circle_yplane.xml.gz");
 
@@ -138,8 +136,6 @@ int main()
   // Save solution in VTK format
   File file("displacement.pvd");
   file << *u;
-
-#endif
 
   return 0;
 }

--- a/cpp/demo/undocumented/contact-vi-tao/main.cpp
+++ b/cpp/demo/undocumented/contact-vi-tao/main.cpp
@@ -60,8 +60,6 @@ public:
 
 int main()
 {
-#ifdef HAS_PETSC
-
   // Read mesh
   auto mesh = std::make_shared<Mesh>("../circle_yplane.xml.gz");
 
@@ -114,12 +112,6 @@ int main()
   TAOSolver.solve(A, *usol.vector(), b, *xl_f.vector(), *xu_f.vector());
 
   XDMFFile("u.xdmf").write(usol);
-
-  #else
-
-  cout << "This demo requires DOLFIN to be configured with PETSc version 3.6 or later" << endl;
-
-  #endif
 
   return 0;
 }

--- a/cpp/demo/undocumented/curl-curl/main.cpp
+++ b/cpp/demo/undocumented/curl-curl/main.cpp
@@ -43,13 +43,10 @@
 
 using namespace dolfin;
 
-#if defined(HAS_PETSC) and defined(PETSC_HAVE_HYPRE)
+#if defined(PETSC_HAVE_HYPRE)
 
 int main()
 {
-  // Set PETSc as default linear algebra backend
-  parameters["linear_algebra_backend"] = "PETSc";
-
   // Everywhere on exterior surface
   class DirichletBoundary: public SubDomain
   {
@@ -156,7 +153,7 @@ int main()
 
 int main()
 {
-  log::info("This demo requires DOLFIN to be configured with PETSc (with Hypre).");
+  log::info("This demo requires PETSc to be configured with Hypre.");
   return 0;
 }
 

--- a/cpp/demo/undocumented/elasticity/main.cpp
+++ b/cpp/demo/undocumented/elasticity/main.cpp
@@ -67,11 +67,6 @@ dolfin::VectorSpaceBasis build_near_nullspace(const dolfin::FunctionSpace& V,
 
 int main()
 {
-  #ifdef HAS_PETSC
-
-  // Set backend to PETSC
-  parameters["linear_algebra_backend"] = "PETSc";
-
   // Inner surface subdomain
   class InnerSurface : public SubDomain
   {
@@ -201,14 +196,9 @@ int main()
     file << partitions;
   }
 
-  // Displace mesh and write 
+  // Displace mesh and write
   ALE::move(*mesh, *u);
   XDMFFile("deformed_mesh.xdmf").write(*mesh);
-
-  #else
-  dolfin::cout << "DOLFIN must be configured with PETSc to run this demo."
-               << dolfin::endl;
-  #endif
 
   return 0;
 }

--- a/cpp/demo/undocumented/gmg-poisson/main.cpp
+++ b/cpp/demo/undocumented/gmg-poisson/main.cpp
@@ -48,8 +48,6 @@ class DirichletBoundary : public SubDomain
 
 int main()
 {
-#ifdef HAS_PETSC
-
   // Create hierarchy of meshes
   std::vector<std::shared_ptr<Mesh>> meshes
     = {std::make_shared<UnitSquareMesh>(16, 16),
@@ -107,10 +105,6 @@ int main()
 
   Function u(V.back());
   solver.solve(*u.vector(), b);
-
-#else
-  log::info("This demo requires DOLFIN to be configured with PETSc");
-#endif
 
   return 0;
 }

--- a/cpp/dolfin/CMakeLists.txt
+++ b/cpp/dolfin/CMakeLists.txt
@@ -100,12 +100,10 @@ endforeach()
 
 # MPI
 set(DOLFIN_CXX_FLAGS "${DOLFIN_CXX_FLAGS} ${MPI_CXX_COMPILE_FLAGS}")
-target_compile_definitions(dolfin PUBLIC HAS_MPI)
 target_link_libraries(dolfin PUBLIC ${MPI_CXX_LIBRARIES})
 target_include_directories(dolfin SYSTEM PUBLIC ${MPI_CXX_INCLUDE_PATH})
 
 # PETSc
-target_compile_definitions(dolfin PUBLIC HAS_PETSC)
 target_link_libraries(dolfin PUBLIC PETSC::petsc)
 target_link_libraries(dolfin PRIVATE PETSC::petsc_static)
 

--- a/cpp/dolfin/common/MPI.cpp
+++ b/cpp/dolfin/common/MPI.cpp
@@ -12,7 +12,6 @@
 //-----------------------------------------------------------------------------
 dolfin::MPI::Comm::Comm(MPI_Comm comm)
 {
-#ifdef HAS_MPI
   // Duplicate communicator
   if (comm != MPI_COMM_NULL)
   {
@@ -22,9 +21,6 @@ dolfin::MPI::Comm::Comm(MPI_Comm comm)
   }
   else
     _comm = MPI_COMM_NULL;
-#else
-  _comm = comm;
-#endif
 
   std::vector<double> x = {{1.0, 3.0}};
 }
@@ -44,7 +40,6 @@ dolfin::MPI::Comm::~Comm() { free(); }
 //-----------------------------------------------------------------------------
 void dolfin::MPI::Comm::free()
 {
-#ifdef HAS_MPI
   if (_comm != MPI_COMM_NULL)
   {
     int err = MPI_Comm_free(&_comm);
@@ -54,7 +49,6 @@ void dolfin::MPI::Comm::free()
                 << std::endl;
     }
   }
-#endif
 }
 //-----------------------------------------------------------------------------
 std::uint32_t dolfin::MPI::Comm::rank() const
@@ -64,25 +58,18 @@ std::uint32_t dolfin::MPI::Comm::rank() const
 //-----------------------------------------------------------------------------
 std::uint32_t dolfin::MPI::Comm::size() const
 {
-#ifdef HAS_MPI
   int size;
   MPI_Comm_size(_comm, &size);
   return size;
-#else
-  return 1;
-#endif
 }
 //-----------------------------------------------------------------------------
 void dolfin::MPI::Comm::barrier() const
 {
-#ifdef HAS_MPI
   MPI_Barrier(_comm);
-#endif
 }
 //-----------------------------------------------------------------------------
 void dolfin::MPI::Comm::reset(MPI_Comm comm)
 {
-#ifdef HAS_MPI
   if (_comm != MPI_COMM_NULL)
   {
     int err = 0;
@@ -101,15 +88,9 @@ void dolfin::MPI::Comm::reset(MPI_Comm comm)
   {
     // Raise error
   }
-#else
-  _comm = comm;
-#endif
 }
 //-----------------------------------------------------------------------------
 MPI_Comm dolfin::MPI::Comm::comm() const { return _comm; }
-//-----------------------------------------------------------------------------
-
-#ifdef HAS_MPI
 //-----------------------------------------------------------------------------
 dolfin::MPIInfo::MPIInfo() { MPI_Info_create(&info); }
 //-----------------------------------------------------------------------------
@@ -117,51 +98,34 @@ dolfin::MPIInfo::~MPIInfo() { MPI_Info_free(&info); }
 //-----------------------------------------------------------------------------
 MPI_Info& dolfin::MPIInfo::operator*() { return info; }
 //-----------------------------------------------------------------------------
-#endif
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
 std::uint32_t dolfin::MPI::rank(const MPI_Comm comm)
 {
-#ifdef HAS_MPI
   int rank;
   MPI_Comm_rank(comm, &rank);
   return rank;
-#else
-  return 0;
-#endif
 }
 //-----------------------------------------------------------------------------
 std::uint32_t dolfin::MPI::size(const MPI_Comm comm)
 {
-#ifdef HAS_MPI
   int size;
   MPI_Comm_size(comm, &size);
   return size;
-#else
-  return 1;
-#endif
 }
 //-----------------------------------------------------------------------------
 void dolfin::MPI::barrier(const MPI_Comm comm)
 {
-#ifdef HAS_MPI
   MPI_Barrier(comm);
-#endif
 }
 //-----------------------------------------------------------------------------
 std::size_t dolfin::MPI::global_offset(const MPI_Comm comm, std::size_t range,
                                        bool exclusive)
 {
-#ifdef HAS_MPI
   // Compute inclusive or exclusive partial reduction
   std::size_t offset = 0;
   MPI_Scan(&range, &offset, 1, mpi_type<std::size_t>(), MPI_SUM, comm);
   if (exclusive)
     offset -= range;
   return offset;
-#else
-  return 0;
-#endif
 }
 //-----------------------------------------------------------------------------
 std::array<std::int64_t, 2> dolfin::MPI::local_range(const MPI_Comm comm,
@@ -214,7 +178,6 @@ std::uint32_t dolfin::MPI::index_owner(const MPI_Comm comm, std::size_t index,
   return r + (index - r * (n + 1)) / n;
 }
 //-----------------------------------------------------------------------------
-#ifdef HAS_MPI
 template <>
 dolfin::Table dolfin::MPI::all_reduce(const MPI_Comm comm,
                                       const dolfin::Table& table,
@@ -308,22 +271,16 @@ dolfin::Table dolfin::MPI::all_reduce(const MPI_Comm comm,
 
   return table_all;
 }
-#endif
 //-----------------------------------------------------------------------------
-#ifdef HAS_MPI
 template <>
 dolfin::Table dolfin::MPI::avg(MPI_Comm comm, const dolfin::Table& table)
 {
   return all_reduce(comm, table, MPI_AVG());
 }
-#endif
 //-----------------------------------------------------------------------------
-#ifdef HAS_MPI
 std::map<MPI_Op, std::string> dolfin::MPI::operation_map
     = {{MPI_SUM, "MPI_SUM"}, {MPI_MAX, "MPI_MAX"}, {MPI_MIN, "MPI_MIN"}};
-#endif
 //-----------------------------------------------------------------------------
-#ifdef HAS_MPI
 MPI_Op dolfin::MPI::MPI_AVG()
 {
   // Return dummy MPI_Op which we identify with average
@@ -336,5 +293,4 @@ MPI_Op dolfin::MPI::MPI_AVG()
   }
   return op;
 }
-#endif
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/common/SubSystemsManager.cpp
+++ b/cpp/dolfin/common/SubSystemsManager.cpp
@@ -4,12 +4,9 @@
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
-#ifdef HAS_MPI
 #define MPICH_IGNORE_CXX_SEEK 1
 #include <iostream>
 #include <mpi.h>
-#endif
-
 #include <petsc.h>
 
 #ifdef HAS_SLEPC
@@ -46,7 +43,6 @@ SubSystemsManager::~SubSystemsManager() { finalize(); }
 //-----------------------------------------------------------------------------
 void SubSystemsManager::init_mpi()
 {
-#ifdef HAS_MPI
   int mpi_initialized;
   MPI_Initialized(&mpi_initialized);
   if (mpi_initialized)
@@ -58,15 +54,11 @@ void SubSystemsManager::init_mpi()
   char* c = const_cast<char*>(s.c_str());
   SubSystemsManager::init_mpi(0, &c, MPI_THREAD_MULTIPLE);
   singleton().control_mpi = true;
-#else
-// Do nothing
-#endif
 }
 //-----------------------------------------------------------------------------
 int SubSystemsManager::init_mpi(int argc, char* argv[],
                                 int required_thread_level)
 {
-#ifdef HAS_MPI
   int mpi_initialized;
   MPI_Initialized(&mpi_initialized);
   if (mpi_initialized)
@@ -78,9 +70,6 @@ int SubSystemsManager::init_mpi(int argc, char* argv[],
   singleton().control_mpi = true;
 
   return provided;
-#else
-  return -1;
-#endif
 }
 //-----------------------------------------------------------------------------
 void SubSystemsManager::init_petsc()
@@ -153,7 +142,6 @@ bool SubSystemsManager::responsible_petsc()
 //-----------------------------------------------------------------------------
 void SubSystemsManager::finalize_mpi()
 {
-#ifdef HAS_MPI
   int mpi_initialized;
   MPI_Initialized(&mpi_initialized);
 
@@ -182,9 +170,6 @@ void SubSystemsManager::finalize_mpi()
 
     singleton().control_mpi = false;
   }
-#else
-// Do nothing
-#endif
 }
 //-----------------------------------------------------------------------------
 void SubSystemsManager::finalize_petsc()
@@ -209,26 +194,16 @@ bool SubSystemsManager::mpi_initialized()
 // returns true if MPI_Init has been called at any point, even if
 // MPI_Finalize has been called.
 
-#ifdef HAS_MPI
   int mpi_initialized;
   MPI_Initialized(&mpi_initialized);
   return mpi_initialized;
-#else
-  // DOLFIN is not configured for MPI (it might be through PETSc)
-  return false;
-#endif
 }
 //-----------------------------------------------------------------------------
 bool SubSystemsManager::mpi_finalized()
 {
-#ifdef HAS_MPI
   int mpi_finalized;
   MPI_Finalized(&mpi_finalized);
   return mpi_finalized;
-#else
-  // DOLFIN is not configured for MPI (it might be through PETSc)
-  return false;
-#endif
 }
 //-----------------------------------------------------------------------------
 PetscErrorCode SubSystemsManager::PetscDolfinErrorHandler(

--- a/cpp/dolfin/common/defines.cpp
+++ b/cpp/dolfin/common/defines.cpp
@@ -34,15 +34,6 @@ bool dolfin::has_debug()
 #endif
 }
 //-------------------------------------------------------------------------
-bool dolfin::has_mpi()
-{
-#ifdef HAS_MPI
-  return true;
-#else
-  return false;
-#endif
-}
-//-------------------------------------------------------------------------
 bool dolfin::has_petsc_complex()
 {
 #ifdef PETSC_USE_COMPLEX

--- a/cpp/dolfin/common/defines.h
+++ b/cpp/dolfin/common/defines.h
@@ -28,9 +28,6 @@ std::size_t sizeof_la_index_t();
 /// i.e., with assertions on
 bool has_debug();
 
-/// Return true if DOLFIN is compiled with MPI
-bool has_mpi();
-
 /// Return true if DOLFIN is configured with PETSc compiled
 /// with scalars represented as complex numbers
 bool has_petsc_complex();

--- a/cpp/dolfin/io/HDF5Interface.cpp
+++ b/cpp/dolfin/io/HDF5Interface.cpp
@@ -27,15 +27,11 @@ hid_t HDF5Interface::open_file(MPI_Comm mpi_comm, const std::string filename,
 #ifdef H5_HAVE_PARALLEL
   if (use_mpi_io)
   {
-#ifdef HAS_MPI
     MPI_Info info;
     MPI_Info_create(&info);
     herr_t status = H5Pset_fapl_mpio(plist_id, mpi_comm, info);
     assert(status != HDF5_FAIL);
     MPI_Info_free(&info);
-#else
-    throw std::runtime_error("Cannot use MPI-IO output if DOLFIN is not configured with MPI");
-#endif
   }
 #endif
 

--- a/cpp/test/unit/common/SubSystemsManager.cpp
+++ b/cpp/test/unit/common/SubSystemsManager.cpp
@@ -29,7 +29,6 @@ namespace
   void init_petsc()
   {
     // Test user initialisation of PETSc
-#ifdef HAS_PETSC
     int argc = 0;
     char **argv = NULL;
     PetscInitialize(&argc, &argv, NULL, NULL);
@@ -37,7 +36,6 @@ namespace
     Vec x;
     VecCreate(MPI_COMM_WORLD, &x);
     VecDestroy(&x);
-#endif
   }
 }
 

--- a/python/demo/documented/maxwell-eigenvalues/demo_maxwell-eigenvalues.py.rst
+++ b/python/demo/documented/maxwell-eigenvalues/demo_maxwell-eigenvalues.py.rst
@@ -122,15 +122,12 @@ spot.
 The implementation
 ------------------
 
-**Preamble.** First we import ``dolfin`` and ``numpy`` and make sure
-that dolfin has been configured with PETSc and SLEPc (since we depend
-on the SLEPc eigenvalue solver). ::
+**Preamble.** First we import ``dolfin`` and ``numpy`` and
+make sure that dolfin has been configured with SLEPc (since
+we depend on the SLEPc eigenvalue solver). ::
 
   from dolfin import *
   import numpy as np
-  if not has_linear_algebra_backend("PETSc"):
-      print("DOLFIN has not been configured with PETSc. Exiting.")
-      exit()
   if not has_slepc():
       print("DOLFIN has not been configured with SLEPc. Exiting.")
       exit()

--- a/python/demo/documented/singular-poisson/demo_singular-poisson.py.rst
+++ b/python/demo/documented/singular-poisson/demo_singular-poisson.py.rst
@@ -99,18 +99,6 @@ First, the modules :py:mod:`dolfin` and matplotlib are imported: ::
    from dolfin import *
    import matplotlib.pyplot as plt
 
-Then, we check that dolfin is configured with the backend called
-PETSc, since it provides us with a wide range of methods used by
-:py:class:`KrylovSolver <dolfin.cpp.la.KrylovSolver>`. We set PETSc as
-our backend for linear algebra::
-
-   # Test for PETSc
-   if not has_linear_algebra_backend("PETSc"):
-       info("DOLFIN has not been configured with PETSc. Exiting.")
-       exit()
-
-   parameters["linear_algebra_backend"] = "PETSc"
-
 We begin by defining a mesh of the domain and a finite element
 function space :math:`V` relative to this mesh. We use a built-in mesh
 provided by the class :py:class:`UnitSquareMesh

--- a/python/demo/undocumented/buckling-tao/demo_buckling-tao.py
+++ b/python/demo/undocumented/buckling-tao/demo_buckling-tao.py
@@ -17,10 +17,6 @@ from dolfin import *
 import matplotlib.pyplot as plt
 
 
-if not has_petsc():
-    print("DOLFIN must be compiled at least with PETSc 3.6 to run this demo.")
-    exit(0)
-
 # Read mesh and refine once
 mesh = Mesh("../buckling.xml.gz")
 mesh = refine(mesh)

--- a/python/demo/undocumented/contact-vi-snes/demo_contact-vi-snes.py
+++ b/python/demo/undocumented/contact-vi-snes/demo_contact-vi-snes.py
@@ -13,11 +13,6 @@ from dolfin import *
 import matplotlib.pyplot as plt
 
 
-# This demo requires PETSc
-if not has_petsc():
-    print("DOLFIN must be compiled with PETSc to run this demo.")
-    exit(0)
-
 # Create mesh
 mesh = Mesh("../circle_yplane.xml.gz")
 

--- a/python/demo/undocumented/contact-vi-tao/demo_contact-vi-tao.py
+++ b/python/demo/undocumented/contact-vi-tao/demo_contact-vi-tao.py
@@ -14,10 +14,6 @@ from dolfin import *
 import matplotlib.pyplot as plt
 
 
-if not has_petsc():
-    print("DOLFIN must be compiled with PETSc to run this demo.")
-    exit(0)
-
 # Read mesh
 mesh = Mesh("../circle_yplane.xml.gz")
 

--- a/python/demo/undocumented/curl-curl/demo_curl-curl.py
+++ b/python/demo/undocumented/curl-curl/demo_curl-curl.py
@@ -32,11 +32,6 @@ from dolfin import *
 import matplotlib.pyplot as plt
 
 
-# Check that DOLFIN has been configured with PETSc
-if not has_petsc():
-    print("This demo requires DOLFIN to be configured with PETSc.")
-    exit()
-
 # Check that PETSc has been configured with HYPRE
 if not "hypre_amg" in PETScPreconditioner.preconditioners():
     print("This demo requires PETSc to be configured with HYPRE.")
@@ -53,9 +48,6 @@ try:
 except AttributeError:
     print("This demo requires a recent petsc4py with HYPRE bindings.")
     exit()
-
-# Set PETSc as default linear algebra backend
-parameters["linear_algebra_backend"] = "PETSc";
 
 # Load sphere mesh
 mesh = Mesh("../sphere.xml.gz")

--- a/python/demo/undocumented/mixed-poisson-sphere/demo_mixed-poisson-sphere.py
+++ b/python/demo/undocumented/mixed-poisson-sphere/demo_mixed-poisson-sphere.py
@@ -39,12 +39,11 @@ a = (inner(sigma, tau) + div(sigma)*v + div(tau)*u + r*v + t*u)*dx
 L = g*v*dx
 
 # Tune some factorization options
-if has_petsc():
-    # Avoid factors memory exhaustion due to excessive pivoting
-    PETScOptions.set("mat_mumps_icntl_14", 40.0)
-    PETScOptions.set("mat_mumps_icntl_7", "0")
-    # Avoid zero pivots on 64-bit SuperLU_dist
-    PETScOptions.set("mat_superlu_dist_colperm", "MMD_ATA")
+# Avoid factors memory exhaustion due to excessive pivoting
+PETScOptions.set("mat_mumps_icntl_14", 40.0)
+PETScOptions.set("mat_mumps_icntl_7", "0")
+# Avoid zero pivots on 64-bit SuperLU_dist
+PETScOptions.set("mat_superlu_dist_colperm", "MMD_ATA")
 
 # Solve problem
 w = Function(W)

--- a/python/dolfin/__init__.py
+++ b/python/dolfin/__init__.py
@@ -32,7 +32,7 @@ del sys
 from .cpp import __version__
 
 from .cpp.common import (Variable, has_debug, has_hdf5, has_scotch,
-                         has_hdf5_parallel, has_mpi, has_mpi4py, has_petsc_complex,
+                         has_hdf5_parallel, has_mpi4py, has_petsc_complex,
                          has_petsc4py, has_parmetis, has_slepc, has_slepc4py,
                          git_commit_hash, DOLFIN_EPS, DOLFIN_PI, TimingType,
                          timing, timings, list_timings)

--- a/python/dolfin_utils/test/skips.py
+++ b/python/dolfin_utils/test/skips.py
@@ -11,8 +11,6 @@ from dolfin import *
 
 
 # Skips with dependencies
-skip_if_not_MPI = pytest.mark.skipif(not has_mpi(),
-                                     reason="Skipping unit test(s) depending on MPI.")
 skip_if_not_HDF5 = pytest.mark.skipif(not has_hdf5(),
                                       reason="Skipping unit test(s) depending on HDF5.")
 skip_if_not_petsc4py = pytest.mark.skipif(not has_petsc4py(),

--- a/python/src/common.cpp
+++ b/python/src/common.cpp
@@ -45,7 +45,6 @@ void common(py::module& m)
   m.def("has_debug", &dolfin::has_debug);
   m.def("has_hdf5", &dolfin::has_hdf5);
   m.def("has_hdf5_parallel", &dolfin::has_hdf5_parallel);
-  m.def("has_mpi", &dolfin::has_mpi);
   m.def("has_mpi4py",
         []() {
 #ifdef HAS_PYBIND11_MPI4PY

--- a/python/src/fem.cpp
+++ b/python/src/fem.cpp
@@ -393,7 +393,6 @@ void fem(py::module& m)
         self.set_bounds(_lb, _ub);
       });
 
-#ifdef HAS_PETSC
   // dolfin::fem::PETScDMCollection
   py::class_<dolfin::fem::PETScDMCollection,
              std::shared_ptr<dolfin::fem::PETScDMCollection>>(
@@ -425,6 +424,5 @@ void fem(py::module& m)
           })
       .def("check_ref_count", &dolfin::fem::PETScDMCollection::check_ref_count)
       .def("get_dm", &dolfin::fem::PETScDMCollection::get_dm);
-#endif
 }
 } // namespace dolfin_wrappers

--- a/python/src/mpi_casters.h
+++ b/python/src/mpi_casters.h
@@ -11,7 +11,6 @@
 #include <pybind11/pybind11.h>
 
 // Macro for casting between dolfin and mpi4py MPI communicators
-#ifdef HAS_MPI
 #ifdef HAS_PYBIND11_MPI4PY
 #include <mpi4py/mpi4py.h>
 
@@ -65,4 +64,3 @@ public:
 }
 
 #endif // HAS_PYBIND11_MPI4PY
-#endif // HAS_MPI

--- a/python/src/petsc_casters.h
+++ b/python/src/petsc_casters.h
@@ -9,7 +9,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#ifdef HAS_PETSC
 #include <petscdm.h>
 #include <petscksp.h>
 #include <petscmat.h>
@@ -97,5 +96,3 @@ PETSC_CASTER_MACRO(Vec, vec);
 }
 
 #undef PETSC_CASTER_MACRO
-
-#endif

--- a/python/test/unit/la/test_mg_solver.py
+++ b/python/test/unit/la/test_mg_solver.py
@@ -14,7 +14,6 @@ from dolfin import (TestFunction, TrialFunction, dot, grad, dx,
 from dolfin.la import PETScVector, PETScOptions, PETScKrylovSolver
 from dolfin.cpp.fem import PETScDMCollection
 from dolfin.fem.assembling import assemble_system
-from dolfin.parameter import parameters
 
 import pytest
 from dolfin_utils.test import skip_if_not_petsc4py
@@ -82,9 +81,7 @@ def test_mg_solver_laplace():
 
 
 @skip_if_not_petsc4py
-def xtest_mg_solver_stokes(pushpop_parameters):
-
-    parameters["linear_algebra_backend"] = "PETSc"
+def xtest_mg_solver_stokes():
 
     mesh0 = UnitCubeMesh(2, 2, 2)
     mesh1 = UnitCubeMesh(4, 4, 4)


### PR DESCRIPTION
First step.

The following step is renaming `dolfin.has_foo()` into `dolfin.config.has_foo` (property) and alternative names where appropriate, e.g., `dolfin.config.complex_mode`. The question is whether we want to do the the namespacing into `dolfin::config` in C++ too.