### PR TITLE
Simplify mesh connectivity

### DIFF
--- a/cpp/dolfin/graph/CSRGraph.h
+++ b/cpp/dolfin/graph/CSRGraph.h
@@ -189,5 +189,5 @@ private:
   // MPI communicator attached to graph
   dolfin::MPI::Comm _mpi_comm;
 };
-}
-}
+} // namespace graph
+} // namespace dolfin

--- a/cpp/dolfin/mesh/CoordinateDofs.cpp
+++ b/cpp/dolfin/mesh/CoordinateDofs.cpp
@@ -19,15 +19,24 @@ CoordinateDofs::CoordinateDofs(std::uint32_t tdim)
 }
 //-----------------------------------------------------------------------------
 void CoordinateDofs::init(std::size_t dim,
-                          Eigen::Ref<const EigenRowArrayXXi32> point_dofs,
+                          const Eigen::Ref<const EigenRowArrayXXi32> point_dofs,
                           const std::vector<std::uint8_t>& cell_permutation)
 {
   assert(dim < _coord_dofs.size());
-
   _coord_dofs[dim].init(point_dofs.rows(), point_dofs.cols());
   for (std::uint32_t i = 0; i < point_dofs.rows(); ++i)
     _coord_dofs[dim].set(i, point_dofs.row(i));
-
   _cell_permutation = cell_permutation;
+}
+//-----------------------------------------------------------------------------
+const MeshConnectivity& CoordinateDofs::entity_points(std::uint32_t dim) const
+{
+  assert(dim < _coord_dofs.size());
+  return _coord_dofs[dim];
+}
+//-----------------------------------------------------------------------------
+const std::vector<std::uint8_t>& CoordinateDofs::cell_permutation() const
+{
+  return _cell_permutation;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/mesh/CoordinateDofs.cpp
+++ b/cpp/dolfin/mesh/CoordinateDofs.cpp
@@ -10,7 +10,7 @@ using namespace dolfin;
 using namespace dolfin::mesh;
 
 //-----------------------------------------------------------------------------
-CoordinateDofs::CoordinateDofs(std::uint32_t tdim) : _coord_dofs(tdim)
+CoordinateDofs::CoordinateDofs(std::uint32_t tdim) : _coord_dofs(tdim + 1)
 {
   // Do nothing
 }

--- a/cpp/dolfin/mesh/CoordinateDofs.cpp
+++ b/cpp/dolfin/mesh/CoordinateDofs.cpp
@@ -10,12 +10,9 @@ using namespace dolfin;
 using namespace dolfin::mesh;
 
 //-----------------------------------------------------------------------------
-CoordinateDofs::CoordinateDofs(std::uint32_t tdim)
+CoordinateDofs::CoordinateDofs(std::uint32_t tdim) : _coord_dofs(tdim)
 {
-  // Create mappings from entities to points for all topological dimensions
-  // but only fill in cell_dofs for now
-  for (unsigned int i = 0; i <= tdim; ++i)
-    _coord_dofs.push_back(MeshConnectivity(i, 0));
+  // Do nothing
 }
 //-----------------------------------------------------------------------------
 void CoordinateDofs::init(std::size_t dim,

--- a/cpp/dolfin/mesh/CoordinateDofs.cpp
+++ b/cpp/dolfin/mesh/CoordinateDofs.cpp
@@ -26,7 +26,7 @@ void CoordinateDofs::init(std::size_t dim,
 
   _coord_dofs[dim].init(point_dofs.rows(), point_dofs.cols());
   for (std::uint32_t i = 0; i < point_dofs.rows(); ++i)
-    _coord_dofs[dim].set(i, point_dofs.row(i).data());
+    _coord_dofs[dim].set(i, point_dofs.row(i));
 
   _cell_permutation = cell_permutation;
 }

--- a/cpp/dolfin/mesh/CoordinateDofs.h
+++ b/cpp/dolfin/mesh/CoordinateDofs.h
@@ -52,7 +52,8 @@ public:
   /// @param cell_permutation
   ///   Array containing permutation for cell_vertices required for higher order
   ///   elements which are input in gmsh/vtk order.
-  void init(std::size_t dim, Eigen::Ref<const EigenRowArrayXXi32> point_dofs,
+  void init(std::size_t dim,
+            const Eigen::Ref<const EigenRowArrayXXi32> point_dofs,
             const std::vector<std::uint8_t>& cell_permutation);
 
   /// Get the entity points associated with entities of dimension i
@@ -61,27 +62,19 @@ public:
   ///   Entity dimension
   /// @return MeshConnectivity
   ///   Connections from entities of given dimension to points
-  const MeshConnectivity& entity_points(std::uint32_t dim) const
-  {
-    assert(dim < _coord_dofs.size());
-    return _coord_dofs[dim];
-  }
+  const MeshConnectivity& entity_points(std::uint32_t dim) const;
 
-  const std::vector<std::uint8_t>& cell_permutation() const
-  {
-    return _cell_permutation;
-  }
+  const std::vector<std::uint8_t>& cell_permutation() const;
 
 private:
-  // Connectivity from entities to points.
-  // Initially only defined for cells
+  // Connectivity from entities to points. Initially only defined for
+  // cells
   std::vector<MeshConnectivity> _coord_dofs;
 
-  // Permutation required to transform to/from
-  // VTK/gmsh ordering to DOLFIN ordering
-  // needed for higher order elements
-  // FIXME: ideally remove this, but would need to harmonise
-  // the dof ordering between dolfin/ffc/gmsh
+  // Permutation required to transform to/from VTK/gmsh ordering to
+  // DOLFIN ordering needed for higher order elements
+  // FIXME: ideally remove this, but would need to harmonise the dof
+  // ordering between dolfin/ffc/gmsh
   std::vector<std::uint8_t> _cell_permutation;
 };
 } // namespace mesh

--- a/cpp/dolfin/mesh/DistributedMeshTools.cpp
+++ b/cpp/dolfin/mesh/DistributedMeshTools.cpp
@@ -16,6 +16,7 @@
 #include "dolfin/graph/Graph.h"
 #include "dolfin/graph/SCOTCH.h"
 #include "dolfin/log/log.h"
+#include <Eigen/Dense>
 #include <boost/multi_array.hpp>
 #include <complex>
 
@@ -1093,7 +1094,9 @@ void DistributedMeshTools::init_facet_cell_connections(Mesh& mesh)
 
   // Create vector to hold number of cells connected to each
   // facet. Initially copy over from local values.
-  std::vector<std::uint32_t> num_global_neighbors(mesh.num_facets());
+
+  Eigen::Array<std::uint32_t, Eigen::Dynamic, 1> num_global_neighbors(
+      mesh.num_facets());
 
   std::map<std::int32_t, std::set<std::uint32_t>>& shared_facets
       = mesh.topology().shared_entities(D - 1);

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -154,7 +154,7 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
   // Add cells. Only copies the first few entries on each row corresponding to
   // vertices.
   for (std::int32_t i = 0; i < num_cells; ++i)
-    _topology.connectivity(tdim, 0).set(i, coordinate_dofs.row(i).data());
+    _topology.connectivity(tdim, 0).set(i, coordinate_dofs.row(i));
 
   // Global cell indices - construct if none given
   if (global_cell_indices.empty())

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -154,7 +154,10 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
   // Add cells. Only copies the first few entries on each row corresponding to
   // vertices.
   for (std::int32_t i = 0; i < num_cells; ++i)
-    _topology.connectivity(tdim, 0).set(i, coordinate_dofs.row(i));
+  {
+    _topology.connectivity(tdim, 0).set(
+        i, coordinate_dofs.row(i).leftCols(num_vertices_per_cell));
+  }
 
   // Global cell indices - construct if none given
   if (global_cell_indices.empty())

--- a/cpp/dolfin/mesh/Mesh.h
+++ b/cpp/dolfin/mesh/Mesh.h
@@ -162,7 +162,8 @@ public:
   /// @return std::vector<std::uint32_t>&
   ///         Connectivity for all cells.
   ///
-  const std::vector<std::int32_t>& cells() const
+  Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
+  cells() const
   {
     return _topology.connectivity(_topology.dim(), 0).connections();
   }

--- a/cpp/dolfin/mesh/MeshConnectivity.cpp
+++ b/cpp/dolfin/mesh/MeshConnectivity.cpp
@@ -13,8 +13,7 @@ using namespace dolfin;
 using namespace dolfin::mesh;
 
 //-----------------------------------------------------------------------------
-MeshConnectivity::MeshConnectivity(std::size_t d0, std::size_t d1)
-    : _d0(d0), _d1(d1)
+MeshConnectivity::MeshConnectivity()
 {
   // Do nothing
 }
@@ -111,8 +110,7 @@ std::string MeshConnectivity::str(bool verbose) const
   }
   else
   {
-    s << "<MeshConnectivity " << _d0 << " -- " << _d1 << " of size "
-      << _connections.size() << ">";
+    s << "<MeshConnectivity of size " << _connections.size() << ">";
   }
 
   return s.str();

