### PR TITLE
Go back to MPICH in container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ unit-tests-python-mpi: &unit-tests-python-mpi
   name: Run unit tests (Python, MPI)
   command: |
     cd python/test/unit
-    mpirun --allow-run-as-root -n 3 python3 -m pytest .
+    mpirun -n 3 python3 -m pytest .
 
 demos-python: &demos-python
   name: Run demos (Python, serial)
@@ -83,7 +83,7 @@ demos-python-mpi: &demos-python-mpi
   command: |
     cd python/demo
     python3 ./generate-demo-files.py
-    python3 -m pytest -n2 -v -m mpi test.py --mpi-options="--allow-run-as-root" --num-proc=3
+    python3 -m pytest -n2 -v -m mpi test.py --num-proc=3
 
 version: 2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 # Download Install gmsh
 RUN cd /usr/local && \
-    wget http://gmsh.info/bin/Linux/gmsh-${GMSH_VERSION}-Linux64.tgz && \
+    wget -nc --quiet http://gmsh.info/bin/Linux/gmsh-${GMSH_VERSION}-Linux64.tgz && \
     tar -xf gmsh-${GMSH_VERSION}-Linux64.tgz
 ENV PATH=/usr/local/gmsh-${GMSH_VERSION}-Linux64/bin:$PATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@
 #    docker run -p 8888:8888 -v "$(pwd)":/tmp quay.io/fenicsproject/dolfinx:notebook
 #
 
+ARG GMSH_VERSION=4.1.0
 ARG PYBIND11_VERSION=2.2.4
-ARG PETSC_VERSION=3.10.3
+ARG PETSC_VERSION=3.10.2
 ARG SLEPC_VERSION=3.10.1
 ARG PETSC4PY_VERSION=3.10.0
 ARG SLEPC4PY_VERSION=3.10.0
@@ -36,6 +37,8 @@ FROM ubuntu:18.04 as base
 LABEL maintainer="fenics-project <fenics-support@googlegroups.org>"
 LABEL description="Base image for real and complex FEniCS test environments"
 
+
+ARG GMSH_VERSION
 ARG PYBIND11_VERSION
 
 WORKDIR /tmp
@@ -63,12 +66,12 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         libboost-thread-dev \
         libboost-timer-dev \
         libeigen3-dev \
-        libhdf5-openmpi-dev \
+        libhdf5-mpich-dev \
         liblapack-dev \
-        libopenmpi-dev \
+        libmpich-dev \
         libopenblas-dev \
+        mpich \
         ninja-build \
-        openmpi-bin \
         pkg-config \
         python3-dev \
         python3-matplotlib \
@@ -79,12 +82,17 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -y install \
         doxygen \
         git \
-        gmsh \
         graphviz \
         valgrind \
         wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Download Install gmsh
+RUN cd /usr/local && \
+    wget http://gmsh.info/bin/Linux/gmsh-${GMSH_VERSION}-Linux64.tgz && \
+    tar -xf gmsh-${GMSH_VERSION}-Linux64.tgz
+ENV PATH=/usr/local/gmsh-${GMSH_VERSION}-Linux64/bin:$PATH
 
 # Install Python packages (via pip)
 # First set of packages are required to build and run FEniCS.


### PR DESCRIPTION
- Some new code/tests were failing with OpenMPI.
- Removes OpenMPI specific option that was required to run in container.
- Download gmsh binary from gmsh page. 