### PR TITLE
Replace la_index_t with PetscInt

### DIFF
--- a/cpp/dolfin/common/IndexMap.cpp
+++ b/cpp/dolfin/common/IndexMap.cpp
@@ -55,7 +55,7 @@ std::int32_t IndexMap::size_local() const
 //-----------------------------------------------------------------------------
 std::int64_t IndexMap::size_global() const { return _all_ranges.back(); }
 //-----------------------------------------------------------------------------
-const Eigen::Array<la_index_t, Eigen::Dynamic, 1>& IndexMap::ghosts() const
+const Eigen::Array<PetscInt, Eigen::Dynamic, 1>& IndexMap::ghosts() const
 {
   return _ghosts;
 }

--- a/cpp/dolfin/common/IndexMap.h
+++ b/cpp/dolfin/common/IndexMap.h
@@ -61,7 +61,7 @@ public:
 
   /// Local-to-global map for ghosts (local indexing beyond end of local
   /// range)
-  const Eigen::Array<la_index_t, Eigen::Dynamic, 1>& ghosts() const;
+  const Eigen::Array<PetscInt, Eigen::Dynamic, 1>& ghosts() const;
 
   /// Get global index for local index i (index of the block)
   std::size_t local_to_global(std::size_t i) const
@@ -103,7 +103,7 @@ public:
 
 private:
   // Local-to-global map for ghost indices
-  Eigen::Array<la_index_t, Eigen::Dynamic, 1> _ghosts;
+  Eigen::Array<PetscInt, Eigen::Dynamic, 1> _ghosts;
 
   // Owning process for each ghost index
   EigenArrayXi32 _ghost_owners;

--- a/cpp/dolfin/common/defines.cpp
+++ b/cpp/dolfin/common/defines.cpp
@@ -23,8 +23,6 @@ std::string dolfin::git_commit_hash()
   return std::string(DOLFIN_GIT_COMMIT_HASH);
 }
 //-------------------------------------------------------------------------
