### PR TITLE
Uptade XDMF tests to cover complex mode

### DIFF
--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -68,7 +68,7 @@ def worker_id(request):
 
 @pytest.fixture
 def imaginary_part():
-    """Return the imaginary unit in complex mode (complex scalar), 
+    """Return the imaginary unit in complex mode (complex scalar),
     in real mode return zero (float)
 
     """

--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -10,10 +10,11 @@ from dolfin import (MPI, MeshValueCollection, MeshEntities, Vertices, Facets, Ce
                     UnitCubeMesh, FunctionSpace, Function, Edges, MeshFunction, UnitSquareMesh,
                     VectorFunctionSpace, TensorFunctionSpace, UnitIntervalMesh, cpp, Expression,
                     interpolate, FiniteElement, VectorElement, Constant, has_hdf5, has_hdf5_parallel,
-                    CellType)
+                    has_petsc_complex, CellType)
 from dolfin.io import XDMFFile
 from dolfin_utils.test import tempdir
 assert(tempdir)
+
 
 # Supported XDMF file encoding
 encodings = (XDMFFile.Encoding.HDF5, XDMFFile.Encoding.ASCII)
@@ -63,6 +64,18 @@ def worker_id(request):
         return request.config.slaveinput['slaveid']
     else:
         return 'master'
+
+
+@pytest.fixture
+def imaginary_part():
+    """Return the imaginary part, in real mode should be a 
+    zero (float).
+
+    """
+    if has_petsc_complex():
+        return 1j
+    else:
+        return 0.
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -165,7 +178,8 @@ def test_save_1d_scalar(tempdir, encoding):
     # FIXME: This randomly hangs in parallel
     V = FunctionSpace(mesh, "Lagrange", 2)
     u = Function(V)
-    u.vector()[:] = 1.0
+    A = imaginary_part()
+    u.vector()[:] = 1.0 + A
 
     with XDMFFile(mesh.mpi_comm(), filename2, encoding=encoding) as file:
         file.write(u)
@@ -191,7 +205,10 @@ def test_save_and_checkpoint_scalar(tempdir, encoding, fe_degree, fe_family,
     u_in = Function(V)
     u_out = Function(V)
 
-    u_out.interpolate(Expression("x[0]", degree=1))
+    if has_petsc_complex():
+        u_out.interpolate(Expression("x[0] + j*x[0]", degree=1))
+    else:
+        u_out.interpolate(Expression("x[0]", degree=1))
 
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         file.write_checkpoint(u_out, "u_out", 0)
@@ -223,12 +240,20 @@ def test_save_and_checkpoint_vector(tempdir, encoding, fe_degree, fe_family,
     u_in = Function(V)
     u_out = Function(V)
 
-    if mesh.geometry.dim == 1:
-        u_out.interpolate(Expression(("x[0]", ), degree=1))
-    elif mesh.geometry.dim == 2:
-        u_out.interpolate(Expression(("x[0]*x[1]", "x[0]"), degree=2))
-    elif mesh.geometry.dim == 3:
-        u_out.interpolate(Expression(("x[0]*x[1]", "x[0]", "x[2]"), degree=2))
+    if has_petsc_complex():
+        if mesh.geometry.dim == 1:
+            u_out.interpolate(Expression(("x[0] + j*x[0]", ), degree=1))
+        elif mesh.geometry.dim == 2:
+            u_out.interpolate(Expression(("x[0]*x[1]", "x[0] + j*x[0]"), degree=2))
+        elif mesh.geometry.dim == 3:
+            u_out.interpolate(Expression(("x[0]*x[1]", "x[0] + j*x[0]", "x[2]"), degree=2))
+    else:
+        if mesh.geometry.dim == 1:
+            u_out.interpolate(Expression(("x[0]", ), degree=1))
+        elif mesh.geometry.dim == 2:
+            u_out.interpolate(Expression(("x[0]*x[1]", "x[0]"), degree=2))
+        elif mesh.geometry.dim == 3:
+            u_out.interpolate(Expression(("x[0]*x[1]", "x[0]", "x[2]"), degree=2))
 
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         file.write_checkpoint(u_out, "u_out", 0)
@@ -284,7 +309,8 @@ def test_save_2d_scalar(tempdir, encoding):
     # FIXME: This randomly hangs in parallel
     V = FunctionSpace(mesh, "Lagrange", 2)
     u = Function(V)
-    u.vector()[:] = 1.0
+    A = imaginary_part()
+    u.vector()[:] = 1.0 + A
 
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         file.write(u)
@@ -298,7 +324,8 @@ def test_save_3d_scalar(tempdir, encoding):
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 4)
     V = FunctionSpace(mesh, "Lagrange", 2)
     u = Function(V)
-    u.vector()[:] = 1.0
+    A = imaginary_part()
+    u.vector()[:] = 1.0 + A
 
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         file.write(u)
@@ -312,7 +339,8 @@ def test_save_2d_vector(tempdir, encoding):
     mesh = UnitSquareMesh(MPI.comm_world, 16, 16)
     V = VectorFunctionSpace(mesh, "Lagrange", 2)
     u = Function(V)
-    c = Constant((1.0, 2.0))
+    A = imaginary_part()
+    c = Constant((1.0 + A, 2.0 + 2 * A))
     u.interpolate(c)
 
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
@@ -326,7 +354,8 @@ def test_save_3d_vector(tempdir, encoding):
     filename = os.path.join(tempdir, "u_3Dv.xdmf")
     mesh = UnitCubeMesh(MPI.comm_world, 2, 2, 2)
     u = Function(VectorFunctionSpace(mesh, "Lagrange", 1))
-    c = Constant((1.0, 2.0, 3.0))
+    A = imaginary_part()
+    c = Constant((1.0 + A, 2.0 + 2 * A, 3.0 + 3 * A))
     u.interpolate(c)
 
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
@@ -340,15 +369,16 @@ def test_save_3d_vector_series(tempdir, encoding):
     filename = os.path.join(tempdir, "u_3D.xdmf")
     mesh = UnitCubeMesh(MPI.comm_world, 2, 2, 2)
     u = Function(VectorFunctionSpace(mesh, "Lagrange", 2))
+    A = imaginary_part()
 
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
-        u.vector()[:] = 1.0
+        u.vector()[:] = 1.0 + A
         file.write(u, 0.1)
 
-        u.vector()[:] = 2.0
+        u.vector()[:] = 2.0 + 2 * A
         file.write(u, 0.2)
 
-        u.vector()[:] = 3.0
+        u.vector()[:] = 3.0 + 3 * A
         file.write(u, 0.3)
 
 
@@ -359,7 +389,8 @@ def test_save_2d_tensor(tempdir, encoding):
     filename = os.path.join(tempdir, "tensor.xdmf")
     mesh = UnitSquareMesh(MPI.comm_world, 16, 16)
     u = Function(TensorFunctionSpace(mesh, "Lagrange", 2))
-    u.vector()[:] = 1.0
+    A = imaginary_part()
+    u.vector()[:] = 1.0 + A
 
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         file.write(u)
@@ -372,7 +403,8 @@ def test_save_3d_tensor(tempdir, encoding):
     filename = os.path.join(tempdir, "u3t.xdmf")
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 4)
     u = Function(TensorFunctionSpace(mesh, "Lagrange", 2))
-    u.vector()[:] = 1.0
+    A = imaginary_part()
+    u.vector()[:] = 1.0 + A
 
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         file.write(u)

--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -68,8 +68,8 @@ def worker_id(request):
 
 @pytest.fixture
 def imaginary_part():
-    """Return the imaginary part, in real mode should be a 
-    zero (float).
+    """Return the imaginary unit in complex mode (complex scalar), 
+    in real mode return zero (float)
 
     """
     if has_petsc_complex():
