### PR TITLE
Get dolfinx to compile with petsc-complex (remaining changes)

### DIFF
--- a/cpp/dolfin/io/HDF5File.cpp
+++ b/cpp/dolfin/io/HDF5File.cpp
@@ -136,7 +136,7 @@ void HDF5File::write(const la::PETScVector& x, const std::string dataset_name)
   assert(_hdf5_file_id > 0);
 
   // Get all local data
-  std::vector<double> local_data;
+  std::vector<PetscScalar> local_data;
   x.get_local(local_data);
 
   // Write data to file
@@ -223,7 +223,7 @@ la::PETScVector HDF5File::read_vector(MPI_Comm comm,
   const std::array<std::int64_t, 2> local_range = x.local_range();
 
   // Read data from file
-  std::vector<double> data = HDF5Interface::read_dataset<double>(
+  std::vector<PetscScalar> data = HDF5Interface::read_dataset<PetscScalar>(
       _hdf5_file_id, dataset_name, local_range);
 
   // Set data
@@ -1006,8 +1006,9 @@ HDF5File::read(std::shared_ptr<const function::FunctionSpace> V,
   const std::array<std::int64_t, 2> input_vector_range
       = MPI::local_range(_mpi_comm.comm(), vector_shape[0]);
 
-  std::vector<double> input_values = HDF5Interface::read_dataset<double>(
-      _hdf5_file_id, vector_dataset_name, input_vector_range);
+  std::vector<PetscScalar> input_values
+      = HDF5Interface::read_dataset<PetscScalar>(
+          _hdf5_file_id, vector_dataset_name, input_vector_range);
 
   // HDF5Utility::set_local_vector_values(_mpi_comm.comm(), x, mesh,
   // input_cells,

--- a/cpp/dolfin/io/VTKWriter.cpp
+++ b/cpp/dolfin/io/VTKWriter.cpp
@@ -114,7 +114,7 @@ void VTKWriter::write_cell_data(const function::Function& u,
   }
 
   // Get  values
-  std::vector<double> values(dof_set.size());
+  std::vector<PetscScalar> values(dof_set.size());
   assert(u.vector());
   u.vector()->get_local(values.data(), dof_set.size(), dof_set.data());
 
@@ -126,7 +126,7 @@ void VTKWriter::write_cell_data(const function::Function& u,
 //----------------------------------------------------------------------------
 std::string VTKWriter::ascii_cell_data(const mesh::Mesh& mesh,
                                        const std::vector<std::size_t>& offset,
-                                       const std::vector<double>& values,
+                                       const std::vector<PetscScalar>& values,
                                        std::size_t data_dim, std::size_t rank)
 {
   std::ostringstream ss;

--- a/cpp/dolfin/io/VTKWriter.h
+++ b/cpp/dolfin/io/VTKWriter.h
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <string>
+#include <petscsys.h>
 #include <vector>
 
 namespace dolfin
@@ -40,7 +41,7 @@ private:
   // Write cell data (ascii)
   static std::string ascii_cell_data(const mesh::Mesh& mesh,
                                      const std::vector<std::size_t>& offset,
-                                     const std::vector<double>& values,
+                                     const std::vector<PetscScalar>& values,
                                      std::size_t dim, std::size_t rank);
 
   // mesh::Mesh writer (ascii)


### PR DESCRIPTION
Remaining modifications to get dolfinx to compile with PETSc-complex, in preparation to run nightly tests for the complex mode on master branch.

Since `PetscScalar = double` for PETSc real, these changes do not affect the real mode.