### PR TITLE
Rewrite expressions to UFL in python tests

### DIFF
--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -22,9 +22,8 @@ def test_assemble_functional():
     M = dolfin.Constant(1.0) * dx(domain=mesh)
     value = dolfin.fem.assemble(M)
     assert value == pytest.approx(1.0, 1e-12)
-
-    f = dolfin.function.expression.Expression("x[0]", degree=1)
-    M = f * dx(domain=mesh)
+    x = dolfin.SpatialCoordinate(mesh)
+    M = x[0] * dx(domain=mesh)
     value = dolfin.fem.assemble(M)
     assert value == pytest.approx(0.5, 1e-12)
 

--- a/python/test/unit/fem/test_complex_assembler.py
+++ b/python/test/unit/fem/test_complex_assembler.py
@@ -37,15 +37,17 @@ def test_complex_assembly():
     assert np.isclose(bnorm, b_norm_ref)
     A0_norm = dolfin.fem.assemble(a_real).norm(dolfin.cpp.la.Norm.frobenius)
 
+    x = dolfin.SpatialCoordinate(mesh)
+
     a_imag = j * inner(u, v) * dx
-    f = dolfin.Expression("j*sin(2*pi*x[0])", degree=2)
+    f = 1j * ufl.sin(2 * np.pi * x[0])
     L0 = inner(f, v) * dx
     A1_norm = dolfin.fem.assemble(a_imag).norm(dolfin.cpp.la.Norm.frobenius)
     assert np.isclose(A0_norm, A1_norm)
     b1_norm = dolfin.fem.assemble(L0).norm(dolfin.cpp.la.Norm.l2)
 
     a_complex = (1 + j) * inner(u, v) * dx
-    f = dolfin.Expression("sin(2*pi*x[0])", degree=2)
+    f = ufl.sin(2 * np.pi * x[0])
     L2 = inner(f, v) * dx
     A2_norm = dolfin.fem.assemble(a_complex).norm(dolfin.cpp.la.Norm.frobenius)
     assert np.isclose(A1_norm, A2_norm / np.sqrt(2))
@@ -64,10 +66,11 @@ def test_complex_assembly_solve():
     P = ufl.FiniteElement("Lagrange", mesh.ufl_cell(), degree)
     V = dolfin.function.functionspace.FunctionSpace(mesh, P)
 
+    x = dolfin.SpatialCoordinate(mesh)
+
     # Define source term
     A = 1 + 2 * (2 * np.pi)**2
-    f = dolfin.Expression(
-        "(1.+j)*A*cos(2*pi*x[0])*cos(2*pi*x[1])", degree=degree, A=A)
+    f = (1. + 1j) * A * ufl.cos(2 * np.pi * x[1])
 
     # Variational problem
     u = dolfin.function.argument.TrialFunction(V)

--- a/python/test/unit/fem/test_complex_assembler.py
+++ b/python/test/unit/fem/test_complex_assembler.py
@@ -70,7 +70,7 @@ def test_complex_assembly_solve():
 
     # Define source term
     A = 1 + 2 * (2 * np.pi)**2
-    f = (1. + 1j) * A * ufl.cos(2 * np.pi * x[1])
+    f = (1. + 1j) * A * ufl.cos(2 * np.pi * x[0]) * ufl.cos(2 * np.pi * x[1])
 
     # Variational problem
     u = dolfin.function.argument.TrialFunction(V)

--- a/python/test/unit/fem/test_local_assembler.py
+++ b/python/test/unit/fem/test_local_assembler.py
@@ -11,7 +11,7 @@ import numpy
 from dolfin import (UnitIntervalMesh, UnitSquareMesh,
                     Constant, Cell, TestFunction, TrialFunction, MPI, Cells, dx,
                     ds, dS, dot, Form, FunctionSpace, VectorFunctionSpace,
-                    Expression, FacetNormal)
+                    Expression, FacetNormal, SpatialCoordinate)
 from dolfin.fem.assembling import assemble_local
 
 
@@ -54,10 +54,9 @@ def test_local_assembler_on_facet_integrals():
     Vdgt = FunctionSpace(mesh, 'DGT', 1)
 
     v = TestFunction(Vdgt)
+    x = dolfin.SpatialCoordinate(mesh)
 
-    # Initialize DG function "w" in discontinuous pattern
-    w = Expression('(1.0 + pow(x[0], 2.2) + 1/(0.1 + pow(x[1], 3)))*300.0',
-                   element=Vdg.ufl_element())
+    w = (1.0 + x[0] ** 2.2 + 1. / (0.1 + x[1] ** 3)) * 300
 
     # Define form that tests that the correct + and - values are used
     L = w('-') * v('+') * dS

