### PR TITLE
Update Form to be less dependent on ufc_form

### DIFF
--- a/cpp/dolfin/fem/Form.cpp
+++ b/cpp/dolfin/fem/Form.cpp
@@ -69,7 +69,7 @@ Form::Form(const ufc_form& ufc_form,
   std::free(cmap);
 
   // Save coefficient maps
-  for (std::size_t i = 0; i < ufc_form.num_coefficients; ++i)
+  for (int i = 0; i < ufc_form.num_coefficients; ++i)
     _coefficient_names.push_back(ufc_form.coefficient_name_map(i));
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/fem/Form.cpp
+++ b/cpp/dolfin/fem/Form.cpp
@@ -27,7 +27,8 @@ using namespace dolfin::fem;
 Form::Form(const ufc_form& ufc_form,
            const std::vector<std::shared_ptr<const function::FunctionSpace>>
                function_spaces)
-    : _integrals(ufc_form), _coefficients([ufc_form]() {
+    : _coefficients([ufc_form]() {
+        // FIXME: using lambda for now.
         std::vector<
             std::tuple<int, std::string, std::shared_ptr<function::Function>>>
             coeffs;
@@ -69,6 +70,53 @@ Form::Form(const ufc_form& ufc_form,
   {
     if (_mesh != f->mesh())
       throw std::runtime_error("Incompatible mesh");
+  }
+
+  // Get list of integral IDs, and load tabulate tensor into memory for each
+  std::vector<int> cell_integral_ids(ufc_form.num_cell_integrals);
+  ufc_form.get_cell_integral_ids(cell_integral_ids.data());
+  for (auto id : cell_integral_ids)
+  {
+    ufc_cell_integral* cell_integral = ufc_form.create_cell_integral(id);
+    assert(cell_integral);
+    _integrals.register_tabulate_tensor_cell(id,
+                                             cell_integral->tabulate_tensor);
+    std::free(cell_integral);
+  }
+
+  std::vector<int> exterior_facet_integral_ids(
+      ufc_form.num_exterior_facet_integrals);
+  ufc_form.get_exterior_facet_integral_ids(exterior_facet_integral_ids.data());
+  for (auto id : exterior_facet_integral_ids)
+  {
+    ufc_exterior_facet_integral* exterior_facet_integral
+        = ufc_form.create_exterior_facet_integral(id);
+    assert(exterior_facet_integral);
+    _integrals.register_tabulate_tensor_exterior_facet(
+        id, exterior_facet_integral->tabulate_tensor);
+    std::free(exterior_facet_integral);
+  }
+
+  std::vector<int> interior_facet_integral_ids(
+      ufc_form.num_interior_facet_integrals);
+  ufc_form.get_interior_facet_integral_ids(interior_facet_integral_ids.data());
+  for (auto id : interior_facet_integral_ids)
+  {
+    ufc_interior_facet_integral* interior_facet_integral
+        = ufc_form.create_interior_facet_integral(id);
+    assert(interior_facet_integral);
+    _integrals.register_tabulate_tensor_interior_facet(
+        id, interior_facet_integral->tabulate_tensor);
+    std::free(interior_facet_integral);
+  }
+
+  // Not currently working
+  std::vector<int> vertex_integral_ids(ufc_form.num_vertex_integrals);
+  ufc_form.get_vertex_integral_ids(vertex_integral_ids.data());
+  if (vertex_integral_ids.size() > 0)
+  {
+    throw std::runtime_error(
+        "Vertex integrals not supported. Under development.");
   }
 
   // Set markers for default integrals
@@ -121,7 +169,7 @@ void Form::set_coefficients(
 {
   for (auto c : coefficients)
   {
-    int index = this->get_coefficient_index(c.first);
+    int index = _coefficients.get_index(c.first);
     _coefficients.set(index, c.second);
   }
 }

--- a/cpp/dolfin/fem/Form.h
+++ b/cpp/dolfin/fem/Form.h
@@ -99,12 +99,6 @@ public:
   ///         The rank of the form.
   std::size_t rank() const;
 
-  /// Get the coefficient index for a named coefficient
-  int get_coefficient_index(std::string name) const;
-
-  /// Get the coefficient name for a given coefficient index
-  std::string get_coefficient_name(int i) const;
-
   /// Set coefficient with given number (shared pointer version)
   ///
   /// @param[in]  i (std::size_t)

--- a/cpp/dolfin/fem/Form.h
+++ b/cpp/dolfin/fem/Form.h
@@ -8,7 +8,6 @@
 
 #include "FormCoefficients.h"
 #include "FormIntegrals.h"
-#include <dolfin/common/types.h>
 #include <functional>
 #include <map>
 #include <memory>
@@ -172,12 +171,7 @@ public:
   /// Register the function for 'tabulate_tensor' for cell integral i
   void register_tabulate_tensor_cell(int i, void (*fn)(PetscScalar*,
                                                        const PetscScalar*,
-                                                       const double*, int))
-  {
-    _integrals.register_tabulate_tensor_cell(i, fn);
-    if (i == -1 and _mesh)
-      _integrals.set_default_domains(*_mesh);
-  }
+                                                       const double*, int));
 
   /// Return exterior facet domains (zero pointer if no domains have
   /// been specified)
@@ -239,11 +233,7 @@ public:
   const FormIntegrals& integrals() const { return _integrals; }
 
   /// Get coordinate_mapping (experimental)
-  std::shared_ptr<const fem::CoordinateMapping> coordinate_mapping() const
-  {
-    return _coord_mapping;
-  }
-
+  std::shared_ptr<const fem::CoordinateMapping> coordinate_mapping() const;
 private:
   // Integrals associated with the Form
   FormIntegrals _integrals;

--- a/cpp/dolfin/fem/Form.h
+++ b/cpp/dolfin/fem/Form.h
@@ -265,10 +265,6 @@ private:
 
   // Coordinate_mapping
   std::shared_ptr<const fem::CoordinateMapping> _coord_mapping;
-
-  // Coefficient names
-  std::vector<std::string> _coefficient_names;
-
 };
 } // namespace fem
 } // namespace dolfin

--- a/cpp/dolfin/fem/Form.h
+++ b/cpp/dolfin/fem/Form.h
@@ -266,9 +266,9 @@ private:
   // Coordinate_mapping
   std::shared_ptr<const fem::CoordinateMapping> _coord_mapping;
 
-  // Function pointers for coeffiecient name <-> index mapping
-  std::function<int(const char*)> _coefficient_index_map;
-  std::function<const char*(int)> _coefficient_name_map;
+  // Coefficient names
+  std::vector<std::string> _coefficient_names;
+
 };
 } // namespace fem
 } // namespace dolfin