--- a/cpp/dolfin/mesh/MeshConnectivity.cpp
+++ b/cpp/dolfin/mesh/MeshConnectivity.cpp
@@ -22,7 +22,7 @@ MeshConnectivity::MeshConnectivity(std::size_t d0, std::size_t d1)
 void MeshConnectivity::clear()
 {
   _connections = Eigen::Array<std::int32_t, Eigen::Dynamic, 1>();
-  std::vector<std::uint32_t>().swap(_index_to_position);
+  _index_to_position = Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>();
 }
 //-----------------------------------------------------------------------------
 void MeshConnectivity::init(std::size_t num_entities,
@@ -36,10 +36,11 @@ void MeshConnectivity::init(std::size_t num_entities,
 
   // Allocate
   _connections = Eigen::Array<std::int32_t, Eigen::Dynamic, 1>::Zero(size);
-  _index_to_position.resize(num_entities + 1);
+  _index_to_position
+      = Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>(num_entities + 1);
 
   // Initialize data
-  for (std::size_t e = 0; e < _index_to_position.size(); e++)
+  for (Eigen::Index e = 0; e < _index_to_position.size(); e++)
     _index_to_position[e] = e * num_connections;
 }
 //-----------------------------------------------------------------------------
@@ -66,7 +67,7 @@ void MeshConnectivity::init(std::vector<std::size_t>& num_connections)
 void MeshConnectivity::set(std::size_t entity, std::size_t connection,
                            std::size_t pos)
 {
-  assert((entity + 1) < _index_to_position.size());
+  assert((Eigen::Index) (entity + 1) < _index_to_position.size());
   assert(pos < _index_to_position[entity + 1] - _index_to_position[entity]);
   _connections[_index_to_position[entity] + pos] = connection;
 }
@@ -87,7 +88,7 @@ std::string MeshConnectivity::str(bool verbose) const
   if (verbose)
   {
     s << str(false) << std::endl << std::endl;
-    for (std::size_t e = 0; e < _index_to_position.size() - 1; e++)
+    for (Eigen::Index e = 0; e < _index_to_position.size() - 1; e++)
     {
       s << "  " << e << ":";
       for (std::size_t i = _index_to_position[e]; i < _index_to_position[e + 1];

--- a/cpp/dolfin/mesh/MeshConnectivity.cpp
+++ b/cpp/dolfin/mesh/MeshConnectivity.cpp
@@ -21,7 +21,7 @@ MeshConnectivity::MeshConnectivity(std::size_t d0, std::size_t d1)
 //-----------------------------------------------------------------------------
 void MeshConnectivity::clear()
 {
-  std::vector<std::int32_t>().swap(_connections);
+  _connections = Eigen::Array<std::int32_t, Eigen::Dynamic, 1>();
   std::vector<std::uint32_t>().swap(_index_to_position);
 }
 //-----------------------------------------------------------------------------
@@ -35,8 +35,7 @@ void MeshConnectivity::init(std::size_t num_entities,
   const std::size_t size = num_entities * num_connections;
 
   // Allocate
-  _connections.resize(size);
-  std::fill(_connections.begin(), _connections.end(), 0);
+  _connections = Eigen::Array<std::int32_t, Eigen::Dynamic, 1>::Zero(size);
   _index_to_position.resize(num_entities + 1);
 
   // Initialize data
@@ -61,24 +60,24 @@ void MeshConnectivity::init(std::vector<std::size_t>& num_connections)
   _index_to_position[num_entities] = size;
 
   // Initialize connections
-  _connections.resize(size);
-  std::fill(_connections.begin(), _connections.end(), 0);
+  _connections = Eigen::Array<std::int32_t, Eigen::Dynamic, 1>::Zero(size);
 }
 //-----------------------------------------------------------------------------
 void MeshConnectivity::set(std::size_t entity, std::size_t connection,
                            std::size_t pos)
 {
   assert((entity + 1) < _index_to_position.size());
-  assert(pos
-                < _index_to_position[entity + 1] - _index_to_position[entity]);
+  assert(pos < _index_to_position[entity + 1] - _index_to_position[entity]);
   _connections[_index_to_position[entity] + pos] = connection;
 }
 //-----------------------------------------------------------------------------
 std::size_t MeshConnectivity::hash() const
 {
   // Compute local hash key
-  boost::hash<std::vector<std::int32_t>> uhash;
-  return uhash(_connections);
+  // boost::hash<std::vector<std::int32_t>> uhash;
+  // return uhash(_connections);
+  return boost::hash_range(_connections.data(),
+                           _connections.data() + _connections.size());
 }
 //-----------------------------------------------------------------------------
 std::string MeshConnectivity::str(bool verbose) const

--- a/cpp/dolfin/mesh/MeshConnectivity.cpp
+++ b/cpp/dolfin/mesh/MeshConnectivity.cpp
@@ -67,16 +67,26 @@ void MeshConnectivity::init(std::vector<std::size_t>& num_connections)
 void MeshConnectivity::set(std::size_t entity, std::size_t connection,
                            std::size_t pos)
 {
-  assert((Eigen::Index) (entity + 1) < _index_to_position.size());
+  assert((Eigen::Index)(entity + 1) < _index_to_position.size());
   assert(pos < _index_to_position[entity + 1] - _index_to_position[entity]);
   _connections[_index_to_position[entity] + pos] = connection;
 }
 //-----------------------------------------------------------------------------
+void MeshConnectivity::set(
+    std::uint32_t entity,
+    const Eigen::Ref<const Eigen::Array<std::int32_t, 1, Eigen::Dynamic>>
+        connections)
+{
+  assert((entity + 1) < _index_to_position.size());
+  assert(connections.size()
+         == _index_to_position[entity + 1] - _index_to_position[entity]);
+  std::copy(connections.data(), connections.data() + connections.size(),
+            _connections.data() + _index_to_position[entity]);
+}
+//-----------------------------------------------------------------------------
+
 std::size_t MeshConnectivity::hash() const
 {
-  // Compute local hash key
-  // boost::hash<std::vector<std::int32_t>> uhash;
-  // return uhash(_connections);
   return boost::hash_range(_connections.data(),
                            _connections.data() + _connections.size());
 }

--- a/cpp/dolfin/mesh/MeshConnectivity.h
+++ b/cpp/dolfin/mesh/MeshConnectivity.h
@@ -28,8 +28,8 @@ namespace mesh
 class MeshConnectivity
 {
 public:
-  /// Create empty connectivity between given dimensions (d0 -- d1)
-  MeshConnectivity(std::size_t d0, std::size_t d1);
+  /// Create empty connectivity
+  MeshConnectivity();
 
   /// Copy constructor
   MeshConnectivity(const MeshConnectivity& connectivity) = default;
@@ -168,9 +168,6 @@ public:
   std::string str(bool verbose) const;
 
 private:
-  // Dimensions (only used for pretty-printing)
-  std::size_t _d0, _d1;
-
   // Connections for all entities stored as a contiguous array
   Eigen::Array<std::int32_t, Eigen::Dynamic, 1> _connections;
 

--- a/cpp/dolfin/mesh/MeshConnectivity.h
+++ b/cpp/dolfin/mesh/MeshConnectivity.h
@@ -64,7 +64,7 @@ public:
   std::size_t size_global(std::int32_t entity) const
   {
     if (_num_global_connections.size() == 0)
-      return this->size(entity);
+      return size(entity);
     else
     {
       assert(entity < _num_global_connections.size());
@@ -113,21 +113,10 @@ public:
   /// Set given connection for given entity
   void set(std::size_t entity, std::size_t connection, std::size_t pos);
 
-  /// Set all connections for given entity. T is a container,
-  /// e.g. std::vector<std::size_t>, or a Eigen 1D array
-  template <typename T>
-  void set(std::int32_t entity, const T& connections)
-  {
-    assert((entity + 1) < _index_to_position.size());
-    assert(connections.size()
-           == _index_to_position[entity + 1] - _index_to_position[entity]);
-
-    // Copy data
-    // std::copy(connections.data(), connections.data() + connections.size() ,
-    //           _connections.begin() + _index_to_position[entity]);
-    std::copy(connections.data(), connections.data() + connections.size(),
-              _connections.data() + _index_to_position[entity]);
-  }
+  /// Set all connections for given entity
+  void set(std::uint32_t entity,
+           const Eigen::Ref<const Eigen::Array<std::int32_t, 1, Eigen::Dynamic>>
+               connections);
 
   /// Set all connections for all entities (T is a '2D' container, e.g.
   /// a std::vector<<std::vector<std::size_t>>,

--- a/cpp/dolfin/mesh/MeshConnectivity.h
+++ b/cpp/dolfin/mesh/MeshConnectivity.h
@@ -53,7 +53,7 @@ public:
   inline std::size_t size() const { return _connections.size(); }
 
   /// Return number of connections for given entity
-  std::size_t size(std::size_t entity) const
+  std::size_t size(std::int32_t entity) const
   {
     return (entity + 1) < _index_to_position.size()
                ? _index_to_position[entity + 1] - _index_to_position[entity]
@@ -61,9 +61,9 @@ public:
   }
 
   /// Return global number of connections for given entity
-  std::size_t size_global(std::size_t entity) const
+  std::size_t size_global(std::int32_t entity) const
   {
-    if (_num_global_connections.empty())
+    if (_num_global_connections.size() == 0)
       return size(entity);
     else
     {
@@ -73,7 +73,7 @@ public:
   }
 
   /// Return array of connections for given entity
-  const std::int32_t* operator()(std::size_t entity) const
+  const std::int32_t* operator()(std::int32_t entity) const
   {
     return (entity + 1) < _index_to_position.size()
                ? &_connections[_index_to_position[entity]]
@@ -113,25 +113,25 @@ public:
   /// Set given connection for given entity
   void set(std::size_t entity, std::size_t connection, std::size_t pos);
 
-  /// Set all connections for given entity. T is a contains,
+  /// Set all connections for given entity. T is a container,
   /// e.g. std::vector<std::size_t>
-  template <typename T>
-  void set(std::size_t entity, const T& connections)
-  {
-    assert((entity + 1) < _index_to_position.size());
-    assert(connections.size()
-           == _index_to_position[entity + 1] - _index_to_position[entity]);
+  // template <typename T>
+  // void set(std::int32_t entity, const T& connections)
+  // {
+  //   assert((entity + 1) < _index_to_position.size());
+  //   assert(connections.size()
+  //          == _index_to_position[entity + 1] - _index_to_position[entity]);
 
-    // Copy data
-    // std::copy(connections.begin(), connections.end(),
-    //           _connections.begin() + _index_to_position[entity]);
-    std::copy(connections.data(), connections.data() + connections.size(),
-              _connections.data() + _index_to_position[entity]);
-  }
+  //   // Copy data
+  //   // std::copy(connections.begin(), connections.end(),
+  //   //           _connections.begin() + _index_to_position[entity]);
+  //   std::copy(connections.data(), connections.data() + connections.size(),
+  //             _connections.data() + _index_to_position[entity]);
+  // }
 
   /// Set all connections for given entity
   template <typename T>
-  void set(std::size_t entity, T* connections)
+  void set(std::uint32_t entity, T* connections)
   {
     assert((entity + 1) < _index_to_position.size());
     assert(connections);
@@ -145,8 +145,8 @@ public:
               _connections.data() + _index_to_position[entity]);
   }
 
-  /// Set all connections for all entities (T is a '2D' container, e.g. a
-  /// std::vector<<std::vector<std::size_t>>,
+  /// Set all connections for all entities (T is a '2D' container, e.g.
+  /// a std::vector<<std::vector<std::size_t>>,
   /// std::vector<<std::set<std::size_t>>, etc)
   template <typename T>
   void set(const T& connections)
@@ -181,7 +181,8 @@ public:
   }
 
   /// Set global number of connections for all local entities
-  void set_global_size(const std::vector<std::uint32_t>& num_global_connections)
+  void set_global_size(const Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>&
+                           num_global_connections)
   {
     assert(num_global_connections.size() == _index_to_position.size() - 1);
     _num_global_connections = num_global_connections;
@@ -203,10 +204,12 @@ private:
 
   // Global number of connections for all entities (possibly not
   // computed)
-  std::vector<std::uint32_t> _num_global_connections;
+  Eigen::Array<std::uint32_t, Eigen::Dynamic, 1> _num_global_connections;
+  // std::vector<std::uint32_t> _num_global_connections;
 
   // Position of first connection for each entity (using local index)
-  std::vector<std::uint32_t> _index_to_position;
+  Eigen::Array<std::uint32_t, Eigen::Dynamic, 1> _index_to_position;
+  // std::vector<std::uint32_t> _index_to_position;
 };
 } // namespace mesh
 } // namespace dolfin

--- a/cpp/dolfin/mesh/MeshConnectivity.h
+++ b/cpp/dolfin/mesh/MeshConnectivity.h
@@ -64,7 +64,7 @@ public:
   std::size_t size_global(std::int32_t entity) const
   {
     if (_num_global_connections.size() == 0)
-      return size(entity);
+      return this->size(entity);
     else
     {
       assert(entity < _num_global_connections.size());
@@ -114,34 +114,18 @@ public:
   void set(std::size_t entity, std::size_t connection, std::size_t pos);
 
   /// Set all connections for given entity. T is a container,
-  /// e.g. std::vector<std::size_t>
-  // template <typename T>
-  // void set(std::int32_t entity, const T& connections)
-  // {
-  //   assert((entity + 1) < _index_to_position.size());
-  //   assert(connections.size()
-  //          == _index_to_position[entity + 1] - _index_to_position[entity]);
-
-  //   // Copy data
-  //   // std::copy(connections.begin(), connections.end(),
-  //   //           _connections.begin() + _index_to_position[entity]);
-  //   std::copy(connections.data(), connections.data() + connections.size(),
-  //             _connections.data() + _index_to_position[entity]);
-  // }
-
-  /// Set all connections for given entity
+  /// e.g. std::vector<std::size_t>, or a Eigen 1D array
   template <typename T>
-  void set(std::uint32_t entity, T* connections)
+  void set(std::int32_t entity, const T& connections)
   {
     assert((entity + 1) < _index_to_position.size());
-    assert(connections);
+    assert(connections.size()
+           == _index_to_position[entity + 1] - _index_to_position[entity]);
 
     // Copy data
-    const std::size_t num_connections
-        = _index_to_position[entity + 1] - _index_to_position[entity];
-    // std::copy(connections, connections + num_connections,
+    // std::copy(connections.data(), connections.data() + connections.size() ,
     //           _connections.begin() + _index_to_position[entity]);
-    std::copy(connections, connections + num_connections,
+    std::copy(connections.data(), connections.data() + connections.size(),
               _connections.data() + _index_to_position[entity]);
   }
 
@@ -200,16 +184,13 @@ private:
 
   // Connections for all entities stored as a contiguous array
   Eigen::Array<std::int32_t, Eigen::Dynamic, 1> _connections;
-  // std::vector<std::int32_t> _connections;
 
   // Global number of connections for all entities (possibly not
   // computed)
   Eigen::Array<std::uint32_t, Eigen::Dynamic, 1> _num_global_connections;
-  // std::vector<std::uint32_t> _num_global_connections;
 
   // Position of first connection for each entity (using local index)
   Eigen::Array<std::uint32_t, Eigen::Dynamic, 1> _index_to_position;
-  // std::vector<std::uint32_t> _index_to_position;
 };
 } // namespace mesh
 } // namespace dolfin

--- a/cpp/dolfin/mesh/MeshFunction.h
+++ b/cpp/dolfin/mesh/MeshFunction.h
@@ -228,7 +228,7 @@ MeshFunction<T>::MeshFunction(std::shared_ptr<const Mesh> mesh,
   // Generate connectivity if it does not exist
   _mesh->init(D, d);
   const MeshConnectivity& connectivity = _mesh->topology().connectivity(D, d);
-  assert(!connectivity.empty());
+  // assert(!connectivity.empty());
 
   // Iterate over all values
   std::unordered_set<std::size_t> entities_values_set;

--- a/cpp/dolfin/mesh/MeshIterator.h
+++ b/cpp/dolfin/mesh/MeshIterator.h
@@ -126,7 +126,7 @@ public:
         = e.mesh().topology().connectivity(e.dim(), _entity.dim());
 
     // Pointer to array of connections
-    assert(!c.empty());
+    //assert(!c.empty());
     _connections = c(e.index()) + pos;
   }
 

--- a/cpp/dolfin/mesh/MeshTopology.cpp
+++ b/cpp/dolfin/mesh/MeshTopology.cpp
@@ -16,21 +16,13 @@ using namespace dolfin::mesh;
 
 //-----------------------------------------------------------------------------
 MeshTopology::MeshTopology(std::size_t dim)
-    : common::Variable("topology")
+    : common::Variable("topology"), _num_entities(dim + 1, 0),
+      _ghost_offset_index(dim + 1, 0), _global_num_entities(dim + 1, 0),
+      _global_indices(dim + 1),
+      _connectivity(dim + 1, std::vector<MeshConnectivity>(dim + 1))
+
 {
-  // Initialize number of mesh entities
-  _num_entities = std::vector<std::int32_t>(dim + 1, 0);
-  _global_num_entities = std::vector<std::int64_t>(dim + 1, 0);
-  _ghost_offset_index = std::vector<std::size_t>(dim + 1, 0);
-
-  // Initialize storage for global indices
-  _global_indices.resize(dim + 1);
-
-  // Initialize mesh connectivity
-  _connectivity.resize(dim + 1);
-  for (std::size_t d0 = 0; d0 <= dim; d0++)
-    for (std::size_t d1 = 0; d1 <= dim; d1++)
-      _connectivity[d0].push_back(MeshConnectivity(d0, d1));
+  // Do nothing
 }
 //-----------------------------------------------------------------------------
 std::uint32_t MeshTopology::dim() const { return _num_entities.size() - 1; }

--- a/cpp/dolfin/mesh/MeshTopology.h
+++ b/cpp/dolfin/mesh/MeshTopology.h
@@ -6,13 +6,12 @@
 
 #pragma once
 
+#include "MeshConnectivity.h"
 #include <cstdint>
+#include <dolfin/common/Variable.h>
 #include <map>
 #include <set>
 #include <vector>
-
-#include "MeshConnectivity.h"
-#include <dolfin/common/Variable.h>
 
 namespace dolfin
 {
@@ -187,5 +186,5 @@ private:
   // Connectivity for pairs of topological dimensions
   std::vector<std::vector<MeshConnectivity>> _connectivity;
 };
-}
-}
+} // namespace mesh
+} // namespace dolfin

--- a/cpp/dolfin/mesh/TopologyComputation.cpp
+++ b/cpp/dolfin/mesh/TopologyComputation.cpp
@@ -407,7 +407,7 @@ void TopologyComputation::compute_from_map(Mesh& mesh, std::size_t d0,
       assert(it != entity_to_index.end());
       entities.push_back(it->second);
     }
-    connectivity.set(e.index(), entities.data());
+    connectivity.set(e.index(), entities);
   }
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/mesh/TopologyComputation.cpp
+++ b/cpp/dolfin/mesh/TopologyComputation.cpp
@@ -394,7 +394,7 @@ void TopologyComputation::compute_from_map(Mesh& mesh, std::size_t d0,
   }
 
   // Search for d1 entities of d0 in map, and recover index
