### PR TITLE
Remove DOLFIN_EPS and DOLFIN_PI from Python dolfin namespace

### DIFF
--- a/python/demo/documented/mixed-poisson/demo_mixed-poisson.py.rst
+++ b/python/demo/documented/mixed-poisson/demo_mixed-poisson.py.rst
@@ -223,7 +223,7 @@ essential boundary): ::
 
     # Define essential boundary
     def boundary(x):
-        return x[1] < DOLFIN_EPS or x[1] > 1.0 - DOLFIN_EPS
+        return x[1] < config.DOLFIN_EPS or x[1] > 1.0 - config.DOLFIN_EPS
 
 Now, all the pieces are in place for the construction of the essential
 boundary condition: ::

--- a/python/demo/documented/navier-stokes/demo_navier-stokes.py
+++ b/python/demo/documented/navier-stokes/demo_navier-stokes.py
@@ -87,7 +87,7 @@ pfile = File("results/pressure.pvd")
 
 # Time-stepping
 t = dt
-while t < T + DOLFIN_EPS:
+while t < T + config.DOLFIN_EPS:
 
     # Update pressure boundary condition
     p_in.t = t

--- a/python/demo/documented/navier-stokes/documentation.rst
+++ b/python/demo/documented/navier-stokes/documentation.rst
@@ -170,7 +170,7 @@ The time-stepping loop is now implemented as follows:
 
     # Time-stepping
     t = dt
-    while t < T + DOLFIN_EPS:
+    while t < T + config.DOLFIN_EPS:
 
         # Update pressure boundary condition
         p_in.t = t

--- a/python/demo/documented/nonlinear-poisson/demo_nonlinear-poisson.py.rst
+++ b/python/demo/documented/nonlinear-poisson/demo_nonlinear-poisson.py.rst
@@ -118,7 +118,7 @@ often wise to instead specify :math:`|x - 1| < \epsilon`, where
     # Sub domain for Dirichlet boundary condition
     class DirichletBoundary(SubDomain):
         def inside(self, x, on_boundary):
-            return abs(x[0] - 1.0) < DOLFIN_EPS and on_boundary
+            return abs(x[0] - 1.0) < config.DOLFIN_EPS and on_boundary
 
 We then define a mesh of the domain and a finite element function
 space V relative to this mesh. We use the built-in mesh provided by

--- a/python/demo/documented/periodic/demo_periodic.py
+++ b/python/demo/documented/periodic/demo_periodic.py
@@ -12,13 +12,13 @@ class Source(UserExpression):
     def eval(self, values, x):
         dx = x[0] - 0.5
         dy = x[1] - 0.5
-        values[0] = x[0]*sin(5.0*DOLFIN_PI*x[1]) \
+        values[0] = x[0]*sin(5.0*config.DOLFIN_PI*x[1]) \
                     + 1.0*exp(-(dx*dx + dy*dy)/0.02)
 
 # Sub domain for Dirichlet boundary condition
 class DirichletBoundary(SubDomain):
     def inside(self, x, on_boundary):
-        return bool((x[1] < DOLFIN_EPS or x[1] > (1.0 - DOLFIN_EPS)) \
+        return bool((x[1] < config.DOLFIN_EPS or x[1] > (1.0 - config.DOLFIN_EPS)) \
                     and on_boundary)
 
 # Sub domain for Periodic boundary condition
@@ -26,7 +26,7 @@ class PeriodicBoundary(SubDomain):
 
     # Left boundary is "target domain" G
     def inside(self, x, on_boundary):
-        return bool(x[0] < DOLFIN_EPS and x[0] > -DOLFIN_EPS and on_boundary)
+        return bool(x[0] < config.DOLFIN_EPS and x[0] > -config.DOLFIN_EPS and on_boundary)
 
     # Map right boundary (H) to left boundary (G)
     def map(self, x, y):

--- a/python/demo/documented/periodic/documentation.rst
+++ b/python/demo/documented/periodic/documentation.rst
@@ -37,7 +37,7 @@ for a function at the given point ``x``.
         def eval(self, values, x):
             dx = x[0] - 0.5
             dy = x[1] - 0.5
-            values[0] = x[0]*sin(5.0*DOLFIN_PI*x[1]) \
+            values[0] = x[0]*sin(5.0*config.DOLFIN_PI*x[1]) \
                         + 1.0*exp(-(dx*dx + dy*dy)/0.02)
 
 To define the boundaries, we create subclasses of the class
@@ -57,7 +57,7 @@ precision).)
     # Sub domain for Dirichlet boundary condition
     class DirichletBoundary(SubDomain):
         def inside(self, x, on_boundary):
