### PR TITLE
flatten coefficient dofs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ install-python-components: &install-python-components
             pip3 install git+https://bitbucket.org/fenics-project/fiat.git --upgrade
             pip3 install git+https://bitbucket.org/fenics-project/ufl.git --upgrade
             pip3 install git+https://bitbucket.org/fenics-project/dijitso.git --upgrade
-            pip3 install git+https://github.com/FEniCS/ffcx@chris/flatten-coeff-dofs --upgrade
+            pip3 install git+https://github.com/FEniCS/ffcx --upgrade
             rm -rf /usr/local/include/dolfin /usr/local/include/dolfin.h
 
 flake8-python-code: &flake8-python-code
@@ -170,7 +170,7 @@ jobs:
       - run:
           name: Push C++ API doc to fenicsproject.org
           command: cd /tmp/cpp/doc/html && scp -r * docs@fenicsproject.org:/var/www/vhosts/fenicsproject.org/docs/dolfinx/dev/cpp/
-
+  
   build-and-push-docker-images:
     docker:
       - image: docker:18.05.0-git
@@ -192,13 +192,13 @@ jobs:
           command: docker build --build-arg MAKEFLAGS='-j3' --target real -t quay.io/fenicsproject/dolfinx:latest . && docker tag quay.io/fenicsproject/dolfinx:latest quay.io/fenicsproject/dolfinx:real && docker push quay.io/fenicsproject/dolfinx:latest && docker push quay.io/fenicsproject/dolfinx:real
       - run:
           name: Build complex Docker image tag complex
-          command: docker build --build-arg MAKEFLAGS='-j3' --target complex -t quay.io/fenicsproject/dolfinx:complex . && docker push quay.io/fenicsproject/dolfinx:complex
+          command: docker build --build-arg MAKEFLAGS='-j3' --target complex -t quay.io/fenicsproject/dolfinx:complex . && docker push quay.io/fenicsproject/dolfinx:complex 
       - run:
           name: Build real notebook Docker image tag notebook
-          command: docker build --build-arg MAKEFLAGS='-j3' --target notebook -t quay.io/fenicsproject/dolfinx:notebook . && docker push quay.io/fenicsproject/dolfinx:notebook
+          command: docker build --build-arg MAKEFLAGS='-j3' --target notebook -t quay.io/fenicsproject/dolfinx:notebook . && docker push quay.io/fenicsproject/dolfinx:notebook 
       - run:
           name: Build complex notebook Docker image tag notebook-complex
-          command: docker build --build-arg MAKEFLAGS='-j3' --target notebook-complex -t quay.io/fenicsproject/dolfinx:notebook-complex . && docker push quay.io/fenicsproject/dolfinx:notebook-complex
+          command: docker build --build-arg MAKEFLAGS='-j3' --target notebook-complex -t quay.io/fenicsproject/dolfinx:notebook-complex . && docker push quay.io/fenicsproject/dolfinx:notebook-complex 
 
 workflows:
   version: 2
@@ -213,7 +213,7 @@ workflows:
             branches:
               only:
                 - master
-
+  
   biweekly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ install-python-components: &install-python-components
             pip3 install git+https://bitbucket.org/fenics-project/fiat.git --upgrade
             pip3 install git+https://bitbucket.org/fenics-project/ufl.git --upgrade
             pip3 install git+https://bitbucket.org/fenics-project/dijitso.git --upgrade
-            pip3 install git+https://github.com/FEniCS/ffcx --upgrade
+            pip3 install git+https://github.com/FEniCS/ffcx@chris/flatten-coeff-dofs --upgrade
             rm -rf /usr/local/include/dolfin /usr/local/include/dolfin.h
 
 flake8-python-code: &flake8-python-code
@@ -170,7 +170,7 @@ jobs:
       - run:
           name: Push C++ API doc to fenicsproject.org
           command: cd /tmp/cpp/doc/html && scp -r * docs@fenicsproject.org:/var/www/vhosts/fenicsproject.org/docs/dolfinx/dev/cpp/
-  
+
   build-and-push-docker-images:
     docker:
       - image: docker:18.05.0-git
@@ -192,13 +192,13 @@ jobs:
           command: docker build --build-arg MAKEFLAGS='-j3' --target real -t quay.io/fenicsproject/dolfinx:latest . && docker tag quay.io/fenicsproject/dolfinx:latest quay.io/fenicsproject/dolfinx:real && docker push quay.io/fenicsproject/dolfinx:latest && docker push quay.io/fenicsproject/dolfinx:real
       - run:
           name: Build complex Docker image tag complex
