### PR TITLE
Pass on form compiler parameters in Assembler

### DIFF
--- a/python/dolfin/fem/assembling.py
+++ b/python/dolfin/fem/assembling.py
@@ -33,19 +33,20 @@ class Assembler:
         else:
             self.bcs = bcs
         self.assembler = None
+        self.form_compiler_parameters = form_compiler_parameters
 
     def assemble(self, A=None, b=None, mat_type=cpp.fem.Assembler.BlockType.monolithic):
         if self.assembler is None:
             # Compile forms
             try:
-                a_forms = [[_create_dolfin_form(a)
+                a_forms = [[_create_dolfin_form(a, self.form_compiler_parameters)
                             for a in row] for row in self.a]
             except TypeError:
-                a_forms = [[_create_dolfin_form(self.a)]]
+                a_forms = [[_create_dolfin_form(self.a, self.form_compiler_parameters)]]
             try:
-                L_forms = [_create_dolfin_form(L) for L in self.L]
+                L_forms = [_create_dolfin_form(L, self.form_compiler_parameters) for L in self.L]
             except TypeError:
-                L_forms = [_create_dolfin_form(self.L)]
+                L_forms = [_create_dolfin_form(self.L, self.form_compiler_parameters)]
 
             # Create assembler
             self.assembler = cpp.fem.Assembler(a_forms, L_forms, self.bcs)


### PR DESCRIPTION
`Assembler` used to swallow `form_compiler_parameters`