### PR TITLE
Add cffi-based element kernels to tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 install-dependencies: &install-dependencies
   name: Install/update Python (test/doc) dependencies
-  command: pip3 install decorator flake8 matplotlib numba pygmsh pytest pytest-xdist sphinx sphinx_rtd_theme --upgrade
+  command: pip3 install cffi decorator flake8 matplotlib numba pygmsh pytest pytest-xdist sphinx sphinx_rtd_theme --upgrade
 
 install-python-components: &install-python-components
   name: Install FEniCS Python components

--- a/cpp/dolfin/fem/Form.cpp
+++ b/cpp/dolfin/fem/Form.cpp
@@ -169,7 +169,7 @@ std::size_t Form::original_coefficient_position(std::size_t i) const
 std::size_t Form::max_element_tensor_size() const
 {
   std::size_t num_entries = 1;
-  for (const auto& V : _function_spaces)
+  for (auto& V : _function_spaces)
   {
     assert(V->dofmap());
     num_entries *= V->dofmap()->max_element_dofs();
@@ -278,7 +278,9 @@ void Form::tabulate_tensor(
   }
 
   // Compute cell matrix
-  auto tab_fn = _integrals.cell_tabulate_tensor(idx);
+  const std::function<void(PetscScalar*, const PetscScalar* const*,
+                           const double*, int)>& tab_fn
+      = _integrals.cell_tabulate_tensor(idx);
   tab_fn(A, _wpointer.data(), coordinate_dofs.data(), 1);
 }
 //-----------------------------------------------------------------------------

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -21,7 +21,7 @@ c_signature = numba.types.void(
     numba.types.CPointer(numba.types.double), numba.types.intc)
 
 
-@numba.cfunc(c_signature, cache=True)
+@numba.cfunc(c_signature, nopython=True)
 def tabulate_tensor_A(A_, w_, coords_, cell_orientation):
     A = numba.carray(A_, (3, 3), dtype=PETSc.ScalarType)
     coordinate_dofs = numba.carray(coords_, (3, 2), dtype=np.float64)
@@ -39,7 +39,7 @@ def tabulate_tensor_A(A_, w_, coords_, cell_orientation):
     A[:, :] = np.dot(B.T, B) / (2 * Ae)
 
 
-@numba.cfunc(c_signature, cache=True)
+@numba.cfunc(c_signature, nopython=True)
 def tabulate_tensor_b(b_, w_, coords_, cell_orientation):
     b = numba.carray(b_, (3), dtype=PETSc.ScalarType)
     coordinate_dofs = numba.carray(coords_, (3, 2), dtype=np.float64)
@@ -78,7 +78,7 @@ def test_numba_assembly():
     list_timings([TimingType.wall])
 
 
-def test_cffi_assembly():
+def xtest_cffi_assembly():
     mesh = UnitSquareMesh(MPI.comm_world, 13, 13)
     V = FunctionSpace(mesh, "Lagrange", 1)
 

--- a/python/test/unit/fem/test_numba_assembly.py
+++ b/python/test/unit/fem/test_numba_assembly.py
@@ -10,12 +10,17 @@ import numba
 import numpy as np
 from petsc4py import PETSc
 
-from dolfin import (MPI, FunctionSpace, TestFunction, TimingType,
-                    TrialFunction, UnitSquareMesh, cpp, dot, dx, grad,
+from dolfin import (MPI, FunctionSpace, TimingType, UnitSquareMesh, cpp,
                     list_timings)
-from dolfin.jit.jit import ffc_jit
+
+c_signature = numba.types.void(
+    numba.types.CPointer(numba.typeof(PETSc.ScalarType())),
+    numba.types.CPointer(
+        numba.types.CPointer(numba.typeof(PETSc.ScalarType()))),
+    numba.types.CPointer(numba.types.double), numba.types.intc)
 
 
+@numba.cfunc(c_signature, cache=True)
 def tabulate_tensor_A(A_, w_, coords_, cell_orientation):
     A = numba.carray(A_, (3, 3), dtype=PETSc.ScalarType)
     coordinate_dofs = numba.carray(coords_, (3, 2), dtype=np.float64)
@@ -33,6 +38,7 @@ def tabulate_tensor_A(A_, w_, coords_, cell_orientation):
     A[:, :] = np.dot(B.T, B) / (2 * Ae)
 
 
+@numba.cfunc(c_signature, cache=True)
 def tabulate_tensor_b(b_, w_, coords_, cell_orientation):
     b = numba.carray(b_, (3), dtype=PETSc.ScalarType)
     coordinate_dofs = numba.carray(coords_, (3, 2), dtype=np.float64)
@@ -48,29 +54,129 @@ def tabulate_tensor_b(b_, w_, coords_, cell_orientation):
 def test_numba_assembly():
     mesh = UnitSquareMesh(MPI.comm_world, 13, 13)
     V = FunctionSpace(mesh, "Lagrange", 1)
-    u, v = TrialFunction(V), TestFunction(V)
 
     a = cpp.fem.Form([V._cpp_object, V._cpp_object])
+    a.set_cell_tabulate(0, tabulate_tensor_A.address)
+
     L = cpp.fem.Form([V._cpp_object])
+    L.set_cell_tabulate(0, tabulate_tensor_b.address)
 
-    signature = numba.types.void(
-        numba.types.CPointer(numba.typeof(PETSc.ScalarType())),
-        numba.types.CPointer(numba.types.CPointer(numba.typeof(PETSc.ScalarType()))),
-        numba.types.CPointer(numba.types.double), numba.types.intc)
+    assembler = cpp.fem.Assembler([[a]], [L], [])
+    A = assembler.assemble_matrix(cpp.fem.Assembler.BlockType.monolithic)
+    b = assembler.assemble_vector(cpp.fem.Assembler.BlockType.monolithic)
 
-    fnA = numba.cfunc(signature, cache=True)(tabulate_tensor_A)
-    a.set_cell_tabulate(0, fnA.address)
+    Anorm = A.norm(cpp.la.Norm.frobenius)
+    bnorm = b.norm(cpp.la.Norm.l2)
+    assert (np.isclose(Anorm, 56.124860801609124))
+    assert (np.isclose(bnorm, 0.0739710713711999))
 
-    fnb = numba.cfunc(signature, cache=True)(tabulate_tensor_b)
-    L.set_cell_tabulate(0, fnb.address)
+    list_timings([TimingType.wall])
 
-    # if (False):
-    #     ufc_form = ffc_jit(dot(grad(u), grad(v)) * dx)
-    #     ufc_form = cpp.fem.make_ufc_form(ufc_form[0])
-    #     a = cpp.fem.Form(ufc_form, [Q._cpp_object, Q._cpp_object])
-    #     ufc_form = ffc_jit(v * dx)
-    #     ufc_form = cpp.fem.make_ufc_form(ufc_form[0])
-    #     L = cpp.fem.Form(ufc_form, [Q._cpp_object])
+
+def test_cffi_assembly():
+    mesh = UnitSquareMesh(MPI.comm_world, 13, 13)
+    V = FunctionSpace(mesh, "Lagrange", 1)
+
+    if MPI.rank(mesh.mpi_comm()) == 0:
+        from cffi import FFI
+        ffibuilder = FFI()
+        ffibuilder.set_source(
+            "_cffi_kernelA",
+            r"""
+        #include <stdalign.h>
+        void tabulate_tensor_poissonA(double* restrict A, const double* const* w,
+                                    const double* restrict coordinate_dofs,
+                                    int cell_orientation)
+        {
+        // Precomputed values of basis functions and precomputations
+        // FE* dimensions: [entities][points][dofs]
+        // PI* dimensions: [entities][dofs][dofs] or [entities][dofs]
+        // PM* dimensions: [entities][dofs][dofs]
+        alignas(32) static const double FE3_C0_D01_Q1[1][1][2] = { { { -1.0, 1.0 } } };
+        // Unstructured piecewise computations
+        const double J_c0 = coordinate_dofs[0] * FE3_C0_D01_Q1[0][0][0] + coordinate_dofs[2] * FE3_C0_D01_Q1[0][0][1];
+        const double J_c3 = coordinate_dofs[1] * FE3_C0_D01_Q1[0][0][0] + coordinate_dofs[5] * FE3_C0_D01_Q1[0][0][1];
+        const double J_c1 = coordinate_dofs[0] * FE3_C0_D01_Q1[0][0][0] + coordinate_dofs[4] * FE3_C0_D01_Q1[0][0][1];
+        const double J_c2 = coordinate_dofs[1] * FE3_C0_D01_Q1[0][0][0] + coordinate_dofs[3] * FE3_C0_D01_Q1[0][0][1];
+        alignas(32) double sp[20];
+        sp[0] = J_c0 * J_c3;
+        sp[1] = J_c1 * J_c2;
+        sp[2] = sp[0] + -1 * sp[1];
+        sp[3] = J_c0 / sp[2];
+        sp[4] = -1 * J_c1 / sp[2];
+        sp[5] = sp[3] * sp[3];
+        sp[6] = sp[3] * sp[4];
+        sp[7] = sp[4] * sp[4];
+        sp[8] = J_c3 / sp[2];
+        sp[9] = -1 * J_c2 / sp[2];
+        sp[10] = sp[9] * sp[9];
+        sp[11] = sp[8] * sp[9];
+        sp[12] = sp[8] * sp[8];
+        sp[13] = sp[5] + sp[10];
+        sp[14] = sp[6] + sp[11];
+        sp[15] = sp[12] + sp[7];
+        sp[16] = fabs(sp[2]);
+        sp[17] = sp[13] * sp[16];
+        sp[18] = sp[14] * sp[16];
+        sp[19] = sp[15] * sp[16];
+        // UFLACS block mode: preintegrated
+        A[0] = 0.5 * sp[19] + 0.5 * sp[18] + 0.5 * sp[18] + 0.5 * sp[17];
+        A[1] = -0.5 * sp[19] + -0.5 * sp[18];
+        A[2] = -0.5 * sp[18] + -0.5 * sp[17];
+        A[3] = -0.5 * sp[19] + -0.5 * sp[18];
+        A[4] = 0.5 * sp[19];
+        A[5] = 0.5 * sp[18];
+        A[6] = -0.5 * sp[18] + -0.5 * sp[17];
+        A[7] = 0.5 * sp[18];
+        A[8] = 0.5 * sp[17];
+        }
+
+        void tabulate_tensor_poissonL(double* restrict A, const double* const* w,
+                                     const double* restrict coordinate_dofs,
+                                     int cell_orientation)
+        {
+        // Precomputed values of basis functions and precomputations
+        // FE* dimensions: [entities][points][dofs]
+        // PI* dimensions: [entities][dofs][dofs] or [entities][dofs]
+        // PM* dimensions: [entities][dofs][dofs]
+        alignas(32) static const double FE4_C0_D01_Q1[1][1][2] = { { { -1.0, 1.0 } } };
+        // Unstructured piecewise computations
+        const double J_c0 = coordinate_dofs[0] * FE4_C0_D01_Q1[0][0][0] + coordinate_dofs[2] * FE4_C0_D01_Q1[0][0][1];
+        const double J_c3 = coordinate_dofs[1] * FE4_C0_D01_Q1[0][0][0] + coordinate_dofs[5] * FE4_C0_D01_Q1[0][0][1];
+        const double J_c1 = coordinate_dofs[0] * FE4_C0_D01_Q1[0][0][0] + coordinate_dofs[4] * FE4_C0_D01_Q1[0][0][1];
+        const double J_c2 = coordinate_dofs[1] * FE4_C0_D01_Q1[0][0][0] + coordinate_dofs[3] * FE4_C0_D01_Q1[0][0][1];
+        alignas(32) double sp[4];
+        sp[0] = J_c0 * J_c3;
+        sp[1] = J_c1 * J_c2;
+        sp[2] = sp[0] + -1 * sp[1];
+        sp[3] = fabs(sp[2]);
+        // UFLACS block mode: preintegrated
+        A[0] = 0.1666666666666667 * sp[3];
+        A[1] = 0.1666666666666667 * sp[3];
+        A[2] = 0.1666666666666667 * sp[3];
+        }
+        """)
+        ffibuilder.cdef("""
+        void tabulate_tensor_poissonA(double* restrict A, const double* const* w,
+                                    const double* restrict coordinate_dofs,
+                                    int cell_orientation);
+        void tabulate_tensor_poissonL(double* restrict A, const double* const* w,
+                                    const double* restrict coordinate_dofs,
+                                    int cell_orientation);
+        """)
+
+        ffibuilder.compile(verbose=True)
+
+    MPI.barrier(mesh.mpi_comm())
+    from _cffi_kernelA import ffi, lib
+
+    a = cpp.fem.Form([V._cpp_object, V._cpp_object])
+    ptrA = ffi.cast("intptr_t", ffi.addressof(lib, "tabulate_tensor_poissonA"))
+    a.set_cell_tabulate(0, ptrA)
+
+    L = cpp.fem.Form([V._cpp_object])
+    ptrL = ffi.cast("intptr_t", ffi.addressof(lib, "tabulate_tensor_poissonL"))
+    L.set_cell_tabulate(0, ptrL)
 
     assembler = cpp.fem.Assembler([[a]], [L], [])
     A = assembler.assemble_matrix(cpp.fem.Assembler.BlockType.monolithic)

--- a/python/test/unit/fem/test_numba_assembly.py
+++ b/python/test/unit/fem/test_numba_assembly.py
@@ -67,8 +67,8 @@ def test_numba_assembly():
     b = PETScVector()
     assembler.assemble(A, cpp.fem.Assembler.BlockType.monolithic)
     assembler.assemble(b, cpp.fem.Assembler.BlockType.monolithic)
-    #A = assembler.assemble_matrix(cpp.fem.Assembler.BlockType.monolithic)
-    #b = assembler.assemble_vector(cpp.fem.Assembler.BlockType.monolithic)
+    # A = assembler.assemble_matrix(cpp.fem.Assembler.BlockType.monolithic)
+    # b = assembler.assemble_vector(cpp.fem.Assembler.BlockType.monolithic)
 
     Anorm = A.norm(cpp.la.Norm.frobenius)
     bnorm = b.norm(cpp.la.Norm.l2)
@@ -85,9 +85,7 @@ def test_cffi_assembly():
     if MPI.rank(mesh.mpi_comm()) == 0:
         from cffi import FFI
         ffibuilder = FFI()
-        ffibuilder.set_source(
-            "_cffi_kernelA",
-            r"""
+        ffibuilder.set_source("_cffi_kernelA", r"""
         #include <stdalign.h>
         void tabulate_tensor_poissonA(double* restrict A, const double* const* w,
                                     const double* restrict coordinate_dofs,
@@ -197,3 +195,8 @@ def test_cffi_assembly():
     assert (np.isclose(bnorm, 0.0739710713711999))
 
     list_timings([TimingType.wall])
+
+    print("Test:", PETSc.ScalarType)
+    print("Test:", PETSc.ScalarType())
+    print("Test:", type(PETSc.ScalarType()))
+    print("Test:", numba.typeof(PETSc.ScalarType()))

--- a/python/test/unit/fem/test_numba_assembly.py
+++ b/python/test/unit/fem/test_numba_assembly.py
@@ -6,19 +6,19 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
-from dolfin import (cpp, UnitSquareMesh, MPI, FunctionSpace,
-                    dx, dot, grad, TestFunction, TrialFunction, list_timings,
-                    TimingType)
-from dolfin.la import PETScMatrix, PETScVector
-from numba import cfunc, types, carray, typeof
-from dolfin.jit.jit import ffc_jit
+import numba
 import numpy as np
-from petsc4py.PETSc import ScalarType
+from petsc4py import PETSc
+
+from dolfin import (MPI, FunctionSpace, TestFunction, TimingType,
+                    TrialFunction, UnitSquareMesh, cpp, dot, dx, grad,
+                    list_timings)
+from dolfin.jit.jit import ffc_jit
 
 
 def tabulate_tensor_A(A_, w_, coords_, cell_orientation):
-    A = carray(A_, (3, 3), dtype=ScalarType)
-    coordinate_dofs = carray(coords_, (3, 2), dtype=np.float64)
+    A = numba.carray(A_, (3, 3), dtype=PETSc.ScalarType)
+    coordinate_dofs = numba.carray(coords_, (3, 2), dtype=np.float64)
 
     # Ke=∫Ωe BTe Be dΩ
     x0, y0 = coordinate_dofs[0, :]
@@ -27,17 +27,15 @@ def tabulate_tensor_A(A_, w_, coords_, cell_orientation):
 
     # 2x Element area Ae
     Ae = abs((x0 - x1) * (y2 - y1) - (y0 - y1) * (x2 - x1))
-
     B = np.array(
         [y1 - y2, y2 - y0, y0 - y1, x2 - x1, x0 - x2, x1 - x0],
-        dtype=ScalarType).reshape(2, 3)
-
+        dtype=PETSc.ScalarType).reshape(2, 3)
     A[:, :] = np.dot(B.T, B) / (2 * Ae)
 
 
 def tabulate_tensor_b(b_, w_, coords_, cell_orientation):
-    b = carray(b_, (3), dtype=ScalarType)
-    coordinate_dofs = carray(coords_, (3, 2), dtype=np.float64)
+    b = numba.carray(b_, (3), dtype=PETSc.ScalarType)
+    coordinate_dofs = numba.carray(coords_, (3, 2), dtype=np.float64)
     x0, y0 = coordinate_dofs[0, :]
     x1, y1 = coordinate_dofs[1, :]
     x2, y2 = coordinate_dofs[2, :]
@@ -49,44 +47,37 @@ def tabulate_tensor_b(b_, w_, coords_, cell_orientation):
 
 def test_numba_assembly():
     mesh = UnitSquareMesh(MPI.comm_world, 13, 13)
-    Q = FunctionSpace(mesh, "Lagrange", 1)
+    V = FunctionSpace(mesh, "Lagrange", 1)
+    u, v = TrialFunction(V), TestFunction(V)
 
-    u = TrialFunction(Q)
-    v = TestFunction(Q)
+    a = cpp.fem.Form([V._cpp_object, V._cpp_object])
+    L = cpp.fem.Form([V._cpp_object])
 
-    a = cpp.fem.Form([Q._cpp_object, Q._cpp_object])
-    L = cpp.fem.Form([Q._cpp_object])
+    signature = numba.types.void(
+        numba.types.CPointer(numba.typeof(PETSc.ScalarType())),
+        numba.types.CPointer(numba.types.CPointer(numba.typeof(PETSc.ScalarType()))),
+        numba.types.CPointer(numba.types.double), numba.types.intc)
 
-    sig = types.void(
-        types.CPointer(typeof(ScalarType())),
-        types.CPointer(types.CPointer(typeof(ScalarType()))),
-        types.CPointer(types.double), types.intc)
-
-    fnA = cfunc(sig, cache=True)(tabulate_tensor_A)
+    fnA = numba.cfunc(signature, cache=True)(tabulate_tensor_A)
     a.set_cell_tabulate(0, fnA.address)
 
-    fnb = cfunc(sig, cache=True)(tabulate_tensor_b)
+    fnb = numba.cfunc(signature, cache=True)(tabulate_tensor_b)
     L.set_cell_tabulate(0, fnb.address)
 
-    if (False):
-        ufc_form = ffc_jit(dot(grad(u), grad(v)) * dx)
-        ufc_form = cpp.fem.make_ufc_form(ufc_form[0])
-        a = cpp.fem.Form(ufc_form, [Q._cpp_object, Q._cpp_object])
-        ufc_form = ffc_jit(v * dx)
-        ufc_form = cpp.fem.make_ufc_form(ufc_form[0])
-        L = cpp.fem.Form(ufc_form, [Q._cpp_object])
+    # if (False):
+    #     ufc_form = ffc_jit(dot(grad(u), grad(v)) * dx)
+    #     ufc_form = cpp.fem.make_ufc_form(ufc_form[0])
+    #     a = cpp.fem.Form(ufc_form, [Q._cpp_object, Q._cpp_object])
+    #     ufc_form = ffc_jit(v * dx)
+    #     ufc_form = cpp.fem.make_ufc_form(ufc_form[0])
+    #     L = cpp.fem.Form(ufc_form, [Q._cpp_object])
 
     assembler = cpp.fem.Assembler([[a]], [L], [])
-    A = PETScMatrix()
-    b = PETScVector()
-    assembler.assemble(A, cpp.fem.Assembler.BlockType.monolithic)
-    assembler.assemble(b, cpp.fem.Assembler.BlockType.monolithic)
+    A = assembler.assemble_matrix(cpp.fem.Assembler.BlockType.monolithic)
+    b = assembler.assemble_vector(cpp.fem.Assembler.BlockType.monolithic)
 
     Anorm = A.norm(cpp.la.Norm.frobenius)
     bnorm = b.norm(cpp.la.Norm.l2)
-
-    print(Anorm, bnorm)
-
     assert (np.isclose(Anorm, 56.124860801609124))
     assert (np.isclose(bnorm, 0.0739710713711999))
 

--- a/python/test/unit/fem/test_numba_assembly.py
+++ b/python/test/unit/fem/test_numba_assembly.py
@@ -12,6 +12,7 @@ from petsc4py import PETSc
 
 from dolfin import (MPI, FunctionSpace, TimingType, UnitSquareMesh, cpp,
                     list_timings)
+from dolfin.la import PETScMatrix, PETScVector
 
 c_signature = numba.types.void(
     numba.types.CPointer(numba.typeof(PETSc.ScalarType())),
@@ -62,8 +63,12 @@ def test_numba_assembly():
     L.set_cell_tabulate(0, tabulate_tensor_b.address)
 
     assembler = cpp.fem.Assembler([[a]], [L], [])
-    A = assembler.assemble_matrix(cpp.fem.Assembler.BlockType.monolithic)
-    b = assembler.assemble_vector(cpp.fem.Assembler.BlockType.monolithic)
+    A = PETScMatrix()
+    b = PETScVector()
+    assembler.assemble(A, cpp.fem.Assembler.BlockType.monolithic)
+    assembler.assemble(b, cpp.fem.Assembler.BlockType.monolithic)
+    #A = assembler.assemble_matrix(cpp.fem.Assembler.BlockType.monolithic)
+    #b = assembler.assemble_vector(cpp.fem.Assembler.BlockType.monolithic)
 
     Anorm = A.norm(cpp.la.Norm.frobenius)
     bnorm = b.norm(cpp.la.Norm.l2)
@@ -179,8 +184,12 @@ def test_cffi_assembly():
     L.set_cell_tabulate(0, ptrL)
 
     assembler = cpp.fem.Assembler([[a]], [L], [])
-    A = assembler.assemble_matrix(cpp.fem.Assembler.BlockType.monolithic)
-    b = assembler.assemble_vector(cpp.fem.Assembler.BlockType.monolithic)
+    A = PETScMatrix()
+    b = PETScVector()
+    assembler.assemble(A, cpp.fem.Assembler.BlockType.monolithic)
+    assembler.assemble(b, cpp.fem.Assembler.BlockType.monolithic)
+    # A = assembler.assemble_matrix(cpp.fem.Assembler.BlockType.monolithic)
+    # b = assembler.assemble_vector(cpp.fem.Assembler.BlockType.monolithic)
 
     Anorm = A.norm(cpp.la.Norm.frobenius)
     bnorm = b.norm(cpp.la.Norm.l2)

--- a/python/test/unit/fem/test_numba_assembly.py
+++ b/python/test/unit/fem/test_numba_assembly.py
@@ -86,6 +86,7 @@ def test_cffi_assembly():
         from cffi import FFI
         ffibuilder = FFI()
         ffibuilder.set_source("_cffi_kernelA", r"""
+        #include <math.h>
         #include <stdalign.h>
         void tabulate_tensor_poissonA(double* restrict A, const double* const* w,
                                     const double* restrict coordinate_dofs,

--- a/python/test/unit/fem/test_numba_assembly.py
+++ b/python/test/unit/fem/test_numba_assembly.py
@@ -195,8 +195,3 @@ def test_cffi_assembly():
     assert (np.isclose(bnorm, 0.0739710713711999))
 
     list_timings([TimingType.wall])
-
-    print("Test:", PETSc.ScalarType)
-    print("Test:", PETSc.ScalarType())
-    print("Test:", type(PETSc.ScalarType()))
-    print("Test:", numba.typeof(PETSc.ScalarType()))


### PR DESCRIPTION
Shows how to easily write a `tabulate_tensor` kernel in C from Python.