### PR TITLE
Rename config.has_petsc_complex to config.complex_mode 

### DIFF
--- a/cpp/dolfin/common/defines.cpp
+++ b/cpp/dolfin/common/defines.cpp
@@ -34,7 +34,7 @@ bool dolfin::has_debug()
 #endif
 }
 //-------------------------------------------------------------------------
-bool dolfin::has_petsc_complex()
+bool dolfin::has_complex_mode()
 {
 #ifdef PETSC_USE_COMPLEX
   return true;

--- a/cpp/dolfin/common/defines.h
+++ b/cpp/dolfin/common/defines.h
@@ -28,9 +28,8 @@ std::size_t sizeof_la_index_t();
 /// i.e., with assertions on
 bool has_debug();
 
-/// Return true if DOLFIN is configured with PETSc compiled
-/// with scalars represented as complex numbers
-bool has_petsc_complex();
+/// Return true if DOLFIN is compiled with complex numbers
+bool has_complex_mode();
 
 /// Return true if DOLFIN is compiled with SLEPc
 bool has_slepc();

--- a/python/dolfin/function/constant.py
+++ b/python/dolfin/function/constant.py
@@ -54,7 +54,7 @@ class Constant(ufl.Coefficient):
 
         array = numpy.array(value)
         rank = len(array.shape)
-        if cpp.common.config.has_petsc_complex:
+        if cpp.common.config.complex_mode:
             value_list = list(map(numpy.complex128, array.flat))
         else:
             value_list = list(map(float, array.flat))

--- a/python/dolfin/function/expression.py
+++ b/python/dolfin/function/expression.py
@@ -100,7 +100,7 @@ class BaseExpression(ufl.Coefficient):
             assert len(shape) == len(component)
             value_size = product(shape)
             index = flatten_multiindex(component, shape_to_strides(shape))
-            if cpp.common.config.has_petsc_complex:
+            if cpp.common.config.complex_mode:
                 dtype = numpy.complex128
             else:
                 dtype = numpy.float64
@@ -138,7 +138,7 @@ class BaseExpression(ufl.Coefficient):
 
         # If values (return argument) is passed, check the type and
         # length
-        if cpp.common.config.has_petsc_complex:
+        if cpp.common.config.complex_mode:
             dtype = numpy.complex128
         else:
             dtype = numpy.float64

--- a/python/dolfin/function/function.py
+++ b/python/dolfin/function/function.py
@@ -287,7 +287,7 @@ class Function(ufl.Coefficient):
                             "length %d" % dim)
 
         value_size = ufl.product(self.ufl_element().value_shape())
-        if cpp.common.config.has_petsc_complex:
+        if cpp.common.config.complex_mode:
             values = np.empty((1, value_size), dtype=np.complex128)
         else:
             values = np.empty((1, value_size))

--- a/python/dolfin_utils/test/skips.py
+++ b/python/dolfin_utils/test/skips.py
@@ -35,10 +35,10 @@ skip_in_serial = pytest.mark.skipif(MPI.size(MPI.comm_world) <= 1,
 #                                     reason="This test does not work with 64-bit linear algebra indices.")
 
 # Skips with respect to the scalar type
-skip_if_complex = pytest.mark.skipif(config.has_petsc_complex,
-                                     reason="This test does not work in complex mode.")
-xfail_if_complex = pytest.mark.xfail(config.has_petsc_complex,
-                                      reason="This test does not work in complex mode.")
+skip_if_complex = pytest.mark.skipif(config.complex_mode,
+                                     reason="This test should not be run in complex mode.")
+xfail_if_complex = pytest.mark.xfail(config.complex_mode,
+                                     reason="This test is broken in complex mode.")
 
 # Skips with respect to build type
 skip_in_debug = pytest.mark.skipif(config.has_debug,

--- a/python/dolfin_utils/test/skips.py
+++ b/python/dolfin_utils/test/skips.py
@@ -37,6 +37,8 @@ skip_in_serial = pytest.mark.skipif(MPI.size(MPI.comm_world) <= 1,
 # Skips with respect to the scalar type
 skip_if_complex = pytest.mark.skipif(config.complex_mode,
                                      reason="This test should not be run in complex mode.")
+skip_if_not_complex = pytest.mark.skipif(not config.complex_mode,
+                                         reason="This test should not be run in non-complex mode.")
 xfail_if_complex = pytest.mark.xfail(config.complex_mode,
                                      reason="This test is broken in complex mode.")
 

--- a/python/src/common.cpp
+++ b/python/src/common.cpp
@@ -61,6 +61,8 @@ void common(py::module& m)
 
   // From dolfin/common/defines.h
   py::class_<py::handle>(m, "config", "DOLFIN configuration")
+      .def_property_readonly_static("complex_mode",
+                                    STATIC_METHOD(dolfin::has_complex_mode()))
       .def_property_readonly_static("has_debug",
                                     STATIC_METHOD(dolfin::has_debug()))
       .def_property_readonly_static("has_hdf5",
@@ -71,8 +73,6 @@ void common(py::module& m)
                                     STATIC_METHOD(dolfin::has_parmetis()))
       .def_property_readonly_static("has_scotch",
                                     STATIC_METHOD(dolfin::has_scotch()))
-      .def_property_readonly_static("has_petsc_complex",
-                                    STATIC_METHOD(dolfin::has_petsc_complex()))
       .def_property_readonly_static("has_slepc",
                                     STATIC_METHOD(dolfin::has_slepc()))
       .def_property_readonly_static("git_commit_hash",

--- a/python/test/unit/fem/test_complex_assembler.py
+++ b/python/test/unit/fem/test_complex_assembler.py
@@ -11,10 +11,6 @@ import numpy as np
 import pytest
 from ufl import dx, grad, inner
 
-# FIXME: Move to dolfin_utils.test.skips
-pytestmark = pytest.mark.skipif(not dolfin.config.has_petsc_complex,
-                                reason="Only works in complex mode.")
-
 
 def test_complex_assembly():
     """Test assembly of complex matrices and vectors"""

--- a/python/test/unit/fem/test_complex_assembler.py
+++ b/python/test/unit/fem/test_complex_assembler.py
@@ -9,8 +9,10 @@ import ufl
 import dolfin
 import numpy as np
 from ufl import dx, grad, inner
+from dolfin_utils.test.skips import skip_if_not_complex
 
 
+@skip_if_not_complex
 def test_complex_assembly():
     """Test assembly of complex matrices and vectors"""
 
@@ -54,6 +56,7 @@ def test_complex_assembly():
     assert np.isclose(b2_norm, b1_norm)
 
 
+@skip_if_not_complex
 def test_complex_assembly_solve():
     """
     Solve a positive definite helmholtz problem and verify solution

--- a/python/test/unit/fem/test_complex_assembler.py
+++ b/python/test/unit/fem/test_complex_assembler.py
@@ -8,7 +8,6 @@
 import ufl
 import dolfin
 import numpy as np
-import pytest
 from ufl import dx, grad, inner
 
 


### PR DESCRIPTION
Based on #131 

Rename `config.has_petsc_complex` to `config.complex_mode`

Also rename `dolfin::has_petsc_complex()` to `dolfin::has_complex_mode()`.
Keeping `has_` because there is not an appropriate namespace.