--- a/cpp/dolfin/fem/FormCoefficients.cpp
+++ b/cpp/dolfin/fem/FormCoefficients.cpp
@@ -44,7 +44,19 @@ std::vector<int> FormCoefficients::offsets() const
 void FormCoefficients::set(
     int i, std::shared_ptr<const function::Function> coefficient)
 {
-  assert(i < (int)_coefficients.size());
+  if (i >= (int)_coefficients.size())
+    _coefficients.resize(i + 1);
+
+  _coefficients[i] = coefficient;
+}
+//-----------------------------------------------------------------------------
+void FormCoefficients::set(
+    std::string name, std::shared_ptr<const function::Function> coefficient)
+{
+  int i = get_index(name);
+  if (i >= (int)_coefficients.size())
+    _coefficients.resize(i + 1);
+
   _coefficients[i] = coefficient;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/fem/FormCoefficients.h
+++ b/cpp/dolfin/fem/FormCoefficients.h
@@ -31,7 +31,9 @@ class FormCoefficients
 public:
   /// Initialise the FormCoefficients from a ufc_form, instantiating all
   /// the required elements
-  FormCoefficients(const ufc_form& ufc_form);
+  FormCoefficients(const std::vector<
+                   std::tuple<int, std::string, std::shared_ptr<function::Function>>>&
+                       coefficients);
 
   /// Get number of coefficients
   int size() const;
@@ -50,12 +52,21 @@ public:
   /// Original position of coefficient in UFL form
   int original_position(int i) const;
 
+  /// Get index from name of coefficient
+  int get_index(std::string name) const;
+
+  /// Get name from index of coefficient
+  std::string get_name(int index) const;
+
 private:
   // Functions for the coefficients
   std::vector<std::shared_ptr<const function::Function>> _coefficients;
 
   // Copy of 'original positions' in UFL form
   std::vector<int> _original_pos;
+
+  // Names of coefficients
+  std::vector<std::string> _names;
 };
 } // namespace fem
 } // namespace dolfin

