### PR TITLE
Refactor dolfin python's Form

### DIFF
--- a/python/dolfin/fem/__init__.py
+++ b/python/dolfin/fem/__init__.py
@@ -11,6 +11,8 @@ import dolfin.cpp
 
 from .form import Form
 
+__all__ = ["Form"]
+
 
 def create_coordinate_map(o):
     """Return a compiled UFC coordinate_mapping object"""

--- a/python/dolfin/fem/__init__.py
+++ b/python/dolfin/fem/__init__.py
@@ -9,6 +9,8 @@ import ufl
 from dolfin.jit.jit import ffc_jit
 import dolfin.cpp
 
+from .form import Form
+
 
 def create_coordinate_map(o):
     """Return a compiled UFC coordinate_mapping object"""

--- a/python/dolfin/fem/__init__.py
+++ b/python/dolfin/fem/__init__.py
@@ -8,8 +8,7 @@
 import ufl
 from dolfin.jit.jit import ffc_jit
 import dolfin.cpp
-
-from .form import Form
+from dolfin.fem.form import Form
 
 __all__ = ["Form"]
 

--- a/python/dolfin/fem/assembling.py
+++ b/python/dolfin/fem/assembling.py
@@ -18,7 +18,7 @@ rely on the dolfin::Form class which is not used on the Python side.
 
 import ufl
 import dolfin.cpp as cpp
-from dolfin.fem.form import Form
+import dolfin.fem as fem
 
 __all__ = ["assemble_local", "SystemAssembler"]
 
@@ -38,7 +38,7 @@ def _create_cpp_form(form, form_compiler_parameters=None):
                 "Ignoring form_compiler_parameters when passed a dolfin Form!")
         return form
     elif isinstance(form, ufl.Form):
