### PR TITLE
Some refactoring of vector assembly

### DIFF
--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -4,12 +4,10 @@
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
-#include <petscis.h>
-
+#include "assemble_vector_impl.h"
 #include "DirichletBC.h"
 #include "Form.h"
 #include "GenericDofMap.h"
-#include "assemble_vector_impl.h"
 #include <dolfin/common/types.h>
 #include <dolfin/function/FunctionSpace.h>
 #include <dolfin/mesh/Cell.h>
@@ -33,26 +31,17 @@ void fem::impl::set_bc(
 //-----------------------------------------------------------------------------
 void fem::impl::set_bc(
     Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
-    std::vector<std::shared_ptr<const DirichletBC>> bcs, const Vec x0,
+    std::vector<std::shared_ptr<const DirichletBC>> bcs,
+    const Eigen::Ref<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x0,
     double scale)
 {
-  assert(x0);
-  PetscInt local_size_x0;
-  VecGetLocalSize(x0, &local_size_x0);
-
-  if (b.size() != local_size_x0)
+  if (b.size() != x0.size())
     throw std::runtime_error("Size mismtach between b and x0 vectors.");
-  PetscScalar const* values_x0;
-  VecGetArrayRead(x0, &values_x0);
-  const Eigen::Map<const Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> vec_x0(
-      values_x0, local_size_x0);
   for (auto bc : bcs)
   {
     assert(bc);
-    bc->set(b, vec_x0, scale);
+    bc->set(b, x0, scale);
   }
-
-  VecRestoreArrayRead(x0, &values_x0);
 }
 //-----------------------------------------------------------------------------
 void fem::impl::modify_bc(

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -120,11 +120,9 @@ void fem::impl::modify_bc(
   // Restore ghosted form and update local (owned) entries that are
   // ghosts on other processes
   VecGhostRestoreLocalForm(b, &b_local);
-  VecGhostUpdateBegin(b, ADD_VALUES, SCATTER_REVERSE);
-  VecGhostUpdateEnd(b, ADD_VALUES, SCATTER_REVERSE);
 }
 //-----------------------------------------------------------------------------
-void fem::impl::assemble_eigen(
+void fem::impl::assemble(
     Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b, const Form& L)
 {
   // Get mesh from form

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -121,7 +121,7 @@ void fem::impl::modify_bc(
   if (x0)
   {
     PetscInt size_x0 = 0;
-    VecGetSize(x0, &size_x0);
+    VecGetSize(x0_local, &size_x0);
     PetscScalar const* array_x0;
     VecGetArrayRead(x0_local, &array_x0);
     const Eigen::Map<const Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> x0vec(

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -44,26 +44,6 @@ void fem::impl::set_bc(
   }
 }
 //-----------------------------------------------------------------------------
-void fem::impl::modify_bc_old(
-    Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b, const Form& L,
-    const std::vector<std::shared_ptr<const Form>> a,
-    const std::vector<std::shared_ptr<const DirichletBC>> bcs,
-    const Eigen::Ref<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x0,
-    double scale)
-{
-  for (std::size_t i = 0; i < a.size(); ++i)
-    fem::impl::modify_bc(b, *a[i], bcs, x0, scale);
-}
-//-----------------------------------------------------------------------------
-void fem::impl::modify_bc_old(
-    Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b, const Form& L,
-    const std::vector<std::shared_ptr<const Form>> a,
-    const std::vector<std::shared_ptr<const DirichletBC>> bcs, double scale)
-{
-  for (std::size_t i = 0; i < a.size(); ++i)
-    fem::impl::modify_bc(b, *a[i], bcs, scale);
-}
-//-----------------------------------------------------------------------------
 void fem::impl::assemble(
     Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b, const Form& L)
 {

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -73,36 +73,21 @@ void fem::impl::set_bc(Vec b,
 void fem::impl::modify_bc(
     Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b, const Form& L,
     const std::vector<std::shared_ptr<const Form>> a,
-    const std::vector<std::shared_ptr<const DirichletBC>> bcs, Vec x0,
+    const std::vector<std::shared_ptr<const DirichletBC>> bcs,
+    const Eigen::Ref<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x0,
     double scale)
 {
-  // Get local form of PETSc ghosted Vec
-  Vec x0_local(nullptr);
-  if (x0)
-  {
-    VecGhostGetLocalForm(x0, &x0_local);
-    if (!x0_local)
-      throw std::runtime_error("Expected ghosted PETSc Vec.");
-  }
-
-  // Modify for essential bcs
-  if (x0)
-  {
-    PetscInt size_x0 = 0;
-    VecGetSize(x0_local, &size_x0);
-    PetscScalar const* array_x0;
-    VecGetArrayRead(x0_local, &array_x0);
-    const Eigen::Map<const Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> x0vec(
-        array_x0, size_x0);
-    for (std::size_t i = 0; i < a.size(); ++i)
-      fem::impl::modify_bc(b, *a[i], bcs, x0vec, scale);
-    VecRestoreArrayRead(x0_local, &array_x0);
-  }
-  else
-  {
-    for (std::size_t i = 0; i < a.size(); ++i)
-      fem::impl::modify_bc(b, *a[i], bcs, scale);
-  }
+  for (std::size_t i = 0; i < a.size(); ++i)
+    fem::impl::modify_bc(b, *a[i], bcs, x0, scale);
+}
+//-----------------------------------------------------------------------------
+void fem::impl::modify_bc(
+    Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b, const Form& L,
+    const std::vector<std::shared_ptr<const Form>> a,
+    const std::vector<std::shared_ptr<const DirichletBC>> bcs, double scale)
+{
+  for (std::size_t i = 0; i < a.size(); ++i)
+    fem::impl::modify_bc(b, *a[i], bcs, scale);
 }
 //-----------------------------------------------------------------------------
 void fem::impl::assemble(

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -71,29 +71,19 @@ void fem::impl::set_bc(Vec b,
 }
 //-----------------------------------------------------------------------------
 void fem::impl::modify_bc(
-    Vec b, const Form& L, const std::vector<std::shared_ptr<const Form>> a,
+    Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b, const Form& L,
+    const std::vector<std::shared_ptr<const Form>> a,
     const std::vector<std::shared_ptr<const DirichletBC>> bcs, Vec x0,
     double scale)
 {
   // Get local form of PETSc ghosted Vec
-  Vec b_local(nullptr), x0_local(nullptr);
-  VecGhostGetLocalForm(b, &b_local);
-  if (!b_local)
-    throw std::runtime_error("Expected ghosted PETSc Vec.");
+  Vec x0_local(nullptr);
   if (x0)
   {
     VecGhostGetLocalForm(x0, &x0_local);
     if (!x0_local)
       throw std::runtime_error("Expected ghosted PETSc Vec.");
   }
-
-  // Wrap local PETSc Vec as an Eigen vector
-  PetscInt size_b = 0;
-  VecGetSize(b_local, &size_b);
-  PetscScalar* array_b;
-  VecGetArray(b_local, &array_b);
-  Eigen::Map<Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> bvec(array_b,
-                                                                size_b);
 
   // Modify for essential bcs
   if (x0)
@@ -105,21 +95,14 @@ void fem::impl::modify_bc(
     const Eigen::Map<const Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> x0vec(
         array_x0, size_x0);
     for (std::size_t i = 0; i < a.size(); ++i)
-      fem::impl::modify_bc(bvec, *a[i], bcs, x0vec, scale);
+      fem::impl::modify_bc(b, *a[i], bcs, x0vec, scale);
     VecRestoreArrayRead(x0_local, &array_x0);
   }
   else
   {
     for (std::size_t i = 0; i < a.size(); ++i)
-      fem::impl::modify_bc(bvec, *a[i], bcs, scale);
+      fem::impl::modify_bc(b, *a[i], bcs, scale);
   }
-
-  // Restore array
-  VecRestoreArray(b_local, &array_b);
-
-  // Restore ghosted form and update local (owned) entries that are
-  // ghosts on other processes
-  VecGhostRestoreLocalForm(b, &b_local);
 }
 //-----------------------------------------------------------------------------
 void fem::impl::assemble(

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -88,8 +88,8 @@ void fem::impl::assemble_ghosted(Vec b, const Form& L)
   // Restore ghosted form and update local (owned) entries that are
   // ghosts on other processes
   VecGhostRestoreLocalForm(b, &b_local);
-  VecGhostUpdateBegin(b, ADD_VALUES, SCATTER_REVERSE);
-  VecGhostUpdateEnd(b, ADD_VALUES, SCATTER_REVERSE);
+  // VecGhostUpdateBegin(b, ADD_VALUES, SCATTER_REVERSE);
+  // VecGhostUpdateEnd(b, ADD_VALUES, SCATTER_REVERSE);
 }
 //-----------------------------------------------------------------------------
 void fem::impl::modify_bc(

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -70,7 +70,29 @@ void fem::impl::set_bc(Vec b,
   VecRestoreArray(b, &values_b);
 }
 //-----------------------------------------------------------------------------
-void fem::impl::assemble_ghosted(
+void fem::impl::assemble_ghosted(Vec b, const Form& L)
+{
+  // Get local form of PETSc ghosted Vec
+  Vec b_local(nullptr);
+  VecGhostGetLocalForm(b, &b_local);
+  if (!b_local)
+    throw std::runtime_error("Expected ghosted PETSc Vec.");
+
+  // FIXME: should zeroing be an option?
+  // Zero vector
+  VecSet(b_local, 0.0);
+
+  // Assemble over local mesh. modifying b for Dirichlet conditions
+  fem::impl::_assemble_local(b_local, L);
+
+  // Restore ghosted form and update local (owned) entries that are
+  // ghosts on other processes
+  VecGhostRestoreLocalForm(b, &b_local);
+  VecGhostUpdateBegin(b, ADD_VALUES, SCATTER_REVERSE);
+  VecGhostUpdateEnd(b, ADD_VALUES, SCATTER_REVERSE);
+}
+//-----------------------------------------------------------------------------
+void fem::impl::modify_bc(
     Vec b, const Form& L, const std::vector<std::shared_ptr<const Form>> a,
     const std::vector<std::shared_ptr<const DirichletBC>> bcs, Vec x0,
     double scale)
@@ -87,12 +109,35 @@ void fem::impl::assemble_ghosted(
       throw std::runtime_error("Expected ghosted PETSc Vec.");
   }
 
-  // FIXME: should zeroing be an option?
-  // Zero vector
-  VecSet(b_local, 0.0);
+  // Wrap local PETSc Vec as an Eigen vector
+  PetscInt size_b = 0;
+  VecGetSize(b_local, &size_b);
+  PetscScalar* array_b;
+  VecGetArray(b_local, &array_b);
+  Eigen::Map<Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> bvec(array_b,
+                                                                size_b);
 
-  // Assemble over local mesh. modifying b for Dirichlet conditions
-  fem::impl::_assemble_local(b_local, L, a, bcs, x0_local, scale);
+  // Modify for essential bcs
+  if (x0)
+  {
+    PetscInt size_x0 = 0;
+    VecGetSize(x0, &size_x0);
+    PetscScalar const* array_x0;
+    VecGetArrayRead(x0_local, &array_x0);
+    const Eigen::Map<const Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> x0vec(
+        array_x0, size_x0);
+    for (std::size_t i = 0; i < a.size(); ++i)
+      fem::impl::modify_bc(bvec, *a[i], bcs, x0vec, scale);
+    VecRestoreArrayRead(x0_local, &array_x0);
+  }
+  else
+  {
+    for (std::size_t i = 0; i < a.size(); ++i)
+      fem::impl::modify_bc(bvec, *a[i], bcs, scale);
+  }
+
+  // Restore array
+  VecRestoreArray(b_local, &array_b);
 
   // Restore ghosted form and update local (owned) entries that are
   // ghosts on other processes
@@ -101,10 +146,7 @@ void fem::impl::assemble_ghosted(
   VecGhostUpdateEnd(b, ADD_VALUES, SCATTER_REVERSE);
 }
 //-----------------------------------------------------------------------------
-void fem::impl::_assemble_local(
-    Vec b, const Form& L, const std::vector<std::shared_ptr<const Form>> a,
-    const std::vector<std::shared_ptr<const DirichletBC>> bcs, const Vec x0,
-    double scale)
+void fem::impl::_assemble_local(Vec b, const Form& L)
 {
   // FIXME: check that b is a local PETSc Vec
 
@@ -120,24 +162,25 @@ void fem::impl::_assemble_local(
   // Assemble
   assemble_eigen(bvec, L);
 
-  // Modify for essential bcs
-  if (x0)
-  {
-    PetscInt size_x0 = 0;
-    VecGetSize(x0, &size_x0);
-    PetscScalar const* array_x0;
-    VecGetArrayRead(x0, &array_x0);
-    const Eigen::Map<const Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> x0vec(
-        array_x0, size_x0);
-    for (std::size_t i = 0; i < a.size(); ++i)
-      fem::impl::modify_bc(bvec, *a[i], bcs, x0vec, scale);
-    VecRestoreArrayRead(x0, &array_x0);
-  }
-  else
-  {
-    for (std::size_t i = 0; i < a.size(); ++i)
-      fem::impl::modify_bc(bvec, *a[i], bcs, scale);
-  }
+  // // Modify for essential bcs
+  // if (x0)
+  // {
+  //   PetscInt size_x0 = 0;
+  //   VecGetSize(x0, &size_x0);
+  //   PetscScalar const* array_x0;
+  //   VecGetArrayRead(x0, &array_x0);
+  //   const Eigen::Map<const Eigen::Array<PetscScalar, Eigen::Dynamic, 1>>
+  //   x0vec(
+  //       array_x0, size_x0);
+  //   for (std::size_t i = 0; i < a.size(); ++i)
+  //     fem::impl::modify_bc(bvec, *a[i], bcs, x0vec, scale);
+  //   VecRestoreArrayRead(x0, &array_x0);
+  // }
+  // else
+  // {
+  //   for (std::size_t i = 0; i < a.size(); ++i)
+  //     fem::impl::modify_bc(bvec, *a[i], bcs, scale);
+  // }
 
   // Restore array
   VecRestoreArray(b, &array_b);

--- a/cpp/dolfin/fem/assemble_vector_impl.h
+++ b/cpp/dolfin/fem/assemble_vector_impl.h
@@ -37,13 +37,14 @@ void modify_bc(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
 
 /// Set bc values in owned (local) part of the PETSc Vec to scale*x_bc
 /// value
-void set_bc(Vec b, std::vector<std::shared_ptr<const DirichletBC>> bcs,
-            double scale);
+void set_bc(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
+            std::vector<std::shared_ptr<const DirichletBC>> bcs, double scale);
 
 /// Set bc values in owned (local) part of the PETSc Vec to scale*(x0 -
 /// x_bc)
-void set_bc(Vec b, std::vector<std::shared_ptr<const DirichletBC>> bcs,
-            const Vec x0, double scale);
+void set_bc(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
+            std::vector<std::shared_ptr<const DirichletBC>> bcs, const Vec x0,
+            double scale);
 
 /// Assemble linear form into an Eigen vector. Assembly is performed
 /// over the portion of the mesh belonging to the process. No

--- a/cpp/dolfin/fem/assemble_vector_impl.h
+++ b/cpp/dolfin/fem/assemble_vector_impl.h
@@ -23,8 +23,8 @@ class Form;
 namespace impl
 {
 
-void modify_bc(Vec b, const Form& L,
-               const std::vector<std::shared_ptr<const Form>> a,
+void modify_bc(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
+               const Form& L, const std::vector<std::shared_ptr<const Form>> a,
                const std::vector<std::shared_ptr<const DirichletBC>> bcs,
                const Vec x0, double scale);
 

--- a/cpp/dolfin/fem/assemble_vector_impl.h
+++ b/cpp/dolfin/fem/assemble_vector_impl.h
@@ -23,19 +23,6 @@ class Form;
 namespace impl
 {
 
-/// Assemble linear form into a ghosted PETSc Vec. The vector is
-/// modified such that:
-///
-/// 1. If x0 is null b <- b - scale*A x_bc; or
-///
-/// 2. If x0 is not null b <- b - scale * A (x_bc - x0).
-///
-/// Essential bc dofs entries are *not* set.
-///
-/// This function essentially unwraps the pointer to the PETSc Vec data
-/// and calls the Eigen-based functions for assembly.
-void assemble_ghosted(Vec b, const Form& L);
-
 void modify_bc(Vec b, const Form& L,
                const std::vector<std::shared_ptr<const Form>> a,
                const std::vector<std::shared_ptr<const DirichletBC>> bcs,
@@ -81,12 +68,6 @@ void _modify_bc(
     Eigen::Ref<const Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> x0,
     double scale);
 
-// Assemble linear form into a local PETSc Vec. The vector b is modified
-// to account for essential (Dirichlet) boundary conditions.
-//
-// The implementation of this function unwraps the PETSc Vec as a plain
-// pointer, and call the Eigen-based assembly interface.
-void _assemble_local(Vec b, const Form& L);
 } // namespace impl
 } // namespace fem
 } // namespace dolfin

--- a/cpp/dolfin/fem/assemble_vector_impl.h
+++ b/cpp/dolfin/fem/assemble_vector_impl.h
@@ -23,18 +23,6 @@ class Form;
 namespace impl
 {
 
-void modify_bc_old(
-    Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b, const Form& L,
-    const std::vector<std::shared_ptr<const Form>> a,
-    const std::vector<std::shared_ptr<const DirichletBC>> bcs,
-    const Eigen::Ref<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x0,
-    double scale);
-
-void modify_bc_old(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
-               const Form& L, const std::vector<std::shared_ptr<const Form>> a,
-               const std::vector<std::shared_ptr<const DirichletBC>> bcs,
-               double scale);
-
 /// Set bc values in owned (local) part of the PETSc Vec to scale*x_bc
 /// value
 void set_bc(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
@@ -64,12 +52,11 @@ void modify_bc(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
 
 /// Modify RHS vector to account for boundary condition such that b <- b
 /// - scale*A (x_bc - x0)
-void
-    modify_bc(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
-              const Form& a,
-              std::vector<std::shared_ptr<const DirichletBC>> bcs,
-              Eigen::Ref<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x0,
-              double scale);
+void modify_bc(
+    Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b, const Form& a,
+    std::vector<std::shared_ptr<const DirichletBC>> bcs,
+    Eigen::Ref<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x0,
+    double scale);
 
 // Implementation of bc application
 void _modify_bc(

--- a/cpp/dolfin/fem/assemble_vector_impl.h
+++ b/cpp/dolfin/fem/assemble_vector_impl.h
@@ -43,8 +43,8 @@ void set_bc(Vec b, std::vector<std::shared_ptr<const DirichletBC>> bcs,
 /// communication is performed. The Eigen vector must be passed in with
 /// the correct size.
 // FIXME: Clarify docstring regarding ghosts
-void assemble_eigen(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
-                    const Form& L);
+void assemble(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
+              const Form& L);
 
 /// Modify RHS vector to account for boundary condition b <- b - scale*Ax_bc
 void modify_bc(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> b,

--- a/cpp/dolfin/fem/assemble_vector_impl.h
+++ b/cpp/dolfin/fem/assemble_vector_impl.h
@@ -23,10 +23,17 @@ class Form;
 namespace impl
 {
 
+void modify_bc(
+    Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b, const Form& L,
+    const std::vector<std::shared_ptr<const Form>> a,
+    const std::vector<std::shared_ptr<const DirichletBC>> bcs,
+    const Eigen::Ref<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x0,
+    double scale);
+
 void modify_bc(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
                const Form& L, const std::vector<std::shared_ptr<const Form>> a,
                const std::vector<std::shared_ptr<const DirichletBC>> bcs,
-               const Vec x0, double scale);
+               double scale);
 
 /// Set bc values in owned (local) part of the PETSc Vec to scale*x_bc
 /// value

--- a/cpp/dolfin/fem/assemble_vector_impl.h
+++ b/cpp/dolfin/fem/assemble_vector_impl.h
@@ -34,10 +34,12 @@ namespace impl
 ///
 /// This function essentially unwraps the pointer to the PETSc Vec data
 /// and calls the Eigen-based functions for assembly.
-void assemble_ghosted(Vec b, const Form& L,
-                      const std::vector<std::shared_ptr<const Form>> a,
-                      const std::vector<std::shared_ptr<const DirichletBC>> bcs,
-                      const Vec x0, double scale);
+void assemble_ghosted(Vec b, const Form& L);
+
+void modify_bc(Vec b, const Form& L,
+               const std::vector<std::shared_ptr<const Form>> a,
+               const std::vector<std::shared_ptr<const DirichletBC>> bcs,
+               const Vec x0, double scale);
 
 /// Set bc values in owned (local) part of the PETSc Vec to scale*x_bc
 /// value
@@ -84,10 +86,7 @@ void _modify_bc(
 //
 // The implementation of this function unwraps the PETSc Vec as a plain
 // pointer, and call the Eigen-based assembly interface.
-void _assemble_local(Vec b, const Form& L,
-                     const std::vector<std::shared_ptr<const Form>> a,
-                     const std::vector<std::shared_ptr<const DirichletBC>> bcs,
-                     const Vec x0, double scale);
+void _assemble_local(Vec b, const Form& L);
 } // namespace impl
 } // namespace fem
 } // namespace dolfin

--- a/cpp/dolfin/fem/assemble_vector_impl.h
+++ b/cpp/dolfin/fem/assemble_vector_impl.h
@@ -23,14 +23,14 @@ class Form;
 namespace impl
 {
 
-void modify_bc(
+void modify_bc_old(
     Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b, const Form& L,
     const std::vector<std::shared_ptr<const Form>> a,
     const std::vector<std::shared_ptr<const DirichletBC>> bcs,
     const Eigen::Ref<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x0,
     double scale);
 
-void modify_bc(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
+void modify_bc_old(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
                const Form& L, const std::vector<std::shared_ptr<const Form>> a,
                const std::vector<std::shared_ptr<const DirichletBC>> bcs,
                double scale);
@@ -57,7 +57,7 @@ void assemble(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
               const Form& L);
 
 /// Modify RHS vector to account for boundary condition b <- b - scale*Ax_bc
-void modify_bc(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> b,
+void modify_bc(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
                const Form& a,
                std::vector<std::shared_ptr<const DirichletBC>> bcs,
                double scale);
@@ -65,17 +65,17 @@ void modify_bc(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> b,
 /// Modify RHS vector to account for boundary condition such that b <- b
 /// - scale*A (x_bc - x0)
 void
-    modify_bc(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> b,
+    modify_bc(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
               const Form& a,
               std::vector<std::shared_ptr<const DirichletBC>> bcs,
-              Eigen::Ref<const Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> x0,
+              Eigen::Ref<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x0,
               double scale);
 
 // Implementation of bc application
 void _modify_bc(
-    Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> b, const Form& a,
+    Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b, const Form& a,
     std::vector<std::shared_ptr<const DirichletBC>> bcs,
-    Eigen::Ref<const Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> x0,
+    Eigen::Ref<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x0,
     double scale);
 
 } // namespace impl

--- a/cpp/dolfin/fem/assemble_vector_impl.h
+++ b/cpp/dolfin/fem/assemble_vector_impl.h
@@ -9,7 +9,7 @@
 #include <Eigen/Dense>
 #include <dolfin/common/types.h>
 #include <memory>
-#include <petscvec.h>
+#include <petscsys.h>
 #include <vector>
 
 namespace dolfin
@@ -42,9 +42,11 @@ void set_bc(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
 
 /// Set bc values in owned (local) part of the PETSc Vec to scale*(x0 -
 /// x_bc)
-void set_bc(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
-            std::vector<std::shared_ptr<const DirichletBC>> bcs, const Vec x0,
-            double scale);
+void set_bc(
+    Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
+    std::vector<std::shared_ptr<const DirichletBC>> bcs,
+    const Eigen::Ref<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x0,
+    double scale);
 
 /// Assemble linear form into an Eigen vector. Assembly is performed
 /// over the portion of the mesh belonging to the process. No

--- a/cpp/dolfin/fem/assembler.cpp
+++ b/cpp/dolfin/fem/assembler.cpp
@@ -78,9 +78,6 @@ la::PETScVector _assemble_vector(const Form& L)
 
   VecRestoreArray(b_local, &array);
   VecGhostRestoreLocalForm(b.vec(), &b_local);
-
-  fem::impl::modify_bc(b.vec(), L, {}, {}, nullptr, 1.0);
-
   VecGhostUpdateBegin(b.vec(), ADD_VALUES, SCATTER_REVERSE);
   VecGhostUpdateEnd(b.vec(), ADD_VALUES, SCATTER_REVERSE);
 
@@ -189,21 +186,16 @@ void fem::assemble(
       VecRestoreArray(b_local, &array);
       VecGhostRestoreLocalForm(sub_b, &b_local);
       if (x0)
-      {
         fem::impl::modify_bc(sub_b, *L[i], a[i], bcs, x0->vec(), scale);
-        VecGhostUpdateBegin(sub_b, ADD_VALUES, SCATTER_REVERSE);
-        VecGhostUpdateEnd(sub_b, ADD_VALUES, SCATTER_REVERSE);
-
-        fem::impl::set_bc(sub_b, _bcs, x0->vec(), 1.0);
-      }
       else
-      {
         fem::impl::modify_bc(sub_b, *L[i], a[i], bcs, nullptr, scale);
-        VecGhostUpdateBegin(sub_b, ADD_VALUES, SCATTER_REVERSE);
-        VecGhostUpdateEnd(sub_b, ADD_VALUES, SCATTER_REVERSE);
+      VecGhostUpdateBegin(sub_b, ADD_VALUES, SCATTER_REVERSE);
+      VecGhostUpdateEnd(sub_b, ADD_VALUES, SCATTER_REVERSE);
 
+      if (x0)
+        fem::impl::set_bc(sub_b, _bcs, x0->vec(), 1.0);
+      else
         fem::impl::set_bc(sub_b, _bcs, 1.0);
-      }
 
       // FIXME: free sub-vector here (dereference)?
     }
@@ -305,21 +297,16 @@ void fem::assemble(
     VecGhostRestoreLocalForm(b.vec(), &b_local);
 
     if (x0)
-    {
       fem::impl::modify_bc(b.vec(), *L[0], a[0], bcs, x0->vec(), scale);
-      VecGhostUpdateBegin(b.vec(), ADD_VALUES, SCATTER_REVERSE);
-      VecGhostUpdateEnd(b.vec(), ADD_VALUES, SCATTER_REVERSE);
-
-      impl::set_bc(b.vec(), bcs, x0->vec(), scale);
-    }
     else
-    {
       fem::impl::modify_bc(b.vec(), *L[0], a[0], bcs, nullptr, scale);
-      VecGhostUpdateBegin(b.vec(), ADD_VALUES, SCATTER_REVERSE);
-      VecGhostUpdateEnd(b.vec(), ADD_VALUES, SCATTER_REVERSE);
+    VecGhostUpdateBegin(b.vec(), ADD_VALUES, SCATTER_REVERSE);
+    VecGhostUpdateEnd(b.vec(), ADD_VALUES, SCATTER_REVERSE);
 
+    if (x0)
+      impl::set_bc(b.vec(), bcs, x0->vec(), scale);
+    else
       impl::set_bc(b.vec(), bcs, scale);
-    }
   }
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/fem/assembler.cpp
+++ b/cpp/dolfin/fem/assembler.cpp
@@ -197,10 +197,10 @@ void fem::assemble(
         new (&x0vec)
             Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>>(
                 array_x0, size_x0);
-        fem::impl::modify_bc(bvec, *L[i], a[i], bcs, x0vec, scale);
+        fem::impl::modify_bc_old(bvec, *L[i], a[i], bcs, x0vec, scale);
       }
       else
-        fem::impl::modify_bc(bvec, *L[i], a[i], bcs, scale);
+        fem::impl::modify_bc_old(bvec, *L[i], a[i], bcs, scale);
 
       VecRestoreArray(b_local, &array);
       VecGhostRestoreLocalForm(sub_b, &b_local);
@@ -289,9 +289,9 @@ void fem::assemble(
 
       PetscScalar* values;
       VecGetArray(b.vec(), &values);
-      Eigen::Map<Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> vec(
+      Eigen::Map<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> vec(
           values + offset, map_size0);
-      Eigen::Map<Eigen::Array<PetscScalar, Eigen::Dynamic, 1>> vec_x0(nullptr,
+      Eigen::Map<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> vec_x0(nullptr,
                                                                       0);
 
       std::vector<std::shared_ptr<const DirichletBC>> _bcs;
@@ -332,10 +332,11 @@ void fem::assemble(
       new (&x0vec)
           Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>>(
               array_x0, size_x0);
-      fem::impl::modify_bc(bvec, *L[0], a[0], bcs, x0vec, scale);
+      fem::impl::modify_bc_old(bvec, *L[0], a[0], bcs, x0vec, scale);
     }
     else
-      fem::impl::modify_bc(bvec, *L[0], a[0], bcs, scale);
+      fem::impl::modify_bc_old(bvec, *L[0], a[0], bcs, scale);
+
     VecRestoreArray(b_local, &array);
     VecGhostRestoreLocalForm(b.vec(), &b_local);
     VecGhostUpdateBegin(b.vec(), ADD_VALUES, SCATTER_REVERSE);

--- a/cpp/dolfin/fem/assembler.cpp
+++ b/cpp/dolfin/fem/assembler.cpp
@@ -184,9 +184,20 @@ void fem::assemble(
       bvec.setZero();
       fem::impl::assemble(bvec, *L[i]);
       if (x0)
-        fem::impl::modify_bc(bvec, *L[i], a[i], bcs, x0->vec(), scale);
+      {
+        Vec x0_local = nullptr;
+        VecGhostGetLocalForm(x0->vec(), &x0_local);
+        PetscInt size_x0 = 0;
+        VecGetSize(x0_local, &size_x0);
+        PetscScalar const* array_x0;
+        VecGetArrayRead(x0_local, &array_x0);
+        const Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>>
+            x0vec(array_x0, size_x0);
+        fem::impl::modify_bc(bvec, *L[i], a[i], bcs, x0vec, scale);
+        VecRestoreArrayRead(x0_local, &array_x0);
+      }
       else
-        fem::impl::modify_bc(bvec, *L[i], a[i], bcs, nullptr, scale);
+        fem::impl::modify_bc(bvec, *L[i], a[i], bcs, scale);
       VecRestoreArray(b_local, &array);
       VecGhostRestoreLocalForm(sub_b, &b_local);
       VecGhostUpdateBegin(sub_b, ADD_VALUES, SCATTER_REVERSE);
@@ -294,9 +305,22 @@ void fem::assemble(
     bvec.setZero();
     fem::impl::assemble(bvec, *L[0]);
     if (x0)
-      fem::impl::modify_bc(bvec, *L[0], a[0], bcs, x0->vec(), scale);
+    {
+      Vec x0_local = nullptr;
+      VecGhostGetLocalForm(x0->vec(), &x0_local);
+      PetscInt size_x0 = 0;
+      VecGetSize(x0_local, &size_x0);
+      PetscScalar const* array_x0;
+      VecGetArrayRead(x0_local, &array_x0);
+      const Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>>
+          x0vec(array_x0, size_x0);
+
+      fem::impl::modify_bc(bvec, *L[0], a[0], bcs, x0vec, scale);
+
+      VecRestoreArrayRead(x0_local, &array_x0);
+    }
     else
-      fem::impl::modify_bc(bvec, *L[0], a[0], bcs, nullptr, scale);
+      fem::impl::modify_bc(bvec, *L[0], a[0], bcs, scale);
     VecRestoreArray(b_local, &array);
     VecGhostRestoreLocalForm(b.vec(), &b_local);
     VecGhostUpdateBegin(b.vec(), ADD_VALUES, SCATTER_REVERSE);

--- a/cpp/dolfin/fem/assembler.cpp
+++ b/cpp/dolfin/fem/assembler.cpp
@@ -197,10 +197,14 @@ void fem::assemble(
         new (&x0vec)
             Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>>(
                 array_x0, size_x0);
-        fem::impl::modify_bc_old(bvec, *L[i], a[i], bcs, x0vec, scale);
+        for (std::size_t j = 0; j < a[0].size(); ++j)
+          fem::impl::modify_bc(bvec, *a[i][j], bcs, x0vec, scale);
       }
       else
-        fem::impl::modify_bc_old(bvec, *L[i], a[i], bcs, scale);
+      {
+        for (std::size_t j = 0; j < a[0].size(); ++j)
+          fem::impl::modify_bc(bvec, *a[i][j], bcs, scale);
+      }
 
       VecRestoreArray(b_local, &array);
       VecGhostRestoreLocalForm(sub_b, &b_local);
@@ -292,7 +296,7 @@ void fem::assemble(
       Eigen::Map<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> vec(
           values + offset, map_size0);
       Eigen::Map<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> vec_x0(nullptr,
-                                                                      0);
+                                                                       0);
 
       std::vector<std::shared_ptr<const DirichletBC>> _bcs;
       for (auto bc : bcs)
@@ -332,10 +336,14 @@ void fem::assemble(
       new (&x0vec)
           Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>>(
               array_x0, size_x0);
-      fem::impl::modify_bc_old(bvec, *L[0], a[0], bcs, x0vec, scale);
+      for (std::size_t j = 0; j < a[0].size(); ++j)
+        fem::impl::modify_bc(bvec, *a[0][j], bcs, x0vec, scale);
     }
     else
-      fem::impl::modify_bc_old(bvec, *L[0], a[0], bcs, scale);
+    {
+      for (std::size_t j = 0; j < a[0].size(); ++j)
+        fem::impl::modify_bc(bvec, *a[0][j], bcs, scale);
+    }
 
     VecRestoreArray(b_local, &array);
     VecGhostRestoreLocalForm(b.vec(), &b_local);

--- a/cpp/dolfin/fem/assembler.cpp
+++ b/cpp/dolfin/fem/assembler.cpp
@@ -61,7 +61,8 @@ la::PETScVector _assemble_vector(const Form& L)
     throw std::runtime_error("Form must be rank 1");
   la::PETScVector b
       = la::PETScVector(*L.function_space(0)->dofmap()->index_map());
-  fem::impl::assemble_ghosted(b.vec(), L, {}, {}, nullptr, 1.0);
+  fem::impl::assemble_ghosted(b.vec(), L);
+  fem::impl::modify_bc(b.vec(), L, {}, {}, nullptr, 1.0);
 
   return b;
 }
@@ -153,12 +154,14 @@ void fem::assemble(
       VecNestGetSubVec(b.vec(), i, &sub_b);
       if (x0)
       {
-        fem::impl::assemble_ghosted(sub_b, *L[i], a[i], bcs, x0->vec(), scale);
+        fem::impl::assemble_ghosted(sub_b, *L[i]);
+        fem::impl::modify_bc(sub_b, *L[i], a[i], bcs, x0->vec(), scale);
         fem::impl::set_bc(sub_b, _bcs, x0->vec(), 1.0);
       }
       else
       {
-        fem::impl::assemble_ghosted(sub_b, *L[i], a[i], bcs, nullptr, scale);
+        fem::impl::assemble_ghosted(sub_b, *L[i]);
+        fem::impl::modify_bc(sub_b, *L[i], a[i], bcs, nullptr, scale);
         fem::impl::set_bc(sub_b, _bcs, 1.0);
       }
 
@@ -249,12 +252,14 @@ void fem::assemble(
   {
     if (x0)
     {
-      fem::impl::assemble_ghosted(b.vec(), *L[0], a[0], bcs, x0->vec(), scale);
+      fem::impl::assemble_ghosted(b.vec(), *L[0]);
+      fem::impl::modify_bc(b.vec(), *L[0], a[0], bcs, x0->vec(), scale);
       impl::set_bc(b.vec(), bcs, x0->vec(), scale);
     }
     else
     {
-      fem::impl::assemble_ghosted(b.vec(), *L[0], a[0], bcs, nullptr, scale);
+      fem::impl::assemble_ghosted(b.vec(), *L[0]);
+      fem::impl::modify_bc(b.vec(), *L[0], a[0], bcs, nullptr, scale);
       impl::set_bc(b.vec(), bcs, scale);
     }
   }

--- a/cpp/dolfin/fem/assembler.cpp
+++ b/cpp/dolfin/fem/assembler.cpp
@@ -183,12 +183,12 @@ void fem::assemble(
                                                                      size);
       bvec.setZero();
       fem::impl::assemble(bvec, *L[i]);
+      if (x0)
+        fem::impl::modify_bc(bvec, *L[i], a[i], bcs, x0->vec(), scale);
+      else
+        fem::impl::modify_bc(bvec, *L[i], a[i], bcs, nullptr, scale);
       VecRestoreArray(b_local, &array);
       VecGhostRestoreLocalForm(sub_b, &b_local);
-      if (x0)
-        fem::impl::modify_bc(sub_b, *L[i], a[i], bcs, x0->vec(), scale);
-      else
-        fem::impl::modify_bc(sub_b, *L[i], a[i], bcs, nullptr, scale);
       VecGhostUpdateBegin(sub_b, ADD_VALUES, SCATTER_REVERSE);
       VecGhostUpdateEnd(sub_b, ADD_VALUES, SCATTER_REVERSE);
 
@@ -293,13 +293,12 @@ void fem::assemble(
     Eigen::Map<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> bvec(array, size);
     bvec.setZero();
     fem::impl::assemble(bvec, *L[0]);
+    if (x0)
+      fem::impl::modify_bc(bvec, *L[0], a[0], bcs, x0->vec(), scale);
+    else
+      fem::impl::modify_bc(bvec, *L[0], a[0], bcs, nullptr, scale);
     VecRestoreArray(b_local, &array);
     VecGhostRestoreLocalForm(b.vec(), &b_local);
-
-    if (x0)
-      fem::impl::modify_bc(b.vec(), *L[0], a[0], bcs, x0->vec(), scale);
-    else
-      fem::impl::modify_bc(b.vec(), *L[0], a[0], bcs, nullptr, scale);
     VecGhostUpdateBegin(b.vec(), ADD_VALUES, SCATTER_REVERSE);
     VecGhostUpdateEnd(b.vec(), ADD_VALUES, SCATTER_REVERSE);
 


### PR DESCRIPTION
Some simplification and unpicking of the new vector assembly.

The implementation use Eigen. The data pointer underlying PETSc `Vec`s is wrapped as an `Eigen::Map`, into which a form is assembled.