--- a/python/test/unit/fem/test_local_assembler.py
+++ b/python/test/unit/fem/test_local_assembler.py
@@ -11,7 +11,7 @@ import numpy
 from dolfin import (UnitIntervalMesh, UnitSquareMesh,
                     Constant, Cell, TestFunction, TrialFunction, MPI, Cells, dx,
                     ds, dS, dot, Form, FunctionSpace, VectorFunctionSpace,
-                    Expression, FacetNormal, SpatialCoordinate)
+                    FacetNormal, SpatialCoordinate)
 from dolfin.fem.assembling import assemble_local
 
 
@@ -50,11 +50,10 @@ def test_local_assembler_1D():
 @pytest.mark.skip
 def test_local_assembler_on_facet_integrals():
     mesh = UnitSquareMesh(MPI.comm_world, 4, 4, 'right')
-    Vdg = FunctionSpace(mesh, 'DG', 0)
     Vdgt = FunctionSpace(mesh, 'DGT', 1)
 
     v = TestFunction(Vdgt)
-    x = dolfin.SpatialCoordinate(mesh)
+    x = SpatialCoordinate(mesh)
 
     w = (1.0 + x[0] ** 2.2 + 1. / (0.1 + x[1] ** 3)) * 300
 

--- a/python/test/unit/parallel-assembly-solve/test_solve_result_against_reference.py
+++ b/python/test/unit/parallel-assembly-solve/test_solve_result_against_reference.py
@@ -12,9 +12,8 @@ parallel assembly/solve."""
 import ufl
 
 from dolfin import (MPI, TestFunction, TrialFunction, FunctionSpace,
-                    UnitSquareMesh, UnitCubeMesh, Expression,
-                    inner, grad, dx, ds, Function, solve, cpp,
-                    SpatialCoordinate)
+                    UnitSquareMesh, UnitCubeMesh, inner, grad, dx, ds,
+                    Function, solve, cpp, SpatialCoordinate)
 from dolfin.la import PETScOptions
 from dolfin_utils.test import gc_barrier
 

--- a/python/test/unit/parallel-assembly-solve/test_solve_result_against_reference.py
+++ b/python/test/unit/parallel-assembly-solve/test_solve_result_against_reference.py
@@ -9,9 +9,12 @@ parallel assembly/solve."""
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+import ufl
+
 from dolfin import (MPI, TestFunction, TrialFunction, FunctionSpace,
                     UnitSquareMesh, UnitCubeMesh, Expression,
-                    inner, grad, dx, ds, Function, solve, cpp)
+                    inner, grad, dx, ds, Function, solve, cpp,
+                    SpatialCoordinate)
 from dolfin.la import PETScOptions
 from dolfin_utils.test import gc_barrier
 
@@ -28,8 +31,9 @@ def compute_norm(mesh, degree):
     # Define variational problem
     v = TestFunction(V)
     u = TrialFunction(V)
-    f = Expression("sin(x[0])", degree=degree)
-    g = Expression("x[0]*x[1]", degree=degree)
+    x = SpatialCoordinate(mesh)
+    f = ufl.sin(x[0])
+    g = x[0] * x[1]
     a = inner(grad(u), grad(v)) * dx + inner(u, v) * dx
     L = inner(f, v) * dx - inner(g, v) * ds
 
@@ -97,22 +101,10 @@ def print_errors(errors):
 
 def test_computed_norms_against_references():
     # Reference values for norm of solution vector
-    reference = {("16x16 unit tri square", 1): 9.547454087328376,
-                 ("16x16 unit tri square", 2): 18.42366670418269,
-                 ("16x16 unit tri square", 3): 27.29583104732836,
-                 ("16x16 unit tri square", 4): 36.16867128121694,
-                 ("4x4x4 unit tet cube", 1): 12.23389289626038,
-                 ("4x4x4 unit tet cube", 2): 28.96491629163837,
-                 ("4x4x4 unit tet cube", 3): 49.97350551329799,
-                 ("4x4x4 unit tet cube", 4): 74.49938266409099,
-                 ("16x16 unit quad square", 1): 9.550848071820747,
-                 ("16x16 unit quad square", 2): 18.423668706176354,
-                 ("16x16 unit quad square", 3): 27.295831017251672,
-                 ("16x16 unit quad square", 4): 36.168671281610855,
-                 ("4x4x4 unit hex cube", 1): 12.151954087339782,
-                 ("4x4x4 unit hex cube", 2): 28.965646690046885,
-                 ("4x4x4 unit hex cube", 3): 49.97349423895635,
-                 ("4x4x4 unit hex cube", 4): 74.49938136593539}
+    reference = {("16x16 unit tri square", 1): 9.544967937540488,
+                 ("16x16 unit tri square", 2): 18.42366676312568,
+                 ("4x4x4 unit tet cube", 1): 12.09116450742752,
+                 ("4x4x4 unit tet cube", 2): 28.96492975422821}
 
     # Mesh files and degrees to check
     meshes = [(UnitSquareMesh(MPI.comm_world, 16, 16), "16x16 unit tri square"),


### PR DESCRIPTION
Rewrite iff C++ Expression is used in a form to assemble.

C++ Expression still present in interpolation and DirichletBC.