### PR TITLE
Make HDF5 (parallel) a required dependency

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -69,14 +69,12 @@ option(CMAKE_USE_RELATIVE_PATHS "Use relative paths in makefiles and projects." 
 #option(DOLFIN_ENABLE_CODE_COVERAGE "Enable code coverage." OFF)
 option(DOLFIN_SKIP_BUILD_TESTS "Skip build tests for testing usability of dependency packages." OFF)
 option(DOLFIN_WITH_LIBRARY_VERSION "Build with library version information." ON)
-#option(DOLFIN_ENABLE_GEOMETRY_DEBUGGING "Enable geometry debugging (developers only; requires libcgal-dev and libcgal-qt5-dev)." OFF)
 
 add_feature_info(BUILD_SHARED_LIBS BUILD_SHARED_LIBS "Build DOLFIN with shared libraries.")
 add_feature_info(CMAKE_USE_RELATIVE_PATHS CMAKE_USE_RELATIVE_PATHS "Use relative paths in makefiles and projects.")
 #add_feature_info(DOLFIN_ENABLE_CODE_COVERAGE DOLFIN_ENABLE_CODE_COVERAGE "Enable code coverage.")
 add_feature_info(DOLFIN_WITH_LIBRARY_VERSION DOLFIN_WITH_LIBRARY_VERSION "Build with library version information.")
 add_feature_info(DOLFIN_SKIP_BUILD_TESTS DOLFIN_SKIP_BUILD_TESTS "Skip build tests for testing usability of dependency packages.")
-#add_feature_info(DOLFIN_ENABLE_GEOMETRY_DEBUGGING DOLFIN_ENABLE_GEOMETRY_DEBUGGING "Enable geometry debugging.")
 
 # Add shared library paths so shared libs in non-system paths are found
 option(CMAKE_INSTALL_RPATH_USE_LINK_PATH "Add paths to linker search and installed rpath." ON)
@@ -103,7 +101,6 @@ set(OPTIONAL_PACKAGES "")
 list(APPEND OPTIONAL_PACKAGES "SLEPc")
 list(APPEND OPTIONAL_PACKAGES "SCOTCH")
 list(APPEND OPTIONAL_PACKAGES "ParMETIS")
-list(APPEND OPTIONAL_PACKAGES "HDF5")
 
 # Add options
 foreach (OPTIONAL_PACKAGE ${OPTIONAL_PACKAGES})
@@ -215,16 +212,26 @@ set_package_properties(PETSc PROPERTIES TYPE REQUIRED
   URL "https://www.mcs.anl.gov/petsc/"
   PURPOSE "PETSc linear algebra backend")
 
-#------------------------------------------------------------------------------
-# Run tests to find optional packages
-
 # Check for required package UFC
 find_package(UFC MODULE ${DOLFIN_VERSION_MAJOR}.${DOLFIN_VERSION_MINOR})
 set_package_properties(UFC PROPERTIES TYPE REQUIRED
-  DESCRIPTION "Unified language for form-compilers (part of FFC)"
-  URL "https://bitbucket.org/fenics-project/ffc")
+  DESCRIPTION "Unified language for form-compilers (part of FFC-X)"
+  URL "https://github.com/fenics/ffcx")
 
-# Check for PETSc and SLEPc
+  # Check for HDF5
+set(HDF5_PREFER_PARALLEL TRUE)
+find_package(HDF5 REQUIRED)
+if (NOT HDF5_IS_PARALLEL)
+  message(FATAL_ERROR "Found serial HDF5 build, MPI HDF5 build required, try setting HDF5_DIR")
+endif()
+set_package_properties(HDF5 PROPERTIES TYPE REQUIRED
+  DESCRIPTION "Hierarchical Data Format 5 (HDF5)"
+  URL "https://www.hdfgroup.org/HDF5")
+
+#------------------------------------------------------------------------------
+# Run tests to find optional packages
+
+# Check for SLEPc
 set(SLEPC_FOUND FALSE)
 if (DOLFIN_ENABLE_SLEPC)
   find_package(SLEPc 3.7)
@@ -248,39 +255,6 @@ if (DOLFIN_ENABLE_SCOTCH)
     DESCRIPTION "Programs and libraries for graph, mesh and hypergraph partitioning"
     URL "https://www.labri.fr/perso/pelegrin/scotch"
     PURPOSE "Enables parallel graph partitioning")
-endif()
-
-# Check for HDF5
-if (DOLFIN_ENABLE_HDF5)
-  if (NOT DEFINED ENV{HDF5_ROOT})
-    set(ENV{HDF5_ROOT} "$ENV{HDF5_DIR}")
-  endif()
-  set(HDF5_PREFER_PARALLEL TRUE)
-  find_package(HDF5 COMPONENTS C)
-  if (NOT HDF5_IS_PARALLEL)
-      set(HDF5_FOUND FALSE)
-      message(STATUS "Found serial HDF5 build, MPI HDF5 build required, try setting HDF5_DIR")
-  endif()
-  set_package_properties(HDF5 PROPERTIES TYPE OPTIONAL
-    DESCRIPTION "Hierarchical Data Format 5 (HDF5)"
-    URL "https://www.hdfgroup.org/HDF5")
-endif()
-
-# Check for geometry debugging
-if (DOLFIN_ENABLE_GEOMETRY_DEBUGGING)
-  message(STATUS "Enabling geometry debugging")
-  find_package(CGAL REQUIRED)
-  find_package(GMP REQUIRED)
-  find_package(MPFR REQUIRED)
-  if (NOT CGAL_FOUND)
-    message(FATAL_ERROR "Unable to find package CGAL required for DOLFIN_ENABLE_GEOMETRY_DEBUGGING")
-  endif()
-  if (NOT GMP_FOUND)
-    message(FATAL_ERROR "Unable to find package GMP required for DOLFIN_ENABLE_GEOMETRY_DEBUGGING")
-  endif()
-  if (NOT MPFR_FOUND)
-    message(FATAL_ERROR "Unable to find package MPFR required for DOLFIN_ENABLE_GEOMETRY_DEBUGGING")
-  endif()
 endif()
 
 #------------------------------------------------------------------------------