-            return bool((x[1] < DOLFIN_EPS or x[1] > (1.0 - DOLFIN_EPS)) \
+            return bool((x[1] < config.DOLFIN_EPS or x[1] > (1.0 - config.DOLFIN_EPS)) \
                         and on_boundary)
 
 The periodic boundary is defined by PeriodicBoundary and we define
@@ -75,7 +75,7 @@ the boundary by making an instance of the class.
 
         # Left boundary is "target domain" G
         def inside(self, x, on_boundary):
-            return bool(x[0] < DOLFIN_EPS and x[0] > -DOLFIN_EPS and on_boundary)
+            return bool(x[0] < config.DOLFIN_EPS and x[0] > -config.DOLFIN_EPS and on_boundary)
 
         # Map right boundary (H) to left boundary (G)
         def map(self, x, y):

--- a/python/demo/documented/poisson/demo_poisson.py.rst
+++ b/python/demo/documented/poisson/demo_poisson.py.rst
@@ -116,7 +116,7 @@ small number (such as machine precision).) ::
 
     # Define Dirichlet boundary (x = 0 or x = 1)
     def boundary(x):
-        return np.logical_or(x[:, 0] < DOLFIN_EPS, x[:, 0] > 1.0 - DOLFIN_EPS)
+        return np.logical_or(x[:, 0] < config.DOLFIN_EPS, x[:, 0] > 1.0 - config.DOLFIN_EPS)
 
 Now, the Dirichlet boundary condition can be created using the class
 :py:class:`DirichletBC <dolfin.fem.bcs.DirichletBC>`. A

--- a/python/demo/documented/stokes-iterative/demo_stokes-iterative.py.rst
+++ b/python/demo/documented/stokes-iterative/demo_stokes-iterative.py.rst
@@ -115,10 +115,10 @@ and is a stable, standard element pair for the Stokes equations.) ::
 Next, we define the boundary conditions. ::
 
     # Boundaries
-    def right(x, on_boundary): return x[0] > (1.0 - DOLFIN_EPS)
-    def left(x, on_boundary): return x[0] < DOLFIN_EPS
+    def right(x, on_boundary): return x[0] > (1.0 - config.DOLFIN_EPS)
+    def left(x, on_boundary): return x[0] < config.DOLFIN_EPS
     def top_bottom(x, on_boundary):
-        return x[1] > 1.0 - DOLFIN_EPS or x[1] < DOLFIN_EPS
+        return x[1] > 1.0 - config.DOLFIN_EPS or x[1] < config.DOLFIN_EPS
 
     # No-slip boundary condition for velocity
     noslip = Constant((0.0, 0.0, 0.0))

--- a/python/demo/documented/tensor-weighted-poisson/demo_tensor-weighted-poisson.py
+++ b/python/demo/documented/tensor-weighted-poisson/demo_tensor-weighted-poisson.py
@@ -41,7 +41,7 @@ V = FunctionSpace(mesh, "Lagrange", 1)
 
 # Define Dirichlet boundary (x = 0 or x = 1)
 def boundary(x):
-    return x[0] < DOLFIN_EPS or x[0] > 1.0 - DOLFIN_EPS
+    return x[0] < config.DOLFIN_EPS or x[0] > 1.0 - config.DOLFIN_EPS
 
 # Define boundary condition
 u0 = Constant(0.0)

--- a/python/demo/documented/tensor-weighted-poisson/documentation.rst
+++ b/python/demo/documented/tensor-weighted-poisson/documentation.rst
@@ -127,7 +127,7 @@ small number (such as machine precision).)::
 
     # Define Dirichlet boundary (x = 0 or x = 1)
     def boundary(x):
-        return x[0] < DOLFIN_EPS or x[0] > 1.0 - DOLFIN_EPS
+        return x[0] < config.DOLFIN_EPS or x[0] > 1.0 - config.DOLFIN_EPS
 
 Now, the Dirichlet boundary condition can be created using the class
 :py:class:`DirichletBC <dolfin.cpp.fem.DirichletBC>`.  A

--- a/python/demo/undocumented/advection-diffusion/demo_advection-diffusion.py
+++ b/python/demo/undocumented/advection-diffusion/demo_advection-diffusion.py
@@ -81,7 +81,7 @@ plt.figure()
 plot(u, title=r"t = {0:1.1f}".format(0.0))
 i += 1 
 
