### PR TITLE
Move PETScVector forward declaration in dolfin::la namespace

### DIFF
--- a/cpp/dolfin/la/PETScMatrix.h
+++ b/cpp/dolfin/la/PETScMatrix.h
@@ -16,10 +16,9 @@
 namespace dolfin
 {
 
-class PETScVector;
-
 namespace la
 {
+class PETScVector;
 class SparsityPattern;
 class VectorSpaceBasis;
 


### PR DESCRIPTION
Fix  a minor error in cpp/dolfin/la/PETScMatrix.h