### PR TITLE
Put encoding to XDMFFile constructor

### DIFF
--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -291,7 +291,7 @@ void XDMFFile::write_checkpoint(const function::Function& u,
 
 #ifdef HAS_HDF5
   // Close the HDF5 file if in "flush" mode
-  if (encoding == Encoding::HDF5 and parameters["flush_output"])
+  if (_encoding == Encoding::HDF5 and parameters["flush_output"])
   {
     log::log(PROGRESS, "Writing function in \"flush_output\" mode. HDF5 "
                        "file will be flushed (closed).");

--- a/cpp/dolfin/io/XDMFFile.h
+++ b/cpp/dolfin/io/XDMFFile.h
@@ -217,8 +217,7 @@ public:
   /// @param    encoding (_Encoding_)
   ///         Encoding to use: HDF5 or ASCII
   ///
-  void write(const mesh::MeshFunction<int>& meshfunction,
-             Encoding encoding = default_encoding);
+  void write(const mesh::MeshFunction<int>& meshfunction);
 
   /// Save mesh::MeshFunction to file using an associated HDF5 file, or
   /// storing the data inline as XML.

--- a/cpp/dolfin/io/XDMFFile.h
+++ b/cpp/dolfin/io/XDMFFile.h
@@ -105,10 +105,11 @@ public:
 #endif
 
   /// Constructor
-  XDMFFile(const std::string filename) : XDMFFile(MPI_COMM_WORLD, filename) {}
+  XDMFFile(const std::string filename)
+      : XDMFFile(MPI_COMM_WORLD, filename, default_encoding) {}
 
   /// Constructor
-  XDMFFile(MPI_Comm comm, const std::string filename);
+  XDMFFile(MPI_Comm comm, const std::string filename, Encoding encoding);
 
   /// Destructor
   ~XDMFFile();
@@ -136,7 +137,7 @@ public:
   /// @param    encoding (_Encoding_)
   ///         Encoding to use: HDF5 or ASCII
   ///
-  void write(const mesh::Mesh& mesh, Encoding encoding = default_encoding);
+  void write(const mesh::Mesh& mesh);
 
   /// Save a function::Function to XDMF file for checkpointing, using an
   /// associated HDF5 file, or storing the data inline as XML.
@@ -160,8 +161,7 @@ public:
   ///         Encoding to use: HDF5 or ASCII
   ///
   void write_checkpoint(const function::Function& u, std::string function_name,
-                        double time_step = 0.0,
-                        Encoding encoding = default_encoding);
+                        double time_step = 0.0);
 
   /// Save a function::Function to XDMF file for visualisation, using an
   /// associated HDF5 file, or storing the data inline as XML.
@@ -171,7 +171,7 @@ public:
   /// @param    encoding (_Encoding_)
   ///         Encoding to use: HDF5 or ASCII
   ///
-  void write(const function::Function& u, Encoding encoding = default_encoding);
+  void write(const function::Function& u);
 
   /// Save a function::Function with timestamp to XDMF file for visualisation,
   /// using an associated HDF5 file, or storing the data inline as
@@ -197,8 +197,7 @@ public:
   /// @param   encoding (_Encoding_)
   ///         Encoding to use: HDF5 or ASCII
   ///
-  void write(const function::Function& u, double t,
-             Encoding encoding = default_encoding);
+  void write(const function::Function& u, double t);
 
   /// Save mesh::MeshFunction to file using an associated HDF5 file, or
   /// storing the data inline as XML.
@@ -208,8 +207,7 @@ public:
   /// @param    encoding (_Encoding_)
   ///         Encoding to use: HDF5 or ASCII
   ///
-  void write(const mesh::MeshFunction<bool>& meshfunction,
-             Encoding encoding = default_encoding);
+  void write(const mesh::MeshFunction<bool>& meshfunction);
 
   /// Save mesh::MeshFunction to file using an associated HDF5 file, or
   /// storing the data inline as XML.
@@ -230,8 +228,7 @@ public:
   /// @param    encoding (_Encoding_)
   ///         Encoding to use: HDF5 or ASCII
   ///
-  void write(const mesh::MeshFunction<std::size_t>& meshfunction,
-             Encoding encoding = default_encoding);
+  void write(const mesh::MeshFunction<std::size_t>& meshfunction);
 
   /// Save mesh::MeshFunction to file using an associated HDF5 file, or
   /// storing the data inline as XML.
@@ -241,8 +238,7 @@ public:
   /// @param    encoding (_Encoding_)
   ///         Encoding to use: HDF5 or ASCII
   ///
-  void write(const mesh::MeshFunction<double>& meshfunction,
-             Encoding encoding = default_encoding);
+  void write(const mesh::MeshFunction<double>& meshfunction);
 
   /// Write out mesh value collection (subset) using an associated
   /// HDF5 file, or storing the data inline as XML.
@@ -252,8 +248,7 @@ public:
   /// @param encoding (_Encoding_)
   ///         Encoding to use: HDF5 or ASCII
   ///
-  void write(const mesh::MeshValueCollection<bool>& mvc,
-             Encoding encoding = default_encoding);
+  void write(const mesh::MeshValueCollection<bool>& mvc);
 
   /// Write out mesh value collection (subset) using an associated
   /// HDF5 file, or storing the data inline as XML.
@@ -263,8 +258,7 @@ public:
   /// @param encoding (_Encoding_)
   ///         Encoding to use: HDF5 or ASCII
   ///
-  void write(const mesh::MeshValueCollection<int>& mvc,
-             Encoding encoding = default_encoding);
+  void write(const mesh::MeshValueCollection<int>& mvc);
 
   /// Write out mesh value collection (subset) using an associated
   /// HDF5 file, or storing the data inline as XML.
@@ -274,8 +268,7 @@ public:
   /// @param  encoding (_Encoding_)
   ///         Encoding to use: HDF5 or ASCII
   ///
-  void write(const mesh::MeshValueCollection<std::size_t>& mvc,
-             Encoding encoding = default_encoding);
+  void write(const mesh::MeshValueCollection<std::size_t>& mvc);
 
   /// Write out mesh value collection (subset) using an associated
   /// HDF5 file, or storing the data inline as XML.
@@ -285,8 +278,7 @@ public:
   /// @param encoding (_Encoding_)
   ///         Encoding to use: HDF5 or ASCII
   ///
-  void write(const mesh::MeshValueCollection<double>& mvc,
-             Encoding encoding = default_encoding);
+  void write(const mesh::MeshValueCollection<double>& mvc);
 
   /// Save a cloud of points to file using an associated HDF5 file,
   /// or storing the data inline as XML.
@@ -296,8 +288,7 @@ public:
   /// @param    encoding (_Encoding_)
   ///         Encoding to use: HDF5 or ASCII
   ///
-  void write(const std::vector<geometry::Point>& points,
-             Encoding encoding = default_encoding);
+  void write(const std::vector<geometry::Point>& points);
 
   /// Save a cloud of points, with scalar values using an associated
   /// HDF5 file, or storing the data inline as XML.
@@ -310,8 +301,7 @@ public:
   ///         Encoding to use: HDF5 or ASCII
   ///
   void write(const std::vector<geometry::Point>& points,
-             const std::vector<double>& values,
-             Encoding encoding = default_encoding);
+             const std::vector<double>& values);
 
   /// Read in the first mesh::Mesh in XDMF file
   ///