-          command: docker build --build-arg MAKEFLAGS='-j3' --target complex -t quay.io/fenicsproject/dolfinx:complex . && docker push quay.io/fenicsproject/dolfinx:complex 
+          command: docker build --build-arg MAKEFLAGS='-j3' --target complex -t quay.io/fenicsproject/dolfinx:complex . && docker push quay.io/fenicsproject/dolfinx:complex
       - run:
           name: Build real notebook Docker image tag notebook
-          command: docker build --build-arg MAKEFLAGS='-j3' --target notebook -t quay.io/fenicsproject/dolfinx:notebook . && docker push quay.io/fenicsproject/dolfinx:notebook 
+          command: docker build --build-arg MAKEFLAGS='-j3' --target notebook -t quay.io/fenicsproject/dolfinx:notebook . && docker push quay.io/fenicsproject/dolfinx:notebook
       - run:
           name: Build complex notebook Docker image tag notebook-complex
-          command: docker build --build-arg MAKEFLAGS='-j3' --target notebook-complex -t quay.io/fenicsproject/dolfinx:notebook-complex . && docker push quay.io/fenicsproject/dolfinx:notebook-complex 
+          command: docker build --build-arg MAKEFLAGS='-j3' --target notebook-complex -t quay.io/fenicsproject/dolfinx:notebook-complex . && docker push quay.io/fenicsproject/dolfinx:notebook-complex
 
 workflows:
   version: 2
@@ -213,7 +213,7 @@ workflows:
             branches:
               only:
                 - master
-  
+
   biweekly:
     triggers:
       - schedule:

--- a/cpp/dolfin/fem/Form.cpp
+++ b/cpp/dolfin/fem/Form.cpp
@@ -298,8 +298,8 @@ void Form::init_coeff_scratch_space()
   _w.resize(n.back());
 
   // Create pointers into _w for each coefficient
-  _wpointer.resize(num_coeffs);
-  for (std::uint32_t i = 0; i < num_coeffs; ++i)
+  _wpointer.resize(n.size());
+  for (std::uint32_t i = 0; i < n.size(); ++i)
     _wpointer[i] = _w.data() + n[i];
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/fem/Form.cpp
+++ b/cpp/dolfin/fem/Form.cpp
@@ -71,6 +71,8 @@ Form::Form(const std::vector<std::shared_ptr<const function::FunctionSpace>>
                function_spaces)
     : _coefficients({}), _function_spaces(function_spaces)
 {
+  init_coeff_scratch_space();
+
   // Set _mesh from function::FunctionSpace and check they are the same
   if (!function_spaces.empty())
     _mesh = function_spaces[0]->mesh();

--- a/cpp/dolfin/fem/Form.cpp
+++ b/cpp/dolfin/fem/Form.cpp
@@ -293,7 +293,7 @@ void Form::init_coeff_scratch_space()
   for (std::uint32_t i = 0; i < num_coeffs; ++i)
   {
     const FiniteElement& element = _coefficients.element(i);
-    n.push_back(n.back() + element.space_dimension() * 2);
+    n.push_back(n.back() + element.space_dimension());
   }
   // Allocate memory capable of storing all coefficient values in a
   // contiguous block

--- a/cpp/dolfin/fem/Form.cpp
+++ b/cpp/dolfin/fem/Form.cpp
@@ -177,10 +177,7 @@ std::size_t Form::max_element_tensor_size() const
   return num_entries;
 }
 //-----------------------------------------------------------------------------
-void Form::set_mesh(std::shared_ptr<const mesh::Mesh> mesh)
-{
-  _mesh = mesh;
-}
+void Form::set_mesh(std::shared_ptr<const mesh::Mesh> mesh) { _mesh = mesh; }
 //-----------------------------------------------------------------------------
 std::shared_ptr<const mesh::Mesh> Form::mesh() const
 {
@@ -276,10 +273,10 @@ void Form::tabulate_tensor(
   }
 
   // Compute cell matrix
-  const std::function<void(PetscScalar*, const PetscScalar* const*,
-                           const double*, int)>& tab_fn
+  const std::function<void(PetscScalar*, const PetscScalar*, const double*,
+                           int)>& tab_fn
       = _integrals.cell_tabulate_tensor(idx);
-  tab_fn(A, _wpointer.data(), coordinate_dofs.data(), 1);
+  tab_fn(A, _wpointer.data()[0], coordinate_dofs.data(), 1);
 }
 //-----------------------------------------------------------------------------
 void Form::init_coeff_scratch_space()

