### PR TITLE
Use reference to pass ufc_form

### DIFF
--- a/cpp/demo/hyperelasticity/hyperelasticity.ufl
+++ b/cpp/demo/hyperelasticity/hyperelasticity.ufl
@@ -10,7 +10,7 @@
 # trial and test functions on this space::
 
 # Function spaces
-element = VectorElement("Lagrange", tetrahedron, 2)
+element = VectorElement("Lagrange", tetrahedron, 1)
 
 # Trial and test functions
 du = TrialFunction(element)     # Incremental displacement

--- a/cpp/dolfin/fem/Form.cpp
+++ b/cpp/dolfin/fem/Form.cpp
@@ -24,21 +24,20 @@ using namespace dolfin;
 using namespace dolfin::fem;
 
 //-----------------------------------------------------------------------------
-Form::Form(std::shared_ptr<const ufc_form> ufc_form,
+Form::Form(const ufc_form& ufc_form,
            const std::vector<std::shared_ptr<const function::FunctionSpace>>
                function_spaces)
-    : _integrals(*ufc_form), _coefficients(*ufc_form),
+    : _integrals(ufc_form), _coefficients(ufc_form),
       _function_spaces(function_spaces)
 {
-  assert(ufc_form);
-  assert(ufc_form->rank == (int)function_spaces.size());
+  assert(ufc_form.rank == (int)function_spaces.size());
 
   // Check argument function spaces
   for (std::size_t i = 0; i < function_spaces.size(); ++i)
   {
     assert(function_spaces[i]->element());
     std::unique_ptr<ufc_finite_element, decltype(free)*> ufc_element(
-        ufc_form->create_finite_element(i), free);
+        ufc_form.create_finite_element(i), free);
 
     if (std::string(ufc_element->signature)
         != function_spaces[i]->element()->signature())
@@ -67,11 +66,11 @@ Form::Form(std::shared_ptr<const ufc_form> ufc_form,
   // Create CoordinateMapping
   _coord_mapping = std::make_shared<fem::CoordinateMapping>(
       std::shared_ptr<const ufc_coordinate_mapping>(
-          ufc_form->create_coordinate_mapping()));
+          ufc_form.create_coordinate_mapping()));
 
   // Set coefficient maps
-  _coefficient_index_map = ufc_form->coefficient_number_map;
-  _coefficient_name_map = ufc_form->coefficient_name_map;
+  _coefficient_index_map = ufc_form.coefficient_number_map;
+  _coefficient_name_map = ufc_form.coefficient_name_map;
 }
 //-----------------------------------------------------------------------------
 Form::Form(const std::vector<std::shared_ptr<const function::FunctionSpace>>

--- a/cpp/dolfin/fem/Form.h
+++ b/cpp/dolfin/fem/Form.h
@@ -77,7 +77,7 @@ public:
   ///         The UFC form.
   /// @param[in] function_spaces (std::vector<_function::FunctionSpace_>)
   ///         Vector of function spaces.
-  Form(std::shared_ptr<const ufc_form> ufc_form,
+  Form(const ufc_form& ufc_form,
        const std::vector<std::shared_ptr<const function::FunctionSpace>>
            function_spaces);
 

--- a/python/src/fem.cpp
+++ b/python/src/fem.cpp
@@ -292,7 +292,7 @@ void fem(py::module& m)
   // dolfin::fem::Form
   py::class_<dolfin::fem::Form, std::shared_ptr<dolfin::fem::Form>>(
       m, "Form", "Variational form object")
-      .def(py::init<std::shared_ptr<const ufc_form>,
+      .def(py::init<const ufc_form&,
                     std::vector<std::shared_ptr<
                         const dolfin::function::FunctionSpace>>>())
       .def(py::init<std::vector<


### PR DESCRIPTION
Stop using `shared_ptr` where it is no longer needed for ufc objects passed into dolfin.