### PR TITLE
Make mpi4py and petsc4py mandatory requirements

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -42,14 +42,14 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 # Check for petsc4py
-find_package(PETSc4py)
+find_package(PETSc4py REQUIRED)
 if (PETSC4PY_FOUND)
   target_include_directories(cpp PRIVATE ${PETSC4PY_INCLUDE_DIRS})
   target_compile_definitions(cpp PRIVATE HAS_PYBIND11_PETSC4PY)
 endif()
 
 # Check for mpi4py
-find_package(MPI4PY)
+find_package(MPI4PY REQUIRED)
 if (MPI4PY_FOUND)
   target_include_directories(cpp PRIVATE ${MPI4PY_INCLUDE_DIR})
   target_compile_definitions(cpp PRIVATE HAS_PYBIND11_MPI4PY)

--- a/python/dolfin/MPI.py
+++ b/python/dolfin/MPI.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
-from dolfin import common, cpp
+from dolfin import cpp
 
 comm_world = cpp.MPI.comm_world
 comm_self = cpp.MPI.comm_self

--- a/python/dolfin/MPI.py
+++ b/python/dolfin/MPI.py
@@ -7,18 +7,6 @@
 
 from dolfin import common, cpp
 
-if not common.has_mpi4py:
-
-    class MPICommWrapper:
-        """DOLFIN is compiled without support for mpi4py. This object
-        can be passed into DOLFIN as an MPI communicator, but is not
-        an mpi4py comm.
-        """
-
-        def underlying_comm(self):
-            return cpp.MPICommWrapper.underlying_comm()
-
-
 comm_world = cpp.MPI.comm_world
 comm_self = cpp.MPI.comm_self
 comm_null = cpp.MPI.comm_null

--- a/python/dolfin/__init__.py
+++ b/python/dolfin/__init__.py
@@ -33,10 +33,9 @@ from .cpp import __version__
 
 
 from dolfin.common import (
-    has_debug, has_scotch,
-    has_mpi4py, has_petsc_complex, has_petsc4py, has_parmetis,
-    has_slepc, has_slepc4py, git_commit_hash,
-    TimingType, timing, timings, list_timings, DOLFIN_EPS)
+    has_debug, has_scotch, has_petsc_complex, has_parmetis, 
+    has_slepc, has_slepc4py, git_commit_hash, TimingType, 
+    timing, timings, list_timings, DOLFIN_EPS)
 
 import dolfin.MPI
 

--- a/python/dolfin/common.py
+++ b/python/dolfin/common.py
@@ -13,12 +13,10 @@ from dolfin import cpp
 DOLFIN_EPS = cpp.common.DOLFIN_EPS
 
 has_debug = cpp.common.has_debug()
-has_mpi4py = cpp.common.has_mpi4py()
 has_parmetis = cpp.common.has_parmetis()
 has_scotch = cpp.common.has_scotch()
 has_petsc_complex = cpp.common.has_petsc_complex()
 has_slepc = cpp.common.has_slepc()
-has_petsc4py = cpp.common.has_petsc4py()
 has_slepc4py = cpp.common.has_slepc4py()
 
 git_commit_hash = cpp.common.git_commit_hash()

--- a/python/dolfin_utils/test/skips.py
+++ b/python/dolfin_utils/test/skips.py
@@ -9,12 +9,9 @@
 import pytest
 
 from dolfin import MPI
-from dolfin.common import (has_debug,
-                           has_petsc4py, has_petsc_complex, has_slepc)
+from dolfin.common import (has_debug, has_petsc_complex, has_slepc)
 
 # Skips with dependencies
