### PR TITLE
Simplify mesh connectivity

### DIFF
--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -175,7 +175,7 @@ int main(int argc, char* argv[])
   std::array<geometry::Point, 2> pt
       = {geometry::Point(0., 0.), geometry::Point(1., 1.)};
   auto mesh = std::make_shared<mesh::Mesh>(generation::RectangleMesh::create(
-      MPI_COMM_WORLD, pt, {{2, 2}}, mesh::CellType::Type::triangle,
+      MPI_COMM_WORLD, pt, {{32, 32}}, mesh::CellType::Type::triangle,
       mesh::GhostMode::none));
 
 

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -175,7 +175,7 @@ int main(int argc, char* argv[])
   std::array<geometry::Point, 2> pt
       = {geometry::Point(0., 0.), geometry::Point(1., 1.)};
   auto mesh = std::make_shared<mesh::Mesh>(generation::RectangleMesh::create(
-      MPI_COMM_WORLD, pt, {{32, 32}}, mesh::CellType::Type::triangle,
+      MPI_COMM_WORLD, pt, {{2, 2}}, mesh::CellType::Type::triangle,
       mesh::GhostMode::none));
 
 

--- a/cpp/dolfin/function/Function.cpp
+++ b/cpp/dolfin/function/Function.cpp
@@ -348,7 +348,7 @@ Function::compute_point_values(const mesh::Mesh& mesh) const
       values(num_cell_vertices, value_size_loc);
 
   const std::size_t tdim = mesh.topology().dim();
-  const mesh::MeshConnectivity& cell_dofs
+  const mesh::Connectivity& cell_dofs
       = mesh.coordinate_dofs().entity_points(tdim);
 
   for (auto& cell : mesh::MeshRange<mesh::Cell>(mesh, mesh::MeshRangeType::ALL))

--- a/cpp/dolfin/function/Function.cpp
+++ b/cpp/dolfin/function/Function.cpp
@@ -361,7 +361,7 @@ Function::compute_point_values(const mesh::Mesh& mesh) const
     eval(values, x, cell);
 
     // Copy values to array of point values
-    const std::int32_t* dofs = cell_dofs(cell.index());
+    const std::int32_t* dofs = cell_dofs.connections(cell.index());
     for (unsigned int i = 0; i < x.rows(); ++i)
       point_values.row(dofs[i]) = values.row(i);
   }