--- a/cpp/dolfin/fem/FormCoefficients.h
+++ b/cpp/dolfin/fem/FormCoefficients.h
@@ -44,8 +44,11 @@ public:
   /// the size required to store all coefficients.
   std::vector<int> offsets() const;
 
-  /// Set a coefficient to be a Function
+  /// Set coefficient with index i to be a Function
   void set(int i, std::shared_ptr<const function::Function> coefficient);
+
+  /// Set coefficient with name to be a Function
+  void set(std::string name, std::shared_ptr<const function::Function> coefficient);
 
   /// Get the Function coefficient i
   std::shared_ptr<const function::Function> get(int i) const;

--- a/cpp/dolfin/fem/FormCoefficients.h
+++ b/cpp/dolfin/fem/FormCoefficients.h
@@ -9,8 +9,6 @@
 #include <memory>
 #include <vector>
 
-struct ufc_form;
-
 namespace dolfin
 {
 
@@ -29,11 +27,14 @@ class FiniteElement;
 class FormCoefficients
 {
 public:
-  /// Initialise the FormCoefficients from a ufc_form, instantiating all
-  /// the required elements
-  FormCoefficients(const std::vector<
-                   std::tuple<int, std::string, std::shared_ptr<function::Function>>>&
-                       coefficients);
+  /// Initialise the FormCoefficients, using tuples of
+  /// (original_coeff_position, name, shared_ptr<function::Function>). The
+  /// shared_ptr<Function> may be a nullptr and assigned later.
+
+  FormCoefficients(
+      const std::vector<
+          std::tuple<int, std::string, std::shared_ptr<function::Function>>>&
+          coefficients);
 
   /// Get number of coefficients
   int size() const;

--- a/cpp/dolfin/fem/FormCoefficients.h
+++ b/cpp/dolfin/fem/FormCoefficients.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace dolfin
@@ -48,7 +49,8 @@ public:
   void set(int i, std::shared_ptr<const function::Function> coefficient);
 
   /// Set coefficient with name to be a Function
-  void set(std::string name, std::shared_ptr<const function::Function> coefficient);
+  void set(std::string name,
+           std::shared_ptr<const function::Function> coefficient);
 
   /// Get the Function coefficient i
   std::shared_ptr<const function::Function> get(int i) const;

--- a/cpp/dolfin/fem/FormIntegrals.cpp
+++ b/cpp/dolfin/fem/FormIntegrals.cpp
@@ -5,12 +5,11 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "FormIntegrals.h"
+#include <cstdlib>
 #include <dolfin/common/types.h>
 #include <dolfin/mesh/Facet.h>
 #include <dolfin/mesh/MeshFunction.h>
 #include <dolfin/mesh/MeshIterator.h>
-
-#include <cstdlib>
 
 using namespace dolfin;
 using namespace dolfin::fem;
@@ -252,9 +251,7 @@ void FormIntegrals::set_domains(FormIntegrals::Type type,
     }
   }
   else
-  {
     throw std::runtime_error("FormIntegral type not supported.");
-  }
 }
 //-----------------------------------------------------------------------------
 void FormIntegrals::set_default_domains(const mesh::Mesh& mesh)
@@ -274,7 +271,6 @@ void FormIntegrals::set_default_domains(const mesh::Mesh& mesh)
   {
     // If there is a default integral, define it only on surface facets
     _exterior_facet_integral_domains[0].clear();
-    const std::size_t tdim = mesh.topology().dim();
     for (const mesh::Facet& facet : mesh::MeshRange<mesh::Facet>(mesh))
     {
       if (facet.num_global_entities(tdim) == 1)
@@ -288,7 +284,6 @@ void FormIntegrals::set_default_domains(const mesh::Mesh& mesh)
     // If there is a default integral, define it only on interior facets
     _interior_facet_integral_domains[0].clear();
     _interior_facet_integral_domains[0].reserve(mesh.num_entities(tdim - 1));
-    const std::size_t tdim = mesh.topology().dim();
     for (const mesh::Facet& facet : mesh::MeshRange<mesh::Facet>(mesh))
     {
       if (facet.num_global_entities(tdim) != 1)
@@ -296,3 +291,4 @@ void FormIntegrals::set_default_domains(const mesh::Mesh& mesh)
     }
   }
 }