@@ -244,9 +244,9 @@ def test_save_and_checkpoint_vector(tempdir, encoding, fe_degree, fe_family,
         if mesh.geometry.dim == 1:
             u_out.interpolate(Expression(("x[0] + j*x[0]", ), degree=1))
         elif mesh.geometry.dim == 2:
-            u_out.interpolate(Expression(("x[0]*x[1]", "x[0] + j*x[0]"), degree=2))
+            u_out.interpolate(Expression(("j*x[0]*x[1]", "x[0] + j*x[0]"), degree=2))
         elif mesh.geometry.dim == 3:
-            u_out.interpolate(Expression(("x[0]*x[1]", "x[0] + j*x[0]", "x[2]"), degree=2))
+            u_out.interpolate(Expression(("j*x[0]*x[1]", "x[0] + j*x[0]", "x[2]"), degree=2))
     else:
         if mesh.geometry.dim == 1:
             u_out.interpolate(Expression(("x[0]", ), degree=1))

--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -66,17 +66,6 @@ def worker_id(request):
         return 'master'
 
 
-def imaginary_part():
-    """Return the imaginary unit in complex mode (complex scalar),
-    in real mode return zero (float)
-
-    """
-    if has_petsc_complex():
-        return 1j
-    else:
-        return 0.
-
-
 @pytest.mark.parametrize("encoding", encodings)
 def test_multiple_datasets(tempdir, encoding):
     if invalid_config(encoding):
@@ -177,8 +166,7 @@ def test_save_1d_scalar(tempdir, encoding):
     # FIXME: This randomly hangs in parallel
     V = FunctionSpace(mesh, "Lagrange", 2)
     u = Function(V)
-    A = imaginary_part()
-    u.vector()[:] = 1.0 + A
+    u.vector()[:] = 1.0 + (1j if has_petsc_complex() else 0)
 
     with XDMFFile(mesh.mpi_comm(), filename2, encoding=encoding) as file:
         file.write(u)
@@ -308,8 +296,7 @@ def test_save_2d_scalar(tempdir, encoding):
     # FIXME: This randomly hangs in parallel
     V = FunctionSpace(mesh, "Lagrange", 2)
     u = Function(V)
-    A = imaginary_part()
-    u.vector()[:] = 1.0 + A
+    u.vector()[:] = 1.0 + (1j if has_petsc_complex() else 0)
 
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         file.write(u)
@@ -323,8 +310,7 @@ def test_save_3d_scalar(tempdir, encoding):
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 4)
     V = FunctionSpace(mesh, "Lagrange", 2)
     u = Function(V)
