### PR TITLE
Add Complex support to XDMFFile

### DIFF
--- a/cpp/dolfin/io/HDF5File.h
+++ b/cpp/dolfin/io/HDF5File.h
@@ -30,7 +30,7 @@ namespace function
 {
 // class Function;
 class FunctionSpace;
-}
+} // namespace function
 
 namespace geometry
 {
@@ -278,5 +278,5 @@ void HDF5File::write_data(const std::string dataset_name,
                                global_size, use_mpi_io, chunking);
 }
 //---------------------------------------------------------------------------
-}
-}
+} // namespace io
+} // namespace dolfin

--- a/cpp/dolfin/io/HDF5Utility.cpp
+++ b/cpp/dolfin/io/HDF5Utility.cpp
@@ -285,7 +285,7 @@ void HDF5Utility::set_local_vector_values(
     const std::vector<size_t>& cells,
     const std::vector<dolfin::la_index_t>& cell_dofs,
     const std::vector<std::int64_t>& x_cell_dofs,
-    const std::vector<double>& vector,
+    const std::vector<PetscScalar>& vector,
     const std::array<std::int64_t, 2> input_vector_range,
     const fem::GenericDofMap& dofmap)
 {
@@ -316,10 +316,10 @@ void HDF5Utility::set_local_vector_values(
   // Shift to dividing things into the vector range of Function Vector
   const std::array<std::int64_t, 2> vector_range = x.local_range();
 
-  std::vector<std::vector<double>> receive_values(num_processes);
+  std::vector<std::vector<PetscScalar>> receive_values(num_processes);
   std::vector<std::vector<dolfin::la_index_t>> receive_indices(num_processes);
   {
-    std::vector<std::vector<double>> send_values(num_processes);
+    std::vector<std::vector<PetscScalar>> send_values(num_processes);
     std::vector<std::vector<dolfin::la_index_t>> send_indices(num_processes);
     const std::size_t n_vector_vals
         = input_vector_range[1] - input_vector_range[0];
@@ -348,7 +348,7 @@ void HDF5Utility::set_local_vector_values(
   std::vector<PetscScalar> vector_values(vector_range[1] - vector_range[0]);
   for (std::size_t i = 0; i != num_processes; ++i)
   {
-    const std::vector<double>& rval = receive_values[i];
+    const std::vector<PetscScalar>& rval = receive_values[i];
     const std::vector<dolfin::la_index_t>& rindex = receive_indices[i];
     assert(rval.size() == rindex.size());
     for (std::size_t j = 0; j != rindex.size(); ++j)

--- a/cpp/dolfin/io/HDF5Utility.cpp
+++ b/cpp/dolfin/io/HDF5Utility.cpp
@@ -345,7 +345,7 @@ void HDF5Utility::set_local_vector_values(
     MPI::all_to_all(mpi_comm, send_indices, receive_indices);
   }
 
-  std::vector<double> vector_values(vector_range[1] - vector_range[0]);
+  std::vector<PetscScalar> vector_values(vector_range[1] - vector_range[0]);
   for (std::size_t i = 0; i != num_processes; ++i)
   {
     const std::vector<double>& rval = receive_values[i];

--- a/cpp/dolfin/io/HDF5Utility.h
+++ b/cpp/dolfin/io/HDF5Utility.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
+#include <array>
 #include <dolfin/common/MPI.h>
 #include <dolfin/common/types.h>
-#include <array>
 #include <string>
 #include <utility>
 #include <vector>
@@ -86,7 +86,7 @@ public:
                           const std::vector<size_t>& cells,
                           const std::vector<dolfin::la_index_t>& cell_dofs,
                           const std::vector<std::int64_t>& x_cell_dofs,
-                          const std::vector<double>& vector,
+                          const std::vector<PetscScalar>& vector,
                           std::array<std::int64_t, 2> input_vector_range,
                           const fem::GenericDofMap& dofmap);
 };

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -1629,9 +1629,9 @@ XDMFFile::read_checkpoint(std::shared_ptr<const function::FunctionSpace> V,
                           + func_name + "']/Grid[" + selector + "]")
                              .c_str())
             .node();
-
   assert(grid_node);
 
+#ifdef PETSC_USE_COMPLEX
   pugi::xml_node fe_attribute_node
       = grid_node
             .select_node(("Attribute[@ItemType=\"FiniteElementFunction\" and"
@@ -1639,6 +1639,12 @@ XDMFFile::read_checkpoint(std::shared_ptr<const function::FunctionSpace> V,
                           + func_name + "']")
                              .c_str())
             .node();
+#else
+  pugi::xml_node fe_attribute_node
+      = grid_node.select_node("Attribute[@ItemType=\"FiniteElementFunction\"]")
+            .node();
+#endif
+
   assert(fe_attribute_node);
 
   // Get cells dofs indices = dofmap

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -1639,24 +1639,13 @@ XDMFFile::read_checkpoint(std::shared_ptr<const function::FunctionSpace> V,
                           + func_name + "']")
                              .c_str())
             .node();
-  assert(fe_attribute_node);
-
-  // Find FE attribute node of the imaginary component
-  pugi::xml_node imag_fe_attribute_node
-      = grid_node
-            .select_node(("Attribute[@ItemType=\"FiniteElementFunction\" and"
-                          "@Name='imag_"
-                          + func_name + "']")
-                             .c_str())
-            .node();
-  assert(imag_fe_attribute_node);
 #else
   pugi::xml_node fe_attribute_node
       = grid_node.select_node("Attribute[@ItemType=\"FiniteElementFunction\"]")
             .node();
-  assert(fe_attribute_node);
 #endif
 
+  assert(fe_attribute_node);
   // Get cells dofs indices = dofmap
   pugi::xml_node cell_dofs_dataitem
       = fe_attribute_node.select_node("DataItem[position()=1]").node();
@@ -1720,6 +1709,16 @@ XDMFFile::read_checkpoint(std::shared_ptr<const function::FunctionSpace> V,
   // Read real component of function vector
   std::vector<double> real_vector = get_dataset<double>(
       _mpi_comm.comm(), vector_dataitem, parent_path, input_vector_range);
+
+  // Find FE attribute node of the imaginary component
+  pugi::xml_node imag_fe_attribute_node
+      = grid_node
+            .select_node(("Attribute[@ItemType=\"FiniteElementFunction\" and"
+                          "@Name='imag_"
+                          + func_name + "']")
+                             .c_str())
+            .node();
+  assert(imag_fe_attribute_node);
 
   // Get extra FE attribute of the imaginary component
   pugi::xml_node imag_vector_dataitem

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -219,64 +219,64 @@ void XDMFFile::write_checkpoint(const function::Function& u,
     h5_id = _hdf5_file->h5_id();
   }
 #endif
-    // From this point _xml_doc points to a valid XDMF XML document
-    // with expected structure
+  // From this point _xml_doc points to a valid XDMF XML document
+  // with expected structure
 
-    // Find temporal grid with name equal to the name of function we're about
-    // to save
-    pugi::xml_node func_temporal_grid_node
-        = _xml_doc
-              ->select_node(("/Xdmf/Domain/Grid[@CollectionType='Temporal' and "
-                             "@Name='"
+  // Find temporal grid with name equal to the name of function we're about
+  // to save
+  pugi::xml_node func_temporal_grid_node
+      = _xml_doc
+            ->select_node(("/Xdmf/Domain/Grid[@CollectionType='Temporal' and "
+                           "@Name='"
                            + function_name + "']")
-                                .c_str())
-              .node();
+                              .c_str())
+            .node();
 
-    // If there is no such temporal grid then create one
-    if (func_temporal_grid_node.empty())
-    {
-      func_temporal_grid_node
-          = _xml_doc->select_node("/Xdmf/Domain").node().append_child("Grid");
-      func_temporal_grid_node.append_attribute("GridType") = "Collection";
-      func_temporal_grid_node.append_attribute("CollectionType") = "Temporal";
-func_temporal_grid_node.append_attribute("Name") = function_name.c_str();
-    }
-    else
-    {
-      log::log(PROGRESS,
-               "XDMF time series for function \"%s\" not empty. Appending.",
+  // If there is no such temporal grid then create one
+  if (func_temporal_grid_node.empty())
+  {
+    func_temporal_grid_node
+        = _xml_doc->select_node("/Xdmf/Domain").node().append_child("Grid");
+    func_temporal_grid_node.append_attribute("GridType") = "Collection";
+    func_temporal_grid_node.append_attribute("CollectionType") = "Temporal";
+    func_temporal_grid_node.append_attribute("Name") = function_name.c_str();
+  }
+  else
+  {
+    log::log(PROGRESS,
+             "XDMF time series for function \"%s\" not empty. Appending.",
              function_name.c_str());
-    }
+  }
 
-    //
-    // Write mesh
-    //
+  //
+  // Write mesh
+  //
 
-    std::size_t counter = func_temporal_grid_node.select_nodes("Grid").size();
-    std::string function_time_name
+  std::size_t counter = func_temporal_grid_node.select_nodes("Grid").size();
+  std::string function_time_name
       = function_name + "_" + std::to_string(counter);
 
-    const mesh::Mesh& mesh = *u.function_space()->mesh();
-    add_mesh(_mpi_comm.comm(), func_temporal_grid_node, h5_id, mesh,
+  const mesh::Mesh& mesh = *u.function_space()->mesh();
+  add_mesh(_mpi_comm.comm(), func_temporal_grid_node, h5_id, mesh,
            function_name + "/" + function_time_name);
 
-    // Get newly (by add_mesh) created Grid
-    pugi::xml_node mesh_grid_node
-        = func_temporal_grid_node
-              .select_node(("Grid[@Name='" + mesh.name() + "']").c_str())
-              .node();
-    assert(mesh_grid_node);
+  // Get newly (by add_mesh) created Grid
+  pugi::xml_node mesh_grid_node
+      = func_temporal_grid_node
+            .select_node(("Grid[@Name='" + mesh.name() + "']").c_str())
+            .node();
+  assert(mesh_grid_node);
 
-    // Change it's name to {function_name}_{counter}
-    // where counter = number of children in temporal grid node
-    mesh_grid_node.attribute("Name") = function_time_name.c_str();
+  // Change it's name to {function_name}_{counter}
+  // where counter = number of children in temporal grid node
+  mesh_grid_node.attribute("Name") = function_time_name.c_str();
 
-    pugi::xml_node time_node = mesh_grid_node.append_child("Time");
-    time_node.append_attribute("Value") = std::to_string(time_step).c_str();
+  pugi::xml_node time_node = mesh_grid_node.append_child("Time");
+  time_node.append_attribute("Value") = std::to_string(time_step).c_str();
 
-    //
-    // Write function
-    //
+  //
+  // Write function
+  //
 
   add_function(_mpi_comm.comm(), mesh_grid_node, h5_id,
                function_name + "/" + function_time_name, u, function_name,
@@ -2847,7 +2847,8 @@ XDMFFile::get_point_data_values(const function::Function& u)
   return _data_values;
 }
 //-----------------------------------------------------------------------------
-std::vector<PetscScalar> XDMFFile::get_p2_data_values(const function::Function& u)
+std::vector<PetscScalar>
+XDMFFile::get_p2_data_values(const function::Function& u)
 {
   const auto mesh = u.function_space()->mesh();
 
@@ -3047,6 +3048,6 @@ std::string XDMFFile::rank_to_string(std::size_t value_rank)
     return "Scalar";
   else if (value_rank == 1)
     return "Vector";
-  return "Tensor"; 
+  return "Tensor";
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -289,8 +289,8 @@ void XDMFFile::write_checkpoint(const function::Function& u,
 #else
   // Write function
   add_function(_mpi_comm.comm(), mesh_grid_node, h5_id,
-               function_name + "/" + function_time_name, u, function_name,
-               mesh);
+               function_name + "/" + function_time_name, u, function_name, mesh,
+               "");
 #endif
 
   // Save XML file (on process 0 only)
@@ -1442,9 +1442,8 @@ void XDMFFile::add_function(MPI_Comm mpi_comm, pugi::xml_node& xml_node,
                 h5_path + "/" + component + "/vector", component_data_values,
                 {(std::int64_t)u_vector.size(), 1}, "Float");
 #else
-  std::vector<double> local_data;
   u_vector.get_local(local_data);
-  add_data_item(mpi_comm, fe_attribute_node, h5_id, h5_path "/vector",
+  add_data_item(mpi_comm, fe_attribute_node, h5_id, h5_path + "/vector",
                 local_data, {(std::int64_t)u_vector.size(), 1}, "Float");
 #endif
 

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -41,9 +41,9 @@ using namespace dolfin;
 using namespace dolfin::io;
 
 //-----------------------------------------------------------------------------
-XDMFFile::XDMFFile(MPI_Comm comm, const std::string filename)
+XDMFFile::XDMFFile(MPI_Comm comm, const std::string filename, Encoding encoding)
     : _mpi_comm(comm), _filename(filename), _counter(0),
-      _xml_doc(new pugi::xml_document)
+      _xml_doc(new pugi::xml_document), _encoding(encoding)
 {
   // Rewrite the mesh at every time step in a time series. Should be
   // turned off if the mesh remains constant.
@@ -69,16 +69,16 @@ void XDMFFile::close()
 #endif
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write(const mesh::Mesh& mesh, const Encoding encoding)
+void XDMFFile::write(const mesh::Mesh& mesh)
 {
   // Check that encoding
-  if (encoding == Encoding::HDF5 and !has_hdf5())
+  if (_encoding == Encoding::HDF5 and !has_hdf5())
   {
     throw std::runtime_error("Cannot write XDMF in HDF5 encoding. (DOLFIN not "
                              "compied with HDF5 support)");
   }
 
-  if (encoding == Encoding::ASCII and _mpi_comm.size() != 1)
+  if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(
         "Cannot write ASCII XDMF in parallel (use HDF5 encoding).");
@@ -88,7 +88,7 @@ void XDMFFile::write(const mesh::Mesh& mesh, const Encoding encoding)
   hid_t h5_id = -1;
 #ifdef HAS_HDF5
   std::unique_ptr<HDF5File> h5_file;
-  if (encoding == Encoding::HDF5)
+  if (_encoding == Encoding::HDF5)
   {
     // Open file
     h5_file = std::make_unique<HDF5File>(mesh.mpi_comm(),
@@ -124,17 +124,16 @@ void XDMFFile::write(const mesh::Mesh& mesh, const Encoding encoding)
 }
 //-----------------------------------------------------------------------------
 void XDMFFile::write_checkpoint(const function::Function& u,
-                                std::string function_name, double time_step,
-                                const Encoding encoding)
+                                std::string function_name, double time_step)
 {
   // Check that encoding
-  if (encoding == Encoding::HDF5 and !has_hdf5())
+  if (_encoding == Encoding::HDF5 and !has_hdf5())
   {
     throw std::runtime_error("DOLFIN has not been compiled with HDF5 support. "
                              "Cannot write XDMF in HDF5 encoding.");
   }
 
-  if (encoding == Encoding::ASCII and _mpi_comm.size() != 1)
+  if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(
         "Cannot write ASCII XDMF in parallel (use HDF5 encoding).");
@@ -195,7 +194,7 @@ void XDMFFile::write_checkpoint(const function::Function& u,
   // Open the HDF5 file if using HDF5 encoding (truncate)
   hid_t h5_id = -1;
 #ifdef HAS_HDF5
-  if (encoding == Encoding::HDF5)
+  if (_encoding == Encoding::HDF5)
   {
     if (truncate_hdf)
     {
@@ -305,7 +304,7 @@ void XDMFFile::write_checkpoint(const function::Function& u,
 
 #ifdef HAS_HDF5
   // Close the HDF5 file if in "flush" mode
-  if (encoding == Encoding::HDF5 and parameters["flush_output"])
+  if (_encoding == Encoding::HDF5 and parameters["flush_output"])
   {
     log::log(PROGRESS, "Writing function in \"flush_output\" mode. HDF5 "
                        "file will be flushed (closed).");
@@ -316,16 +315,16 @@ void XDMFFile::write_checkpoint(const function::Function& u,
 #endif
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write(const function::Function& u, const Encoding encoding)
+void XDMFFile::write(const function::Function& u)
 {
   // Check that encoding
-  if (encoding == Encoding::HDF5 and !has_hdf5())
+  if (_encoding == Encoding::HDF5 and !has_hdf5())
   {
     throw std::runtime_error("DOLFIN has not been compiled with HDF5 support. "
                              "Cannot write XDMF in HDF5 encoding.");
   }
 
-  if (encoding == Encoding::ASCII and _mpi_comm.size() != 1)
+  if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(
         "Cannot write ASCII XDMF in parallel (use HDF5 encoding).");
@@ -347,7 +346,7 @@ void XDMFFile::write(const function::Function& u, const Encoding encoding)
   hid_t h5_id = -1;
 #ifdef HAS_HDF5
   std::unique_ptr<HDF5File> h5_file;
-  if (encoding == Encoding::HDF5)
+  if (_encoding == Encoding::HDF5)
   {
     // Open file
     h5_file = std::make_unique<HDF5File>(mesh.mpi_comm(),
@@ -439,17 +438,16 @@ void XDMFFile::write(const function::Function& u, const Encoding encoding)
     _xml_doc->save_file(_filename.c_str(), "  ");
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write(const function::Function& u, double time_step,
-                     const Encoding encoding)
+void XDMFFile::write(const function::Function& u, double time_step)
 {
   // Check that encoding
-  if (encoding == Encoding::HDF5 and !has_hdf5())
+  if (_encoding == Encoding::HDF5 and !has_hdf5())
   {
     throw std::runtime_error("DOLFIN has not been compiled with HDF5 support. "
                              "Cannot write XDMF in HDF5 encoding.");
   }
 
-  if (encoding == Encoding::ASCII and _mpi_comm.size() != 1)
+  if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(
         "Cannot write ASCII XDMF in parallel (use HDF5 encoding).");
@@ -476,7 +474,7 @@ void XDMFFile::write(const function::Function& u, double time_step,
   hid_t h5_id = -1;
 #ifdef HAS_HDF5
   // Open the HDF5 file for first time, if using HDF5 encoding
-  if (encoding == Encoding::HDF5)
+  if (_encoding == Encoding::HDF5)
   {
     // Truncate the file the first time
     if (_counter == 0)
@@ -643,7 +641,7 @@ void XDMFFile::write(const function::Function& u, double time_step,
 
 #ifdef HAS_HDF5
   // Close the HDF5 file if in "flush" mode
-  if (encoding == Encoding::HDF5 and parameters["flush_output"])
+  if (_encoding == Encoding::HDF5 and parameters["flush_output"])
   {
     assert(_hdf5_file);
     _hdf5_file.reset();
@@ -653,66 +651,58 @@ void XDMFFile::write(const function::Function& u, double time_step,
   ++_counter;
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write(const mesh::MeshFunction<bool>& meshfunction,
-                     const Encoding encoding)
+void XDMFFile::write(const mesh::MeshFunction<bool>& meshfunction)
 {
-  write_mesh_function(meshfunction, encoding);
+  write_mesh_function(meshfunction);
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write(const mesh::MeshFunction<int>& meshfunction,
-                     const Encoding encoding)
+void XDMFFile::write(const mesh::MeshFunction<int>& meshfunction)
 {
-  write_mesh_function(meshfunction, encoding);
+  write_mesh_function(meshfunction);
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write(const mesh::MeshFunction<std::size_t>& meshfunction,
-                     const Encoding encoding)
+void XDMFFile::write(const mesh::MeshFunction<std::size_t>& meshfunction)
 {
-  write_mesh_function(meshfunction, encoding);
+  write_mesh_function(meshfunction);
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write(const mesh::MeshFunction<double>& meshfunction,
-                     const Encoding encoding)
+void XDMFFile::write(const mesh::MeshFunction<double>& meshfunction)
 {
-  write_mesh_function(meshfunction, encoding);
+  write_mesh_function(meshfunction);
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write(const mesh::MeshValueCollection<bool>& mvc,
-                     const Encoding encoding)
+void XDMFFile::write(const mesh::MeshValueCollection<bool>& mvc)
 {
-  write_mesh_value_collection(mvc, encoding);
+  write_mesh_value_collection(mvc);
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write(const mesh::MeshValueCollection<int>& mvc,
-                     const Encoding encoding)
+void XDMFFile::write(const mesh::MeshValueCollection<int>& mvc)
 {
-  write_mesh_value_collection(mvc, encoding);
+  write_mesh_value_collection(mvc);
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write(const mesh::MeshValueCollection<std::size_t>& mvc,
-                     const Encoding encoding)
+void XDMFFile::write(const mesh::MeshValueCollection<std::size_t>& mvc)
 {
-  write_mesh_value_collection(mvc, encoding);
+  write_mesh_value_collection(mvc);
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write(const mesh::MeshValueCollection<double>& mvc,
-                     const Encoding encoding)
+void XDMFFile::write(const mesh::MeshValueCollection<double>& mvc)
 {
-  write_mesh_value_collection(mvc, encoding);
+  write_mesh_value_collection(mvc);
 }
 //-----------------------------------------------------------------------------
 template <typename T>
 void XDMFFile::write_mesh_value_collection(
-    const mesh::MeshValueCollection<T>& mvc, const Encoding encoding)
+    const mesh::MeshValueCollection<T>& mvc)
 {
   // Check that encoding
-  if (encoding == Encoding::HDF5 and !has_hdf5())
+  if (_encoding == Encoding::HDF5 and !has_hdf5())
   {
     throw std::runtime_error("DOLFIN has not been compiled with HDF5 support. "
                              "Cannot write XDMF in HDF5 encoding.");
   }
 
-  if (encoding == Encoding::ASCII and _mpi_comm.size() != 1)
+  if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(
         "Cannot write ASCII XDMF in parallel (use HDF5 encoding).");
@@ -759,7 +749,7 @@ void XDMFFile::write_mesh_value_collection(
   hid_t h5_id = -1;
 #ifdef HAS_HDF5
   std::unique_ptr<HDF5File> h5_file;
-  if (encoding == Encoding::HDF5)
+  if (_encoding == Encoding::HDF5)
   {
     // Open file
     h5_file = std::make_unique<HDF5File>(
@@ -1109,17 +1099,16 @@ XDMFFile::read_mesh_value_collection(std::shared_ptr<const mesh::Mesh> mesh,
   return mvc;
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write(const std::vector<geometry::Point>& points,
-                     const Encoding encoding)
+void XDMFFile::write(const std::vector<geometry::Point>& points)
 {
   // Check that encoding
-  if (encoding == Encoding::HDF5 and !has_hdf5())
+  if (_encoding == Encoding::HDF5 and !has_hdf5())
   {
     throw std::runtime_error("DOLFIN has not been compiled with HDF5 support. "
                              "Cannot write XDMF in HDF5 encoding.");
   }
 
-  if (encoding == Encoding::ASCII and _mpi_comm.size() != 1)
+  if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(
         "Cannot write ASCII XDMF in parallel (use HDF5 encoding).");
@@ -1129,7 +1118,7 @@ void XDMFFile::write(const std::vector<geometry::Point>& points,
   hid_t h5_id = -1;
 #ifdef HAS_HDF5
   std::unique_ptr<HDF5File> h5_file;
-  if (encoding == Encoding::HDF5)
+  if (_encoding == Encoding::HDF5)
   {
     // Open file
     h5_file = std::make_unique<HDF5File>(_mpi_comm.comm(),
@@ -1194,19 +1183,19 @@ void XDMFFile::add_points(MPI_Comm comm, pugi::xml_node& xdmf_node, hid_t h5_id,
 }
 //----------------------------------------------------------------------------
 void XDMFFile::write(const std::vector<geometry::Point>& points,
-                     const std::vector<double>& values, const Encoding encoding)
+                     const std::vector<double>& values)
 {
   // Write clouds of points to XDMF/HDF5 with values
   assert(points.size() == values.size());
 
   // Check that encoding is supported
-  if (encoding == Encoding::HDF5 and !has_hdf5())
+  if (_encoding == Encoding::HDF5 and !has_hdf5())
   {
     throw std::runtime_error("DOLFIN has not been compiled with HDF5 support. "
                              "Cannot write XDMF in HDF5 encoding.");
   }
 
-  if (encoding == Encoding::ASCII and _mpi_comm.size() != 1)
+  if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(
         "Cannot write ASCII XDMF in parallel (use HDF5 encoding).");
@@ -1219,7 +1208,7 @@ void XDMFFile::write(const std::vector<geometry::Point>& points,
   hid_t h5_id = -1;
 #ifdef HAS_HDF5
   std::unique_ptr<HDF5File> h5_file;
-  if (encoding == Encoding::HDF5)
+  if (_encoding == Encoding::HDF5)
   {
     // Open file
     h5_file = std::make_unique<HDF5File>(_mpi_comm.comm(),
@@ -2596,17 +2585,16 @@ std::string XDMFFile::get_hdf5_filename(std::string xdmf_filename)
 }
 //----------------------------------------------------------------------------
 template <typename T>
-void XDMFFile::write_mesh_function(const mesh::MeshFunction<T>& meshfunction,
-                                   Encoding encoding)
+void XDMFFile::write_mesh_function(const mesh::MeshFunction<T>& meshfunction)
 {
   // Check that encoding
-  if (encoding == Encoding::HDF5 and !has_hdf5())
+  if (_encoding == Encoding::HDF5 and !has_hdf5())
   {
     throw std::runtime_error("DOLFIN has not been compiled with HDF5 support. "
                              "Cannot write XDMF in HDF5 encoding.");
   }
 
-  if (encoding == Encoding::ASCII and _mpi_comm.size() != 1)
+  if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(
         "Cannot write ASCII XDMF in parallel (use HDF5 encoding).");
@@ -2653,7 +2641,7 @@ void XDMFFile::write_mesh_function(const mesh::MeshFunction<T>& meshfunction,
   hid_t h5_id = -1;
 #ifdef HAS_HDF5
   std::unique_ptr<HDF5File> h5_file;
-  if (encoding == Encoding::HDF5)
+  if (_encoding == Encoding::HDF5)
   {
     // Open file
     h5_file = std::make_unique<HDF5File>(

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -289,8 +289,8 @@ void XDMFFile::write_checkpoint(const function::Function& u,
 #else
   // Write function
   add_function(_mpi_comm.comm(), mesh_grid_node, h5_id,
-               function_name + "/" + function_time_name, u, function_name, mesh,
-               "");
+               function_name + "/" + function_time_name, u, function_name,
+               mesh);
 #endif
 
   // Save XML file (on process 0 only)
@@ -1315,7 +1315,7 @@ void XDMFFile::add_function(MPI_Comm mpi_comm, pugi::xml_node& xml_node,
                             hid_t h5_id, std::string h5_path,
                             const function::Function& u,
                             std::string function_name, const mesh::Mesh& mesh,
-                            std::string component = "")
+                            const std::string component)
 {
   log::log(PROGRESS, "Adding function to node \"%s\"",
            xml_node.path('/').c_str());

--- a/cpp/dolfin/io/XDMFFile.h
+++ b/cpp/dolfin/io/XDMFFile.h
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <petscsys.h>
 #include <string>
 #include <utility>
 #include <vector>
@@ -28,13 +29,13 @@ namespace filesystem
 {
 class path;
 }
-}
+} // namespace boost
 
 namespace pugi
 {
 class xml_node;
 class xml_document;
-}
+} // namespace pugi
 
 namespace dolfin
 {
@@ -42,7 +43,7 @@ namespace function
 {
 class Function;
 class FunctionSpace;
-}
+} // namespace function
 
 namespace geometry
 {
@@ -58,7 +59,7 @@ class MeshFunction;
 template <typename T>
 class MeshValueCollection;
 class MeshPartitioning;
-}
+} // namespace mesh
 
 namespace io
 {
@@ -321,8 +322,7 @@ public:
   ///        Ghost mode for mesh partition
   /// @returns mesh::Mesh
   ///        Mesh
-  mesh::Mesh read_mesh(MPI_Comm comm,
-                       const mesh::GhostMode ghost_mode) const;
+  mesh::Mesh read_mesh(MPI_Comm comm, const mesh::GhostMode ghost_mode) const;
 
   /// Read a function from the XDMF file. Supplied function must
   /// come with already initialized and compatible function space.
@@ -537,14 +537,16 @@ private:
 
   // Get point data values for linear or quadratic mesh into flattened
   // 2D array
-  static std::vector<double> get_point_data_values(const function::Function& u);
+  static std::vector<PetscScalar>
+  get_point_data_values(const function::Function& u);
 
   // Get point data values collocated at P2 geometry points (vertices
   // and edges) flattened as a 2D array
-  static std::vector<double> get_p2_data_values(const function::Function& u);
+  static std::vector<PetscScalar> get_p2_data_values(const function::Function& u);
 
   // Get cell data values as a flattened 2D array
-  static std::vector<double> get_cell_data_values(const function::Function& u);
+  static std::vector<PetscScalar>
+  get_cell_data_values(const function::Function& u);
 
   // Check that string is the same on all processes. Returns true of
   // same on all processes.
@@ -609,5 +611,5 @@ inline void XDMFFile::add_data_item(MPI_Comm comm, pugi::xml_node& xml_node,
   add_data_item(comm, xml_node, h5_id, h5_path, x_int, shape, number_type);
 }
 #endif
-}
-}
+} // namespace io
+} // namespace dolfin

--- a/cpp/dolfin/io/XDMFFile.h
+++ b/cpp/dolfin/io/XDMFFile.h
@@ -435,7 +435,8 @@ private:
   // Add function to a XML node
   static void add_function(MPI_Comm comm, pugi::xml_node& xml_node, hid_t h5_id,
                            std::string h5_path, const function::Function& u,
-                           std::string function_name, const mesh::Mesh& mesh);
+                           std::string function_name, const mesh::Mesh& mesh, 
+                           std::string component);
 
   // Add set of points to XDMF xml_node and write data
   static void add_points(MPI_Comm comm, pugi::xml_node& xml_node, hid_t h5_id,

--- a/cpp/dolfin/io/XDMFFile.h
+++ b/cpp/dolfin/io/XDMFFile.h
@@ -435,8 +435,8 @@ private:
   // Add function to a XML node
   static void add_function(MPI_Comm comm, pugi::xml_node& xml_node, hid_t h5_id,
                            std::string h5_path, const function::Function& u,
-                           std::string function_name, const mesh::Mesh& mesh, 
-                           std::string component);
+                           std::string function_name, const mesh::Mesh& mesh,
+                           const std::string component = "");
 
   // Add set of points to XDMF xml_node and write data
   static void add_points(MPI_Comm comm, pugi::xml_node& xml_node, hid_t h5_id,
@@ -527,7 +527,8 @@ private:
 
   // Get point data values collocated at P2 geometry points (vertices
   // and edges) flattened as a 2D array
-  static std::vector<PetscScalar> get_p2_data_values(const function::Function& u);
+  static std::vector<PetscScalar>
+  get_p2_data_values(const function::Function& u);
 
   // Get cell data values as a flattened 2D array
   static std::vector<PetscScalar>

--- a/python/test/unit/io/test_XDMF_P2.py
+++ b/python/test/unit/io/test_XDMF_P2.py
@@ -8,7 +8,7 @@ import os
 from dolfin import (Function, FunctionSpace,
                     VectorFunctionSpace, Expression, MPI, cpp, fem)
 from dolfin.io import XDMFFile
-from dolfin_utils.test import tempdir, xfail_if_complex
+from dolfin_utils.test import tempdir
 assert(tempdir)
 
 
@@ -28,7 +28,6 @@ def test_read_write_p2_mesh(tempdir):
     assert mesh2.num_entities_global(0) == mesh.num_entities_global(0)
 
 
-@xfail_if_complex
 def test_read_write_p2_function(tempdir):
     mesh = cpp.generation.UnitDiscMesh.create(MPI.comm_world, 3,
                                               cpp.mesh.GhostMode.none)


### PR DESCRIPTION
Add support to:
 - Write complex functions 
        - `XDMFFile::write(const function::Function& u, const Encoding encoding)`
        - `XDMFFile::write(const function::Function& u, double time_step, const Encoding encoding)`

Different `Attribute` (`AttributeType = {Scalar, Vector, Tensor}`) are created for each component (real and imaginary). The prefixes `"real"` and `"imag"` are attached to the function name to identify the component. 

Excerpt from an output file :
```        
<Attribute Name="real_field" AttributeType="Scalar" Center="Node">
      <DataItem Dimensions="36 1" Format="HDF">output.h5:/VisualisationVector/real/0</DataItem>
</Attribute>
<Attribute Name="imag_field" AttributeType="Scalar" Center="Node">
      <DataItem Dimensions="36 1" Format="HDF">output.h5:/VisualisationVector/imag/0</DataItem>
</Attribute>
```

 - complex checkpointing (write and read): 
Three options have been tested for complex checkpointing:
1 - ~Add a `DataItem` for each component  (avoids additional copies but it is not compatible with Paraview)~
2 - Add a `FiniteElementFunction` for each component, similar to applying `add_function` twice
3 - ~Add a `Temporal` collection for each component, similar to calling `write_checkpoint` twice (Compatible with Paraview visualization; however data storage is doubled).~

**Edited:**
After some discussions,  option 2 was considered more convenient, 
All test are now green on both complex and real modes.
