### PR TITLE
Remove holding of ufc_finite_element struct

### DIFF
--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -172,10 +172,11 @@ int main(int argc, char* argv[])
 
   ufc_function_space* space = hyperelasticity_functionspace_create();
   ufc_dofmap* ufc_map = space->create_dofmap();
+  std::shared_ptr<ufc_finite_element> ufc_element(space->create_element(),
+                                                  free);
+
   auto V = std::make_shared<function::FunctionSpace>(
-      mesh,
-      std::make_shared<fem::FiniteElement>(
-          std::shared_ptr<ufc_finite_element>(space->create_element(), free)),
+      mesh, std::make_shared<fem::FiniteElement>(*ufc_element),
       std::make_shared<fem::DofMap>(*ufc_map, *mesh));
   std::free(ufc_map);
   std::free(space);

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -179,10 +179,10 @@ int main(int argc, char* argv[])
 
   ufc_function_space* space = poisson_functionspace_create();
   ufc_dofmap* ufc_map = space->create_dofmap();
+  std::shared_ptr<ufc_finite_element> ufc_element(space->create_element(),
+                                                  free);
   auto V = std::make_shared<function::FunctionSpace>(
-      mesh,
-      std::make_shared<fem::FiniteElement>(
-          std::shared_ptr<ufc_finite_element>(space->create_element(), free)),
+      mesh, std::make_shared<fem::FiniteElement>(*ufc_element),
       std::make_shared<fem::DofMap>(*ufc_map, *mesh));
   std::free(ufc_map);
   std::free(space);

