### PR TITLE
Use paths set by GNUInstallDirs in root CMakeLists.txt

### DIFF
--- a/cpp/cmake/templates/dolfin.pc.in
+++ b/cpp/cmake/templates/dolfin.pc.in
@@ -1,8 +1,8 @@
 # pkg-config configuration for DOLFIN
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
+libdir=@DOLFIN_LIB_DIR@
+includedir=@DOLFIN_INCLUDE_DIR@
 compiler=@CMAKE_CXX_COMPILER@
 definitions=@PKG_DEFINITIONS@
 extlibs=@DOLFIN_EXT_LIBS@


### PR DESCRIPTION
Old hardcoded version causes issues on e.g. platforms using lib64/.