@@ -426,8 +416,7 @@ public:
 private:
   // Generic MVC writer
   template <typename T>
-  void write_mesh_value_collection(const mesh::MeshValueCollection<T>& mvc,
-                                   Encoding encoding);
+  void write_mesh_value_collection(const mesh::MeshValueCollection<T>& mvc);
 
   // Generic MVC reader
   template <typename T>
@@ -525,8 +514,7 @@ private:
 
   // Generic mesh::MeshFunction writer
   template <typename T>
-  void write_mesh_function(const mesh::MeshFunction<T>& meshfunction,
-                           Encoding encoding);
+  void write_mesh_function(const mesh::MeshFunction<T>& meshfunction);
 
   // Get data width - normally the same as u.value_size(), but expand
   // for 2D vector/tensor because XDMF presents everything as 3D
@@ -590,6 +578,8 @@ private:
   // The XML document currently representing the XDMF which needs to be
   // kept open for time series etc.
   std::unique_ptr<pugi::xml_document> _xml_doc;
+
+  Encoding _encoding;
 };
 
 #ifndef DOXYGEN_IGNORE

--- a/cpp/dolfin/io/XDMFFile.h
+++ b/cpp/dolfin/io/XDMFFile.h
@@ -105,11 +105,8 @@ public:
 #endif
 
   /// Constructor