-std::size_t dolfin::sizeof_la_index_t() { return sizeof(dolfin::la_index_t); }
-//-------------------------------------------------------------------------
 bool dolfin::has_debug()
 {
 #ifdef DEBUG

--- a/cpp/dolfin/common/defines.h
+++ b/cpp/dolfin/common/defines.h
@@ -21,9 +21,6 @@ std::string ufc_signature();
 /// not known)
 std::string git_commit_hash();
 
-/// Return sizeof the dolfin::la_index_t type
-std::size_t sizeof_la_index_t();
-
 /// Return true if DOLFIN is compiled in debugging mode,
 /// i.e., with assertions on
 bool has_debug();

--- a/cpp/dolfin/common/types.h
+++ b/cpp/dolfin/common/types.h
@@ -21,9 +21,6 @@ using ufc_scalar_t = double;
 namespace dolfin
 {
 
-// Index type for compatibility with linear algebra backend
-using la_index_t = PetscInt;
-
 // Typedefs for Eigen
 
 // bool Arrays
@@ -49,8 +46,8 @@ using EigenRowArrayXi64 = Eigen::Array<std::int64_t, 1, Eigen::Dynamic>;
 using EigenRowArrayXXi64 = Eigen::Array<std::int64_t, Eigen::Dynamic,
                                         Eigen::Dynamic, Eigen::RowMajor>;
 
-// la_index_t Arrays
-using EigenArrayXlaindex = Eigen::Array<dolfin::la_index_t, Eigen::Dynamic, 1>;
+// PetscInt Arrays
+using EigenArrayXpetscint = Eigen::Array<PetscInt, Eigen::Dynamic, 1>;
 
 // double Matrices
 using EigenRowMatrixXd

--- a/cpp/dolfin/fem/Assembler.cpp
+++ b/cpp/dolfin/fem/Assembler.cpp
@@ -198,7 +198,7 @@ void Assembler::assemble(la::PETScMatrix& A, BlockType block_type)
           this->assemble_matrix(mat, *_a[i][j], bc_dofs0, bc_dofs1);
           if (*_a[i][j]->function_space(0) == *_a[i][j]->function_space(1))
           {
-            const std::vector<la_index_t> rows
+            const std::vector<PetscInt> rows
                 = get_local_bc_rows(*_a[i][j]->function_space(0), _bcs);
             ident(mat, rows);
           }
@@ -236,7 +236,7 @@ void Assembler::assemble(la::PETScMatrix& A, BlockType block_type)
     this->assemble_matrix(A, *_a[0][0], bc_dofs0, bc_dofs1);
     if (*_a[0][0]->function_space(0) == *_a[0][0]->function_space(1))
     {
-      const std::vector<la_index_t> rows
+      const std::vector<PetscInt> rows
           = get_local_bc_rows(*_a[0][0]->function_space(0), _bcs);
       ident(A, rows);
     }
@@ -437,14 +437,14 @@ void Assembler::assemble(la::PETScMatrix& A, la::PETScVector& b)
   assemble(b);
 }
 //-----------------------------------------------------------------------------
-void Assembler::ident(la::PETScMatrix& A, const std::vector<la_index_t>& rows,
+void Assembler::ident(la::PETScMatrix& A, const std::vector<PetscInt>& rows,
                       PetscScalar diag)
 {
   for (auto row : rows)
     A.add_local(&diag, 1, &row, 1, &row);
 }
 //-----------------------------------------------------------------------------
-std::vector<la_index_t> Assembler::get_local_bc_rows(
+std::vector<PetscInt> Assembler::get_local_bc_rows(
     const function::FunctionSpace& V,
     std::vector<std::shared_ptr<const DirichletBC>> bcs)
 {
@@ -471,10 +471,10 @@ std::vector<la_index_t> Assembler::get_local_bc_rows(
 
   auto map = V.dofmap()->index_map();
   int local_size = map->block_size() * map->size_local();
-  std::vector<la_index_t> rows;
+  std::vector<PetscInt> rows;
   for (auto bc : boundary_values)
   {
-    la_index_t row = bc.first;
+    PetscInt row = bc.first;
     if (row < local_size)
       rows.push_back(row);
   }
@@ -598,9 +598,9 @@ void Assembler::assemble_matrix(la::PETScMatrix& A, const Form& a,
     cell.get_coordinate_dofs(coordinate_dofs);
 
     // Get dof maps for cell
-    Eigen::Map<const Eigen::Array<dolfin::la_index_t, Eigen::Dynamic, 1>> dmap0
+    Eigen::Map<const Eigen::Array<PetscInt, Eigen::Dynamic, 1>> dmap0
         = map0.cell_dofs(cell.index());
-    Eigen::Map<const Eigen::Array<dolfin::la_index_t, Eigen::Dynamic, 1>> dmap1
+    Eigen::Map<const Eigen::Array<PetscInt, Eigen::Dynamic, 1>> dmap1
         = map1.cell_dofs(cell.index());
 
     Ae.resize(dmap0.size(), dmap1.size());

--- a/cpp/dolfin/fem/Assembler.h
+++ b/cpp/dolfin/fem/Assembler.h
@@ -66,11 +66,11 @@ public:
 
   /// Add '1' to diagonal for Dirichlet rows. Rows must be local to the
   /// process.
-  static void ident(la::PETScMatrix& A, const std::vector<la_index_t>& rows,
+  static void ident(la::PETScMatrix& A, const std::vector<PetscInt>& rows,
                     PetscScalar diag = 1.0);
 
 private:
-  static std::vector<la_index_t>
+  static std::vector<PetscInt>
   get_local_bc_rows(const function::FunctionSpace& V,
                     std::vector<std::shared_ptr<const DirichletBC>> bcs);
 

--- a/cpp/dolfin/fem/DiscreteOperators.cpp
+++ b/cpp/dolfin/fem/DiscreteOperators.cpp
@@ -59,9 +59,9 @@ DiscreteOperators::build_gradient(const function::FunctionSpace& V0,
   }
 
   // Build maps from entities to local dof indices
-  const std::vector<dolfin::la_index_t> edge_to_dof
+  const std::vector<PetscInt> edge_to_dof
       = V0.dofmap()->dofs(mesh, 1);
-  const std::vector<dolfin::la_index_t> vertex_to_dof
+  const std::vector<PetscInt> vertex_to_dof
       = V1.dofmap()->dofs(mesh, 0);
 
   // Build maps from local dof numbering to global
@@ -83,8 +83,8 @@ DiscreteOperators::build_gradient(const function::FunctionSpace& V0,
   la::SparsityPattern pattern(mesh.mpi_comm(), index_maps);
 
   // Build sparsity pattern
-  std::vector<dolfin::la_index_t> rows;
-  std::vector<dolfin::la_index_t> cols;
+  std::vector<PetscInt> rows;
+  std::vector<PetscInt> cols;
   for (auto& edge : mesh::MeshRange<mesh::Edge>(mesh))
   {
     // Row index (global indices)
@@ -103,8 +103,8 @@ DiscreteOperators::build_gradient(const function::FunctionSpace& V0,
     }
   }
 
-  Eigen::Map<const EigenArrayXlaindex> _rows(rows.data(), rows.size());
-  Eigen::Map<const EigenArrayXlaindex> _cols(cols.data(), cols.size());
+  Eigen::Map<const EigenArrayXpetscint> _rows(rows.data(), rows.size());
+  Eigen::Map<const EigenArrayXpetscint> _cols(cols.data(), cols.size());
   pattern.insert_global(_rows, _cols);
   pattern.apply();
 
@@ -114,8 +114,8 @@ DiscreteOperators::build_gradient(const function::FunctionSpace& V0,
   // Build discrete gradient operator/matrix
   for (auto& edge : mesh::MeshRange<mesh::Edge>(mesh))
   {
-    dolfin::la_index_t row;
-    dolfin::la_index_t cols[2];
+    PetscInt row;
+    PetscInt cols[2];
     PetscScalar values[2];
 
     row = local_to_global_map0[edge_to_dof[edge.index()]];

--- a/cpp/dolfin/fem/DofMap.h
+++ b/cpp/dolfin/fem/DofMap.h
@@ -155,15 +155,15 @@ public:
   /// @param     cell_index (std::size_t)
   ///         The cell index.
   ///
-  /// @return         Eigen::Map<const Eigen::Array<dolfin::la_index_t,
+  /// @return         Eigen::Map<const Eigen::Array<PetscInt,
   /// Eigen::Dynamic, 1>>
-  Eigen::Map<const Eigen::Array<dolfin::la_index_t, Eigen::Dynamic, 1>>
+  Eigen::Map<const Eigen::Array<PetscInt, Eigen::Dynamic, 1>>
   cell_dofs(std::size_t cell_index) const
   {
     const std::size_t index = cell_index * _cell_dimension;
     assert(index + _cell_dimension <= _dofmap.size());
     return Eigen::Map<
-        const Eigen::Array<dolfin::la_index_t, Eigen::Dynamic, 1>>(
+        const Eigen::Array<PetscInt, Eigen::Dynamic, 1>>(
         &_dofmap[index], _cell_dimension);
   }
 
@@ -250,7 +250,7 @@ private:
                                       const mesh::Mesh& mesh);
 
   // Cell-local-to-dof map (dofs for cell dofmap[i])
-  std::vector<dolfin::la_index_t> _dofmap;
+  std::vector<PetscInt> _dofmap;
 
   // List of global nodes
   std::set<std::size_t> _global_nodes;

--- a/cpp/dolfin/fem/DofMapBuilder.h
+++ b/cpp/dolfin/fem/DofMapBuilder.h
@@ -50,7 +50,7 @@ public:
   /// @param[in] dolfin_mesh
   static std::tuple<std::size_t, std::unique_ptr<common::IndexMap>,
                     std::vector<int>, std::unordered_map<int, std::vector<int>>,
-                    std::set<int>, std::vector<dolfin::la_index_t>>
+                    std::set<int>, std::vector<PetscInt>>
   build(const ufc_dofmap& ufc_map, const mesh::Mesh& dolfin_mesh);
 
   /// Build sub-dofmap. This is a view into the parent dofmap.
@@ -60,7 +60,7 @@ public:
   /// @param[in] component
   /// @param[in] mesh
   static std::tuple<std::unique_ptr<const ufc_dofmap>, std::int64_t,
-                    std::int64_t, std::vector<dolfin::la_index_t>>
+                    std::int64_t, std::vector<PetscInt>>
   build_sub_map_view(const ufc_dofmap& parent_ufc_dofmap,
                      const std::vector<int>& parent_ufc_local_to_local,
                      const int parent_block_size,
@@ -70,7 +70,7 @@ public:
 
 private:
   // Build simple local UFC-based dofmap data structure
-  static std::vector<std::vector<dolfin::la_index_t>>
+  static std::vector<std::vector<PetscInt>>
   build_local_ufc_dofmap(const ufc_dofmap& ufc_dofmap, const mesh::Mesh& mesh);
 
   // Compute which process 'owns' each node (point at which dofs live)
@@ -88,14 +88,14 @@ private:
   static std::tuple<int, std::vector<short int>,
                     std::unordered_map<int, std::vector<int>>, std::set<int>>
   compute_node_ownership(
-      const std::vector<std::vector<la_index_t>>& node_dofmap,
+      const std::vector<std::vector<PetscInt>>& node_dofmap,
       const std::vector<int>& boundary_nodes,
       const std::vector<std::size_t>& node_local_to_global,
       const mesh::Mesh& mesh, const std::size_t global_dim);
 
   // Build dofmap based on re-ordered nodes
-  static std::vector<std::vector<la_index_t>>
-  build_dofmap(const std::vector<std::vector<la_index_t>>& node_dofmap,
+  static std::vector<std::vector<PetscInt>>
+  build_dofmap(const std::vector<std::vector<PetscInt>>& node_dofmap,
                const std::vector<int>& old_to_new_node_local,
                const std::size_t block_size);
 
@@ -123,7 +123,7 @@ private:
   // Build graph from UFC 'node' dofmap. Returns (ufc_dofmap,
   // node_dofmap, node_local_to_global)
   static std::tuple<std::unique_ptr<const ufc_dofmap>,
-                    std::vector<std::vector<la_index_t>>,
+                    std::vector<std::vector<PetscInt>>,
                     std::vector<std::size_t>>
   build_ufc_node_graph(const ufc_dofmap& ufc_map, const mesh::Mesh& mesh,
                        const std::size_t block_size);
@@ -133,7 +133,7 @@ private:
   // nodes in ghost layer of other processes are marked -2, and
   // ghost nodes are marked as -3
   static std::vector<int>
-  compute_shared_nodes(const std::vector<std::vector<la_index_t>>& node_dofmap,
+  compute_shared_nodes(const std::vector<std::vector<PetscInt>>& node_dofmap,
                        const std::size_t num_nodes_local,
                        const ufc_dofmap& ufc_dofmap, const mesh::Mesh& mesh);
 
@@ -144,7 +144,7 @@ private:
       const std::unordered_map<int, std::vector<int>>&
           node_to_sharing_processes,
       const std::vector<std::size_t>& old_local_to_global,
-      const std::vector<std::vector<la_index_t>>& node_dofmap,
+      const std::vector<std::vector<PetscInt>>& node_dofmap,
       const std::vector<short int>& node_ownership, const MPI_Comm mpi_comm);
 
   static void

--- a/cpp/dolfin/fem/GenericDofMap.cpp
+++ b/cpp/dolfin/fem/GenericDofMap.cpp
@@ -38,7 +38,7 @@ std::vector<std::size_t> GenericDofMap::tabulate_local_to_global_dofs() const
   return local_to_global_map;
 }
 //-----------------------------------------------------------------------------
-std::vector<dolfin::la_index_t> GenericDofMap::dofs(const mesh::Mesh& mesh,
+std::vector<PetscInt> GenericDofMap::dofs(const mesh::Mesh& mesh,
                                                     std::size_t dim) const
 {
   // Check number of dofs per entity (on each cell)
@@ -46,10 +46,10 @@ std::vector<dolfin::la_index_t> GenericDofMap::dofs(const mesh::Mesh& mesh,
 
   // Return empty vector if not dofs on requested entity
   if (num_dofs_per_entity == 0)
-    return std::vector<dolfin::la_index_t>();
+    return std::vector<PetscInt>();
 
   // Vector to hold list of dofs
-  std::vector<dolfin::la_index_t> dof_list(mesh.num_entities(dim)
+  std::vector<PetscInt> dof_list(mesh.num_entities(dim)
                                            * num_dofs_per_entity);
 
   // Iterate over cells
@@ -70,7 +70,7 @@ std::vector<dolfin::la_index_t> GenericDofMap::dofs(const mesh::Mesh& mesh,
       for (std::size_t i = 0; i < entity_dofs_local.size(); ++i)
       {
         const std::size_t entity_dof_local = entity_dofs_local[i];
-        const dolfin::la_index_t dof_index = cell_dof_list[entity_dof_local];
+        const PetscInt dof_index = cell_dof_list[entity_dof_local];
         assert(e.index() * num_dofs_per_entity + i < dof_list.size());
         dof_list[e.index() * num_dofs_per_entity + i] = dof_index;
       }
@@ -82,7 +82,7 @@ std::vector<dolfin::la_index_t> GenericDofMap::dofs(const mesh::Mesh& mesh,
   return dof_list;
 }
 //-----------------------------------------------------------------------------
-std::vector<dolfin::la_index_t>
+std::vector<PetscInt>
 GenericDofMap::entity_dofs(const mesh::Mesh& mesh, std::size_t entity_dim,
                            const std::vector<std::size_t>& entity_indices) const
 {
@@ -95,7 +95,7 @@ GenericDofMap::entity_dofs(const mesh::Mesh& mesh, std::size_t entity_dim,
 
   // Allocate the the array to return
   const std::size_t num_marked_entities = entity_indices.size();
-  std::vector<dolfin::la_index_t> entity_to_dofs(num_marked_entities
+  std::vector<PetscInt> entity_to_dofs(num_marked_entities
                                                  * dofs_per_entity);
 
   // Allocate data for tabulating local to local map
@@ -131,7 +131,7 @@ GenericDofMap::entity_dofs(const mesh::Mesh& mesh, std::size_t entity_dim,
     for (std::size_t local_dof = 0; local_dof < dofs_per_entity; ++local_dof)
     {
       // Map dofs
-      const dolfin::la_index_t global_dof
+      const PetscInt global_dof
           = cell_dof_list[local_to_local_map[local_dof]];
       entity_to_dofs[dofs_per_entity * i + local_dof] = global_dof;
     }
@@ -139,7 +139,7 @@ GenericDofMap::entity_dofs(const mesh::Mesh& mesh, std::size_t entity_dim,
   return entity_to_dofs;
 }
 //-----------------------------------------------------------------------------
-std::vector<dolfin::la_index_t>
+std::vector<PetscInt>
 GenericDofMap::entity_dofs(const mesh::Mesh& mesh, std::size_t entity_dim) const
 {
   // Get some dimensions
@@ -151,7 +151,7 @@ GenericDofMap::entity_dofs(const mesh::Mesh& mesh, std::size_t entity_dim) const
   mesh.init(entity_dim, top_dim);
 
   // Allocate the the array to return
-  std::vector<dolfin::la_index_t> entity_to_dofs(num_mesh_entities
+  std::vector<PetscInt> entity_to_dofs(num_mesh_entities
                                                  * dofs_per_entity);
 
   // Allocate data for tabulating local to local map
@@ -185,7 +185,7 @@ GenericDofMap::entity_dofs(const mesh::Mesh& mesh, std::size_t entity_dim) const
     for (std::size_t local_dof = 0; local_dof < dofs_per_entity; ++local_dof)
     {
       // Map dofs
-      const dolfin::la_index_t global_dof
+      const PetscInt global_dof
           = cell_dof_list[local_to_local_map[local_dof]];
       entity_to_dofs[dofs_per_entity * entity.index() + local_dof] = global_dof;
     }

--- a/cpp/dolfin/fem/GenericDofMap.h
+++ b/cpp/dolfin/fem/GenericDofMap.h
@@ -68,17 +68,17 @@ public:
   virtual std::array<std::int64_t, 2> ownership_range() const = 0;
 
   /// Local-to-global mapping of dofs on a cell
-  virtual Eigen::Map<const Eigen::Array<dolfin::la_index_t, Eigen::Dynamic, 1>>
+  virtual Eigen::Map<const Eigen::Array<PetscInt, Eigen::Dynamic, 1>>
   cell_dofs(std::size_t cell_index) const = 0;
 
   /// Return the dof indices associated with entities of given dimension and
   /// entity indices
-  std::vector<dolfin::la_index_t>
+  std::vector<PetscInt>
   entity_dofs(const mesh::Mesh& mesh, std::size_t entity_dim,
               const std::vector<std::size_t>& entity_indices) const;
 
   /// Return the dof indices associated with all entities of given dimension
-  std::vector<dolfin::la_index_t> entity_dofs(const mesh::Mesh& mesh,
+  std::vector<PetscInt> entity_dofs(const mesh::Mesh& mesh,
                                               std::size_t entity_dim) const;
 
   /// Tabulate local-local facet dofs
@@ -107,7 +107,7 @@ public:
 
   /// Return list of dof indices on this process that belong to mesh
   /// entities of dimension dim
-  std::vector<dolfin::la_index_t> dofs(const mesh::Mesh& mesh,
+  std::vector<PetscInt> dofs(const mesh::Mesh& mesh,
                                        std::size_t dim) const;
 
   /// Set dof entries in vector to a specified value. Parallel

--- a/cpp/dolfin/fem/PETScDMCollection.cpp
+++ b/cpp/dolfin/fem/PETScDMCollection.cpp
@@ -484,7 +484,7 @@ std::shared_ptr<la::PETScMatrix> PETScDMCollection::create_transfer_matrix(
 
   // Initialise row and column indices and values of the transfer
   // matrix
-  Eigen::Array<dolfin::la_index_t, Eigen::Dynamic, Eigen::Dynamic,
+  Eigen::Array<PetscInt, Eigen::Dynamic, Eigen::Dynamic,
                Eigen::RowMajor>
       col_indices(m_owned, eldim);
   Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
@@ -493,8 +493,8 @@ std::shared_ptr<la::PETScMatrix> PETScDMCollection::create_transfer_matrix(
 
   // Initialise global sparsity pattern: record on-process and
   // off-process dependencies of fine dofs
-  std::vector<std::vector<dolfin::la_index_t>> send_dnnz(mpi_size);
-  std::vector<std::vector<dolfin::la_index_t>> send_onnz(mpi_size);
+  std::vector<std::vector<PetscInt>> send_dnnz(mpi_size);
+  std::vector<std::vector<PetscInt>> send_onnz(mpi_size);
 
   // Initialise local to global dof maps (needed to allocate the
   // entries of the transfer matrix with the correct global indices)
@@ -564,24 +564,24 @@ std::shared_ptr<la::PETScMatrix> PETScDMCollection::create_transfer_matrix(
   // row we also keep track of the ownership range
   std::size_t mbegin = m[0];
   std::size_t mend = m[1];
-  std::vector<dolfin::la_index_t> recv_onnz;
+  std::vector<PetscInt> recv_onnz;
   MPI::all_to_all(mpi_comm, send_onnz, recv_onnz);
 
-  std::vector<dolfin::la_index_t> onnz(m[1] - m[0], 0);
+  std::vector<PetscInt> onnz(m[1] - m[0], 0);
   for (const auto& q : recv_onnz)
   {
-    assert(q >= (dolfin::la_index_t)mbegin and q < (dolfin::la_index_t)mend);
+    assert(q >= (PetscInt)mbegin and q < (PetscInt)mend);
     ++onnz[q - mbegin];
   }
 
   // Communicate on-process columns nnz, and flatten to get nnz per
   // row
-  std::vector<dolfin::la_index_t> recv_dnnz;
+  std::vector<PetscInt> recv_dnnz;
   MPI::all_to_all(mpi_comm, send_dnnz, recv_dnnz);
-  std::vector<dolfin::la_index_t> dnnz(m[1] - m[0], 0);
+  std::vector<PetscInt> dnnz(m[1] - m[0], 0);
   for (const auto& q : recv_dnnz)
   {
-    assert(q >= (dolfin::la_index_t)mbegin and q < (dolfin::la_index_t)mend);
+    assert(q >= (PetscInt)mbegin and q < (PetscInt)mend);
     ++dnnz[q - mbegin];
   }
 

--- a/cpp/dolfin/fem/SparsityPatternBuilder.cpp
+++ b/cpp/dolfin/fem/SparsityPatternBuilder.cpp
@@ -39,10 +39,10 @@ la::SparsityPattern SparsityPatternBuilder::build(
   la::SparsityPattern pattern(comm, index_maps);
 
   // Array to store macro-dofs, if required (for interior facets)
-  std::array<EigenArrayXlaindex, 2> macro_dofs;
+  std::array<EigenArrayXpetscint, 2> macro_dofs;
 
   // Create vector to point to dofs
-  // std::array<common::ArrayView<const dolfin::la_index_t>, 2> dofs;
+  // std::array<common::ArrayView<const PetscInt>, 2> dofs;
 
   // Build sparsity pattern for reals (globally supported basis members)
   // NOTE: It is very important that this is done before other integrals
@@ -79,7 +79,7 @@ la::SparsityPattern SparsityPatternBuilder::build(
     // mesh.init(0);
     // mesh.init(0, D);
 
-    // std::array<std::vector<dolfin::la_index_t>, 2> global_dofs;
+    // std::array<std::vector<PetscInt>, 2> global_dofs;
     // std::array<std::vector<int>, 2> local_to_local_dofs;
 
     // // Resize local dof map vector
@@ -112,7 +112,7 @@ la::SparsityPattern SparsityPatternBuilder::build(
     //   }
 
     //   // Insert non-zeroes in sparsity pattern
-    //   std::array<common::ArrayView<const dolfin::la_index_t>, 2>
+    //   std::array<common::ArrayView<const PetscInt>, 2>
     //   global_dofs_p; for (std::size_t i = 0; i < 2; ++i)
     //     global_dofs_p[i].set(global_dofs[i]);
     //   pattern.insert_local(global_dofs_p);
@@ -196,16 +196,16 @@ la::SparsityPattern SparsityPatternBuilder::build(
           "Add diagonal with non-matching block sizes not working yet.");
     std::size_t bs = index_maps[0]->block_size();
 
-    std::vector<dolfin::la_index_t> indices(
+    std::vector<PetscInt> indices(
         bs * (diagonal_range - primary_range[0]));
     std::iota(indices.begin(), indices.end(), bs * primary_range[0]);
 
-    // const std::array<common::ArrayView<const dolfin::la_index_t>, 2> diags
-    //     = {{common::ArrayView<const dolfin::la_index_t>(indices.size(),
+    // const std::array<common::ArrayView<const PetscInt>, 2> diags
+    //     = {{common::ArrayView<const PetscInt>(indices.size(),
     //                                                     indices.data()),
-    //         common::ArrayView<const dolfin::la_index_t>(indices.size(),
+    //         common::ArrayView<const PetscInt>(indices.size(),
     //                                                     indices.data())}};
-    Eigen::Map<const EigenArrayXlaindex> rows(indices.data(), indices.size());
+    Eigen::Map<const EigenArrayXpetscint> rows(indices.data(), indices.size());
     pattern.insert_global(rows, rows);
   }
 

--- a/cpp/dolfin/fem/SystemAssembler.cpp
+++ b/cpp/dolfin/fem/SystemAssembler.cpp
@@ -238,7 +238,7 @@ void SystemAssembler::assemble(la::PETScMatrix* A, la::PETScVector* b,
     assert(x0->size() == _a->function_space(1)->dofmap()->global_dimension());
 
     const std::size_t num_bc_dofs = boundary_values[0].size();
-    std::vector<dolfin::la_index_t> bc_indices;
+    std::vector<PetscInt> bc_indices;
     std::vector<PetscScalar> bc_values;
     bc_indices.reserve(num_bc_dofs);
     bc_values.reserve(num_bc_dofs);
@@ -313,10 +313,10 @@ void SystemAssembler::cell_wise_assembly(
   dofmaps[1].push_back(ufc[1]->dolfin_form.function_space(0)->dofmap().get());
 
   // Vector to hold dof map for a cell
-  std::array<std::vector<common::ArrayView<const dolfin::la_index_t>>, 2>
+  std::array<std::vector<common::ArrayView<const PetscInt>>, 2>
       cell_dofs
-      = {{std::vector<common::ArrayView<const dolfin::la_index_t>>(2),
-          std::vector<common::ArrayView<const dolfin::la_index_t>>(1)}};
+      = {{std::vector<common::ArrayView<const PetscInt>>(2),
+          std::vector<common::ArrayView<const PetscInt>>(1)}};
 
   // Create pointers to hold integral objects
   std::array<const ufc_cell_integral*, 2> cell_integrals
@@ -507,7 +507,7 @@ void SystemAssembler::facet_wise_assembly(
 
   // Cell dofmaps [form][cell][form dim]
   std::array<
-      std::array<std::vector<common::ArrayView<const dolfin::la_index_t>>, 2>,
+      std::array<std::vector<common::ArrayView<const PetscInt>>, 2>,
       2>
       cell_dofs;
   cell_dofs[0][0].resize(2);
@@ -521,7 +521,7 @@ void SystemAssembler::facet_wise_assembly(
   std::array<std::size_t, 2> local_facet;
 
   // Vectors to hold dofs for macro cells
-  std::array<std::vector<std::vector<dolfin::la_index_t>>, 2> macro_dofs;
+  std::array<std::vector<std::vector<PetscInt>>, 2> macro_dofs;
   macro_dofs[0].resize(2);
   macro_dofs[1].resize(1);
 
@@ -725,15 +725,15 @@ void SystemAssembler::facet_wise_assembly(
                                     vector_size, compute_cell_tensor);
 
       // Modify local tensors for bcs
-      common::ArrayView<const la_index_t> mdofs0(macro_dofs[0][0]);
-      common::ArrayView<const la_index_t> mdofs1(macro_dofs[0][1]);
+      common::ArrayView<const PetscInt> mdofs0(macro_dofs[0][0]);
+      common::ArrayView<const PetscInt> mdofs1(macro_dofs[0][1]);
       apply_bc(ufc[0]->macro_A.data(), ufc[1]->macro_A.data(), boundary_values,
                mdofs0, mdofs1);
 
       // Add entries to global tensor
       if (b)
       {
-        std::vector<common::ArrayView<const la_index_t>> mdofs(
+        std::vector<common::ArrayView<const PetscInt>> mdofs(
             macro_dofs[1].size());
         for (std::size_t i = 0; i < macro_dofs[1].size(); ++i)
           mdofs[i].set(macro_dofs[1][i]);
@@ -744,7 +744,7 @@ void SystemAssembler::facet_wise_assembly(
           = ufc[0]->dolfin_form.integrals().num_interior_facet_integrals() > 0;
       if (A && add_macro_element)
       {
-        std::vector<common::ArrayView<const la_index_t>> mdofs(
+        std::vector<common::ArrayView<const PetscInt>> mdofs(
             macro_dofs[0].size());
         for (std::size_t i = 0; i < macro_dofs[0].size(); ++i)
           mdofs[i].set(macro_dofs[0][i]);
@@ -984,7 +984,7 @@ void SystemAssembler::matrix_block_add(
     la::PETScMatrix& tensor, std::vector<PetscScalar>& Ae,
     std::vector<PetscScalar>& macro_A,
     const std::array<bool, 2>& add_local_tensor,
-    const std::array<std::vector<common::ArrayView<const la_index_t>>, 2>&
+    const std::array<std::vector<common::ArrayView<const PetscInt>>, 2>&
         cell_dofs)
 {
   for (std::size_t c = 0; c < 2; ++c)
@@ -1011,8 +1011,8 @@ void SystemAssembler::matrix_block_add(
 void SystemAssembler::apply_bc(
     PetscScalar* A, PetscScalar* b,
     const std::vector<DirichletBC::Map>& boundary_values,
-    const common::ArrayView<const dolfin::la_index_t>& global_dofs0,
-    const common::ArrayView<const dolfin::la_index_t>& global_dofs1)
+    const common::ArrayView<const PetscInt>& global_dofs0,
+    const common::ArrayView<const PetscInt>& global_dofs1)
 {
   assert(A);
   assert(b);
@@ -1089,7 +1089,7 @@ void SystemAssembler::apply_bc(
 //-----------------------------------------------------------------------------
 bool SystemAssembler::has_bc(
     const DirichletBC::Map& boundary_values,
-    const common::ArrayView<const dolfin::la_index_t>& dofs)
+    const common::ArrayView<const PetscInt>& dofs)
 {
   // Loop over dofs and check if bc is applied
   for (auto dof = dofs.begin(); dof != dofs.end(); ++dof)
@@ -1105,7 +1105,7 @@ bool SystemAssembler::has_bc(
 bool SystemAssembler::cell_matrix_required(
     const la::PETScMatrix* A, const void* integral,
     const std::vector<DirichletBC::Map>& boundary_values,
-    const common::ArrayView<const dolfin::la_index_t>& dofs)
+    const common::ArrayView<const PetscInt>& dofs)
 {
   if (A && integral)
     return true;

--- a/cpp/dolfin/fem/SystemAssembler.h
+++ b/cpp/dolfin/fem/SystemAssembler.h
@@ -167,25 +167,25 @@ private:
       la::PETScMatrix& tensor, std::vector<PetscScalar>& Ae,
       std::vector<PetscScalar>& macro_A,
       const std::array<bool, 2>& add_local_tensor,
-      const std::array<std::vector<common::ArrayView<const la_index_t>>, 2>&
+      const std::array<std::vector<common::ArrayView<const PetscInt>>, 2>&
           cell_dofs);
 
   static void
   apply_bc(PetscScalar* A, PetscScalar* b,
            const std::vector<DirichletBC::Map>& boundary_values,
-           const common::ArrayView<const dolfin::la_index_t>& global_dofs0,
-           const common::ArrayView<const dolfin::la_index_t>& global_dofs1);
+           const common::ArrayView<const PetscInt>& global_dofs0,
+           const common::ArrayView<const PetscInt>& global_dofs1);
 
   // Return true if cell has an Dirichlet/essential boundary
   // condition applied
   static bool has_bc(const DirichletBC::Map& boundary_values,
-                     const common::ArrayView<const dolfin::la_index_t>& dofs);
+                     const common::ArrayView<const PetscInt>& dofs);
 
   // Return true if element matrix is required
   static bool
   cell_matrix_required(const la::PETScMatrix* A, const void* integral,
                        const std::vector<DirichletBC::Map>& boundary_values,
-                       const common::ArrayView<const dolfin::la_index_t>& dofs);
+                       const common::ArrayView<const PetscInt>& dofs);
 };
 } // namespace fem
 } // namespace dolfin

--- a/cpp/dolfin/fem/utils.cpp
+++ b/cpp/dolfin/fem/utils.cpp
@@ -208,7 +208,7 @@ la::PETScVector fem::init_monolithic(std::vector<const fem::Form*> L)
   std::vector<std::size_t> ghosts;
   for (std::size_t i = 0; i < L.size(); ++i)
   {
-    const Eigen::Array<la_index_t, Eigen::Dynamic, 1>& field_ghosts
+    const Eigen::Array<PetscInt, Eigen::Dynamic, 1>& field_ghosts
         = index_maps[i]->ghosts();
     for (Eigen::Index j = 0; j < field_ghosts.size(); ++j)
     {
@@ -278,7 +278,7 @@ la::PETScMatrix dolfin::fem::init_matrix(const Form& a)
 
     // Set zeros in dense rows in order of increasing column index
     const PetscScalar block = 0.0;
-    dolfin::la_index_t IJ[2];
+    PetscInt IJ[2];
     for (Eigen::Index i = 0; i < global_dofs.size(); ++i)
     {
       const std::int64_t I = index_map_0.local_to_global(global_dofs[i]);
@@ -310,7 +310,7 @@ la::PETScMatrix dolfin::fem::init_matrix(const Form& a)
 
     for (std::int64_t i = row_range[0]; i < range; i++)
     {
-      const dolfin::la_index_t _i = i;
+      const PetscInt _i = i;
       A.set(&block, 1, &_i, 1, &_i);
     }
 

--- a/cpp/dolfin/function/Function.cpp
+++ b/cpp/dolfin/function/Function.cpp
@@ -79,8 +79,8 @@ Function::Function(const Function& v)
 
     // Get row indices of original and new vectors
     std::unordered_map<std::size_t, std::size_t>::const_iterator entry;
-    std::vector<dolfin::la_index_t> new_rows(collapsed_map.size());
-    std::vector<dolfin::la_index_t> old_rows(collapsed_map.size());
+    std::vector<PetscInt> new_rows(collapsed_map.size());
+    std::vector<PetscInt> old_rows(collapsed_map.size());
     std::size_t i = 0;
     for (entry = collapsed_map.begin(); entry != collapsed_map.end(); ++entry)
     {
@@ -134,8 +134,8 @@ const Function& Function::operator= (const Function& v)
 
     // Get row indices of original and new vectors
     std::unordered_map<std::size_t, std::size_t>::const_iterator entry;
-    std::vector<dolfin::la_index_t> new_rows(collapsed_map.size());
-    std::vector<dolfin::la_index_t> old_rows(collapsed_map.size());
+    std::vector<PetscInt> new_rows(collapsed_map.size());
+    std::vector<PetscInt> old_rows(collapsed_map.size());
     std::size_t i = 0;
     for (entry = collapsed_map.begin(); entry != collapsed_map.end(); ++entry)
     {

--- a/cpp/dolfin/function/FunctionSpace.cpp
+++ b/cpp/dolfin/function/FunctionSpace.cpp
@@ -291,8 +291,8 @@ EigenRowArrayXXd FunctionSpace::tabulate_dof_coordinates() const
     // Copy dof coordinates into vector
     for (Eigen::Index i = 0; i < dofs.size(); ++i)
     {
-      const dolfin::la_index_t dof = dofs[i];
-      if (dof < (dolfin::la_index_t)local_size)
+      const PetscInt dof = dofs[i];
+      if (dof < (PetscInt)local_size)
         x.row(dof) = coordinates.row(i);
     }
   }

--- a/cpp/dolfin/graph/GraphBuilder.cpp
+++ b/cpp/dolfin/graph/GraphBuilder.cpp
@@ -38,9 +38,9 @@ dolfin::graph::GraphBuilder::local_graph(const mesh::Mesh& mesh,
   // Build graph
   for (auto& cell : mesh::MeshRange<mesh::Cell>(mesh))
   {
-    Eigen::Map<const Eigen::Array<dolfin::la_index_t, Eigen::Dynamic, 1>> dofs0
+    Eigen::Map<const Eigen::Array<PetscInt, Eigen::Dynamic, 1>> dofs0
         = dofmap0.cell_dofs(cell.index());
-    Eigen::Map<const Eigen::Array<dolfin::la_index_t, Eigen::Dynamic, 1>> dofs1
+    Eigen::Map<const Eigen::Array<PetscInt, Eigen::Dynamic, 1>> dofs1
         = dofmap1.cell_dofs(cell.index());
 
     for (Eigen::Index i = 0; i < dofs0.size(); ++i)

--- a/cpp/dolfin/io/HDF5File.cpp
+++ b/cpp/dolfin/io/HDF5File.cpp
@@ -210,7 +210,7 @@ la::PETScVector HDF5File::read_vector(MPI_Comm comm,
     x = la::PETScVector(comm,
                         {{(std::int64_t)partitions[process_num],
                           (std::int64_t)partitions[process_num + 1]}},
-                        Eigen::Array<la_index_t, Eigen::Dynamic, 1>(), 1);
+                        Eigen::Array<PetscInt, Eigen::Dynamic, 1>(), 1);
   }
   else
   {
@@ -829,7 +829,7 @@ void HDF5File::write(const function::Function& u, const std::string name)
   // the start of each row
 
   const std::size_t tdim = mesh.topology().dim();
-  std::vector<dolfin::la_index_t> cell_dofs;
+  std::vector<PetscInt> cell_dofs;
   std::vector<std::size_t> x_cell_dofs;
   const std::size_t n_cells = mesh.topology().ghost_offset(tdim);
   x_cell_dofs.reserve(n_cells);
@@ -844,7 +844,7 @@ void HDF5File::write(const function::Function& u, const std::string name)
     for (Eigen::Index j = 0; j < cell_dofs_i.size(); ++j)
     {
       auto p = cell_dofs_i[j];
-      assert(p < (dolfin::la_index_t)local_to_global_map.size());
+      assert(p < (PetscInt)local_to_global_map.size());
       cell_dofs.push_back(local_to_global_map[p]);
     }
   }
@@ -992,8 +992,8 @@ HDF5File::read(std::shared_ptr<const function::FunctionSpace> V,
           {{cell_range[0], cell_range[1] + 1}});
 
   // Read cell-DOF maps
-  std::vector<dolfin::la_index_t> input_cell_dofs
-      = HDF5Interface::read_dataset<dolfin::la_index_t>(
+  std::vector<PetscInt> input_cell_dofs
+      = HDF5Interface::read_dataset<PetscInt>(
           _hdf5_file_id, cell_dofs_dataset_name,
           {{x_cell_dofs.front(), x_cell_dofs.back()}});
 

--- a/cpp/dolfin/io/HDF5Utility.cpp
+++ b/cpp/dolfin/io/HDF5Utility.cpp
@@ -23,7 +23,7 @@ using namespace dolfin::io;
 std::pair<std::vector<std::size_t>, std::vector<std::size_t>>
 HDF5Utility::map_gdof_to_cell(
     const MPI_Comm mpi_comm, const std::vector<std::size_t>& input_cells,
-    const std::vector<dolfin::la_index_t>& input_cell_dofs,
+    const std::vector<PetscInt>& input_cell_dofs,
     const std::vector<std::int64_t>& x_cell_dofs,
     const std::array<std::int64_t, 2> vector_range)
 {
@@ -32,28 +32,28 @@ HDF5Utility::map_gdof_to_cell(
   // Some overwriting will occur if multiple cells refer to the same DOF
 
   const std::size_t num_processes = MPI::size(mpi_comm);
-  std::vector<dolfin::la_index_t> all_vec_range;
-  std::vector<dolfin::la_index_t> vector_range_second(1, vector_range[1]);
+  std::vector<PetscInt> all_vec_range;
+  std::vector<PetscInt> vector_range_second(1, vector_range[1]);
   MPI::gather(mpi_comm, vector_range_second, all_vec_range);
   MPI::broadcast(mpi_comm, all_vec_range);
 
-  std::map<dolfin::la_index_t, std::pair<std::size_t, std::size_t>> dof_to_cell;
+  std::map<PetscInt, std::pair<std::size_t, std::size_t>> dof_to_cell;
   const std::size_t offset = x_cell_dofs[0];
   for (std::size_t i = 0; i < x_cell_dofs.size() - 1; ++i)
   {
     for (std::int64_t j = x_cell_dofs[i]; j != x_cell_dofs[i + 1]; ++j)
     {
       const unsigned char local_dof_i = j - x_cell_dofs[i];
-      const dolfin::la_index_t global_dof = input_cell_dofs[j - offset];
+      const PetscInt global_dof = input_cell_dofs[j - offset];
       dof_to_cell[global_dof] = std::make_pair(input_cells[i], local_dof_i);
     }
   }
 
   // Transfer dof_to_cell map to processes which hold the
   // vector data for that DOF
-  std::vector<std::vector<dolfin::la_index_t>> send_dofs(num_processes);
+  std::vector<std::vector<PetscInt>> send_dofs(num_processes);
   std::vector<std::vector<std::size_t>> send_cell_dofs(num_processes);
-  for (std::map<dolfin::la_index_t,
+  for (std::map<PetscInt,
                 std::pair<std::size_t, std::size_t>>::const_iterator p
        = dof_to_cell.begin();
        p != dof_to_cell.end(); ++p)
@@ -66,7 +66,7 @@ HDF5Utility::map_gdof_to_cell(
     send_cell_dofs[dest].push_back(p->second.second);
   }
 
-  std::vector<std::vector<dolfin::la_index_t>> receive_dofs(num_processes);
+  std::vector<std::vector<PetscInt>> receive_dofs(num_processes);
   std::vector<std::vector<std::size_t>> receive_cell_dofs(num_processes);
   MPI::all_to_all(mpi_comm, send_dofs, receive_dofs);
   MPI::all_to_all(mpi_comm, send_cell_dofs, receive_cell_dofs);
@@ -79,7 +79,7 @@ HDF5Utility::map_gdof_to_cell(
   std::vector<std::size_t> remote_local_dofi(vector_range[1] - vector_range[0]);
   for (std::size_t i = 0; i < num_processes; ++i)
   {
-    std::vector<dolfin::la_index_t>& rdofs = receive_dofs[i];
+    std::vector<PetscInt>& rdofs = receive_dofs[i];
     std::vector<std::size_t>& rcelldofs = receive_cell_dofs[i];
     assert(rcelldofs.size() == 2 * rdofs.size());
     for (std::size_t j = 0; j < rdofs.size(); ++j)
@@ -94,7 +94,7 @@ HDF5Utility::map_gdof_to_cell(
   return std::make_pair(std::move(global_cells), std::move(remote_local_dofi));
 }
 //-----------------------------------------------------------------------------
-std::vector<dolfin::la_index_t> HDF5Utility::get_global_dof(
+std::vector<PetscInt> HDF5Utility::get_global_dof(
     const MPI_Comm mpi_comm,
     const std::vector<std::pair<std::size_t, std::size_t>>& cell_ownership,
     const std::vector<std::size_t>& remote_local_dofi,
@@ -105,7 +105,7 @@ std::vector<dolfin::la_index_t> HDF5Utility::get_global_dof(
   std::vector<std::vector<std::size_t>> send_cell_dofs(num_processes);
   const std::size_t n_vector_vals = vector_range[1] - vector_range[0];
 
-  std::vector<dolfin::la_index_t> global_dof(n_vector_vals);
+  std::vector<PetscInt> global_dof(n_vector_vals);
   for (std::size_t i = 0; i != n_vector_vals; ++i)
   {
     const std::size_t dest = cell_ownership[i].first;
@@ -121,7 +121,7 @@ std::vector<dolfin::la_index_t> HDF5Utility::get_global_dof(
       = dofmap.tabulate_local_to_global_dofs();
 
   // Return back the global dof to the process the request came from
-  std::vector<std::vector<dolfin::la_index_t>> send_global_dof_back(
+  std::vector<std::vector<PetscInt>> send_global_dof_back(
       num_processes);
   for (std::size_t i = 0; i < num_processes; ++i)
   {
@@ -130,14 +130,14 @@ std::vector<dolfin::la_index_t> HDF5Utility::get_global_dof(
     {
       auto dmap = dofmap.cell_dofs(rdof[j]);
       assert(rdof[j + 1] < (std::size_t)dmap.size());
-      const dolfin::la_index_t local_index = dmap[rdof[j + 1]];
+      const PetscInt local_index = dmap[rdof[j + 1]];
       assert(local_index >= 0);
       assert((std::size_t)local_index < local_to_global_map.size());
       send_global_dof_back[i].push_back(local_to_global_map[local_index]);
     }
   }
 
-  std::vector<std::vector<dolfin::la_index_t>> receive_global_dof_back(
+  std::vector<std::vector<PetscInt>> receive_global_dof_back(
       num_processes);
   MPI::all_to_all(mpi_comm, send_global_dof_back, receive_global_dof_back);
 
@@ -150,7 +150,7 @@ std::vector<dolfin::la_index_t> HDF5Utility::get_global_dof(
   {
     const std::size_t src = cell_ownership[i].first;
     assert(src < num_processes);
-    const std::vector<dolfin::la_index_t>& rgdof = receive_global_dof_back[src];
+    const std::vector<PetscInt>& rgdof = receive_global_dof_back[src];
     assert(pos[src] < rgdof.size());
     global_dof[i] = rgdof[pos[src]];
     pos[src]++;
@@ -283,7 +283,7 @@ void HDF5Utility::cell_owners_in_range(
 void HDF5Utility::set_local_vector_values(
     const MPI_Comm mpi_comm, la::PETScVector& x, const mesh::Mesh& mesh,
     const std::vector<size_t>& cells,
-    const std::vector<dolfin::la_index_t>& cell_dofs,
+    const std::vector<PetscInt>& cell_dofs,
     const std::vector<std::int64_t>& x_cell_dofs,
     const std::vector<PetscScalar>& vector,
     const std::array<std::int64_t, 2> input_vector_range,
@@ -308,7 +308,7 @@ void HDF5Utility::set_local_vector_values(
   // Having found the cell location, the actual global_dof index held
   // by that (cell, local_dof) is needed on the process which holds
   // the data values
-  std::vector<dolfin::la_index_t> global_dof = HDF5Utility::get_global_dof(
+  std::vector<PetscInt> global_dof = HDF5Utility::get_global_dof(
       mpi_comm, cell_ownership, remote_local_dofi, input_vector_range, dofmap);
 
   const std::size_t num_processes = MPI::size(mpi_comm);
@@ -317,15 +317,15 @@ void HDF5Utility::set_local_vector_values(
   const std::array<std::int64_t, 2> vector_range = x.local_range();
 
   std::vector<std::vector<PetscScalar>> receive_values(num_processes);
-  std::vector<std::vector<dolfin::la_index_t>> receive_indices(num_processes);
+  std::vector<std::vector<PetscInt>> receive_indices(num_processes);
   {
     std::vector<std::vector<PetscScalar>> send_values(num_processes);
-    std::vector<std::vector<dolfin::la_index_t>> send_indices(num_processes);
+    std::vector<std::vector<PetscInt>> send_indices(num_processes);
     const std::size_t n_vector_vals
         = input_vector_range[1] - input_vector_range[0];
-    std::vector<dolfin::la_index_t> all_vec_range;
+    std::vector<PetscInt> all_vec_range;
 
-    std::vector<dolfin::la_index_t> vector_range_second(1, vector_range[1]);
+    std::vector<PetscInt> vector_range_second(1, vector_range[1]);
     MPI::gather(mpi_comm, vector_range_second, all_vec_range);
     MPI::broadcast(mpi_comm, all_vec_range);
 
@@ -349,7 +349,7 @@ void HDF5Utility::set_local_vector_values(
   for (std::size_t i = 0; i != num_processes; ++i)
   {
     const std::vector<PetscScalar>& rval = receive_values[i];
-    const std::vector<dolfin::la_index_t>& rindex = receive_indices[i];
+    const std::vector<PetscInt>& rindex = receive_indices[i];
     assert(rval.size() == rindex.size());
     for (std::size_t j = 0; j != rindex.size(); ++j)
     {

--- a/cpp/dolfin/io/HDF5Utility.h
+++ b/cpp/dolfin/io/HDF5Utility.h
@@ -51,7 +51,7 @@ public:
   static std::pair<std::vector<std::size_t>, std::vector<std::size_t>>
   map_gdof_to_cell(const MPI_Comm mpi_comm,
                    const std::vector<std::size_t>& input_cells,
-                   const std::vector<dolfin::la_index_t>& input_cell_dofs,
+                   const std::vector<PetscInt>& input_cell_dofs,
                    const std::vector<std::int64_t>& x_cell_dofs,
                    const std::array<std::int64_t, 2> vector_range);
 
@@ -61,7 +61,7 @@ public:
   /// DOFs in the range of "vector_range".
   ///
   /// Returns global_dof
-  static std::vector<dolfin::la_index_t> get_global_dof(
+  static std::vector<PetscInt> get_global_dof(
       MPI_Comm mpi_comm,
       const std::vector<std::pair<std::size_t, std::size_t>>& cell_ownership,
       const std::vector<std::size_t>& remote_local_dofi,
@@ -84,7 +84,7 @@ public:
   set_local_vector_values(MPI_Comm mpi_comm, la::PETScVector& x,
                           const mesh::Mesh& mesh,
                           const std::vector<size_t>& cells,
-                          const std::vector<dolfin::la_index_t>& cell_dofs,
+                          const std::vector<PetscInt>& cell_dofs,
                           const std::vector<std::int64_t>& x_cell_dofs,
                           const std::vector<PetscScalar>& vector,
                           std::array<std::int64_t, 2> input_vector_range,

--- a/cpp/dolfin/io/VTKWriter.cpp
+++ b/cpp/dolfin/io/VTKWriter.cpp
@@ -98,7 +98,7 @@ void VTKWriter::write_cell_data(const function::Function& u,
   const std::size_t size = num_cells * data_dim;
 
   // Build lists of dofs and create map
-  std::vector<dolfin::la_index_t> dof_set;
+  std::vector<PetscInt> dof_set;
   std::vector<std::size_t> offset(size + 1);
   std::vector<std::size_t>::iterator cell_offset = offset.begin();
   for (auto& cell : mesh::MeshRange<mesh::Cell>(mesh))

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -1388,7 +1388,7 @@ void XDMFFile::add_function(MPI_Comm mpi_comm, pugi::xml_node& xml_node,
   const fem::GenericDofMap& dofmap = *u.function_space()->dofmap();
 
   const std::size_t tdim = mesh.topology().dim();
-  std::vector<dolfin::la_index_t> cell_dofs;
+  std::vector<PetscInt> cell_dofs;
   std::vector<std::size_t> x_cell_dofs;
   const std::size_t n_cells = mesh.topology().ghost_offset(tdim);
   x_cell_dofs.reserve(n_cells);
@@ -1405,7 +1405,7 @@ void XDMFFile::add_function(MPI_Comm mpi_comm, pugi::xml_node& xml_node,
     for (Eigen::Index j = 0; j < cell_dofs_i.size(); ++j)
     {
       auto p = cell_dofs_i[j];
-      assert(p < (dolfin::la_index_t)local_to_global_map.size());
+      assert(p < (PetscInt)local_to_global_map.size());
       cell_dofs.push_back(local_to_global_map[p]);
     }
   }
@@ -1693,7 +1693,7 @@ XDMFFile::read_checkpoint(std::shared_ptr<const function::FunctionSpace> V,
       {{cell_range[0], cell_range[1] + 1}});
 
   // Read cell dofmaps
-  std::vector<dolfin::la_index_t> cell_dofs = get_dataset<dolfin::la_index_t>(
+  std::vector<PetscInt> cell_dofs = get_dataset<PetscInt>(
       _mpi_comm.comm(), cell_dofs_dataitem, parent_path,
       {{x_cell_dofs.front(), x_cell_dofs.back()}});
 
@@ -2797,7 +2797,7 @@ XDMFFile::get_cell_data_values(const function::Function& u)
   const std::size_t local_size = num_local_cells * value_size;
 
   // Build lists of dofs and create map
-  std::vector<dolfin::la_index_t> dof_set;
+  std::vector<PetscInt> dof_set;
   dof_set.reserve(local_size);
   const auto dofmap = u.function_space()->dofmap();
   for (auto& cell : mesh::MeshRange<mesh::Cell>(*mesh))
@@ -2927,7 +2927,7 @@ XDMFFile::get_p2_data_values(const function::Function& u)
       = mesh->num_entities(0) + mesh->num_entities(1);
   const std::size_t width = get_padded_width(u);
   std::vector<PetscScalar> data_values(width * num_local_points);
-  std::vector<dolfin::la_index_t> data_dofs(data_values.size(), 0);
+  std::vector<PetscInt> data_dofs(data_values.size(), 0);
 
   assert(u.function_space()->dofmap());
   const auto dofmap = u.function_space()->dofmap();

--- a/cpp/dolfin/la/PETScMatrix.cpp
+++ b/cpp/dolfin/la/PETScMatrix.cpp
@@ -190,8 +190,8 @@ std::array<std::int64_t, 2> PETScMatrix::local_range(std::size_t dim) const
 }
 //-----------------------------------------------------------------------------
 void PETScMatrix::set(const PetscScalar* block, std::size_t m,
-                      const dolfin::la_index_t* rows, std::size_t n,
-                      const dolfin::la_index_t* cols)
+                      const PetscInt* rows, std::size_t n,
+                      const PetscInt* cols)
 {
   assert(_matA);
   PetscErrorCode ierr
@@ -201,8 +201,8 @@ void PETScMatrix::set(const PetscScalar* block, std::size_t m,
 }
 //-----------------------------------------------------------------------------
 void PETScMatrix::set_local(const PetscScalar* block, std::size_t m,
-                            const dolfin::la_index_t* rows, std::size_t n,
-                            const dolfin::la_index_t* cols)
+                            const PetscInt* rows, std::size_t n,
+                            const PetscInt* cols)
 {
   assert(_matA);
   PetscErrorCode ierr
@@ -212,8 +212,8 @@ void PETScMatrix::set_local(const PetscScalar* block, std::size_t m,
 }
 //-----------------------------------------------------------------------------
 void PETScMatrix::add(const PetscScalar* block, std::size_t m,
-                      const dolfin::la_index_t* rows, std::size_t n,
-                      const dolfin::la_index_t* cols)
+                      const PetscInt* rows, std::size_t n,
+                      const PetscInt* cols)
 {
   assert(_matA);
   PetscErrorCode ierr
@@ -223,8 +223,8 @@ void PETScMatrix::add(const PetscScalar* block, std::size_t m,
 }
 //-----------------------------------------------------------------------------
 void PETScMatrix::add_local(const PetscScalar* block, std::size_t m,
-                            const dolfin::la_index_t* rows, std::size_t n,
-                            const dolfin::la_index_t* cols)
+                            const PetscInt* rows, std::size_t n,
+                            const PetscInt* cols)
 {
   assert(_matA);
   PetscErrorCode ierr

--- a/cpp/dolfin/la/PETScMatrix.h
+++ b/cpp/dolfin/la/PETScMatrix.h
@@ -88,23 +88,23 @@ public:
 
   /// Set block of values using global indices
   void set(const PetscScalar* block, std::size_t m,
-           const dolfin::la_index_t* rows, std::size_t n,
-           const dolfin::la_index_t* cols);
+           const PetscInt* rows, std::size_t n,
+           const PetscInt* cols);
 
   /// Set block of values using local indices
   void set_local(const PetscScalar* block, std::size_t m,
-                 const dolfin::la_index_t* rows, std::size_t n,
-                 const dolfin::la_index_t* cols);
+                 const PetscInt* rows, std::size_t n,
+                 const PetscInt* cols);
 
   /// Add block of values using global indices
   void add(const PetscScalar* block, std::size_t m,
-           const dolfin::la_index_t* rows, std::size_t n,
-           const dolfin::la_index_t* cols);
+           const PetscInt* rows, std::size_t n,
+           const PetscInt* cols);
 
   /// Add block of values using local indices
   void add_local(const PetscScalar* block, std::size_t m,
-                 const dolfin::la_index_t* rows, std::size_t n,
-                 const dolfin::la_index_t* cols);
+                 const PetscInt* rows, std::size_t n,
+                 const PetscInt* cols);
 
   /// Return norm of matrix
   double norm(la::Norm norm_type) const;

--- a/cpp/dolfin/la/PETScVector.cpp
+++ b/cpp/dolfin/la/PETScVector.cpp
@@ -36,7 +36,7 @@ PETScVector::PETScVector(const common::IndexMap& map)
 //-----------------------------------------------------------------------------
 PETScVector::PETScVector(
     MPI_Comm comm, std::array<std::int64_t, 2> range,
-    const Eigen::Array<la_index_t, Eigen::Dynamic, 1>& ghost_indices,
+    const Eigen::Array<PetscInt, Eigen::Dynamic, 1>& ghost_indices,
     int block_size)
     : _x(nullptr)
 {
@@ -235,7 +235,7 @@ void PETScVector::add_local(const std::vector<PetscScalar>& values)
 }
 //-----------------------------------------------------------------------------
 void PETScVector::get_local(PetscScalar* block, std::size_t m,
-                            const dolfin::la_index_t* rows) const
+                            const PetscInt* rows) const
 {
   if (m == 0)
     return;
@@ -276,7 +276,7 @@ void PETScVector::get_local(PetscScalar* block, std::size_t m,
 }
 //-----------------------------------------------------------------------------
 void PETScVector::set(const PetscScalar* block, std::size_t m,
-                      const dolfin::la_index_t* rows)
+                      const PetscInt* rows)
 {
   assert(_x);
   PetscErrorCode ierr = VecSetValues(_x, m, rows, block, INSERT_VALUES);
@@ -284,7 +284,7 @@ void PETScVector::set(const PetscScalar* block, std::size_t m,
 }
 //-----------------------------------------------------------------------------
 void PETScVector::set_local(const PetscScalar* block, std::size_t m,
-                            const dolfin::la_index_t* rows)
+                            const PetscInt* rows)
 {
   assert(_x);
   PetscErrorCode ierr = VecSetValuesLocal(_x, m, rows, block, INSERT_VALUES);
@@ -292,7 +292,7 @@ void PETScVector::set_local(const PetscScalar* block, std::size_t m,
 }
 //-----------------------------------------------------------------------------
 void PETScVector::add(const PetscScalar* block, std::size_t m,
-                      const dolfin::la_index_t* rows)
+                      const PetscInt* rows)
 {
   assert(_x);
   PetscErrorCode ierr = VecSetValues(_x, m, rows, block, ADD_VALUES);
@@ -300,7 +300,7 @@ void PETScVector::add(const PetscScalar* block, std::size_t m,
 }
 //-----------------------------------------------------------------------------
 void PETScVector::add_local(const PetscScalar* block, std::size_t m,
-                            const dolfin::la_index_t* rows)
+                            const PetscInt* rows)
 {
   assert(_x);
   PetscErrorCode ierr = VecSetValuesLocal(_x, m, rows, block, ADD_VALUES);
@@ -534,7 +534,7 @@ std::string PETScVector::str(bool verbose) const
 }
 //-----------------------------------------------------------------------------
 void PETScVector::gather(PETScVector& y,
-                         const std::vector<dolfin::la_index_t>& indices) const
+                         const std::vector<PetscInt>& indices) const
 {
   assert(_x);
   PetscErrorCode ierr;

--- a/cpp/dolfin/la/PETScVector.h
+++ b/cpp/dolfin/la/PETScVector.h
@@ -35,7 +35,7 @@ public:
 
   /// Create vector
   PETScVector(MPI_Comm comm, std::array<std::int64_t, 2> range,
-              const Eigen::Array<la_index_t, Eigen::Dynamic, 1>& ghost_indices,
+              const Eigen::Array<PetscInt, Eigen::Dynamic, 1>& ghost_indices,
               int block_size);
 
   // FIXME: Try to remove
@@ -111,23 +111,23 @@ public:
 
   /// Get block of values using local indices
   void get_local(PetscScalar* block, std::size_t m,
-                 const dolfin::la_index_t* rows) const;
+                 const PetscInt* rows) const;
 
   /// Set block of values using global indices
   void set(const PetscScalar* block, std::size_t m,
-           const dolfin::la_index_t* rows);
+           const PetscInt* rows);
 
   /// Set block of values using local indices
   void set_local(const PetscScalar* block, std::size_t m,
-                 const dolfin::la_index_t* rows);
+                 const PetscInt* rows);
 
   /// Add block of values using global indices
   void add(const PetscScalar* block, std::size_t m,
-           const dolfin::la_index_t* rows);
+           const PetscInt* rows);
 
   /// Add block of values using local indices
   void add_local(const PetscScalar* block, std::size_t m,
-                 const dolfin::la_index_t* rows);
+                 const PetscInt* rows);
 
   /// Get all values on local process
   void get_local(std::vector<PetscScalar>& values) const;
@@ -143,7 +143,7 @@ public:
   /// dimension (same as provided indices). This operation is
   /// collective.
   void gather(PETScVector& y,
-              const std::vector<dolfin::la_index_t>& indices) const;
+              const std::vector<PetscInt>& indices) const;
 
   /// Add multiple of given vector (AXPY operation, this = a*x + this)
   void axpy(PetscScalar a, const PETScVector& x);

--- a/cpp/dolfin/la/SparsityPattern.h
+++ b/cpp/dolfin/la/SparsityPattern.h
@@ -68,18 +68,18 @@ public:
   SparsityPattern& operator=(SparsityPattern&& pattern) = default;
 
   /// Insert non-zero entries using global indices
-  void insert_global(const Eigen::Ref<const EigenArrayXlaindex> rows,
-                     const Eigen::Ref<const EigenArrayXlaindex> cols);
+  void insert_global(const Eigen::Ref<const EigenArrayXpetscint> rows,
+                     const Eigen::Ref<const EigenArrayXpetscint> cols);
 
   /// Insert non-zero entries using local (process-wise) indices
-  void insert_local(const Eigen::Ref<const EigenArrayXlaindex> rows,
-                    const Eigen::Ref<const EigenArrayXlaindex> cols);
+  void insert_local(const Eigen::Ref<const EigenArrayXpetscint> rows,
+                    const Eigen::Ref<const EigenArrayXpetscint> cols);
 
   // FIXME: Remove?
   /// Insert non-zero entries using local (process-wise) indices for the
   /// primary dimension and global indices for the co-dimension
-  void insert_local_global(const Eigen::Ref<const EigenArrayXlaindex> rows,
-                           const Eigen::Ref<const EigenArrayXlaindex> cols);
+  void insert_local_global(const Eigen::Ref<const EigenArrayXpetscint> rows,
+                           const Eigen::Ref<const EigenArrayXpetscint> cols);
 
   /// Insert full rows (or columns, according to primary dimension)
   /// using local (process-wise) indices. This must be called before any
@@ -138,9 +138,9 @@ private:
   void insert_entries(
       const Eigen::Ref<const EigenArrayXi32> rows,
       const Eigen::Ref<const EigenArrayXi32> cols,
-      const std::function<la_index_t(const la_index_t,
+      const std::function<PetscInt(const PetscInt,
                                      const common::IndexMap&)>& row_map,
-      const std::function<la_index_t(const la_index_t,
+      const std::function<PetscInt(const PetscInt,
                                      const common::IndexMap&)>& col_map);
 
   // Print some useful information

--- a/python/src/common.cpp
+++ b/python/src/common.cpp
@@ -80,7 +80,6 @@ void common(py::module& m)
         "Return `True` if DOLFIN is configured with slepc4py");
   m.def("git_commit_hash", &dolfin::git_commit_hash,
         "Returns git hash for this build.");
-  m.def("sizeof_la_index_t", &dolfin::sizeof_la_index_t);
 
   m.attr("DOLFIN_EPS") = DOLFIN_EPS;
   m.attr("DOLFIN_PI") = DOLFIN_PI;

--- a/python/src/fem.cpp
+++ b/python/src/fem.cpp
@@ -138,19 +138,19 @@ void fem(py::module& m)
       .def("neighbours", &dolfin::fem::GenericDofMap::neighbours)
       .def("shared_nodes", &dolfin::fem::GenericDofMap::shared_nodes)
       .def("cell_dofs", &dolfin::fem::GenericDofMap::cell_dofs)
-      .def("dofs", (std::vector<dolfin::la_index_t>(
+      .def("dofs", (std::vector<PetscInt>(
                        dolfin::fem::GenericDofMap::*)() const)
                        & dolfin::fem::GenericDofMap::dofs)
       .def("dofs",
-           (std::vector<dolfin::la_index_t>(dolfin::fem::GenericDofMap::*)(
+           (std::vector<PetscInt>(dolfin::fem::GenericDofMap::*)(
                const dolfin::mesh::Mesh&, std::size_t) const)
                & dolfin::fem::GenericDofMap::dofs)
       .def("entity_dofs",
-           (std::vector<dolfin::la_index_t>(dolfin::fem::GenericDofMap::*)(
+           (std::vector<PetscInt>(dolfin::fem::GenericDofMap::*)(
                const dolfin::mesh::Mesh&, std::size_t) const)
                & dolfin::fem::GenericDofMap::entity_dofs)
       .def("entity_dofs",
-           (std::vector<dolfin::la_index_t>(dolfin::fem::GenericDofMap::*)(
+           (std::vector<PetscInt>(dolfin::fem::GenericDofMap::*)(
                const dolfin::mesh::Mesh&, std::size_t,
                const std::vector<std::size_t>&) const)
                & dolfin::fem::GenericDofMap::entity_dofs)

--- a/python/src/la.cpp
+++ b/python/src/la.cpp
@@ -166,7 +166,7 @@ void la(py::module& m)
       .def(py::init(
           [](const MPICommWrapper comm, std::array<std::int64_t, 2> range,
              const Eigen::Ref<
-                 const Eigen::Array<dolfin::la_index_t, Eigen::Dynamic, 1>>
+                 const Eigen::Array<PetscInt, Eigen::Dynamic, 1>>
                  ghost_indices,
              int block_size) {
             return dolfin::la::PETScVector(comm.get(), range, ghost_indices,


### PR DESCRIPTION
Just dirty work to support https://github.com/FEniCS/dolfinx/issues/165. 

In addition to "replace" operation the method `dolfin::sizeof_la_index_t()` was removed.