### PR TITLE
Wrap dolfin.generation module

### DIFF
--- a/python/demo/elasticity/demo_elasticity.py
+++ b/python/demo/elasticity/demo_elasticity.py
@@ -55,7 +55,7 @@ def build_nullspace(V):
 # XDMFFile(MPI.comm_world, "../pulley.xdmf").read(mesh)
 
 # mesh = UnitCubeMesh(2, 2, 2)
-mesh = BoxMesh.create(
+mesh = BoxMesh(
     MPI.comm_world, [Point(0, 0, 0)._cpp_object,
                      Point(2, 1, 1)._cpp_object], [12, 12, 12],
     CellType.Type.tetrahedron, dolfin.cpp.mesh.GhostMode.none)

--- a/python/demo/poisson/demo_poisson.py
+++ b/python/demo/poisson/demo_poisson.py
@@ -95,7 +95,7 @@ from ufl import ds, dx, grad, inner
 # divided into two triangles, we do as follows ::
 
 # Create mesh and define function space
-mesh = RectangleMesh.create(
+mesh = RectangleMesh(
     MPI.comm_world,
     [Point(0, 0)._cpp_object, Point(1, 1)._cpp_object], [32, 32],
     CellType.Type.triangle, dolfin.cpp.mesh.GhostMode.none)

--- a/python/dolfin/__init__.py
+++ b/python/dolfin/__init__.py
@@ -40,8 +40,7 @@ import dolfin.MPI
 
 from dolfin.fem import DofMap
 from dolfin.geometry import BoundingBoxTree, Point
-
-from .cpp.generation import IntervalMesh, BoxMesh, RectangleMesh
+from dolfin.generation import IntervalMesh, BoxMesh, RectangleMesh
 
 from .cpp.mesh import (Mesh, MeshTopology, MeshGeometry, CellType, Cell, Facet,
                        Face, Edge, Vertex, MeshEntity, Cells, Facets, Faces,

--- a/python/dolfin/generation.py
+++ b/python/dolfin/generation.py
@@ -1,23 +1,84 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2017 Chris N. Richardson
+# Copyright (C) 2017-2019 Chris N. Richardson and Michal Habera
 #
 # This file is part of DOLFIN (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Simple mesh generation module"""
 
-from dolfin import cpp, fem
+import typing
 
-__all__ = ["UnitIntervalMesh", "UnitSquareMesh", "UnitCubeMesh"]
+from dolfin import cpp, fem, geometry
 
-# FIXME: Remove, and use 'create' method?
+__all__ = ["IntervalMesh", "UnitIntervalMesh",
+           "RectangleMesh", "UnitSquareMesh",
+           "BoxMesh", "UnitCubeMesh"]
+
+
+def IntervalMesh(comm,
+                 nx: int,
+                 points: list,
+                 ghost_mode=cpp.mesh.GhostMode.none):
+    """Create an interval mesh
+
+    Parameters
+    ----------
+    comm
+        MPI communicator
+    nx
+        Number of cells
+    point
+        Coordinates of the end points
+    ghost_mode
+
+    Note
+    ----
+    Coordinate mapping is not attached
+    """
+    return cpp.generation.IntervalMesh.create(comm, nx, points, ghost_mode)
 
 
 def UnitIntervalMesh(comm, nx, ghost_mode=cpp.mesh.GhostMode.none):
-    """Create a mesh on the unit interval"""
-    mesh = cpp.generation.IntervalMesh.create(comm, nx, [0.0, 1.0], ghost_mode)
+    """Create a mesh on the unit interval with coordinate mapping attached
+
+    Parameters
+    ----------
+    comm
+        MPI communicator
+    nx
+        Number of cells
+
+    """
+    mesh = IntervalMesh(comm, nx, [0.0, 1.0], ghost_mode)
     mesh.geometry.coord_mapping = fem.create_coordinate_map(mesh)
     return mesh
+
+
+def RectangleMesh(comm,
+                  points: typing.List[geometry.Point],
+                  n: list,
+                  cell_type=cpp.mesh.CellType.Type.triangle,
+                  ghost_mode=cpp.mesh.GhostMode.none,
+                  diagonal: str = "right"):
+    """Create rectangle mesh
+
+    Parameters
+    ----------
+    comm
+        MPI communicator
+    points
+        List of `Points` representing vertices
+    n
+        List of number of cells in each direction
+    diagonal
+        Direction of diagonal
+
+    Note
+    ----
+    Coordinate mapping is not attached
+
+    """
+    return cpp.generation.RectangleMesh.create(comm, points, n, cell_type, ghost_mode, diagonal)
 
 
 def UnitSquareMesh(comm,
@@ -26,14 +87,49 @@ def UnitSquareMesh(comm,
                    cell_type=cpp.mesh.CellType.Type.triangle,
                    ghost_mode=cpp.mesh.GhostMode.none,
                    diagonal="right"):
-    """Create a mesh of a unit square"""
+    """Create a mesh of a unit square with coordinate mapping attached
+
+    Parameters
+    ----------
+    comm
+        MPI communicator
+    nx
+        Number of cells in "x" direction
+    ny
+        Number of cells in "y" direction
+    diagonal
+        Direction of diagonal
+
+    """
     from dolfin.geometry import Point
-    mesh = cpp.generation.RectangleMesh.create(
-        comm, [Point(0.0, 0.0)._cpp_object,
-               Point(1.0, 1.0)._cpp_object], [nx, ny], cell_type, ghost_mode,
-        diagonal)
+    mesh = RectangleMesh(comm, [Point(0.0, 0.0)._cpp_object,
+                                Point(1.0, 1.0)._cpp_object],
+                         [nx, ny], cell_type, ghost_mode, diagonal)
     mesh.geometry.coord_mapping = fem.create_coordinate_map(mesh)
     return mesh
+
+
+def BoxMesh(comm,
+            points: typing.List[geometry.Point],
+            n: list,
+            cell_type=cpp.mesh.CellType.Type.tetrahedron,
+            ghost_mode=cpp.mesh.GhostMode.none):
+    """Create box mesh
+
+    Parameters
+    ----------
+    comm
+        MPI communicator
+    points
+        List of points representing vertices
+    n
+        List of cells in each direction
+
+    Note
+    ----
+    Coordinate mapping is not attached
+    """
+    return cpp.generation.BoxMesh.create(comm, points, n, cell_type, ghost_mode)
 
 
 def UnitCubeMesh(comm,
@@ -42,12 +138,23 @@ def UnitCubeMesh(comm,
                  nz,
                  cell_type=cpp.mesh.CellType.Type.tetrahedron,
                  ghost_mode=cpp.mesh.GhostMode.none):
-    """Create a mesh of a unit cube"""
+    """Create a mesh of a unit cube with coordinate mapping attached
+
+    Parameters
+    ----------
+    comm
+        MPI communicator
+    nx
+        Number of cells in "x" direction
+    ny
+        Number of cells in "y" direction
+    nz
+        Number of cells in "z" direction
+
+    """
     from dolfin.geometry import Point
-    mesh = cpp.generation.BoxMesh.create(
-        comm,
-        [Point(0.0, 0.0, 0.0)._cpp_object,
-         Point(1.0, 1.0, 1.0)._cpp_object], [nx, ny, nz], cell_type,
-        ghost_mode)
+    mesh = BoxMesh(comm, [Point(0.0, 0.0, 0.0)._cpp_object,
+                          Point(1.0, 1.0, 1.0)._cpp_object],
+                   [nx, ny, nz], cell_type, ghost_mode)
     mesh.geometry.coord_mapping = fem.create_coordinate_map(mesh)
     return mesh

--- a/python/test/unit/la/test_nullspace.py
+++ b/python/test/unit/la/test_nullspace.py
@@ -11,7 +11,7 @@ import pytest
 import ufl
 from dolfin import (MPI, Point, TestFunction, TrialFunction, UnitCubeMesh,
                     UnitSquareMesh, VectorFunctionSpace, cpp, fem, la)
-from dolfin.cpp.generation import BoxMesh
+from dolfin.generation import BoxMesh
 from dolfin.cpp.mesh import CellType, GhostMode
 from dolfin.fem import assemble_matrix
 from ufl import dx, grad, inner

--- a/python/test/unit/la/test_nullspace.py
+++ b/python/test/unit/la/test_nullspace.py
@@ -90,7 +90,7 @@ def test_nullspace_orthogonal(mesh, degree):
 
 @pytest.mark.parametrize("mesh", [
     UnitSquareMesh(MPI.comm_world, 12, 13),
-    BoxMesh.create(
+    BoxMesh(
         MPI.comm_world,
         [Point(0.8, -0.2, 1.2)._cpp_object,
          Point(3.0, 11.0, -5.0)._cpp_object], [12, 18, 25],

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -32,7 +32,7 @@ def mesh1d():
 @fixture
 def mesh2d():
     # Create 2D mesh with one equilateral triangle
-    mesh2d = RectangleMesh.create(
+    mesh2d = RectangleMesh(
         MPI.comm_world, [Point(0, 0)._cpp_object,
                          Point(1, 1)._cpp_object], [1, 1],
         CellType.Type.triangle, cpp.mesh.GhostMode.none, 'left')
@@ -79,7 +79,7 @@ def square():
 
 @fixture
 def rectangle():
-    return RectangleMesh.create(
+    return RectangleMesh(
         MPI.comm_world, [Point(0, 0)._cpp_object,
                          Point(2, 2)._cpp_object], [5, 5],
         CellType.Type.triangle, cpp.mesh.GhostMode.none)
@@ -92,7 +92,7 @@ def cube():
 
 @fixture
 def box():
-    return BoxMesh.create(
+    return BoxMesh(
         MPI.comm_world,
         [Point(0, 0, 0)._cpp_object,
          Point(2, 2, 2)._cpp_object], [2, 2, 5], CellType.Type.tetrahedron,

--- a/python/test/unit/mesh/test_mesh_quality.py
+++ b/python/test/unit/mesh/test_mesh_quality.py
@@ -66,7 +66,7 @@ def test_radius_ratio_min_radius_ratio_max():
     x[4] = mesh1d.geometry.points[3]
 
     # Create 2D mesh with one equilateral triangle
-    mesh2d = RectangleMesh.create(
+    mesh2d = RectangleMesh(
         MPI.comm_world, [Point(0, 0)._cpp_object,
                          Point(1, 1)._cpp_object], [1, 1],
         CellType.Type.triangle, cpp.mesh.GhostMode.none, 'left')

--- a/python/test/unit/ufl-jit-assemble-chain/test_form_operations.py
+++ b/python/test/unit/ufl-jit-assemble-chain/test_form_operations.py
@@ -16,7 +16,7 @@ def test_lhs_rhs_simple():
     """Test taking lhs/rhs of DOLFIN specific forms (constants
     without cell). """
 
-    mesh = RectangleMesh.create(MPI.comm_world, [Point(0, 0), Point(2, 1)], [3, 5], CellType.Type.triangle)
+    mesh = RectangleMesh(MPI.comm_world, [Point(0, 0), Point(2, 1)], [3, 5], CellType.Type.triangle)
     V = FunctionSpace(mesh, "CG", 1)
     f = 2.0
     g = 3.0


### PR DESCRIPTION
Another bunch of python wrappers. Calling `dolfin.cpp.generation` should be avoided in user code from now on.