-    A = imaginary_part()
-    u.vector()[:] = 1.0 + A
+    u.vector()[:] = 1.0 + (1j if has_petsc_complex() else 0)
 
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         file.write(u)
@@ -338,8 +324,7 @@ def test_save_2d_vector(tempdir, encoding):
     mesh = UnitSquareMesh(MPI.comm_world, 16, 16)
     V = VectorFunctionSpace(mesh, "Lagrange", 2)
     u = Function(V)
-    A = imaginary_part()
-    c = Constant((1.0 + A, 2.0 + 2 * A))
+    c = Constant((1.0 + (1j if has_petsc_complex() else 0), 2.0))
     u.interpolate(c)
 
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
@@ -353,7 +338,7 @@ def test_save_3d_vector(tempdir, encoding):
     filename = os.path.join(tempdir, "u_3Dv.xdmf")
     mesh = UnitCubeMesh(MPI.comm_world, 2, 2, 2)
     u = Function(VectorFunctionSpace(mesh, "Lagrange", 1))
-    A = imaginary_part()
+    A = 1.0 + (1j if has_petsc_complex() else 0)
     c = Constant((1.0 + A, 2.0 + 2 * A, 3.0 + 3 * A))
     u.interpolate(c)
 
@@ -368,16 +353,15 @@ def test_save_3d_vector_series(tempdir, encoding):
     filename = os.path.join(tempdir, "u_3D.xdmf")
     mesh = UnitCubeMesh(MPI.comm_world, 2, 2, 2)
     u = Function(VectorFunctionSpace(mesh, "Lagrange", 2))
