### PR TITLE
Remove pybind11 unwrapping of Python objects

### DIFF
--- a/python/dolfin/jit/jit.py
+++ b/python/dolfin/jit/jit.py
@@ -183,7 +183,7 @@ def compile_class(cpp_data):
 
     # Set properties to initial values
     # FIXME: maybe remove from here (do it in Expression instead)
-    for k, v in properties.items():
-        python_object.set_property(k, v)
+    for name, v in properties.items():
+        python_object.set_property(name, v)
 
     return python_object

--- a/python/src/function.cpp
+++ b/python/src/function.cpp
@@ -52,11 +52,11 @@ void function(py::module& m)
               const dolfin::mesh::Cell& cell) { self.eval(u, x, cell); },
            "Evaluate GenericFunction (cell version)")
       .def("eval",
-           (void (dolfin::function::GenericFunction::*)(
+           py::overload_cast<
                Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
                                        Eigen::Dynamic, Eigen::RowMajor>>,
-               Eigen::Ref<const dolfin::EigenRowArrayXXd>) const)
-               & dolfin::function::GenericFunction::eval,
+               Eigen::Ref<const dolfin::EigenRowArrayXXd>>(
+               &dolfin::function::GenericFunction::eval, py::const_),
            py::arg("values"), py::arg("x"), "Evaluate GenericFunction")
       .def("compute_point_values",
            py::overload_cast<const dolfin::mesh::Mesh&>(

--- a/python/src/function.cpp
+++ b/python/src/function.cpp
@@ -135,28 +135,9 @@ void function(py::module& m)
            })
       .def("value_dimension", &dolfin::function::Expression::value_dimension)
       .def("get_property", &dolfin::function::Expression::get_property)
-      .def("set_property",
-           [](dolfin::function::Expression& self, std::string name,
-              py::object value) {
-             if (py::isinstance<dolfin::function::GenericFunction>(value))
-             {
-               auto _v = value.cast<
-                   std::shared_ptr<dolfin::function::GenericFunction>>();
-               self.set_generic_function(name, _v);
-             }
-             else if (py::hasattr(value, "_cpp_object"))
-             {
-               auto _v = value.attr("_cpp_object")
-                             .cast<std::shared_ptr<
-                                 dolfin::function::GenericFunction>>();
-               self.set_generic_function(name, _v);
-             }
-             else
-             {
-               PetscScalar _v = value.cast<PetscScalar>();
-               self.set_property(name, _v);
-             }
-           })
+      .def("set_property", &dolfin::function::Expression::set_property)
+      .def("set_generic_function",
+           &dolfin::function::Expression::set_generic_function)
       .def("get_generic_function",
            &dolfin::function::Expression::get_generic_function);
 
@@ -236,17 +217,7 @@ void function(py::module& m)
            })
       .def("sub", &dolfin::function::Function::sub,
            "Return sub-function (view into parent Function")
