### PR TITLE
Remove check on _compiled_form attribute in _create_cpp_form

### DIFF
--- a/python/dolfin/fem/assembling.py
+++ b/python/dolfin/fem/assembling.py
@@ -24,12 +24,6 @@ from dolfin.fem.form import Form
 def _create_cpp_form(form, form_compiler_parameters=None):
     # First check if we got a cpp.Form
     if isinstance(form, cpp.fem.Form):
-
-        # Check that jit compilation has already happened
-        if not hasattr(form, "_compiled_form"):
-            raise TypeError(
-                "Expected a dolfin form to have a _compiled_form attribute.")
-
         # Warn that we don't use the parameters if we get any
         if form_compiler_parameters is not None:
             cpp.warning(


### PR DESCRIPTION
Hi,
I believe that the condition showed in the diff is a leftover from previous implementations, because:
(i) I cannot find any other _compiled_form in the entire fenics/fenicsx codebase
(ii) if there was, it definitely could not be attached to cpp.fem.Form object, because cpp.fem.Form wrapper was declared without py::dynamic_attr()

Feel free to close in case I overlooked something else and the check is actually needed.

Francesco
