### PR TITLE
Start with hiding of dolfin.cpp (for IO) and improved doc generation

### DIFF
--- a/python/demo/documented/poisson/demo_poisson.py.rst
+++ b/python/demo/documented/poisson/demo_poisson.py.rst
@@ -190,7 +190,7 @@ the :py:func:`plot <dolfin.common.plot.plot>` command: ::
 
     # Save solution in XDMF format
     with XDMFFile(MPI.comm_world, "poisson.xdmf") as file:
-        file.write(u, XDMFFile.Encoding.HDF5)
+        file.write(u, encoding=XDMFFile.Encoding.HDF5)
 
     # Plot solution
     import matplotlib.pyplot as plt

--- a/python/demo/undocumented/poisson-disc/demo_poisson-disc.py
+++ b/python/demo/undocumented/poisson-disc/demo_poisson-disc.py
@@ -92,6 +92,6 @@ def compute_rates():
                 if MPI.size(MPI.comm_world) > 1 and encoding == XDMFFile.Encoding.ASCII:
                     print("XDMF file output not supported in parallel without HDF5")
                 else:
-                    ufile.write(u, encoding)
+                    ufile.write(u, encoding=encoding)
 
 compute_rates()

--- a/python/doc/source/conf.py
+++ b/python/doc/source/conf.py
@@ -170,3 +170,8 @@ texinfo_documents = [
 
 autodoc_default_flags = ['members', 'show-inheritance']
 autosummary_generate = True
+autoclass_content = "init"
+
+napoleon_google_docstring = False
+napoleon_use_admonition_for_notes = False
+#napoleon_include_init_with_doc= False

--- a/python/dolfin/io.py
+++ b/python/dolfin/io.py
@@ -38,15 +38,15 @@ class HDF5File:
         """Get atomicity of the HDF5 file"""
         return self._cpp_object.get_mpi_atomicity()
 
-    def set_mpi_atomicity(self, atomicity: bool):
+    def set_mpi_atomicity(self, atomicity: bool) -> None:
         """Set atomicity of the HDF5 file"""
         self._cpp_object.set_mpi_atomicity(atomicity)
 
-    def close(self):
+    def close(self) -> None:
         """Close file"""
         self._cpp_object.close()
 
-    def write(self, o, name, t=None):
+    def write(self, o, name, t=None) -> None:
         """Write object to file"""
         o_cpp = getattr(o, "_cpp_object", o)
         if t is None:
@@ -137,11 +137,11 @@ class XDMFFile:
     def __exit__(self, exception_type, exception_value, traceback):
         return self._cpp_object.close()
 
-    def close(self):
+    def close(self) -> None:
         """Close file"""
         self._cpp_object.close()
 
-    def write(self, o, t=None, encoding=Encoding.HDF5):
+    def write(self, o, t=None, encoding=Encoding.HDF5) -> None:
         """Write object to file
 
         Parameters
@@ -197,7 +197,7 @@ class XDMFFile:
     def read_mesh(self, mpi_comm, ghost_mode):
         return self._cpp_object.read_mesh(mpi_comm, ghost_mode)
 
-    def read_checkpoint(self, V, name: str, counter: int = -1):
+    def read_checkpoint(self, V, name: str, counter: int = -1) -> Function:
         """Read finite element Function from checkpointing format
 
         Parameters
@@ -229,7 +229,7 @@ class XDMFFile:
                          u,
                          name: str,
                          time_step: float = 0.0,
-                         encoding=Encoding.HDF5):
+                         encoding=Encoding.HDF5) -> None:
         """Write finite element Function in checkpointing format
 
         """

--- a/python/dolfin/io.py
+++ b/python/dolfin/io.py
@@ -141,12 +141,24 @@ class XDMFFile:
         """Close file"""
         self._cpp_object.close()
 
-    # FIXME: Clean up the ordering of arguments and remove *args and
-    # **kwargs - it's very confused
-    def write(self, o, *args, **kwargs):
-        """Write object to file"""
+    def write(self, o, t=None, encoding=Encoding.HDF5):
+        """Write object to file
+
+        Parameters
+        ----------
+        o
+            The object to write to file
+        t
+            The time stamp
+        encoding
+            File encoding for 'heavy' data
+
+        """
         o_cpp = getattr(o, "_cpp_object", o)
-        self._cpp_object.write(o_cpp, *args, **kwargs)
+        if t is None:
+            self._cpp_object.write(o_cpp, encoding)
+        else:
+            self._cpp_object.write(o_cpp, t, encoding)
 
     # ----------------------------------------------------------
 

