### PR TITLE
Removes ufc_coordinate_mapping from dolfin

### DIFF
--- a/cpp/dolfin/fem/CoordinateMapping.h
+++ b/cpp/dolfin/fem/CoordinateMapping.h
@@ -28,11 +28,11 @@ public:
   /// shared)
   /// @param cm (ufc::coordinate_mapping)
   ///  UFC coordinate mapping
-  CoordinateMapping(std::shared_ptr<const ufc_coordinate_mapping> cm)
-      : _tdim(cm->topological_dimension), _gdim(cm->geometric_dimension),
-        _signature(cm->signature),
-        _compute_physical_coordinates(cm->compute_physical_coordinates),
-        _compute_reference_geometry(cm->compute_reference_geometry)
+  CoordinateMapping(const ufc_coordinate_mapping& cm)
+      : _tdim(cm.topological_dimension), _gdim(cm.geometric_dimension),
+        _signature(cm.signature),
+        _compute_physical_coordinates(cm.compute_physical_coordinates),
+        _compute_reference_geometry(cm.compute_reference_geometry)
   {
     static const std::map<ufc_shape, CellType> ufc_to_cell
         = {{vertex, CellType::point},
@@ -41,7 +41,7 @@ public:
            {tetrahedron, CellType::tetrahedron},
            {quadrilateral, CellType::quadrilateral},
            {hexahedron, CellType::hexahedron}};
-    const auto it = ufc_to_cell.find(cm->cell_shape);
+    const auto it = ufc_to_cell.find(cm.cell_shape);
     assert(it != ufc_to_cell.end());
 
     _cell = it->second;

--- a/cpp/dolfin/fem/Form.cpp
+++ b/cpp/dolfin/fem/Form.cpp
@@ -64,9 +64,9 @@ Form::Form(const ufc_form& ufc_form,
     _integrals.set_default_domains(*_mesh);
 
   // Create CoordinateMapping
-  _coord_mapping = std::make_shared<fem::CoordinateMapping>(
-      std::shared_ptr<const ufc_coordinate_mapping>(
-          ufc_form.create_coordinate_mapping()));
+  ufc_coordinate_mapping* cmap = ufc_form.create_coordinate_mapping();
+  _coord_mapping = std::make_shared<fem::CoordinateMapping>(*cmap);
+  std::free(cmap);
 
   // Set coefficient maps
   _coefficient_index_map = ufc_form.coefficient_number_map;

--- a/python/src/fem.cpp
+++ b/python/src/fem.cpp
@@ -188,7 +188,7 @@ void fem(py::module& m)
   py::class_<dolfin::fem::CoordinateMapping,
              std::shared_ptr<dolfin::fem::CoordinateMapping>>(
       m, "CoordinateMapping", "Coordinate mapping object")
-      .def(py::init<std::shared_ptr<const ufc_coordinate_mapping>>());
+      .def(py::init<const ufc_coordinate_mapping&>());
 
   // dolfin::fem::SparsityPatternBuilder
   // py::class_<dolfin::fem::SparsityPatternBuilder>(m,


### PR DESCRIPTION
Extracts essential information (including two functions) from `ufc_coordinate_mapping` at the construction time of dolfin's `CoordinateMapping` class. 

* Potential for user mappings in the future without using ffc/ufc.