-      .def("interpolate",
-           (void (dolfin::function::Function::*)(
-               const dolfin::function::GenericFunction&))
-               & dolfin::function::Function::interpolate,
-           "Interpolate the function u")
-      .def("interpolate",
-           [](dolfin::function::Function& instance, const py::object v) {
-             auto _v = v.attr("_cpp_object")
-                           .cast<dolfin::function::GenericFunction*>();
-             instance.interpolate(*_v);
-           },
+      .def("interpolate", &dolfin::function::Function::interpolate,
            "Interpolate the function u")
       // FIXME: A lot of error when using non-const version - misused
       // by Python interface?

--- a/python/test/unit/fem/test_discrete_operators.py
+++ b/python/test/unit/fem/test_discrete_operators.py
@@ -24,14 +24,18 @@ def test_gradient():
         V = FunctionSpace(mesh, "Lagrange", 1)
         W = FunctionSpace(mesh, "Nedelec 1st kind H(curl)", 1)
 
-        G = DiscreteOperators.build_gradient(W, V)
+        G = DiscreteOperators.build_gradient(W._cpp_object, V._cpp_object)
         num_edges = mesh.num_entities_global(1)
         assert G.size()[0] == num_edges
         assert G.size()[1] == mesh.num_entities_global(0)
-        assert round(G.norm(dolfin.cpp.la.Norm.frobenius) - sqrt(2.0 * num_edges), 8) == 0.0
+        assert round(
+            G.norm(dolfin.cpp.la.Norm.frobenius) - sqrt(2.0 * num_edges),
+            8) == 0.0
 
-    meshes = [UnitSquareMesh(MPI.comm_world, 11, 6),
-              UnitCubeMesh(MPI.comm_world, 4, 3, 7)]
+    meshes = [
+        UnitSquareMesh(MPI.comm_world, 11, 6),
+        UnitCubeMesh(MPI.comm_world, 4, 3, 7)
+    ]
     for mesh in meshes:
         compute_discrete_gradient(mesh)
 
@@ -43,12 +47,12 @@ def test_incompatible_spaces():
     V = FunctionSpace(mesh, "Lagrange", 1)
     W = FunctionSpace(mesh, "Nedelec 1st kind H(curl)", 1)
     with pytest.raises(RuntimeError):
-        DiscreteOperators.build_gradient(V, W)
+        DiscreteOperators.build_gradient(V._cpp_object, W._cpp_object)
     with pytest.raises(RuntimeError):
-        DiscreteOperators.build_gradient(V, V)
+        DiscreteOperators.build_gradient(V._cpp_object, V._cpp_object)
     with pytest.raises(RuntimeError):
-        DiscreteOperators.build_gradient(W, W)
+        DiscreteOperators.build_gradient(W._cpp_object, W._cpp_object)
 
     V = FunctionSpace(mesh, "Lagrange", 2)
     with pytest.raises(RuntimeError):
-        DiscreteOperators.build_gradient(W, V)
+        DiscreteOperators.build_gradient(W._cpp_object, V._cpp_object)

--- a/python/test/unit/fem/test_petsc_transfer_matrix.py
+++ b/python/test/unit/fem/test_petsc_transfer_matrix.py
@@ -7,8 +7,9 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import pytest
-from dolfin import (UnitCubeMesh, UnitSquareMesh, FunctionSpace, MPI, Expression, interpolate, Function,
-                    VectorElement, FiniteElement, MixedElement, VectorFunctionSpace)
+from dolfin import (UnitCubeMesh, UnitSquareMesh, FunctionSpace, MPI,
+                    Expression, interpolate, Function, VectorElement,
+                    FiniteElement, MixedElement, VectorFunctionSpace)
 from dolfin.cpp.fem import PETScDMCollection
 from dolfin.cpp.la import Norm
 
@@ -24,7 +25,8 @@ def test_scalar_p1():
     uc = interpolate(u, Vc)
     uf = interpolate(u, Vf)
 
-    mat = PETScDMCollection.create_transfer_matrix(Vc, Vf).mat()
+    mat = PETScDMCollection.create_transfer_matrix(Vc._cpp_object,
+                                                   Vf._cpp_object).mat()
     Vuc = Function(Vf)
     mat.mult(uc.vector().vec(), Vuc.vector().vec())
 
@@ -48,7 +50,8 @@ def test_scalar_p1_scaled_mesh():
     uc = interpolate(u, Vc)
     uf = interpolate(u, Vf)
 
-    mat = PETScDMCollection.create_transfer_matrix(Vc, Vf).mat()
+    mat = PETScDMCollection.create_transfer_matrix(Vc._cpp_object,
+                                                   Vf._cpp_object).mat()
     Vuc = Function(Vf)
     mat.mult(uc.vector().vec(), Vuc.vector().vec())
 
@@ -62,7 +65,8 @@ def test_scalar_p1_scaled_mesh():
 
     uc = interpolate(u, Vc)
 
-    mat = PETScDMCollection.create_transfer_matrix(Vc, Vf).mat()
+    mat = PETScDMCollection.create_transfer_matrix(Vc._cpp_object,
+                                                   Vf._cpp_object).mat()
     mat.mult(uc.vector().vec(), Vuc.vector().vec())
 
     diff = Vuc.vector()
@@ -82,7 +86,8 @@ def test_scalar_p2():
     uc = interpolate(u, Vc)
     uf = interpolate(u, Vf)
 
-    mat = PETScDMCollection.create_transfer_matrix(Vc, Vf).mat()
+    mat = PETScDMCollection.create_transfer_matrix(Vc._cpp_object,
+                                                   Vf._cpp_object).mat()
     Vuc = Function(Vf)
     mat.mult(uc.vector().vec(), Vuc.vector().vec())
 
@@ -103,7 +108,8 @@ def test_vector_p1_2d():
     uc = interpolate(u, Vc)
     uf = interpolate(u, Vf)
 
-    mat = PETScDMCollection.create_transfer_matrix(Vc, Vf).mat()
+    mat = PETScDMCollection.create_transfer_matrix(Vc._cpp_object,
+                                                   Vf._cpp_object).mat()
 
     Vuc = Function(Vf)
     mat.mult(uc.vector().vec(), Vuc.vector().vec())
@@ -124,7 +130,8 @@ def test_vector_p2_2d():
     uc = interpolate(u, Vc)
     uf = interpolate(u, Vf)
 
-    mat = PETScDMCollection.create_transfer_matrix(Vc, Vf).mat()
+    mat = PETScDMCollection.create_transfer_matrix(Vc._cpp_object,
+                                                   Vf._cpp_object).mat()
     Vuc = Function(Vf)
     mat.mult(uc.vector().vec(), Vuc.vector().vec())
 
@@ -144,7 +151,8 @@ def test_vector_p1_3d():
     uc = interpolate(u, Vc)
     uf = interpolate(u, Vf)
 
-    mat = PETScDMCollection.create_transfer_matrix(Vc, Vf).mat()
+    mat = PETScDMCollection.create_transfer_matrix(Vc._cpp_object,
+                                                   Vf._cpp_object).mat()
     Vuc = Function(Vf)
     mat.mult(uc.vector().vec(), Vuc.vector().vec())
 
@@ -166,7 +174,9 @@ def test_taylor_hood_cube():
     Zc = FunctionSpace(meshc, Ze)
     Zf = FunctionSpace(meshf, Ze)
 
-    z = Expression(("x[0]*x[1]", "x[1]*x[2]", "x[2]*x[0]", "x[0] + 3*x[1] + x[2]"), degree=2)
+    z = Expression(
+        ("x[0]*x[1]", "x[1]*x[2]", "x[2]*x[0]", "x[0] + 3*x[1] + x[2]"),
+        degree=2)
     zc = interpolate(z, Zc)
     zf = interpolate(z, Zf)
 


### PR DESCRIPTION
This makes the pybind11 code a whole lot simpler.

One change should have broken user jit, but mustn't be covered at the moment by tests. Will be an easy fix.