-  XDMFFile(const std::string filename)
-      : XDMFFile(MPI_COMM_WORLD, filename, default_encoding) {}
-
-  /// Constructor
-  XDMFFile(MPI_Comm comm, const std::string filename, Encoding encoding);
+  XDMFFile(MPI_Comm comm, const std::string filename,
+           Encoding encoding = default_encoding);
 
   /// Destructor
   ~XDMFFile();
@@ -578,7 +575,7 @@ private:
   // kept open for time series etc.
   std::unique_ptr<pugi::xml_document> _xml_doc;
 
-  Encoding _encoding;
+  const Encoding _encoding;
 };
 
 #ifndef DOXYGEN_IGNORE

--- a/python/demo/documented/poisson/demo_poisson.py.rst
+++ b/python/demo/documented/poisson/demo_poisson.py.rst
@@ -189,8 +189,9 @@ for later visualization and also plot it using
 the :py:func:`plot <dolfin.common.plot.plot>` command: ::
 
     # Save solution in XDMF format
-    with XDMFFile(MPI.comm_world, "poisson.xdmf") as file:
-        file.write(u, encoding=XDMFFile.Encoding.HDF5)
+    with XDMFFile(MPI.comm_world, "poisson.xdmf",
+                  encoding=XDMFFile.Encoding.HDF5) as file:
+        file.write(u)
 
     # Plot solution
     import matplotlib.pyplot as plt

--- a/python/dolfin/io.py
+++ b/python/dolfin/io.py
@@ -118,7 +118,7 @@ class XDMFFile:
     # Import encoding (find better way?)
     Encoding = cpp.io.XDMFFile.Encoding
 
-    def __init__(self, mpi_comm, filename: str):
+    def __init__(self, mpi_comm, filename: str, encoding=Encoding.HDF5):
         """Open XDMF file
 
         Parameters
@@ -127,9 +127,11 @@ class XDMFFile:
             The MPI communicator
         filename
             Name of the file
+        encoding
+            Encoding used for 'heavy' data when writing/appending
 
         """
-        self._cpp_object = cpp.io.XDMFFile(mpi_comm, filename)
+        self._cpp_object = cpp.io.XDMFFile(mpi_comm, filename, encoding)
 
     def __enter__(self):
         return self
@@ -141,7 +143,7 @@ class XDMFFile:
         """Close file"""
         self._cpp_object.close()
 
-    def write(self, o, t=None, encoding=Encoding.HDF5) -> None:
+    def write(self, o, t=None) -> None:
         """Write object to file
 
         Parameters
@@ -150,15 +152,13 @@ class XDMFFile:
             The object to write to file
         t
             The time stamp
-        encoding
-            File encoding for 'heavy' data
 
         """
         o_cpp = getattr(o, "_cpp_object", o)
         if t is None:
-            self._cpp_object.write(o_cpp, encoding)
+            self._cpp_object.write(o_cpp)
         else:
-            self._cpp_object.write(o_cpp, t, encoding)
+            self._cpp_object.write(o_cpp, t)
 
     # ----------------------------------------------------------
 
@@ -228,11 +228,10 @@ class XDMFFile:
     def write_checkpoint(self,
                          u,
                          name: str,
-                         time_step: float = 0.0,
-                         encoding=Encoding.HDF5) -> None:
+                         time_step: float = 0.0) -> None:
         """Write finite element Function in checkpointing format
 
         """
 
         o_cpp = getattr(u, "_cpp_object", u)