-while t - T < DOLFIN_EPS:
+while t - T < config.DOLFIN_EPS:
     # Assemble vector and apply boundary conditions
     b = assemble(L)
     bc.apply(b)

--- a/python/demo/undocumented/conditional/demo_conditional.py
+++ b/python/demo/undocumented/conditional/demo_conditional.py
@@ -28,7 +28,7 @@ V = FunctionSpace(mesh, "CG", 2)
 
 # Define Dirichlet boundary (x = 0 or x = 1)
 def boundary(x):
-    return x[0] < DOLFIN_EPS or x[0] > 1.0 - DOLFIN_EPS or x[1] < DOLFIN_EPS or x[1] > 1.0 - DOLFIN_EPS
+    return x[0] < config.DOLFIN_EPS or x[0] > 1.0 - config.DOLFIN_EPS or x[1] < config.DOLFIN_EPS or x[1] > 1.0 - config.DOLFIN_EPS
 
 # Define boundary condition
 u0 = Constant(0.0)

--- a/python/demo/undocumented/contact-vi-snes/demo_contact-vi-snes.py
+++ b/python/demo/undocumented/contact-vi-snes/demo_contact-vi-snes.py
@@ -53,15 +53,15 @@ J = derivative(F, u, du)
 # Symmetry condition (to block rigid body rotations)
 tol = mesh.hmin()
 def symmetry_line(x):
-    return abs(x[0]) < DOLFIN_EPS
+    return abs(x[0]) < config.DOLFIN_EPS
 bc = DirichletBC(V.sub(0), 0., symmetry_line, method="pointwise")
 
 # The displacement u must be such that the current configuration x+u
 # remains in the box [xmin,xmax] x [umin,ymax]
 constraint_u = Expression(("xmax - x[0]","ymax - x[1]"),
-                          xmax=1.0+DOLFIN_EPS,  ymax=1.0, degree=1)
+                          xmax=1.0+config.DOLFIN_EPS,  ymax=1.0, degree=1)
 constraint_l = Expression(("xmin - x[0]","ymin - x[1]"),
-                          xmin=-1.0-DOLFIN_EPS, ymin=-1.0, degree=1)
+                          xmin=-1.0-config.DOLFIN_EPS, ymin=-1.0, degree=1)
 umin = interpolate(constraint_l, V)
 umax = interpolate(constraint_u, V)
 

--- a/python/demo/undocumented/dg-advection-diffusion/demo_dg-advection-diffusion.py
+++ b/python/demo/undocumented/dg-advection-diffusion/demo_dg-advection-diffusion.py
@@ -19,7 +19,7 @@ parameters["ghost_mode"] = "shared_facet"
 
 class DirichletBoundary(SubDomain):
     def inside(self, x, on_boundary):
-        return abs(x[0] - 1.0) < DOLFIN_EPS and on_boundary
+        return abs(x[0] - 1.0) < config.DOLFIN_EPS and on_boundary
 
 # Load mesh
 mesh = Mesh("../unitsquare_64_64.xml.gz")

--- a/python/demo/undocumented/elasticity/demo_elasticity.py
+++ b/python/demo/undocumented/elasticity/demo_elasticity.py
@@ -66,7 +66,7 @@ mesh.geometry.coord_mapping = cmap
 
 
 def boundary(x, on_boundary):
-    return np.logical_or(x[:, 0] < DOLFIN_EPS, x[:, 0] > 1.0 - DOLFIN_EPS)
+    return np.logical_or(x[:, 0] < config.DOLFIN_EPS, x[:, 0] > 1.0 - config.DOLFIN_EPS)
 
 
 # Rotation rate and mass density

--- a/python/demo/undocumented/point-integral/demo_point-integral.py
+++ b/python/demo/undocumented/point-integral/demo_point-integral.py
@@ -29,7 +29,7 @@ V = FunctionSpace(mesh, "Lagrange", 1)
 
 # Define Dirichlet boundary (x = 0 or x = 1)
 def boundary(x):
-    return x[0] < DOLFIN_EPS or x[0] > 1.0 - DOLFIN_EPS
+    return x[0] < config.DOLFIN_EPS or x[0] > 1.0 - config.DOLFIN_EPS
 
 def center_func(x):
     return (0.45 <= x[0] and x[0] <= 0.55 and near(x[1], 0.5)) or \

--- a/python/demo/undocumented/poisson1D-in-2D/demo_poisson1D-in-2D.py
+++ b/python/demo/undocumented/poisson1D-in-2D/demo_poisson1D-in-2D.py
@@ -69,7 +69,7 @@ rotation.rotate(mesh)
 # Sub domain for Dirichlet boundary condition
 class DirichletBoundary(SubDomain):
     def inside(self, x, on_boundary):