+//-----------------------------------------------------------------------------

--- a/cpp/dolfin/fem/FormIntegrals.cpp
+++ b/cpp/dolfin/fem/FormIntegrals.cpp
@@ -11,7 +11,6 @@
 #include <dolfin/mesh/MeshIterator.h>
 
 #include <cstdlib>
-#include <ufc.h>
 
 using namespace dolfin;
 using namespace dolfin::fem;
@@ -20,55 +19,6 @@ using namespace dolfin::fem;
 FormIntegrals::FormIntegrals()
 {
   // Do nothing
-}
-//-----------------------------------------------------------------------------
-FormIntegrals::FormIntegrals(const ufc_form& ufc_form)
-{
-  // Get list of integral IDs, and load tabulate tensor into memory for each
-  std::vector<int> cell_integral_ids(ufc_form.num_cell_integrals);
-  ufc_form.get_cell_integral_ids(cell_integral_ids.data());
-  for (auto id : cell_integral_ids)
-  {
-    ufc_cell_integral* cell_integral = ufc_form.create_cell_integral(id);
-    assert(cell_integral);
-    register_tabulate_tensor_cell(id, cell_integral->tabulate_tensor);
-    std::free(cell_integral);
-  }
-
-  std::vector<int> exterior_facet_integral_ids(
-      ufc_form.num_exterior_facet_integrals);
-  ufc_form.get_exterior_facet_integral_ids(exterior_facet_integral_ids.data());
-  for (auto id : exterior_facet_integral_ids)
-  {
-    ufc_exterior_facet_integral* exterior_facet_integral
-        = ufc_form.create_exterior_facet_integral(id);
-    assert(exterior_facet_integral);
-    register_tabulate_tensor_exterior_facet(
-        id, exterior_facet_integral->tabulate_tensor);
-    std::free(exterior_facet_integral);
-  }
-
-  std::vector<int> interior_facet_integral_ids(
-      ufc_form.num_interior_facet_integrals);
-  ufc_form.get_interior_facet_integral_ids(interior_facet_integral_ids.data());
-  for (auto id : interior_facet_integral_ids)
-  {
-    ufc_interior_facet_integral* interior_facet_integral
-        = ufc_form.create_interior_facet_integral(id);
-    assert(interior_facet_integral);
-    register_tabulate_tensor_interior_facet(
-        id, interior_facet_integral->tabulate_tensor);
-    std::free(interior_facet_integral);
-  }
-
-  // Not currently working
-  std::vector<int> vertex_integral_ids(ufc_form.num_vertex_integrals);
-  ufc_form.get_vertex_integral_ids(vertex_integral_ids.data());
-  if (vertex_integral_ids.size() > 0)
-  {
-    throw std::runtime_error(
-        "Vertex integrals not supported. Under development.");
-  }
 }
 //-----------------------------------------------------------------------------
 const std::function<void(PetscScalar*, const PetscScalar*, const double*, int)>&

--- a/cpp/dolfin/fem/FormIntegrals.h
+++ b/cpp/dolfin/fem/FormIntegrals.h
@@ -11,12 +11,6 @@
 #include <petscsys.h>
 #include <vector>
 