-        self._cpp_object.write_checkpoint(o_cpp, name, time_step, encoding)
+        self._cpp_object.write_checkpoint(o_cpp, name, time_step)

--- a/python/src/io.cpp
+++ b/python/src/io.cpp
@@ -140,11 +140,12 @@ void io(py::module& m)
       xdmf_file(m, "XDMFFile");
 
   xdmf_file
-      .def(py::init([](const MPICommWrapper comm, std::string filename) {
-             return std::make_unique<dolfin::io::XDMFFile>(comm.get(),
-                                                           filename);
+      .def(py::init([](const MPICommWrapper comm, std::string filename,
+                       dolfin::io::XDMFFile::Encoding encoding) {
+             return std::make_unique<dolfin::io::XDMFFile>(comm.get(), filename,
+                                                           encoding);
            }),
-           py::arg("comm"), py::arg("filename"))
+           py::arg("comm"), py::arg("filename"), py::arg("encoding"))
       .def("close", &dolfin::io::XDMFFile::close);
 
   // dolfin::io::XDMFFile::Encoding enums
@@ -156,99 +157,76 @@ void io(py::module& m)
   xdmf_file
       // Function
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(const dolfin::function::Function&,
-                                           dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
-           py::arg("u"), py::arg("encoding"))
+           py::overload_cast<const dolfin::function::Function&>(
+               &dolfin::io::XDMFFile::write),
+           py::arg("u"))
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(const dolfin::function::Function&,
-                                           double,
-                                           dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
-           py::arg("u"), py::arg("t"), py::arg("encoding"))
+           py::overload_cast<const dolfin::function::Function&, double>(
+               &dolfin::io::XDMFFile::write),
+           py::arg("u"), py::arg("t"))
       // Mesh
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(const dolfin::mesh::Mesh&,
-                                           dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
-           py::arg("mesh"), py::arg("encoding"))
+           py::overload_cast<const dolfin::mesh::Mesh&>(
+               &dolfin::io::XDMFFile::write),
+           py::arg("mesh"))
       // MeshFunction
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshFunction<bool>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
-           py::arg("mvc"), py::arg("encoding"))
+           py::overload_cast<const dolfin::mesh::MeshFunction<bool>&>(
+               &dolfin::io::XDMFFile::write),
+           py::arg("mf"))
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshFunction<std::size_t>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
-           py::arg("mvc"), py::arg("encoding"))
+           py::overload_cast<const dolfin::mesh::MeshFunction<std::size_t>&>(
+               &dolfin::io::XDMFFile::write),
+           py::arg("mf"))
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshFunction<int>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
-           py::arg("mvc"), py::arg("encoding"))
+           py::overload_cast<const dolfin::mesh::MeshFunction<int>&>(
+               &dolfin::io::XDMFFile::write),
+           py::arg("mf"))
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshFunction<double>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
-           py::arg("mvc"), py::arg("encoding"))
+           py::overload_cast<const dolfin::mesh::MeshFunction<double>&>(
+               &dolfin::io::XDMFFile::write),
+           py::arg("mf"))
       // MeshValueCollection
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshValueCollection<bool>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
-           py::arg("mvc"), py::arg("encoding"))
+           py::overload_cast<const dolfin::mesh::MeshValueCollection<bool>&>(
+               &dolfin::io::XDMFFile::write),
+           py::arg("mvc"))
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshValueCollection<std::size_t>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
-           py::arg("mvc"), py::arg("encoding"))
+           py::overload_cast<
+               const dolfin::mesh::MeshValueCollection<std::size_t>&>(
+               &dolfin::io::XDMFFile::write),
+           py::arg("mvc"))
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshValueCollection<int>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
-           py::arg("mvc"), py::arg("encoding"))
+           py::overload_cast<const dolfin::mesh::MeshValueCollection<int>&>(
+               &dolfin::io::XDMFFile::write),
+           py::arg("mvc"))
       .def("write",
-           (void (dolfin::io::XDMFFile::*)(
-               const dolfin::mesh::MeshValueCollection<double>&,
-               dolfin::io::XDMFFile::Encoding))
-               & dolfin::io::XDMFFile::write,
-           py::arg("mvc"), py::arg("encoding"))
+           py::overload_cast<const dolfin::mesh::MeshValueCollection<double>&>(
+               &dolfin::io::XDMFFile::write),
+           py::arg("mvc"))
       // Points
       .def("write",
-           [](dolfin::io::XDMFFile& instance, py::list points,
-              dolfin::io::XDMFFile::Encoding encoding) {
+           [](dolfin::io::XDMFFile& instance, py::list points) {
              auto _points = points.cast<std::vector<dolfin::geometry::Point>>();
-             instance.write(_points, encoding);
+             instance.write(_points);
            },
-           py::arg("points"), py::arg("encoding"))
+           py::arg("points"))
       // Points with values
       .def("write",
            [](dolfin::io::XDMFFile& instance, py::list points,
-              std::vector<double>& values,
-              dolfin::io::XDMFFile::Encoding encoding) {
+              std::vector<double>& values) {
              auto _points = points.cast<std::vector<dolfin::geometry::Point>>();
-             instance.write(_points, values, encoding);
+             instance.write(_points, values);
            },
-           py::arg("points"), py::arg("values"),
-           py::arg("encoding"))
+           py::arg("points"), py::arg("values"))
       // Check points
       .def("write_checkpoint",
            [](dolfin::io::XDMFFile& instance,
               const dolfin::function::Function& u, std::string function_name,
-              double time_step, dolfin::io::XDMFFile::Encoding encoding) {
-             instance.write_checkpoint(u, function_name, time_step, encoding);
+              double time_step) {
+             instance.write_checkpoint(u, function_name, time_step);
            },
-           py::arg("u"), py::arg("function_name"), py::arg("time_step") = 0.0,
-           py::arg("encoding"));
+           py::arg("u"), py::arg("function_name"), py::arg("time_step") = 0.0);
 
   // XDFMFile::read
   xdmf_file