-  std::vector<std::size_t> entities;
+  std::vector<std::int32_t> entities;
   boost::multi_array<std::int32_t, 2> keys;
   for (auto& e : MeshRange<MeshEntity>(mesh, d0, MeshRangeType::ALL))
   {
@@ -407,7 +407,9 @@ void TopologyComputation::compute_from_map(Mesh& mesh, std::size_t d0,
       assert(it != entity_to_index.end());
       entities.push_back(it->second);
     }
-    connectivity.set(e.index(), entities);
+    Eigen::Map<const Eigen::Array<std::int32_t, 1, Eigen::Dynamic>> _e(
+        entities.data(), entities.size());
+    connectivity.set(e.index(), _e);
   }
 }
 //-----------------------------------------------------------------------------

--- a/python/dolfin/function/specialfunctions.py
+++ b/python/dolfin/function/specialfunctions.py
@@ -69,10 +69,10 @@ def FacetNormal(mesh: cpp.mesh.Mesh) -> ufl.FacetNormal:
 
 
 def CellDiameter(mesh: cpp.mesh.Mesh) -> ufl.CellDiameter:
-    """Return function cell diameter for given mesh.
+    r"""Return function cell diameter for given mesh.
 
     Note that diameter of cell :math:`K` is defined as
-    :math:`\sup_{\mathbf{x,y}\in K} |\mathbf{x-y}|`.
+    :math:`\sup_{\mathbf{x, y} \in K} |\mathbf{x - y}|`.
 
     *Example of usage*
 