-skip_if_not_petsc4py = pytest.mark.skipif(
-    not has_petsc4py, reason="Skipping unit test(s) depending on petsc4py.")
 skip_if_not_SLEPc = pytest.mark.skipif(
     not has_slepc, reason="Skipping unit test(s) depending on SLEPc.")
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -19,6 +19,8 @@ RESTRICT_REQUIREMENTS = ">=2018.2.0.dev0,<2018.3"
 REQUIREMENTS = [
     "numpy",
     "numba",
+    "mpi4py",
+    "petsc4py",
     "fenics-ffc{}".format(RESTRICT_REQUIREMENTS),
     "fenics-ufl{}".format(RESTRICT_REQUIREMENTS),
     "fenics-dijitso{}".format(RESTRICT_REQUIREMENTS),

--- a/python/src/common.cpp
+++ b/python/src/common.cpp
@@ -43,30 +43,12 @@ void common(py::module& m)
 
   // From dolfin/common/defines.h
   m.def("has_debug", &dolfin::has_debug);
-  m.def("has_mpi4py",
-        []() {
-#ifdef HAS_PYBIND11_MPI4PY
-          return true;
-#else
-          return false;
-#endif
-        },
-        "Return `True` if DOLFIN is configured with mpi4py");
   m.def("has_parmetis", &dolfin::has_parmetis);
   m.def("has_scotch", &dolfin::has_scotch);
   m.def("has_petsc_complex", &dolfin::has_petsc_complex,
         "Return True if PETSc scalar is complex.");
   m.def("has_slepc", &dolfin::has_slepc,
         "Return `True` if DOLFIN is configured with SLEPc");
-  m.def("has_petsc4py",
-        []() {
-#ifdef HAS_PYBIND11_PETSC4PY
-          return true;
-#else
-          return false;
-#endif
-        },
-        "Return `True` if DOLFIN is configured with petsc4py");
   m.def("has_slepc4py",
         []() {
 #ifdef HAS_PYBIND11_SLEPC4PY

--- a/python/src/mpi_casters.h
+++ b/python/src/mpi_casters.h
@@ -10,8 +10,6 @@
 #include <dolfin/common/SubSystemsManager.h>
 #include <pybind11/pybind11.h>
 
-// Macro for casting between dolfin and mpi4py MPI communicators
-#ifdef HAS_PYBIND11_MPI4PY
 #include <mpi4py/mpi4py.h>
 
 // Import mpi4py on demand
@@ -62,5 +60,3 @@ public:
 };
 }
 }
-
-#endif // HAS_PYBIND11_MPI4PY

--- a/python/src/petsc_casters.h
+++ b/python/src/petsc_casters.h
@@ -16,7 +16,6 @@
 #include <petscvec.h>
 
 // pybind11 casters for PETSc/petsc4py objects
-#ifdef HAS_PYBIND11_PETSC4PY
 #include <petsc4py/petsc4py.h>
 
 // Import petsc4py on demand
@@ -55,33 +54,6 @@
                                                                                \
     operator TYPE() { return value; }                                          \
   }
