### PR TITLE
Wrap cpp.io in python

### DIFF
--- a/python/demo/documented/biharmonic/demo_biharmonic.py.rst
+++ b/python/demo/documented/biharmonic/demo_biharmonic.py.rst
@@ -101,6 +101,7 @@ First, the necessary modules are imported::
 
     import matplotlib.pyplot as plt
     from dolfin import *
+    from dolfin.io import XDMFFile
 
 Next, some parameters for the form compiler are set::
 

--- a/python/demo/documented/poisson/demo_poisson.py.rst
+++ b/python/demo/documented/poisson/demo_poisson.py.rst
@@ -79,6 +79,7 @@ First, the :py:mod:`dolfin` module is imported: ::
     import numpy as np
     import dolfin
     from dolfin import *
+    from dolfin.io import XDMFFile
 
 We begin by defining a mesh of the domain and a finite element
 function space :math:`V` relative to this mesh. As the unit square is

--- a/python/demo/documented/stokes-iterative/demo_stokes-iterative.py.rst
+++ b/python/demo/documented/stokes-iterative/demo_stokes-iterative.py.rst
@@ -95,6 +95,7 @@ subspace method which is suitable for symmetric indefinite problems.
 If not available, costly QMR method is choosen. ::
 
     from dolfin import *
+    from dolfin.io import XDMFFile
 
 Next, we define the mesh (a :py:class:`UnitCubeMesh
 <dolfin.cpp.UnitCubeMesh>`) and a mixed finite element ``TH``.  Then

--- a/python/demo/documented/stokes-taylor-hood/demo_stokes-taylor-hood.py.rst
+++ b/python/demo/documented/stokes-taylor-hood/demo_stokes-taylor-hood.py.rst
@@ -85,6 +85,7 @@ following way::
 
     import dolfin
     from dolfin import *
+    from dolfin.io import XDMFFile
 
     # Load mesh and subdomains
     xdmf = XDMFFile(MPI.comm_world, "../dolfin_fine.xdmf")

--- a/python/demo/undocumented/buckling-tao/demo_buckling-tao.py
+++ b/python/demo/undocumented/buckling-tao/demo_buckling-tao.py
@@ -14,6 +14,7 @@ upwards (and not downwards) in order to minimise the potential energy."""
 
 
 from dolfin import *
+from dolfin.io import XDMFFile
 import matplotlib.pyplot as plt
 
 

--- a/python/demo/undocumented/contact-vi-tao/demo_contact-vi-tao.py
+++ b/python/demo/undocumented/contact-vi-tao/demo_contact-vi-tao.py
@@ -11,6 +11,7 @@ in a box of the same size."""
 
 
 from dolfin import *
+from dolfin.io import XDMFFile
 import matplotlib.pyplot as plt
 
 

--- a/python/demo/undocumented/elasticity/demo_elasticity.py
+++ b/python/demo/undocumented/elasticity/demo_elasticity.py
@@ -11,6 +11,7 @@ smoothed aggregation algerbaric multigrid."""
 import numpy as np
 import dolfin
 from dolfin import *
+from dolfin.io import XDMFFile
 from dolfin.la import (VectorSpaceBasis, PETScVector, PETScOptions,
                        PETScKrylovSolver)
 from dolfin.fem.assembling import assemble_system

--- a/python/demo/undocumented/poisson-disc/demo_poisson-disc.py
+++ b/python/demo/undocumented/poisson-disc/demo_poisson-disc.py
@@ -23,6 +23,7 @@ du/dn(x, y) = sin(5*x) for y = 0 or y = 1
 
 
 from dolfin import *
+from dolfin.io import XDMFFile
 import math
 parameters["form_compiler"]["representation"] = "uflacs"
 

--- a/python/doc/source/api.rst
+++ b/python/doc/source/api.rst
@@ -39,6 +39,8 @@ Python
 
    dolfin.generation
 
+   dolfin.io
+
    dolfin.jit
    dolfin.jit.jit
    dolfin.jit.pybind11jit

--- a/python/dolfin/__init__.py
+++ b/python/dolfin/__init__.py
@@ -37,16 +37,12 @@ from .cpp.common import (Variable, has_debug, has_hdf5, has_scotch,
                          git_commit_hash, DOLFIN_EPS, DOLFIN_PI, TimingType,
                          timing, timings, list_timings)
 
-if has_hdf5():
-    from .cpp.io import HDF5File
-
 from .cpp import MPI
 from .cpp.function import (Expression, Constant)
 from .cpp.fem import (FiniteElement, DofMap)
 
 from .cpp.geometry import BoundingBoxTree, Point
 from .cpp.generation import IntervalMesh, BoxMesh, RectangleMesh
-from .cpp.io import XDMFFile, VTKFile
 
 if has_slepc():
     from .cpp.la import SLEPcEigenSolver

--- a/python/dolfin/io.py
+++ b/python/dolfin/io.py
@@ -29,9 +29,7 @@ class HDF5File(cpp.io.HDF5File):
         dolfin.Function
         """
 
