### PR TITLE
Remove redundant index updates that may lead to invalid reads for end it

### DIFF
--- a/cpp/dolfin/mesh/MeshIterator.h
+++ b/cpp/dolfin/mesh/MeshIterator.h
@@ -96,7 +96,6 @@ public:
     {
       assert(pos < 2);
       _connections = &e._local_index + pos;
-      _entity._local_index = e._local_index;
       return;
     }
 
@@ -107,7 +106,6 @@ public:
     // Pointer to array of connections
     assert(!c.empty());
     _connections = c(e.index()) + pos;
-    _entity._local_index = *_connections;
   }
 
   /// Constructor from MeshEntity
@@ -120,7 +118,6 @@ public:
     {
       assert(pos < 2);
       _connections = &e._local_index + pos;
-      _entity._local_index = e._local_index;
       return;
     }
 
@@ -131,7 +128,6 @@ public:
     // Pointer to array of connections
     assert(!c.empty());
     _connections = c(e.index()) + pos;
-    _entity._local_index = *_connections;
   }
 
   /// Copy constructor


### PR DESCRIPTION
Fixes https://github.com/FEniCS/dolfinx/issues/145

The removed lines are redundant because `_entity._local_index` is overwritten anyway on every dereferencing operator call and no other access to `_entity` is possible through the iterator. Furthermore it fixes an out of bounds read if the constructor is used to create an past the end iterator.