### PR TITLE
Catch ufc errors

### DIFF
--- a/cpp/dolfin/fem/FiniteElement.cpp
+++ b/cpp/dolfin/fem/FiniteElement.cpp
@@ -19,7 +19,10 @@ FiniteElement::FiniteElement(std::shared_ptr<const ufc_finite_element> element)
   // Store dof coordinates on reference element
   assert(_ufc_element);
   _refX.resize(this->space_dimension(), this->topological_dimension());
-  _ufc_element->tabulate_reference_dof_coordinates(_refX.data());
+  int ret = _ufc_element->tabulate_reference_dof_coordinates(_refX.data());
+  if (ret == -1)
+    throw std::runtime_error("Generated code returned error "
+                             "in tabulate_reference_dof_coordinates");
 }
 //-----------------------------------------------------------------------------
 std::unique_ptr<FiniteElement>

--- a/cpp/dolfin/fem/FiniteElement.h
+++ b/cpp/dolfin/fem/FiniteElement.h
@@ -122,8 +122,11 @@ public:
   {
     assert(_ufc_element);
     std::size_t num_points = X.rows();
-    _ufc_element->evaluate_reference_basis(reference_values.data(), num_points,
-                                           X.data());
+    int ret = _ufc_element->evaluate_reference_basis(reference_values.data(),
+                                                     num_points, X.data());
+    if (ret == -1)
+      throw std::runtime_error("Generated code returned error "
+                               "in evaluate_reference_basis");
   }
 
   /// Push basis functions forward to physical element
@@ -137,9 +140,12 @@ public:
   {
     assert(_ufc_element);
     std::size_t num_points = X.rows();
-    _ufc_element->transform_reference_basis_derivatives(
+    int ret = _ufc_element->transform_reference_basis_derivatives(
         values.data(), 0, num_points, reference_values.data(), X.data(),
         J.data(), detJ.data(), K.data(), 1);
+    if (ret == -1)
+      throw std::runtime_error("Generated code returned error "
+                               "in transform_reference_basis_derivatives");
   }
 
   /// Push basis function (derivatives) forward to physical element

--- a/cpp/dolfin/fem/FiniteElement.h
+++ b/cpp/dolfin/fem/FiniteElement.h
@@ -159,9 +159,12 @@ public:
   {
     assert(_ufc_element);
     std::size_t num_points = X.rows();
-    _ufc_element->transform_reference_basis_derivatives(
+    int ret = _ufc_element->transform_reference_basis_derivatives(
         values.data(), order, num_points, reference_values.data(), X.data(),
         J.data(), detJ.data(), K.data(), 1);
+    if (ret == -1)
+      throw std::runtime_error("Generated code returned error "
+                               "in transform_reference_basis_derivatives");
   }
 
   /// Tabulate the reference coordinates of all dofs on an element


### PR DESCRIPTION
* Catches the `return -1` from various ufc functions when they are not defined.