--- a/cpp/dolfin/CMakeLists.txt
+++ b/cpp/dolfin/CMakeLists.txt
@@ -105,7 +105,7 @@ compatibility with AVX user-compiled code and 64 for AVX-512 user-compiled \
 code. Set to 0 for ideal alignment according to -march. Note that if an architecture \
 flag (e.g. \"-march=skylake-avx512\") is set for DOLFIN, Eigen will use the \
 appropriate ideal alignment instead if it is stricter. Otherwise, the value \
-of this variable will be used by Eigen for the alignment of all data structures.\\ 
+of this variable will be used by Eigen for the alignment of all data structures.\\
 ")
 
 # Eigen3
@@ -128,17 +128,14 @@ target_link_libraries(dolfin PUBLIC MPI::MPI_CXX)
 target_link_libraries(dolfin PUBLIC PETSC::petsc)
 target_link_libraries(dolfin PRIVATE PETSC::petsc_static)
 
+# HDF5
+target_compile_definitions(dolfin PUBLIC HAS_HDF5)
+target_compile_definitions(dolfin PUBLIC ${HDF5_DEFINITIONS})
+target_link_libraries(dolfin PUBLIC ${HDF5_C_LIBRARIES})
+target_include_directories(dolfin SYSTEM PUBLIC ${HDF5_INCLUDE_DIRS})
+
 #------------------------------------------------------------------------------
 # Optional packages
-
-# HDF5
-if (DOLFIN_ENABLE_HDF5 AND HDF5_FOUND)
-  #list(APPEND DOLFIN_LINK_FLAGS ${HDF5_LINK_FLAGS})
-  target_compile_definitions(dolfin PUBLIC HAS_HDF5)
-  target_compile_definitions(dolfin PUBLIC ${HDF5_DEFINITIONS})
-  target_link_libraries(dolfin PUBLIC ${HDF5_C_LIBRARIES})
-  target_include_directories(dolfin SYSTEM PUBLIC ${HDF5_INCLUDE_DIRS})
-endif()
 
 # SLEPC
 if (DOLFIN_ENABLE_PETSC AND DOLFIN_ENABLE_SLEPC AND SLEPC_FOUND)
@@ -159,17 +156,6 @@ if (DOLFIN_ENABLE_PARMETIS AND PARMETIS_FOUND)
   target_compile_definitions(dolfin PUBLIC HAS_PARMETIS)
   target_link_libraries(dolfin PRIVATE ${PARMETIS_LIBRARIES})
   target_include_directories(dolfin SYSTEM PRIVATE ${PARMETIS_INCLUDE_DIRS})
-endif()
-
-
-if (DOLFIN_ENABLE_GEOMETRY_DEBUGGING AND GMP_FOUND AND MPFR_FOUND AND CGAL_FOUND)
-  message(STATUS "Appending link flags for geometry debugging")
-  target_compile_definitions(dolfin PUBLIC "-DDOLFIN_ENABLE_GEOMETRY_DEBUGGING")
-  target_include_directories(dolfin PRIVATE ${CGAL_INCLUDE_DIRS})
-  target_include_directories(dolfin PRIVATE ${GMP_INCLUDE_DIRS})
-  target_include_directories(dolfin PRIVATE ${MPFR_INCLUDE_DIRS})
-  target_link_libraries(dolfin PRIVATE ${GMP_LIBRARIES})
-  target_link_libraries(dolfin PRIVATE ${MPFR_LIBRARIES})
 endif()
 
 #------------------------------------------------------------------------------

--- a/cpp/dolfin/common/defines.cpp
+++ b/cpp/dolfin/common/defines.cpp
@@ -5,11 +5,7 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include <petscversion.h>
-
-#ifdef HAS_HDF5
 #include <hdf5.h>
-#endif
-
 #include "defines.h"
 #include "types.h"
 
@@ -62,24 +58,6 @@ bool dolfin::has_scotch()
 bool dolfin::has_parmetis()
 {
 #ifdef HAS_PARMETIS
-  return true;
-#else
-  return false;
-#endif
-}
-//-------------------------------------------------------------------------
-bool dolfin::has_hdf5()
-{
-#ifdef HAS_HDF5
-  return true;
-#else
-  return false;
-#endif
-}
-//-----------------------------------------------------------------------------
-bool dolfin::has_hdf5_parallel()
-{
-#ifdef H5_HAVE_PARALLEL
   return true;
 #else
   return false;

--- a/cpp/dolfin/common/defines.h
+++ b/cpp/dolfin/common/defines.h
@@ -38,9 +38,4 @@ bool has_scotch();
 /// Return true if DOLFIN is compiled with ParMETIS
 bool has_parmetis();
 
-/// Return true if DOLFIN is compiled with HDF5
-bool has_hdf5();
-
-/// Return true if DOLFIN is compiled with Parallel HDF5
-bool has_hdf5_parallel();
 } // namespace dolfin

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -63,16 +63,14 @@ XDMFFile::~XDMFFile() { close(); }
 //-----------------------------------------------------------------------------
 void XDMFFile::close()
 {
-#ifdef HAS_HDF5
   // Close the HDF5 file
   _hdf5_file.reset();
-#endif
 }
 //-----------------------------------------------------------------------------
 void XDMFFile::write(const mesh::Mesh& mesh)
 {
   // Check that encoding
-  if (_encoding == Encoding::HDF5 and !has_hdf5())
+  if (_encoding == Encoding::HDF5 and !())
   {
     throw std::runtime_error("Cannot write XDMF in HDF5 encoding. (DOLFIN not "
                              "compied with HDF5 support)");
@@ -86,7 +84,6 @@ void XDMFFile::write(const mesh::Mesh& mesh)
 
   // Open a HDF5 file if using HDF5 encoding (truncate)
   hid_t h5_id = -1;
-#ifdef HAS_HDF5
   std::unique_ptr<HDF5File> h5_file;
   if (_encoding == Encoding::HDF5)
   {
@@ -98,7 +95,6 @@ void XDMFFile::write(const mesh::Mesh& mesh)
     // Get file handle
     h5_id = h5_file->h5_id();
   }
-#endif
 
   // Reset pugi doc
   _xml_doc->reset();
@@ -126,13 +122,6 @@ void XDMFFile::write(const mesh::Mesh& mesh)
 void XDMFFile::write_checkpoint(const function::Function& u,
                                 std::string function_name, double time_step)
 {
-  // Check that encoding
-  if (_encoding == Encoding::HDF5 and !has_hdf5())
-  {
-    throw std::runtime_error("DOLFIN has not been compiled with HDF5 support. "
-                             "Cannot write XDMF in HDF5 encoding.");
-  }
-
   if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(
@@ -193,7 +182,6 @@ void XDMFFile::write_checkpoint(const function::Function& u,
 
   // Open the HDF5 file if using HDF5 encoding (truncate)
   hid_t h5_id = -1;
-#ifdef HAS_HDF5
   if (_encoding == Encoding::HDF5)
   {
     if (truncate_hdf)
@@ -217,7 +205,7 @@ void XDMFFile::write_checkpoint(const function::Function& u,
     assert(_hdf5_file);
     h5_id = _hdf5_file->h5_id();
   }
-#endif
+
   // From this point _xml_doc points to a valid XDMF XML document
   // with expected structure
 
@@ -296,7 +284,6 @@ void XDMFFile::write_checkpoint(const function::Function& u,
     _xml_doc->save_file(_filename.c_str(), "  ");
   }
 
-#ifdef HAS_HDF5
   // Close the HDF5 file if in "flush" mode
   if (_encoding == Encoding::HDF5 and parameters["flush_output"])
   {
@@ -306,18 +293,11 @@ void XDMFFile::write_checkpoint(const function::Function& u,
     assert(_hdf5_file);
     _hdf5_file.reset();
   }
-#endif
 }
 //-----------------------------------------------------------------------------
 void XDMFFile::write(const function::Function& u)
 {
   // Check that encoding
-  if (_encoding == Encoding::HDF5 and !has_hdf5())
-  {
-    throw std::runtime_error("DOLFIN has not been compiled with HDF5 support. "
-                             "Cannot write XDMF in HDF5 encoding.");
-  }
-
   if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(
@@ -338,7 +318,6 @@ void XDMFFile::write(const function::Function& u)
 
   // Open the HDF5 file if using HDF5 encoding (truncate)
   hid_t h5_id = -1;
-#ifdef HAS_HDF5
   std::unique_ptr<HDF5File> h5_file;
   if (_encoding == Encoding::HDF5)
   {
@@ -350,7 +329,6 @@ void XDMFFile::write(const function::Function& u)
     // Get file handle
     h5_id = h5_file->h5_id();
   }
-#endif
 
   // Add XDMF node and version attribute
   pugi::xml_node xdmf_node = _xml_doc->append_child("Xdmf");
@@ -436,12 +414,6 @@ void XDMFFile::write(const function::Function& u)
 void XDMFFile::write(const function::Function& u, double time_step)
 {
   // Check that encoding
-  if (_encoding == Encoding::HDF5 and !has_hdf5())
-  {
-    throw std::runtime_error("DOLFIN has not been compiled with HDF5 support. "
-                             "Cannot write XDMF in HDF5 encoding.");
-  }
-
   if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(
@@ -467,7 +439,6 @@ void XDMFFile::write(const function::Function& u, double time_step)
   }
 
   hid_t h5_id = -1;
-#ifdef HAS_HDF5
   // Open the HDF5 file for first time, if using HDF5 encoding
   if (_encoding == Encoding::HDF5)
   {
@@ -491,7 +462,6 @@ void XDMFFile::write(const function::Function& u, double time_step)
     assert(_hdf5_file);
     h5_id = _hdf5_file->h5_id();
   }
-#endif
 
   pugi::xml_node xdmf_node = _xml_doc->child("Xdmf");
   assert(xdmf_node);
@@ -636,14 +606,12 @@ void XDMFFile::write(const function::Function& u, double time_step)
   if (_mpi_comm.rank() == 0)
     _xml_doc->save_file(_filename.c_str(), "  ");
 
-#ifdef HAS_HDF5
   // Close the HDF5 file if in "flush" mode
   if (_encoding == Encoding::HDF5 and parameters["flush_output"])
   {
     assert(_hdf5_file);
     _hdf5_file.reset();
   }
-#endif
 
   ++_counter;
 }
@@ -693,12 +661,6 @@ void XDMFFile::write_mesh_value_collection(
     const mesh::MeshValueCollection<T>& mvc)
 {
   // Check that encoding
-  if (_encoding == Encoding::HDF5 and !has_hdf5())
-  {
-    throw std::runtime_error("DOLFIN has not been compiled with HDF5 support. "
-                             "Cannot write XDMF in HDF5 encoding.");
-  }
-
   if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(
@@ -744,7 +706,6 @@ void XDMFFile::write_mesh_value_collection(
 
   // Open a HDF5 file if using HDF5 encoding
   hid_t h5_id = -1;
-#ifdef HAS_HDF5
   std::unique_ptr<HDF5File> h5_file;
   if (_encoding == Encoding::HDF5)
   {
@@ -756,7 +717,6 @@ void XDMFFile::write_mesh_value_collection(
     // Get file handle
     h5_id = h5_file->h5_id();
   }
-#endif
 
   // Check domain node for existing mesh::Mesh Grid and check it is compatible
   // with
@@ -1099,12 +1059,6 @@ XDMFFile::read_mesh_value_collection(std::shared_ptr<const mesh::Mesh> mesh,
 void XDMFFile::write(const std::vector<geometry::Point>& points)
 {
   // Check that encoding
-  if (_encoding == Encoding::HDF5 and !has_hdf5())
-  {
-    throw std::runtime_error("DOLFIN has not been compiled with HDF5 support. "
-                             "Cannot write XDMF in HDF5 encoding.");
-  }
-
   if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(
@@ -1113,7 +1067,6 @@ void XDMFFile::write(const std::vector<geometry::Point>& points)
 
   // Open a HDF5 file if using HDF5 encoding (truncate)
   hid_t h5_id = -1;
-#ifdef HAS_HDF5
   std::unique_ptr<HDF5File> h5_file;
   if (_encoding == Encoding::HDF5)
   {
@@ -1125,7 +1078,6 @@ void XDMFFile::write(const std::vector<geometry::Point>& points)
     // Get file handle
     h5_id = h5_file->h5_id();
   }
-#endif
 
   // Create pugi doc
   _xml_doc->reset();
@@ -1186,12 +1138,6 @@ void XDMFFile::write(const std::vector<geometry::Point>& points,
   assert(points.size() == values.size());
 
   // Check that encoding is supported
-  if (_encoding == Encoding::HDF5 and !has_hdf5())
-  {
-    throw std::runtime_error("DOLFIN has not been compiled with HDF5 support. "
-                             "Cannot write XDMF in HDF5 encoding.");
-  }
-
   if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(
@@ -1203,7 +1149,6 @@ void XDMFFile::write(const std::vector<geometry::Point>& points,
 
   // Open a HDF5 file if using HDF5 encoding (truncate)
   hid_t h5_id = -1;
-#ifdef HAS_HDF5
   std::unique_ptr<HDF5File> h5_file;
   if (_encoding == Encoding::HDF5)
   {
@@ -1215,7 +1160,6 @@ void XDMFFile::write(const std::vector<geometry::Point>& points,
     // Get file handle
     h5_id = h5_file->h5_id();
   }
-#endif
 
   // Add XDMF node and version attribute
   _xml_doc->append_child(pugi::node_doctype)
@@ -1891,7 +1835,6 @@ void XDMFFile::add_data_item(MPI_Comm comm, pugi::xml_node& xml_node,
   }
   else
   {
-#ifdef HAS_HDF5
     data_item_node.append_attribute("Format") = "HDF";
 
     // Get name of HDF5 file
@@ -1931,12 +1874,6 @@ void XDMFFile::add_data_item(MPI_Comm comm, pugi::xml_node& xml_node,
     MPI::gather(comm, offset_tmp, partitions);
     MPI::broadcast(comm, partitions);
     HDF5Interface::add_attribute(h5_id, h5_path, "partition", partitions);
-
-#else
-    // Should never reach this point
-    log::dolfin_error("XDMFFile.cpp", "add dataitem",
-                      "DOLFIN has not been configured with HDF5");
-#endif
   }
 }
 //----------------------------------------------------------------------------
@@ -2226,7 +2163,6 @@ std::vector<T> XDMFFile::get_dataset(MPI_Comm comm,
   }
   else if (format == "HDF")
   {
-#ifdef HAS_HDF5
     // Get file and data path
     auto paths = get_hdf5_paths(dataset_node);
 
@@ -2290,11 +2226,6 @@ std::vector<T> XDMFFile::get_dataset(MPI_Comm comm,
     // Retrieve data
     data_vector
         = HDF5Interface::read_dataset<T>(h5_file.h5_id(), paths[1], range);
-#else
-    // Should never reach this point
-    log::dolfin_error("XDMFFile.cpp", "get dataset",
-                      "DOLFIN has not been configured with HDF5");
-#endif
   }
   else
   {
@@ -2626,12 +2557,6 @@ template <typename T>
 void XDMFFile::write_mesh_function(const mesh::MeshFunction<T>& meshfunction)
 {
   // Check that encoding
-  if (_encoding == Encoding::HDF5 and !has_hdf5())
-  {
-    throw std::runtime_error("DOLFIN has not been compiled with HDF5 support. "
-                             "Cannot write XDMF in HDF5 encoding.");
-  }
-
   if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(
@@ -2677,7 +2602,6 @@ void XDMFFile::write_mesh_function(const mesh::MeshFunction<T>& meshfunction)
 
   // Open a HDF5 file if using HDF5 encoding
   hid_t h5_id = -1;
-#ifdef HAS_HDF5
   std::unique_ptr<HDF5File> h5_file;
   if (_encoding == Encoding::HDF5)
   {
@@ -2689,7 +2613,6 @@ void XDMFFile::write_mesh_function(const mesh::MeshFunction<T>& meshfunction)
     // Get file handle
     h5_id = h5_file->h5_id();
   }
-#endif
 
   const std::string mf_name = "/MeshFunction/" + std::to_string(_counter);
 

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -70,12 +70,6 @@ void XDMFFile::close()
 void XDMFFile::write(const mesh::Mesh& mesh)
 {
   // Check that encoding
-  if (_encoding == Encoding::HDF5 and !())
-  {
-    throw std::runtime_error("Cannot write XDMF in HDF5 encoding. (DOLFIN not "
-                             "compied with HDF5 support)");
-  }
-
   if (_encoding == Encoding::ASCII and _mpi_comm.size() != 1)
   {
     throw std::runtime_error(

--- a/cpp/dolfin/io/XDMFFile.h
+++ b/cpp/dolfin/io/XDMFFile.h
@@ -12,13 +12,7 @@
 #include <string>
 #include <utility>
 #include <vector>
-
-#ifdef HAS_HDF5
 #include <hdf5.h>
-#else
-typedef int hid_t;
-#endif
-
 #include <dolfin/common/MPI.h>
 #include <dolfin/common/Variable.h>
 #include <dolfin/mesh/CellType.h>
@@ -63,9 +57,7 @@ class MeshPartitioning;
 
 namespace io
 {
-#ifdef HAS_HDF5
 class HDF5File;
-#endif
 
 /// Read and write mesh::Mesh, function::Function, mesh::MeshFunction and other
 /// objects in XDMF
@@ -99,11 +91,7 @@ public:
   };
 
 /// Default encoding type
-#ifdef HAS_HDF5
-  static const Encoding default_encoding = Encoding::HDF5;
-#else
-  static const Encoding default_encoding = Encoding::ASCII;
-#endif
+static const Encoding default_encoding = Encoding::HDF5;
 
   /// Constructor
   XDMFFile(MPI_Comm comm, const std::string filename,
@@ -564,10 +552,8 @@ private:
   // MPI communicator
   dolfin::MPI::Comm _mpi_comm;
 
-#ifdef HAS_HDF5
   // HDF5 data file
   std::unique_ptr<HDF5File> _hdf5_file;
-#endif
 
   // Cached filename
   const std::string _filename;

--- a/python/dolfin/__init__.py
+++ b/python/dolfin/__init__.py
@@ -33,7 +33,7 @@ from .cpp import __version__
 
 
 from dolfin.common import (
-    has_debug, has_hdf5, has_scotch, has_hdf5_parallel,
+    has_debug, has_scotch,
     has_mpi4py, has_petsc_complex, has_petsc4py, has_parmetis,
     has_slepc, has_slepc4py, git_commit_hash,
     TimingType, timing, timings, list_timings, DOLFIN_EPS)

--- a/python/dolfin/common.py
+++ b/python/dolfin/common.py
@@ -13,8 +13,6 @@ from dolfin import cpp
 DOLFIN_EPS = cpp.common.DOLFIN_EPS
 
 has_debug = cpp.common.has_debug()
-has_hdf5 = cpp.common.has_hdf5()
-has_hdf5_parallel = cpp.common.has_hdf5_parallel()
 has_mpi4py = cpp.common.has_mpi4py()
 has_parmetis = cpp.common.has_parmetis()
 has_scotch = cpp.common.has_scotch()

--- a/python/dolfin_utils/test/skips.py
+++ b/python/dolfin_utils/test/skips.py
@@ -9,12 +9,10 @@
 import pytest
 
 from dolfin import MPI
-from dolfin.common import (has_debug, has_hdf5, has_hdf5_parallel,
+from dolfin.common import (has_debug,
                            has_petsc4py, has_petsc_complex, has_slepc)
 
 # Skips with dependencies
-skip_if_not_HDF5 = pytest.mark.skipif(
-    not has_hdf5, reason="Skipping unit test(s) depending on HDF5.")
 skip_if_not_petsc4py = pytest.mark.skipif(
     not has_petsc4py, reason="Skipping unit test(s) depending on petsc4py.")
 skip_if_not_SLEPc = pytest.mark.skipif(
@@ -24,15 +22,9 @@ skip_if_not_SLEPc = pytest.mark.skipif(
 xfail_in_parallel = pytest.mark.xfail(
     MPI.size(MPI.comm_world) > 1,
     reason="This test does not yet work in parallel.")
-xfail_with_serial_hdf5_in_parallel = pytest.mark.xfail(
-    MPI.size(MPI.comm_world) > 1 and not has_hdf5_parallel,
-    reason="Serial HDF5 library cannot work in parallel.")
 skip_in_parallel = pytest.mark.skipif(
     MPI.size(MPI.comm_world) > 1,
     reason="This test should only be run in serial.")
-skip_with_serial_hdf5_in_parallel = pytest.mark.skipif(
-    MPI.size(MPI.comm_world) > 1 and not has_hdf5_parallel,
-    reason="Serial HDF5 library cannot work in parallel.")
 skip_in_serial = pytest.mark.skipif(
     MPI.size(MPI.comm_world) <= 1,
     reason="This test should only be run in parallel.")

--- a/python/src/common.cpp
+++ b/python/src/common.cpp
@@ -43,8 +43,6 @@ void common(py::module& m)
 
   // From dolfin/common/defines.h
   m.def("has_debug", &dolfin::has_debug);
-  m.def("has_hdf5", &dolfin::has_hdf5);
-  m.def("has_hdf5_parallel", &dolfin::has_hdf5_parallel);
   m.def("has_mpi4py",
         []() {
 #ifdef HAS_PYBIND11_MPI4PY

--- a/python/test/unit/io/test_HDF5.py
+++ b/python/test/unit/io/test_HDF5.py
@@ -10,26 +10,20 @@ import dolfin
 from dolfin import (MPI, Cell, Expression, Function, FunctionSpace,
                     MeshEntities, MeshEntity, MeshFunction,
                     MeshValueCollection, UnitCubeMesh, UnitSquareMesh, cpp)
+from dolfin.io import HDF5File
 from dolfin.la import PETScVector
 from dolfin_utils.test.fixtures import tempdir
-from dolfin_utils.test.skips import (skip_if_not_HDF5, xfail_if_complex,
-                                     xfail_with_serial_hdf5_in_parallel)
-from dolfin.io import HDF5File
+from dolfin_utils.test.skips import xfail_if_complex
 
 assert (tempdir)
 
 
-@skip_if_not_HDF5
-@xfail_with_serial_hdf5_in_parallel
 def test_parallel(tempdir):
     filename = os.path.join(tempdir, "y.h5")
     hdf5 = HDF5File(MPI.comm_world, filename, "w")
     assert (hdf5)
 
 
-@xfail_if_complex
-@skip_if_not_HDF5
-@xfail_with_serial_hdf5_in_parallel
 def test_save_vector(tempdir):
     filename = os.path.join(tempdir, "x.h5")
     x = PETScVector(MPI.comm_world, [0, 305], [], 1)
@@ -38,9 +32,6 @@ def test_save_vector(tempdir):
         vector_file.write(x, "/my_vector")
 
 
-@xfail_if_complex
-@skip_if_not_HDF5
-@xfail_with_serial_hdf5_in_parallel
 def test_save_and_read_vector(tempdir):
     filename = os.path.join(tempdir, "vector.h5")
 
@@ -59,8 +50,6 @@ def test_save_and_read_vector(tempdir):
         assert x.norm(dolfin.cpp.la.Norm.l2) == 0.0
 
 
-@skip_if_not_HDF5
-@xfail_with_serial_hdf5_in_parallel
 def test_save_and_read_meshfunction_2D(tempdir):
     filename = os.path.join(tempdir, "meshfn-2d.h5")
 
@@ -87,8 +76,6 @@ def test_save_and_read_meshfunction_2D(tempdir):
                 assert meshfunctions[i][cell] == mf2[cell]
 
 
-@skip_if_not_HDF5
-@xfail_with_serial_hdf5_in_parallel
 def test_save_and_read_meshfunction_3D(tempdir):
     filename = os.path.join(tempdir, "meshfn-3d.h5")
 
@@ -118,8 +105,6 @@ def test_save_and_read_meshfunction_3D(tempdir):
     mf_file.close()
 
 
-@skip_if_not_HDF5
-@xfail_with_serial_hdf5_in_parallel
 def test_save_and_read_mesh_value_collection(tempdir):
     ndiv = 2
     filename = os.path.join(tempdir, "mesh_value_collection.h5")
@@ -151,8 +136,6 @@ def test_save_and_read_mesh_value_collection(tempdir):
                 assert val == int(ndiv * sum(mid)) + 1
 
 
-@skip_if_not_HDF5
-@xfail_with_serial_hdf5_in_parallel
 def test_save_and_read_mesh_value_collection_with_only_one_marked_entity(
         tempdir):
     ndiv = 2
@@ -176,8 +159,6 @@ def test_save_and_read_mesh_value_collection_with_only_one_marked_entity(
 
 
 @xfail_if_complex
-@skip_if_not_HDF5
-@xfail_with_serial_hdf5_in_parallel
 def test_save_and_read_function(tempdir):
     filename = os.path.join(tempdir, "function.h5")
 
@@ -202,8 +183,6 @@ def test_save_and_read_function(tempdir):
     hdf5_file.close()
 
 
-@skip_if_not_HDF5
-@xfail_with_serial_hdf5_in_parallel
 def test_save_and_read_mesh_2D(tempdir):
     filename = os.path.join(tempdir, "mesh2d.h5")
 
@@ -224,8 +203,6 @@ def test_save_and_read_mesh_2D(tempdir):
     assert mesh0.num_entities_global(dim) == mesh1.num_entities_global(dim)
 
 
-@skip_if_not_HDF5
-@xfail_with_serial_hdf5_in_parallel
 def test_save_and_read_mesh_3D(tempdir):
     filename = os.path.join(tempdir, "mesh3d.h5")
 
@@ -246,8 +223,6 @@ def test_save_and_read_mesh_3D(tempdir):
     assert mesh0.num_entities_global(dim) == mesh1.num_entities_global(dim)
 
 
-@skip_if_not_HDF5
-@xfail_with_serial_hdf5_in_parallel
 def test_mpi_atomicity(tempdir):
     comm_world = MPI.comm_world
     if MPI.size(comm_world) > 1:

--- a/python/test/unit/io/test_HDF5.py
+++ b/python/test/unit/io/test_HDF5.py
@@ -24,6 +24,7 @@ def test_parallel(tempdir):
     assert (hdf5)
 
 
+@xfail_if_complex
 def test_save_vector(tempdir):
     filename = os.path.join(tempdir, "x.h5")
     x = PETScVector(MPI.comm_world, [0, 305], [], 1)
@@ -32,6 +33,7 @@ def test_save_vector(tempdir):
         vector_file.write(x, "/my_vector")
 
 
+@xfail_if_complex
 def test_save_and_read_vector(tempdir):
     filename = os.path.join(tempdir, "vector.h5")
 

--- a/python/test/unit/io/test_HDF5.py
+++ b/python/test/unit/io/test_HDF5.py
@@ -9,15 +9,12 @@ import os
 import dolfin
 from dolfin import (MPI, Cell, Expression, Function, FunctionSpace,
                     MeshEntities, MeshEntity, MeshFunction,
-                    MeshValueCollection, UnitCubeMesh, UnitSquareMesh, cpp,
-                    has_hdf5)
+                    MeshValueCollection, UnitCubeMesh, UnitSquareMesh, cpp)
 from dolfin.la import PETScVector
 from dolfin_utils.test.fixtures import tempdir
 from dolfin_utils.test.skips import (skip_if_not_HDF5, xfail_if_complex,
                                      xfail_with_serial_hdf5_in_parallel)
-
-if has_hdf5:
-    from dolfin.io import HDF5File
+from dolfin.io import HDF5File
 
 assert (tempdir)
 

--- a/python/test/unit/io/test_HDF5_series.py
+++ b/python/test/unit/io/test_HDF5_series.py
@@ -7,14 +7,11 @@
 import os
 
 import dolfin.cpp as cpp
-from dolfin import (MPI, Expression, Function, FunctionSpace, UnitSquareMesh,
-                    has_hdf5)
+from dolfin import (MPI, Expression, Function, FunctionSpace, UnitSquareMesh)
 from dolfin_utils.test.fixtures import tempdir
 from dolfin_utils.test.skips import (skip_if_not_HDF5, xfail_if_complex,
                                      xfail_with_serial_hdf5_in_parallel)
-
-if has_hdf5:
-    from dolfin.io import HDF5File
+from dolfin.io import HDF5File
 assert (tempdir)
 
 

--- a/python/test/unit/io/test_HDF5_series.py
+++ b/python/test/unit/io/test_HDF5_series.py
@@ -9,14 +9,13 @@ import os
 import dolfin.cpp as cpp
 from dolfin import (MPI, Expression, Function, FunctionSpace, UnitSquareMesh)
 from dolfin_utils.test.fixtures import tempdir
-from dolfin_utils.test.skips import (skip_if_not_HDF5, xfail_if_complex,
+from dolfin_utils.test.skips import (xfail_if_complex,
                                      xfail_with_serial_hdf5_in_parallel)
 from dolfin.io import HDF5File
 assert (tempdir)
 
 
 @xfail_if_complex
-@skip_if_not_HDF5
 @xfail_with_serial_hdf5_in_parallel
 def test_save_and_read_function_timeseries(tempdir):
     filename = os.path.join(tempdir, "function.h5")

--- a/python/test/unit/io/test_HDF5_series.py
+++ b/python/test/unit/io/test_HDF5_series.py
@@ -7,16 +7,15 @@
 import os
 
 import dolfin.cpp as cpp
-from dolfin import (MPI, Expression, Function, FunctionSpace, UnitSquareMesh)
-from dolfin_utils.test.fixtures import tempdir
-from dolfin_utils.test.skips import (xfail_if_complex,
-                                     xfail_with_serial_hdf5_in_parallel)
+from dolfin import MPI, Expression, Function, FunctionSpace, UnitSquareMesh
 from dolfin.io import HDF5File
+from dolfin_utils.test.fixtures import tempdir
+from dolfin_utils.test.skips import xfail_if_complex
+
 assert (tempdir)
 
 
 @xfail_if_complex
-@xfail_with_serial_hdf5_in_parallel
 def test_save_and_read_function_timeseries(tempdir):
     filename = os.path.join(tempdir, "function.h5")
 

--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -47,6 +47,7 @@ def mesh_factory(tdim, n):
     elif tdim == 3:
         return UnitCubeMesh(MPI.comm_world, n, n, n)
 
+
 def invalid_fe(fe_family, fe_degree):
     return (fe_family == "CG" and fe_degree == 0)
 
@@ -65,8 +66,6 @@ def worker_id(request):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_multiple_datasets(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     mesh = UnitSquareMesh(MPI.comm_world, 2, 2)
     cf0 = MeshFunction('size_t', mesh, 2, 11)
     cf0.rename('cf0')
@@ -88,8 +87,6 @@ def test_multiple_datasets(tempdir, encoding):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_and_load_1d_mesh(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     filename = os.path.join(tempdir, "mesh.xdmf")
     mesh = UnitIntervalMesh(MPI.comm_world, 32)
 
@@ -105,8 +102,6 @@ def test_save_and_load_1d_mesh(tempdir, encoding):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_and_load_2d_mesh(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     filename = os.path.join(tempdir, "mesh_2D.xdmf")
     mesh = UnitSquareMesh(MPI.comm_world, 32, 32)
 
@@ -122,8 +117,6 @@ def test_save_and_load_2d_mesh(tempdir, encoding):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_and_load_2d_quad_mesh(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     filename = os.path.join(tempdir, "mesh_2D_quad.xdmf")
     mesh = UnitSquareMesh(MPI.comm_world, 32, 32, CellType.Type.quadrilateral)
 
@@ -139,8 +132,6 @@ def test_save_and_load_2d_quad_mesh(tempdir, encoding):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_and_load_3d_mesh(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     filename = os.path.join(tempdir, "mesh_3D.xdmf")
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 4)
 
@@ -156,8 +147,6 @@ def test_save_and_load_3d_mesh(tempdir, encoding):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_1d_scalar(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     filename2 = os.path.join(tempdir, "u1_.xdmf")
     mesh = UnitIntervalMesh(MPI.comm_world, 32)
     # FIXME: This randomly hangs in parallel
@@ -176,9 +165,6 @@ def test_save_1d_scalar(tempdir, encoding):
 @pytest.mark.parametrize("mesh_n", mesh_ns)
 def test_save_and_checkpoint_scalar(tempdir, encoding, fe_degree, fe_family,
                                     mesh_tdim, mesh_n):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
-
     if invalid_fe(fe_family, fe_degree):
         pytest.skip("Trivial finite element")
 
@@ -211,9 +197,6 @@ def test_save_and_checkpoint_scalar(tempdir, encoding, fe_degree, fe_family,
 @pytest.mark.parametrize("mesh_n", mesh_ns)
 def test_save_and_checkpoint_vector(tempdir, encoding, fe_degree, fe_family,
                                     mesh_tdim, mesh_n):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
-
     if invalid_fe(fe_family, fe_degree):
         pytest.skip("Trivial finite element")
 
@@ -254,9 +237,6 @@ def test_save_and_checkpoint_vector(tempdir, encoding, fe_degree, fe_family,
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_and_checkpoint_timeseries(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
-
     mesh = UnitSquareMesh(MPI.comm_world, 16, 16)
     filename = os.path.join(tempdir, "u2_checkpoint.xdmf")
     FE = FiniteElement("CG", mesh.ufl_cell(), 2)
@@ -289,8 +269,6 @@ def test_save_and_checkpoint_timeseries(tempdir, encoding):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_2d_scalar(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     filename = os.path.join(tempdir, "u2.xdmf")
     mesh = UnitSquareMesh(MPI.comm_world, 16, 16)
     # FIXME: This randomly hangs in parallel
@@ -304,8 +282,6 @@ def test_save_2d_scalar(tempdir, encoding):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_3d_scalar(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     filename = os.path.join(tempdir, "u3.xdmf")
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 4)
     V = FunctionSpace(mesh, ("Lagrange", 2))
@@ -318,8 +294,6 @@ def test_save_3d_scalar(tempdir, encoding):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_2d_vector(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     filename = os.path.join(tempdir, "u_2dv.xdmf")
     mesh = UnitSquareMesh(MPI.comm_world, 16, 16)
     V = VectorFunctionSpace(mesh, ("Lagrange", 2))
@@ -333,8 +307,6 @@ def test_save_2d_vector(tempdir, encoding):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_3d_vector(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     filename = os.path.join(tempdir, "u_3Dv.xdmf")
     mesh = UnitCubeMesh(MPI.comm_world, 2, 2, 2)
     u = Function(VectorFunctionSpace(mesh, ("Lagrange", 1)))
@@ -348,8 +320,6 @@ def test_save_3d_vector(tempdir, encoding):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_3d_vector_series(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     filename = os.path.join(tempdir, "u_3D.xdmf")
     mesh = UnitCubeMesh(MPI.comm_world, 2, 2, 2)
     u = Function(VectorFunctionSpace(mesh, ("Lagrange", 2)))
@@ -367,8 +337,6 @@ def test_save_3d_vector_series(tempdir, encoding):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_2d_tensor(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     filename = os.path.join(tempdir, "tensor.xdmf")
     mesh = UnitSquareMesh(MPI.comm_world, 16, 16)
     u = Function(TensorFunctionSpace(mesh, ("Lagrange", 2)))
@@ -380,8 +348,6 @@ def test_save_2d_tensor(tempdir, encoding):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_3d_tensor(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     filename = os.path.join(tempdir, "u3t.xdmf")
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 4)
     u = Function(TensorFunctionSpace(mesh, ("Lagrange", 2)))
@@ -393,8 +359,6 @@ def test_save_3d_tensor(tempdir, encoding):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_1d_mesh(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     filename = os.path.join(tempdir, "mf_1D.xdmf")
     mesh = UnitIntervalMesh(MPI.comm_world, 32)
     mf = MeshFunction("size_t", mesh, mesh.topology.dim, 0)
@@ -408,11 +372,7 @@ def test_save_1d_mesh(tempdir, encoding):
 @pytest.mark.parametrize("encoding", encodings)
 @pytest.mark.parametrize("data_type", data_types)
 def test_save_2D_cell_function(tempdir, encoding, data_type):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
-
     dtype_str, dtype = data_type
-
     filename = os.path.join(tempdir, "mf_2D_%s.xdmf" % dtype_str)
     mesh = UnitSquareMesh(MPI.comm_world, 32, 32)
     mf = MeshFunction(dtype_str, mesh, mesh.topology.dim, 0)
@@ -436,11 +396,7 @@ def test_save_2D_cell_function(tempdir, encoding, data_type):
 @pytest.mark.parametrize("encoding", encodings)
 @pytest.mark.parametrize("data_type", data_types)
 def test_save_3D_cell_function(tempdir, encoding, data_type):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
-
     dtype_str, dtype = data_type
-
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 4)
     mf = MeshFunction(dtype_str, mesh, mesh.topology.dim, 0)
     mf.rename("cells")
@@ -465,11 +421,7 @@ def test_save_3D_cell_function(tempdir, encoding, data_type):
 @pytest.mark.parametrize("encoding", encodings)
 @pytest.mark.parametrize("data_type", data_types)
 def test_save_2D_facet_function(tempdir, encoding, data_type):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
-
     dtype_str, dtype = data_type
-
     mesh = UnitSquareMesh(MPI.comm_world, 32, 32)
     mf = MeshFunction(dtype_str, mesh, mesh.topology.dim - 1, 0)
     mf.rename("facets")
@@ -498,11 +450,7 @@ def test_save_2D_facet_function(tempdir, encoding, data_type):
 @pytest.mark.parametrize("encoding", encodings)
 @pytest.mark.parametrize("data_type", data_types)
 def test_save_3D_facet_function(tempdir, encoding, data_type):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
-
     dtype_str, dtype = data_type
-
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 4)
     mf = MeshFunction(dtype_str, mesh, mesh.topology.dim - 1, 0)
     mf.rename("facets")
@@ -531,11 +479,7 @@ def test_save_3D_facet_function(tempdir, encoding, data_type):
 @pytest.mark.parametrize("encoding", encodings)
 @pytest.mark.parametrize("data_type", data_types)
 def test_save_3D_edge_function(tempdir, encoding, data_type):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
-
     dtype_str, dtype = data_type
-
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 4)
     mf = MeshFunction(dtype_str, mesh, 1, 0)
     mf.rename("edges")
@@ -550,11 +494,7 @@ def test_save_3D_edge_function(tempdir, encoding, data_type):
 @pytest.mark.parametrize("encoding", encodings)
 @pytest.mark.parametrize("data_type", data_types)
 def test_save_2D_vertex_function(tempdir, encoding, data_type):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
-
     dtype_str, dtype = data_type
-
     mesh = UnitSquareMesh(MPI.comm_world, 32, 32)
     mf = MeshFunction(dtype_str, mesh, 0, 0)
     mf.rename("vertices")
@@ -578,11 +518,7 @@ def test_save_2D_vertex_function(tempdir, encoding, data_type):
 @pytest.mark.parametrize("encoding", encodings)
 @pytest.mark.parametrize("data_type", data_types)
 def test_save_3D_vertex_function(tempdir, encoding, data_type):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
-
     dtype_str, dtype = data_type
-
     filename = os.path.join(tempdir, "mf_vertex_3D_%s.xdmf" % dtype_str)
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 4)
     mf = MeshFunction(dtype_str, mesh, 0, 0)
@@ -595,8 +531,6 @@ def test_save_3D_vertex_function(tempdir, encoding, data_type):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_points_2D(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     import numpy
     mesh = UnitSquareMesh(MPI.comm_world, 16, 16)
     points, values = [], []
@@ -620,8 +554,6 @@ def test_save_points_2D(tempdir, encoding):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_save_points_3D(tempdir, encoding):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
     import numpy
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 4)
     points, values = [], []
@@ -646,14 +578,9 @@ def test_save_points_3D(tempdir, encoding):
 @pytest.mark.parametrize("encoding", encodings)
 @pytest.mark.parametrize("data_type", data_types)
 def test_save_mesh_value_collection(tempdir, encoding, data_type):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
-
     dtype_str, dtype = data_type
-
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 4)
     tdim = mesh.topology.dim
-
     meshfn = MeshFunction(dtype_str, mesh, mesh.topology.dim, False)
     meshfn.rename("volume_marker")
     for c in Cells(mesh):
@@ -685,19 +612,13 @@ def test_save_mesh_value_collection(tempdir, encoding, data_type):
 @pytest.mark.parametrize("encoding", encodings)
 @pytest.mark.parametrize("data_type", data_types)
 def test_append_and_load_mesh_functions(tempdir, encoding, data_type):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
-
     dtype_str, dtype = data_type
-
     meshes = [
         UnitSquareMesh(MPI.comm_world, 12, 12),
         UnitCubeMesh(MPI.comm_world, 2, 2, 2)
     ]
-
     for mesh in meshes:
         dim = mesh.topology.dim
-
         vf = MeshFunction(dtype_str, mesh, 0, 0)
         vf.rename("vertices")
         ff = MeshFunction(dtype_str, mesh, mesh.topology.dim - 1, 0)
@@ -747,11 +668,7 @@ def test_append_and_load_mesh_functions(tempdir, encoding, data_type):
 @pytest.mark.parametrize("encoding", encodings)
 @pytest.mark.parametrize("data_type", data_types)
 def test_append_and_load_mesh_value_collections(tempdir, encoding, data_type):
-    if invalid_config(encoding):
-        pytest.skip("XDMF unsupported in current configuration")
-
     dtype_str, dtype = data_type
-
     mesh = UnitCubeMesh(MPI.comm_world, 2, 2, 2)
     mesh.init()
     for d in range(mesh.geometry.dim + 1):

--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -13,7 +13,7 @@ from dolfin import (MPI, Cells, CellType, Constant, Edges, Expression, Facets,
                     MeshFunction, MeshValueCollection, TensorFunctionSpace,
                     UnitCubeMesh, UnitIntervalMesh, UnitSquareMesh,
                     VectorElement, VectorFunctionSpace, Vertices, cpp,
-                    has_hdf5, has_hdf5_parallel, has_petsc_complex,
+                    has_petsc_complex,
                     interpolate)
 from dolfin.io import XDMFFile
 from dolfin_utils.test.fixtures import tempdir
@@ -46,13 +46,6 @@ def mesh_factory(tdim, n):
         return UnitSquareMesh(MPI.comm_world, n, n)
     elif tdim == 3:
         return UnitCubeMesh(MPI.comm_world, n, n, n)
-
-
-def invalid_config(encoding):
-    return (not has_hdf5 and encoding == XDMFFile.Encoding.HDF5) \
-        or (encoding == XDMFFile.Encoding.ASCII and MPI.size(MPI.comm_world) > 1) \
-        or (not has_hdf5_parallel and MPI.size(MPI.comm_world) > 1)
-
 
 def invalid_fe(fe_family, fe_degree):
     return (fe_family == "CG" and fe_degree == 0)


### PR DESCRIPTION
This includes updates around the ifdefs for HDF5. 

Making HDF5 required simplifies the logic around tests, and required dependencies provide more clarity for users.