### PR TITLE
Add back an overloaded SparsityPatternBuilder::build which takes a SparsityPattern as first input argument

### DIFF
--- a/cpp/dolfin/fem/SparsityPatternBuilder.cpp
+++ b/cpp/dolfin/fem/SparsityPatternBuilder.cpp
@@ -32,13 +32,23 @@ la::SparsityPattern SparsityPatternBuilder::build(
   std::array<std::shared_ptr<const common::IndexMap>, 2> index_maps
       = {{dofmaps[0]->index_map(), dofmaps[1]->index_map()}};
 
-
-  const std::size_t D = mesh.topology().dim();
-
   // FIXME: Should check that index maps are matching
 
   // Create empty sparsity pattern
   la::SparsityPattern pattern(comm, index_maps);
+  
+  // Build sparsity pattern and return
+  SparsityPatternBuilder::build(pattern, mesh, dofmaps,
+                                cells, interior_facets, exterior_facets);
+  return pattern;
+}
+//-----------------------------------------------------------------------------
+void SparsityPatternBuilder::build(
+    la::SparsityPattern& pattern, const mesh::Mesh& mesh,
+    const std::array<const fem::GenericDofMap*, 2> dofmaps, bool cells,
+    bool interior_facets, bool exterior_facets)
+{
+  const std::size_t D = mesh.topology().dim();
 
   // Array to store macro-dofs, if required (for interior facets)
   std::array<Eigen::Array<PetscInt, Eigen::Dynamic, 1>, 2> macro_dofs;
@@ -121,7 +131,5 @@ la::SparsityPattern SparsityPatternBuilder::build(
       }
     }
   }
-
-  return pattern;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/fem/SparsityPatternBuilder.h
+++ b/cpp/dolfin/fem/SparsityPatternBuilder.h
@@ -27,10 +27,16 @@ class GenericDofMap;
 class SparsityPatternBuilder
 {
 public:
-  // FIXME: Simplify
   /// Build sparsity pattern for assembly of given bilinear form
   static la::SparsityPattern
   build(MPI_Comm comm, const mesh::Mesh& mesh,
+        const std::array<const fem::GenericDofMap*, 2> dofmaps, bool cells,
+        bool interior_facets, bool exterior_facets);
+        
+  // FIXME: Simplify
+  /// Build sparsity pattern for assembly of given bilinear form
+  static void
+  build(la::SparsityPattern& pattern, const mesh::Mesh& mesh,
         const std::array<const fem::GenericDofMap*, 2> dofmaps, bool cells,
         bool interior_facets, bool exterior_facets);
 };


### PR DESCRIPTION
Signature of SparsityPatternBuilder::build was changed a few PRs ago. With this PR, I add back the old signature. I'll happily provide a link to a concrete example in which I need this.