-        # Try to extract cpp object
         V_cpp = getattr(V, "_cpp_object", V)
-
         u_cpp = self.read(V_cpp, name)
         return Function(V, u_cpp.vector())
 
@@ -64,8 +62,6 @@ class XDMFFile(cpp.io.XDMFFile):
         dolfin.Function
         """
 
-        # Try to extract cpp object
         V_cpp = getattr(V, "_cpp_object", V)
-
         u_cpp = self._read_checkpoint(V_cpp, name, counter)
         return Function(V, u_cpp.vector())

--- a/python/dolfin/io.py
+++ b/python/dolfin/io.py
@@ -13,7 +13,7 @@ class HDF5File(cpp.io.HDF5File):
 
     def read_function(self, V, name: str):
         """Reads in function
-        
+
         Parameters
         ----------
         V
@@ -36,7 +36,8 @@ class HDF5File(cpp.io.HDF5File):
         return Function(V, u_cpp.vector())
 
 
-class VTKFile(cpp.io.VTKFile): pass
+class VTKFile(cpp.io.VTKFile):
+    pass
 
 
 class XDMFFile(cpp.io.XDMFFile):

--- a/python/test/unit/io/test_HDF5.py
+++ b/python/test/unit/io/test_HDF5.py
@@ -7,13 +7,14 @@
 import os
 
 import dolfin