--- a/cpp/dolfin/fem/FiniteElement.cpp
+++ b/cpp/dolfin/fem/FiniteElement.cpp
@@ -164,13 +164,13 @@ std::unique_ptr<FiniteElement>
 FiniteElement::create_sub_element(std::size_t i) const
 {
   std::shared_ptr<ufc_finite_element> ufc_element(_create_sub_element(i), free);
-  return std::make_unique<FiniteElement>(ufc_element);
+  return std::make_unique<FiniteElement>(*ufc_element);
 }
 //-----------------------------------------------------------------------------
 std::unique_ptr<FiniteElement> FiniteElement::create() const
 {
   std::shared_ptr<ufc_finite_element> ufc_element(_create(), free);
-  return std::make_unique<FiniteElement>(ufc_element);
+  return std::make_unique<FiniteElement>(*ufc_element);
 }
 //-----------------------------------------------------------------------------
 std::shared_ptr<FiniteElement> FiniteElement::extract_sub_element(

--- a/cpp/dolfin/fem/FiniteElement.cpp
+++ b/cpp/dolfin/fem/FiniteElement.cpp
@@ -33,7 +33,10 @@ FiniteElement::FiniteElement(const ufc_finite_element& element)
 {
   // Store dof coordinates on reference element
   _refX.resize(this->space_dimension(), this->topological_dimension());
-  int ret = _tabulate_reference_dof_coordinates(_refX.data());
+  // assert(_tabulate_reference_dof_coordinates);
+  // int ret = _tabulate_reference_dof_coordinates(_refX.data());
+  assert(element.tabulate_reference_dof_coordinates);
+  int ret = element.tabulate_reference_dof_coordinates(_refX.data());
   if (ret == -1)
   {
     throw std::runtime_error(
@@ -45,14 +48,19 @@ FiniteElement::FiniteElement(const ufc_finite_element& element)
   {
   case interval:
     _cell_shape = CellType::interval;
+    break;
   case triangle:
     _cell_shape = CellType::triangle;
+    break;
   case quadrilateral:
     _cell_shape = CellType::quadrilateral;
+    break;
   case tetrahedron:
     _cell_shape = CellType::tetrahedron;
+    break;
   case hexahedron:
     _cell_shape = CellType::hexahedron;
+    break;
   default:
     throw std::runtime_error("Unknown UFC cell type");
   }
@@ -77,6 +85,7 @@ std::size_t FiniteElement::value_rank() const { return _value_rank; }
 //-----------------------------------------------------------------------------
 std::size_t FiniteElement::value_dimension(std::size_t i) const
 {
+  assert(_value_dimension);
   return _value_dimension(i);
 }
 //-----------------------------------------------------------------------------
@@ -89,6 +98,7 @@ void FiniteElement::evaluate_reference_basis(
     const Eigen::Ref<const EigenRowArrayXXd> X) const
 {
   std::size_t num_points = X.rows();
+  assert( _evaluate_reference_basis);
   int ret = _evaluate_reference_basis(reference_values.data(), num_points,
                                       X.data());
   if (ret == -1)
@@ -107,6 +117,7 @@ void FiniteElement::transform_reference_basis(
     const Eigen::Tensor<double, 3, Eigen::RowMajor>& K) const
 {
   std::size_t num_points = X.rows();
+  assert(_transform_reference_basis_derivatives);
   int ret = _transform_reference_basis_derivatives(
       values.data(), 0, num_points, reference_values.data(), X.data(), J.data(),
       detJ.data(), K.data(), 1);
@@ -126,6 +137,7 @@ void FiniteElement::transform_reference_basis_derivatives(
     const Eigen::Tensor<double, 3, Eigen::RowMajor>& K) const
 {
   std::size_t num_points = X.rows();
+  assert(_transform_reference_basis_derivatives);
   int ret = _transform_reference_basis_derivatives(
       values.data(), order, num_points, reference_values.data(), X.data(),
       J.data(), detJ.data(), K.data(), 1);
@@ -148,6 +160,7 @@ void FiniteElement::transform_values(
         physical_values,
     const Eigen::Ref<const EigenRowArrayXXd>& coordinate_dofs) const
 {
+  assert(_transform_values);
   _transform_values(reference_values, physical_values.data(),
                     coordinate_dofs.data(), 1, nullptr);
 }
@@ -163,12 +176,14 @@ std::size_t FiniteElement::hash() const { return _hash; }
 std::unique_ptr<FiniteElement>
 FiniteElement::create_sub_element(std::size_t i) const
 {
+  assert(_create_sub_element);
   std::shared_ptr<ufc_finite_element> ufc_element(_create_sub_element(i), free);
   return std::make_unique<FiniteElement>(*ufc_element);
 }
 //-----------------------------------------------------------------------------
 std::unique_ptr<FiniteElement> FiniteElement::create() const
 {
+  assert(_create);
   std::shared_ptr<ufc_finite_element> ufc_element(_create(), free);
   return std::make_unique<FiniteElement>(*ufc_element);
 }

--- a/cpp/dolfin/fem/FiniteElement.h
+++ b/cpp/dolfin/fem/FiniteElement.h
@@ -135,6 +135,13 @@ public:
   extract_sub_element(const std::vector<std::size_t>& component) const;
 
 private:
+  std::string _signature, _family;
+
+  CellType _cell_shape;
+
+  int _tdim, _space_dim, _value_size, _reference_value_size, _value_rank,
+      _degree, _num_sub_elements;
+
   // UFC finite element
   std::shared_ptr<const ufc_finite_element> _ufc_element;
 

--- a/cpp/dolfin/fem/FiniteElement.h
+++ b/cpp/dolfin/fem/FiniteElement.h
@@ -8,11 +8,13 @@
 
 #include "ReferenceCellTopology.h"
 #include <dolfin/common/types.h>
+#include <functional>
 #include <memory>
 #include <petscsys.h>
 #include <unsupported/Eigen/CXX11/Tensor>
 #include <vector>
 
+struct ufc_coordinate_mapping;
 struct ufc_finite_element;
 
 namespace dolfin
@@ -29,7 +31,7 @@ public:
   /// Create finite element from UFC finite element (data may be shared)
   /// @param element (ufc::finite_element)
   ///  UFC finite element
-  FiniteElement(std::shared_ptr<const ufc_finite_element> element);
+  FiniteElement(const ufc_finite_element& element);
 
   /// Destructor
   virtual ~FiniteElement() = default;
@@ -142,9 +144,6 @@ private:
   int _tdim, _space_dim, _value_size, _reference_value_size, _value_rank,
       _degree, _num_sub_elements;
 
-  // UFC finite element
-  std::shared_ptr<const ufc_finite_element> _ufc_element;
-
   // Dof coordinates on the reference element
   Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> _refX;
 
@@ -155,6 +154,21 @@ private:
 
   // Simple hash of the signature string
   std::size_t _hash;
+
+  std::function<int(int)> _value_dimension;
+  std::function<int(double*, int, const double*)> _evaluate_reference_basis;
+  std::function<int(double*, int, int, const double*)>
+      _evaluate_reference_basis_derivatives;
+  std::function<int(double*, int, int, const double*, const double*,
+                    const double*, const double*, const double*, int)>
+      _transform_reference_basis_derivatives;
+  std::function<int(ufc_scalar_t*, const ufc_scalar_t*, const double*, int,
+                    const ufc_coordinate_mapping*)>
+      _transform_values;
+  std::function<int(double*)> _tabulate_reference_dof_coordinates;
+
+  std::function<ufc_finite_element*(int i)> _create_sub_element;
+  std::function<ufc_finite_element*()> _create;
 };
 } // namespace fem
 } // namespace dolfin

--- a/cpp/dolfin/fem/FiniteElement.h
+++ b/cpp/dolfin/fem/FiniteElement.h
@@ -165,7 +165,6 @@ private:
   std::function<int(ufc_scalar_t*, const ufc_scalar_t*, const double*, int,
                     const ufc_coordinate_mapping*)>
       _transform_values;
-  std::function<int(double*)> _tabulate_reference_dof_coordinates;
 
   std::function<ufc_finite_element*(int i)> _create_sub_element;
   std::function<ufc_finite_element*()> _create;

--- a/python/src/fem.cpp
+++ b/python/src/fem.cpp
@@ -133,7 +133,7 @@ void fem(py::module& m)
   py::class_<dolfin::fem::FiniteElement,
              std::shared_ptr<dolfin::fem::FiniteElement>>(
       m, "FiniteElement", "Finite element object")
-      .def(py::init<const ufc_finite_elemen>&>())
+      .def(py::init<const ufc_finite_element&>())
       .def("num_sub_elements", &dolfin::fem::FiniteElement::num_sub_elements)
       .def("dof_reference_coordinates",
            &dolfin::fem::FiniteElement::dof_reference_coordinates)

--- a/python/src/fem.cpp
+++ b/python/src/fem.cpp
@@ -133,7 +133,7 @@ void fem(py::module& m)
   py::class_<dolfin::fem::FiniteElement,
              std::shared_ptr<dolfin::fem::FiniteElement>>(
       m, "FiniteElement", "Finite element object")
-      .def(py::init<std::shared_ptr<const ufc_finite_element>>())
+      .def(py::init<const ufc_finite_elemen>&>())
       .def("num_sub_elements", &dolfin::fem::FiniteElement::num_sub_elements)
       .def("dof_reference_coordinates",
            &dolfin::fem::FiniteElement::dof_reference_coordinates)


### PR DESCRIPTION
Hangs onto the function pointers instead. Part of move to make ufc optional.