--- a/python/dolfin/io.py
+++ b/python/dolfin/io.py
@@ -4,7 +4,7 @@
 # This file is part of DOLFIN (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
-"""IO interfaces for inout data, post-processing and checkpointing"""
+"""IO module for input data, post-processing and checkpointing"""
 
 import dolfin.cpp as cpp
 from dolfin.function.function import Function
@@ -112,11 +112,6 @@ class HDF5File:
         return Function(V, u_cpp.vector())
 
 
-class VTKFile(cpp.io.VTKFile):
-    """Interface to VTK files"""
-    pass
-
-
 class XDMFFile:
     """Interface to XDMF files"""
 
@@ -214,7 +209,7 @@ class XDMFFile:
         """
 
         V_cpp = getattr(V, "_cpp_object", V)
-        u_cpp = self._cpp_object._read_checkpoint(V_cpp, name, counter)
+        u_cpp = self._cpp_object.read_checkpoint(V_cpp, name, counter)
         return Function(V, u_cpp.vector())
 
     def write_checkpoint(self,

--- a/python/dolfin/io.py
+++ b/python/dolfin/io.py
@@ -4,15 +4,80 @@
 # This file is part of DOLFIN (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
-
 """IO interfaces for inout data, post-processing and checkpointing"""
 
 import dolfin.cpp as cpp
 from dolfin.function.function import Function
 
 
-class HDF5File(cpp.io.HDF5File):
+class HDF5File:
     """Interface to HDF5 files"""
+
+    def __init__(self, mpi_comm, filename: str, mode: str):
+        """Open HDF5 file
+
+        Parameters
+        ----------
+        mpi_comm
+            The MPI communicator
+        filename
+            Name of the file
+        mode
+            File opening mode, which can be write (w), read (r) or append (a)
+
+        """
+        self._cpp_object = cpp.io.HDF5File(mpi_comm, filename, mode)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        return self._cpp_object.close()
+
+    def close(self):
+        """Close file"""
+        self._cpp_object.close()
+
+    def write(self, o, name, t=None):
+        """Write object to file"""
+        o_cpp = getattr(o, "_cpp_object", o)
+        if t is None:
+            self._cpp_object.write(o_cpp, name)
+        else:
+            self._cpp_object.write(o_cpp, name, t)
+
+    def read_mvc(self, mesh, name: str = ""):
+        # FIXME: figure type out from file (or pass string)  and return?
+        raise NotImplementedError("General MVC read function not implemented.")
+
+    # def read_mvc(self, mesh, type: str, name: str = ""):
+    #     # FIXME: return appropriate MVC based on type string
+    #     raise NotImplementedError("General MVC read function not implemented.")
+
+    # ----------------------------------------------------------
+
+    # FIXME: implement a common function for multiple types
+
+    def read_mvc_size_t(self, mesh, name: str = ""):
+        """Read MeshValueCollection of type size_t"""
+        return self._cpp_object.read_mvc_size_t(mesh, name)
+
+    def read_mf_double(self, mesh, name: str = ""):
+        """Read MeshFunction of type float"""
+        return self._cpp_object.read_mf_double(mesh, name)
+
+    # ----------------------------------------------------------
+
+    def read_vector(self, mpi_comm, data_path: str,
+                    use_partition_from_file: bool):
+        """Read Vector"""
+        return self._cpp_object.read_vector(mpi_comm, data_path,
+                                            use_partition_from_file)
+
+    def read_mesh(self, mpi_comm, data_path: str,
+                  use_partition_from_file: bool, ghost_mode):
+        return self._cpp_object.read_mesh(mpi_comm, data_path,
+                                          use_partition_from_file, ghost_mode)
 
     def read_function(self, V, name: str):
         """Read finite element Function from file
@@ -23,18 +88,19 @@ class HDF5File(cpp.io.HDF5File):
             Function space of saved function.
         name
             Name of function as saved into HDF file.
-        Note
-        ----
-        Parameter `V: Function space` must be the same as saved function space
-        except for ordering of mesh entities.
         Returns
         -------
         dolfin.function.function.Function
             Function read from file
+
+        Note
+        ----
+        Parameter `V: Function space` must be the same as saved function space
+        except for ordering of mesh entities.
         """
 
         V_cpp = getattr(V, "_cpp_object", V)
-        u_cpp = self.read(V_cpp, name)
+        u_cpp = self._cpp_object.read(V_cpp, name)
         return Function(V, u_cpp.vector())
 
 
@@ -46,7 +112,7 @@ class VTKFile(cpp.io.VTKFile):
 class XDMFFile(cpp.io.XDMFFile):
     """Interface to XDMF files"""
 
-    def read_checkpoint(self, V, name: str, counter: int=-1):
+    def read_checkpoint(self, V, name: str, counter: int = -1):
         """Read finite element Function from checkpointing format
         Parameters
         ----------