-from dolfin import (MPI, Cell, Expression, Function, FunctionSpace, HDF5File,
-                    MeshEntities, MeshEntity, MeshFunction,
+from dolfin import (MPI, Cell, Expression, Function, FunctionSpace,
+                    MeshEntities, MeshEntity, MeshFunction, has_hdf5,
                     MeshValueCollection, UnitCubeMesh, UnitSquareMesh, cpp)
+if has_hdf5():
+    from dolfin.io import HDF5File
 from dolfin.la import PETScVector
 from dolfin_utils.test import (skip_if_not_HDF5, tempdir, xfail_if_complex,
                                xfail_with_serial_hdf5_in_parallel)
-import dolfin.io
 
 assert(tempdir)
 

--- a/python/test/unit/io/test_HDF5.py
+++ b/python/test/unit/io/test_HDF5.py
@@ -10,11 +10,11 @@ import dolfin
 from dolfin import (MPI, Cell, Expression, Function, FunctionSpace,
                     MeshEntities, MeshEntity, MeshFunction, has_hdf5,
                     MeshValueCollection, UnitCubeMesh, UnitSquareMesh, cpp)
-if has_hdf5():
-    from dolfin.io import HDF5File
 from dolfin.la import PETScVector
 from dolfin_utils.test import (skip_if_not_HDF5, tempdir, xfail_if_complex,
                                xfail_with_serial_hdf5_in_parallel)
+if has_hdf5():
+    from dolfin.io import HDF5File
 
 assert(tempdir)
 

--- a/python/test/unit/io/test_HDF5_series.py
+++ b/python/test/unit/io/test_HDF5_series.py
@@ -8,10 +8,10 @@ import os
 from dolfin import (UnitSquareMesh, MPI, FunctionSpace, Function, Expression,
                     has_hdf5)
 import dolfin.cpp as cpp
-if has_hdf5():
-    from dolfin.io import HDF5File
 from dolfin_utils.test import (skip_if_not_HDF5, tempdir, xfail_if_complex,
                                xfail_with_serial_hdf5_in_parallel)
+if has_hdf5():
+    from dolfin.io import HDF5File
 assert(tempdir)
 
 

--- a/python/test/unit/io/test_HDF5_series.py
+++ b/python/test/unit/io/test_HDF5_series.py
@@ -5,10 +5,13 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import os
-from dolfin import (UnitSquareMesh, MPI, FunctionSpace, Function, Expression, HDF5File)
+from dolfin import (UnitSquareMesh, MPI, FunctionSpace, Function, Expression,
+                    has_hdf5)
+import dolfin.cpp as cpp
+if has_hdf5():
+    from dolfin.io import HDF5File
 from dolfin_utils.test import (skip_if_not_HDF5, tempdir, xfail_if_complex,
                                xfail_with_serial_hdf5_in_parallel)
-import dolfin.io
 assert(tempdir)
 
 
@@ -43,5 +46,5 @@ def test_save_and_read_function_timeseries(tempdir):
         # timestamp = hdf5_file.attributes(vec_name)["timestamp"]
         # assert timestamp == t
         F0.vector().axpy(-1.0, F1.vector())
-        assert F0.vector().norm(dolfin.cpp.la.Norm.l2) < 1.0e-12
+        assert F0.vector().norm(cpp.la.Norm.l2) < 1.0e-12
     hdf5_file.close()

--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -6,11 +6,12 @@
 
 import pytest
 import os
-from dolfin import (XDMFFile, MPI, MeshValueCollection, MeshEntities, Vertices, Facets, Cells,
+from dolfin import (MPI, MeshValueCollection, MeshEntities, Vertices, Facets, Cells,
                     UnitCubeMesh, FunctionSpace, Function, Edges, MeshFunction, UnitSquareMesh,
                     VectorFunctionSpace, TensorFunctionSpace, UnitIntervalMesh, cpp, Expression,
                     interpolate, FiniteElement, VectorElement, Constant, has_hdf5, has_hdf5_parallel,
                     CellType)
+from dolfin.io import XDMFFile
 from dolfin_utils.test import tempdir
 assert(tempdir)
 

--- a/python/test/unit/io/test_XDMF_P2.py
+++ b/python/test/unit/io/test_XDMF_P2.py
@@ -5,8 +5,9 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import os
-from dolfin import (XDMFFile, Function, FunctionSpace,
+from dolfin import (Function, FunctionSpace,
                     VectorFunctionSpace, Expression, MPI, cpp, fem)
+from dolfin.io import XDMFFile
 from dolfin_utils.test import tempdir, xfail_if_complex
 assert(tempdir)
 

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -14,8 +14,9 @@ import FIAT
 from math import sqrt
 from dolfin import (MPI, RectangleMesh, BoxMesh, UnitIntervalMesh,
                     UnitSquareMesh, UnitCubeMesh, CellType, Vertex,
-                    XDMFFile, Point, Cell, Cells, MeshFunction,
+                    Point, Cell, Cells, MeshFunction,
                     MeshEntity, MeshEntities, cpp)
+from dolfin.io import XDMFFile
 from dolfin_utils.test import cd_tempdir, fixture, skip_in_parallel  # noqa
 
 


### PR DESCRIPTION
Idea of this PR is to separate `io` namespace and try new "nothing in cpp namespace be public" approach.
- Removed import of IO to global namespace in `__init__.py`.
- Wrapped `VTKFile`, `XDMFFile`, `HDF5File` in `io.py`