-        form = Form(
+        form = fem.Form(
             form,
             form_compiler_parameters=form_compiler_parameters)
         return form._cpp_object

--- a/python/dolfin/fem/assembling.py
+++ b/python/dolfin/fem/assembling.py
@@ -41,7 +41,7 @@ def _create_cpp_form(form, form_compiler_parameters=None):
         form = Form(
             form,
             form_compiler_parameters=form_compiler_parameters)
-        return form._cpp_form
+        return form._cpp_object
     else:
         raise TypeError("Invalid form type %s" % (type(form), ))
 

--- a/python/dolfin/fem/assembling.py
+++ b/python/dolfin/fem/assembling.py
@@ -23,8 +23,7 @@ from dolfin.fem.form import Form
 __all__ = ["assemble_local", "SystemAssembler"]
 
 
-def _create_cpp_form(form, form_compiler_parameters=None,
-                     function_spaces=None):
+def _create_cpp_form(form, form_compiler_parameters=None):
     # First check if we got a cpp.Form
     if isinstance(form, cpp.fem.Form):
 
@@ -39,10 +38,10 @@ def _create_cpp_form(form, form_compiler_parameters=None,
                 "Ignoring form_compiler_parameters when passed a dolfin Form!")
         return form
     elif isinstance(form, ufl.Form):
-        return Form(
+        form = Form(
             form,
-            form_compiler_parameters=form_compiler_parameters,
-            function_spaces=function_spaces)
+            form_compiler_parameters=form_compiler_parameters)
+        return form._cpp_form
     else:
         raise TypeError("Invalid form type %s" % (type(form), ))
 

--- a/python/dolfin/fem/form.py
+++ b/python/dolfin/fem/form.py
@@ -13,7 +13,7 @@ from dolfin.jit.jit import dolfin_pc, ffc_jit
 class Form:
     def __init__(self, form: ufl.Form, form_compiler_parameters: list=[]):
         """Create dolfin Form
-        
+
         Parameters
         ----------
         form

--- a/python/dolfin/fem/form.py
+++ b/python/dolfin/fem/form.py
@@ -11,7 +11,7 @@ from dolfin.jit.jit import dolfin_pc, ffc_jit
 
 
 class Form(ufl.Form):
-    def __init__(self, form: ufl.Form, form_compiler_parameters: list=[]):
+    def __init__(self, form: ufl.Form, form_compiler_parameters: dict=None):
         """Create dolfin Form
 
         Parameters
@@ -73,14 +73,13 @@ class Form(ufl.Form):
 
         # Attach subdomains to C++ Form if we have them
         subdomains = self._subdomains.get("cell")
-        if subdomains is not None:
-            self._cpp_object.set_cell_domains(subdomains)
+        self._cpp_object.set_cell_domains(subdomains)
+
         subdomains = self._subdomains.get("exterior_facet")
-        if subdomains is not None:
-            self._cpp_object.set_exterior_facet_domains(subdomains)
+        self._cpp_object.set_exterior_facet_domains(subdomains)
+
         subdomains = self._subdomains.get("interior_facet")
-        if subdomains is not None:
-            self._cpp_object.set_interior_facet_domains(subdomains)
+        self._cpp_object.set_interior_facet_domains(subdomains)
+
         subdomains = self._subdomains.get("vertex")
-        if subdomains is not None:
-            self._cpp_object.set_vertex_domains(subdomains)
+        self._cpp_object.set_vertex_domains(subdomains)

--- a/python/dolfin/fem/form.py
+++ b/python/dolfin/fem/form.py
@@ -10,7 +10,7 @@ import dolfin.cpp as cpp
 from dolfin.jit.jit import dolfin_pc, ffc_jit
 
 
-class Form:
+class Form(ufl.Form):
     def __init__(self, form: ufl.Form, form_compiler_parameters: list=[]):
         """Create dolfin Form
 
@@ -54,14 +54,14 @@ class Form:
         function_spaces = [func.function_space()._cpp_object for func in form.arguments()]
 
         # Prepare dolfin.Form and hold it as a member
-        self._cpp_form = cpp.fem.Form(ufc_form, function_spaces)
+        self._cpp_object = cpp.fem.Form(ufc_form, function_spaces)
 
         # Need to fill the form with coefficients data
         # For every coefficient in form take its CPP object
         original_coefficients = form.coefficients()
-        for i in range(self._cpp_form.num_coefficients()):
-            j = self._cpp_form.original_coefficient_position(i)
-            self._cpp_form.set_coefficient(j, original_coefficients[i].cpp_object())
+        for i in range(self._cpp_object.num_coefficients()):
+            j = self._cpp_object.original_coefficient_position(i)
+            self._cpp_object.set_coefficient(j, original_coefficients[i].cpp_object())
 
         if mesh is None:
             raise RuntimeError("Expecting to find a Mesh in the form.")
@@ -69,18 +69,18 @@ class Form:
         # Attach mesh (because function spaces and coefficients may be
         # empty lists)
         if not function_spaces:
-            self._cpp_form.set_mesh(mesh)
+            self._cpp_object.set_mesh(mesh)
 
         # Attach subdomains to C++ Form if we have them
         subdomains = self._subdomains.get("cell")
         if subdomains is not None:
-            self._cpp_form.set_cell_domains(subdomains)
+            self._cpp_object.set_cell_domains(subdomains)
         subdomains = self._subdomains.get("exterior_facet")
         if subdomains is not None:
-            self._cpp_form.set_exterior_facet_domains(subdomains)
+            self._cpp_object.set_exterior_facet_domains(subdomains)
         subdomains = self._subdomains.get("interior_facet")
         if subdomains is not None:
-            self._cpp_form.set_interior_facet_domains(subdomains)
+            self._cpp_object.set_interior_facet_domains(subdomains)
         subdomains = self._subdomains.get("vertex")
         if subdomains is not None:
-            self._cpp_form.set_vertex_domains(subdomains)
+            self._cpp_object.set_vertex_domains(subdomains)

--- a/python/dolfin/fem/solving.py
+++ b/python/dolfin/fem/solving.py
@@ -198,7 +198,7 @@ def _solve_varproblem(*args, **kwargs):
         assembler = SystemAssembler(a._cpp_object, L._cpp_object, bcs)
         assembler.assemble(A, b)
 
-        comm = L.mesh().mpi_comm()
+        comm = L._cpp_object.mesh().mpi_comm()
         solver = PETScKrylovSolver(comm)
 
         solver.set_options_prefix("dolfin_solve_")

--- a/python/dolfin/fem/solving.py
+++ b/python/dolfin/fem/solving.py
@@ -195,7 +195,7 @@ def _solve_varproblem(*args, **kwargs):
         A = PETScMatrix()
         b = PETScVector()
 
-        assembler = SystemAssembler(a, L, bcs)
+        assembler = SystemAssembler(a._cpp_object, L._cpp_object, bcs)
         assembler.assemble(A, b)
 
         comm = L.mesh().mpi_comm()


### PR DESCRIPTION
No python layer wrapper should subclass from its `cpp.foo` counterpart.

I removed this inheritance and added inheritance from `ufl.Form` instead. (the inheritance is not used anywhere, but we should be more systematic)

I also propose to strictly follow the rule: 
> 1. Any dolfin's python object that attaches data (function spaces, coefficients, ...) to UFL object should subclass it.

In the virtue of this rule, `dolfin.fem.Form` is indeed attaching function spaces to `cpp.fem.Form`.



