### PR TITLE
Add Jupyterlab to Docker image collection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,10 +164,10 @@ jobs:
 
   build-and-push-docker-images:
     docker:
-      - image: docker:18.05.0-git
+      - image: docker:18.09-git
     steps:
       - setup_remote_docker:
-          version: 18.05.0-ce
+          version: 18.09.3
       - checkout
       - run:
           name: Login to quay.io
@@ -176,21 +176,26 @@ jobs:
           name: Build and push dev-env-real Docker image tag dev-env-real
           command: docker build --build-arg MAKEFLAGS='-j3' --target dev-env-real -t quay.io/fenicsproject/dolfinx:dev-env-real . && docker push quay.io/fenicsproject/dolfinx:dev-env-real
       - run:
-          name: Build dev-env-complex Docker image tag dev-env-complex
+          name: Build and push dev-env-complex Docker image tag dev-env-complex
           command: docker build --build-arg MAKEFLAGS='-j3' --target dev-env-complex -t quay.io/fenicsproject/dolfinx:dev-env-complex . && docker push quay.io/fenicsproject/dolfinx:dev-env-complex
       - run:
-          name: Build real Docker image tags latest, real
+          name: Build and push real Docker image tags latest, real
           command: docker build --build-arg MAKEFLAGS='-j3' --target real -t quay.io/fenicsproject/dolfinx:latest . && docker tag quay.io/fenicsproject/dolfinx:latest quay.io/fenicsproject/dolfinx:real && docker push quay.io/fenicsproject/dolfinx:latest && docker push quay.io/fenicsproject/dolfinx:real
       - run:
-          name: Build complex Docker image tag complex
+          name: Build and push complex Docker image tag complex
           command: docker build --build-arg MAKEFLAGS='-j3' --target complex -t quay.io/fenicsproject/dolfinx:complex . && docker push quay.io/fenicsproject/dolfinx:complex
       - run:
-          name: Build real notebook Docker image tag notebook
-          command: docker build --build-arg MAKEFLAGS='-j3' --target notebook -t quay.io/fenicsproject/dolfinx:notebook . && docker push quay.io/fenicsproject/dolfinx:notebook
+          name: Build and push real notebook Docker image tag notebook
+          command: docker build --target notebook -t quay.io/fenicsproject/dolfinx:notebook . && docker push quay.io/fenicsproject/dolfinx:notebook
       - run:
-          name: Build complex notebook Docker image tag notebook-complex
-          command: docker build --build-arg MAKEFLAGS='-j3' --target notebook-complex -t quay.io/fenicsproject/dolfinx:notebook-complex . && docker push quay.io/fenicsproject/dolfinx:notebook-complex
-
+          name: Build and push complex notebook Docker image tag notebook-complex
+          command: docker build --target notebook-complex -t quay.io/fenicsproject/dolfinx:notebook-complex . && docker push quay.io/fenicsproject/dolfinx:notebook-complex
+      - run:
+          name: Build and push real lab Docker image tag lab
+          command: docker build --target lab -t quay.io/fenicsproject/dolfinx:lab . && docker push quay.io/fenicsproject/dolfinx:lab
+      - run:
+          name: Build and push complex lab Docker image tag lab-complex
+          command: docker build --target lab-complex -t quay.io/fenicsproject/dolfinx:lab-complex . && docker push quay.io/fenicsproject/dolfinx:lab-complex
 workflows:
   version: 2
   build-and-pushdoc:

--- a/Dockerfile
+++ b/Dockerfile
@@ -304,7 +304,7 @@ WORKDIR /root
 ARG TINI_VERSION
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini && \
-    pip3 install jupyter
+    pip3 install --no-cache-dir jupyter jupyterlab
 
 ENTRYPOINT ["/tini", "--", "jupyter", "notebook", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]
 
@@ -316,7 +316,23 @@ LABEL description="DOLFIN-X (complex mode) Jupyter Notebook"
 ARG TINI_VERSION
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini && \
-    pip3 install jupyter
+    pip3 install --no-cache-dir jupyter jupyterlab
 
 WORKDIR /root
 ENTRYPOINT ["/tini", "--", "jupyter", "notebook", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]
+
+########################################
+
+FROM notebook as lab
+LABEL description="DOLFIN-X Jupyter Lab"
+
+WORKDIR /root
+ENTRYPOINT ["/tini", "--", "jupyter", "lab", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]
+
+########################################
+
+FROM notebook-complex as lab-complex
+LABEL description="DOLFIN-X (complex mode) Jupyter Lab"
+
+WORKDIR /root
+ENTRYPOINT ["/tini", "--", "jupyter", "lab", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]


### PR DESCRIPTION
Jupyterlab will replace Jupyter notebooks soon, and offers a far superior interface (including a more classic write script then execute script workflow).

https://jupyterlab.readthedocs.io/en/stable/

I decided to install Jupyterlab at the same time as Jupyter. This supports one further documented way of getting the lab, which is to navigate to https://localhost:8080/lab after having used the standard `jupyter notebook` call.