### PR TITLE
Fixes for clang on MacOS

### DIFF
--- a/cpp/dolfin/common/MPI.h
+++ b/cpp/dolfin/common/MPI.h
@@ -269,34 +269,24 @@ inline MPI_Datatype MPI::mpi_type<std::complex<double>>()
   return MPI_DOUBLE_COMPLEX;
 }
 template <>
-inline MPI_Datatype MPI::mpi_type<std::int16_t>()
+inline MPI_Datatype MPI::mpi_type<short int>()
 {
-  return MPI_INT16_T;
+  return MPI_SHORT;
 }
 template <>
-inline MPI_Datatype MPI::mpi_type<std::uint16_t>()
+inline MPI_Datatype MPI::mpi_type<int>()
 {
-  return MPI_UINT16_T;
+  return MPI_INT;
 }
 template <>
-inline MPI_Datatype MPI::mpi_type<std::int32_t>()
+inline MPI_Datatype MPI::mpi_type<unsigned int>()
 {
-  return MPI_INT32_T;
+  return MPI_UNSIGNED;
 }
 template <>
-inline MPI_Datatype MPI::mpi_type<std::uint32_t>()
+inline MPI_Datatype MPI::mpi_type<long int>()
 {
-  return MPI_UINT32_T;
-}
-template <>
-inline MPI_Datatype MPI::mpi_type<std::int64_t>()
-{
-  return MPI_INT64_T;
-}
-template <>
-inline MPI_Datatype MPI::mpi_type<std::uint64_t>()
-{
-  return MPI_UINT64_T;
+  return MPI_LONG;
 }
 template <>
 inline MPI_Datatype MPI::mpi_type<unsigned long>()
@@ -304,9 +294,9 @@ inline MPI_Datatype MPI::mpi_type<unsigned long>()
   return MPI_UNSIGNED_LONG;
 }
 template <>
-inline MPI_Datatype MPI::mpi_type<long>()
+inline MPI_Datatype MPI::mpi_type<long long>()
 {
-  return MPI_LONG;
+  return MPI_LONG_LONG;
 }
 //---------------------------------------------------------------------------
 template <typename T>

--- a/cpp/dolfin/common/MPI.h
+++ b/cpp/dolfin/common/MPI.h
@@ -298,6 +298,16 @@ inline MPI_Datatype MPI::mpi_type<std::uint64_t>()
 {
   return MPI_UINT64_T;
 }
+template <>
+inline MPI_Datatype MPI::mpi_type<unsigned long>()
+{
+  return MPI_UNSIGNED_LONG;
+}
+template <>
+inline MPI_Datatype MPI::mpi_type<long>()
+{
+  return MPI_LONG;
+}
 //---------------------------------------------------------------------------
 template <typename T>
 void dolfin::MPI::broadcast(MPI_Comm comm, std::vector<T>& value,

--- a/cpp/dolfin/fem/DirichletBC.cpp
+++ b/cpp/dolfin/fem/DirichletBC.cpp
@@ -271,7 +271,8 @@ DirichletBC::DirichletBC(std::shared_ptr<const function::FunctionSpace> V,
     if (it == shared_dofs.end())
       throw std::runtime_error("Oops, can't find dof (A).");
 
-    auto it_map = dofs_local.insert({it->first, it->second});
+    const std::array<PetscInt, 2> ldofs = {{it->first, it->second}};
+    auto it_map = dofs_local.insert(ldofs);
     if (it_map.second)
       std::cout << "Inserted off-process dof (A)" << std::endl;
   }
@@ -344,7 +345,8 @@ DirichletBC::DirichletBC(std::shared_ptr<const function::FunctionSpace> V,
     auto it = shared_dofs.find(dof_remote);
     if (it == shared_dofs.end())
       throw std::runtime_error("Oops, can't find dof (B).");
-    auto it_map = dofs_local.insert({it->first, it->second});
+    const std::array<PetscInt, 2> ldofs = {{it->first, it->second}};
+    auto it_map = dofs_local.insert(ldofs);
     if (it_map.second)
       std::cout << "Inserted off-process dof (B)" << std::endl;
   }
@@ -559,7 +561,7 @@ std::set<std::array<PetscInt, 2>> DirichletBC::compute_bc_dofs_topological(
       const std::size_t index = facet_dofs[facet_local_index][i];
       const PetscInt dof_index = cell_dofs[index];
       const PetscInt dof_index_g = cell_dofs_g[index];
-      bc_dofs.push_back({dof_index, dof_index_g});
+      bc_dofs.push_back({{dof_index, dof_index_g}});
 
       // std::cout << "Old adding bc (cell, local, global): " << cell.index()
       //           << ", " << index << ", " << dof_index << std::endl;

--- a/cpp/dolfin/fem/utils.cpp
+++ b/cpp/dolfin/fem/utils.cpp
@@ -134,7 +134,7 @@ fem::init_monolithic_matrix(std::vector<std::vector<const fem::Form*>> a)
       {
         // FIXME: create sparsity pattern that has just a row/col range
         const std::array<std::shared_ptr<const common::IndexMap>, 2> maps
-            = {rmaps[row], cmaps[col]};
+            = {{rmaps[row], cmaps[col]}};
         auto sp = std::make_unique<la::SparsityPattern>(mesh.mpi_comm(), maps);
         patterns[row].push_back(std::move(sp));
       }
@@ -356,8 +356,8 @@ dolfin::fem::get_global_index(const std::vector<const common::IndexMap*> maps,
   // FIXME: handle/check block size > 1
 
   // Get process that owns global index
-  const int bs  = maps[field]->block_size();
-  int owner = maps[field]->owner(index/bs);
+  const int bs = maps[field]->block_size();
+  int owner = maps[field]->owner(index / bs);
 
   // Offset from lower rank processes
   std::size_t offset = 0;


### PR DESCRIPTION
Some changes for quirks of clang, also reverting MPI type detection: issues with int types.