-    A = imaginary_part()
 
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
-        u.vector()[:] = 1.0 + A
+        u.vector()[:] = 1.0 + (1j if has_petsc_complex() else 0)
         file.write(u, 0.1)
 
-        u.vector()[:] = 2.0 + 2 * A
+        u.vector()[:] = 2.0 + (2j if has_petsc_complex() else 0)
         file.write(u, 0.2)
 
-        u.vector()[:] = 3.0 + 3 * A
+        u.vector()[:] = 3.0 + (3j if has_petsc_complex() else 0)
         file.write(u, 0.3)
 
 
@@ -388,8 +372,7 @@ def test_save_2d_tensor(tempdir, encoding):
     filename = os.path.join(tempdir, "tensor.xdmf")
     mesh = UnitSquareMesh(MPI.comm_world, 16, 16)
     u = Function(TensorFunctionSpace(mesh, "Lagrange", 2))
-    A = imaginary_part()
-    u.vector()[:] = 1.0 + A
+    u.vector()[:] = 1.0 + (1j if has_petsc_complex() else 0)
 
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         file.write(u)
@@ -402,8 +385,7 @@ def test_save_3d_tensor(tempdir, encoding):
     filename = os.path.join(tempdir, "u3t.xdmf")
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 4)
     u = Function(TensorFunctionSpace(mesh, "Lagrange", 2))
-    A = imaginary_part()
-    u.vector()[:] = 1.0 + A
+    u.vector()[:] = 1.0 + (1j if has_petsc_complex() else 0)
 
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         file.write(u)

--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -66,7 +66,6 @@ def worker_id(request):
         return 'master'
 
 
-@pytest.fixture
 def imaginary_part():
     """Return the imaginary unit in complex mode (complex scalar),
     in real mode return zero (float)

--- a/python/test/unit/io/test_XDMF_P2.py
+++ b/python/test/unit/io/test_XDMF_P2.py
@@ -5,8 +5,8 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import os
-from dolfin import (Function, FunctionSpace,
-                    VectorFunctionSpace, Expression, MPI, cpp, fem)
+from dolfin import (Function, FunctionSpace, VectorFunctionSpace,
+                    Expression, MPI, cpp, fem, has_petsc_complex)
 from dolfin.io import XDMFFile
 from dolfin_utils.test import tempdir
 assert(tempdir)
@@ -36,7 +36,10 @@ def test_read_write_p2_function(tempdir):
     Q = FunctionSpace(mesh, "Lagrange", 2)
 
     F = Function(Q)
-    F.interpolate(Expression("x[0]", degree=1))
+    if has_petsc_complex():
+        F.interpolate(Expression("x[0] + j*x[0]", degree=1))
+    else:
+        F.interpolate(Expression("x[0]", degree=1))
 
     filename = os.path.join(tempdir, "tri6_function.xdmf")
     with XDMFFile(mesh.mpi_comm(), filename,
@@ -45,7 +48,10 @@ def test_read_write_p2_function(tempdir):
 
     Q = VectorFunctionSpace(mesh, "Lagrange", 1)
     F = Function(Q)
-    F.interpolate(Expression(("x[0]", "x[1]"), degree=1))
+    if has_petsc_complex():
+        F.interpolate(Expression(("x[0] + j*x[0]", "x[1] + j*x[1]"), degree=1))
+    else:
+        F.interpolate(Expression(("x[0]", "x[1]"), degree=1))
 
     filename = os.path.join(tempdir, "tri6_vector_function.xdmf")
     with XDMFFile(mesh.mpi_comm(), filename,


### PR DESCRIPTION
This PR aims to increase the coverage of the current xdmf tests to treat the complex case.
The tests remain the same in real mode. 
In the complex mode, a nonzero imaginary part is added to the functions.