--- a/cpp/dolfin/fem/FormIntegrals.cpp
+++ b/cpp/dolfin/fem/FormIntegrals.cpp
@@ -135,8 +135,7 @@ FormIntegrals::cell_integral(unsigned int i) const
     return _cell_integrals[i + 1];
 }
 //-----------------------------------------------------------------------------
-const std::function<void(PetscScalar*, const PetscScalar* const*, const double*,
-                         int)>&
+const std::function<void(PetscScalar*, const PetscScalar*, const double*, int)>&
 FormIntegrals::cell_tabulate_tensor(int i) const
 {
   return _cell_tabulate_tensor[i];
@@ -148,8 +147,7 @@ const bool* FormIntegrals::cell_enabled_coefficients(int i) const
 }
 //-----------------------------------------------------------------------------
 void FormIntegrals::set_cell_tabulate_tensor(
-    int i,
-    void (*fn)(PetscScalar*, const PetscScalar* const*, const double*, int))
+    int i, void (*fn)(PetscScalar*, const PetscScalar*, const double*, int))
 {
   _cell_tabulate_tensor.resize(i + 1);
   _cell_tabulate_tensor[i] = fn;

--- a/cpp/dolfin/fem/FormIntegrals.h
+++ b/cpp/dolfin/fem/FormIntegrals.h
@@ -55,8 +55,8 @@ public:
   ///    Integral number
   /// @returns std::function
   ///    Function to call for tabulate_tensor on a cell
-  const std::function<void(PetscScalar*, const PetscScalar* const*,
-                           const double*, int)>&
+  const std::function<void(PetscScalar*, const PetscScalar*, const double*,
+                           int)>&
   cell_tabulate_tensor(int i) const;
 
   /// Get the enabled coefficients on cell integral i
@@ -67,9 +67,9 @@ public:
   const bool* cell_enabled_coefficients(int i) const;
 
   /// Set the function for 'tabulate_tensor' for cell integral i
-  void set_cell_tabulate_tensor(int i, void (*fn)(PetscScalar*,
-                                                  const PetscScalar* const*,
-                                                  const double*, int));
+  void set_cell_tabulate_tensor(int i,
+                                void (*fn)(PetscScalar*, const PetscScalar*,
+                                           const double*, int));
 
   /// Number of integrals of given type
   int count(FormIntegrals::Type t) const;
@@ -114,8 +114,8 @@ private:
   std::vector<std::shared_ptr<ufc_cell_integral>> _cell_integrals;
 
   // Function pointers to cell tabulate_tensor functions
-  std::vector<std::function<void(PetscScalar*, const PetscScalar* const*,
-                                 const double*, int)>>
+  std::vector<
+      std::function<void(PetscScalar*, const PetscScalar*, const double*, int)>>
       _cell_tabulate_tensor;
 
   // Storage for enabled coefficients, to match the functions

--- a/cpp/dolfin/fem/LocalAssembler.cpp
+++ b/cpp/dolfin/fem/LocalAssembler.cpp
@@ -108,7 +108,7 @@ void LocalAssembler::assemble_cell(
 
   // Tabulate cell tensor directly into A. This overwrites any
   // previous values
-  integral->tabulate_tensor(A.data(), ufc.w(), coordinate_dofs.data(), 1);
+  integral->tabulate_tensor(A.data(), ufc.w()[0], coordinate_dofs.data(), 1);
 }
 //------------------------------------------------------------------------------
 void LocalAssembler::assemble_exterior_facet(
@@ -146,7 +146,7 @@ void LocalAssembler::assemble_exterior_facet(
   // Tabulate exterior facet tensor. Here we cannot tabulate directly
   // into A since this will overwrite any previously assembled dx, ds
   // or dS forms
-  integral->tabulate_tensor(ufc.A.data(), ufc.w(), coordinate_dofs.data(),
+  integral->tabulate_tensor(ufc.A.data(), ufc.w()[0], coordinate_dofs.data(),
                             local_facet, 1);
 
   // Stuff a_ufc.A into A
@@ -251,7 +251,7 @@ void LocalAssembler::assemble_interior_facet(
              integral->enabled_coefficients);
 
   // Tabulate interior facet tensor on macro element
-  integral->tabulate_tensor(ufc.macro_A.data(), ufc.macro_w(),
+  integral->tabulate_tensor(ufc.macro_A.data(), ufc.macro_w()[0],
                             coordinate_dofs0.data(), coordinate_dofs1.data(),
                             local_facet0, local_facet1, 1, 1);
 

--- a/cpp/dolfin/fem/UFC.cpp
+++ b/cpp/dolfin/fem/UFC.cpp
@@ -50,9 +50,9 @@ UFC::UFC(const Form& a) : dolfin_form(a)
   _w.resize(n.back());
   _macro_w.resize(2 * n.back());
 
-  w_pointer.resize(num_coeffs);
-  macro_w_pointer.resize(num_coeffs);
-  for (std::size_t i = 0; i < num_coeffs; ++i)
+  w_pointer.resize(n.size());
+  macro_w_pointer.resize(n.size());
+  for (std::size_t i = 0; i < n.size(); ++i)
   {
     w_pointer[i] = _w.data() + n[i];
     macro_w_pointer[i] = _macro_w.data() + 2 * n[i];

--- a/python/src/fem.cpp
+++ b/python/src/fem.cpp
@@ -356,9 +356,8 @@ void fem(py::module& m)
       .def("set_vertex_domains", &dolfin::fem::Form::set_vertex_domains)
       .def("set_cell_tabulate",
            [](dolfin::fem::Form& self, unsigned int i, std::size_t addr) {
-             auto tabulate_tensor_ptr
-                 = (void (*)(PetscScalar*, const PetscScalar* const*,
-                             const double*, int))addr;
+             auto tabulate_tensor_ptr = (void (*)(
+                 PetscScalar*, const PetscScalar*, const double*, int))addr;
              self.integrals().set_cell_tabulate_tensor(i, tabulate_tensor_ptr);
            })
       .def("rank", &dolfin::fem::Form::rank)

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -50,6 +50,7 @@ def tabulate_tensor_b(b_, w_, coords_, cell_orientation):
     Ae = abs((x0 - x1) * (y2 - y1) - (y0 - y1) * (x2 - x1))
     b[:] = Ae / 6.0
 
+
 def test_numba_assembly():
     mesh = UnitSquareMesh(MPI.comm_world, 13, 13)
     V = FunctionSpace(mesh, ("Lagrange", 1))

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -16,8 +16,7 @@ from dolfin import (MPI, FunctionSpace, TimingType, UnitSquareMesh, cpp,
 
 c_signature = numba.types.void(
     numba.types.CPointer(numba.typeof(PETSc.ScalarType())),
-    numba.types.CPointer(
-        numba.types.CPointer(numba.typeof(PETSc.ScalarType()))),
+    numba.types.CPointer(numba.typeof(PETSc.ScalarType())),
     numba.types.CPointer(numba.types.double), numba.types.intc)
 
 
@@ -51,7 +50,6 @@ def tabulate_tensor_b(b_, w_, coords_, cell_orientation):
     Ae = abs((x0 - x1) * (y2 - y1) - (y0 - y1) * (x2 - x1))
     b[:] = Ae / 6.0
 
-
 def test_numba_assembly():
     mesh = UnitSquareMesh(MPI.comm_world, 13, 13)
     V = FunctionSpace(mesh, ("Lagrange", 1))
@@ -83,7 +81,7 @@ def xtest_cffi_assembly():
         ffibuilder.set_source("_cffi_kernelA", r"""
         #include <math.h>
         #include <stdalign.h>
-        void tabulate_tensor_poissonA(double* restrict A, const double* const* w,
+        void tabulate_tensor_poissonA(double* restrict A, const double* w,
                                     const double* restrict coordinate_dofs,
                                     int cell_orientation)
         {
@@ -130,7 +128,7 @@ def xtest_cffi_assembly():
         A[8] = 0.5 * sp[17];
         }
 
-        void tabulate_tensor_poissonL(double* restrict A, const double* const* w,
+        void tabulate_tensor_poissonL(double* restrict A, const double* w,
                                      const double* restrict coordinate_dofs,
                                      int cell_orientation)
         {
@@ -156,10 +154,10 @@ def xtest_cffi_assembly():
         }
         """)
         ffibuilder.cdef("""
-        void tabulate_tensor_poissonA(double* restrict A, const double* const* w,
+        void tabulate_tensor_poissonA(double* restrict A, const double* w,
                                     const double* restrict coordinate_dofs,
                                     int cell_orientation);
-        void tabulate_tensor_poissonL(double* restrict A, const double* const* w,
+        void tabulate_tensor_poissonL(double* restrict A, const double* w,
                                     const double* restrict coordinate_dofs,
                                     int cell_orientation);
         """)


### PR DESCRIPTION
This is in conjunction with the branch https://github.com/FEniCS/ffcx/tree/chris/flatten-coeff-dofs

* access coefficient dofs through a flat array, with offsets determined by the coefficient element
sizes.