-#else
-#define PETSC_CASTER_MACRO(TYPE, NAME)                                         \
-  template <>                                                                  \
-  class type_caster<_p_##TYPE>                                                 \
-  {                                                                            \
-  public:                                                                      \
-    PYBIND11_TYPE_CASTER(TYPE, _(#NAME));                                      \
-    bool load(handle src, bool)                                                \
-    {                                                                          \
-      throw std::runtime_error("DOLFIN has not been configured with "          \
-                               "petsc4py. Accessing underlying PETSc object "  \
-                               "requires petsc4py");                           \
-      return false;                                                            \
-    }                                                                          \
-                                                                               \
-    static handle cast(TYPE src, pybind11::return_value_policy policy,         \
-                       handle parent)                                          \
-    {                                                                          \
-      throw std::runtime_error("DOLFIN has not been configured with "          \
-                               "petsc4py. Accessing underlying PETSc object "  \
-                               "requires petsc4py");                           \
-      return handle();                                                         \
-    }                                                                          \
-                                                                               \
-    operator TYPE() { return value; }                                          \
-  }
-#endif
 
 namespace pybind11
 {

--- a/python/test/unit/common/test_mpi.py
+++ b/python/test/unit/common/test_mpi.py
@@ -7,24 +7,17 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import dolfin
+from mpi4py import MPI
 
 
 def test_mpi_comm_wrapper():
     """
     Test MPICommWrapper <-> mpi4py.MPI.Comm conversion
     """
-    if dolfin.has_mpi4py:
-        from mpi4py import MPI
-        w1 = MPI.COMM_WORLD
-    else:
-        w1 = dolfin.MPI.comm_world
+    w1 = MPI.COMM_WORLD
 
     m = dolfin.UnitSquareMesh(w1, 4, 4)
     w2 = m.mpi_comm()
 
-    if dolfin.has_mpi4py:
-        assert isinstance(w1, MPI.Comm)
-        assert isinstance(w2, MPI.Comm)
-    else:
-        assert isinstance(w1, dolfin.cpp.MPICommWrapper)
-        assert isinstance(w2, dolfin.cpp.MPICommWrapper)
+    assert isinstance(w1, MPI.Comm)
+    assert isinstance(w2, MPI.Comm)

--- a/python/test/unit/jit/test_jit.py
+++ b/python/test/unit/jit/test_jit.py
@@ -10,8 +10,7 @@ import pytest
 import dolfin
 from dolfin import MPI, compile_cpp_code
 from dolfin.la import PETScVector
-from dolfin_utils.test.skips import (skip_if_not_petsc4py, skip_if_not_SLEPc,
-                                     skip_in_serial)
+from dolfin_utils.test.skips import (skip_if_not_SLEPc, skip_in_serial)
 
 # @pytest.mark.skip
 # def test_nasty_jit_caching_bug():
@@ -51,11 +50,8 @@ def test_mpi_pybind11():
     """
 
     # Import MPI_COMM_WORLD
-    if dolfin.has_mpi4py:
-        from mpi4py import MPI
-        w1 = MPI.COMM_WORLD
-    else:
-        w1 = dolfin.MPI.comm_world
+    from mpi4py import MPI
+    w1 = MPI.COMM_WORLD
 
     # Compile the JIT module
     return pytest.xfail('Include path for dolfin_wrappers/* not set up to '
@@ -65,12 +61,7 @@ def test_mpi_pybind11():
     # Pass a comm into C++ and get a new wrapper of the same comm back
     w2 = mod.test_comm_passing(w1)
 
-    if dolfin.has_mpi4py:
-        assert isinstance(w2, MPI.Comm)
-    else:
-        assert isinstance(w2, dolfin.cpp.MPICommWrapper)
-        assert w1.underlying_comm() == w2.underlying_comm()
-
+    assert isinstance(w2, MPI.Comm)
 
 def test_petsc():
     create_matrix_code = r'''
@@ -215,7 +206,6 @@ def test_compile_extension_module_kwargs():
 
 
 @pytest.mark.skip
-@skip_if_not_petsc4py
 @skip_in_serial
 def test_mpi_dependent_jiting():
     # FIXME: Not a proper unit test...
@@ -227,15 +217,8 @@ def test_mpi_dependent_jiting():
     # all processes)
     SubSystemsManager.init_petsc()
 
-    try:
-        import mpi4py.MPI as mpi
-    except ImportError:
-        return
-
-    try:
-        import petsc4py.PETSc as petsc
-    except ImportError:
-        return
+    import mpi4py.MPI as mpi
+    import petsc4py.PETSc as petsc
 
     # Set communicator and get process information
     comm = mpi.COMM_WORLD

--- a/python/test/unit/jit/test_jit.py
+++ b/python/test/unit/jit/test_jit.py
@@ -63,6 +63,7 @@ def test_mpi_pybind11():
 
     assert isinstance(w2, MPI.Comm)
 
+
 def test_petsc():
     create_matrix_code = r'''
     #include <pybind11/pybind11.h>

--- a/python/test/unit/la/test_mg_solver.py
+++ b/python/test/unit/la/test_mg_solver.py
@@ -20,11 +20,8 @@ from dolfin import function
 from dolfin.cpp.fem import PETScDMCollection
 from dolfin.fem.assembling import assemble_system
 from dolfin.la import PETScKrylovSolver, PETScOptions, PETScVector
-from dolfin_utils.test.skips import skip_if_not_petsc4py
-
 
 @pytest.mark.skip  # See https://bitbucket.org/fenics-project/dolfin/issues/938
-@skip_if_not_petsc4py
 def test_mg_solver_laplace():
 
     # Create meshes and function spaces
@@ -85,7 +82,6 @@ def test_mg_solver_laplace():
         opts.delValue(key)
 
 
-@skip_if_not_petsc4py
 def xtest_mg_solver_stokes():
 
     mesh0 = UnitCubeMesh(2, 2, 2)

--- a/python/test/unit/la/test_mg_solver.py
+++ b/python/test/unit/la/test_mg_solver.py
@@ -21,6 +21,7 @@ from dolfin.cpp.fem import PETScDMCollection
 from dolfin.fem.assembling import assemble_system
 from dolfin.la import PETScKrylovSolver, PETScOptions, PETScVector
 
+
 @pytest.mark.skip  # See https://bitbucket.org/fenics-project/dolfin/issues/938
 def test_mg_solver_laplace():
 


### PR DESCRIPTION
Having mpi4py and petsc4py seems to be required for a decent user experience with the DOLFIN Python bindings. A counter-example of packages that are not required for decent user experience would be SLEPc and SLEPc4py. Building mpi4py and petsc4py is trouble-free, even on HPC. Most HPC toolchains with Python, e.g. Intel, include mpi4py out of the box.

Assuming both exist by default removes complexity and many unneeded codepaths.