--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -76,10 +76,10 @@ def test_multiple_datasets(tempdir, encoding):
     cf1.rename('cf1')
     filename = os.path.join(tempdir, "multiple_mf.xdmf")
 
-    with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-        xdmf.write(mesh, encoding=encoding)
-        xdmf.write(cf0, encoding=encoding)
-        xdmf.write(cf1, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as xdmf:
+        xdmf.write(mesh)
+        xdmf.write(cf0)
+        xdmf.write(cf1)
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
         mesh = xdmf.read_mesh(MPI.comm_world, cpp.mesh.GhostMode.none)
@@ -95,8 +95,8 @@ def test_save_and_load_1d_mesh(tempdir, encoding):
     filename = os.path.join(tempdir, "mesh.xdmf")
     mesh = UnitIntervalMesh(MPI.comm_world, 32)
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mesh, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(mesh)
 
     with XDMFFile(MPI.comm_world, filename) as file:
         mesh2 = file.read_mesh(MPI.comm_world, cpp.mesh.GhostMode.none)
@@ -112,8 +112,8 @@ def test_save_and_load_2d_mesh(tempdir, encoding):
     filename = os.path.join(tempdir, "mesh_2D.xdmf")
     mesh = UnitSquareMesh(MPI.comm_world, 32, 32)
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mesh, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(mesh)
 
     with XDMFFile(MPI.comm_world, filename) as file:
         mesh2 = file.read_mesh(MPI.comm_world, cpp.mesh.GhostMode.none)
@@ -129,8 +129,8 @@ def test_save_and_load_2d_quad_mesh(tempdir, encoding):
     filename = os.path.join(tempdir, "mesh_2D_quad.xdmf")
     mesh = UnitSquareMesh(MPI.comm_world, 32, 32, CellType.Type.quadrilateral)
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mesh, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(mesh)
 
     with XDMFFile(MPI.comm_world, filename) as file:
         mesh2 = file.read_mesh(MPI.comm_world, cpp.mesh.GhostMode.none)
@@ -146,8 +146,8 @@ def test_save_and_load_3d_mesh(tempdir, encoding):
     filename = os.path.join(tempdir, "mesh_3D.xdmf")
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 4)
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mesh, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(mesh)
 
     with XDMFFile(MPI.comm_world, filename) as file:
         mesh2 = file.read_mesh(MPI.comm_world, cpp.mesh.GhostMode.none)
