### PR TITLE
Rename fem::impl assemble methods to assemble_scalar and assemble_vector respectively, for consistency with assemble_matrix

### DIFF
--- a/cpp/dolfin/fem/assemble_scalar_impl.cpp
+++ b/cpp/dolfin/fem/assemble_scalar_impl.cpp
@@ -20,7 +20,7 @@ using namespace dolfin;
 using namespace dolfin::fem;
 
 //-----------------------------------------------------------------------------
-PetscScalar dolfin::fem::impl::assemble(const dolfin::fem::Form& M)
+PetscScalar dolfin::fem::impl::assemble_scalar(const dolfin::fem::Form& M)
 {
   assert(M.mesh());
   const mesh::Mesh& mesh = *M.mesh();

--- a/cpp/dolfin/fem/assemble_scalar_impl.h
+++ b/cpp/dolfin/fem/assemble_scalar_impl.h
@@ -35,7 +35,7 @@ namespace impl
 {
 
 /// Assemble functional into an scalar
-PetscScalar assemble(const fem::Form& M);
+PetscScalar assemble_scalar(const fem::Form& M);
 
 /// Assemble functional over cells
 PetscScalar

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -258,7 +258,7 @@ void _lift_bc_exterior_facets(
 } // namespace
 
 //-----------------------------------------------------------------------------
-void fem::impl::assemble(
+void fem::impl::assemble_vector(
     Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b, const Form& L)
 {
   assert(L.mesh());

--- a/cpp/dolfin/fem/assemble_vector_impl.h
+++ b/cpp/dolfin/fem/assemble_vector_impl.h
@@ -35,8 +35,8 @@ namespace impl
 {
 
 /// Assemble linear form into an Eigen vector
-void assemble(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
-              const Form& L);
+void assemble_vector(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
+                     const Form& L);
 
 /// Execute kernel over cells and accumulate result in vector
 void assemble_cells(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,

--- a/cpp/dolfin/fem/assembler.cpp
+++ b/cpp/dolfin/fem/assembler.cpp
@@ -116,7 +116,7 @@ void _assemble_vector_nest(
     // Assemble
     la::VecWrapper _b(b_sub);
     _b.x.setZero();
-    fem::impl::assemble(_b.x, *L[i]);
+    fem::impl::assemble_vector(_b.x, *L[i]);
 
     // FIXME: sort out x0 \ne nullptr for nested case
     // Apply lifting
@@ -199,7 +199,7 @@ void _assemble_vector_block(
                                                                    + map_size1);
 
     // Assemble and modify for bcs (lifting)
-    fem::impl::assemble(b_vec[i], *L[i]);
+    fem::impl::assemble_vector(b_vec[i], *L[i]);
     fem::impl::apply_lifting(b_vec[i], a[i], bcs1[i], {}, scale);
   }
 
@@ -271,13 +271,13 @@ void _assemble_vector_block(
 //-----------------------------------------------------------------------------
 PetscScalar fem::assemble_scalar(const Form& M)
 {
-  return fem::impl::assemble(M);
+  return fem::impl::assemble_scalar(M);
 }
 //-----------------------------------------------------------------------------
 void fem::assemble_vector(Vec b, const Form& L)
 {
   la::VecWrapper _b(b);
-  fem::impl::assemble(_b.x, L);
+  fem::impl::assemble_vector(_b.x, L);
 }
 //-----------------------------------------------------------------------------
 void fem::assemble_vector(


### PR DESCRIPTION
Very minor change, which could make reading the fem::impl a bit easier