-struct ufc_cell_integral;
-struct ufc_exterior_facet_integral;
-struct ufc_interior_facet_integral;
-struct ufc_vertex_integral;
-struct ufc_form;
-
 namespace dolfin
 {
 namespace mesh
@@ -48,10 +42,6 @@ public:
 
   /// Initialise the FormIntegrals as empty
   FormIntegrals();
-
-  /// Initialise the FormIntegrals from a ufc::form instantiating all
-  /// the required integrals
-  FormIntegrals(const ufc_form& ufc_form);
 
   /// Get the function for 'tabulate_tensor' for cell integral i
   /// @param i
@@ -108,7 +98,8 @@ public:
   /// Get the list of active entities for the ith integral of type t.
   /// Note, these are not retrieved by ID, but stored in order. The IDs can
   /// be obtained with "FormIntegrals::integral_ids()"
-  /// For cell integrals, a list of cells. For facet integrals, a list of facets etc.
+  /// For cell integrals, a list of cells. For facet integrals, a list of facets
+  /// etc.
   const std::vector<std::int32_t>& integral_domains(FormIntegrals::Type t,
                                                     unsigned int i) const;
 
@@ -121,8 +112,9 @@ public:
                    const mesh::MeshFunction<std::size_t>& marker);
 
   /// If there exists a default integral of any type, set the list of entities
-  /// for those integrals from the mesh topology. For cell integrals, this is all cells.
-  /// For facet integrals, it is either all interior or all exterior facets.
+  /// for those integrals from the mesh topology. For cell integrals, this is
+  /// all cells. For facet integrals, it is either all interior or all exterior
+  /// facets.
   void set_default_domains(const mesh::Mesh& mesh);
 
 private:

--- a/cpp/dolfin/fem/utils.cpp
+++ b/cpp/dolfin/fem/utils.cpp
@@ -563,3 +563,17 @@ fem::create_element_dof_layout(const ufc_dofmap& dofmap,
                                cell_type);
 }
 //-----------------------------------------------------------------------------
+std::vector<std::tuple<int, std::string, std::shared_ptr<function::Function>>>
+fem::get_coeffs_from_ufc_form(const ufc_form& ufc_form)
+{
+  std::vector<std::tuple<int, std::string, std::shared_ptr<function::Function>>>
+      coeffs;
+  for (int i = 0; i < ufc_form.num_coefficients; ++i)
+  {
+    coeffs.push_back(
+        std::make_tuple<int, std::string, std::shared_ptr<function::Function>>(
+            ufc_form.original_coefficient_position(i),
+            ufc_form.coefficient_name_map(i), nullptr));
+  }
+  return coeffs;
+}

--- a/cpp/dolfin/fem/utils.h
+++ b/cpp/dolfin/fem/utils.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 struct ufc_dofmap;
+struct ufc_form;
 
 namespace dolfin
 {
@@ -73,6 +74,11 @@ std::size_t get_global_index(const std::vector<const common::IndexMap*> maps,
 ElementDofLayout create_element_dof_layout(const ufc_dofmap& dofmap,
                                            const std::vector<int>& parent_map,
                                            const mesh::CellType& cell_type);
+
+/// Extract coefficients from UFC form
+std::vector<std::tuple<int, std::string, std::shared_ptr<function::Function>>>
+  get_coeffs_from_ufc_form(const ufc_form& ufc_form);
+
 
 } // namespace fem
 } // namespace dolfin

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -51,6 +51,7 @@ def tabulate_tensor_b(b_, w_, coords_, cell_orientation):
     Ae = abs((x0 - x1) * (y2 - y1) - (y0 - y1) * (x2 - x1))
     b[:] = Ae / 6.0
 
+
 @numba.cfunc(c_signature, nopython=True)
 def tabulate_tensor_b_coeff(b_, w_, coords_, cell_orientation):
     b = numba.carray(b_, (3), dtype=PETSc.ScalarType)
@@ -89,6 +90,7 @@ def test_numba_assembly():
 
     list_timings([TimingType.wall])
 
+
 def test_coefficient():
     mesh = UnitSquareMesh(MPI.comm_world, 13, 13)
     V = FunctionSpace(mesh, ("Lagrange", 1))
@@ -105,7 +107,7 @@ def test_coefficient():
 
     bnorm = b.norm(PETSc.NormType.N2)
     print(bnorm)
-    assert (np.isclose(bnorm, 2.0*0.0739710713711999))
+    assert (np.isclose(bnorm, 2.0 * 0.0739710713711999))
 
 
 @skip_if_complex


### PR DESCRIPTION
Makes `FormIntegrals` and `FormCoefficients` free of ufc, and confines conversion from ufc_form to the Form constructor.

* Adds possibility to set coefficients for user kernels + unit test