--- a/python/src/mesh.cpp
+++ b/python/src/mesh.cpp
@@ -207,7 +207,7 @@ void mesh(py::module& m)
            py::return_value_policy::reference_internal)
       .def("size", py::overload_cast<>(&dolfin::mesh::MeshConnectivity::size,
                                        py::const_))
-      .def("size", py::overload_cast<std::size_t>(
+      .def("size", py::overload_cast<std::int32_t>(
                        &dolfin::mesh::MeshConnectivity::size, py::const_));
 
   // dolfin::mesh::MeshEntity class

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -104,29 +104,29 @@ def test_assign(V, W):
         expr = 3 * u - 4 * u1 - 0.1 * 4 * u * 4 + u2 + 3 * u0 / 3. / 0.5
         expr_scalar = 3 - 4 * 3 - 0.1 * 4 * 4 + 4. + 3 * 2. / 3. / 0.5
         uu.assign(expr)
-        assert (round(uu.vector().get_local().sum() -
-                      float(expr_scalar * uu.vector().size()), 7) == 0)
+        assert (round(uu.vector().get_local().sum()
+                      - float(expr_scalar * uu.vector().size()), 7) == 0)
 
         # Test expression scaling
         expr = 3 * expr
         expr_scalar *= 3
         uu.assign(expr)
-        assert (round(uu.vector().get_local().sum() -
-                      float(expr_scalar * uu.vector().size()), 7) == 0)
+        assert (round(uu.vector().get_local().sum()
+                      - float(expr_scalar * uu.vector().size()), 7) == 0)
 
         # Test expression scaling
         expr = expr / 4.5
         expr_scalar /= 4.5
         uu.assign(expr)
-        assert (round(uu.vector().get_local().sum() -
-                      float(expr_scalar * uu.vector().size()), 7) == 0)
+        assert (round(uu.vector().get_local().sum()
+                      - float(expr_scalar * uu.vector().size()), 7) == 0)
 
         # Test self assignment
         expr = 3 * u - Constant(5) * u2 + u1 - 5 * u
         expr_scalar = 3 - 5 * 4. + 3. - 5
         u.assign(expr)
-        assert (round(u.vector().get_local().sum() -
-                      float(expr_scalar * u.vector().size()), 7) == 0)
+        assert (round(u.vector().get_local().sum()
+                      - float(expr_scalar * u.vector().size()), 7) == 0)
 
         # Test zero assignment
         u.assign(-u2 / 2 + 2 * u1 - u1 / 0.5 + u2 * 0.5)


### PR DESCRIPTION
Eventually should remove `MeshConnectivity` and use a CSR graph data structure.