### PR TITLE
Use CMake default root dir for dependencies

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -16,15 +16,13 @@ endif()
 
 #------------------------------------------------------------------------------
 # Set CMake options, see `cmake --help-policy CMP000x`
-cmake_policy(VERSION 3.10.)
 
-if (COMMAND cmake_policy)
-  if (POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-  endif()
-  if (POLICY CMP0075)
-    cmake_policy(SET CMP0075 NEW)
-  endif()
+cmake_policy(VERSION 3.10)
+if (POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+if (POLICY CMP0075)
+  cmake_policy(SET CMP0075 NEW)
 endif()
 
 #------------------------------------------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,4 @@
 # Top level CMakeLists.txt file for DOLFIN
-
 cmake_minimum_required(VERSION 3.9)
 
 #------------------------------------------------------------------------------
@@ -13,6 +12,15 @@ set(DOLFIN_VERSION_MICRO "0")
 set(DOLFIN_VERSION "${DOLFIN_VERSION_MAJOR}.${DOLFIN_VERSION_MINOR}.${DOLFIN_VERSION_MICRO}")
 if (NOT DOLFIN_VERSION_RELEASE)
   set(DOLFIN_VERSION "${DOLFIN_VERSION}.dev0")
+endif()
+
+#------------------------------------------------------------------------------
+# Set CMake options, see `cmake --help-policy CMP000x`
+if (COMMAND cmake_policy)
+  cmake_policy(SET CMP0003 NEW)
+  cmake_policy(SET CMP0004 NEW)
+  cmake_policy(SET CMP0042 NEW)
+  cmake_policy(SET CMP0074 NEW)
 endif()
 
 #------------------------------------------------------------------------------
@@ -44,13 +52,6 @@ endif()
 
 #------------------------------------------------------------------------------
 # General configuration
-
-# Set CMake options, see `cmake --help-policy CMP000x`
-if (COMMAND cmake_policy)
-  cmake_policy(SET CMP0003 NEW)
-  cmake_policy(SET CMP0004 NEW)
-  cmake_policy(SET CMP0042 NEW)
-endif()
 
 # Set location of our FindFoo.cmake modules
 set(DOLFIN_CMAKE_DIR "${DOLFIN_SOURCE_DIR}/cmake" CACHE INTERNAL "")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -21,6 +21,7 @@ if (COMMAND cmake_policy)
   cmake_policy(SET CMP0004 NEW)
   cmake_policy(SET CMP0042 NEW)
   cmake_policy(SET CMP0074 NEW)
+  cmake_policy(SET CMP0075 NEW)
 endif()
 
 #------------------------------------------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Top level CMakeLists.txt file for DOLFIN
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.10)
 
 #------------------------------------------------------------------------------
 # Set project name and version number
@@ -16,12 +16,15 @@ endif()
 
 #------------------------------------------------------------------------------
 # Set CMake options, see `cmake --help-policy CMP000x`
+cmake_policy(VERSION 3.10.)
+
 if (COMMAND cmake_policy)
-  cmake_policy(SET CMP0003 NEW)
-  cmake_policy(SET CMP0004 NEW)
-  cmake_policy(SET CMP0042 NEW)
-  cmake_policy(SET CMP0074 NEW)
-  cmake_policy(SET CMP0075 NEW)
+  if (POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+  endif()
+  if (POLICY CMP0075)
+    cmake_policy(SET CMP0075 NEW)
+  endif()
 endif()
 
 #------------------------------------------------------------------------------

--- a/cpp/cmake/modules/FindEigen3.cmake
+++ b/cpp/cmake/modules/FindEigen3.cmake
@@ -21,9 +21,6 @@
 # Copyright (c) 2009 Benoit Jacob <jacob.benoit.1@gmail.com>
 # Redistribution and use is allowed according to the terms of the 2-clause BSD license.
 
-# Modified by Garth N. Wells <gnw20@cam.ac.uk> to add EIGEN_DIR to
-# search path
-
 if(NOT Eigen3_FIND_VERSION)
   if(NOT Eigen3_FIND_VERSION_MAJOR)
     set(Eigen3_FIND_VERSION_MAJOR 2)
@@ -78,8 +75,8 @@ else (EIGEN3_INCLUDE_DIR)
   if(NOT EIGEN3_INCLUDE_DIR)
     find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
         HINTS
-        ${EIGEN_DIR}
-        ENV EIGEN_DIR
+        ${EIGEN_ROOT}
+        ENV EIGEN_ROOT
         ENV EIGEN3_ROOT
         ENV EIGEN3_ROOT_DIR
         PATHS

--- a/cpp/cmake/modules/FindParMETIS.cmake
+++ b/cpp/cmake/modules/FindParMETIS.cmake
@@ -37,12 +37,12 @@
 
 if (MPI_CXX_FOUND)
   find_path(PARMETIS_INCLUDE_DIRS parmetis.h
-    HINTS ${PARMETIS_DIR}/include $ENV{PARMETIS_DIR}/include ${PETSC_INCLUDE_DIRS}
+    HINTS ${PARMETIS_ROOT}/include $ENV{PARMETIS_ROOT}/include ${PETSC_INCLUDE_DIRS}
     DOC "Directory where the ParMETIS header files are located"
   )
 
   find_library(PARMETIS_LIBRARY parmetis
-    HINTS ${PARMETIS_DIR}/lib $ENV{PARMETIS_DIR}/lib ${PETSC_LIBRARY_DIRS}
+    HINTS ${PARMETIS_ROOT}/lib $ENV{PARMETIS_ROOT}/lib ${PETSC_LIBRARY_DIRS}
     NO_DEFAULT_PATH
     DOC "Directory where the ParMETIS library is located"
   )
@@ -51,7 +51,7 @@ if (MPI_CXX_FOUND)
   )
 
   find_library(METIS_LIBRARY metis
-    HINTS ${PARMETIS_DIR}/lib $ENV{PARMETIS_DIR}/lib ${PETSC_LIBRARY_DIRS}
+    HINTS ${PARMETIS_ROOT}/lib $ENV{PARMETIS_ROOT}/lib ${PETSC_LIBRARY_DIRS}
     NO_DEFAULT_PATH
     DOC "Directory where the METIS library is located"
   )

--- a/cpp/cmake/modules/FindSCOTCH.cmake
+++ b/cpp/cmake/modules/FindSCOTCH.cmake
@@ -48,7 +48,7 @@ message(STATUS "Checking for package 'SCOTCH-PT'")
 
 # Check for header file
 find_path(SCOTCH_INCLUDE_DIRS ptscotch.h
-  HINTS ${SCOTCH_DIR}/include $ENV{SCOTCH_DIR}/include ${PETSC_INCLUDE_DIRS}
+  HINTS ${SCOTCH_ROOT}/include $ENV{SCOTCH_ROOT}/include ${PETSC_INCLUDE_DIRS}
   PATH_SUFFIXES scotch
   DOC "Directory where the SCOTCH-PT header is located"
   )
@@ -56,7 +56,7 @@ find_path(SCOTCH_INCLUDE_DIRS ptscotch.h
 # Check for scotch
 find_library(SCOTCH_LIBRARY
   NAMES scotch
-  HINTS ${SCOTCH_DIR}/lib $ENV{SCOTCH_DIR}/lib ${PETSC_LIBRARY_DIRS}
+  HINTS ${SCOTCH_ROOT}/lib $ENV{SCOTCH_ROOT}/lib ${PETSC_LIBRARY_DIRS}
   NO_DEFAULT_PATH
   DOC "The SCOTCH library"
   )
@@ -68,7 +68,7 @@ find_library(SCOTCH_LIBRARY
 # Check for scotcherr
 find_library(SCOTCHERR_LIBRARY
   NAMES scotcherr
-  HINTS ${SCOTCH_DIR}/lib $ENV{SCOTCH_DIR}/lib
+  HINTS ${SCOTCH_ROOT}/lib $ENV{SCOTCH_ROOT}/lib
   NO_DEFAULT_PATH
   DOC "The SCOTCH-ERROR library"
   )
@@ -80,7 +80,7 @@ find_library(SCOTCHERR_LIBRARY
 # Check for ptscotch
 find_library(PTSCOTCH_LIBRARY
   NAMES ptscotch
-  HINTS ${SCOTCH_DIR}/lib $ENV{SCOTCH_DIR}/lib ${PETSC_LIBRARY_DIRS}
+  HINTS ${SCOTCH_ROOT}/lib $ENV{SCOTCH_ROOT}/lib ${PETSC_LIBRARY_DIRS}
   NO_DEFAULT_PATH
   DOC "The PTSCOTCH library"
   )
@@ -92,7 +92,7 @@ find_library(PTSCOTCH_LIBRARY
 # Check for ptesmumps
 find_library(PTESMUMPS_LIBRARY
   NAMES ptesmumps esmumps
-  HINTS ${SCOTCH_DIR}/lib $ENV{SCOTCH_DIR}/lib ${PETSC_LIBRARY_DIRS}
+  HINTS ${SCOTCH_ROOT}/lib $ENV{SCOTCH_ROOT}/lib ${PETSC_LIBRARY_DIRS}
   NO_DEFAULT_PATH
   DOC "The PTSCOTCH-ESMUMPS library"
   )
@@ -104,7 +104,7 @@ find_library(PTESMUMPS_LIBRARY
 # Check for ptscotcherr
 find_library(PTSCOTCHERR_LIBRARY
   NAMES ptscotcherr
-  HINTS ${SCOTCH_DIR}/lib $ENV{SCOTCH_DIR}/lib ${PETSC_LIBRARY_DIRS}
+  HINTS ${SCOTCH_ROOT}/lib $ENV{SCOTCH_ROOT}/lib ${PETSC_LIBRARY_DIRS}
   NO_DEFAULT_PATH
   DOC "The PTSCOTCH-ERROR library"
   )
@@ -326,7 +326,7 @@ endif()
 
 # Standard package handling
 find_package_handle_standard_args(SCOTCH
-                                  "SCOTCH could not be found. Be sure to set SCOTCH_DIR."
+                                  "SCOTCH could not be found. Be sure to set SCOTCH_ROOT."
                                   SCOTCH_LIBRARIES
                                   SCOTCH_INCLUDE_DIRS
                                   SCOTCH_TEST_RUNS)

--- a/python/cmake/FindPETSc4py.cmake
+++ b/python/cmake/FindPETSc4py.cmake
@@ -1,9 +1,9 @@
 # - Try to find petsc4py
 # Once done this will define
 #
-#  PETSC4PY_FOUND        - system has petsc4py
+#  PETSC4PY_FOUND         - system has petsc4py
 #  PETSC4PY_INCLUDE_DIRS  - include directories for petsc4py
-#  PETSC4PY_VERSION      - version of petsc4py
+#  PETSC4PY_VERSION       - version of petsc4py
 #  PETSC4PY_VERSION_MAJOR - first number in PETSC4PY_VERSION
 #  PETSC4PY_VERSION_MINOR - second number in PETSC4PY_VERSION
 
@@ -97,16 +97,3 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(PETSc4py
   "PETSc4py could not be found. Be sure to set PYTHONPATH appropriately."
   PETSC4PY_INCLUDE_DIRS PETSC4PY_VERSION PETSC4PY_VERSION_OK)
-
-# Check petsc4py.i for PETSC_INT
-#if(PETSC4PY_INCLUDE_DIRS)
-#  file(STRINGS "${PETSC4PY_INCLUDE_DIRS}/petsc4py/petsc4py.i" PETSC4PY_INT)
-#  string(REGEX MATCH "SWIG_TYPECHECK_INT[0-9]+" PETSC4PY_INT "${PETSC4PY_INT}")
-#  string(REPLACE "SWIG_TYPECHECK_INT" "" PETSC4PY_INT "${PETSC4PY_INT}")
-#  math(EXPR PETSC_INT "${PETSC_INT_SIZE}*8")
-#  if(NOT PETSC_INT STREQUAL PETSC4PY_INT)
-#    message(STATUS "PETSC_INT = ${PETSC4PY_INT} ${PETSC_INT}")
-#    message(STATUS " - does not match")
-#    set(PETSC4PY_FOUND FALSE)
-#  endif()
-#endif()

--- a/python/dolfin/pybind11jit.py
+++ b/python/dolfin/pybind11jit.py
@@ -103,8 +103,8 @@ def compile_cpp_code(cpp_code,
 def get_pybind_include():
     """Find the pybind11 include path"""
 
-    # Look in PYBIND11_DIR
-    pybind_dir = os.getenv('PYBIND11_DIR', None)
+    # Look in PYBIND11_ROOT
+    pybind_dir = os.getenv('PYBIND11_ROOT', None)
     if pybind_dir:
         p = os.path.join(pybind_dir, "include")
         if (_check_pybind_path(p)):


### PR DESCRIPTION
Switch to CMake standard variable `FOO_ROOT` in place of `FOO_DIR`.

Also clean up some CMake policy settings.