-        return on_boundary and rotation.to_interval(x) < DOLFIN_EPS
+        return on_boundary and rotation.to_interval(x) < config.DOLFIN_EPS
 
 
 # Define variational problem

--- a/python/demo/undocumented/poisson1D/demo_poisson1D.py
+++ b/python/demo/undocumented/poisson1D/demo_poisson1D.py
@@ -29,7 +29,7 @@ V = FunctionSpace(mesh, "CG", 1)
 # Sub domain for Dirichlet boundary condition
 class DirichletBoundary(SubDomain):
     def inside(self, x, on_boundary):
-        return on_boundary and x[0] < DOLFIN_EPS
+        return on_boundary and x[0] < config.DOLFIN_EPS
 
 # Define variational problem
 u = TrialFunction(V)

--- a/python/dolfin/__init__.py
+++ b/python/dolfin/__init__.py
@@ -33,8 +33,6 @@ from .cpp import __version__
 
 from .cpp.common import Variable, TimingType, timing, timings, list_timings
 from .cpp.common import config
-DOLFIN_EPS = config.DOLFIN_EPS  # FIXME: Remove me
-DOLFIN_PI = config.DOLFIN_PI  # FIXME: Remove me
 
 if config.has_hdf5:
     from .cpp.io import HDF5File

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -14,7 +14,7 @@ import pytest
 from dolfin import (UnitSquareMesh, UnitIntervalMesh, UnitCubeMesh, MPI, CellType,
                     VectorFunctionSpace,
                     FunctionSpace, MixedElement, FiniteElement, VectorElement, Point,
-                    Cells, SubDomain, DOLFIN_EPS)
+                    Cells, SubDomain, config)
 from dolfin_utils.test import fixture, skip_in_serial, skip_in_parallel, set_parameters_fixture
 
 xfail = pytest.mark.xfail(strict=True)
@@ -131,7 +131,7 @@ def test_tabulate_dofs(mesh_factory):
 def test_tabulate_coord_periodic(mesh_factory):
     class PeriodicBoundary2(SubDomain):
         def inside(self, x, on_boundary):
-            return x[0] < DOLFIN_EPS
+            return x[0] < config.DOLFIN_EPS
 
         def map(self, x, y):
             y[0] = x[0] - 1.0
@@ -183,7 +183,7 @@ def test_tabulate_coord_periodic(mesh_factory):
 def test_tabulate_dofs_periodic(mesh_factory):
     class PeriodicBoundary2(SubDomain):
         def inside(self, x, on_boundary):
-            return x[0] < DOLFIN_EPS
+            return x[0] < config.DOLFIN_EPS
 
         def map(self, x, y):
             y[0] = x[0] - 1.0

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -10,7 +10,7 @@ import pytest
 from dolfin import (UnitCubeMesh,
                     FunctionSpace, VectorFunctionSpace, TensorFunctionSpace,
                     Constant, MPI, Point, Function,
-                    UserExpression, interpolate, Expression, DOLFIN_EPS, Vertex, lt, cpp)
+                    UserExpression, interpolate, Expression, config, Vertex, lt, cpp)
 from math import sqrt
 import numpy
 import ufl
@@ -248,7 +248,7 @@ def test_near_evaluations(R, mesh):
     u0 = Function(R)
     u0.vector()[:] = 1.0
     a = Vertex(mesh, 0).point().array()
-    offset = 0.99 * DOLFIN_EPS
+    offset = 0.99 * config.DOLFIN_EPS
 
     a_shift_x = Point(a[0] - offset, a[1], a[2]).array()
     assert round(u0(a)[0] - u0(a_shift_x)[0], 7) == 0

--- a/python/test/unit/geometry/test_point.py
+++ b/python/test/unit/geometry/test_point.py
@@ -9,7 +9,7 @@
 import pytest
 import numpy as np
 
-from dolfin import Point, DOLFIN_EPS, DOLFIN_PI
+from dolfin import Point, config
 
 
 def test_point_getitem():
@@ -66,8 +66,8 @@ def test_point_array():
 
 
 def test_point_equality():
-    p = Point(1.23, 2, DOLFIN_PI)
-    q = Point(1.23, 2, DOLFIN_PI)
-    r = Point(1.23 + DOLFIN_EPS, 2, DOLFIN_PI)
+    p = Point(1.23, 2, config.DOLFIN_PI)
+    q = Point(1.23, 2, config.DOLFIN_PI)
+    r = Point(1.23 + config.DOLFIN_EPS, 2, config.DOLFIN_PI)
     assert p == q
     assert p != r