--- a/cpp/dolfin/io/HDF5File.cpp
+++ b/cpp/dolfin/io/HDF5File.cpp
@@ -328,7 +328,7 @@ void HDF5File::write(const mesh::Mesh& mesh, int cell_dim,
       // dimension
 
       const std::size_t mpi_rank = _mpi_comm.rank();
-      const std::map<std::int32_t, std::set<unsigned int>>& shared_entities
+      const std::map<std::int32_t, std::set<std::int32_t>>& shared_entities
           = mesh.topology().shared_entities(cell_dim);
 
       std::set<unsigned int> non_local_entities;
@@ -721,7 +721,7 @@ void HDF5File::write_mesh_function(const mesh::MeshFunction<T>& meshfunction,
     // Drop duplicate data
     const std::size_t tdim = mesh.topology().dim();
     const std::size_t mpi_rank = _mpi_comm.rank();
-    const std::map<std::int32_t, std::set<unsigned int>>& shared_entities
+    const std::map<std::int32_t, std::set<std::int32_t>>& shared_entities
         = mesh.topology().shared_entities(cell_dim);
 
     std::set<unsigned int> non_local_entities;
@@ -1375,15 +1375,15 @@ mesh::Mesh HDF5File::read_mesh(MPI_Comm comm, const std::string data_path,
   if (coords_shape.size() == 1)
   {
     // spdlog::error("HDF5File.cpp", "get geometric dimension",
-    //               "Cannot determine geometric dimension from one-dimensional "
-    //               "array storage in HDF5 file");
+    //               "Cannot determine geometric dimension from one-dimensional
+    //               " "array storage in HDF5 file");
     throw std::runtime_error("IO Error");
   }
   else if (coords_shape.size() > 2)
   {
     // spdlog::error("HDF5File.cpp", "get geometric dimension",
-    //               "Cannot determine geometric dimension from high-rank array "
-    //               "storage in HDF5 file");
+    //               "Cannot determine geometric dimension from high-rank array
+    //               " "storage in HDF5 file");
     throw std::runtime_error("IO Error");
   }
 

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -27,7 +27,7 @@
 #include <dolfin/mesh/DistributedMeshTools.h>
 #include <dolfin/mesh/Edge.h>
 #include <dolfin/mesh/Mesh.h>
-#include <dolfin/mesh/MeshConnectivity.h>
+#include <dolfin/mesh/Connectivity.h>
 #include <dolfin/mesh/MeshIterator.h>
 #include <dolfin/mesh/MeshPartitioning.h>
 #include <dolfin/mesh/MeshValueCollection.h>
@@ -1715,7 +1715,7 @@ void XDMFFile::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
     }
 
     const auto& global_points = mesh.geometry().global_indices();
-    const mesh::MeshConnectivity& cell_points
+    const mesh::Connectivity& cell_points
         = mesh.coordinate_dofs().entity_points(tdim);
 
     // Adjust num_nodes_per_cell to appropriate size

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -24,10 +24,10 @@
 #include <dolfin/la/PETScVector.h>
 #include <dolfin/la/utils.h>
 #include <dolfin/mesh/Cell.h>
+#include <dolfin/mesh/Connectivity.h>
 #include <dolfin/mesh/DistributedMeshTools.h>
 #include <dolfin/mesh/Edge.h>
 #include <dolfin/mesh/Mesh.h>
-#include <dolfin/mesh/Connectivity.h>
 #include <dolfin/mesh/MeshIterator.h>
 #include <dolfin/mesh/MeshPartitioning.h>
 #include <dolfin/mesh/MeshValueCollection.h>
@@ -1871,7 +1871,7 @@ XDMFFile::compute_nonlocal_entities(const mesh::Mesh& mesh, int cell_dim)
   mesh::DistributedMeshTools::number_entities(mesh, cell_dim);
 
   const int mpi_rank = MPI::rank(mesh.mpi_comm());
-  const std::map<std::int32_t, std::set<std::uint32_t>>& shared_entities
+  const std::map<std::int32_t, std::set<std::int32_t>>& shared_entities
       = mesh.topology().shared_entities(cell_dim);
 
   std::set<std::uint32_t> non_local_entities;

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -1726,7 +1726,7 @@ void XDMFFile::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
 
     for (std::int32_t c = 0; c < mesh.num_entities(tdim); ++c)
     {
-      const std::int32_t* points = cell_points(c);
+      const std::int32_t* points = cell_points.connections(c);
       for (std::int32_t i = 0; i < num_nodes_per_cell; ++i)
         topology_data.push_back(global_points[points[perm[i]]]);
     }

--- a/cpp/dolfin/mesh/CMakeLists.txt
+++ b/cpp/dolfin/mesh/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(HEADERS
   Cell.h
   CellType.h
+  Connectivity.h
   CoordinateDofs.h
   DistributedMeshTools.h
   dolfin_mesh.h
@@ -10,7 +11,6 @@ set(HEADERS
   HexahedronCell.h
   IntervalCell.h
   Mesh.h
-  MeshConnectivity.h
   MeshEntity.h
   MeshFunction.h
   MeshGeometry.h
@@ -33,6 +33,7 @@ set(HEADERS
 
 set(SOURCES
   CellType.cpp
+  Connectivity.cpp
   CoordinateDofs.cpp
   DistributedMeshTools.cpp
   Edge.cpp
@@ -41,7 +42,6 @@ set(SOURCES
   HexahedronCell.cpp
   IntervalCell.cpp
   Mesh.cpp
-  MeshConnectivity.cpp
   MeshEntity.cpp
   MeshFunction.cpp
   MeshGeometry.cpp

--- a/cpp/dolfin/mesh/Cell.h
+++ b/cpp/dolfin/mesh/Cell.h
@@ -205,7 +205,7 @@ public:
   {
     const MeshGeometry& geom = _mesh->geometry();
     const std::uint32_t tdim = _mesh->topology().dim();
-    const MeshConnectivity& conn = _mesh->coordinate_dofs().entity_points(tdim);
+    const Connectivity& conn = _mesh->coordinate_dofs().entity_points(tdim);
     const std::size_t ndofs = conn.size(_local_index);
     const std::int32_t* dofs = conn.connections(_local_index);
 

--- a/cpp/dolfin/mesh/Cell.h
+++ b/cpp/dolfin/mesh/Cell.h
@@ -207,7 +207,7 @@ public:
     const std::uint32_t tdim = _mesh->topology().dim();
     const MeshConnectivity& conn = _mesh->coordinate_dofs().entity_points(tdim);
     const std::size_t ndofs = conn.size(_local_index);
-    const std::int32_t* dofs = conn(_local_index);
+    const std::int32_t* dofs = conn.connections(_local_index);
 
     const EigenRowArrayXXd& x = geom.points();
     const std::size_t gdim = geom.dim();

--- a/cpp/dolfin/mesh/Connectivity.cpp
+++ b/cpp/dolfin/mesh/Connectivity.cpp
@@ -27,7 +27,7 @@ Connectivity::Connectivity(
     const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic,
                                         Eigen::Dynamic, Eigen::RowMajor>>
         connections)
-    : _connections(connections.rows()*connections.cols()),
+    : _connections(connections.rows() * connections.cols()),
       _index_to_position(connections.rows() + 1)
 {
   // NOTE: cannot directly copy data from connections because it may be

--- a/cpp/dolfin/mesh/Connectivity.cpp
+++ b/cpp/dolfin/mesh/Connectivity.cpp
@@ -12,22 +12,6 @@ using namespace dolfin;
 using namespace dolfin::mesh;
 
 //-----------------------------------------------------------------------------
-Connectivity::Connectivity(std::size_t num_entities,
-                           std::size_t num_connections)
-{
-  // Compute the total size
-  const std::size_t size = num_entities * num_connections;
-
-  // Allocate
-  _connections = Eigen::Array<std::int32_t, Eigen::Dynamic, 1>::Zero(size);
-
-  // Initialize data
-  _index_to_position
-      = Eigen::Array<std::int32_t, Eigen::Dynamic, 1>(num_entities + 1);
-  for (Eigen::Index e = 0; e < _index_to_position.size(); e++)
-    _index_to_position[e] = e * num_connections;
-}
-//-----------------------------------------------------------------------------
 Connectivity::Connectivity(const std::vector<std::int32_t>& connections,
                            const std::vector<std::int32_t>& positions)
     : _connections(connections.size()), _index_to_position(positions.size())
@@ -80,18 +64,6 @@ Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
 Connectivity::entity_positions() const
 {
   return _index_to_position;
-}
-//-----------------------------------------------------------------------------
-void Connectivity::set(
-    std::int32_t entity,
-    const Eigen::Ref<const Eigen::Array<std::int32_t, 1, Eigen::Dynamic>>
-        connections)
-{
-  assert((entity + 1) < _index_to_position.size());
-  assert(connections.size()
-         == _index_to_position[entity + 1] - _index_to_position[entity]);
-  std::copy(connections.data(), connections.data() + connections.size(),
-            _connections.data() + _index_to_position[entity]);
 }
 //-----------------------------------------------------------------------------
 void Connectivity::set_global_size(

--- a/cpp/dolfin/mesh/Connectivity.cpp
+++ b/cpp/dolfin/mesh/Connectivity.cpp
@@ -20,10 +20,10 @@ Connectivity::Connectivity(std::size_t num_entities,
 
   // Allocate
   _connections = Eigen::Array<std::int32_t, Eigen::Dynamic, 1>::Zero(size);
-  _index_to_position
-      = Eigen::Array<std::int32_t, Eigen::Dynamic, 1>(num_entities + 1);
 
   // Initialize data
+  _index_to_position
+      = Eigen::Array<std::int32_t, Eigen::Dynamic, 1>(num_entities + 1);
   for (Eigen::Index e = 0; e < _index_to_position.size(); e++)
     _index_to_position[e] = e * num_connections;
 }
@@ -88,6 +88,13 @@ void Connectivity::set(
          == _index_to_position[entity + 1] - _index_to_position[entity]);
   std::copy(connections.data(), connections.data() + connections.size(),
             _connections.data() + _index_to_position[entity]);
+}
+//-----------------------------------------------------------------------------
+void Connectivity::set_global_size(
+    const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& num_global_connections)
+{
+  assert(num_global_connections.size() == _index_to_position.size() - 1);
+  _num_global_connections = num_global_connections;
 }
 //-----------------------------------------------------------------------------
 std::size_t Connectivity::hash() const

--- a/cpp/dolfin/mesh/Connectivity.cpp
+++ b/cpp/dolfin/mesh/Connectivity.cpp
@@ -32,7 +32,7 @@ Connectivity::Connectivity(const std::vector<std::int32_t>& connections,
                            const std::vector<std::int32_t>& positions)
     : _connections(connections.size()), _index_to_position(positions.size())
 {
-  assert(positions.size() <= connections.size());
+  assert(positions.back() == (std::int32_t)connections.size());
   for (std::size_t i = 0; i < connections.size(); ++i)
     _connections[i] = connections[i];
   for (std::size_t i = 0; i < positions.size(); ++i)

--- a/cpp/dolfin/mesh/Connectivity.cpp
+++ b/cpp/dolfin/mesh/Connectivity.cpp
@@ -12,11 +12,6 @@ using namespace dolfin;
 using namespace dolfin::mesh;
 
 //-----------------------------------------------------------------------------
-Connectivity::Connectivity()
-{
-  // Do nothing
-}
-//-----------------------------------------------------------------------------
 Connectivity::Connectivity(std::size_t num_entities,
                            std::size_t num_connections)
 {

--- a/cpp/dolfin/mesh/Connectivity.cpp
+++ b/cpp/dolfin/mesh/Connectivity.cpp
@@ -28,21 +28,15 @@ Connectivity::Connectivity(std::size_t num_entities,
     _index_to_position[e] = e * num_connections;
 }
 //-----------------------------------------------------------------------------
-Connectivity::Connectivity(std::vector<std::size_t>& num_connections)
+Connectivity::Connectivity(const std::vector<std::int32_t>& connections,
+                           const std::vector<std::int32_t>& positions)
+    : _connections(connections.size()), _index_to_position(positions.size())
 {
-  // Initialize offsets and compute total size
-  const std::size_t num_entities = num_connections.size();
-  _index_to_position.resize(num_entities + 1);
-  std::size_t size = 0;
-  for (std::size_t e = 0; e < num_entities; e++)
-  {
-    _index_to_position[e] = size;
-    size += num_connections[e];
-  }
-  _index_to_position[num_entities] = size;
-
-  // Initialize connections
-  _connections = Eigen::Array<std::int32_t, Eigen::Dynamic, 1>::Zero(size);
+  assert(positions.size() <= connections.size());
+  for (std::size_t i = 0; i < connections.size(); ++i)
+    _connections[i] = connections[i];
+  for (std::size_t i = 0; i < positions.size(); ++i)
+    _index_to_position[i] = positions[i];
 }
 //-----------------------------------------------------------------------------
 Eigen::Ref<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>

--- a/cpp/dolfin/mesh/Connectivity.cpp
+++ b/cpp/dolfin/mesh/Connectivity.cpp
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
-#include "MeshConnectivity.h"
+#include "Connectivity.h"
 #include <boost/functional/hash.hpp>
 #include <sstream>
 
@@ -12,13 +12,13 @@ using namespace dolfin;
 using namespace dolfin::mesh;
 
 //-----------------------------------------------------------------------------
-MeshConnectivity::MeshConnectivity()
+Connectivity::Connectivity()
 {
   // Do nothing
 }
 //-----------------------------------------------------------------------------
-MeshConnectivity::MeshConnectivity(std::size_t num_entities,
-                                   std::size_t num_connections)
+Connectivity::Connectivity(std::size_t num_entities,
+                           std::size_t num_connections)
 {
   // Compute the total size
   const std::size_t size = num_entities * num_connections;
@@ -33,7 +33,7 @@ MeshConnectivity::MeshConnectivity(std::size_t num_entities,
     _index_to_position[e] = e * num_connections;
 }
 //-----------------------------------------------------------------------------
-MeshConnectivity::MeshConnectivity(std::vector<std::size_t>& num_connections)
+Connectivity::Connectivity(std::vector<std::size_t>& num_connections)
 {
   // Initialize offsets and compute total size
   const std::size_t num_entities = num_connections.size();
@@ -51,31 +51,31 @@ MeshConnectivity::MeshConnectivity(std::vector<std::size_t>& num_connections)
 }
 //-----------------------------------------------------------------------------
 Eigen::Ref<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
-MeshConnectivity::connections()
+Connectivity::connections()
 {
   return _connections;
 }
 //-----------------------------------------------------------------------------
 Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
-MeshConnectivity::connections() const
+Connectivity::connections() const
 {
   return _connections;
 }
 //-----------------------------------------------------------------------------
 Eigen::Ref<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
-MeshConnectivity::entity_positions()
+Connectivity::entity_positions()
 {
   return _index_to_position;
 }
 //-----------------------------------------------------------------------------
 Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
-MeshConnectivity::entity_positions() const
+Connectivity::entity_positions() const
 {
   return _index_to_position;
 }
 //-----------------------------------------------------------------------------
-void MeshConnectivity::set(std::size_t entity, std::size_t connection,
-                           std::size_t pos)
+void Connectivity::set(std::size_t entity, std::size_t connection,
+                       std::size_t pos)
 {
   assert((Eigen::Index)(entity + 1) < _index_to_position.size());
   assert((std::int32_t)pos
@@ -83,7 +83,7 @@ void MeshConnectivity::set(std::size_t entity, std::size_t connection,
   _connections[_index_to_position[entity] + pos] = connection;
 }
 //-----------------------------------------------------------------------------
-void MeshConnectivity::set(
+void Connectivity::set(
     std::int32_t entity,
     const Eigen::Ref<const Eigen::Array<std::int32_t, 1, Eigen::Dynamic>>
         connections)
@@ -95,13 +95,13 @@ void MeshConnectivity::set(
             _connections.data() + _index_to_position[entity]);
 }
 //-----------------------------------------------------------------------------
-std::size_t MeshConnectivity::hash() const
+std::size_t Connectivity::hash() const
 {
   return boost::hash_range(_connections.data(),
                            _connections.data() + _connections.size());
 }
 //-----------------------------------------------------------------------------
-std::string MeshConnectivity::str(bool verbose) const
+std::string Connectivity::str(bool verbose) const
 {
   std::stringstream s;
 
@@ -121,7 +121,7 @@ std::string MeshConnectivity::str(bool verbose) const
   }
   else
   {
-    s << "<MeshConnectivity of size " << _connections.size() << ">";
+    s << "<Connectivity of size " << _connections.size() << ">";
   }
 
   return s.str();

--- a/cpp/dolfin/mesh/Connectivity.cpp
+++ b/cpp/dolfin/mesh/Connectivity.cpp
@@ -63,15 +63,6 @@ Connectivity::entity_positions() const
   return _index_to_position;
 }
 //-----------------------------------------------------------------------------
-void Connectivity::set(std::size_t entity, std::size_t connection,
-                       std::size_t pos)
-{
-  assert((Eigen::Index)(entity + 1) < _index_to_position.size());
-  assert((std::int32_t)pos
-         < _index_to_position[entity + 1] - _index_to_position[entity]);
-  _connections[_index_to_position[entity] + pos] = connection;
-}
-//-----------------------------------------------------------------------------
 void Connectivity::set(
     std::int32_t entity,
     const Eigen::Ref<const Eigen::Array<std::int32_t, 1, Eigen::Dynamic>>

--- a/cpp/dolfin/mesh/Connectivity.cpp
+++ b/cpp/dolfin/mesh/Connectivity.cpp
@@ -43,13 +43,18 @@ Connectivity::Connectivity(
     const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic,
                                         Eigen::Dynamic, Eigen::RowMajor>>
         connections)
-    : _connections(connections.size()),
+    : _connections(connections.rows()*connections.cols()),
       _index_to_position(connections.rows() + 1)
 {
-  std::copy(connections.data(), connections.data() + connections.size(),
-            _connections.data());
+  // NOTE: cannot directly copy data from connections because it may be
+  // a view into a larger array, e.g. for non-affine cells
+  Eigen::Index k = 0;
+  for (Eigen::Index i = 0; i < connections.rows(); ++i)
+    for (Eigen::Index j = 0; j < connections.cols(); ++j)
+      _connections[k++] = connections(i, j);
+
   const std::int32_t num_connections_per_entity = connections.cols();
-  for (Eigen::Index e = 0; e < _index_to_position.size(); e++)
+  for (Eigen::Index e = 0; e < _index_to_position.rows(); e++)
     _index_to_position[e] = e * num_connections_per_entity;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/mesh/Connectivity.cpp
+++ b/cpp/dolfin/mesh/Connectivity.cpp
@@ -42,6 +42,38 @@ Connectivity::Connectivity(
     _index_to_position[e] = e * num_connections_per_entity;
 }
 //-----------------------------------------------------------------------------
+std::size_t Connectivity::size(std::int32_t entity) const
+{
+  return (entity + 1) < _index_to_position.size()
+             ? _index_to_position[entity + 1] - _index_to_position[entity]
+             : 0;
+}
+//-----------------------------------------------------------------------------
+std::size_t Connectivity::size_global(std::int32_t entity) const
+{
+  if (_num_global_connections.size() == 0)
+    return size(entity);
+  else
+  {
+    assert(entity < _num_global_connections.size());
+    return _num_global_connections[entity];
+  }
+}
+//-----------------------------------------------------------------------------
+std::int32_t* Connectivity::connections(int entity)
+{
+  return (entity + 1) < _index_to_position.size()
+             ? &_connections[_index_to_position[entity]]
+             : nullptr;
+}
+//-----------------------------------------------------------------------------
+const std::int32_t* Connectivity::connections(int entity) const
+{
+  return (entity + 1) < _index_to_position.size()
+             ? &_connections[_index_to_position[entity]]
+             : nullptr;
+}
+//-----------------------------------------------------------------------------
 Eigen::Ref<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
 Connectivity::connections()
 {

--- a/cpp/dolfin/mesh/Connectivity.cpp
+++ b/cpp/dolfin/mesh/Connectivity.cpp
@@ -39,6 +39,20 @@ Connectivity::Connectivity(const std::vector<std::int32_t>& connections,
     _index_to_position[i] = positions[i];
 }
 //-----------------------------------------------------------------------------
+Connectivity::Connectivity(
+    const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic,
+                                        Eigen::Dynamic, Eigen::RowMajor>>
+        connections)
+    : _connections(connections.size()),
+      _index_to_position(connections.rows() + 1)
+{
+  std::copy(connections.data(), connections.data() + connections.size(),
+            _connections.data());
+  const std::int32_t num_connections_per_entity = connections.cols();
+  for (Eigen::Index e = 0; e < _index_to_position.size(); e++)
+    _index_to_position[e] = e * num_connections_per_entity;
+}
+//-----------------------------------------------------------------------------
 Eigen::Ref<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
 Connectivity::connections()
 {

--- a/cpp/dolfin/mesh/Connectivity.h
+++ b/cpp/dolfin/mesh/Connectivity.h
@@ -35,7 +35,8 @@ public:
   // TOOD: remove this constructor
   /// Initialize number of entities and number of connections
   /// (individually)
-  Connectivity(std::vector<std::size_t>& num_connections);
+  Connectivity(const std::vector<std::int32_t>& connections,
+               const std::vector<std::int32_t>& positions);
 
   /// Set all connections for all entities (T is a '2D' container, e.g.
   /// a std::vector<<std::vector<std::size_t>>,

--- a/cpp/dolfin/mesh/Connectivity.h
+++ b/cpp/dolfin/mesh/Connectivity.h
@@ -27,9 +27,6 @@ namespace mesh
 class Connectivity
 {
 public:
-  /// Create empty connectivity
-  Connectivity();
-
   /// Initialize number of entities and number of connections (equal
   /// for all)
   Connectivity(std::size_t num_entities, std::size_t num_connections);

--- a/cpp/dolfin/mesh/Connectivity.h
+++ b/cpp/dolfin/mesh/Connectivity.h
@@ -24,25 +24,25 @@ namespace mesh
 /// which may either be equal for all entities or different, or by
 /// giving the entire (sparse) connectivity pattern.
 
-class MeshConnectivity
+class Connectivity
 {
 public:
   /// Create empty connectivity
-  MeshConnectivity();
+  Connectivity();
 
   /// Initialize number of entities and number of connections (equal
   /// for all)
-  MeshConnectivity(std::size_t num_entities, std::size_t num_connections);
+  Connectivity(std::size_t num_entities, std::size_t num_connections);
 
   /// Initialize number of entities and number of connections
   /// (individually)
-  MeshConnectivity(std::vector<std::size_t>& num_connections);
+  Connectivity(std::vector<std::size_t>& num_connections);
 
   /// Set all connections for all entities (T is a '2D' container, e.g.
   /// a std::vector<<std::vector<std::size_t>>,
   /// std::vector<<std::set<std::size_t>>, etc)
   template <typename T>
-  MeshConnectivity(const T& connections)
+  Connectivity(const T& connections)
   {
     // Initialize offsets and compute total size
     _index_to_position.resize(connections.size() + 1);
@@ -64,19 +64,19 @@ public:
   }
 
   /// Copy constructor
-  MeshConnectivity(const MeshConnectivity& connectivity) = default;
+  Connectivity(const Connectivity& connectivity) = default;
 
   /// Move constructor
-  MeshConnectivity(MeshConnectivity&& connectivity) = default;
+  Connectivity(Connectivity&& connectivity) = default;
 
   /// Destructor
-  ~MeshConnectivity() = default;
+  ~Connectivity() = default;
 
   /// Assignment
-  MeshConnectivity& operator=(const MeshConnectivity& connectivity) = default;
+  Connectivity& operator=(const Connectivity& connectivity) = default;
 
   /// Move assignment
-  MeshConnectivity& operator=(MeshConnectivity&& connectivity) = default;
+  Connectivity& operator=(Connectivity&& connectivity) = default;
 
   // /// Return true if the total number of connections is equal to zero
   bool empty() const { return _connections.size() == 0; }

--- a/cpp/dolfin/mesh/Connectivity.h
+++ b/cpp/dolfin/mesh/Connectivity.h
@@ -27,10 +27,12 @@ namespace mesh
 class Connectivity
 {
 public:
+  // TOOD: remove this constructor
   /// Initialize number of entities and number of connections (equal
   /// for all)
   Connectivity(std::size_t num_entities, std::size_t num_connections);
 
+  // TOOD: remove this constructor
   /// Initialize number of entities and number of connections
   /// (individually)
   Connectivity(std::vector<std::size_t>& num_connections);
@@ -75,7 +77,7 @@ public:
   /// Move assignment
   Connectivity& operator=(Connectivity&& connectivity) = default;
 
-  // /// Return true if the total number of connections is equal to zero
+  /// Return true if the total number of connections is equal to zero
   bool empty() const { return _connections.size() == 0; }
 
   /// Return number of connections for given entity
@@ -141,11 +143,7 @@ public:
 
   /// Set global number of connections for all local entities
   void set_global_size(const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>&
-                           num_global_connections)
-  {
-    assert(num_global_connections.size() == _index_to_position.size() - 1);
-    _num_global_connections = num_global_connections;
-  }
+                           num_global_connections);
 
   /// Hash of connections
   std::size_t hash() const;

--- a/cpp/dolfin/mesh/Connectivity.h
+++ b/cpp/dolfin/mesh/Connectivity.h
@@ -38,6 +38,13 @@ public:
   Connectivity(const std::vector<std::int32_t>& connections,
                const std::vector<std::int32_t>& positions);
 
+  /// Initialize with all connections for case where each entity has the
+  /// same number of connections
+  Connectivity(
+      const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic,
+                                          Eigen::Dynamic, Eigen::RowMajor>>
+          connections);
+
   /// Set all connections for all entities (T is a '2D' container, e.g.
   /// a std::vector<<std::vector<std::size_t>>,
   /// std::vector<<std::set<std::size_t>>, etc)
@@ -134,6 +141,7 @@ public:
   Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
   entity_positions() const;
 
+  // TODO: remove
   /// Set all connections for given entity
   void set(std::int32_t entity,
            const Eigen::Ref<const Eigen::Array<std::int32_t, 1, Eigen::Dynamic>>

--- a/cpp/dolfin/mesh/Connectivity.h
+++ b/cpp/dolfin/mesh/Connectivity.h
@@ -80,9 +80,6 @@ public:
   /// Move assignment
   Connectivity& operator=(Connectivity&& connectivity) = default;
 
-  /// Return true if the total number of connections is equal to zero
-  bool empty() const { return _connections.size() == 0; }
-
   /// Return number of connections for given entity
   std::size_t size(std::int32_t entity) const
   {

--- a/cpp/dolfin/mesh/Connectivity.h
+++ b/cpp/dolfin/mesh/Connectivity.h
@@ -28,11 +28,6 @@ namespace mesh
 class Connectivity
 {
 public:
-  // TOOD: remove this constructor
-  /// Initialize number of entities and number of connections (equal
-  /// for all)
-  Connectivity(std::size_t num_entities, std::size_t num_connections);
-
   /// Initialize with all connections and pointer to each entity
   /// position
   Connectivity(const std::vector<std::int32_t>& connections,
@@ -140,12 +135,6 @@ public:
   /// (using local index) (const version)
   Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
   entity_positions() const;
-
-  // TODO: remove
-  /// Set all connections for given entity
-  void set(std::int32_t entity,
-           const Eigen::Ref<const Eigen::Array<std::int32_t, 1, Eigen::Dynamic>>
-               connections);
 
   /// Set global number of connections for all local entities
   void set_global_size(const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>&

--- a/cpp/dolfin/mesh/Connectivity.h
+++ b/cpp/dolfin/mesh/Connectivity.h
@@ -81,40 +81,16 @@ public:
   Connectivity& operator=(Connectivity&& connectivity) = default;
 
   /// Return number of connections for given entity
-  std::size_t size(std::int32_t entity) const
-  {
-    return (entity + 1) < _index_to_position.size()
-               ? _index_to_position[entity + 1] - _index_to_position[entity]
-               : 0;
-  }
+  std::size_t size(std::int32_t entity) const;
 
   /// Return global number of connections for given entity
-  std::size_t size_global(std::int32_t entity) const
-  {
-    if (_num_global_connections.size() == 0)
-      return size(entity);
-    else
-    {
-      assert(entity < _num_global_connections.size());
-      return _num_global_connections[entity];
-    }
-  }
+  std::size_t size_global(std::int32_t entity) const;
 
   /// Return array of connections for given entity
-  std::int32_t* connections(int entity)
-  {
-    return (entity + 1) < _index_to_position.size()
-               ? &_connections[_index_to_position[entity]]
-               : nullptr;
-  }
+  std::int32_t* connections(int entity);
 
   /// Return array of connections for given entity (const version)
-  const std::int32_t* connections(int entity) const
-  {
-    return (entity + 1) < _index_to_position.size()
-               ? &_connections[_index_to_position[entity]]
-               : nullptr;
-  }
+  const std::int32_t* connections(int entity) const;
 
   /// Return contiguous array of connections for all entities
   Eigen::Ref<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> connections();

--- a/cpp/dolfin/mesh/Connectivity.h
+++ b/cpp/dolfin/mesh/Connectivity.h
@@ -49,7 +49,7 @@ public:
   /// a std::vector<<std::vector<std::size_t>>,
   /// std::vector<<std::set<std::size_t>>, etc)
   template <typename T>
-  Connectivity(const T& connections)
+  Connectivity(const std::vector<T>& connections)
       : _index_to_position(connections.size() + 1)
   {
     // Initialize offsets and compute total size

--- a/cpp/dolfin/mesh/Connectivity.h
+++ b/cpp/dolfin/mesh/Connectivity.h
@@ -134,9 +134,6 @@ public:
   Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
   entity_positions() const;
 
-  /// Set given connection for given entity
-  void set(std::size_t entity, std::size_t connection, std::size_t pos);
-
   /// Set all connections for given entity
   void set(std::int32_t entity,
            const Eigen::Ref<const Eigen::Array<std::int32_t, 1, Eigen::Dynamic>>

--- a/cpp/dolfin/mesh/Connectivity.h
+++ b/cpp/dolfin/mesh/Connectivity.h
@@ -8,6 +8,7 @@
 
 #include <Eigen/Dense>
 #include <cassert>
+#include <numeric>
 #include <vector>
 
 namespace dolfin
@@ -32,9 +33,8 @@ public:
   /// for all)
   Connectivity(std::size_t num_entities, std::size_t num_connections);
 
-  // TOOD: remove this constructor
-  /// Initialize number of entities and number of connections
-  /// (individually)
+  /// Initialize with all connections and pointer to each entity
+  /// position
   Connectivity(const std::vector<std::int32_t>& connections,
                const std::vector<std::int32_t>& positions);
 
@@ -43,9 +43,9 @@ public:
   /// std::vector<<std::set<std::size_t>>, etc)
   template <typename T>
   Connectivity(const T& connections)
+      : _index_to_position(connections.size() + 1)
   {
     // Initialize offsets and compute total size
-    _index_to_position.resize(connections.size() + 1);
     std::int32_t size = 0;
     for (std::size_t e = 0; e < connections.size(); e++)
     {

--- a/cpp/dolfin/mesh/CoordinateDofs.cpp
+++ b/cpp/dolfin/mesh/CoordinateDofs.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "CoordinateDofs.h"
-#include "MeshConnectivity.h"
+#include "Connectivity.h"
 
 using namespace dolfin;
 using namespace dolfin::mesh;
@@ -21,14 +21,14 @@ void CoordinateDofs::init(std::size_t dim,
                           const std::vector<std::uint8_t>& cell_permutation)
 {
   assert(dim < _coord_dofs.size());
-  _coord_dofs[dim] = std::make_shared<MeshConnectivity>(point_dofs.rows(),
-                                                        point_dofs.cols());
+  _coord_dofs[dim]
+      = std::make_shared<Connectivity>(point_dofs.rows(), point_dofs.cols());
   for (std::uint32_t i = 0; i < point_dofs.rows(); ++i)
     _coord_dofs[dim]->set(i, point_dofs.row(i));
   _cell_permutation = cell_permutation;
 }
 //-----------------------------------------------------------------------------
-const MeshConnectivity& CoordinateDofs::entity_points(std::uint32_t dim) const
+const Connectivity& CoordinateDofs::entity_points(std::uint32_t dim) const
 {
   assert(dim < _coord_dofs.size());
   assert(_coord_dofs[dim]);

--- a/cpp/dolfin/mesh/CoordinateDofs.cpp
+++ b/cpp/dolfin/mesh/CoordinateDofs.cpp
@@ -21,10 +21,7 @@ void CoordinateDofs::init(std::size_t dim,
                           const std::vector<std::uint8_t>& cell_permutation)
 {
   assert(dim < _coord_dofs.size());
-  _coord_dofs[dim]
-      = std::make_shared<Connectivity>(point_dofs.rows(), point_dofs.cols());
-  for (std::uint32_t i = 0; i < point_dofs.rows(); ++i)
-    _coord_dofs[dim]->set(i, point_dofs.row(i));
+  _coord_dofs[dim] = std::make_shared<Connectivity>(point_dofs);
   _cell_permutation = cell_permutation;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/mesh/CoordinateDofs.h
+++ b/cpp/dolfin/mesh/CoordinateDofs.h
@@ -14,7 +14,7 @@ namespace dolfin
 {
 namespace mesh
 {
-class MeshConnectivity;
+class Connectivity;
 
 /// CoordinateDofs contains the connectivity from MeshEntities to the geometric
 /// points which make up the mesh.
@@ -60,16 +60,16 @@ public:
   ///
   /// @param dim
   ///   Entity dimension
-  /// @return MeshConnectivity
+  /// @return Connectivity
   ///   Connections from entities of given dimension to points
-  const MeshConnectivity& entity_points(std::uint32_t dim) const;
+  const Connectivity& entity_points(std::uint32_t dim) const;
 
   const std::vector<std::uint8_t>& cell_permutation() const;
 
 private:
   // Connectivity from entities to points. Initially only defined for
   // cells
-  std::vector<std::shared_ptr<MeshConnectivity>> _coord_dofs;
+  std::vector<std::shared_ptr<Connectivity>> _coord_dofs;
 
   // Permutation required to transform to/from VTK/gmsh ordering to
   // DOLFIN ordering needed for higher order elements

--- a/cpp/dolfin/mesh/DistributedMeshTools.cpp
+++ b/cpp/dolfin/mesh/DistributedMeshTools.cpp
@@ -125,7 +125,7 @@ void DistributedMeshTools::number_entities(const Mesh& mesh, int d)
   }
 
   // Get shared entities map
-  std::map<std::int32_t, std::set<std::uint32_t>>& shared_entities
+  std::map<std::int32_t, std::set<std::int32_t>>& shared_entities
       = _mesh.topology().shared_entities(d);
 
   // Number entities
@@ -135,7 +135,7 @@ void DistributedMeshTools::number_entities(const Mesh& mesh, int d)
   // const std::size_t num_global_entities = number_entities(
   //     mesh, slave_entities, global_entity_indices, shared_entities, d);
   std::vector<std::int64_t> global_entity_indices;
-  const std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>>
+  const std::map<std::int32_t, std::pair<std::int32_t, std::int32_t>>
       slave_entities;
   std::size_t num_global_entities;
   std::tie(global_entity_indices, shared_entities, num_global_entities)
@@ -152,7 +152,7 @@ std::tuple<std::vector<std::int64_t>,
            std::map<std::int32_t, std::set<std::uint32_t>>, std::size_t>
 DistributedMeshTools::number_entities(
     const Mesh& mesh,
-    const std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>>&
+    const std::map<std::int32_t, std::pair<std::int32_t, std::int32_t>>&
         slave_entities,
     int d)
 {
@@ -163,8 +163,8 @@ DistributedMeshTools::number_entities(
   // numbering for problems with periodic boundary conditions.
 
   // spdlog::info(
-  //     "Number mesh entities for distributed mesh (for specified vertex ids).",
-  //     d);
+  //     "Number mesh entities for distributed mesh (for specified vertex
+  //     ids).", d);
   common::Timer timer(
       "Number mesh entities for distributed mesh (for specified vertex ids)");
 
@@ -230,7 +230,7 @@ DistributedMeshTools::number_entities(
       = mesh.topology().global_indices(0);
 
   // Get shared vertices (local index, [sharing processes])
-  const std::map<std::int32_t, std::set<std::uint32_t>>& shared_vertices_local
+  const std::map<std::int32_t, std::set<std::int32_t>>& shared_vertices_local
       = mesh.topology().shared_entities(0);
 
   // Compute ownership of entities of dimension d ([entity vertices], data):
@@ -425,7 +425,8 @@ DistributedMeshTools::locate_off_process_entities(
 
   // if (dim == 0)
   // {
-  //   spdlog::warn("DistributedMeshTools::host_processes has not been tested for "
+  //   spdlog::warn("DistributedMeshTools::host_processes has not been tested
+  //   for "
   //                "vertices.");
   // }
 
@@ -471,7 +472,7 @@ DistributedMeshTools::locate_off_process_entities(
     std::set<std::size_t> set_of_my_entities(entity_indices.begin(),
                                              entity_indices.end());
 
-    const std::map<std::int32_t, std::set<std::uint32_t>>& sharing_map
+    const std::map<std::int32_t, std::set<std::int32_t>>& sharing_map
         = mesh.topology().shared_entities(D);
 
     // FIXME: This can be made more efficient by exploiting fact that
@@ -585,7 +586,7 @@ DistributedMeshTools::compute_shared_entities(const Mesh& mesh, std::size_t d)
   number_entities(mesh, d);
 
   // Get shared entities to processes map
-  const std::map<std::int32_t, std::set<std::uint32_t>>& shared_entities
+  const std::map<std::int32_t, std::set<std::int32_t>>& shared_entities
       = mesh.topology().shared_entities(d);
 
   // Get local-to-global indices map
@@ -599,7 +600,7 @@ DistributedMeshTools::compute_shared_entities(const Mesh& mesh, std::size_t d)
   // Pack global indices for sending to sharing processes
   std::vector<std::vector<std::size_t>> send_indices(comm_size);
   std::vector<std::vector<std::size_t>> local_sent_indices(comm_size);
-  std::map<std::int32_t, std::set<std::uint32_t>>::const_iterator shared_entity;
+  std::map<std::int32_t, std::set<std::int32_t>>::const_iterator shared_entity;
   for (shared_entity = shared_entities.begin();
        shared_entity != shared_entities.end(); ++shared_entity)
   {
@@ -611,10 +612,10 @@ DistributedMeshTools::compute_shared_entities(const Mesh& mesh, std::size_t d)
     std::size_t global_index = global_indices_map[local_index];
 
     // Destination process
-    const std::set<std::uint32_t>& sharing_processes = shared_entity->second;
+    const std::set<std::int32_t>& sharing_processes = shared_entity->second;
 
     // Pack data for sending and build global-to-local map
-    std::set<std::uint32_t>::const_iterator dest;
+    std::set<std::int32_t>::const_iterator dest;
     for (dest = sharing_processes.begin(); dest != sharing_processes.end();
          ++dest)
     {
@@ -1097,7 +1098,7 @@ void DistributedMeshTools::init_facet_cell_connections(Mesh& mesh)
   Eigen::Array<std::int32_t, Eigen::Dynamic, 1> num_global_neighbors(
       mesh.num_entities(D - 1));
 
-  std::map<std::int32_t, std::set<std::uint32_t>>& shared_facets
+  std::map<std::int32_t, std::set<std::int32_t>>& shared_facets
       = mesh.topology().shared_entities(D - 1);
 
   // Check if no ghost cells

--- a/cpp/dolfin/mesh/DistributedMeshTools.cpp
+++ b/cpp/dolfin/mesh/DistributedMeshTools.cpp
@@ -1094,7 +1094,7 @@ void DistributedMeshTools::init_facet_cell_connections(Mesh& mesh)
   // Create vector to hold number of cells connected to each
   // facet. Initially copy over from local values.
 
-  Eigen::Array<std::uint32_t, Eigen::Dynamic, 1> num_global_neighbors(
+  Eigen::Array<std::int32_t, Eigen::Dynamic, 1> num_global_neighbors(
       mesh.num_entities(D - 1));
 
   std::map<std::int32_t, std::set<std::uint32_t>>& shared_facets

--- a/cpp/dolfin/mesh/DistributedMeshTools.h
+++ b/cpp/dolfin/mesh/DistributedMeshTools.h
@@ -37,11 +37,11 @@ public:
   /// given global vertex indices. Returns  global_entity_indices,
   /// shared_entities, and XXXX?
   static std::tuple<std::vector<std::int64_t>,
-                    std::map<std::int32_t, std::set<std::uint32_t>>,
+                    std::map<std::int32_t, std::set<std::int32_t>>,
                     std::size_t>
   number_entities(
       const Mesh& mesh,
-      const std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>>&
+      const std::map<std::int32_t, std::pair<std::int32_t, std::int32_t>>&
           slave_entities,
       int d);
 
@@ -62,7 +62,7 @@ public:
   /// of sharing process and local index,
   /// i.e. (local index, [(sharing process p, local index on p)])
   static std::unordered_map<
-      std::uint32_t, std::vector<std::pair<std::uint32_t, std::uint32_t>>>
+      std::int32_t, std::vector<std::pair<std::int32_t, std::int32_t>>>
   compute_shared_entities(const Mesh& mesh, std::size_t d);
 
   /// Reorder the values according to explicit global indices, distributing
@@ -114,27 +114,27 @@ private:
     EntityData& operator=(EntityData&&) = default;
 
     // Constructor  (index is local)
-    explicit EntityData(std::uint32_t index) : local_index(index) {}
+    explicit EntityData(std::int32_t index) : local_index(index) {}
 
     // Constructor (index is local)
-    EntityData(std::uint32_t index, const std::vector<std::uint32_t>& procs)
+    EntityData(std::int32_t index, const std::vector<std::int32_t>& procs)
         : local_index(index), processes(procs)
     {
       // Do nothing
     }
 
     // Constructor  (index is local)
-    EntityData(std::uint32_t index, std::uint32_t process)
+    EntityData(std::int32_t index, std::int32_t process)
         : local_index(index), processes(1, process)
     {
       // Do nothing
     }
 
     // Local (this process) entity index
-    std::uint32_t local_index;
+    std::int32_t local_index;
 
     // Processes on which entity resides
-    std::vector<std::uint32_t> processes;
+    std::vector<std::int32_t> processes;
   };
 
   // Compute ownership of entities ([entity vertices], data)
@@ -148,8 +148,8 @@ private:
                    std::array<std::map<Entity, EntityData>, 2>>
   compute_entity_ownership(
       const MPI_Comm mpi_comm,
-      const std::map<std::vector<std::size_t>, std::uint32_t>& entities,
-      const std::map<std::int32_t, std::set<std::uint32_t>>&
+      const std::map<std::vector<std::size_t>, std::int32_t>& entities,
+      const std::map<std::int32_t, std::set<std::int32_t>>&
           shared_vertices_local,
       const std::vector<std::int64_t>& global_vertex_indices, std::size_t d);
 
@@ -160,8 +160,8 @@ private:
                    std::array<std::map<Entity, EntityData>, 2>>
   compute_preliminary_entity_ownership(
       const MPI_Comm mpi_comm,
-      const std::map<std::size_t, std::set<std::uint32_t>>& shared_vertices,
-      const std::map<Entity, std::uint32_t>& entities);
+      const std::map<std::size_t, std::set<std::int32_t>>& shared_vertices,
+      const std::map<Entity, std::int32_t>& entities);
 
   // Communicate with other processes to finalise entity ownership
   static void compute_final_entity_ownership(
@@ -171,7 +171,7 @@ private:
   // Check if all entity vertices are the shared vertices in overlap
   static bool is_shared(
       const std::vector<std::size_t>& entity_vertices,
-      const std::map<std::size_t, std::set<std::uint32_t>>& shared_vertices);
+      const std::map<std::size_t, std::set<std::int32_t>>& shared_vertices);
 
   // Compute and return (number of global entities, process offset)
   static std::pair<std::size_t, std::size_t> compute_num_global_entities(

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -6,6 +6,7 @@
 
 #include "Mesh.h"
 #include "Cell.h"
+#include "Connectivity.h"
 #include "DistributedMeshTools.h"
 #include "Facet.h"
 #include "MeshIterator.h"

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -152,9 +152,8 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
 
   // Add cells. Only copies the first few entries on each row corresponding to
   // vertices.
-  auto cv = std::make_shared<Connectivity>(num_cells, num_vertices_per_cell);
-  for (std::int32_t i = 0; i < num_cells; ++i)
-    cv->set(i, coordinate_dofs.row(i).leftCols(num_vertices_per_cell));
+  auto cv = std::make_shared<Connectivity>(
+      coordinate_dofs.leftCols(num_vertices_per_cell));
   _topology.set_connectivity(cv, tdim, 0);
 
   // Global cell indices - construct if none given

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -151,8 +151,7 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
 
   // Add cells. Only copies the first few entries on each row corresponding to
   // vertices.
-  auto cv
-      = std::make_shared<MeshConnectivity>(num_cells, num_vertices_per_cell);
+  auto cv = std::make_shared<Connectivity>(num_cells, num_vertices_per_cell);
   for (std::int32_t i = 0; i < num_cells; ++i)
     cv->set(i, coordinate_dofs.row(i).leftCols(num_vertices_per_cell));
   _topology.set_connectivity(cv, tdim, 0);

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -79,8 +79,8 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
   const std::int32_t num_local_cells = num_cells - num_ghost_cells;
   const std::uint64_t num_cells_global = MPI::sum(comm, num_local_cells);
 
-  // Compute point local-to-global map from global indices, and compute cell
-  // topology using new local indices.
+  // Compute point local-to-global map from global indices, and compute
+  // cell topology using new local indices.
   std::int32_t num_vertices;
   std::vector<std::int64_t> global_point_indices;
   EigenRowArrayXXi32 coordinate_dofs;
@@ -95,8 +95,8 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
   std::tie(distributed_points, shared_points)
       = MeshPartitioning::distribute_points(comm, points, global_point_indices);
 
-  // Initialise geometry with global size, actual points,
-  // and local to global map
+  // Initialise geometry with global size, actual points, and local to
+  // global map
   _geometry.init(num_points_global, distributed_points, global_point_indices);
 
   // Get global vertex information
@@ -112,8 +112,8 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
   }
   else
   {
-    // For higher order meshes, vertices are a subset of points,
-    // so need to build a distinct global indexing for vertices.
+    // For higher order meshes, vertices are a subset of points, so need
+    // to build a distinct global indexing for vertices.
     std::tie(num_vertices_global, global_vertex_indices)
         = MeshPartitioning::build_global_vertex_indices(
             comm, num_vertices, global_point_indices, shared_points);
@@ -150,8 +150,8 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
   else
     _topology.init_ghost(0, num_vertices);
 
-  // Add cells. Only copies the first few entries on each row corresponding to
-  // vertices.
+  // Add cells. Only copies the first few entries on each row
+  // corresponding to vertices.
   auto cv = std::make_shared<Connectivity>(
       coordinate_dofs.leftCols(num_vertices_per_cell));
   _topology.set_connectivity(cv, tdim, 0);
@@ -223,8 +223,8 @@ Mesh& Mesh::operator=(const Mesh& mesh)
 std::size_t Mesh::init(int dim) const
 {
   // This function is obviously not const since it may potentially
-  // compute new connectivity. However, in a sense all connectivity of
-  // a mesh always exists, it just hasn't been computed yet. The
+  // compute new connectivity. However, in a sense all connectivity of a
+  // mesh always exists, it just hasn't been computed yet. The
   // const_cast is also needed to allow iterators over a const Mesh to
   // create new connectivity.
 
@@ -254,8 +254,8 @@ std::size_t Mesh::init(int dim) const
 void Mesh::init(std::size_t d0, std::size_t d1) const
 {
   // This function is obviously not const since it may potentially
-  // compute new connectivity. However, in a sense all connectivity of
-  // a mesh always exists, it just hasn't been computed yet. The
+  // compute new connectivity. However, in a sense all connectivity of a
+  // mesh always exists, it just hasn't been computed yet. The
   // const_cast is also needed to allow iterators over a const Mesh to
   // create new connectivity.
 

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -91,7 +91,7 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
 
   // Distribute the points across processes and calculate shared points
   EigenRowArrayXXd distributed_points;
-  std::map<std::int32_t, std::set<std::uint32_t>> shared_points;
+  std::map<std::int32_t, std::set<std::int32_t>> shared_points;
   std::tie(distributed_points, shared_points)
       = MeshPartitioning::distribute_points(comm, points, global_point_indices);
 
@@ -102,7 +102,7 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
   // Get global vertex information
   std::uint64_t num_vertices_global;
   std::vector<std::int64_t> global_vertex_indices;
-  std::map<std::int32_t, std::set<std::uint32_t>> shared_vertices;
+  std::map<std::int32_t, std::set<std::int32_t>> shared_vertices;
 
   if (_degree == 1)
   {

--- a/cpp/dolfin/mesh/Mesh.h
+++ b/cpp/dolfin/mesh/Mesh.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "CellType.h"
-#include "Connectivity.h"
 #include "CoordinateDofs.h"
 #include "MeshGeometry.h"
 #include "MeshTopology.h"
@@ -127,17 +126,6 @@ public:
   ///         Number of entities of topological dimension d.
   ///
   std::int32_t num_entities(int d) const { return _topology.size(d); }
-
-  /// Get cell connectivity.
-  ///
-  /// @return std::vector<std::uint32_t>&
-  ///         Connectivity for all cells.
-  ///
-  Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cells() const
-  {
-    assert(_topology.connectivity(_topology.dim(), 0));
-    return _topology.connectivity(_topology.dim(), 0)->connections();
-  }
 
   /// Get global number of entities of given topological dimension.
   ///

--- a/cpp/dolfin/mesh/Mesh.h
+++ b/cpp/dolfin/mesh/Mesh.h
@@ -7,8 +7,8 @@
 #pragma once
 
 #include "CellType.h"
+#include "Connectivity.h"
 #include "CoordinateDofs.h"
-#include "MeshConnectivity.h"
 #include "MeshGeometry.h"
 #include "MeshTopology.h"
 #include <dolfin/common/MPI.h>

--- a/cpp/dolfin/mesh/MeshConnectivity.cpp
+++ b/cpp/dolfin/mesh/MeshConnectivity.cpp
@@ -50,10 +50,22 @@ MeshConnectivity::MeshConnectivity(std::vector<std::size_t>& num_connections)
   _connections = Eigen::Array<std::int32_t, Eigen::Dynamic, 1>::Zero(size);
 }
 //-----------------------------------------------------------------------------
+Eigen::Ref<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
+MeshConnectivity::connections()
+{
+  return _connections;
+}
+//-----------------------------------------------------------------------------
 Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
 MeshConnectivity::connections() const
 {
   return _connections;
+}
+//-----------------------------------------------------------------------------
+Eigen::Ref<Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>>
+MeshConnectivity::entity_positions()
+{
+  return _index_to_position;
 }
 //-----------------------------------------------------------------------------
 Eigen::Ref<const Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>>

--- a/cpp/dolfin/mesh/MeshConnectivity.cpp
+++ b/cpp/dolfin/mesh/MeshConnectivity.cpp
@@ -26,7 +26,7 @@ MeshConnectivity::MeshConnectivity(std::size_t num_entities,
   // Allocate
   _connections = Eigen::Array<std::int32_t, Eigen::Dynamic, 1>::Zero(size);
   _index_to_position
-      = Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>(num_entities + 1);
+      = Eigen::Array<std::int32_t, Eigen::Dynamic, 1>(num_entities + 1);
 
   // Initialize data
   for (Eigen::Index e = 0; e < _index_to_position.size(); e++)
@@ -62,13 +62,13 @@ MeshConnectivity::connections() const
   return _connections;
 }
 //-----------------------------------------------------------------------------
-Eigen::Ref<Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>>
+Eigen::Ref<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
 MeshConnectivity::entity_positions()
 {
   return _index_to_position;
 }
 //-----------------------------------------------------------------------------
-Eigen::Ref<const Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>>
+Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
 MeshConnectivity::entity_positions() const
 {
   return _index_to_position;
@@ -78,7 +78,8 @@ void MeshConnectivity::set(std::size_t entity, std::size_t connection,
                            std::size_t pos)
 {
   assert((Eigen::Index)(entity + 1) < _index_to_position.size());
-  assert(pos < _index_to_position[entity + 1] - _index_to_position[entity]);
+  assert((std::int32_t)pos
+         < _index_to_position[entity + 1] - _index_to_position[entity]);
   _connections[_index_to_position[entity] + pos] = connection;
 }
 //-----------------------------------------------------------------------------
@@ -110,8 +111,8 @@ std::string MeshConnectivity::str(bool verbose) const
     for (Eigen::Index e = 0; e < _index_to_position.size() - 1; e++)
     {
       s << "  " << e << ":";
-      for (std::size_t i = _index_to_position[e]; i < _index_to_position[e + 1];
-           i++)
+      for (std::int32_t i = _index_to_position[e];
+           i < _index_to_position[e + 1]; i++)
       {
         s << " " << _connections[i];
       }

--- a/cpp/dolfin/mesh/MeshConnectivity.cpp
+++ b/cpp/dolfin/mesh/MeshConnectivity.cpp
@@ -84,7 +84,7 @@ void MeshConnectivity::set(std::size_t entity, std::size_t connection,
 }
 //-----------------------------------------------------------------------------
 void MeshConnectivity::set(
-    std::uint32_t entity,
+    std::int32_t entity,
     const Eigen::Ref<const Eigen::Array<std::int32_t, 1, Eigen::Dynamic>>
         connections)
 {

--- a/cpp/dolfin/mesh/MeshConnectivity.h
+++ b/cpp/dolfin/mesh/MeshConnectivity.h
@@ -127,11 +127,11 @@ public:
 
   /// Position of first connection in connections() for each entity
   /// (using local index)
-  Eigen::Ref<Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>> entity_positions();
+  Eigen::Ref<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> entity_positions();
 
   /// Position of first connection in connections() for each entity
   /// (using local index) (const version)
-  Eigen::Ref<const Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>>
+  Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
   entity_positions() const;
 
   /// Set given connection for given entity
@@ -161,7 +161,7 @@ private:
   Eigen::Array<std::int32_t, Eigen::Dynamic, 1> _connections;
 
   // Position of first connection for each entity (using local index)
-  Eigen::Array<std::uint32_t, Eigen::Dynamic, 1> _index_to_position;
+  Eigen::Array<std::int32_t, Eigen::Dynamic, 1> _index_to_position;
 
   // Global number of connections for all entities (possibly not
   // computed)

--- a/cpp/dolfin/mesh/MeshConnectivity.h
+++ b/cpp/dolfin/mesh/MeshConnectivity.h
@@ -102,6 +102,14 @@ public:
   }
 
   /// Return array of connections for given entity
+  std::int32_t* connections(int entity)
+  {
+    return (entity + 1) < _index_to_position.size()
+               ? &_connections[_index_to_position[entity]]
+               : nullptr;
+  }
+
+  /// Return array of connections for given entity (const version)
   const std::int32_t* connections(int entity) const
   {
     return (entity + 1) < _index_to_position.size()
@@ -110,11 +118,19 @@ public:
   }
 
   /// Return contiguous array of connections for all entities
+  Eigen::Ref<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> connections();
+
+  /// Return contiguous array of connections for all entities (const
+  /// version)
   Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
   connections() const;
 
   /// Position of first connection in connections() for each entity
   /// (using local index)
+  Eigen::Ref<Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>> entity_positions();
+
+  /// Position of first connection in connections() for each entity
+  /// (using local index) (const version)
   Eigen::Ref<const Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>>
   entity_positions() const;
 

--- a/cpp/dolfin/mesh/MeshConnectivity.h
+++ b/cpp/dolfin/mesh/MeshConnectivity.h
@@ -102,7 +102,7 @@ public:
   }
 
   /// Return array of connections for given entity
-  const std::int32_t* operator()(std::int32_t entity) const
+  const std::int32_t* connections(int entity) const
   {
     return (entity + 1) < _index_to_position.size()
                ? &_connections[_index_to_position[entity]]

--- a/cpp/dolfin/mesh/MeshConnectivity.h
+++ b/cpp/dolfin/mesh/MeshConnectivity.h
@@ -138,12 +138,12 @@ public:
   void set(std::size_t entity, std::size_t connection, std::size_t pos);
 
   /// Set all connections for given entity
-  void set(std::uint32_t entity,
+  void set(std::int32_t entity,
            const Eigen::Ref<const Eigen::Array<std::int32_t, 1, Eigen::Dynamic>>
                connections);
 
   /// Set global number of connections for all local entities
-  void set_global_size(const Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>&
+  void set_global_size(const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>&
                            num_global_connections)
   {
     assert(num_global_connections.size() == _index_to_position.size() - 1);
@@ -165,7 +165,7 @@ private:
 
   // Global number of connections for all entities (possibly not
   // computed)
-  Eigen::Array<std::uint32_t, Eigen::Dynamic, 1> _num_global_connections;
+  Eigen::Array<std::int32_t, Eigen::Dynamic, 1> _num_global_connections;
 };
 } // namespace mesh
 } // namespace dolfin

--- a/cpp/dolfin/mesh/MeshEntity.cpp
+++ b/cpp/dolfin/mesh/MeshEntity.cpp
@@ -48,8 +48,9 @@ bool MeshEntity::incident(const MeshEntity& entity) const
     return false;
 
   // Get list of entities for given topological dimension
-  const std::int32_t* entities
-      = (*_mesh->topology().connectivity(_dim, entity._dim))(_local_index);
+  const std::int32_t* entities = _mesh->topology()
+                                     .connectivity(_dim, entity._dim)
+                                     ->connections(_local_index);
   const std::size_t num_entities
       = _mesh->topology().connectivity(_dim, entity._dim)->size(_local_index);
 
@@ -73,8 +74,9 @@ std::size_t MeshEntity::index(const MeshEntity& entity) const
   }
 
   // Get list of entities for given topological dimension
-  const std::int32_t* entities
-      = (*_mesh->topology().connectivity(_dim, entity._dim))(_local_index);
+  const std::int32_t* entities = _mesh->topology()
+                                     .connectivity(_dim, entity._dim)
+                                     ->connections(_local_index);
   const std::size_t num_entities
       = _mesh->topology().connectivity(_dim, entity._dim)->size(_local_index);
 

--- a/cpp/dolfin/mesh/MeshEntity.h
+++ b/cpp/dolfin/mesh/MeshEntity.h
@@ -171,7 +171,7 @@ public:
     {
       assert(_mesh->topology().connectivity(_dim, dim));
       const std::int32_t* initialized_mesh_entities
-          = (*_mesh->topology().connectivity(_dim, dim))(_local_index);
+          = (*_mesh->topology().connectivity(_dim, dim)).connections(_local_index);
       assert(initialized_mesh_entities);
       return initialized_mesh_entities;
     }

--- a/cpp/dolfin/mesh/MeshEntity.h
+++ b/cpp/dolfin/mesh/MeshEntity.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "Connectivity.h"
 #include "Mesh.h"
 #include <dolfin/geometry/Point.h>
 
@@ -171,7 +172,8 @@ public:
     {
       assert(_mesh->topology().connectivity(_dim, dim));
       const std::int32_t* initialized_mesh_entities
-          = (*_mesh->topology().connectivity(_dim, dim)).connections(_local_index);
+          = _mesh->topology().connectivity(_dim, dim)->connections(
+              _local_index);
       assert(initialized_mesh_entities);
       return initialized_mesh_entities;
     }

--- a/cpp/dolfin/mesh/MeshEntity.h
+++ b/cpp/dolfin/mesh/MeshEntity.h
@@ -216,13 +216,13 @@ public:
   /// Return set of sharing processes
   /// @return std::set<std::uint32_t>
   ///   List of sharing processes
-  std::set<std::uint32_t> sharing_processes() const
+  std::set<std::int32_t> sharing_processes() const
   {
-    const std::map<std::int32_t, std::set<std::uint32_t>>& sharing_map
+    const std::map<std::int32_t, std::set<std::int32_t>>& sharing_map
         = _mesh->topology().shared_entities(_dim);
     const auto map_it = sharing_map.find(_local_index);
     if (map_it == sharing_map.end())
-      return std::set<std::uint32_t>();
+      return std::set<std::int32_t>();
     else
       return map_it->second;
   }
@@ -234,7 +234,7 @@ public:
   {
     if (_mesh->topology().have_shared_entities(_dim))
     {
-      const std::map<std::int32_t, std::set<std::uint32_t>>& sharing_map
+      const std::map<std::int32_t, std::set<std::int32_t>>& sharing_map
           = _mesh->topology().shared_entities(_dim);
       return (sharing_map.find(_local_index) != sharing_map.end());
     }

--- a/cpp/dolfin/mesh/MeshEntity.h
+++ b/cpp/dolfin/mesh/MeshEntity.h
@@ -103,8 +103,7 @@ public:
   /// Return global index of mesh entity
   ///
   /// @return     std::size_t
-  ///         The global index. Set to
-  ///         std::numerical_limits<std::size_t>::max() if global index
+  ///         The global index. Set to -1  if global index
   ///         has not been computed
   std::int64_t global_index() const
   {

--- a/cpp/dolfin/mesh/MeshFunction.h
+++ b/cpp/dolfin/mesh/MeshFunction.h
@@ -247,7 +247,7 @@ MeshFunction<T>::MeshFunction(std::shared_ptr<const Mesh> mesh,
     {
       // Get global (local to to process) entity index
       assert(cell_index < _mesh->num_entities(D));
-      entity_index = connectivity(cell_index)[local_entity];
+      entity_index = connectivity.connections(cell_index)[local_entity];
     }
     else
     {

--- a/cpp/dolfin/mesh/MeshFunction.h
+++ b/cpp/dolfin/mesh/MeshFunction.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
+#include "Connectivity.h"
 #include "Mesh.h"
-#include "MeshConnectivity.h"
 #include "MeshEntity.h"
 #include <boost/container/vector.hpp>
 #include <dolfin/common/MPI.h>
@@ -211,8 +211,7 @@ template <typename T>
 MeshFunction<T>::MeshFunction(std::shared_ptr<const Mesh> mesh,
                               const MeshValueCollection<T>& value_collection,
                               const T& default_value)
-    : common::Variable("f"), _mesh(mesh),
-      _dim(value_collection.dim())
+    : common::Variable("f"), _mesh(mesh), _dim(value_collection.dim())
 {
   assert(_mesh);
   _mesh->init(_dim);
@@ -228,7 +227,7 @@ MeshFunction<T>::MeshFunction(std::shared_ptr<const Mesh> mesh,
   // Generate connectivity if it does not exist
   _mesh->init(D, d);
   assert(_mesh->topology().connectivity(D, d));
-  const MeshConnectivity& connectivity = *_mesh->topology().connectivity(D, d);
+  const Connectivity& connectivity = *_mesh->topology().connectivity(D, d);
 
   // Iterate over all values
   std::unordered_set<std::size_t> entities_values_set;
@@ -267,7 +266,8 @@ MeshFunction<T>::MeshFunction(std::shared_ptr<const Mesh> mesh,
   // if (entities_values_set.size() != _values.size())
   // {
   //   spdlog::debug(
-  //       "Mesh value collection does not contain all values for all entities");
+  //       "Mesh value collection does not contain all values for all
+  //       entities");
   // }
 }
 //---------------------------------------------------------------------------
@@ -381,5 +381,5 @@ std::string MeshFunction<T>::str(bool verbose) const
   return s.str();
 }
 //---------------------------------------------------------------------------
-}
-}
+} // namespace mesh
+} // namespace dolfin

--- a/cpp/dolfin/mesh/MeshIterator.h
+++ b/cpp/dolfin/mesh/MeshIterator.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
+#include "Connectivity.h"
 #include "Mesh.h"
-#include "MeshConnectivity.h"
 #include "MeshEntity.h"
 #include "MeshTopology.h"
 #include <iterator>
@@ -101,7 +101,7 @@ public:
 
     // Get connectivity
     assert(e.mesh().topology().connectivity(e.dim(), _entity.dim()));
-    const MeshConnectivity& c
+    const Connectivity& c
         = *e.mesh().topology().connectivity(e.dim(), _entity.dim());
 
     // Pointer to array of connections
@@ -123,7 +123,7 @@ public:
 
     // Get connectivity
     assert(e.mesh().topology().connectivity(e.dim(), _entity.dim()));
-    const MeshConnectivity& c
+    const Connectivity& c
         = *e.mesh().topology().connectivity(e.dim(), _entity.dim());
 
     // Pointer to array of connections

--- a/cpp/dolfin/mesh/MeshIterator.h
+++ b/cpp/dolfin/mesh/MeshIterator.h
@@ -105,7 +105,7 @@ public:
         = *e.mesh().topology().connectivity(e.dim(), _entity.dim());
 
     // Pointer to array of connections
-    _connections = c(e.index()) + pos;
+    _connections = c.connections(e.index()) + pos;
   }
 
   /// Constructor from MeshEntity
@@ -128,7 +128,7 @@ public:
 
     // Pointer to array of connections
     // assert(!c.empty());
-    _connections = c(e.index()) + pos;
+    _connections = c.connections(e.index()) + pos;
   }
 
   /// Copy constructor

--- a/cpp/dolfin/mesh/MeshPartitioning.cpp
+++ b/cpp/dolfin/mesh/MeshPartitioning.cpp
@@ -185,7 +185,7 @@ mesh::Mesh MeshPartitioning::build(
     return mesh;
 
   // Copy cell ownership (only needed for ghost cells)
-  std::vector<std::uint32_t>& cell_owner = mesh.topology().cell_owner();
+  std::vector<std::int32_t>& cell_owner = mesh.topology().cell_owner();
   cell_owner.clear();
   cell_owner.insert(cell_owner.begin(),
                     new_cell_partition.begin() + num_regular_cells,

--- a/cpp/dolfin/mesh/MeshPartitioning.cpp
+++ b/cpp/dolfin/mesh/MeshPartitioning.cpp
@@ -157,7 +157,7 @@ mesh::Mesh MeshPartitioning::build(
   // if (parameter::parameters["reorder_cells_gps"])
   // {
   //   // Allocate objects to hold re-ordering
-  //   std::map<std::int32_t, std::set<std::uint32_t>> reordered_shared_cells;
+  //   std::map<std::int32_t, std::set<std::int32_t>> reordered_shared_cells;
   //   EigenRowArrayXXi64 reordered_cell_vertices;
   //   std::vector<std::int64_t> reordered_global_cell_indices;
 
@@ -197,12 +197,12 @@ mesh::Mesh MeshPartitioning::build(
   return mesh;
 }
 //-----------------------------------------------------------------------------
-std::tuple<std::map<std::int32_t, std::set<std::uint32_t>>, EigenRowArrayXXi64,
+std::tuple<std::map<std::int32_t, std::set<std::int32_t>>, EigenRowArrayXXi64,
            std::vector<std::int64_t>>
 MeshPartitioning::reorder_cells_gps(
-    MPI_Comm mpi_comm, const std::uint32_t num_regular_cells,
+    MPI_Comm mpi_comm, const std::int32_t num_regular_cells,
     const CellType& cell_type,
-    const std::map<std::int32_t, std::set<std::uint32_t>>& shared_cells,
+    const std::map<std::int32_t, std::set<std::int32_t>>& shared_cells,
     const Eigen::Ref<const EigenRowArrayXXi64>& global_cell_vertices,
     const std::vector<std::int64_t>& global_cell_indices)
 {
@@ -233,7 +233,7 @@ MeshPartitioning::reorder_cells_gps(
   dolfin::graph::Graph g_dual;
   // Ignore the ghost cells - they will not be reordered
   // FIXME: reorder ghost cells too
-  for (std::uint32_t i = 0; i != num_regular_cells; ++i)
+  for (std::int32_t i = 0; i < num_regular_cells; ++i)
   {
     dolfin::common::Set<int> conn_set;
     for (auto q = local_graph[i].begin(); q != local_graph[i].end(); ++q)
@@ -257,10 +257,10 @@ MeshPartitioning::reorder_cells_gps(
   EigenRowArrayXXi64 reordered_cell_vertices(global_cell_vertices.rows(),
                                              global_cell_vertices.cols());
   std::vector<std::int64_t> reordered_global_cell_indices(g_dual.size());
-  for (std::uint32_t i = 0; i != g_dual.size(); ++i)
+  for (std::size_t i = 0; i < g_dual.size(); ++i)
   {
     // Remap data
-    const std::uint32_t j = remap[i];
+    const int j = remap[i];
     reordered_cell_vertices.row(j) = global_cell_vertices.row(i);
     reordered_global_cell_indices[j] = global_cell_indices[i];
   }
@@ -268,7 +268,7 @@ MeshPartitioning::reorder_cells_gps(
   std::map<std::int32_t, std::set<std::int32_t>> reordered_shared_cells;
   for (auto p = shared_cells.begin(); p != shared_cells.end(); ++p)
   {
-    const std::uint32_t cell_index = p->first;
+    const std::int32_t cell_index = p->first;
     if (cell_index < num_regular_cells)
       reordered_shared_cells.insert({remap[cell_index], p->second});
     else
@@ -355,7 +355,7 @@ void MeshPartitioning::distribute_cell_layer(
 
   MPI::all_to_all(mpi_comm, send_vertcells, recv_vertcells);
 
-  const std::uint32_t num_cell_vertices = cell_vertices.cols();
+  const std::int32_t num_cell_vertices = cell_vertices.cols();
 
   // Collect up cells on common vertices
 
@@ -399,8 +399,8 @@ void MeshPartitioning::distribute_cell_layer(
   // Count up new cells, assign local index, set owner
   // and initialise shared_cells
 
-  const std::uint32_t num_cells = cell_vertices.rows();
-  std::uint32_t count = num_cells;
+  const std::int32_t num_cells = cell_vertices.rows();
+  std::int32_t count = num_cells;
 
   for (const auto& p : recv_vertcells)
   {
@@ -412,7 +412,7 @@ void MeshPartitioning::distribute_cell_layer(
       auto cell_insert = cell_global_to_local.insert({cell_index, count});
       if (cell_insert.second)
       {
-        shared_cells.insert({count, std::set<std::uint32_t>()});
+        shared_cells.insert({count, std::set<std::int32_t>()});
         global_cell_indices.push_back(cell_index);
         cell_partition.push_back(owner);
         ++count;
@@ -424,7 +424,7 @@ void MeshPartitioning::distribute_cell_layer(
   cell_vertices.conservativeResize(count, num_cell_vertices);
 
   // Set of processes and cells sharing the same vertex
-  std::set<std::uint32_t> sharing_procs;
+  std::set<std::int32_t> sharing_procs;
   std::vector<std::size_t> sharing_cells;
 
   std::size_t last_vertex = std::numeric_limits<std::size_t>::max();
@@ -435,13 +435,13 @@ void MeshPartitioning::distribute_cell_layer(
       const int owner = *q;
       const std::size_t cell_index = *(q + 1);
       const std::size_t shared_vertex = *(q + 2);
-      const std::size_t local_index
+      const std::int32_t local_index
           = cell_global_to_local.find(cell_index)->second;
 
       // Add vertices to new cells
       if (local_index >= num_cells)
       {
-        for (std::uint32_t j = 0; j != num_cell_vertices; ++j)
+        for (std::int32_t j = 0; j != num_cell_vertices; ++j)
           cell_vertices(local_index, j) = *(q + j + 2);
       }
 
@@ -503,8 +503,8 @@ MeshPartitioning::distribute_cells(
   bool build_global_index = global_cell_indices.empty();
 
   // Get dimensions
-  const std::size_t num_local_cells = cell_vertices.rows();
-  const std::size_t num_cell_vertices = cell_vertices.cols();
+  const std::int32_t num_local_cells = cell_vertices.rows();
+  const std::int32_t num_cell_vertices = cell_vertices.cols();
   assert(mp.size() == num_local_cells);
 
   // Send all cells to their destinations including their global
@@ -513,12 +513,11 @@ MeshPartitioning::distribute_cells(
   std::vector<std::vector<std::size_t>> send_cell_vertices(
       mpi_size, std::vector<std::size_t>(2, 0));
 
-  for (std::uint32_t i = 0; i != mp.size(); ++i)
+  for (std::int32_t i = 0; i < mp.size(); ++i)
   {
-    std::uint32_t num_procs = mp.num_procs(i);
-
-    const std::uint32_t* sharing_procs = mp.procs(i);
-    for (std::uint32_t j = 0; j < num_procs; ++j)
+    std::int32_t num_procs = mp.num_procs(i);
+    const std::int32_t* sharing_procs = mp.procs(i);
+    for (std::int32_t j = 0; j < num_procs; ++j)
     {
       // Create reference to destination vector
       std::vector<std::size_t>& send_cell_dest
@@ -598,7 +597,7 @@ MeshPartitioning::distribute_cells(
       new_cell_partition[idx] = owner;
       if (num_ghosts != 0)
       {
-        std::set<std::uint32_t> proc_set(tmp_it, tmp_it + num_ghosts);
+        std::set<std::int32_t> proc_set(tmp_it, tmp_it + num_ghosts);
 
         // Remove self from set of sharing processes
         proc_set.erase(mpi_rank);
@@ -607,7 +606,7 @@ MeshPartitioning::distribute_cells(
       }
 
       new_global_cell_indices[idx] = *tmp_it++;
-      for (std::size_t j = 0; j < num_cell_vertices; ++j)
+      for (std::int32_t j = 0; j < num_cell_vertices; ++j)
         new_cell_vertices(idx, j) = *tmp_it++;
 
       if (owner == mpi_rank)
@@ -627,12 +626,12 @@ MeshPartitioning::distribute_cells(
 //-----------------------------------------------------------------------------
 std::tuple<std::uint64_t, std::vector<std::int64_t>, EigenRowArrayXXi32>
 MeshPartitioning::compute_point_mapping(
-    std::uint32_t num_cell_vertices,
+    std::int32_t num_cell_vertices,
     const Eigen::Ref<const EigenRowArrayXXi64>& cell_points,
     const std::vector<std::uint8_t>& cell_permutation)
 {
-  const std::uint32_t num_cells = cell_points.rows();
-  const std::uint32_t num_cell_points = cell_points.cols();
+  const std::int32_t num_cells = cell_points.rows();
+  const std::int32_t num_cell_points = cell_points.cols();
 
   // Cell points in local indexing
   EigenRowArrayXXi32 local_cell_points(num_cells, num_cell_points);
@@ -647,10 +646,10 @@ MeshPartitioning::compute_point_mapping(
   // Loop over cells mapping vertices (but not other points)
   std::int32_t nv = 0;
   std::map<std::int64_t, std::int32_t> point_global_to_local;
-  for (std::uint32_t c = 0; c < num_cells; ++c)
+  for (std::int32_t c = 0; c < num_cells; ++c)
   {
     // Loop over cell points
-    for (std::uint32_t v = 0; v < num_cell_vertices; ++v)
+    for (std::int32_t v = 0; v < num_cell_vertices; ++v)
     {
       // Get global cell index
       std::int64_t q = cell_points(c, v);
@@ -670,13 +669,13 @@ MeshPartitioning::compute_point_mapping(
     }
   }
 
-  const std::uint32_t num_local_vertices = nv;
+  const std::int32_t num_local_vertices = nv;
 
   // Repeat and map non-vertex points
-  for (std::uint32_t c = 0; c < num_cells; ++c)
+  for (std::int32_t c = 0; c < num_cells; ++c)
   {
     // Loop over cell points
-    for (std::uint32_t v = num_cell_vertices; v < num_cell_points; ++v)
+    for (std::int32_t v = num_cell_vertices; v < num_cell_points; ++v)
     {
       // Get global cell index
       std::int64_t q = cell_points(c, v);
@@ -730,14 +729,14 @@ MeshPartitioning::distribute_points(
   // Compute where (process number) the points we need are located
   std::vector<std::size_t> ranges(mpi_size);
   MPI::all_gather(mpi_comm, (std::size_t)points.rows(), ranges);
-  for (std::uint32_t i = 1; i != ranges.size(); ++i)
+  for (std::size_t i = 1; i < ranges.size(); ++i)
     ranges[i] += ranges[i - 1];
   ranges.insert(ranges.begin(), 0);
 
   // Send global indices to the processes that own them, also recording
   // in local_indexing the original position on this process
   std::vector<std::vector<std::size_t>> send_point_indices(mpi_size);
-  std::vector<std::vector<std::uint32_t>> local_indexing(mpi_size);
+  std::vector<std::vector<std::int32_t>> local_indexing(mpi_size);
   for (unsigned int i = 0; i != global_point_indices.size(); ++i)
   {
     const std::size_t required_point = global_point_indices[i];
@@ -850,22 +849,24 @@ MeshPartitioning::build_shared_points(
     MPI_Comm mpi_comm,
     const std::vector<std::vector<std::size_t>>& received_point_indices,
     const std::pair<std::size_t, std::size_t> local_point_range,
-    const std::vector<std::vector<std::uint32_t>>& local_indexing)
+    const std::vector<std::vector<std::int32_t>>& local_indexing)
 {
   // spdlog::info("Build shared points during distributed mesh construction");
 
-  const std::uint32_t mpi_size = MPI::size(mpi_comm);
+  const std::int32_t mpi_size = MPI::size(mpi_comm);
 
   // Count number sharing each local point
   std::vector<std::int32_t> n_sharing(
       local_point_range.second - local_point_range.first, 0);
   for (const auto& p : received_point_indices)
+  {
     for (const auto& q : p)
     {
       assert(q >= local_point_range.first and q < local_point_range.second);
       const std::size_t local_index = q - local_point_range.first;
       ++n_sharing[local_index];
     }
+  }
 
   // Create an array of 'pointers' to shared entries
   // (where number shared, p > 1).
@@ -886,7 +887,7 @@ MeshPartitioning::build_shared_points(
   // Fill with list of sharing processes and position in
   // received_point_indices to send back to originating process
   std::vector<std::int32_t> process_list(index);
-  for (std::uint32_t p = 0; p < mpi_size; ++p)
+  for (std::int32_t p = 0; p < mpi_size; ++p)
     for (unsigned int i = 0; i < received_point_indices[p].size(); ++i)
     {
       // Convert global to local index
@@ -929,7 +930,7 @@ MeshPartitioning::build_shared_points(
 
   // Unpack and store to shared_points_local
   std::map<std::int32_t, std::set<std::int32_t>> shared_points_local;
-  for (unsigned int p = 0; p < mpi_size; ++p)
+  for (std::int32_t p = 0; p < mpi_size; ++p)
   {
     const std::vector<std::int32_t>& local_index_p = local_indexing[p];
     for (auto q = recv_sharing[p].begin(); q != recv_sharing[p].end();
@@ -949,7 +950,7 @@ MeshPartitioning::build_shared_points(
 //-----------------------------------------------------------------------------
 std::pair<std::int64_t, std::vector<std::int64_t>>
 MeshPartitioning::build_global_vertex_indices(
-    MPI_Comm mpi_comm, std::uint32_t num_vertices,
+    MPI_Comm mpi_comm, std::int32_t num_vertices,
     const std::vector<std::int64_t>& global_point_indices,
     const std::map<std::int32_t, std::set<std::int32_t>>& shared_points)
 {
@@ -961,7 +962,7 @@ MeshPartitioning::build_global_vertex_indices(
   std::vector<std::int64_t> recv_data(mpi_size);
 
   std::int64_t v = 0;
-  for (std::uint32_t i = 0; i < num_vertices; ++i)
+  for (std::int32_t i = 0; i < num_vertices; ++i)
   {
     const auto it = shared_points.find(i);
     if (it == shared_points.end())
@@ -1007,7 +1008,7 @@ MeshPartitioning::build_global_vertex_indices(
 
   // Adjust global_vertex_indices either by adding offset
   // or inserting remote index
-  for (std::uint32_t i = 0; i < num_vertices; ++i)
+  for (std::int32_t i = 0; i < num_vertices; ++i)
   {
     const auto it = global_point_to_vertex.find(global_point_indices[i]);
     if (it == global_point_to_vertex.end())

--- a/cpp/dolfin/mesh/MeshPartitioning.h
+++ b/cpp/dolfin/mesh/MeshPartitioning.h
@@ -108,7 +108,7 @@ public:
   ///   topology in local indexing (EigenRowArrayXXi32)
   static std::tuple<std::uint64_t, std::vector<std::int64_t>,
                     EigenRowArrayXXi32>
-  compute_point_mapping(std::uint32_t num_cell_vertices,
+  compute_point_mapping(std::int32_t num_cell_vertices,
                         const Eigen::Ref<const EigenRowArrayXXi64>& cell_points,
                         const std::vector<std::uint8_t>& cell_permutation);
 
@@ -117,7 +117,7 @@ public:
   // at the vertex nodes
   static std::pair<std::int64_t, std::vector<std::int64_t>>
   build_global_vertex_indices(
-      MPI_Comm mpi_comm, std::uint32_t num_vertices,
+      MPI_Comm mpi_comm, std::int32_t num_vertices,
       const std::vector<std::int64_t>& global_point_indices,
       const std::map<std::int32_t, std::set<std::int32_t>>& shared_points);
 
@@ -159,7 +159,7 @@ private:
   static std::tuple<std::map<std::int32_t, std::set<std::int32_t>>,
                     EigenRowArrayXXi64, std::vector<std::int64_t>>
   reorder_cells_gps(
-      MPI_Comm mpi_comm, const std::uint32_t num_regular_cells,
+      MPI_Comm mpi_comm, const std::int32_t num_regular_cells,
       const mesh::CellType& cell_type,
       const std::map<std::int32_t, std::set<std::int32_t>>& shared_cells,
       const Eigen::Ref<const EigenRowArrayXXi64>& global_cell_vertices,
@@ -189,7 +189,7 @@ private:
       MPI_Comm mpi_comm,
       const std::vector<std::vector<std::size_t>>& received_point_indices,
       const std::pair<std::size_t, std::size_t> local_point_range,
-      const std::vector<std::vector<std::uint32_t>>& local_indexing);
+      const std::vector<std::vector<std::int32_t>>& local_indexing);
 };
 } // namespace mesh
 } // namespace dolfin

--- a/cpp/dolfin/mesh/MeshPartitioning.h
+++ b/cpp/dolfin/mesh/MeshPartitioning.h
@@ -89,7 +89,7 @@ public:
   ///   distribution) and shared_vertices_local (map from local index to set of
   ///   sharing processes for each shared vertex)
   static std::pair<EigenRowArrayXXd,
-                   std::map<std::int32_t, std::set<std::uint32_t>>>
+                   std::map<std::int32_t, std::set<std::int32_t>>>
   distribute_points(const MPI_Comm mpi_comm,
                     const Eigen::Ref<const EigenRowArrayXXd>& points,
                     const std::vector<std::int64_t>& global_point_indices);
@@ -119,7 +119,7 @@ public:
   build_global_vertex_indices(
       MPI_Comm mpi_comm, std::uint32_t num_vertices,
       const std::vector<std::int64_t>& global_point_indices,
-      const std::map<std::int32_t, std::set<std::uint32_t>>& shared_points);
+      const std::map<std::int32_t, std::set<std::int32_t>>& shared_points);
 
 private:
   // Compute cell partitioning from local mesh data. Returns a
@@ -147,7 +147,7 @@ private:
   // are all modified by this function.
   static void distribute_cell_layer(
       MPI_Comm mpi_comm, const int num_regular_cells,
-      std::map<std::int32_t, std::set<std::uint32_t>>& shared_cells,
+      std::map<std::int32_t, std::set<std::int32_t>>& shared_cells,
       EigenRowArrayXXi64& cell_vertices,
       std::vector<std::int64_t>& global_cell_indices,
       std::vector<int>& cell_partition);
@@ -156,12 +156,12 @@ private:
   // Reorder cells by Gibbs-Poole-Stockmeyer algorithm (via SCOTCH). Returns
   // the tuple (reordered_shared_cells, reordered_cell_vertices,
   // reordered_global_cell_indices)
-  static std::tuple<std::map<std::int32_t, std::set<std::uint32_t>>,
+  static std::tuple<std::map<std::int32_t, std::set<std::int32_t>>,
                     EigenRowArrayXXi64, std::vector<std::int64_t>>
   reorder_cells_gps(
       MPI_Comm mpi_comm, const std::uint32_t num_regular_cells,
       const mesh::CellType& cell_type,
-      const std::map<std::int32_t, std::set<std::uint32_t>>& shared_cells,
+      const std::map<std::int32_t, std::set<std::int32_t>>& shared_cells,
       const Eigen::Ref<const EigenRowArrayXXi64>& global_cell_vertices,
       const std::vector<std::int64_t>& global_cell_indices);
 
@@ -176,7 +176,7 @@ private:
   // process).
   static std::tuple<
       EigenRowArrayXXi64, std::vector<std::int64_t>, std::vector<int>,
-      std::map<std::int32_t, std::set<std::uint32_t>>, std::int32_t>
+      std::map<std::int32_t, std::set<std::int32_t>>, std::int32_t>
   distribute_cells(const MPI_Comm mpi_comm,
                    const Eigen::Ref<const EigenRowArrayXXi64>& cell_vertices,
                    const std::vector<std::int64_t>& global_cell_indices,
@@ -185,7 +185,7 @@ private:
   // FIXME: Improve explanation
   // Utility to convert received_point_indices into
   // point sharing information
-  static std::map<std::int32_t, std::set<std::uint32_t>> build_shared_points(
+  static std::map<std::int32_t, std::set<std::int32_t>> build_shared_points(
       MPI_Comm mpi_comm,
       const std::vector<std::vector<std::size_t>>& received_point_indices,
       const std::pair<std::size_t, std::size_t> local_point_range,

--- a/cpp/dolfin/mesh/MeshTopology.cpp
+++ b/cpp/dolfin/mesh/MeshTopology.cpp
@@ -106,7 +106,7 @@ bool MeshTopology::have_global_indices(std::size_t dim) const
   return !_global_indices[dim].empty();
 }
 //-----------------------------------------------------------------------------
-bool MeshTopology::have_shared_entities(std::uint32_t dim) const
+bool MeshTopology::have_shared_entities(int dim) const
 {
   return (_shared_entities.find(dim) != _shared_entities.end());
 }
@@ -117,7 +117,7 @@ void MeshTopology::init_global_indices(std::size_t dim, std::int64_t size)
   _global_indices[dim] = std::vector<std::int64_t>(size, -1);
 }
 //-----------------------------------------------------------------------------
-std::map<std::int32_t, std::set<std::uint32_t>>&
+std::map<std::int32_t, std::set<std::int32_t>>&
 MeshTopology::shared_entities(int dim)
 {
   assert(dim <= this->dim());
@@ -155,7 +155,7 @@ void MeshTopology::set_connectivity(std::shared_ptr<Connectivity> c,
   _connectivity[d0][d1] = c;
 }
 //-----------------------------------------------------------------------------
-const std::map<std::int32_t, std::set<std::uint32_t>>&
+const std::map<std::int32_t, std::set<std::int32_t>>&
 MeshTopology::shared_entities(int dim) const
 {
   auto e = _shared_entities.find(dim);

--- a/cpp/dolfin/mesh/MeshTopology.cpp
+++ b/cpp/dolfin/mesh/MeshTopology.cpp
@@ -124,9 +124,9 @@ MeshTopology::shared_entities(int dim)
   return _shared_entities[dim];
 }
 //-----------------------------------------------------------------------------
-std::vector<std::uint32_t>& MeshTopology::cell_owner() { return _cell_owner; }
+std::vector<std::int32_t>& MeshTopology::cell_owner() { return _cell_owner; }
 //-----------------------------------------------------------------------------
-const std::vector<std::uint32_t>& MeshTopology::cell_owner() const
+const std::vector<std::int32_t>& MeshTopology::cell_owner() const
 {
   return _cell_owner;
 }

--- a/cpp/dolfin/mesh/MeshTopology.cpp
+++ b/cpp/dolfin/mesh/MeshTopology.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "MeshTopology.h"
-#include "MeshConnectivity.h"
+#include "Connectivity.h"
 #include <dolfin/common/utils.h>
 #include <numeric>
 #include <sstream>
@@ -18,7 +18,7 @@ MeshTopology::MeshTopology(std::size_t dim)
     : _num_entities(dim + 1, 0), _ghost_offset_index(dim + 1, 0),
       _global_num_entities(dim + 1, 0), _global_indices(dim + 1),
       _connectivity(dim + 1,
-                    std::vector<std::shared_ptr<MeshConnectivity>>(dim + 1))
+                    std::vector<std::shared_ptr<Connectivity>>(dim + 1))
 {
   // Do nothing
 }

--- a/cpp/dolfin/mesh/MeshTopology.cpp
+++ b/cpp/dolfin/mesh/MeshTopology.cpp
@@ -47,16 +47,16 @@ std::int64_t MeshTopology::size_global(int dim) const
   }
 }
 //-----------------------------------------------------------------------------
-/*
-std::uint32_t MeshTopology::ghost_offset(std::uint32_t dim) const
+std::int32_t MeshTopology::ghost_offset(int dim) const
 {
   if (_ghost_offset_index.empty())
     return 0;
-
-  assert(dim < _ghost_offset_index.size());
-  return _ghost_offset_index[dim];
+  else
+  {
+    assert(dim < (int)_ghost_offset_index.size());
+    return _ghost_offset_index[dim];
+  }
 }
-*/
 //-----------------------------------------------------------------------------
 void MeshTopology::clear(int d0, int d1)
 {
@@ -85,6 +85,32 @@ void MeshTopology::init_ghost(std::size_t dim, std::size_t index)
   _ghost_offset_index[dim] = index;
 }
 //-----------------------------------------------------------------------------
+void MeshTopology::set_global_index(std::size_t dim, std::int32_t local_index,
+                                    std::int64_t global_index)
+{
+  assert(dim < _global_indices.size());
+  assert(local_index < (std::int32_t)_global_indices[dim].size());
+  _global_indices[dim][local_index] = global_index;
+}
+//-----------------------------------------------------------------------------
+const std::vector<std::int64_t>&
+MeshTopology::global_indices(std::size_t d) const
+{
+  assert(d < _global_indices.size());
+  return _global_indices[d];
+}
+//-----------------------------------------------------------------------------
+bool MeshTopology::have_global_indices(std::size_t dim) const
+{
+  assert(dim < _global_indices.size());
+  return !_global_indices[dim].empty();
+}
+//-----------------------------------------------------------------------------
+bool MeshTopology::have_shared_entities(std::uint32_t dim) const
+{
+  return (_shared_entities.find(dim) != _shared_entities.end());
+}
+//-----------------------------------------------------------------------------
 void MeshTopology::init_global_indices(std::size_t dim, std::int64_t size)
 {
   assert(dim < _global_indices.size());
@@ -96,6 +122,37 @@ MeshTopology::shared_entities(int dim)
 {
   assert(dim <= this->dim());
   return _shared_entities[dim];
+}
+//-----------------------------------------------------------------------------
+std::vector<std::uint32_t>& MeshTopology::cell_owner() { return _cell_owner; }
+//-----------------------------------------------------------------------------
+const std::vector<std::uint32_t>& MeshTopology::cell_owner() const
+{
+  return _cell_owner;
+}
+//-----------------------------------------------------------------------------
+std::shared_ptr<Connectivity> MeshTopology::connectivity(std::size_t d0,
+                                                         std::size_t d1)
+{
+  assert(d0 < _connectivity.size());
+  assert(d1 < _connectivity[d0].size());
+  return _connectivity[d0][d1];
+}
+//-----------------------------------------------------------------------------
+std::shared_ptr<const Connectivity>
+MeshTopology::connectivity(std::size_t d0, std::size_t d1) const
+{
+  assert(d0 < _connectivity.size());
+  assert(d1 < _connectivity[d0].size());
+  return _connectivity[d0][d1];
+}
+//-----------------------------------------------------------------------------
+void MeshTopology::set_connectivity(std::shared_ptr<Connectivity> c,
+                                    std::size_t d0, std::size_t d1)
+{
+  assert(d0 < _connectivity.size());
+  assert(d1 < _connectivity[d0].size());
+  _connectivity[d0][d1] = c;
 }
 //-----------------------------------------------------------------------------
 const std::map<std::int32_t, std::set<std::uint32_t>>&

--- a/cpp/dolfin/mesh/MeshTopology.h
+++ b/cpp/dolfin/mesh/MeshTopology.h
@@ -92,15 +92,15 @@ public:
 
   /// Check whether there are any shared entities calculated of
   /// dimension dim
-  bool have_shared_entities(std::uint32_t dim) const;
+  bool have_shared_entities(int dim) const;
 
   /// Return map from shared entities (local index) to processes
   /// that share the entity
-  std::map<std::int32_t, std::set<std::uint32_t>>& shared_entities(int dim);
+  std::map<std::int32_t, std::set<std::int32_t>>& shared_entities(int dim);
 
   /// Return map from shared entities (local index) to process that
   /// share the entity (const version)
-  const std::map<std::int32_t, std::set<std::uint32_t>>&
+  const std::map<std::int32_t, std::set<std::int32_t>>&
   shared_entities(int dim) const;
 
   /// Return mapping from local ghost cell index to owning process Since
@@ -146,7 +146,7 @@ private:
 
   // For entities of a given dimension d, maps each shared entity
   // (local index) to a list of the processes sharing the vertex
-  std::map<std::uint32_t, std::map<std::int32_t, std::set<std::uint32_t>>>
+  std::map<std::int32_t, std::map<std::int32_t, std::set<std::int32_t>>>
       _shared_entities;
 
   // For cells which are "ghosted", locate the owning process, using a

--- a/cpp/dolfin/mesh/MeshTopology.h
+++ b/cpp/dolfin/mesh/MeshTopology.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include "Connectivity.h"
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -17,6 +16,8 @@ namespace dolfin
 {
 namespace mesh
 {
+
+class Connectivity;
 
 /// MeshTopology stores the topology of a mesh, consisting of mesh
 /// entities and connectivity (incidence relations for the mesh
@@ -60,16 +61,7 @@ public:
 
   /// Return number of regular (non-ghost) entities or equivalently,
   /// the offset of where ghost entities begin
-  inline std::int32_t ghost_offset(int dim) const
-  {
-    if (_ghost_offset_index.empty())
-      return 0;
-    else
-    {
-      assert(dim < (int)_ghost_offset_index.size());
-      return _ghost_offset_index[dim];
-    }
-  }
+  std::int32_t ghost_offset(int dim) const;
 
   /// Clear data for given pair of topological dimensions
   void clear(int d0, int d1);
@@ -88,35 +80,19 @@ public:
   /// Set global index for entity of dimension dim and with local
   /// index
   void set_global_index(std::size_t dim, std::int32_t local_index,
-                        std::int64_t global_index)
-  {
-    assert(dim < _global_indices.size());
-    assert(local_index < (std::int32_t)_global_indices[dim].size());
-    _global_indices[dim][local_index] = global_index;
-  }
+                        std::int64_t global_index);
 
   /// Get local-to-global index map for entities of topological
   /// dimension d
-  const std::vector<std::int64_t>& global_indices(std::size_t d) const
-  {
-    assert(d < _global_indices.size());
-    return _global_indices[d];
-  }
+  const std::vector<std::int64_t>& global_indices(std::size_t d) const;
 
   /// Check if global indices are available for entities of
   /// dimension dim
-  bool have_global_indices(std::size_t dim) const
-  {
-    assert(dim < _global_indices.size());
-    return !_global_indices[dim].empty();
-  }
+  bool have_global_indices(std::size_t dim) const;
 
-  /// Check whether there are any shared entities calculated
-  /// of dimension dim
-  bool have_shared_entities(std::uint32_t dim) const
-  {
-    return (_shared_entities.find(dim) != _shared_entities.end());
-  }
+  /// Check whether there are any shared entities calculated of
+  /// dimension dim
+  bool have_shared_entities(std::uint32_t dim) const;
 
   /// Return map from shared entities (local index) to processes
   /// that share the entity
@@ -130,39 +106,24 @@ public:
   /// Return mapping from local ghost cell index to owning process
   /// Since ghost cells are at the end of the range, this is just
   /// a vector over those cells
-  std::vector<std::uint32_t>& cell_owner() { return _cell_owner; }
+  std::vector<std::uint32_t>& cell_owner();
 
   /// Return mapping from local ghost cell index to owning process (const
   /// version)
   /// Since ghost cells are at the end of the range, this is just
   /// a vector over those cells
-  const std::vector<std::uint32_t>& cell_owner() const { return _cell_owner; }
+  const std::vector<std::uint32_t>& cell_owner() const;
 
   /// Return connectivity for given pair of topological dimensions
-  std::shared_ptr<Connectivity> connectivity(std::size_t d0, std::size_t d1)
-  {
-    assert(d0 < _connectivity.size());
-    assert(d1 < _connectivity[d0].size());
-    return _connectivity[d0][d1];
-  }
+  std::shared_ptr<Connectivity> connectivity(std::size_t d0, std::size_t d1);
 
   /// Return connectivity for given pair of topological dimensions
   std::shared_ptr<const Connectivity> connectivity(std::size_t d0,
-                                                   std::size_t d1) const
-  {
-    assert(d0 < _connectivity.size());
-    assert(d1 < _connectivity[d0].size());
-    return _connectivity[d0][d1];
-  }
+                                                   std::size_t d1) const;
 
   /// Set connectivity for given pair of topological dimensions
   void set_connectivity(std::shared_ptr<Connectivity> c, std::size_t d0,
-                        std::size_t d1)
-  {
-    assert(d0 < _connectivity.size());
-    assert(d1 < _connectivity[d0].size());
-    _connectivity[d0][d1] = c;
-  }
+                        std::size_t d1);
 
   /// Return hash based on the hash of cell-vertex connectivity
   size_t hash() const;
@@ -196,6 +157,6 @@ private:
 
   // Connectivity for pairs of topological dimensions
   std::vector<std::vector<std::shared_ptr<Connectivity>>> _connectivity;
-};
+}; // namespace mesh
 } // namespace mesh
 } // namespace dolfin

--- a/cpp/dolfin/mesh/MeshTopology.h
+++ b/cpp/dolfin/mesh/MeshTopology.h
@@ -103,16 +103,15 @@ public:
   const std::map<std::int32_t, std::set<std::uint32_t>>&
   shared_entities(int dim) const;
 
-  /// Return mapping from local ghost cell index to owning process
-  /// Since ghost cells are at the end of the range, this is just
-  /// a vector over those cells
-  std::vector<std::uint32_t>& cell_owner();
+  /// Return mapping from local ghost cell index to owning process Since
+  /// ghost cells are at the end of the range, this is just a vector
+  /// over those cells
+  std::vector<std::int32_t>& cell_owner();
 
-  /// Return mapping from local ghost cell index to owning process (const
-  /// version)
-  /// Since ghost cells are at the end of the range, this is just
-  /// a vector over those cells
-  const std::vector<std::uint32_t>& cell_owner() const;
+  /// Return mapping from local ghost cell index to owning process
+  /// (const version). Since ghost cells are at the end of the range,
+  /// this is just a vector over those cells
+  const std::vector<std::int32_t>& cell_owner() const;
 
   /// Return connectivity for given pair of topological dimensions
   std::shared_ptr<Connectivity> connectivity(std::size_t d0, std::size_t d1);
@@ -150,10 +149,10 @@ private:
   std::map<std::uint32_t, std::map<std::int32_t, std::set<std::uint32_t>>>
       _shared_entities;
 
-  // For cells which are "ghosted", locate the owning process,
-  // using a vector rather than a map,
-  // since ghost cells are always at the end of the range.
-  std::vector<std::uint32_t> _cell_owner;
+  // For cells which are "ghosted", locate the owning process, using a
+  // vector rather than a map, since ghost cells are always at the end
+  // of the range.
+  std::vector<std::int32_t> _cell_owner;
 
   // Connectivity for pairs of topological dimensions
   std::vector<std::vector<std::shared_ptr<Connectivity>>> _connectivity;

--- a/cpp/dolfin/mesh/MeshTopology.h
+++ b/cpp/dolfin/mesh/MeshTopology.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "MeshConnectivity.h"
+#include "Connectivity.h"
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -139,7 +139,7 @@ public:
   const std::vector<std::uint32_t>& cell_owner() const { return _cell_owner; }
 
   /// Return connectivity for given pair of topological dimensions
-  std::shared_ptr<MeshConnectivity> connectivity(std::size_t d0, std::size_t d1)
+  std::shared_ptr<Connectivity> connectivity(std::size_t d0, std::size_t d1)
   {
     assert(d0 < _connectivity.size());
     assert(d1 < _connectivity[d0].size());
@@ -147,8 +147,8 @@ public:
   }
 
   /// Return connectivity for given pair of topological dimensions
-  std::shared_ptr<const MeshConnectivity> connectivity(std::size_t d0,
-                                                       std::size_t d1) const
+  std::shared_ptr<const Connectivity> connectivity(std::size_t d0,
+                                                   std::size_t d1) const
   {
     assert(d0 < _connectivity.size());
     assert(d1 < _connectivity[d0].size());
@@ -156,7 +156,7 @@ public:
   }
 
   /// Set connectivity for given pair of topological dimensions
-  void set_connectivity(std::shared_ptr<MeshConnectivity> c, std::size_t d0,
+  void set_connectivity(std::shared_ptr<Connectivity> c, std::size_t d0,
                         std::size_t d1)
   {
     assert(d0 < _connectivity.size());
@@ -195,7 +195,7 @@ private:
   std::vector<std::uint32_t> _cell_owner;
 
   // Connectivity for pairs of topological dimensions
-  std::vector<std::vector<std::shared_ptr<MeshConnectivity>>> _connectivity;
+  std::vector<std::vector<std::shared_ptr<Connectivity>>> _connectivity;
 };
 } // namespace mesh
 } // namespace dolfin

--- a/cpp/dolfin/mesh/MeshValueCollection.h
+++ b/cpp/dolfin/mesh/MeshValueCollection.h
@@ -208,7 +208,6 @@ MeshValueCollection<T>::MeshValueCollection(
   {
     _mesh->init(_dim, D);
     const Connectivity& connectivity = _mesh->topology().connectivity(_dim, D);
-    assert(!connectivity.empty());
     for (std::size_t entity_index = 0; entity_index < mesh_function.size();
          ++entity_index)
     {
@@ -260,7 +259,6 @@ operator=(const MeshFunction<T>& mesh_function)
     _mesh->init(_dim, D);
     assert(_mesh->topology().connectivity(_dim, D));
     const Connectivity& connectivity = *_mesh->topology().connectivity(_dim, D);
-    assert(!connectivity.empty());
     for (std::size_t entity_index = 0; entity_index < mesh_function.size();
          ++entity_index)
     {
@@ -380,7 +378,6 @@ bool MeshValueCollection<T>::set_value(std::size_t entity_index, const T& value)
   const Connectivity& connectivity = *_mesh->topology().connectivity(_dim, D);
 
   // Find the cell
-  assert(!connectivity.empty());
   assert(connectivity.size(entity_index) > 0);
   const MeshEntity entity(*_mesh, _dim, entity_index);
   const mesh::Cell cell(

--- a/cpp/dolfin/mesh/MeshValueCollection.h
+++ b/cpp/dolfin/mesh/MeshValueCollection.h
@@ -207,8 +207,7 @@ MeshValueCollection<T>::MeshValueCollection(
   else
   {
     _mesh->init(_dim, D);
-    const MeshConnectivity& connectivity
-        = _mesh->topology().connectivity(_dim, D);
+    const Connectivity& connectivity = _mesh->topology().connectivity(_dim, D);
     assert(!connectivity.empty());
     for (std::size_t entity_index = 0; entity_index < mesh_function.size();
          ++entity_index)
@@ -260,8 +259,7 @@ operator=(const MeshFunction<T>& mesh_function)
   {
     _mesh->init(_dim, D);
     assert(_mesh->topology().connectivity(_dim, D));
-    const MeshConnectivity& connectivity
-        = *_mesh->topology().connectivity(_dim, D);
+    const Connectivity& connectivity = *_mesh->topology().connectivity(_dim, D);
     assert(!connectivity.empty());
     for (std::size_t entity_index = 0; entity_index < mesh_function.size();
          ++entity_index)
@@ -379,8 +377,7 @@ bool MeshValueCollection<T>::set_value(std::size_t entity_index, const T& value)
   // Get mesh connectivity d --> D
   _mesh->init(_dim, D);
   assert(_mesh->topology().connectivity(_dim, D));
-  const MeshConnectivity& connectivity
-      = *_mesh->topology().connectivity(_dim, D);
+  const Connectivity& connectivity = *_mesh->topology().connectivity(_dim, D);
 
   // Find the cell
   assert(!connectivity.empty());

--- a/cpp/dolfin/mesh/MeshValueCollection.h
+++ b/cpp/dolfin/mesh/MeshValueCollection.h
@@ -219,7 +219,8 @@ MeshValueCollection<T>::MeshValueCollection(
       for (std::size_t i = 0; i < entity.num_entities(D); ++i)
       {
         // Create cell
-        const mesh::Cell cell(*_mesh, connectivity(entity_index)[i]);
+        const mesh::Cell cell(*_mesh,
+                              connectivity.connections(entity_index)[i]);
 
         // Find the local entity index
         const std::size_t local_entity = cell.index(entity);
@@ -271,7 +272,8 @@ operator=(const MeshFunction<T>& mesh_function)
       for (std::size_t i = 0; i < entity.num_entities(D); ++i)
       {
         // Create cell
-        const mesh::Cell cell(*_mesh, connectivity(entity_index)[i]);
+        const mesh::Cell cell(*_mesh,
+                              connectivity.connections(entity_index)[i]);
 
         // Find the local entity index
         const std::size_t local_entity = cell.index(entity);
@@ -323,7 +325,8 @@ bool MeshValueCollection<T>::set_value(std::size_t cell_index,
     // spdlog::error(
     //     "MeshValueCollection.h", "set value",
     //     "A mesh has not been associated with this MeshValueCollection");
-    throw std::runtime_error("A mesh has not been associated with this MeshValueCollection");
+    throw std::runtime_error(
+        "A mesh has not been associated with this MeshValueCollection");
   }
 
   const std::pair<std::size_t, std::size_t> pos(cell_index, local_entity);
@@ -347,7 +350,8 @@ bool MeshValueCollection<T>::set_value(std::size_t entity_index, const T& value)
     // spdlog::error(
     //     "MeshValueCollection.h", "set value",
     //     "A mesh has not been associated with this MeshValueCollection");
-    throw std::runtime_error("A mesh has not been associated with this MeshValueCollection");
+    throw std::runtime_error(
+        "A mesh has not been associated with this MeshValueCollection");
   }
 
   assert(_dim >= 0);
@@ -382,7 +386,8 @@ bool MeshValueCollection<T>::set_value(std::size_t entity_index, const T& value)
   assert(!connectivity.empty());
   assert(connectivity.size(entity_index) > 0);
   const MeshEntity entity(*_mesh, _dim, entity_index);
-  const mesh::Cell cell(*_mesh, connectivity(entity_index)[0]); // choose first
+  const mesh::Cell cell(
+      *_mesh, connectivity.connections(entity_index)[0]); // choose first
 
   // Find the local entity index
   const std::size_t local_entity = cell.index(entity);
@@ -418,7 +423,8 @@ T MeshValueCollection<T>::get_value(std::size_t cell_index,
     // spdlog::error("MeshValueCollection.h", "extract value",
     //               "No value stored for cell index: %d and local index: %d",
     //               cell_index, local_entity);
-    throw std::runtime_error("A mesh has not been associated with this MeshValueCollection");
+    throw std::runtime_error(
+        "A mesh has not been associated with this MeshValueCollection");
   }
 
   return it->second;
@@ -452,7 +458,8 @@ std::string MeshValueCollection<T>::str(bool verbose) const
   {
     s << str(false) << std::endl << std::endl;
     // spdlog::warn(
-    //     "Verbose output of MeshValueCollection must be implemented manually.");
+    //     "Verbose output of MeshValueCollection must be implemented
+    //     manually.");
   }
   else
   {

--- a/cpp/dolfin/mesh/Ordering.cpp
+++ b/cpp/dolfin/mesh/Ordering.cpp
@@ -68,8 +68,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
   // Sort i - j for i > j: 1 - 0, 2 - 0, 2 - 1, 3 - 0, 3 - 1, 3 - 2
 
   // Sort local vertices on edges in ascending order, connectivity 1 - 0
-  std::shared_ptr<mesh::MeshConnectivity> connect_1_0
-      = topology.connectivity(1, 0);
+  std::shared_ptr<mesh::Connectivity> connect_1_0 = topology.connectivity(1, 0);
   if (connect_1_0 and !connect_1_0->empty())
   {
     // assert(!topology(tdim, 1).empty());
@@ -91,8 +90,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
   const int num_faces = cell_type.num_entities(2);
 
   // Sort local vertices on faces in ascending order, connectivity 2 - 0
-  std::shared_ptr<mesh::MeshConnectivity> connect_2_0
-      = topology.connectivity(2, 0);
+  std::shared_ptr<mesh::Connectivity> connect_2_0 = topology.connectivity(2, 0);
   if (connect_2_0 and !connect_2_0->empty())
   {
     // assert(!topology(3, 2).empty());
@@ -110,8 +108,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
 
   // Sort local edges on local faces after non-incident vertex,
   // connectivity 2 - 1
-  std::shared_ptr<mesh::MeshConnectivity> connect_2_1
-      = topology.connectivity(2, 1);
+  std::shared_ptr<mesh::Connectivity> connect_2_1 = topology.connectivity(2, 1);
   if (connect_2_1 and !connect_2_1->empty())
   {
     // dolfin_assert(!topology(3, 2).empty());
@@ -157,8 +154,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
     return;
 
   // Sort local vertices on cell in ascending order, connectivity 3 - 0
-  std::shared_ptr<mesh::MeshConnectivity> connect_3_0
-      = topology.connectivity(3, 0);
+  std::shared_ptr<mesh::Connectivity> connect_3_0 = topology.connectivity(3, 0);
   if (connect_3_0 and !connect_3_0->empty())
   {
     std::int32_t* cell_vertices = connect_3_0->connections(cell.index());
@@ -169,8 +165,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
 
   // Sort local edges on cell after non-incident vertex tuble,
   // connectivity 3-1
-  std::shared_ptr<mesh::MeshConnectivity> connect_3_1
-      = topology.connectivity(3, 1);
+  std::shared_ptr<mesh::Connectivity> connect_3_1 = topology.connectivity(3, 1);
   if (connect_3_1 and !connect_3_1->empty())
   {
     // assert(!topology(1, 0).empty());
@@ -211,8 +206,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
 
   // Sort local facets on cell after non-incident vertex, connectivity 3
   // - 2
-  std::shared_ptr<mesh::MeshConnectivity> connect_3_2
-      = topology.connectivity(3, 2);
+  std::shared_ptr<mesh::Connectivity> connect_3_2 = topology.connectivity(3, 2);
   if (connect_3_2 and !connect_3_2->empty())
   {
     // assert(!topology(2, 0).empty());
@@ -251,7 +245,7 @@ bool ordered_cell_simplex(
   const int c = cell.index();
 
   // Get vertices
-  std::shared_ptr<const mesh::MeshConnectivity> connect_tdim_0
+  std::shared_ptr<const mesh::Connectivity> connect_tdim_0
       = topology.connectivity(tdim, 0);
   assert(connect_tdim_0);
 
@@ -273,13 +267,13 @@ bool ordered_cell_simplex(
   for (int d = 1; d + 1 < tdim; ++d)
   {
     // Check if entities exist, otherwise skip
-    std::shared_ptr<const mesh::MeshConnectivity> connect_d_0
+    std::shared_ptr<const mesh::Connectivity> connect_d_0
         = topology.connectivity(d, 0);
     if (!connect_d_0 or connect_d_0->empty())
       continue;
 
     // Get entities
-    std::shared_ptr<const mesh::MeshConnectivity> connect_tdim_d
+    std::shared_ptr<const mesh::Connectivity> connect_tdim_d
         = topology.connectivity(tdim, d);
     assert(connect_tdim_d);
     const int num_entities = connect_tdim_d->size(c);

--- a/cpp/dolfin/mesh/Ordering.cpp
+++ b/cpp/dolfin/mesh/Ordering.cpp
@@ -69,7 +69,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
 
   // Sort local vertices on edges in ascending order, connectivity 1 - 0
   std::shared_ptr<mesh::Connectivity> connect_1_0 = topology.connectivity(1, 0);
-  if (connect_1_0 and !connect_1_0->empty())
+  if (connect_1_0)
   {
     // assert(!topology(tdim, 1).empty());
 
@@ -91,7 +91,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
 
   // Sort local vertices on faces in ascending order, connectivity 2 - 0
   std::shared_ptr<mesh::Connectivity> connect_2_0 = topology.connectivity(2, 0);
-  if (connect_2_0 and !connect_2_0->empty())
+  if (connect_2_0)
   {
     // assert(!topology(3, 2).empty());
 
@@ -109,7 +109,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
   // Sort local edges on local faces after non-incident vertex,
   // connectivity 2 - 1
   std::shared_ptr<mesh::Connectivity> connect_2_1 = topology.connectivity(2, 1);
-  if (connect_2_1 and !connect_2_1->empty())
+  if (connect_2_1)
   {
     // dolfin_assert(!topology(3, 2).empty());
     // dolfin_assert(!topology(2, 0).empty());
@@ -155,7 +155,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
 
   // Sort local vertices on cell in ascending order, connectivity 3 - 0
   std::shared_ptr<mesh::Connectivity> connect_3_0 = topology.connectivity(3, 0);
-  if (connect_3_0 and !connect_3_0->empty())
+  if (connect_3_0)
   {
     std::int32_t* cell_vertices = connect_3_0->connections(cell.index());
     std::sort(cell_vertices, cell_vertices + 4, [&](auto& a, auto& b) {
@@ -166,7 +166,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
   // Sort local edges on cell after non-incident vertex tuble,
   // connectivity 3-1
   std::shared_ptr<mesh::Connectivity> connect_3_1 = topology.connectivity(3, 1);
-  if (connect_3_1 and !connect_3_1->empty())
+  if (connect_3_1)
   {
     // assert(!topology(1, 0).empty());
 
@@ -207,7 +207,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
   // Sort local facets on cell after non-incident vertex, connectivity 3
   // - 2
   std::shared_ptr<mesh::Connectivity> connect_3_2 = topology.connectivity(3, 2);
-  if (connect_3_2 and !connect_3_2->empty())
+  if (connect_3_2)
   {
     // assert(!topology(2, 0).empty());
 
@@ -269,7 +269,7 @@ bool ordered_cell_simplex(
     // Check if entities exist, otherwise skip
     std::shared_ptr<const mesh::Connectivity> connect_d_0
         = topology.connectivity(d, 0);
-    if (!connect_d_0 or connect_d_0->empty())
+    if (!connect_d_0)
       continue;
 
     // Get entities

--- a/cpp/dolfin/mesh/Ordering.cpp
+++ b/cpp/dolfin/mesh/Ordering.cpp
@@ -71,13 +71,13 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
   std::shared_ptr<mesh::Connectivity> connect_1_0 = topology.connectivity(1, 0);
   if (connect_1_0)
   {
-    // assert(!topology(tdim, 1).empty());
-
     // Sort vertices on each edge
     const std::int32_t* cell_edges = cell.entities(1);
+    assert(cell_edges);
     for (int i = 0; i < num_edges; ++i)
     {
       std::int32_t* edge_vertices = connect_1_0->connections(cell_edges[i]);
+      assert(edge_vertices);
       std::sort(edge_vertices, edge_vertices + 2, [&](auto& a, auto& b) {
         return global_vertex_indices[a] < global_vertex_indices[b];
       });
@@ -93,13 +93,13 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
   std::shared_ptr<mesh::Connectivity> connect_2_0 = topology.connectivity(2, 0);
   if (connect_2_0)
   {
-    // assert(!topology(3, 2).empty());
-
     // Sort vertices on each facet
     const std::int32_t* cell_faces = cell.entities(2);
+    assert(cell_faces);
     for (int i = 0; i < num_faces; ++i)
     {
       std::int32_t* face_vertices = connect_2_0->connections(cell_faces[i]);
+      assert(face_vertices);
       std::sort(face_vertices, face_vertices + 3, [&](auto& a, auto& b) {
         return global_vertex_indices[a] < global_vertex_indices[b];
       });
@@ -111,20 +111,19 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
   std::shared_ptr<mesh::Connectivity> connect_2_1 = topology.connectivity(2, 1);
   if (connect_2_1)
   {
-    // dolfin_assert(!topology(3, 2).empty());
-    // dolfin_assert(!topology(2, 0).empty());
-    // dolfin_assert(!topology(1, 0).empty());
-
     // Loop over faces on cell
     const std::int32_t* cell_faces = cell.entities(2);
+    assert(cell_faces);
     for (int i = 0; i < num_faces; ++i)
     {
       // For each face number get the global vertex numbers
       const std::int32_t* face_vertices
           = connect_2_0->connections(cell_faces[i]);
+      assert(face_vertices);
 
       // For each facet number get the global edge number
       std::int32_t* cell_edges = connect_2_1->connections(cell_faces[i]);
+      assert(cell_edges);
 
       // Loop over vertices on face
       std::size_t m = 0;
@@ -136,6 +135,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
           // For each edge number get the global vertex numbers
           const std::int32_t* edge_vertices
               = connect_1_0->connections(cell_edges[k]);
+          assert(edge_vertices);
 
           // Check if the jth vertex of facet i is non-incident on edge k
           if (!std::count(edge_vertices, edge_vertices + 2, face_vertices[j]))
@@ -158,6 +158,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
   if (connect_3_0)
   {
     std::int32_t* cell_vertices = connect_3_0->connections(cell.index());
+    assert(cell_vertices);
     std::sort(cell_vertices, cell_vertices + 4, [&](auto& a, auto& b) {
       return global_vertex_indices[a] < global_vertex_indices[b];
     });
@@ -168,11 +169,11 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
   std::shared_ptr<mesh::Connectivity> connect_3_1 = topology.connectivity(3, 1);
   if (connect_3_1)
   {
-    // assert(!topology(1, 0).empty());
-
     // Get cell vertices and edge numbers
     const std::int32_t* cell_vertices = cell.entities(0);
+    assert(cell_vertices);
     std::int32_t* cell_edges = connect_3_1->connections(cell.index());
+    assert(cell_edges);
 
     // Loop two vertices on cell as a lexicographical tuple
     // (i, j): (0,1) (0,2) (0,3) (1,2) (1,3) (2,3)
@@ -187,6 +188,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
           // Get local vertices on edge
           const std::int32_t* edge_vertices
               = connect_1_0->connections(cell_edges[k]);
+          assert(edge_vertices);
 
           // Check if the ith and jth vertex of the cell are
           // non-incident on edge k
@@ -209,11 +211,11 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
   std::shared_ptr<mesh::Connectivity> connect_3_2 = topology.connectivity(3, 2);
   if (connect_3_2)
   {
-    // assert(!topology(2, 0).empty());
-
     // Get cell vertices and facet numbers
     const std::int32_t* cell_vertices = cell.entities(0);
+    assert(cell_vertices);
     std::int32_t* cell_faces = connect_3_2->connections(cell.index());
+    assert(cell_faces);
 
     // Loop vertices on cell
     for (int i = 0; i < 4; ++i)
@@ -222,6 +224,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
       for (int j = i; j < 4; ++j)
       {
         std::int32_t* face_vertices = connect_2_0->connections(cell_faces[j]);
+        assert(face_vertices);
 
         // Check if the ith vertex of the cell is non-incident on facet j
         if (!std::count(face_vertices, face_vertices + 3, cell_vertices[i]))
@@ -237,7 +240,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
 //-----------------------------------------------------------------------------
 bool ordered_cell_simplex(
     const std::vector<std::int64_t>& global_vertex_indices,
-    const dolfin::mesh::Cell& cell)
+    const mesh::Cell& cell)
 {
   // Get mesh topology
   const mesh::MeshTopology& topology = cell.mesh().topology();

--- a/cpp/dolfin/mesh/Ordering.cpp
+++ b/cpp/dolfin/mesh/Ordering.cpp
@@ -54,9 +54,9 @@ bool increasing(const int n, const std::int32_t* v0, const std::int32_t* v1,
 }
 //-----------------------------------------------------------------------------
 void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
-                        dolfin::mesh::Cell& cell)
+                        mesh::Mesh& mesh, mesh::Cell& cell)
 {
-  const mesh::MeshTopology& topology = cell.mesh().topology();
+  mesh::MeshTopology& topology = mesh.topology();
   const int tdim = topology.dim();
 
   if (tdim < 1)
@@ -68,7 +68,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
   // Sort i - j for i > j: 1 - 0, 2 - 0, 2 - 1, 3 - 0, 3 - 1, 3 - 2
 
   // Sort local vertices on edges in ascending order, connectivity 1 - 0
-  std::shared_ptr<const mesh::MeshConnectivity> connect_1_0
+  std::shared_ptr<mesh::MeshConnectivity> connect_1_0
       = topology.connectivity(1, 0);
   if (connect_1_0 and !connect_1_0->empty())
   {
@@ -78,9 +78,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
     const std::int32_t* cell_edges = cell.entities(1);
     for (int i = 0; i < num_edges; ++i)
     {
-      std::int32_t* edge_vertices
-          = const_cast<std::int32_t*>(connect_1_0->connections(cell_edges[i]));
-      // sort_entities(2, edge_vertices, global_vertex_indices);
+      std::int32_t* edge_vertices = connect_1_0->connections(cell_edges[i]);
       std::sort(edge_vertices, edge_vertices + 2, [&](auto& a, auto& b) {
         return global_vertex_indices[a] < global_vertex_indices[b];
       });
@@ -93,7 +91,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
   const int num_faces = cell_type.num_entities(2);
 
   // Sort local vertices on faces in ascending order, connectivity 2 - 0
-  std::shared_ptr<const mesh::MeshConnectivity> connect_2_0
+  std::shared_ptr<mesh::MeshConnectivity> connect_2_0
       = topology.connectivity(2, 0);
   if (connect_2_0 and !connect_2_0->empty())
   {
@@ -103,8 +101,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
     const std::int32_t* cell_faces = cell.entities(2);
     for (int i = 0; i < num_faces; ++i)
     {
-      std::int32_t* face_vertices
-          = const_cast<std::int32_t*>(connect_2_0->connections(cell_faces[i]));
+      std::int32_t* face_vertices = connect_2_0->connections(cell_faces[i]);
       std::sort(face_vertices, face_vertices + 3, [&](auto& a, auto& b) {
         return global_vertex_indices[a] < global_vertex_indices[b];
       });
@@ -113,7 +110,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
 
   // Sort local edges on local faces after non-incident vertex,
   // connectivity 2 - 1
-  std::shared_ptr<const mesh::MeshConnectivity> connect_2_1
+  std::shared_ptr<mesh::MeshConnectivity> connect_2_1
       = topology.connectivity(2, 1);
   if (connect_2_1 and !connect_2_1->empty())
   {
@@ -130,8 +127,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
           = connect_2_0->connections(cell_faces[i]);
 
       // For each facet number get the global edge number
-      std::int32_t* cell_edges
-          = const_cast<std::int32_t*>(connect_2_1->connections(cell_faces[i]));
+      std::int32_t* cell_edges = connect_2_1->connections(cell_faces[i]);
 
       // Loop over vertices on face
       std::size_t m = 0;
@@ -161,11 +157,11 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
     return;
 
   // Sort local vertices on cell in ascending order, connectivity 3 - 0
-  std::shared_ptr<const mesh::MeshConnectivity> connect_3_0
+  std::shared_ptr<mesh::MeshConnectivity> connect_3_0
       = topology.connectivity(3, 0);
   if (connect_3_0 and !connect_3_0->empty())
   {
-    std::int32_t* cell_vertices = const_cast<std::int32_t*>(cell.entities(0));
+    std::int32_t* cell_vertices = connect_3_0->connections(cell.index());
     std::sort(cell_vertices, cell_vertices + 4, [&](auto& a, auto& b) {
       return global_vertex_indices[a] < global_vertex_indices[b];
     });
@@ -173,7 +169,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
 
   // Sort local edges on cell after non-incident vertex tuble,
   // connectivity 3-1
-  std::shared_ptr<const mesh::MeshConnectivity> connect_3_1
+  std::shared_ptr<mesh::MeshConnectivity> connect_3_1
       = topology.connectivity(3, 1);
   if (connect_3_1 and !connect_3_1->empty())
   {
@@ -181,7 +177,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
 
     // Get cell vertices and edge numbers
     const std::int32_t* cell_vertices = cell.entities(0);
-    std::int32_t* cell_edges = const_cast<std::int32_t*>(cell.entities(1));
+    std::int32_t* cell_edges = connect_3_1->connections(cell.index());
 
     // Loop two vertices on cell as a lexicographical tuple
     // (i, j): (0,1) (0,2) (0,3) (1,2) (1,3) (2,3)
@@ -215,7 +211,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
 
   // Sort local facets on cell after non-incident vertex, connectivity 3
   // - 2
-  std::shared_ptr<const mesh::MeshConnectivity> connect_3_2
+  std::shared_ptr<mesh::MeshConnectivity> connect_3_2
       = topology.connectivity(3, 2);
   if (connect_3_2 and !connect_3_2->empty())
   {
@@ -223,7 +219,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
 
     // Get cell vertices and facet numbers
     const std::int32_t* cell_vertices = cell.entities(0);
-    std::int32_t* cell_faces = const_cast<std::int32_t*>(cell.entities(2));
+    std::int32_t* cell_faces = connect_3_2->connections(cell.index());
 
     // Loop vertices on cell
     for (int i = 0; i < 4; ++i)
@@ -231,8 +227,7 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
       // Loop facets on cell
       for (int j = i; j < 4; ++j)
       {
-        std::int32_t* face_vertices = const_cast<std::int32_t*>(
-            connect_2_0->connections(cell_faces[j]));
+        std::int32_t* face_vertices = connect_2_0->connections(cell_faces[j]);
 
         // Check if the ith vertex of the cell is non-incident on facet j
         if (!std::count(face_vertices, face_vertices + 3, cell_vertices[i]))
@@ -341,7 +336,7 @@ void mesh::Ordering::order_simplex(mesh::Mesh& mesh)
 
   // Iterate over all cells
   for (mesh::Cell& cell : mesh::MeshRange<mesh::Cell>(mesh))
-    order_cell_simplex(global_vertex_indices, cell);
+    order_cell_simplex(global_vertex_indices, mesh, cell);
 }
 //-----------------------------------------------------------------------------
 bool mesh::Ordering::is_ordered_simplex(const mesh::Mesh& mesh)

--- a/cpp/dolfin/mesh/PartitionData.cpp
+++ b/cpp/dolfin/mesh/PartitionData.cpp
@@ -16,7 +16,7 @@ PartitionData::PartitionData(
     : _offset(1)
 
 {
-  for (std::uint32_t i = 0; i != cell_partition.size(); ++i)
+  for (std::size_t i = 0; i != cell_partition.size(); ++i)
   {
     const auto it = ghost_procs.find(i);
     if (it == ghost_procs.end())
@@ -32,22 +32,23 @@ PartitionData::PartitionData(
 //-----------------------------------------------------------------------------
 PartitionData::PartitionData(
     const std::pair<std::vector<int>, std::map<std::int64_t, std::vector<int>>>&
-        data) : PartitionData(data.first, data.second)
+        data)
+    : PartitionData(data.first, data.second)
 {
   // Do nothing
 }
 //-----------------------------------------------------------------------------
-std::uint32_t PartitionData::num_procs(std::uint32_t i) const
+std::int32_t PartitionData::num_procs(std::int32_t i) const
 {
   return _offset[i + 1] - _offset[i];
 }
 //-----------------------------------------------------------------------------
-const std::uint32_t* PartitionData::procs(std::uint32_t i) const
+const std::int32_t* PartitionData::procs(std::int32_t i) const
 {
   return _dest_processes.data() + _offset[i];
 }
 //-----------------------------------------------------------------------------
-std::uint32_t PartitionData::size() const { return _offset.size() - 1; }
+std::int32_t PartitionData::size() const { return _offset.size() - 1; }
 //-----------------------------------------------------------------------------
 int PartitionData::num_ghosts() const
 {

--- a/cpp/dolfin/mesh/PartitionData.h
+++ b/cpp/dolfin/mesh/PartitionData.h
@@ -58,17 +58,17 @@ public:
   PartitionData& operator=(PartitionData&&) = default;
 
   /// The number of sharing processes of a given cell
-  /// @return std::uint32_t
-  std::uint32_t num_procs(std::uint32_t i) const;
+  /// @return std::int32_t
+  std::int32_t num_procs(std::int32_t i) const;
 
   /// Pointer to sharing processes of a given cell
-  /// @return std::uint32_t*
-  const std::uint32_t* procs(std::uint32_t i) const;
+  /// @return std::int32_t*
+  const std::int32_t* procs(std::int32_t i) const;
 
   /// Number of cells which this partition is defined for
   /// on this process
-  /// @return std::uint32_t
-  std::uint32_t size() const;
+  /// @return std::int32_t
+  std::int32_t size() const;
 
   /// Return the total number of ghosts cells in this partition on this
   /// process. Useful for testing
@@ -77,10 +77,10 @@ public:
 
 private:
   // Contiguous list of processes, indexed with offset, below
-  std::vector<std::uint32_t> _dest_processes;
+  std::vector<std::int32_t> _dest_processes;
 
   // Index offset for each cell into list
-  std::vector<std::uint32_t> _offset;
+  std::vector<std::int32_t> _offset;
 };
 } // namespace mesh
 } // namespace dolfin

--- a/cpp/dolfin/mesh/PeriodicBoundaryComputation.cpp
+++ b/cpp/dolfin/mesh/PeriodicBoundaryComputation.cpp
@@ -57,7 +57,7 @@ struct lt_coordinate
 } // namespace
 
 //-----------------------------------------------------------------------------
-std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>>
+std::map<std::int32_t, std::pair<std::int32_t, std::int32_t>>
 PeriodicBoundaryComputation::compute_periodic_pairs(const Mesh& mesh,
                                                     const SubDomain& sub_domain,
                                                     const std::size_t dim)
@@ -85,7 +85,7 @@ PeriodicBoundaryComputation::compute_periodic_pairs(const Mesh& mesh,
   std::vector<double> x_min_max;
 
   // Map from master entity midpoint coordinate to local facet index
-  std::map<std::vector<double>, std::uint32_t, lt_coordinate>
+  std::map<std::vector<double>, std::int32_t, lt_coordinate>
       master_coord_to_entity_index((lt_coordinate(sub_domain.map_tolerance)));
 
   // Initialise facet-cell connectivity
@@ -150,7 +150,8 @@ PeriodicBoundaryComputation::compute_periodic_pairs(const Mesh& mesh,
             {
               // spdlog::error("PeriodicBoundaryComputation.cpp",
               //               "periodic boundary mapping",
-              //               "Need to set coordinate %d in sub_domain.map", i);
+              //               "Need to set coordinate %d in sub_domain.map",
+              //               i);
               throw std::runtime_error("Not set");
             }
           }
@@ -177,7 +178,7 @@ PeriodicBoundaryComputation::compute_periodic_pairs(const Mesh& mesh,
   // Build send buffer of mapped slave midpoint coordinate to
   // processes that may own the master entity
   std::vector<std::vector<double>> slave_mapped_coords_send(num_processes);
-  std::vector<std::vector<std::uint32_t>> sent_slave_indices(num_processes);
+  std::vector<std::vector<std::int32_t>> sent_slave_indices(num_processes);
   for (std::size_t i = 0; i < slave_entities.size(); ++i)
   {
     for (std::size_t p = 0; p < num_processes; ++p)
@@ -208,7 +209,7 @@ PeriodicBoundaryComputation::compute_periodic_pairs(const Mesh& mesh,
   // Check if this process owns the master facet for a received (mapped)
   // slave
   std::vector<double> coordinates(gdim);
-  std::vector<std::vector<std::uint32_t>> master_local_entity(num_processes);
+  std::vector<std::vector<std::int32_t>> master_local_entity(num_processes);
   for (std::size_t p = 0; p < num_processes; ++p)
   {
     const std::vector<double>& slave_mapped_coords_p
@@ -221,39 +222,39 @@ PeriodicBoundaryComputation::compute_periodic_pairs(const Mesh& mesh,
 
       // Check is this process has a master entity that is paired with
       // a received slave entity
-      std::map<std::vector<double>, std::uint32_t>::const_iterator it
+      std::map<std::vector<double>, std::int32_t>::const_iterator it
           = master_coord_to_entity_index.find(coordinates);
 
       // If this process owns the master, insert master entity index,
-      // else insert std::numeric_limits<std::uint32_t>::max()
+      // else insert std::numeric_limits<std::int32_t>::max()
       if (it != master_coord_to_entity_index.end())
         master_local_entity[p].push_back(it->second);
       else
         master_local_entity[p].push_back(
-            std::numeric_limits<std::uint32_t>::max());
+            std::numeric_limits<std::int32_t>::max());
     }
   }
 
   // Send local index of master entity back to owner of slave entity
-  std::vector<std::vector<std::uint32_t>> master_entity_local_index_recv;
+  std::vector<std::vector<std::int32_t>> master_entity_local_index_recv;
   MPI::all_to_all(mpi_comm, master_local_entity,
                   master_entity_local_index_recv);
 
   // Build map from slave facets on this process to master facet (local
   // facet index, process owner)
-  std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>>
+  std::map<std::int32_t, std::pair<std::int32_t, std::int32_t>>
       slave_to_master_entity;
   std::size_t num_local_slave_entities = 0;
   for (std::size_t p = 0; p < num_processes; ++p)
   {
-    const std::vector<std::uint32_t> master_entity_index_p
+    const std::vector<std::int32_t> master_entity_index_p
         = master_entity_local_index_recv[p];
-    const std::vector<std::uint32_t> sent_slaves_p = sent_slave_indices[p];
+    const std::vector<std::int32_t> sent_slaves_p = sent_slave_indices[p];
     assert(master_entity_index_p.size() == sent_slaves_p.size());
 
     for (std::size_t i = 0; i < master_entity_index_p.size(); ++i)
     {
-      if (master_entity_index_p[i] < std::numeric_limits<std::uint32_t>::max())
+      if (master_entity_index_p[i] < std::numeric_limits<std::int32_t>::max())
       {
         ++num_local_slave_entities;
         slave_to_master_entity.insert(
@@ -276,21 +277,21 @@ PeriodicBoundaryComputation::masters_slaves(std::shared_ptr<const Mesh> mesh,
   MeshFunction<std::size_t> mf(mesh, dim, 0);
 
   // Compute marker
-  const std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>> slaves
+  const std::map<std::int32_t, std::pair<std::int32_t, std::int32_t>> slaves
       = compute_periodic_pairs(*mesh, sub_domain, dim);
 
   // Mark master and slaves, and pack off-process masters to send
   std::vector<std::vector<std::size_t>> master_dofs_send(
       MPI::size(mesh->mpi_comm()));
-  std::map<std::uint32_t,
-           std::pair<std::uint32_t, std::uint32_t>>::const_iterator slave;
+  std::map<std::int32_t, std::pair<std::int32_t, std::int32_t>>::const_iterator
+      slave;
   for (slave = slaves.begin(); slave != slaves.end(); ++slave)
   {
     // Set slave
     mf[slave->first] = 2;
 
     // Pack master entity to send to all sharing processes
-    assert(slave->second.first < master_dofs_send.size());
+    assert(slave->second.first < (std::int32_t)master_dofs_send.size());
     master_dofs_send[slave->second.first].push_back(slave->second.second);
   }
 
@@ -299,18 +300,18 @@ PeriodicBoundaryComputation::masters_slaves(std::shared_ptr<const Mesh> mesh,
   MPI::all_to_all(mesh->mpi_comm(), master_dofs_send, master_dofs_recv);
 
   // Build list of sharing processes
-  std::unordered_map<std::uint32_t,
-                     std::vector<std::pair<std::uint32_t, std::uint32_t>>>
+  std::unordered_map<std::int32_t,
+                     std::vector<std::pair<std::int32_t, std::int32_t>>>
       shared_entities_map
       = DistributedMeshTools::compute_shared_entities(*mesh, dim);
   std::unordered_map<
-      std::uint32_t,
-      std::vector<std::pair<std::uint32_t, std::uint32_t>>>::const_iterator e;
-  std::vector<std::vector<std::pair<std::uint32_t, std::uint32_t>>>
+      std::int32_t,
+      std::vector<std::pair<std::int32_t, std::int32_t>>>::const_iterator e;
+  std::vector<std::vector<std::pair<std::int32_t, std::int32_t>>>
       shared_entities(mesh->num_entities(dim));
   for (e = shared_entities_map.begin(); e != shared_entities_map.end(); ++e)
   {
-    assert(e->first < shared_entities.size());
+    assert(e->first < (std::int32_t)shared_entities.size());
     shared_entities[e->first] = e->second;
   }
 
@@ -322,17 +323,17 @@ PeriodicBoundaryComputation::masters_slaves(std::shared_ptr<const Mesh> mesh,
     for (std::size_t i = 0; i < master_dofs_recv[p].size(); ++i)
     {
       // Get local index
-      const std::size_t local_index = master_dofs_recv[p][i];
+      const std::int32_t local_index = master_dofs_recv[p][i];
 
       // Mark locally
       mf[local_index] = 1;
 
       // Pack to send to sharing processes
-      const std::vector<std::pair<std::uint32_t, std::uint32_t>> sharing
+      const std::vector<std::pair<std::int32_t, std::int32_t>> sharing
           = shared_entities[local_index];
       for (std::size_t j = 0; j < sharing.size(); ++j)
       {
-        assert(sharing[j].first < master_dofs_send.size());
+        assert(sharing[j].first < (std::int32_t)master_dofs_send.size());
         master_dofs_send[sharing[j].first].push_back(sharing[j].second);
       }
     }

--- a/cpp/dolfin/mesh/PeriodicBoundaryComputation.h
+++ b/cpp/dolfin/mesh/PeriodicBoundaryComputation.h
@@ -27,7 +27,7 @@ public:
   /// on this process (local index) to its master entity (owning
   /// process, local index on owner). If a master entity is shared
   /// by processes, only one of the owning processes is returned.
-  static std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>>
+  static std::map<std::int32_t, std::pair<std::int32_t, std::int32_t>>
   compute_periodic_pairs(const Mesh& mesh, const mesh::SubDomain& sub_domain,
                          const std::size_t dim);
 

--- a/cpp/dolfin/mesh/TetrahedronCell.cpp
+++ b/cpp/dolfin/mesh/TetrahedronCell.cpp
@@ -369,7 +369,7 @@ std::size_t TetrahedronCell::find_edge(std::size_t i, const Cell& cell) const
   assert(connectivity);
   for (std::size_t j = 0; j < 6; j++)
   {
-    const std::int32_t* ev = (*connectivity)(e[j]);
+    const std::int32_t* ev = connectivity->connections(e[j]);
     assert(ev);
     const std::int32_t v0 = v[EV[i][0]];
     const std::int32_t v1 = v[EV[i][1]];

--- a/cpp/dolfin/mesh/TriangleCell.cpp
+++ b/cpp/dolfin/mesh/TriangleCell.cpp
@@ -51,8 +51,8 @@ std::size_t TriangleCell::num_vertices(std::size_t dim) const
     return 3; // cells
   default:
     // spdlog::error("TriangleCell.cpp",
-    //               "access number of vertices for subsimplex of triangle cell",
-    //               "Illegal topological dimension (%d)", dim);
+    //               "access number of vertices for subsimplex of triangle
+    //               cell", "Illegal topological dimension (%d)", dim);
     throw std::runtime_error("Illegal topological dimension");
   }
 
@@ -67,7 +67,8 @@ void TriangleCell::create_entities(boost::multi_array<std::int32_t, 2>& e,
   {
     // spdlog::error(
     //     "TriangleCell.cpp", "create entities of triangle cell",
-    //     "Don't know how to create entities of topological dimension %d", dim);
+    //     "Don't know how to create entities of topological dimension %d",
+    //     dim);
     throw std::runtime_error("Illegal topological dimension");
   }
 
@@ -88,7 +89,8 @@ double TriangleCell::volume(const MeshEntity& triangle) const
   // Check that we get a triangle
   if (triangle.dim() != 2)
   {
-    // spdlog::error("TriangleCell.cpp", "compute volume (area) of triangle cell",
+    // spdlog::error("TriangleCell.cpp", "compute volume (area) of triangle
+    // cell",
     //               "Illegal mesh entity, not a triangle");
     throw std::runtime_error("Illegal mesh entity");
   }
@@ -284,8 +286,8 @@ geometry::Point TriangleCell::normal(const Cell& cell, std::size_t facet) const
   if (cell.mesh().geometry().dim() != 2)
   {
     // spdlog::error("TriangleCell.cpp", "find normal",
-    //               "Normal vector is not defined in dimension %d (only defined "
-    //               "when the triangle is in R^2",
+    //               "Normal vector is not defined in dimension %d (only defined
+    //               " "when the triangle is in R^2",
     //               cell.mesh().geometry().dim());
     throw std::runtime_error("Illegal geometric dimension");
   }
@@ -387,7 +389,7 @@ std::size_t TriangleCell::find_edge(std::size_t i, const Cell& cell) const
   assert(connectivity);
   for (std::size_t j = 0; j < 3; j++)
   {
-    const std::int32_t* ev = (*connectivity)(e[j]);
+    const std::int32_t* ev = connectivity->connections(e[j]);
     assert(ev);
     if (ev[0] != v[i] && ev[1] != v[i])
       return j;

--- a/cpp/dolfin/mesh/dolfin_mesh.h
+++ b/cpp/dolfin/mesh/dolfin_mesh.h
@@ -17,7 +17,7 @@ namespace dolfin
 #include <dolfin/mesh/Face.h>
 #include <dolfin/mesh/Facet.h>
 #include <dolfin/mesh/Mesh.h>
-#include <dolfin/mesh/MeshConnectivity.h>
+#include <dolfin/mesh/Connectivity.h>
 #include <dolfin/mesh/MeshEntity.h>
 #include <dolfin/mesh/MeshFunction.h>
 #include <dolfin/mesh/MeshGeometry.h>

--- a/cpp/dolfin/refinement/ParallelRefinement.h
+++ b/cpp/dolfin/refinement/ParallelRefinement.h
@@ -100,25 +100,25 @@ private:
   const mesh::Mesh& _mesh;
 
   // Shared edges between processes. In R^2, vector size is 1
-  std::unordered_map<unsigned int,
-                     std::vector<std::pair<unsigned int, unsigned int>>>
-      shared_edges;
+  std::unordered_map<std::int32_t,
+                     std::vector<std::pair<std::int32_t, std::int32_t>>>
+      _shared_edges;
 
   // Mapping from old local edge index to new global vertex, needed
   // to create new topology
-  std::map<std::size_t, std::size_t> local_edge_to_new_vertex;
+  std::map<std::size_t, std::size_t> _local_edge_to_new_vertex;
 
   // New storage for all coordinates when creating new vertices
   std::vector<double> _new_vertex_coordinates;
 
   // New storage for all cells when creating new topology
-  std::vector<std::int64_t> new_cell_topology;
+  std::vector<std::int64_t> _new_cell_topology;
 
   // Management of marked edges
-  std::vector<bool> marked_edges;
+  std::vector<bool> _marked_edges;
 
   // Temporary storage for edges that have been recently marked
-  std::vector<std::vector<std::size_t>> marked_for_update;
+  std::vector<std::vector<std::size_t>> _marked_for_update;
 };
 } // namespace refinement
 } // namespace dolfin

--- a/python/src/mesh.cpp
+++ b/python/src/mesh.cpp
@@ -11,6 +11,7 @@
 #include <dolfin/function/Expression.h>
 #include <dolfin/mesh/Cell.h>
 #include <dolfin/mesh/CellType.h>
+#include <dolfin/mesh/Connectivity.h>
 #include <dolfin/mesh/CoordinateDofs.h>
 #include <dolfin/mesh/Edge.h>
 #include <dolfin/mesh/Face.h>
@@ -203,8 +204,8 @@ void mesh(py::module& m)
 
   // dolfin::mesh::Connectivity class
   py::class_<dolfin::mesh::Connectivity,
-             std::shared_ptr<dolfin::mesh::Connectivity>>(
-      m, "Connectivity", "Connectivity object")
+             std::shared_ptr<dolfin::mesh::Connectivity>>(m, "Connectivity",
+                                                          "Connectivity object")
       .def("connections",
            [](const dolfin::mesh::Connectivity& self, std::size_t i) {
              return Eigen::Map<const dolfin::EigenArrayXi32>(

--- a/python/src/mesh.cpp
+++ b/python/src/mesh.cpp
@@ -76,7 +76,7 @@ void mesh(py::module& m)
       m, "CoordinateDofs", "CoordinateDofs object")
       .def("entity_points",
            [](const dolfin::mesh::CoordinateDofs& self, std::size_t dim) {
-             const dolfin::mesh::MeshConnectivity& connectivity
+             const dolfin::mesh::Connectivity& connectivity
                  = self.entity_points(dim);
              Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
                  connections = connectivity.connections();
@@ -201,17 +201,17 @@ void mesh(py::module& m)
         return dolfin::mesh::CellType::type2string(self.type().cell_type());
       });
 
-  // dolfin::mesh::MeshConnectivity class
-  py::class_<dolfin::mesh::MeshConnectivity,
-             std::shared_ptr<dolfin::mesh::MeshConnectivity>>(
-      m, "MeshConnectivity", "MeshConnectivity object")
+  // dolfin::mesh::Connectivity class
+  py::class_<dolfin::mesh::Connectivity,
+             std::shared_ptr<dolfin::mesh::Connectivity>>(
+      m, "Connectivity", "Connectivity object")
       .def("connections",
-           [](const dolfin::mesh::MeshConnectivity& self, std::size_t i) {
+           [](const dolfin::mesh::Connectivity& self, std::size_t i) {
              return Eigen::Map<const dolfin::EigenArrayXi32>(
                  self.connections(i), self.size(i));
            },
            py::return_value_policy::reference_internal)
-      .def("size", &dolfin::mesh::MeshConnectivity::size);
+      .def("size", &dolfin::mesh::Connectivity::size);
 
   // dolfin::mesh::MeshEntity class
   py::class_<dolfin::mesh::MeshEntity,

--- a/python/src/mesh.cpp
+++ b/python/src/mesh.cpp
@@ -203,10 +203,10 @@ void mesh(py::module& m)
   py::class_<dolfin::mesh::MeshConnectivity,
              std::shared_ptr<dolfin::mesh::MeshConnectivity>>(
       m, "MeshConnectivity", "MeshConnectivity object")
-      .def("__call__",
+      .def("connections",
            [](const dolfin::mesh::MeshConnectivity& self, std::size_t i) {
-             return Eigen::Map<const dolfin::EigenArrayXi32>(self(i),
-                                                             self.size(i));
+             return Eigen::Map<const dolfin::EigenArrayXi32>(
+                 self.connections(i), self.size(i));
            },
            py::return_value_policy::reference_internal)
       .def("size", &dolfin::mesh::MeshConnectivity::size);

--- a/python/test/unit/mesh/test_ghost_mesh.py
+++ b/python/test/unit/mesh/test_ghost_mesh.py
@@ -86,7 +86,7 @@ def test_ghost_connectivities(mode):
         fidx = facet.index()
         facet_mp = tuple(facet.midpoint()[:])
         reference[facet_mp] = []
-        for cidx in meshR.topology.connectivity(1, 2)(fidx):
+        for cidx in meshR.topology.connectivity(1, 2).connections(fidx):
             cell = Cell(meshR, cidx)
             cell_mp = tuple(cell.midpoint()[:])
             reference[facet_mp].append(cell_mp)
@@ -98,7 +98,7 @@ def test_ghost_connectivities(mode):
         facet_mp = tuple(facet.midpoint()[:])
         assert facet_mp in reference
 
-        for cidx in meshG.topology.connectivity(1, 2)(fidx):
+        for cidx in meshG.topology.connectivity(1, 2).connections(fidx):
             assert cidx in allowable_cell_indices
             cell = Cell(meshG, cidx)
             cell_mp = tuple(cell.midpoint()[:])

--- a/python/test/unit/mesh/test_mesh_iterator.py
+++ b/python/test/unit/mesh/test_mesh_iterator.py
@@ -4,91 +4,90 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
-import pytest
 import numpy
-from dolfin import UnitCubeMesh, MPI, Vertices, Edges, Faces, Facets, Cells, VertexRange
+import pytest
+
+from dolfin import (MPI, Cells, Edges, Faces, Facets, UnitCubeMesh,
+                    VertexRange, Vertices)
 
 
 def test_vertex_iterators():
-    "Iterate over vertices"
+    """Iterate over vertices"""
 
     mesh = UnitCubeMesh(MPI.comm_world, 5, 5, 5)
     for i in range(4):
         mesh.init(0, i)
 
-    # Test connectivity
-    cons = [(i, mesh.topology.connectivity(0, i)) for i in range(4)]
+    connectivities = [(i, mesh.topology.connectivity(0, i)) for i in range(4)]
 
     # Test writability
-    for i, con in cons:
+    for i, connectivity in connectivities:
         def assign(con, i):
-            con(i)[0] = 1
+            connectivity.connecgtions(i)[0] = 1
         with pytest.raises(Exception):
-            assign(con, i)
+            assign(connectivity, i)
 
     n = 0
     for i, v in enumerate(Vertices(mesh)):
         n += 1
-        for j, con in cons:
-            assert numpy.all(con(i) == v.entities(j))
+        for j, connectivity in connectivities:
+            assert numpy.all(connectivity.connections(i) == v.entities(j))
 
     assert n == mesh.num_entities(0)
 
 
 def test_edge_iterators():
-    "Iterate over edges"
+    """Iterate over edges"""
 
     mesh = UnitCubeMesh(MPI.comm_world, 5, 5, 5)
     for i in range(4):
         mesh.init(1, i)
 
-    # Test connectivity
-    cons = [(i, mesh.topology.connectivity(1, i)) for i in range(4)]
+    connectivities = [(i, mesh.topology.connectivity(1, i)) for i in range(4)]
 
     # Test writability
-    for i, con in cons:
+    for i, connectivity in connectivities:
         def assign(con, i):
-            con(i)[0] = 1
+            connectivity.connections(i)[0] = 1
         with pytest.raises(Exception):
-            assign(con, i)
+            assign(connectivity, i)
 
     n = 0
     for i, e in enumerate(Edges(mesh)):
         n += 1
-        for j, con in cons:
-            assert numpy.all(con(i) == e.entities(j))
+        for j, connectivity in connectivities:
+            assert numpy.all(connectivity.connections(i) == e.entities(j))
 
     assert n == mesh.num_entities(1)
 
 
 def test_face_iterator():
-    "Iterate over faces"
+    """Iterate over faces"""
 
     mesh = UnitCubeMesh(MPI.comm_world, 5, 5, 5)
     for i in range(4):
         mesh.init(2, i)
 
-    # Test connectivity
-    cons = [(i, mesh.topology.connectivity(2, i)) for i in range(4)]
+    connectivities = [(i, mesh.topology.connectivity(2, i)) for i in range(4)]
 
     # Test writability
-    for i, con in cons:
+    for i, connectivity in connectivities:
         def assign(con, i):
-            con(i)[0] = 1
+            connectivity.connections(i)[0] = 1
         with pytest.raises(Exception):
-            assign(con, i)
+            assign(connectivity, i)
 
     n = 0
     for i, f in enumerate(Faces(mesh)):
         n += 1
-        for j, con in cons:
-            assert numpy.all(con(i) == f.entities(j))
+        for j, connectivity in connectivities:
+            assert numpy.all(connectivity.connections(i) == f.entities(j))
 
     assert n == mesh.num_entities(2)
 
 
 def test_facet_iterators():
-    "Iterate over facets"
+    """Iterate over facets"""
     mesh = UnitCubeMesh(MPI.comm_world, 5, 5, 5)
     n = 0
     for f in Facets(mesh):
@@ -97,32 +96,31 @@ def test_facet_iterators():
 
 
 def test_cell_iterators():
-    "Iterate over cells"
+    """Iterate over cells"""
     mesh = UnitCubeMesh(MPI.comm_world, 5, 5, 5)
     for i in range(4):
         mesh.init(3, i)
 
-    # Test connectivity
-    cons = [(i, mesh.topology.connectivity(3, i)) for i in range(4)]
+    connectivities = [(i, mesh.topology.connectivity(3, i)) for i in range(4)]
 
     # Test writability
-    for i, con in cons:
-        def assign(con, i):
-            con(i)[0] = 1
+    for i, connectivity in connectivities:
+        def assign(connectivity, i):
+            connectivity.connections(i)[0] = 1
         with pytest.raises(Exception):
-            assign(con, i)
+            assign(connectivity, i)
 
     n = 0
     for i, c in enumerate(Cells(mesh)):
         n += 1
-        for j, con in cons:
-            assert numpy.all(con(i) == c.entities(j))
+        for j, connectivity in connectivities:
+            assert numpy.all(connectivity.connections(i) == c.entities(j))
 
     assert n == mesh.num_cells()
 
 
 def test_mixed_iterators():
-    "Iterate over vertices of cells"
+    """Iterate over vertices of cells"""
 
     mesh = UnitCubeMesh(MPI.comm_world, 5, 5, 5)
     n = 0


### PR DESCRIPTION
Connectivity is fully defined via constructor. Avoids 'half-formed' connectivity objects and need to check for 'empty'.

Also changes a bunch of unsigned int to signed int.