@@ -167,8 +167,8 @@ def test_save_1d_scalar(tempdir, encoding):
     u = Function(V)
     u.vector()[:] = 1.0
 
-    with XDMFFile(mesh.mpi_comm(), filename2) as file:
-        file.write(u, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename2, encoding=encoding) as file:
+        file.write(u)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -193,8 +193,8 @@ def test_save_and_checkpoint_scalar(tempdir, encoding, fe_degree, fe_family,
 
     u_out.interpolate(Expression("x[0]", degree=1))
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write_checkpoint(u_out, "u_out", 0, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write_checkpoint(u_out, "u_out", 0)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
         u_in = file.read_checkpoint(V, "u_out", 0)
@@ -230,8 +230,8 @@ def test_save_and_checkpoint_vector(tempdir, encoding, fe_degree, fe_family,
     elif mesh.geometry.dim == 3:
         u_out.interpolate(Expression(("x[0]*x[1]", "x[0]", "x[2]"), degree=2))
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write_checkpoint(u_out, "u_out", 0, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write_checkpoint(u_out, "u_out", 0)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
         u_in = file.read_checkpoint(V, "u_out", 0)
@@ -254,10 +254,10 @@ def test_save_and_checkpoint_timeseries(tempdir, encoding):
     u_out = [None] * len(times)
     u_in = [None] * len(times)
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         for i, p in enumerate(times):
             u_out[i] = interpolate(Expression("x[0]*p", p=p, degree=1), V)
-            file.write_checkpoint(u_out[i], "u_out", p, encoding=encoding)
+            file.write_checkpoint(u_out[i], "u_out", p)
 
     with XDMFFile(mesh.mpi_comm(), filename) as file:
         for i, p in enumerate(times):
@@ -286,8 +286,8 @@ def test_save_2d_scalar(tempdir, encoding):
     u = Function(V)
     u.vector()[:] = 1.0
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(u)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -300,8 +300,8 @@ def test_save_3d_scalar(tempdir, encoding):
     u = Function(V)
     u.vector()[:] = 1.0
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(u)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -315,8 +315,8 @@ def test_save_2d_vector(tempdir, encoding):
     c = Constant((1.0, 2.0))
     u.interpolate(c)
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(u)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -329,8 +329,8 @@ def test_save_3d_vector(tempdir, encoding):
     c = Constant((1.0, 2.0, 3.0))
     u.interpolate(c)
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(u)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -341,15 +341,15 @@ def test_save_3d_vector_series(tempdir, encoding):
     mesh = UnitCubeMesh(MPI.comm_world, 2, 2, 2)
     u = Function(VectorFunctionSpace(mesh, "Lagrange", 2))
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         u.vector()[:] = 1.0
-        file.write(u, 0.1, encoding=encoding)
+        file.write(u, 0.1)
 
         u.vector()[:] = 2.0
-        file.write(u, 0.2, encoding=encoding)
+        file.write(u, 0.2)
 
         u.vector()[:] = 3.0
-        file.write(u, 0.3, encoding=encoding)
+        file.write(u, 0.3)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -361,8 +361,8 @@ def test_save_2d_tensor(tempdir, encoding):
     u = Function(TensorFunctionSpace(mesh, "Lagrange", 2))
     u.vector()[:] = 1.0
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(u)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -374,8 +374,8 @@ def test_save_3d_tensor(tempdir, encoding):
     u = Function(TensorFunctionSpace(mesh, "Lagrange", 2))
     u.vector()[:] = 1.0
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(u, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(u)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -388,8 +388,8 @@ def test_save_1d_mesh(tempdir, encoding):
     for cell in Cells(mesh):
         mf[cell] = cell.index()
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mf, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(mf)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -407,8 +407,8 @@ def test_save_2D_cell_function(tempdir, encoding, data_type):
     for cell in Cells(mesh):
         mf[cell] = dtype(cell.index())
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mf, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(mf)
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
         read_function = getattr(xdmf, "read_mf_" + dtype_str)
@@ -435,8 +435,8 @@ def test_save_3D_cell_function(tempdir, encoding, data_type):
         mf[cell] = dtype(cell.index())
     filename = os.path.join(tempdir, "mf_3D_%s.xdmf" % dtype_str)
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mf, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(mf)
 
     # mf_in = MeshFunction(dtype_str, mesh, mesh.topology.dim, 0)
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
@@ -469,8 +469,8 @@ def test_save_2D_facet_function(tempdir, encoding, data_type):
             mf[facet] = dtype(facet.global_index())
     filename = os.path.join(tempdir, "mf_facet_2D_%s.xdmf" % dtype_str)
 
-    with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-        xdmf.write(mf, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as xdmf:
+        xdmf.write(mf)
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
         read_function = getattr(xdmf, "read_mf_" + dtype_str)
@@ -502,8 +502,8 @@ def test_save_3D_facet_function(tempdir, encoding, data_type):
             mf[facet] = dtype(facet.global_index())
     filename = os.path.join(tempdir, "mf_facet_3D_%s.xdmf" % dtype_str)
 
-    with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-        xdmf.write(mf, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as xdmf:
+        xdmf.write(mf)
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
         read_function = getattr(xdmf, "read_mf_" + dtype_str)
@@ -530,8 +530,8 @@ def test_save_3D_edge_function(tempdir, encoding, data_type):
         mf[edge] = dtype(edge.index())
 
     filename = os.path.join(tempdir, "mf_edge_3D_%s.xdmf" % dtype_str)
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mf, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(mf)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -549,8 +549,8 @@ def test_save_2D_vertex_function(tempdir, encoding, data_type):
         mf[vertex] = dtype(vertex.global_index())
     filename = os.path.join(tempdir, "mf_vertex_2D_%s.xdmf" % dtype_str)
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mf, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(mf)
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
         read_function = getattr(xdmf, "read_mf_" + dtype_str)
@@ -576,8 +576,8 @@ def test_save_3D_vertex_function(tempdir, encoding, data_type):
     for vertex in Vertices(mesh):
         mf[vertex] = dtype(vertex.index())
 
-    with XDMFFile(mesh.mpi_comm(), filename) as file:
-        file.write(mf, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
+        file.write(mf)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -592,12 +592,14 @@ def test_save_points_2D(tempdir, encoding):
         values.append(v.point().norm())
     vals = numpy.array(values)
 
-    with XDMFFile(mesh.mpi_comm(), os.path.join(tempdir, "points_2D.xdmf")) as file:
-        file.write(points, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), os.path.join(tempdir, "points_2D.xdmf"),
+                  encoding=encoding) as file:
+        file.write(points)
 
-    with XDMFFile(mesh.mpi_comm(), os.path.join(tempdir,
-                                                "points_values_2D.xdmf")) as file:
-        file.write(points, vals, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(),
+                  os.path.join(tempdir, "points_values_2D.xdmf"),
+                  encoding=encoding) as file:
+        file.write(points, vals)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -612,11 +614,14 @@ def test_save_points_3D(tempdir, encoding):
         values.append(v.point().norm())
     vals = numpy.array(values)
 
-    with XDMFFile(mesh.mpi_comm(), os.path.join(tempdir, "points_3D.xdmf")) as file:
-        file.write(points, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(), os.path.join(tempdir, "points_3D.xdmf"),
+                  encoding=encoding) as file:
+        file.write(points)
 
-    with XDMFFile(mesh.mpi_comm(), os.path.join(tempdir, "points_values_3D.xdmf")) as file:
-        file.write(points, vals, encoding=encoding)
+    with XDMFFile(mesh.mpi_comm(),
+                  os.path.join(tempdir, "points_values_3D.xdmf"),
+                  encoding=encoding) as file:
+        file.write(points, vals)
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -649,9 +654,9 @@ def test_save_mesh_value_collection(tempdir, encoding, data_type):
 
         filename = os.path.join(tempdir, "mvc_%d.xdmf" % mvc_dim)
 
-        with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-            xdmf.write(meshfn, encoding=encoding)
-            xdmf.write(mvc, encoding=encoding)
+        with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as xdmf:
+            xdmf.write(meshfn)
+            xdmf.write(mvc)
 
         with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
             read_function = getattr(xdmf, "read_mvc_" + dtype_str)
@@ -696,11 +701,11 @@ def test_append_and_load_mesh_functions(tempdir, encoding, data_type):
 
         filename = os.path.join(tempdir, "appended_mf_%dD.xdmf" % dim)
 
-        with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
+        with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as xdmf:
             xdmf.write(mesh)
-            xdmf.write(vf, encoding=encoding)
-            xdmf.write(ff, encoding=encoding)
-            xdmf.write(cf, encoding=encoding)
+            xdmf.write(vf)
+            xdmf.write(ff)
+            xdmf.write(cf)
 
         with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
             read_function = getattr(xdmf, "read_mf_" + dtype_str)

--- a/python/test/unit/io/test_XDMF_P2.py
+++ b/python/test/unit/io/test_XDMF_P2.py
@@ -17,8 +17,9 @@ def test_read_write_p2_mesh(tempdir):
                                               cpp.mesh.GhostMode.none)
 
     filename = os.path.join(tempdir, "tri6_mesh.xdmf")
-    with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-        xdmf.write(mesh, encoding=XDMFFile.Encoding.HDF5)
+    with XDMFFile(mesh.mpi_comm(), filename,
+                  encoding=XDMFFile.Encoding.HDF5) as xdmf:
+        xdmf.write(mesh)
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
         mesh2 = xdmf.read_mesh(mesh.mpi_comm(), cpp.mesh.GhostMode.none)
@@ -39,13 +40,15 @@ def test_read_write_p2_function(tempdir):
     F.interpolate(Expression("x[0]", degree=1))
 
     filename = os.path.join(tempdir, "tri6_function.xdmf")
-    with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-        xdmf.write(F, encoding=XDMFFile.Encoding.HDF5)
+    with XDMFFile(mesh.mpi_comm(), filename,
+                  encoding=XDMFFile.Encoding.HDF5) as xdmf:
+        xdmf.write(F)
 
     Q = VectorFunctionSpace(mesh, "Lagrange", 1)
     F = Function(Q)
     F.interpolate(Expression(("x[0]", "x[1]"), degree=1))
 
     filename = os.path.join(tempdir, "tri6_vector_function.xdmf")
-    with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-        xdmf.write(F, encoding=XDMFFile.Encoding.HDF5)
+    with XDMFFile(mesh.mpi_comm(), filename,
+                  encoding=XDMFFile.Encoding.HDF5) as xdmf:
+        xdmf.write(F)

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -260,8 +260,9 @@ def test_Write(cd_tempdir, f):
     f = f
     f[0] = 1
     f[1] = 2
-    file = XDMFFile(f.mesh().mpi_comm(), "saved_mesh_function.xdmf")
-    file.write(f, encoding=XDMFFile.Encoding.ASCII)
+    file = XDMFFile(f.mesh().mpi_comm(), "saved_mesh_function.xdmf",
+                    encoding=encoding)
+    file.write(f)
 
 
 def test_hash():

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -260,8 +260,7 @@ def test_Write(cd_tempdir, f):
     f = f
     f[0] = 1
     f[1] = 2
-    file = XDMFFile(f.mesh().mpi_comm(), "saved_mesh_function.xdmf",
-                    encoding=encoding)
+    file = XDMFFile(f.mesh().mpi_comm(), "saved_mesh_function.xdmf")
     file.write(f)
 
 


### PR DESCRIPTION
Adds private variable `_encoding` to XDMFFile. This variable is set by constructor and allows more state dependent calls to io methods.
Reason:
- simplify interface for io methods, no need to spoil encoding everywhere