### PR TITLE
Remove more PETSc wrappers

### DIFF
--- a/cpp/dolfin/fem/SystemAssembler.cpp
+++ b/cpp/dolfin/fem/SystemAssembler.cpp
@@ -224,6 +224,10 @@ void SystemAssembler::assemble(la::PETScMatrix* A, la::PETScVector* b,
   {
     assert(x0->size() == _a->function_space(1)->dofmap()->global_dimension());
 
+    la::VecReadWrapper x0_wrap(x0->vec());
+    Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> _x0
+        = x0_wrap.x;
+
     const std::size_t num_bc_dofs = boundary_values[0].size();
     std::vector<PetscInt> bc_indices;
     std::vector<PetscScalar> bc_values;
@@ -238,10 +242,8 @@ void SystemAssembler::assemble(la::PETScMatrix* A, la::PETScVector* b,
     }
 
     // Modify bc values
-    std::vector<PetscScalar> x0_values(num_bc_dofs);
-    x0->get_local(x0_values.data(), num_bc_dofs, bc_indices.data());
     for (std::size_t i = 0; i < num_bc_dofs; i++)
-      boundary_values[0][bc_indices[i]] = x0_values[i] - bc_values[i];
+      boundary_values[0][bc_indices[i]] = _x0[bc_indices[i]] - bc_values[i];
   }
 
   // Check whether we should do cell-wise or facet-wise assembly

--- a/cpp/dolfin/fem/utils.cpp
+++ b/cpp/dolfin/fem/utils.cpp
@@ -353,7 +353,8 @@ la::PETScMatrix dolfin::fem::init_matrix(const Form& a)
   {
     // Get local row range
     const common::IndexMap& index_map_0 = *dofmaps[0]->index_map();
-    const auto row_range = A.local_range(0);
+    std::array<PetscInt, 2> row_range;
+    MatGetOwnershipRange(A.mat(), &row_range[0], &row_range[1]);
 
     assert(index_map_0.block_size() == 1);
 
@@ -386,8 +387,9 @@ la::PETScMatrix dolfin::fem::init_matrix(const Form& a)
   {
     // Loop over rows and insert 0.0 on the diagonal
     const PetscScalar block = 0.0;
-    const auto row_range = A.local_range(0);
-    const std::int64_t range = std::min(row_range[1], A.size()[1]);
+    std::array<PetscInt, 2> row_range;
+    MatGetOwnershipRange(A.mat(), &row_range[0], &row_range[1]);
+    const std::int64_t range = std::min(row_range[1], (PetscInt)A.size()[1]);
 
     for (std::int64_t i = row_range[0]; i < range; i++)
     {

--- a/cpp/dolfin/io/VTKWriter.cpp
+++ b/cpp/dolfin/io/VTKWriter.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2016 Garth N. Wells
+// Copyright (C) 2010-2019 Garth N. Wells
 //
 // This file is part of DOLFIN (https://www.fenicsproject.org)
 //
@@ -12,6 +12,7 @@
 #include <dolfin/function/Function.h>
 #include <dolfin/function/FunctionSpace.h>
 #include <dolfin/la/PETScVector.h>
+#include <dolfin/la/utils.h>
 #include <dolfin/mesh/Cell.h>
 #include <dolfin/mesh/Mesh.h>
 #include <dolfin/mesh/MeshFunction.h>
@@ -51,8 +52,8 @@ void VTKWriter::write_cell_data(const function::Function& u,
   if (rank > 2)
   {
     log::dolfin_error("VTKFile.cpp", "write data to VTK file",
-                 "Don't know how to handle vector function with dimension "
-                 "other than 2 or 3");
+                      "Don't know how to handle vector function with dimension "
+                      "other than 2 or 3");
   }
 
   // Get number of components
@@ -73,9 +74,10 @@ void VTKWriter::write_cell_data(const function::Function& u,
   {
     if (!(data_dim == 2 || data_dim == 3))
     {
-      log::dolfin_error("VTKWriter.cpp", "write data to VTK file",
-                   "Don't know how to handle vector function with dimension "
-                   "other than 2 or 3");
+      log::dolfin_error(
+          "VTKWriter.cpp", "write data to VTK file",
+          "Don't know how to handle vector function with dimension "
+          "other than 2 or 3");
     }
     fp << "<CellData  Vectors=\"" << u.name() << "\"> " << std::endl;
     fp << "<DataArray  type=\"Float64\"  Name=\"" << u.name()
@@ -85,9 +87,10 @@ void VTKWriter::write_cell_data(const function::Function& u,
   {
     if (!(data_dim == 4 || data_dim == 9))
     {
-      log::dolfin_error("VTKFile.cpp", "write data to VTK file",
-                   "Don't know how to handle tensor function with dimension "
-                   "other than 4 or 9");
+      log::dolfin_error(
+          "VTKFile.cpp", "write data to VTK file",
+          "Don't know how to handle tensor function with dimension "
+          "other than 4 or 9");
     }
     fp << "<CellData  Tensors=\"" << u.name() << "\"> " << std::endl;
     fp << "<DataArray  type=\"Float64\"  Name=\"" << u.name()
@@ -116,7 +119,11 @@ void VTKWriter::write_cell_data(const function::Function& u,
   // Get  values
   std::vector<PetscScalar> values(dof_set.size());
   assert(u.vector());
-  u.vector()->get_local(values.data(), dof_set.size(), dof_set.data());
+  la::VecReadWrapper u_wrapper(u.vector()->vec());
+  Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> _x
+      = u_wrapper.x;
+  for (std::size_t i = 0; i < dof_set.size(); ++i)
+    values[i] = _x[dof_set[i]];
 
   // Get cell data
   fp << ascii_cell_data(mesh, offset, values, data_dim, rank);
@@ -182,9 +189,10 @@ void VTKWriter::write_ascii_mesh(const mesh::Mesh& mesh, std::size_t cell_dim,
   file.precision(16);
   if (!file.is_open())
   {
-    log::dolfin_error("VTKWriter.cpp", "write mesh to VTK file"
-                                  "Unable to open file \"%s\"",
-                 filename.c_str());
+    log::dolfin_error("VTKWriter.cpp",
+                      "write mesh to VTK file"
+                      "Unable to open file \"%s\"",
+                      filename.c_str());
   }
 
   // Write vertex positions
@@ -260,7 +268,7 @@ std::uint8_t VTKWriter::vtk_cell_type(const mesh::Mesh& mesh,
   else
   {
     log::dolfin_error("VTKWriter.cpp", "write data to VTK file",
-                 "Unknown cell type (%d)", cell_type);
+                      "Unknown cell type (%d)", cell_type);
   }
 
   return vtk_cell_type;

--- a/cpp/dolfin/la/PETScMatrix.cpp
+++ b/cpp/dolfin/la/PETScMatrix.cpp
@@ -6,17 +6,12 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "PETScMatrix.h"
-#include "PETScVector.h"
-#include "SparsityPattern.h"
 #include "VectorSpaceBasis.h"
 #include "utils.h"
-#include <dolfin/common/IndexMap.h>
 #include <dolfin/common/MPI.h>
 #include <dolfin/common/Timer.h>
 #include <dolfin/log/log.h>
-#include <iomanip>
 #include <iostream>
-#include <numeric>
 #include <sstream>
 
 // Ceiling division of nonnegative integers
@@ -47,11 +42,6 @@ PETScMatrix::PETScMatrix(const PETScMatrix& A) : PETScOperator()
 PETScMatrix::~PETScMatrix()
 {
   // Do nothing (PETSc matrix is destroyed in base class)
-}
-//-----------------------------------------------------------------------------
-std::array<std::int64_t, 2> PETScMatrix::local_range(std::size_t dim) const
-{
-  return PETScOperator::local_range(dim);
 }
 //-----------------------------------------------------------------------------
 void PETScMatrix::set(const PetscScalar* block, std::size_t m,

--- a/cpp/dolfin/la/PETScMatrix.h
+++ b/cpp/dolfin/la/PETScMatrix.h
@@ -52,10 +52,7 @@ public:
   /// Move assignment operator
   PETScMatrix& operator=(PETScMatrix&& A) = default;
 
-  /// Return local ownership range
-  std::array<std::int64_t, 2> local_range(std::size_t dim) const;
-
-  /// Set all entries to zero and keep any sparse structure
+   /// Set all entries to zero and keep any sparse structure
   void zero();
 
   /// Assembly type

--- a/cpp/dolfin/la/PETScOperator.cpp
+++ b/cpp/dolfin/la/PETScOperator.cpp
@@ -61,23 +61,6 @@ std::array<std::int64_t, 2> PETScOperator::size() const
   return {{m, n}};
 }
 //-----------------------------------------------------------------------------
-std::array<std::int64_t, 2> PETScOperator::local_range(std::size_t dim) const
-{
-  assert(dim <= 1);
-  if (dim == 1)
-  {
-    throw std::runtime_error(
-        "Only local row range is available for PETSc matrices");
-  }
-
-  assert(_matA);
-  PetscInt m(0), n(0);
-  PetscErrorCode ierr = MatGetOwnershipRange(_matA, &m, &n);
-  if (ierr != 0)
-    petsc_error(ierr, __FILE__, "MatGetOwnershipRange");
-  return {{m, n}};
-}
-//-----------------------------------------------------------------------------
 PETScVector PETScOperator::create_vector(std::size_t dim) const
 {
   assert(_matA);

--- a/cpp/dolfin/la/PETScOperator.h
+++ b/cpp/dolfin/la/PETScOperator.h
@@ -49,10 +49,6 @@ public:
   /// returns -1 if size has not been set.
   std::array<std::int64_t, 2> size() const;
 
-  // FIXME: Remove? Not appropriate for operator?
-  /// Return local range along dimension dim
-  std::array<std::int64_t, 2> local_range(std::size_t dim) const;
-
   /// Initialize vector to be compatible with the matrix-vector product
   /// y = Ax. In the parallel case, size and layout are both important.
   ///
@@ -65,7 +61,6 @@ public:
 
   /// Return PETSc Mat pointer
   Mat mat() const;
-
 
 protected:
   // PETSc Mat pointer

--- a/cpp/dolfin/la/PETScVector.cpp
+++ b/cpp/dolfin/la/PETScVector.cpp
@@ -6,15 +6,11 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "PETScVector.h"
-#include "SparsityPattern.h"
 #include "utils.h"
-#include <cmath>
 #include <cstddef>
 #include <cstring>
 #include <dolfin/common/IndexMap.h>
-#include <dolfin/common/MPI.h>
 #include <dolfin/common/Timer.h>
-#include <numeric>
 
 using namespace dolfin;
 using namespace dolfin::la;
@@ -79,12 +75,7 @@ PETScVector& PETScVector::operator=(PETScVector&& v)
 //-----------------------------------------------------------------------------
 std::int64_t PETScVector::size() const
 {
-  if (!_x)
-  {
-    throw std::runtime_error(
-        "PETSc vector has not been initialised. Cannot return size.");
-  }
-
+  assert(_x);
   PetscInt n = 0;
   PetscErrorCode ierr = VecGetSize(_x, &n);
   CHECK_ERROR("VecGetSize");
@@ -93,12 +84,7 @@ std::int64_t PETScVector::size() const
 //-----------------------------------------------------------------------------
 std::size_t PETScVector::local_size() const
 {
-  if (!_x)
-  {
-    throw std::runtime_error(
-        "PETSc vector has not been initialised. Cannot return local size.");
-  }
-
+  assert(_x);
   PetscInt n = 0;
   PetscErrorCode ierr = VecGetLocalSize(_x, &n);
   CHECK_ERROR("VecGetLocalSize");
@@ -107,12 +93,7 @@ std::size_t PETScVector::local_size() const
 //-----------------------------------------------------------------------------
 std::array<std::int64_t, 2> PETScVector::local_range() const
 {
-  if (!_x)
-  {
-    throw std::runtime_error(
-        "PETSc vector has not been initialised. Cannot return local range.");
-  }
-
+  assert(_x);
   PetscInt n0, n1;
   PetscErrorCode ierr = VecGetOwnershipRange(_x, &n0, &n1);
   CHECK_ERROR("VecGetOwnershipRange");
@@ -226,25 +207,14 @@ PetscReal PETScVector::norm(la::Norm norm_type) const
 //-----------------------------------------------------------------------------
 void PETScVector::set_options_prefix(std::string options_prefix)
 {
-  if (!_x)
-  {
-    throw std::runtime_error(
-        "Cannot set options prefix. PETSc Vec has not been initialized.");
-  }
-
-  // Set PETSc options prefix
+  assert(_x);
   PetscErrorCode ierr = VecSetOptionsPrefix(_x, options_prefix.c_str());
   CHECK_ERROR("VecSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string PETScVector::get_options_prefix() const
 {
-  if (!_x)
-  {
-    throw std::runtime_error(
-        "Cannot get options prefix. PETSc Vec has not been initialized.");
-  }
-
+  assert(_x);
   const char* prefix = nullptr;
   PetscErrorCode ierr = VecGetOptionsPrefix(_x, &prefix);
   CHECK_ERROR("VecGetOptionsPrefix");
@@ -253,12 +223,7 @@ std::string PETScVector::get_options_prefix() const
 //-----------------------------------------------------------------------------
 void PETScVector::set_from_options()
 {
-  if (!_x)
-  {
-    throw std::runtime_error(
-        "Cannot call VecSetFromOptions. PETSc Vec has not been initialized.");
-  }
-
+  assert(_x);
   PetscErrorCode ierr = VecSetFromOptions(_x);
   CHECK_ERROR("VecSetFromOptions");
 }

--- a/cpp/dolfin/la/PETScVector.cpp
+++ b/cpp/dolfin/la/PETScVector.cpp
@@ -120,47 +120,6 @@ std::array<std::int64_t, 2> PETScVector::local_range() const
   return {{n0, n1}};
 }
 //-----------------------------------------------------------------------------
-void PETScVector::get_local(PetscScalar* block, std::size_t m,
-                            const PetscInt* rows) const
-{
-  if (m == 0)
-    return;
-
-  assert(_x);
-  PetscErrorCode ierr;
-
-  // Get ghost vector
-  Vec xg = nullptr;
-  ierr = VecGhostGetLocalForm(_x, &xg);
-  CHECK_ERROR("VecGhostGetLocalForm");
-
-  // Use array access if no ghost points, otherwise use VecGetValues on
-  // local ghosted form of vector
-  if (!xg)
-  {
-    // Get pointer to PETSc vector data
-    const PetscScalar* data;
-    ierr = VecGetArrayRead(_x, &data);
-    CHECK_ERROR("VecGetArrayRead");
-
-    for (std::size_t i = 0; i < m; ++i)
-      block[i] = data[rows[i]];
-
-    // Restore array
-    ierr = VecRestoreArrayRead(_x, &data);
-    CHECK_ERROR("VecRestoreArrayRead");
-  }
-  else
-  {
-    assert(xg);
-    ierr = VecGetValues(xg, m, rows, block);
-    CHECK_ERROR("VecGetValues");
-
-    ierr = VecGhostRestoreLocalForm(_x, &xg);
-    CHECK_ERROR("VecGhostRestoreLocalForm");
-  }
-}
-//-----------------------------------------------------------------------------
 void PETScVector::add_local(const PetscScalar* block, std::size_t m,
                             const PetscInt* rows)
 {

--- a/cpp/dolfin/la/PETScVector.cpp
+++ b/cpp/dolfin/la/PETScVector.cpp
@@ -161,14 +161,6 @@ void PETScVector::get_local(PetscScalar* block, std::size_t m,
   }
 }
 //-----------------------------------------------------------------------------
-void PETScVector::set(const PetscScalar* block, std::size_t m,
-                      const PetscInt* rows)
-{
-  assert(_x);
-  PetscErrorCode ierr = VecSetValues(_x, m, rows, block, INSERT_VALUES);
-  CHECK_ERROR("VecSetValues");
-}
-//-----------------------------------------------------------------------------
 void PETScVector::add_local(const PetscScalar* block, std::size_t m,
                             const PetscInt* rows)
 {

--- a/cpp/dolfin/la/PETScVector.h
+++ b/cpp/dolfin/la/PETScVector.h
@@ -91,9 +91,6 @@ public:
   /// Return MPI communicator
   MPI_Comm mpi_comm() const;
 
-  /// Get block of values using local indices
-  void get_local(PetscScalar* block, std::size_t m, const PetscInt* rows) const;
-
   /// Add block of values using local indices
   void add_local(const PetscScalar* block, std::size_t m, const PetscInt* rows);
 

--- a/cpp/dolfin/la/PETScVector.h
+++ b/cpp/dolfin/la/PETScVector.h
@@ -13,7 +13,6 @@
 #include <cstdint>
 #include <petscsys.h>
 #include <petscvec.h>
-#include <vector>
 
 namespace dolfin
 {
@@ -94,9 +93,6 @@ public:
 
   /// Get block of values using local indices
   void get_local(PetscScalar* block, std::size_t m, const PetscInt* rows) const;
-
-  /// Set block of values using global indices
-  void set(const PetscScalar* block, std::size_t m, const PetscInt* rows);
 
   /// Add block of values using local indices
   void add_local(const PetscScalar* block, std::size_t m, const PetscInt* rows);


### PR DESCRIPTION
Replaced with access to underlying `Vec` array, held by `EIgen::Map.