### PR TITLE
Simplify setting of bc on vector

### DIFF
--- a/cpp/dolfin/fem/DirichletBC.cpp
+++ b/cpp/dolfin/fem/DirichletBC.cpp
@@ -410,7 +410,6 @@ void DirichletBC::set(
     Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x,
     double scale) const
 {
-  // assert(x.rows() == (Eigen::Index)_dofs.size());
   assert(_g);
   assert(_g->vector());
   assert(_g->vector()->vec());
@@ -427,7 +426,7 @@ void DirichletBC::set(
   const Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> g(
       g_array, g_size);
 
-  // FIXME: This one excludes ghosts. Need to straighten out
+  // FIXME: This one excludes ghosts. Need to straighten out.
   for (auto& dof : _dofs)
   {
     if (dof[0] < x.rows())
@@ -444,9 +443,6 @@ void DirichletBC::set(
     const Eigen::Ref<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x0,
     double scale) const
 {
-  // assert(x.rows() == (Eigen::Index)_dofs.size());
-  // assert(x.rows() == x0.rows());
-
   assert(_g);
   assert(_g->vector());
   assert(_g->vector()->vec());
@@ -463,7 +459,7 @@ void DirichletBC::set(
   const Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> g(
       g_array, g_size);
 
-  // FIXME: This one excludes ghosts. Need to straighten out
+  // FIXME: This one excludes ghosts. Need to straighten out.
   for (auto& dof : _dofs)
   {
     if (dof[0] < x.rows())

--- a/cpp/dolfin/fem/DirichletBC.cpp
+++ b/cpp/dolfin/fem/DirichletBC.cpp
@@ -367,6 +367,7 @@ void DirichletBC::get_boundary_values(Map& boundary_values) const
   la::VecReadWrapper g(_g->vector()->vec());
   for (auto dof : _dofs)
     boundary_values.insert({dof[0], g.x[dof[1]]});
+  g.restore();
 }
 //-----------------------------------------------------------------------------
 std::shared_ptr<const function::FunctionSpace>
@@ -394,15 +395,14 @@ void DirichletBC::set(
   assert(_g->vector());
   assert(_g->vector()->vec());
 
-  // Unwrap PETSc bc vector (_g)
-  la::VecReadWrapper g(_g->vector()->vec());
-
   // FIXME: This one excludes ghosts. Need to straighten out.
+  la::VecReadWrapper g(_g->vector()->vec());
   for (auto& dof : _dofs)
   {
     if (dof[0] < x.rows())
       x[dof[0]] = g.x[dof[1]];
   }
+  g.restore();
 }
 //-----------------------------------------------------------------------------
 void DirichletBC::set(
@@ -414,15 +414,14 @@ void DirichletBC::set(
   assert(_g->vector());
   assert(_g->vector()->vec());
 
-  // Unwrap PETSc bc vector (_g)
-  la::VecReadWrapper g(_g->vector()->vec());
-
   // FIXME: This one excludes ghosts. Need to straighten out.
+  la::VecReadWrapper g(_g->vector()->vec());
   for (auto& dof : _dofs)
   {
     if (dof[0] < x.rows())
       x[dof[0]] = scale * (g.x[dof[1]] - x0[dof[0]]);
   }
+  g.restore();
 }
 //-----------------------------------------------------------------------------
 void DirichletBC::mark_dofs(std::vector<bool>& markers) const
@@ -445,6 +444,7 @@ void DirichletBC::dof_values(
   la::VecReadWrapper g(_g->vector()->vec());
   for (auto& dof : _dofs)
     values[dof[0]] = g.x[dof[1]];
+  g.restore();
 }
 //-----------------------------------------------------------------------------
 std::map<PetscInt, PetscInt>

--- a/cpp/dolfin/fem/DirichletBC.cpp
+++ b/cpp/dolfin/fem/DirichletBC.cpp
@@ -426,7 +426,6 @@ void DirichletBC::set(
   VecGetArrayRead(g_vec, &g_array);
   const Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> g(
       g_array, g_size);
-  // assert(x.rows() == g.rows());
 
   // FIXME: This one excludes ghosts. Need to straighten out
   for (auto& dof : _dofs)
@@ -435,7 +434,7 @@ void DirichletBC::set(
       x[dof[0]] = g[dof[1]];
   }
 
-  // Restore PETSc array
+  // Restore PETSc array for g
   VecRestoreArrayRead(g_local, &g_array);
   VecGhostRestoreLocalForm(g_vec, &g_local);
 }
@@ -463,7 +462,6 @@ void DirichletBC::set(
   VecGetArrayRead(g_vec, &g_array);
   const Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> g(
       g_array, g_size);
-  // assert(x.rows() == g.rows());
 
   // FIXME: This one excludes ghosts. Need to straighten out
   for (auto& dof : _dofs)
@@ -472,7 +470,7 @@ void DirichletBC::set(
       x[dof[0]] = scale * (g[dof[1]] - x0[dof[0]]);
   }
 
-  // Restore PETSc array
+  // Restore PETSc array for g
   VecRestoreArrayRead(g_local, &g_array);
   VecGhostRestoreLocalForm(g_vec, &g_local);
 }

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -175,29 +175,3 @@ void fem::impl::modify_bc(
   _modify_bc(b, a, bc_values1, bc_markers1, x0, scale);
 }
 //-----------------------------------------------------------------------------
-void fem::impl::set_bc(
-    Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
-    std::vector<std::shared_ptr<const DirichletBC>> bcs, double scale)
-{
-  for (auto bc : bcs)
-  {
-    assert(bc);
-    bc->set(b, scale);
-  }
-}
-//-----------------------------------------------------------------------------
-void fem::impl::set_bc(
-    Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
-    std::vector<std::shared_ptr<const DirichletBC>> bcs,
-    const Eigen::Ref<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x0,
-    double scale)
-{
-  if (b.size() != x0.size())
-    throw std::runtime_error("Size mismatch between b and x0 vectors.");
-  for (auto bc : bcs)
-  {
-    assert(bc);
-    bc->set(b, x0, scale);
-  }
-}
-//-----------------------------------------------------------------------------

--- a/cpp/dolfin/fem/assemble_vector_impl.h
+++ b/cpp/dolfin/fem/assemble_vector_impl.h
@@ -44,21 +44,6 @@ void modify_bc(
     Eigen::Ref<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x0,
     double scale);
 
-// FIXME: clarify what happens with ghosts
-/// Set bc values in owned (local) part of the PETSc Vec to scale*x_bc
-/// value
-void set_bc(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
-            std::vector<std::shared_ptr<const DirichletBC>> bcs, double scale);
-
-// FIXME: clarify what happens with ghosts
-/// Set bc values in owned (local) part of the PETSc Vec to scale*(x0 -
-/// x_bc)
-void set_bc(
-    Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
-    std::vector<std::shared_ptr<const DirichletBC>> bcs,
-    const Eigen::Ref<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x0,
-    double scale);
-
 } // namespace impl
 } // namespace fem
 } // namespace dolfin

--- a/cpp/dolfin/fem/assembler.h
+++ b/cpp/dolfin/fem/assembler.h
@@ -135,6 +135,7 @@ void assemble(la::PETScMatrix& A, const std::vector<std::vector<const Form*>> a,
 // FIXME: Move these function elsewhere?
 
 // FIXME: clarify x0
+// FIXME: clarify what happens with ghosts
 
 /// Set bc values in owned (local) part of the PETScVector, multiplied
 /// by 'scale'. The vectors b and x0 must have the same local size. The

--- a/cpp/dolfin/fem/assembler.h
+++ b/cpp/dolfin/fem/assembler.h
@@ -136,6 +136,7 @@ void assemble(la::PETScMatrix& A, const std::vector<std::vector<const Form*>> a,
 
 // FIXME: clarify x0
 // FIXME: clarify what happens with ghosts
+// FIXME: sort out case when x0 is nested, i.e. len(b) \ne len(x0)
 
 /// Set bc values in owned (local) part of the PETScVector, multiplied
 /// by 'scale'. The vectors b and x0 must have the same local size. The

--- a/cpp/dolfin/la/utils.cpp
+++ b/cpp/dolfin/la/utils.cpp
@@ -62,3 +62,54 @@ void dolfin::la::petsc_error(int error_code, std::string filename,
                            + std::string(desc));
 }
 //-----------------------------------------------------------------------------
+dolfin::la::VecWrapper::VecWrapper(Vec y, bool ghosted) : x(nullptr, 0), _y(y)
+{
+  assert(_y);
+  PetscInt n = 0;
+  if (ghosted)
+    VecGhostGetLocalForm(_y, &_y_local);
+  else
+    VecGetLocalVector(_y, _y_local);
+  VecGetSize(_y_local, &n);
+  VecGetArray(_y_local, &array);
+
+  new (&x) Eigen::Map<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>>(array, n);
+}
+//-----------------------------------------------------------------------------
+dolfin::la::VecWrapper::~VecWrapper()
+{
+  VecRestoreArray(_y_local, &array);
+  PetscBool is_ghost_local_form;
+  VecGhostIsLocalForm(_y, _y_local, &is_ghost_local_form);
+  if (is_ghost_local_form == PETSC_TRUE)
+    VecGhostRestoreLocalForm(_y, &_y_local);
+  else
+    VecRestoreLocalVector(_y, _y_local);
+}
+//-----------------------------------------------------------------------------
+dolfin::la::VecReadWrapper::VecReadWrapper(const Vec y, bool ghosted)
+    : x(nullptr, 0), _y(y)
+{
+  assert(_y);
+  PetscInt n = 0;
+  if (ghosted)
+    VecGhostGetLocalForm(_y, &_y_local);
+  else
+    VecGetLocalVector(_y, _y_local);
+  VecGetSize(_y_local, &n);
+  VecGetArrayRead(_y_local, &array);
+  new (&x)
+      Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>>(array, n);
+}
+//-----------------------------------------------------------------------------
+dolfin::la::VecReadWrapper::~VecReadWrapper()
+{
+  VecRestoreArrayRead(_y_local, &array);
+  PetscBool is_ghost_local_form;
+  VecGhostIsLocalForm(_y, _y_local, &is_ghost_local_form);
+  if (is_ghost_local_form == PETSC_TRUE)
+    VecGhostRestoreLocalForm(_y, &_y_local);
+  else
+    VecRestoreLocalVector(_y, _y_local);
+}
+//-----------------------------------------------------------------------------

--- a/cpp/dolfin/la/utils.cpp
+++ b/cpp/dolfin/la/utils.cpp
@@ -78,8 +78,11 @@ dolfin::la::VecWrapper::VecWrapper(Vec y, bool ghosted) : x(nullptr, 0), _y(y)
 //-----------------------------------------------------------------------------
 dolfin::la::VecWrapper::~VecWrapper()
 {
+  assert(_y_local);
   VecRestoreArray(_y_local, &array);
+
   PetscBool is_ghost_local_form;
+  assert(_y);
   VecGhostIsLocalForm(_y, _y_local, &is_ghost_local_form);
   if (is_ghost_local_form == PETSC_TRUE)
     VecGhostRestoreLocalForm(_y, &_y_local);
@@ -104,8 +107,11 @@ dolfin::la::VecReadWrapper::VecReadWrapper(const Vec y, bool ghosted)
 //-----------------------------------------------------------------------------
 dolfin::la::VecReadWrapper::~VecReadWrapper()
 {
+  assert(_y_local);
   VecRestoreArrayRead(_y_local, &array);
+
   PetscBool is_ghost_local_form;
+  assert(_y);
   VecGhostIsLocalForm(_y, _y_local, &is_ghost_local_form);
   if (is_ghost_local_form == PETSC_TRUE)
     VecGhostRestoreLocalForm(_y, &_y_local);

--- a/cpp/dolfin/la/utils.cpp
+++ b/cpp/dolfin/la/utils.cpp
@@ -65,18 +65,19 @@ void dolfin::la::petsc_error(int error_code, std::string filename,
 dolfin::la::VecWrapper::VecWrapper(Vec y, bool ghosted) : x(nullptr, 0), _y(y)
 {
   assert(_y);
-  PetscInt n = 0;
   if (ghosted)
     VecGhostGetLocalForm(_y, &_y_local);
   else
     VecGetLocalVector(_y, _y_local);
+
+  PetscInt n = 0;
   VecGetSize(_y_local, &n);
   VecGetArray(_y_local, &array);
 
   new (&x) Eigen::Map<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>>(array, n);
 }
 //-----------------------------------------------------------------------------
-dolfin::la::VecWrapper::~VecWrapper()
+void dolfin::la::VecWrapper::restore()
 {
   assert(_y_local);
   VecRestoreArray(_y_local, &array);
@@ -94,24 +95,25 @@ dolfin::la::VecReadWrapper::VecReadWrapper(const Vec y, bool ghosted)
     : x(nullptr, 0), _y(y)
 {
   assert(_y);
-  PetscInt n = 0;
   if (ghosted)
     VecGhostGetLocalForm(_y, &_y_local);
   else
     VecGetLocalVector(_y, _y_local);
+
+  PetscInt n = 0;
   VecGetSize(_y_local, &n);
   VecGetArrayRead(_y_local, &array);
   new (&x)
       Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>>(array, n);
 }
 //-----------------------------------------------------------------------------
-dolfin::la::VecReadWrapper::~VecReadWrapper()
+void dolfin::la::VecReadWrapper::restore()
 {
   assert(_y_local);
   VecRestoreArrayRead(_y_local, &array);
 
-  PetscBool is_ghost_local_form;
   assert(_y);
+  PetscBool is_ghost_local_form;
   VecGhostIsLocalForm(_y, _y_local, &is_ghost_local_form);
   if (is_ghost_local_form == PETSC_TRUE)
     VecGhostRestoreLocalForm(_y, &_y_local);

--- a/cpp/dolfin/la/utils.h
+++ b/cpp/dolfin/la/utils.h
@@ -43,7 +43,10 @@ public:
   VecWrapper(Vec y, bool ghosted = true);
   VecWrapper(const VecWrapper& x) = delete;
   VecWrapper(VecWrapper&& x) = default;
-  ~VecWrapper();
+  VecWrapper& operator=(const VecWrapper& x) = delete;
+  VecWrapper& operator=(VecWrapper&& x) = default;
+  ~VecWrapper() = default;
+  void restore();
   Eigen::Map<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x;
 
 private:
@@ -58,7 +61,10 @@ public:
   VecReadWrapper(const Vec y, bool ghosted = true);
   VecReadWrapper(const VecReadWrapper& x) = delete;
   VecReadWrapper(VecReadWrapper&& x) = default;
-  ~VecReadWrapper();
+  VecReadWrapper& operator=(const VecReadWrapper& x) = delete;
+  VecReadWrapper& operator=(VecReadWrapper&& x) = default;
+  ~VecReadWrapper() = default;
+  void restore();
   Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x;
 
 private:

--- a/cpp/dolfin/la/utils.h
+++ b/cpp/dolfin/la/utils.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include <Eigen/Dense>
 #include <petscis.h>
+#include <petscvec.h>
 #include <string>
 #include <vector>
 
@@ -34,5 +36,32 @@ std::vector<IS> compute_index_sets(std::vector<const common::IndexMap*> maps);
 /// Print error message for PETSc calls that return an error
 void petsc_error(int error_code, std::string filename,
                  std::string petsc_function);
+
+class VecWrapper
+{
+public:
+  VecWrapper(Vec y, bool ghosted = true);
+  ~VecWrapper();
+  Eigen::Map<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x;
+
+private:
+  PetscScalar* array = nullptr;
+  Vec _y;
+  Vec _y_local = nullptr;
+};
+
+class VecReadWrapper
+{
+public:
+  VecReadWrapper(const Vec y, bool ghosted = true);
+  ~VecReadWrapper();
+  Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x;
+
+private:
+  PetscScalar const* array = nullptr;
+  const Vec _y;
+  Vec _y_local = nullptr;
+};
+
 } // namespace la
 } // namespace dolfin

--- a/cpp/dolfin/la/utils.h
+++ b/cpp/dolfin/la/utils.h
@@ -41,6 +41,8 @@ class VecWrapper
 {
 public:
   VecWrapper(Vec y, bool ghosted = true);
+  VecWrapper(const VecWrapper& x) = delete;
+  VecWrapper(VecWrapper&& x) = default;
   ~VecWrapper();
   Eigen::Map<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x;
 
@@ -54,6 +56,8 @@ class VecReadWrapper
 {
 public:
   VecReadWrapper(const Vec y, bool ghosted = true);
+  VecReadWrapper(const VecReadWrapper& x) = delete;
+  VecReadWrapper(VecReadWrapper&& x) = default;
   ~VecReadWrapper();
   Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> x;
 


### PR DESCRIPTION
Add wrapper for representing PETSc `Vec` as `Eigen::Map`. 