--- a/python/test/unit/la/test_mg_solver.py
+++ b/python/test/unit/la/test_mg_solver.py
@@ -9,7 +9,7 @@
 
 from dolfin import (TestFunction, TrialFunction, dot, grad, dx,
                     DirichletBC, UnitSquareMesh, UnitCubeMesh, inner, div, Expression,
-                    Constant, TestFunctions, TrialFunctions, DOLFIN_EPS, FunctionSpace,
+                    Constant, TestFunctions, TrialFunctions, config, FunctionSpace,
                     MixedElement, VectorElement, FiniteElement)
 from dolfin.la import PETScVector, PETScOptions, PETScKrylovSolver
 from dolfin.cpp.fem import PETScDMCollection
@@ -98,13 +98,13 @@ def xtest_mg_solver_stokes():
 
     # Boundaries
     def right(x, on_boundary):
-        return x[0] > (1.0 - DOLFIN_EPS)
+        return x[0] > (1.0 - config.DOLFIN_EPS)
 
     def left(x, on_boundary):
-        return x[0] < DOLFIN_EPS
+        return x[0] < config.DOLFIN_EPS
 
     def top_bottom(x, on_boundary):
-        return x[1] > 1.0 - DOLFIN_EPS or x[1] < DOLFIN_EPS
+        return x[1] > 1.0 - config.DOLFIN_EPS or x[1] < config.DOLFIN_EPS
 
     # No-slip boundary condition for velocity
     noslip = Constant((0.0, 0.0, 0.0))

--- a/python/test/unit/mesh/test_periodic_boundary_computation.py
+++ b/python/test/unit/mesh/test_periodic_boundary_computation.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import numpy as np
-from dolfin import SubDomain, UnitSquareMesh, DOLFIN_EPS, PeriodicBoundaryComputation, MPI
+from dolfin import SubDomain, UnitSquareMesh, config, PeriodicBoundaryComputation, MPI
 from dolfin_utils.test import skip_in_parallel, fixture
 
 
@@ -13,7 +13,7 @@ from dolfin_utils.test import skip_in_parallel, fixture
 def periodic_boundary():
     class PeriodicBoundary(SubDomain):
         def inside(self, x, on_boundary):
-            return x[0] < DOLFIN_EPS
+            return x[0] < config.DOLFIN_EPS
 
         def map(self, x, y):
             y[0] = x[0] - 1.0

--- a/python/test/unit/mesh/test_sub_domain.py
+++ b/python/test/unit/mesh/test_sub_domain.py
@@ -5,26 +5,26 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import numpy as np
-from dolfin import SubDomain, DOLFIN_EPS, MPI, MeshFunction, UnitSquareMesh, UnitCubeMesh, UnitIntervalMesh
+from dolfin import SubDomain, config, MPI, MeshFunction, UnitSquareMesh, UnitCubeMesh, UnitIntervalMesh
 
 
 def test_creation_and_marking():
 
     class Left(SubDomain):
         def inside(self, x, on_boundary):
-            return x[:, 0] < DOLFIN_EPS
+            return x[:, 0] < config.DOLFIN_EPS
 
     class LeftOnBoundary(SubDomain):
         def inside(self, x, on_boundary):
-            return np.logical_and(x[:, 0] < DOLFIN_EPS, on_boundary)
+            return np.logical_and(x[:, 0] < config.DOLFIN_EPS, on_boundary)
 
     class Right(SubDomain):
         def inside(self, x, on_boundary):
-            return x[:, 0] > 1.0 - DOLFIN_EPS
+            return x[:, 0] > 1.0 - config.DOLFIN_EPS
 
     class RightOnBoundary(SubDomain):
         def inside(self, x, on_boundary):
-            return np.logical_and(x[:, 0] > 1.0 - DOLFIN_EPS, on_boundary)
+            return np.logical_and(x[:, 0] > 1.0 - config.DOLFIN_EPS, on_boundary)
 
     subdomain_pairs = [(Left(), Right()),
                        (LeftOnBoundary(), RightOnBoundary())]


### PR DESCRIPTION
Based on #131 

Move `dolfin.DOLFIN_EPS` and `dolfin.DOLFIN_PI` to `dolfin.config.DOLFIN_EPS` and `dolfin.config.DOLFIN_PI` respectively.