### PR TITLE
Allow dynamic attributes in pybind11 wrapped dolfin::la::PETScMatrix and dolfin::la::PETScVector

### DIFF
--- a/python/src/la.cpp
+++ b/python/src/la.cpp
@@ -145,7 +145,7 @@ void la(py::module& m)
 
   // dolfin::la::PETScVector
   py::class_<dolfin::la::PETScVector, std::shared_ptr<dolfin::la::PETScVector>>(
-      m, "PETScVector", "PETScVector object")
+      m, "PETScVector", py::dynamic_attr(), "PETScVector object")
       .def(py::init<>())
       .def(py::init<const dolfin::common::IndexMap&>())
       .def(py::init(
@@ -221,7 +221,7 @@ void la(py::module& m)
 
   // dolfin::la::PETScMatrix
   py::class_<dolfin::la::PETScMatrix, std::shared_ptr<dolfin::la::PETScMatrix>,
-             dolfin::la::PETScOperator>(m, "PETScMatrix", "PETScMatrix object")
+             dolfin::la::PETScOperator>(m, "PETScMatrix", py::dynamic_attr(), "PETScMatrix object")
       .def(py::init<>())
       .def(py::init<Mat>())
       .def(py::init(


### PR DESCRIPTION
This is backport of the last item in https://bitbucket.org/fenics-project/dolfin/pull-requests/424/add-a-few-pybind11-wrappers/diff , that was merged to DOLFIN master after a brief discussion.

A couple of libraries that I develop rely on this for DOLFIN. pyadjoint will need this as well (see e.g. https://bitbucket.org/dolfin-adjoint/pyadjoint/src/master/fenics_adjoint/types/genericmatrix.py )