--- a/python/dolfin/io.py
+++ b/python/dolfin/io.py
@@ -187,6 +187,7 @@ class XDMFFile:
 
     def read_checkpoint(self, V, name: str, counter: int = -1):
         """Read finite element Function from checkpointing format
+
         Parameters
         ----------
         V

--- a/python/src/io.cpp
+++ b/python/src/io.cpp
@@ -8,7 +8,6 @@
 #include <dolfin/function/FunctionSpace.h>
 #include <dolfin/geometry/Point.h>
 #include <dolfin/io/HDF5File.h>
-#include <dolfin/io/VTKFile.h>
 #include <dolfin/io/XDMFFile.h>
 #include <dolfin/la/PETScVector.h>
 #include <dolfin/mesh/Mesh.h>
@@ -30,15 +29,6 @@ namespace dolfin_wrappers
 
 void io(py::module& m)
 {
-  // dolfin::io::VTKFile
-  py::class_<dolfin::io::VTKFile, std::shared_ptr<dolfin::io::VTKFile>>(
-      m, "VTKFile")
-      .def(py::init<std::string>())
-      .def("write",
-           [](dolfin::io::VTKFile& instance, const dolfin::mesh::Mesh& mesh) {
-             instance.write(mesh);
-           });
-
   // dolfin::io::HDF5File
   py::class_<dolfin::io::HDF5File, std::shared_ptr<dolfin::io::HDF5File>,
              dolfin::common::Variable>(m, "HDF5File", py::dynamic_attr())
@@ -155,11 +145,7 @@ void io(py::module& m)
                                                            filename);
            }),
            py::arg("comm"), py::arg("filename"))
-      .def(py::init<std::string>())
-      .def("close", &dolfin::io::XDMFFile::close)
-      .def("__enter__", [](dolfin::io::XDMFFile& self) { return &self; })
-      .def("__exit__", [](dolfin::io::XDMFFile& self, py::args args,
-                          py::kwargs kwargs) { self.close(); });
+      .def("close", &dolfin::io::XDMFFile::close);
 
   // dolfin::io::XDMFFile::Encoding enums
   py::enum_<dolfin::io::XDMFFile::Encoding>(xdmf_file, "Encoding")
@@ -303,7 +289,7 @@ void io(py::module& m)
       .def("read_mvc_double", &dolfin::io::XDMFFile::read_mvc_double,
            py::arg("mesh"), py::arg("name") = "")
       // Checkpointing
-      .def("_read_checkpoint", &dolfin::io::XDMFFile::read_checkpoint,
+      .def("read_checkpoint", &dolfin::io::XDMFFile::read_checkpoint,
            py::arg("V"), py::arg("name"), py::arg("counter") = -1);
 }
 } // namespace dolfin_wrappers

--- a/python/src/io.cpp
+++ b/python/src/io.cpp
@@ -48,9 +48,6 @@ void io(py::module& m)
                                                            file_mode);
            }),
            py::arg("comm"), py::arg("filename"), py::arg("file_mode"))
-      .def("__enter__", [](dolfin::io::HDF5File& self) { return &self; })
-      .def("__exit__", [](dolfin::io::HDF5File& self, py::args args,
-                          py::kwargs kwargs) { self.close(); })
       .def("close", &dolfin::io::HDF5File::close)
       .def("flush", &dolfin::io::HDF5File::flush)
       // read
@@ -67,25 +64,6 @@ void io(py::module& m)
              return self.read_vector(comm.get(), data_path,
                                      use_partition_from_file);
            })
-
-      //   .def("read",
-      //        (void (dolfin::io::HDF5File::*)(
-      //            dolfin::mesh::MeshValueCollection<bool>&, std::string)
-      //            const) & dolfin::io::HDF5File::read,
-      //        py::arg("mvc"), py::arg("name"))
-      //   .def("read",
-      //        (void (dolfin::io::HDF5File::*)(
-      //            dolfin::mesh::MeshValueCollection<std::size_t>&,
-      //            std::string)
-      //             const)
-      //            & dolfin::io::HDF5File::read,
-      //        py::arg("mvc"), py::arg("name"))
-      //   .def("read",
-      //        (void (dolfin::io::HDF5File::*)(
-      //            dolfin::mesh::MeshValueCollection<double>&, std::string)
-      //            const) & dolfin::io::HDF5File::read,
-      //        py::arg("mvc"), py::arg("name"))
-
       .def("read_mf_bool", &dolfin::io::HDF5File::read_mf_bool, py::arg("mesh"),
            py::arg("name"))
       .def("read_mf_int", &dolfin::io::HDF5File::read_mf_int, py::arg("mesh"),
@@ -101,31 +79,6 @@ void io(py::module& m)
            py::arg("mesh"), py::arg("name"))
       .def("read_mvc_double", &dolfin::io::HDF5File::read_mvc_double,
            py::arg("mesh"), py::arg("name"))
-
-      //   .def("read",
-      //        (void
-      //        (dolfin::io::HDF5File::*)(dolfin::mesh::MeshFunction<bool>&,
-      //                                        std::string) const)
-      //            & dolfin::io::HDF5File::read,
-      //        py::arg("meshfunction"), py::arg("name"))
-      //   .def("read",
-      //        (void (dolfin::io::HDF5File::*)(
-      //            dolfin::mesh::MeshFunction<std::size_t>&, std::string)
-      //            const) & dolfin::io::HDF5File::read,
-      //        py::arg("meshfunction"), py::arg("name"))
-      //   .def("read",
-      //        (void
-      //        (dolfin::io::HDF5File::*)(dolfin::mesh::MeshFunction<int>&,
-      //                                        std::string) const)
-      //            & dolfin::io::HDF5File::read,
-      //        py::arg("meshfunction"), py::arg("name"))
-      //   .def("read",
-      //        (void
-      //        (dolfin::io::HDF5File::*)(dolfin::mesh::MeshFunction<double>&,
-      //                                        std::string) const)
-      //            & dolfin::io::HDF5File::read,
-      //        py::arg("meshfunction"), py::arg("name"))
-
       .def("read",
            py::overload_cast<
                std::shared_ptr<const dolfin::function::FunctionSpace>,
@@ -185,21 +138,6 @@ void io(py::module& m)
            (void (dolfin::io::HDF5File::*)(const dolfin::function::Function&,
                                            std::string, double))
                & dolfin::io::HDF5File::write,
-           py::arg("u"), py::arg("name"), py::arg("t"))
-      .def("write",
-           [](dolfin::io::HDF5File& self, py::object u, std::string name) {
-             auto _u
-                 = u.attr("_cpp_object").cast<dolfin::function::Function*>();
-             self.write(*_u, name);
-           },
-           py::arg("u"), py::arg("name"))
-      .def("write",
-           [](dolfin::io::HDF5File& self, py::object u, std::string name,
-              double t) {
-             auto _u
-                 = u.attr("_cpp_object").cast<dolfin::function::Function*>();
-             self.write(*_u, name, t);
-           },
            py::arg("u"), py::arg("name"), py::arg("t"))
       .def("set_mpi_atomicity", &dolfin::io::HDF5File::set_mpi_atomicity)
       .def("get_mpi_atomicity", &dolfin::io::HDF5File::get_mpi_atomicity)
@@ -328,41 +266,12 @@ void io(py::module& m)
            },
            py::arg("points"), py::arg("values"),
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
-      // py:object / dolfin.function.function.Function
-      .def("write",
-           [](dolfin::io::XDMFFile& instance, const py::object u,
-              dolfin::io::XDMFFile::Encoding encoding) {
-             auto _u
-                 = u.attr("_cpp_object").cast<dolfin::function::Function*>();
-             instance.write(*_u, encoding);
-           },
-           py::arg("u"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
-      .def("write",
-           [](dolfin::io::XDMFFile& instance, const py::object u, double t,
-              dolfin::io::XDMFFile::Encoding encoding) {
-             auto _u
-                 = u.attr("_cpp_object").cast<dolfin::function::Function*>();
-             instance.write(*_u, t, encoding);
-           },
-           py::arg("u"), py::arg("t"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
       // Check points
       .def("write_checkpoint",
            [](dolfin::io::XDMFFile& instance,
               const dolfin::function::Function& u, std::string function_name,
               double time_step, dolfin::io::XDMFFile::Encoding encoding) {
              instance.write_checkpoint(u, function_name, time_step, encoding);
-           },
-           py::arg("u"), py::arg("function_name"), py::arg("time_step") = 0.0,
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
-      .def("write_checkpoint",
-           [](dolfin::io::XDMFFile& instance, const py::object u,
-              std::string function_name, double time_step,
-              dolfin::io::XDMFFile::Encoding encoding) {
-             auto _u
-                 = u.attr("_cpp_object").cast<dolfin::function::Function*>();
-             instance.write_checkpoint(*_u, function_name, time_step, encoding);
            },
            py::arg("u"), py::arg("function_name"), py::arg("time_step") = 0.0,
            py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5);

--- a/python/src/io.cpp
+++ b/python/src/io.cpp
@@ -159,80 +159,69 @@ void io(py::module& m)
            (void (dolfin::io::XDMFFile::*)(const dolfin::function::Function&,
                                            dolfin::io::XDMFFile::Encoding))
                & dolfin::io::XDMFFile::write,
-           py::arg("u"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+           py::arg("u"), py::arg("encoding"))
       .def("write",
            (void (dolfin::io::XDMFFile::*)(const dolfin::function::Function&,
                                            double,
                                            dolfin::io::XDMFFile::Encoding))
                & dolfin::io::XDMFFile::write,
-           py::arg("u"), py::arg("t"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+           py::arg("u"), py::arg("t"), py::arg("encoding"))
       // Mesh
       .def("write",
            (void (dolfin::io::XDMFFile::*)(const dolfin::mesh::Mesh&,
                                            dolfin::io::XDMFFile::Encoding))
                & dolfin::io::XDMFFile::write,
-           py::arg("mesh"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+           py::arg("mesh"), py::arg("encoding"))
       // MeshFunction
       .def("write",
            (void (dolfin::io::XDMFFile::*)(
                const dolfin::mesh::MeshFunction<bool>&,
                dolfin::io::XDMFFile::Encoding))
                & dolfin::io::XDMFFile::write,
-           py::arg("mvc"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+           py::arg("mvc"), py::arg("encoding"))
       .def("write",
            (void (dolfin::io::XDMFFile::*)(
                const dolfin::mesh::MeshFunction<std::size_t>&,
                dolfin::io::XDMFFile::Encoding))
                & dolfin::io::XDMFFile::write,
-           py::arg("mvc"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+           py::arg("mvc"), py::arg("encoding"))
       .def("write",
            (void (dolfin::io::XDMFFile::*)(
                const dolfin::mesh::MeshFunction<int>&,
                dolfin::io::XDMFFile::Encoding))
                & dolfin::io::XDMFFile::write,
-           py::arg("mvc"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+           py::arg("mvc"), py::arg("encoding"))
       .def("write",
            (void (dolfin::io::XDMFFile::*)(
                const dolfin::mesh::MeshFunction<double>&,
                dolfin::io::XDMFFile::Encoding))
                & dolfin::io::XDMFFile::write,
-           py::arg("mvc"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+           py::arg("mvc"), py::arg("encoding"))
       // MeshValueCollection
       .def("write",
            (void (dolfin::io::XDMFFile::*)(
                const dolfin::mesh::MeshValueCollection<bool>&,
                dolfin::io::XDMFFile::Encoding))
                & dolfin::io::XDMFFile::write,
-           py::arg("mvc"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+           py::arg("mvc"), py::arg("encoding"))
       .def("write",
            (void (dolfin::io::XDMFFile::*)(
                const dolfin::mesh::MeshValueCollection<std::size_t>&,
                dolfin::io::XDMFFile::Encoding))
                & dolfin::io::XDMFFile::write,
-           py::arg("mvc"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+           py::arg("mvc"), py::arg("encoding"))
       .def("write",
            (void (dolfin::io::XDMFFile::*)(
                const dolfin::mesh::MeshValueCollection<int>&,
                dolfin::io::XDMFFile::Encoding))
                & dolfin::io::XDMFFile::write,
-           py::arg("mvc"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+           py::arg("mvc"), py::arg("encoding"))
       .def("write",
            (void (dolfin::io::XDMFFile::*)(
                const dolfin::mesh::MeshValueCollection<double>&,
                dolfin::io::XDMFFile::Encoding))
                & dolfin::io::XDMFFile::write,
-           py::arg("mvc"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+           py::arg("mvc"), py::arg("encoding"))
       // Points
       .def("write",
            [](dolfin::io::XDMFFile& instance, py::list points,
@@ -240,8 +229,7 @@ void io(py::module& m)
              auto _points = points.cast<std::vector<dolfin::geometry::Point>>();
              instance.write(_points, encoding);
            },
-           py::arg("points"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+           py::arg("points"), py::arg("encoding"))
       // Points with values
       .def("write",
            [](dolfin::io::XDMFFile& instance, py::list points,
@@ -251,7 +239,7 @@ void io(py::module& m)
              instance.write(_points, values, encoding);
            },
            py::arg("points"), py::arg("values"),
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5)
+           py::arg("encoding"))
       // Check points
       .def("write_checkpoint",
            [](dolfin::io::XDMFFile& instance,
@@ -260,7 +248,7 @@ void io(py::module& m)
              instance.write_checkpoint(u, function_name, time_step, encoding);
            },
            py::arg("u"), py::arg("function_name"), py::arg("time_step") = 0.0,
-           py::arg("encoding") = dolfin::io::XDMFFile::Encoding::HDF5);
+           py::arg("encoding"));
 
   // XDFMFile::read
   xdmf_file

--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -77,9 +77,9 @@ def test_multiple_datasets(tempdir, encoding):
     filename = os.path.join(tempdir, "multiple_mf.xdmf")
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-        xdmf.write(mesh, encoding)
-        xdmf.write(cf0, encoding)
-        xdmf.write(cf1, encoding)
+        xdmf.write(mesh, encoding=encoding)
+        xdmf.write(cf0, encoding=encoding)
+        xdmf.write(cf1, encoding=encoding)
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
         mesh = xdmf.read_mesh(MPI.comm_world, cpp.mesh.GhostMode.none)
@@ -96,7 +96,7 @@ def test_save_and_load_1d_mesh(tempdir, encoding):
     mesh = UnitIntervalMesh(MPI.comm_world, 32)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mesh, encoding)
+        file.write(mesh, encoding=encoding)
 
     with XDMFFile(MPI.comm_world, filename) as file:
         mesh2 = file.read_mesh(MPI.comm_world, cpp.mesh.GhostMode.none)
@@ -113,7 +113,7 @@ def test_save_and_load_2d_mesh(tempdir, encoding):
     mesh = UnitSquareMesh(MPI.comm_world, 32, 32)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mesh, encoding)
+        file.write(mesh, encoding=encoding)
 
     with XDMFFile(MPI.comm_world, filename) as file:
         mesh2 = file.read_mesh(MPI.comm_world, cpp.mesh.GhostMode.none)
@@ -130,7 +130,7 @@ def test_save_and_load_2d_quad_mesh(tempdir, encoding):
     mesh = UnitSquareMesh(MPI.comm_world, 32, 32, CellType.Type.quadrilateral)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mesh, encoding)
+        file.write(mesh, encoding=encoding)
 
     with XDMFFile(MPI.comm_world, filename) as file:
         mesh2 = file.read_mesh(MPI.comm_world, cpp.mesh.GhostMode.none)
@@ -147,7 +147,7 @@ def test_save_and_load_3d_mesh(tempdir, encoding):
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 4)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mesh, encoding)
+        file.write(mesh, encoding=encoding)
 
     with XDMFFile(MPI.comm_world, filename) as file:
         mesh2 = file.read_mesh(MPI.comm_world, cpp.mesh.GhostMode.none)
@@ -168,7 +168,7 @@ def test_save_1d_scalar(tempdir, encoding):
     u.vector()[:] = 1.0
 
     with XDMFFile(mesh.mpi_comm(), filename2) as file:
-        file.write(u, encoding)
+        file.write(u, encoding=encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -194,7 +194,7 @@ def test_save_and_checkpoint_scalar(tempdir, encoding, fe_degree, fe_family,
     u_out.interpolate(Expression("x[0]", degree=1))
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write_checkpoint(u_out, "u_out", 0, encoding)
+        file.write_checkpoint(u_out, "u_out", 0, encoding=encoding)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
         u_in = file.read_checkpoint(V, "u_out", 0)
@@ -231,7 +231,7 @@ def test_save_and_checkpoint_vector(tempdir, encoding, fe_degree, fe_family,
         u_out.interpolate(Expression(("x[0]*x[1]", "x[0]", "x[2]"), degree=2))
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write_checkpoint(u_out, "u_out", 0, encoding)
+        file.write_checkpoint(u_out, "u_out", 0, encoding=encoding)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
         u_in = file.read_checkpoint(V, "u_out", 0)
@@ -257,7 +257,7 @@ def test_save_and_checkpoint_timeseries(tempdir, encoding):
     with XDMFFile(mesh.mpi_comm(), filename) as file:
         for i, p in enumerate(times):
             u_out[i] = interpolate(Expression("x[0]*p", p=p, degree=1), V)
-            file.write_checkpoint(u_out[i], "u_out", p, encoding)
+            file.write_checkpoint(u_out[i], "u_out", p, encoding=encoding)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
         for i, p in enumerate(times):
@@ -287,7 +287,7 @@ def test_save_2d_scalar(tempdir, encoding):
     u.vector()[:] = 1.0
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding)
+        file.write(u, encoding=encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -301,7 +301,7 @@ def test_save_3d_scalar(tempdir, encoding):
     u.vector()[:] = 1.0
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding)
+        file.write(u, encoding=encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -316,7 +316,7 @@ def test_save_2d_vector(tempdir, encoding):
     u.interpolate(c)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding)
+        file.write(u, encoding=encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -330,7 +330,7 @@ def test_save_3d_vector(tempdir, encoding):
     u.interpolate(c)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding)
+        file.write(u, encoding=encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -343,13 +343,13 @@ def test_save_3d_vector_series(tempdir, encoding):
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
         u.vector()[:] = 1.0
-        file.write(u, 0.1, encoding)
+        file.write(u, 0.1, encoding=encoding)
 
         u.vector()[:] = 2.0
-        file.write(u, 0.2, encoding)
+        file.write(u, 0.2, encoding=encoding)
 
         u.vector()[:] = 3.0
-        file.write(u, 0.3, encoding)
+        file.write(u, 0.3, encoding=encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -362,7 +362,7 @@ def test_save_2d_tensor(tempdir, encoding):
     u.vector()[:] = 1.0
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding)
+        file.write(u, encoding=encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -375,7 +375,7 @@ def test_save_3d_tensor(tempdir, encoding):
     u.vector()[:] = 1.0
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding)
+        file.write(u, encoding=encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -389,7 +389,7 @@ def test_save_1d_mesh(tempdir, encoding):
         mf[cell] = cell.index()
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mf, encoding)
+        file.write(mf, encoding=encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -408,7 +408,7 @@ def test_save_2D_cell_function(tempdir, encoding, data_type):
         mf[cell] = dtype(cell.index())
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mf, encoding)
+        file.write(mf, encoding=encoding)
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
         read_function = getattr(xdmf, "read_mf_" + dtype_str)
@@ -436,7 +436,7 @@ def test_save_3D_cell_function(tempdir, encoding, data_type):
     filename = os.path.join(tempdir, "mf_3D_%s.xdmf" % dtype_str)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mf, encoding)
+        file.write(mf, encoding=encoding)
 
     # mf_in = MeshFunction(dtype_str, mesh, mesh.topology.dim, 0)
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
@@ -470,7 +470,7 @@ def test_save_2D_facet_function(tempdir, encoding, data_type):
     filename = os.path.join(tempdir, "mf_facet_2D_%s.xdmf" % dtype_str)
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-        xdmf.write(mf, encoding)
+        xdmf.write(mf, encoding=encoding)
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
         read_function = getattr(xdmf, "read_mf_" + dtype_str)
@@ -503,7 +503,7 @@ def test_save_3D_facet_function(tempdir, encoding, data_type):
     filename = os.path.join(tempdir, "mf_facet_3D_%s.xdmf" % dtype_str)
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-        xdmf.write(mf, encoding)
+        xdmf.write(mf, encoding=encoding)
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
         read_function = getattr(xdmf, "read_mf_" + dtype_str)
@@ -531,7 +531,7 @@ def test_save_3D_edge_function(tempdir, encoding, data_type):
 
     filename = os.path.join(tempdir, "mf_edge_3D_%s.xdmf" % dtype_str)
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mf, encoding)
+        file.write(mf, encoding=encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -550,7 +550,7 @@ def test_save_2D_vertex_function(tempdir, encoding, data_type):
     filename = os.path.join(tempdir, "mf_vertex_2D_%s.xdmf" % dtype_str)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mf, encoding)
+        file.write(mf, encoding=encoding)
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
         read_function = getattr(xdmf, "read_mf_" + dtype_str)
@@ -577,7 +577,7 @@ def test_save_3D_vertex_function(tempdir, encoding, data_type):
         mf[vertex] = dtype(vertex.index())
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mf, encoding)
+        file.write(mf, encoding=encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -593,11 +593,11 @@ def test_save_points_2D(tempdir, encoding):
     vals = numpy.array(values)
 
     with XDMFFile(mesh.mpi_comm(), os.path.join(tempdir, "points_2D.xdmf")) as file:
-        file.write(points, encoding)
+        file.write(points, encoding=encoding)
 
     with XDMFFile(mesh.mpi_comm(), os.path.join(tempdir,
                                                 "points_values_2D.xdmf")) as file:
-        file.write(points, vals, encoding)
+        file.write(points, vals, encoding=encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -613,10 +613,10 @@ def test_save_points_3D(tempdir, encoding):
     vals = numpy.array(values)
 
     with XDMFFile(mesh.mpi_comm(), os.path.join(tempdir, "points_3D.xdmf")) as file:
-        file.write(points, encoding)
+        file.write(points, encoding=encoding)
 
     with XDMFFile(mesh.mpi_comm(), os.path.join(tempdir, "points_values_3D.xdmf")) as file:
-        file.write(points, vals, encoding)
+        file.write(points, vals, encoding=encoding)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -650,8 +650,8 @@ def test_save_mesh_value_collection(tempdir, encoding, data_type):
         filename = os.path.join(tempdir, "mvc_%d.xdmf" % mvc_dim)
 
         with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-            xdmf.write(meshfn, encoding)
-            xdmf.write(mvc, encoding)
+            xdmf.write(meshfn, encoding=encoding)
+            xdmf.write(mvc, encoding=encoding)
 
         with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
             read_function = getattr(xdmf, "read_mvc_" + dtype_str)
@@ -698,9 +698,9 @@ def test_append_and_load_mesh_functions(tempdir, encoding, data_type):
 
         with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
             xdmf.write(mesh)
-            xdmf.write(vf, encoding)
-            xdmf.write(ff, encoding)
-            xdmf.write(cf, encoding)
+            xdmf.write(vf, encoding=encoding)
+            xdmf.write(ff, encoding=encoding)
+            xdmf.write(cf, encoding=encoding)
 
         with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
             read_function = getattr(xdmf, "read_mf_" + dtype_str)

--- a/python/test/unit/io/test_XDMF_P2.py
+++ b/python/test/unit/io/test_XDMF_P2.py
@@ -18,7 +18,7 @@ def test_read_write_p2_mesh(tempdir):
 
     filename = os.path.join(tempdir, "tri6_mesh.xdmf")
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-        xdmf.write(mesh, XDMFFile.Encoding.HDF5)
+        xdmf.write(mesh, encoding=XDMFFile.Encoding.HDF5)
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
         mesh2 = xdmf.read_mesh(mesh.mpi_comm(), cpp.mesh.GhostMode.none)
@@ -40,7 +40,7 @@ def test_read_write_p2_function(tempdir):
 
     filename = os.path.join(tempdir, "tri6_function.xdmf")
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-        xdmf.write(F, XDMFFile.Encoding.HDF5)
+        xdmf.write(F, encoding=XDMFFile.Encoding.HDF5)
 
     Q = VectorFunctionSpace(mesh, "Lagrange", 1)
     F = Function(Q)
@@ -48,4 +48,4 @@ def test_read_write_p2_function(tempdir):
 
     filename = os.path.join(tempdir, "tri6_vector_function.xdmf")
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-        xdmf.write(F, XDMFFile.Encoding.HDF5)
+        xdmf.write(F, encoding=XDMFFile.Encoding.HDF5)

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -261,7 +261,7 @@ def test_Write(cd_tempdir, f):
     f[0] = 1
     f[1] = 2
     file = XDMFFile(f.mesh().mpi_comm(), "saved_mesh_function.xdmf")
-    file.write(f, XDMFFile.Encoding.ASCII)
+    file.write(f, encoding=XDMFFile.Encoding.ASCII)
 
 
 def test_hash():


### PR DESCRIPTION
This is a start on designing a way to make the `dolfin.cpp` interface private and to generate much improved documentation for the Python interface. Only `dolfin.io` is addressed at this stage.

- Making the `dolfin.cpp` interface private (still accessible, but not part of the 'public' interface) gives a nice separation between the C++ and Python interfaces, and means that a change in the C++ interface does not need to lead to a consequent change in the Python interface (which will be a very good thing).
- Declaring a 'public' Python interface gives us something we can aim to keep stable and manage changes/deprecations in an orderly fashion, and document well. Advanced users can access the `dolfin.cpp` interfaces, with the awareness that they can change.
- The unwrapping of objects, e.g. getting the `cpp.function.Function` from `dolfin.Function` to pass into the C++ code can be done easily in the Python layer, rather than the more complex present implementation in the pybind11 layer (which involves accessing Python attributes from C++).
- We don't  need special Python functions in the pybind11 layer, e.g. `__exit__` and `__exit__`, since these are implemented in the Python interface.

This isn't the final product for `dolfin.io`, but a basis for further design experimentation and improvement.