### PR TITLE
Improve Mesh method naming

### DIFF
--- a/cpp/dolfin/fem/DirichletBC.cpp
+++ b/cpp/dolfin/fem/DirichletBC.cpp
@@ -127,7 +127,7 @@ std::vector<std::int32_t> facets_marked(std::shared_ptr<const mesh::Mesh> mesh,
   // Create mesh function for sub domain markers on facets and mark
   // all facet as subdomain 1
   const std::size_t dim = mesh->topology().dim();
-  mesh->init(dim - 1);
+  mesh->create_entities(dim - 1);
   mesh::MeshFunction<std::size_t> domain(mesh, dim - 1, 1);
 
   // Mark the sub domain as sub domain 0
@@ -233,8 +233,8 @@ compute_bc_dofs_topological(const function::FunctionSpace& V,
   }
 
   // Initialise facet-cell connectivity
-  mesh.init(tdim);
-  mesh.init(tdim - 1, tdim);
+  mesh.create_entities(tdim);
+  mesh.create_connectivity(tdim - 1, tdim);
 
   // Allocate space
   const std::size_t num_facet_dofs = dofmap.num_entity_closure_dofs(tdim - 1);
@@ -478,7 +478,7 @@ void DirichletBC::mark_dofs(std::vector<bool>& markers) const
 //   // spdlog::info("Computing facets, needed for geometric application of
 //   // boundary "
 //   //              "conditions.");
-//   mesh.init(mesh.topology().dim() - 1);
+//   mesh.create_entities(mesh.topology().dim() - 1);
 
 //   // Speed up the computations by only visiting (most) dofs once
 //   common::RangedIndexSet already_visited(

--- a/cpp/dolfin/fem/DiscreteOperators.cpp
+++ b/cpp/dolfin/fem/DiscreteOperators.cpp
@@ -42,7 +42,7 @@ DiscreteOperators::build_gradient(const function::FunctionSpace& V0,
   }
 
   // Check that V0 is a (lowest-order) edge basis
-  mesh.init(1);
+  mesh.create_entities(1);
   if (V0.dim() != mesh.num_entities_global(1))
   {
     throw std::runtime_error(
@@ -71,7 +71,7 @@ DiscreteOperators::build_gradient(const function::FunctionSpace& V0,
       = V1.dofmap()->tabulate_local_to_global_dofs();
 
   // Initialize edge -> vertex connections
-  mesh.init(1, 0);
+  mesh.create_connectivity(1, 0);
 
   // Copy index maps from dofmaps
   std::array<std::shared_ptr<const common::IndexMap>, 2> index_maps

--- a/cpp/dolfin/fem/DofMapBuilder.cpp
+++ b/cpp/dolfin/fem/DofMapBuilder.cpp
@@ -299,7 +299,7 @@ DofMapStructure build_basic_dofmap(const mesh::Mesh& mesh,
     if (element_dof_layout.num_entity_dofs(d) > 0)
     {
       needs_entities[d] = true;
-      mesh.init(d);
+      mesh.create_entities(d);
       mesh::DistributedMeshTools::number_entities(mesh, d);
       num_mesh_entities_local[d] = mesh.num_entities(d);
       num_mesh_entities_global[d] = mesh.num_entities_global(d);
@@ -682,8 +682,8 @@ DofMapBuilder::build(const mesh::Mesh& mesh,
   // random positive integer, interior nodes are marked as -1, interior
   // nodes in ghost layer of other processes are marked -2, and ghost
   // nodes are marked as -3,
-  mesh.init(D - 1);
-  mesh.init(D - 1, D);
+  mesh.create_entities(D - 1);
+  mesh.create_connectivity(D - 1, D);
   const std::vector<sharing_marker> shared_nodes
       = compute_sharing_markers(node_graph0, element_dof_layout, mesh);
 

--- a/cpp/dolfin/fem/GenericDofMap.cpp
+++ b/cpp/dolfin/fem/GenericDofMap.cpp
@@ -99,7 +99,7 @@ GenericDofMap::entity_dofs(const mesh::Mesh& mesh, std::size_t entity_dim,
   const std::size_t dofs_per_entity = num_entity_dofs(entity_dim);
 
   // Initialize entity to cell connections
-  mesh.init(entity_dim, top_dim);
+  mesh.create_connectivity(entity_dim, top_dim);
 
   // Allocate the the array to return
   const std::size_t num_marked_entities = entity_indices.size();
@@ -156,7 +156,7 @@ GenericDofMap::entity_dofs(const mesh::Mesh& mesh, std::size_t entity_dim) const
   const std::size_t num_mesh_entities = mesh.num_entities(entity_dim);
 
   // Initialize entity to cell connections
-  mesh.init(entity_dim, top_dim);
+  mesh.create_connectivity(entity_dim, top_dim);
 
   // Allocate the the array to return
   Eigen::Array<PetscInt, Eigen::Dynamic, 1> entity_to_dofs(num_mesh_entities

--- a/cpp/dolfin/fem/SparsityPatternBuilder.cpp
+++ b/cpp/dolfin/fem/SparsityPatternBuilder.cpp
@@ -39,8 +39,8 @@ void SparsityPatternBuilder::interior_facets(
   assert(dofmaps[1]);
 
   const std::size_t D = mesh.topology().dim();
-  mesh.init(D - 1);
-  mesh.init(D - 1, D);
+  mesh.create_entities(D - 1);
+  mesh.create_connectivity(D - 1, D);
 
   // Array to store macro-dofs, if required (for interior facets)
   std::array<Eigen::Array<PetscInt, Eigen::Dynamic, 1>, 2> macro_dofs;
@@ -79,8 +79,8 @@ void SparsityPatternBuilder::exterior_facets(
     const std::array<const fem::GenericDofMap*, 2> dofmaps)
 {
   const std::size_t D = mesh.topology().dim();
-  mesh.init(D - 1);
-  mesh.init(D - 1, D);
+  mesh.create_entities(D - 1);
+  mesh.create_connectivity(D - 1, D);
 
   for (auto& facet : mesh::MeshRange<mesh::Facet>(mesh))
   {

--- a/cpp/dolfin/fem/assemble_matrix_impl.cpp
+++ b/cpp/dolfin/fem/assemble_matrix_impl.cpp
@@ -160,8 +160,8 @@ void fem::impl::assemble_exterior_facets(
     const std::vector<int>& offsets)
 {
   const std::size_t tdim = mesh.topology().dim();
-  mesh.init(tdim - 1);
-  mesh.init(tdim - 1, tdim);
+  mesh.create_entities(tdim - 1);
+  mesh.create_connectivity(tdim - 1, tdim);
 
   // Data structures used in assembly
   Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>

--- a/cpp/dolfin/fem/assemble_scalar_impl.cpp
+++ b/cpp/dolfin/fem/assemble_scalar_impl.cpp
@@ -78,7 +78,7 @@ PetscScalar fem::impl::assemble_cells(
     const std::vector<int>& offsets)
 {
   const std::size_t tdim = mesh.topology().dim();
-  mesh.init(tdim);
+  mesh.create_entities(tdim);
 
   // Create data structures used in assembly
   Eigen::Array<PetscScalar, Eigen::Dynamic, 1> coeff_array(offsets.back());
@@ -120,8 +120,8 @@ PetscScalar fem::impl::assemble_exterior_facets(
     const std::vector<int>& offsets)
 {
   const std::size_t tdim = mesh.topology().dim();
-  mesh.init(tdim - 1);
-  mesh.init(tdim - 1, tdim);
+  mesh.create_entities(tdim - 1);
+  mesh.create_connectivity(tdim - 1, tdim);
 
   // Creat data structures used in assembly
   Eigen::Array<PetscScalar, Eigen::Dynamic, 1> coeff_array(offsets.back());

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -149,8 +149,8 @@ void _lift_bc_exterior_facets(
   const mesh::Mesh& mesh = *a.mesh();
 
   const std::size_t tdim = mesh.topology().dim();
-  mesh.init(tdim - 1);
-  mesh.init(tdim - 1, tdim);
+  mesh.create_entities(tdim - 1);
+  mesh.create_connectivity(tdim - 1, tdim);
 
   // Get dofmap for columns and rows of a
   assert(a.function_space(0));
@@ -316,7 +316,7 @@ void fem::impl::assemble_cells(
     const std::vector<int>& offsets)
 {
   const std::size_t tdim = mesh.topology().dim();
-  mesh.init(tdim);
+  mesh.create_entities(tdim);
 
   // Creat data structures used in assembly
   Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
@@ -366,8 +366,8 @@ void fem::impl::assemble_exterior_facets(
     const std::vector<int>& offsets)
 {
   const std::size_t tdim = mesh.topology().dim();
-  mesh.init(tdim - 1);
-  mesh.init(tdim - 1, tdim);
+  mesh.create_entities(tdim - 1);
+  mesh.create_connectivity(tdim - 1, tdim);
 
   // Creat data structures used in assembly
   Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>

--- a/cpp/dolfin/geometry/BoundingBoxTree.cpp
+++ b/cpp/dolfin/geometry/BoundingBoxTree.cpp
@@ -59,7 +59,7 @@ BoundingBoxTree::BoundingBoxTree(const mesh::Mesh& mesh, int tdim)
   _tdim = tdim;
 
   // Initialize entities of given dimension if they don't exist
-  mesh.init(tdim);
+  mesh.create_entities(tdim);
 
   // Create bounding boxes for all entities (leaves)
   const unsigned int num_leaves = mesh.num_entities(tdim);

--- a/cpp/dolfin/graph/GraphBuilder.cpp
+++ b/cpp/dolfin/graph/GraphBuilder.cpp
@@ -58,9 +58,9 @@ dolfin::graph::Graph dolfin::graph::GraphBuilder::local_graph(
 {
   // Initialise mesh
   for (std::size_t i = 0; i < coloring_type.size(); ++i)
-    mesh.init(coloring_type[i]);
+    mesh.create_entities(coloring_type[i]);
   for (std::size_t i = 1; i < coloring_type.size(); ++i)
-    mesh.init(coloring_type[i - 1], coloring_type[i]);
+    mesh.create_connectivity(coloring_type[i - 1], coloring_type[i]);
 
   // Check coloring type
   assert(coloring_type.size() >= 2);
@@ -109,10 +109,10 @@ dolfin::graph::Graph
 dolfin::graph::GraphBuilder::local_graph(const mesh::Mesh& mesh,
                                          std::size_t dim0, std::size_t dim1)
 {
-  mesh.init(dim0);
-  mesh.init(dim1);
-  mesh.init(dim0, dim1);
-  mesh.init(dim1, dim0);
+  mesh.create_entities(dim0);
+  mesh.create_entities(dim1);
+  mesh.create_connectivity(dim0, dim1);
+  mesh.create_connectivity(dim1, dim0);
 
   // Create graph
   const std::size_t num_vertices = mesh.num_entities(dim0);

--- a/cpp/dolfin/io/HDF5File.cpp
+++ b/cpp/dolfin/io/HDF5File.cpp
@@ -1128,7 +1128,7 @@ void HDF5File::write_mesh_value_collection(
   value_data.reserve(values.size());
 
   const std::size_t tdim = mesh->topology().dim();
-  mesh->init(tdim, dim);
+  mesh->create_connectivity(tdim, dim);
   for (auto& p : values)
   {
     mesh::MeshEntity cell = mesh::Cell(*mesh, p.first.first);
@@ -1218,7 +1218,7 @@ HDF5File::read_mesh_value_collection(std::shared_ptr<const mesh::Mesh> mesh,
   /// read data to the 'sorting' hosts.
 
   // Ensure the mesh dimension is initialised
-  mesh->init(dim);
+  mesh->create_entities(dim);
   std::size_t global_vertex_range = mesh->num_entities_global(0);
   std::vector<std::size_t> v(num_verts_per_entity);
   const std::size_t num_processes = _mpi_comm.size();

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -774,7 +774,7 @@ void XDMFFile::write_mesh_value_collection(
   topology_data.reserve(num_cells * num_vertices_per_cell);
   value_data.reserve(num_cells);
 
-  mesh->init(tdim, cell_dim);
+  mesh->create_connectivity(tdim, cell_dim);
   for (auto& p : values)
   {
     mesh::MeshEntity cell = mesh::Cell(*mesh, p.first.first);
@@ -925,7 +925,7 @@ XDMFFile::read_mesh_value_collection(std::shared_ptr<const mesh::Mesh> mesh,
       = get_dataset<T>(_mpi_comm.comm(), attribute_data_node, parent_path);
 
   // Ensure the mesh dimension is initialised
-  mesh->init(dim);
+  mesh->create_entities(dim);
   const std::size_t global_vertex_range = mesh->num_entities_global(0);
   const std::int32_t num_processes = _mpi_comm.size();
 

--- a/cpp/dolfin/mesh/Cell.h
+++ b/cpp/dolfin/mesh/Cell.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "CellType.h"
+#include "CoordinateDofs.h"
 #include "Geometry.h"
 #include "Mesh.h"
 #include "MeshEntity.h"

--- a/cpp/dolfin/mesh/Cell.h
+++ b/cpp/dolfin/mesh/Cell.h
@@ -112,7 +112,7 @@ public:
   double inradius() const
   {
     // We would need facet areas
-    _mesh->init(_mesh->type().dim() - 1);
+    _mesh->create_entities(_mesh->type().dim() - 1);
 
     return _mesh->type().inradius(*this);
   }
@@ -136,7 +136,7 @@ public:
   double radius_ratio() const
   {
     // We would need facet areas
-    _mesh->init(_mesh->type().dim() - 1);
+    _mesh->create_entities(_mesh->type().dim() - 1);
 
     return _mesh->type().radius_ratio(*this);
   }

--- a/cpp/dolfin/mesh/CoordinateDofs.cpp
+++ b/cpp/dolfin/mesh/CoordinateDofs.cpp
@@ -8,31 +8,29 @@
 #include "Connectivity.h"
 
 using namespace dolfin;
-using namespace dolfin::mesh;
 
 //-----------------------------------------------------------------------------
-CoordinateDofs::CoordinateDofs(std::uint32_t tdim) : _coord_dofs(tdim + 1)
+mesh::CoordinateDofs::CoordinateDofs(
+    int tdim,
+    const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic,
+                                        Eigen::Dynamic, Eigen::RowMajor>>
+        point_dofs,
+    const std::vector<std::uint8_t>& cell_permutation)
+    : _coord_dofs(tdim + 1), _cell_permutation(cell_permutation)
+
 {
-  // Do nothing
+  _coord_dofs[tdim] = std::make_shared<Connectivity>(point_dofs);
 }
 //-----------------------------------------------------------------------------
-void CoordinateDofs::init(std::size_t dim,
-                          const Eigen::Ref<const EigenRowArrayXXi32> point_dofs,
-                          const std::vector<std::uint8_t>& cell_permutation)
-{
-  assert(dim < _coord_dofs.size());
-  _coord_dofs[dim] = std::make_shared<Connectivity>(point_dofs);
-  _cell_permutation = cell_permutation;
-}
-//-----------------------------------------------------------------------------
-const Connectivity& CoordinateDofs::entity_points(std::uint32_t dim) const
+const mesh::Connectivity&
+mesh::CoordinateDofs::entity_points(std::uint32_t dim) const
 {
   assert(dim < _coord_dofs.size());
   assert(_coord_dofs[dim]);
   return *_coord_dofs[dim];
 }
 //-----------------------------------------------------------------------------
-const std::vector<std::uint8_t>& CoordinateDofs::cell_permutation() const
+const std::vector<std::uint8_t>& mesh::CoordinateDofs::cell_permutation() const
 {
   return _cell_permutation;
 }

--- a/cpp/dolfin/mesh/CoordinateDofs.h
+++ b/cpp/dolfin/mesh/CoordinateDofs.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <dolfin/common/types.h>
+#include <Eigen/Dense>
 #include <memory>
 #include <vector>
 
@@ -16,18 +16,26 @@ namespace mesh
 {
 class Connectivity;
 
-/// CoordinateDofs contains the connectivity from MeshEntities to the geometric
-/// points which make up the mesh.
+/// CoordinateDofs contains the connectivity from MeshEntities to the
+/// geometric points which make up the mesh.
 
 class CoordinateDofs
 {
 public:
   /// Constructor
   /// @param tdim
-  ///   Topological Dimension
-  /// @param cell_dofs
-  ///   Connections from cells to points in Geometry (cell_dofs)
-  CoordinateDofs(std::uint32_t tdim);
+  ///   Topological dimension
+  /// @param point_dofs
+  ///   Array containing point dofs for each entity
+  /// @param cell_permutation
+  ///   Array containing permutation for cell_vertices required for higher order
+  ///   elements which are input in gmsh/vtk order.
+  CoordinateDofs(
+      int tdim,
+      const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic,
+                                          Eigen::Dynamic, Eigen::RowMajor>>
+          point_dofs,
+      const std::vector<std::uint8_t>& cell_permutation);
 
   /// Copy constructor
   CoordinateDofs(const CoordinateDofs& topology) = default;
@@ -43,18 +51,6 @@ public:
 
   /// Move assignment
   CoordinateDofs& operator=(CoordinateDofs&& topology) = default;
-
-  /// Initialise entity->point dofs for dimension dim
-  /// @param dim
-  ///   Dimension of entity
-  /// @param point_dofs
-  ///   Array containing point dofs for each entity
-  /// @param cell_permutation
-  ///   Array containing permutation for cell_vertices required for higher order
-  ///   elements which are input in gmsh/vtk order.
-  void init(std::size_t dim,
-            const Eigen::Ref<const EigenRowArrayXXi32> point_dofs,
-            const std::vector<std::uint8_t>& cell_permutation);
 
   /// Get the entity points associated with entities of dimension i
   ///

--- a/cpp/dolfin/mesh/DistributedMeshTools.cpp
+++ b/cpp/dolfin/mesh/DistributedMeshTools.cpp
@@ -114,7 +114,7 @@ void DistributedMeshTools::number_entities(const Mesh& mesh, int d)
   if (MPI::size(mesh.mpi_comm()) == 1)
   {
     // Set global entity numbers in mesh
-    mesh.init(d);
+    mesh.create_entities(d);
     _mesh.topology().set_num_entities_global(d, mesh.num_entities(d));
     std::vector<std::int64_t> global_indices(mesh.num_entities(d), 0);
     std::iota(global_indices.begin(), global_indices.end(), 0);
@@ -194,7 +194,7 @@ DistributedMeshTools::number_entities(
   const std::size_t process_number = MPI::rank(mpi_comm);
 
   // Initialize entities of dimension d locally
-  mesh.init(d);
+  mesh.create_entities(d);
 
   // Build list of slave entities to exclude from ownership computation
   std::vector<bool> exclude(mesh.num_entities(d), false);
@@ -570,7 +570,7 @@ DistributedMeshTools::compute_shared_entities(const Mesh& mesh, std::size_t d)
   }
 
   // Initialize entities of dimension d
-  mesh.init(d);
+  mesh.create_entities(d);
 
   // Number entities (globally)
   number_entities(mesh, d);
@@ -1058,10 +1058,10 @@ void DistributedMeshTools::init_facet_cell_connections(Mesh& mesh)
   const int D = mesh.topology().dim();
 
   // Initialize entities of dimension d
-  mesh.init(D - 1);
+  mesh.create_entities(D - 1);
 
   // Initialise local facet-cell connections.
-  mesh.init(D - 1, D);
+  mesh.create_connectivity(D - 1, D);
 
   // Global numbering
   number_entities(mesh, D - 1);

--- a/cpp/dolfin/mesh/Face.cpp
+++ b/cpp/dolfin/mesh/Face.cpp
@@ -32,7 +32,7 @@ double Face::area() const
   {
 
     // Initialize needed connectivity
-    _mesh->init(2, D);
+    _mesh->create_connectivity(2, D);
 
     // Get cell to which face belong (first cell when there is more than one)
     const Cell cell(*_mesh, this->entities(D)[0]);
@@ -68,7 +68,7 @@ geometry::Point Face::normal() const
   }
 
   // Initialize needed connectivity
-  _mesh->init(2, tD);
+  _mesh->create_connectivity(2, tD);
 
   // Get cell to which face belong (first cell when there is more than one)
   const Cell cell(*_mesh, this->entities(tD)[0]);

--- a/cpp/dolfin/mesh/Facet.cpp
+++ b/cpp/dolfin/mesh/Facet.cpp
@@ -17,8 +17,8 @@ using namespace dolfin::mesh;
 geometry::Point Facet::normal() const
 {
   const std::size_t D = _mesh->topology().dim();
-  _mesh->init(D - 1);
-  _mesh->init(D - 1, D);
+  _mesh->create_entities(D - 1);
+  _mesh->create_connectivity(D - 1, D);
 
   // Get cell to which face belong (first cell when there is more than one)
   const Cell cell(*_mesh, this->entities(D)[0]);

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -266,7 +266,7 @@ const mesh::CellType& Mesh::type() const
   return *_cell_type;
 }
 //-----------------------------------------------------------------------------
-std::size_t Mesh::init(int dim) const
+std::size_t Mesh::create_entities(int dim) const
 {
   // This function is obviously not const since it may potentially
   // compute new connectivity. However, in a sense all connectivity of a
@@ -287,7 +287,7 @@ std::size_t Mesh::init(int dim) const
   return _topology->size(dim);
 }
 //-----------------------------------------------------------------------------
-void Mesh::init(std::size_t d0, std::size_t d1) const
+void Mesh::create_connectivity(std::size_t d0, std::size_t d1) const
 {
   // This function is obviously not const since it may potentially
   // compute new connectivity. However, in a sense all connectivity of a
@@ -304,21 +304,21 @@ void Mesh::init(std::size_t d0, std::size_t d1) const
   TopologyComputation::compute_connectivity(*mesh, d0, d1);
 }
 //-----------------------------------------------------------------------------
-void Mesh::init() const
+void Mesh::create_connectivity_all() const
 {
   // Compute all entities
   for (int d = 0; d <= _topology->dim(); d++)
-    init(d);
+    create_entities(d);
 
   // Compute all connectivity
   for (int d0 = 0; d0 <= _topology->dim(); d0++)
     for (int d1 = 0; d1 <= _topology->dim(); d1++)
-      init(d0, d1);
+      create_connectivity(d0, d1);
 }
 //-----------------------------------------------------------------------------
-void Mesh::init_global(std::size_t dim) const
+void Mesh::create_global_indices(std::size_t dim) const
 {
-  init(dim);
+  create_entities(dim);
   DistributedMeshTools::number_entities(*this, dim);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/mesh/Mesh.h
+++ b/cpp/dolfin/mesh/Mesh.h
@@ -55,7 +55,7 @@ class Topology;
 /// by calling init(). For example, all edges in a mesh may be
 /// created by a call to mesh.init(1). Similarly, connectivities
 /// such as all edges connected to a given vertex must also be
-/// explicitly created (in this case by a call to mesh.init(0, 1)).
+/// explicitly created (in this case by a call to mesh.create_connectivity(0, 1)).
 
 class Mesh
 {
@@ -176,29 +176,29 @@ public:
   /// Get mesh cell type (const version).
   const mesh::CellType& type() const;
 
-  /// Compute entities of given topological dimension.
+  /// Create entities of given topological dimension.
   ///
   /// @param  dim (int)
   ///         Topological dimension.
   ///
   /// @return std::size_t
   ///         Number of created entities.
-  std::size_t init(int dim) const;
+  std::size_t create_entities(int dim) const;
 
-  /// Compute connectivity between given pair of dimensions.
+  /// Create connectivity between given pair of dimensions.
   ///
   /// @param    d0 (std::size_t)
   ///         Topological dimension.
   ///
   /// @param    d1 (std::size_t)
   ///         Topological dimension.
-  void init(std::size_t d0, std::size_t d1) const;
+  void create_connectivity(std::size_t d0, std::size_t d1) const;
 
   /// Compute all entities and connectivity.
-  void init() const;
+  void create_connectivity_all() const;
 
   /// Compute global indices for entity dimension dim
-  void init_global(std::size_t dim) const;
+  void create_global_indices(std::size_t dim) const;
 
   /// Clean out all auxiliary topology data. This clears all topological
   /// data, except the connectivity between cells and vertices.

--- a/cpp/dolfin/mesh/Mesh.h
+++ b/cpp/dolfin/mesh/Mesh.h
@@ -7,11 +7,9 @@
 #pragma once
 
 #include "CellType.h"
-#include "CoordinateDofs.h"
 #include <dolfin/common/MPI.h>
 #include <dolfin/common/UniqueIdGenerator.h>
 #include <dolfin/common/types.h>
-#include <dolfin/fem/utils.h>
 #include <memory>
 #include <string>
 #include <utility>
@@ -26,9 +24,10 @@ class Function;
 
 namespace mesh
 {
+class CoordinateDofs;
+class Geometry;
 enum class GhostMode : int;
 class MeshEntity;
-class Geometry;
 class Topology;
 
 /// A _Mesh_ consists of a set of connected and numbered mesh entities.
@@ -55,7 +54,8 @@ class Topology;
 /// by calling init(). For example, all edges in a mesh may be
 /// created by a call to mesh.init(1). Similarly, connectivities
 /// such as all edges connected to a given vertex must also be
-/// explicitly created (in this case by a call to mesh.create_connectivity(0, 1)).
+/// explicitly created (in this case by a call to mesh.create_connectivity(0,
+/// 1)).
 
 class Mesh
 {
@@ -272,10 +272,10 @@ public:
   mesh::GhostMode get_ghost_mode() const;
 
   /// Get coordinate dofs for all local cells
-  const CoordinateDofs& coordinate_dofs() const { return _coordinate_dofs; }
+  const CoordinateDofs& coordinate_dofs() const;
 
   // FIXME: This should be with Geometry
-  std::int32_t degree() const { return _degree; }
+  std::int32_t degree() const;
 
 private:
   // Cell type
@@ -289,7 +289,7 @@ private:
 
   // FIXME: This should be in geometry!
   // Coordinate dofs
-  CoordinateDofs _coordinate_dofs;
+  std::unique_ptr<CoordinateDofs> _coordinate_dofs;
 
   // FXIME: This shouldn't be here
   // Mesh geometric degree (in Lagrange basis) describing coordinate dofs

--- a/cpp/dolfin/mesh/MeshEntity.cpp
+++ b/cpp/dolfin/mesh/MeshEntity.cpp
@@ -27,7 +27,7 @@ void MeshEntity::init(const Mesh& mesh, std::size_t dim, std::size_t index)
     return;
 
   // Initialize mesh entities
-  _mesh->init(dim);
+  _mesh->create_entities(dim);
 
   // Check index range again
   if ((std::int64_t)index < _mesh->num_entities(dim))

--- a/cpp/dolfin/mesh/MeshEntity.cpp
+++ b/cpp/dolfin/mesh/MeshEntity.cpp
@@ -15,32 +15,6 @@ using namespace dolfin;
 using namespace dolfin::mesh;
 
 //-----------------------------------------------------------------------------
-void MeshEntity::init(const Mesh& mesh, std::size_t dim, std::size_t index)
-{
-  // Store variables
-  _mesh = &mesh; // Yes, we should probably use a shared pointer here...
-  _dim = dim;
-  _local_index = index;
-
-  // Check index range
-  if ((std::int64_t)index < _mesh->num_entities(dim))
-    return;
-
-  // Initialize mesh entities
-  _mesh->create_entities(dim);
-
-  // Check index range again
-  if ((std::int64_t)index < _mesh->num_entities(dim))
-    return;
-
-  // Illegal index range
-  // spdlog::error(
-  //     "MeshEntity.cpp", "create mesh entity",
-  //     "Mesh entity index %d out of range [0, %d] for entity of dimension %d",
-  //     index, _mesh->num_entities(dim), dim);
-  throw std::runtime_error("Out of range");
-}
-//-----------------------------------------------------------------------------
 bool MeshEntity::incident(const MeshEntity& entity) const
 {
   // Must be in the same mesh to be incident

--- a/cpp/dolfin/mesh/MeshEntity.h
+++ b/cpp/dolfin/mesh/MeshEntity.h
@@ -51,16 +51,6 @@ public:
   /// Move assignement operator
   MeshEntity& operator=(MeshEntity&& e) = default;
 
-  /// Initialize mesh entity with given data
-  ///
-  /// @param      mesh (_Mesh_)
-  ///         The mesh.
-  /// @param     dim (std::size_t)
-  ///         The topological dimension.
-  /// @param     index (std::size_t)
-  ///         The index.
-  void init(const Mesh& mesh, std::size_t dim, std::size_t index);
-
   /// Comparison Operator
   ///
   /// @param e (MeshEntity)

--- a/cpp/dolfin/mesh/MeshFunction.h
+++ b/cpp/dolfin/mesh/MeshFunction.h
@@ -204,7 +204,7 @@ MeshFunction<T>::MeshFunction(std::shared_ptr<const Mesh> mesh, std::size_t dim,
     : _mesh(mesh), _dim(dim)
 {
   assert(mesh);
-  mesh->init(dim);
+  mesh->create_entities(dim);
   _values.resize(mesh->num_entities(dim), value);
 }
 //---------------------------------------------------------------------------
@@ -215,7 +215,7 @@ MeshFunction<T>::MeshFunction(std::shared_ptr<const Mesh> mesh,
     : common::Variable("f"), _mesh(mesh), _dim(value_collection.dim())
 {
   assert(_mesh);
-  _mesh->init(_dim);
+  _mesh->create_entities(_dim);
 
   // Initialise values with default
   _values.resize(_mesh->topology().size(_dim), default_value);
@@ -226,7 +226,7 @@ MeshFunction<T>::MeshFunction(std::shared_ptr<const Mesh> mesh,
   assert(d <= D);
 
   // Generate connectivity if it does not exist
-  _mesh->init(D, d);
+  _mesh->create_connectivity(D, d);
   assert(_mesh->topology().connectivity(D, d));
   const Connectivity& connectivity = *_mesh->topology().connectivity(D, d);
 

--- a/cpp/dolfin/mesh/MeshValueCollection.h
+++ b/cpp/dolfin/mesh/MeshValueCollection.h
@@ -206,7 +206,7 @@ MeshValueCollection<T>::MeshValueCollection(
   }
   else
   {
-    _mesh->init(_dim, D);
+    _mesh->create_connectivity(_dim, D);
     const Connectivity& connectivity = _mesh->topology().connectivity(_dim, D);
     for (std::size_t entity_index = 0; entity_index < mesh_function.size();
          ++entity_index)
@@ -256,7 +256,7 @@ operator=(const MeshFunction<T>& mesh_function)
   }
   else
   {
-    _mesh->init(_dim, D);
+    _mesh->create_connectivity(_dim, D);
     assert(_mesh->topology().connectivity(_dim, D));
     const Connectivity& connectivity = *_mesh->topology().connectivity(_dim, D);
     for (std::size_t entity_index = 0; entity_index < mesh_function.size();
@@ -373,7 +373,7 @@ bool MeshValueCollection<T>::set_value(std::size_t entity_index, const T& value)
   }
 
   // Get mesh connectivity d --> D
-  _mesh->init(_dim, D);
+  _mesh->create_connectivity(_dim, D);
   assert(_mesh->topology().connectivity(_dim, D));
   const Connectivity& connectivity = *_mesh->topology().connectivity(_dim, D);
 

--- a/cpp/dolfin/mesh/PeriodicBoundaryComputation.cpp
+++ b/cpp/dolfin/mesh/PeriodicBoundaryComputation.cpp
@@ -89,9 +89,9 @@ PeriodicBoundaryComputation::compute_periodic_pairs(const Mesh& mesh,
       master_coord_to_entity_index((lt_coordinate(sub_domain.map_tolerance)));
 
   // Initialise facet-cell connectivity
-  mesh.init(tdim - 1, tdim);
-  mesh.init(dim);
-  mesh.init(tdim - 1, dim);
+  mesh.create_connectivity(tdim - 1, tdim);
+  mesh.create_entities(dim);
+  mesh.create_connectivity(tdim - 1, dim);
 
   std::vector<bool> visited(mesh.num_entities(dim), false);
   for (auto& f : MeshRange<Facet>(mesh))

--- a/cpp/dolfin/mesh/QuadrilateralCell.cpp
+++ b/cpp/dolfin/mesh/QuadrilateralCell.cpp
@@ -181,7 +181,7 @@ geometry::Point QuadrilateralCell::normal(const Cell& cell,
                                           std::size_t facet) const
 {
   // Make sure we have facets
-  cell.mesh().init(2, 1);
+  cell.mesh().create_connectivity(2, 1);
 
   // Create facet from the mesh and local facet number
   Facet f(cell.mesh(), cell.entities(1)[facet]);

--- a/cpp/dolfin/mesh/SubDomain.cpp
+++ b/cpp/dolfin/mesh/SubDomain.cpp
@@ -64,10 +64,10 @@ void SubDomain::apply_markers(std::map<std::size_t, std::size_t>& sub_domains,
   const std::size_t D = mesh.topology().dim();
   if (dim < D)
   {
-    mesh.init(dim);
+    mesh.create_entities(dim);
     if (dim != D - 1)
-      mesh.init(dim, D - 1);
-    mesh.init(D - 1, D);
+      mesh.create_connectivity(dim, D - 1);
+    mesh.create_connectivity(D - 1, D);
   }
 
   // Speed up the computation by only checking each vertex once (or

--- a/cpp/dolfin/mesh/SubDomain.h
+++ b/cpp/dolfin/mesh/SubDomain.h
@@ -127,10 +127,10 @@ void SubDomain::mark(S& sub_domains, T sub_domain, const Mesh& mesh,
   const std::size_t D = mesh.topology().dim();
   if (dim < D)
   {
-    mesh.init(dim);
+    mesh.create_entities(dim);
     if (dim != D - 1)
-      mesh.init(dim, D - 1);
-    mesh.init(D - 1, D);
+      mesh.create_connectivity(dim, D - 1);
+    mesh.create_connectivity(D - 1, D);
   }
 
   // Find all vertices on boundary

--- a/cpp/dolfin/mesh/TetrahedronCell.cpp
+++ b/cpp/dolfin/mesh/TetrahedronCell.cpp
@@ -268,7 +268,7 @@ geometry::Point TetrahedronCell::normal(const Cell& cell,
                                         std::size_t facet) const
 {
   // Make sure we have facets
-  cell.mesh().init(3, 2);
+  cell.mesh().create_connectivity(3, 2);
 
   // Create facet from the mesh and local facet number
   Facet f(cell.mesh(), cell.entities(2)[facet]);

--- a/cpp/dolfin/mesh/TriangleCell.cpp
+++ b/cpp/dolfin/mesh/TriangleCell.cpp
@@ -277,7 +277,7 @@ double TriangleCell::normal(const Cell& cell, std::size_t facet,
 geometry::Point TriangleCell::normal(const Cell& cell, std::size_t facet) const
 {
   // Make sure we have facets
-  cell.mesh().init(2, 1);
+  cell.mesh().create_connectivity(2, 1);
 
   // Create facet from the mesh and local facet number
   Facet f(cell.mesh(), cell.entities(1)[facet]);

--- a/cpp/dolfin/refinement/PlazaRefinementND.cpp
+++ b/cpp/dolfin/refinement/PlazaRefinementND.cpp
@@ -236,9 +236,9 @@ std::pair<std::vector<std::int32_t>, std::vector<bool>>
 PlazaRefinementND::face_long_edge(const mesh::Mesh& mesh)
 {
   const std::int32_t tdim = mesh.topology().dim();
-  mesh.init(1);
-  mesh.init(2);
-  mesh.init(2, 1);
+  mesh.create_entities(1);
+  mesh.create_entities(2);
+  mesh.create_connectivity(2, 1);
 
   // Storage for face-local index of longest edge
   std::vector<std::int32_t> long_edge(mesh.num_entities(2));

--- a/python/src/mesh.cpp
+++ b/python/src/mesh.cpp
@@ -167,12 +167,11 @@ void mesh(py::module& m)
       .def("hash", &dolfin::mesh::Mesh::hash)
       .def("hmax", &dolfin::mesh::Mesh::hmax)
       .def("hmin", &dolfin::mesh::Mesh::hmin)
-      .def("init_global", &dolfin::mesh::Mesh::init_global)
-      .def("init", py::overload_cast<>(&dolfin::mesh::Mesh::init, py::const_))
-      .def("init",
-           py::overload_cast<int>(&dolfin::mesh::Mesh::init, py::const_))
-      .def("init", py::overload_cast<std::size_t, std::size_t>(
-                       &dolfin::mesh::Mesh::init, py::const_))
+      .def("create_global_indices", &dolfin::mesh::Mesh::create_global_indices)
+      .def("create_entities", &dolfin::mesh::Mesh::create_entities)
+      .def("create_connectivity", &dolfin::mesh::Mesh::create_connectivity)
+      .def("create_connectivity_all",
+           &dolfin::mesh::Mesh::create_connectivity_all)
       .def("mpi_comm",
            [](dolfin::mesh::Mesh& self) {
              return MPICommWrapper(self.mpi_comm());
@@ -197,13 +196,12 @@ void mesh(py::module& m)
   py::class_<dolfin::mesh::Connectivity,
              std::shared_ptr<dolfin::mesh::Connectivity>>(m, "Connectivity",
                                                           "Connectivity object")
-      .def(
-          "connections",
-          [](const dolfin::mesh::Connectivity& self, std::size_t i) {
-            return Eigen::Map<const dolfin::EigenArrayXi32>(self.connections(i),
-                                                            self.size(i));
-          },
-          py::return_value_policy::reference_internal)
+      .def("connections",
+           [](const dolfin::mesh::Connectivity& self, std::size_t i) {
+             return Eigen::Map<const dolfin::EigenArrayXi32>(
+                 self.connections(i), self.size(i));
+           },
+           py::return_value_policy::reference_internal)
       .def("size", &dolfin::mesh::Connectivity::size);
 
   // dolfin::mesh::MeshEntity class
@@ -224,13 +222,12 @@ void mesh(py::module& m)
       .def("num_global_entities",
            &dolfin::mesh::MeshEntity::num_global_entities,
            "Global number of incident entities of given dimension")
-      .def(
-          "entities",
-          [](dolfin::mesh::MeshEntity& self, std::size_t dim) {
-            return Eigen::Map<const dolfin::EigenArrayXi32>(
-                self.entities(dim), self.num_entities(dim));
-          },
-          py::return_value_policy::reference_internal)
+      .def("entities",
+           [](dolfin::mesh::MeshEntity& self, std::size_t dim) {
+             return Eigen::Map<const dolfin::EigenArrayXi32>(
+                 self.entities(dim), self.num_entities(dim));
+           },
+           py::return_value_policy::reference_internal)
       .def("midpoint", &dolfin::mesh::MeshEntity::midpoint,
            "Midpoint of Entity")
       .def("sharing_processes", &dolfin::mesh::MeshEntity::sharing_processes)
@@ -379,13 +376,12 @@ void mesh(py::module& m)
       .def("set_all", [](dolfin::mesh::MeshFunction<SCALAR>& self,             \
                          const SCALAR& value) { self = value; })               \
       .def("where_equal", &dolfin::mesh::MeshFunction<SCALAR>::where_equal)    \
-      .def(                                                                    \
-          "array",                                                             \
-          [](dolfin::mesh::MeshFunction<SCALAR>& self) {                       \
-            return Eigen::Map<Eigen::Array<SCALAR, Eigen::Dynamic, 1>>(        \
-                self.values(), self.size());                                   \
-          },                                                                   \
-          py::return_value_policy::reference_internal)
+      .def("array",                                                            \
+           [](dolfin::mesh::MeshFunction<SCALAR>& self) {                      \
+             return Eigen::Map<Eigen::Array<SCALAR, Eigen::Dynamic, 1>>(       \
+                 self.values(), self.size());                                  \
+           },                                                                  \
+           py::return_value_policy::reference_internal)
 
   MESHFUNCTION_MACRO(bool, Bool);
   MESHFUNCTION_MACRO(int, Int);

--- a/python/test/unit/io/test_HDF5.py
+++ b/python/test/unit/io/test_HDF5.py
@@ -114,7 +114,7 @@ def test_save_and_read_mesh_value_collection(tempdir):
     with HDF5File(mesh.mpi_comm(), filename, 'w') as f:
         for dim in range(mesh.topology.dim):
             mvc = MeshValueCollection("size_t", mesh, dim)
-            mesh.init(dim)
+            mesh.create_entities(dim)
             for e in MeshEntities(mesh, dim):
                 # this can be easily computed to the check the value
                 val = int(ndiv * sum(point2list(e.midpoint()))) + 1
@@ -139,7 +139,7 @@ def test_save_and_read_mesh_value_collection_with_only_one_marked_entity(
     filename = os.path.join(tempdir, "mesh_value_collection.h5")
     mesh = UnitCubeMesh(MPI.comm_world, ndiv, ndiv, ndiv)
     mvc = MeshValueCollection("size_t", mesh, 3)
-    mesh.init(3)
+    mesh.create_entities(3)
     if MPI.rank(mesh.mpi_comm()) == 0:
         mvc.set_value(0, 1)
 

--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -602,7 +602,7 @@ def test_save_mesh_value_collection(tempdir, encoding, data_type):
         mvc = MeshValueCollection(dtype_str, mesh, mvc_dim)
         tag = "dim_%d_marker" % mvc_dim
         mvc.rename(tag)
-        mesh.init(mvc_dim, tdim)
+        mesh.create_connectivity(mvc_dim, tdim)
         for e in MeshEntities(mesh, mvc_dim):
             if (e.midpoint()[0] > 0.5):
                 mvc.set_value(e.index(), dtype(1))
@@ -681,9 +681,9 @@ def test_append_and_load_mesh_functions(tempdir, encoding, data_type):
 def test_append_and_load_mesh_value_collections(tempdir, encoding, data_type):
     dtype_str, dtype = data_type
     mesh = UnitCubeMesh(MPI.comm_world, 2, 2, 2)
-    mesh.init()
+    mesh.create_connectivity_all()
     for d in range(mesh.geometry.dim + 1):
-        mesh.init_global(d)
+        mesh.create_global_indices(d)
 
     mvc_v = MeshValueCollection(dtype_str, mesh, 0)
     mvc_v.rename("vertices")

--- a/python/test/unit/mesh/test_cell.py
+++ b/python/test/unit/mesh/test_cell.py
@@ -62,7 +62,7 @@ def test_issue_568():
         cell.facet_area(0)
 
     # Should work after initializing the connectivity
-    mesh.init(2, 1)
+    mesh.create_connectivity(2, 1)
     cell.facet_area(0)
 
 
@@ -85,7 +85,7 @@ def test_volume_quadrilateralR3(coordinates):
                 numpy.array([[0, 1, 2, 3]], dtype=numpy.int32), [],
                 cpp.mesh.GhostMode.none)
 
-    mesh.init()
+    mesh.create_connectivity_all()
     cell = Cell(mesh, 0)
 
     assert cell.volume() == 1.0
@@ -109,7 +109,7 @@ def test_volume_quadrilateral_coplanarity_check_1(scaling):
             numpy.array([[0, 1, 2, 3]],
                         dtype=numpy.int32), [], cpp.mesh.GhostMode.none)
 
-        mesh.init()
+        mesh.create_connectivity_all()
         cell = Cell(mesh, 0)
         cell.volume()
 
@@ -132,7 +132,7 @@ def test_volume_quadrilateral_coplanarity_check_2(scaling):
                         dtype=numpy.float64),
                     numpy.array([[0, 1, 2, 3]], dtype=numpy.int32), [],
                     cpp.mesh.GhostMode.none)
-        mesh.init()
+        mesh.create_connectivity_all()
         cell = Cell(mesh, 0)
         cell.volume()
 

--- a/python/test/unit/mesh/test_edge.py
+++ b/python/test/unit/mesh/test_edge.py
@@ -31,7 +31,7 @@ def meshes(cube, square, request):
 def test_2DEdgeLength(square):
     """Iterate over edges and sum length."""
     length = 0.0
-    square.init(1)
+    square.create_entities(1)
     print(square.num_entities(1))
     for e in Edges(square):
         length += e.length()
@@ -42,7 +42,7 @@ def test_2DEdgeLength(square):
 def test_3DEdgeLength(cube):
     """Iterate over edges and sum length."""
     length = 0.0
-    cube.init(1)
+    cube.create_entities(1)
     for e in Edges(cube):
         length += e.length()
     assert round(length - 278.58049080280125053832, 7) == 0
@@ -50,7 +50,7 @@ def test_3DEdgeLength(cube):
 
 def test_EdgeDot(meshes):
     """Iterate over edges compute dot product with ."""
-    meshes.init(1)
+    meshes.create_entities(1)
     for e in Edges(meshes):
         dot = e.dot(e) / (e.length()**2)
         assert round(dot - 1.0, 7) == 0

--- a/python/test/unit/mesh/test_face.py
+++ b/python/test/unit/mesh/test_face.py
@@ -25,7 +25,7 @@ def square():
 def test_Area(cube, square):
     """Iterate over faces and sum area."""
     area = 0.0
-    cube.init(2)
+    cube.create_entities(2)
     for f in Faces(cube):
         area += f.area()
     assert round(area - 39.21320343559672494393, 7) == 0
@@ -39,7 +39,7 @@ def test_Area(cube, square):
 @skip_in_parallel
 def test_NormalPoint(cube, square):
     """Compute normal vector to each face."""
-    cube.init(2)
+    cube.create_entities(2)
     for f in Faces(cube):
         n = f.normal()
         assert round(n.norm() - 1.0, 7) == 0
@@ -52,7 +52,7 @@ def test_NormalPoint(cube, square):
 @skip_in_parallel
 def test_NormalComponent(cube, square):
     """Compute normal vector components to each face."""
-    cube.init(2)
+    cube.create_entities(2)
     for f in Faces(cube):
         n = f.normal()
         norm = sum([x * x for x in n])

--- a/python/test/unit/mesh/test_facet.py
+++ b/python/test/unit/mesh/test_facet.py
@@ -10,7 +10,7 @@ from dolfin import UnitSquareMesh, Facets, MPI
 def test_normal():
     "Test that the normal() method is wrapped"
     mesh = UnitSquareMesh(MPI.comm_world, 4, 4)
-    mesh.init(1)
+    mesh.create_entities(1)
     for facet in Facets(mesh):
         n = facet.normal()
         nx, ny, nz = n[0], n[1], n[2]

--- a/python/test/unit/mesh/test_ghost_mesh.py
+++ b/python/test/unit/mesh/test_ghost_mesh.py
@@ -74,11 +74,11 @@ def test_ghost_3d(mode):
 def test_ghost_connectivities(mode):
     # Ghosted mesh
     meshG = UnitSquareMesh(MPI.comm_world, 4, 4, ghost_mode=mode)
-    meshG.init(1, 2)
+    meshG.create_connectivity(1, 2)
 
     # Reference mesh, not ghosted, not parallel
     meshR = UnitSquareMesh(MPI.comm_self, 4, 4, ghost_mode=cpp.mesh.GhostMode.none)
-    meshR.init(1, 2)
+    meshR.create_connectivity(1, 2)
 
     # Create reference mapping from facet midpoint to cell midpoint
     reference = {}

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -389,7 +389,7 @@ def test_shared_entities(mesh_factory):
     # FIXME: Implement a proper test
     for shared_dim in range(dim + 1):
         # Initialise global indices (if not already)
-        mesh.init_global(shared_dim)
+        mesh.create_global_indices(shared_dim)
 
         assert isinstance(mesh.topology.shared_entities(shared_dim), dict)
         assert isinstance(
@@ -431,7 +431,7 @@ def test_mesh_topology_against_fiat(mesh_factory, ghost_mode=cpp.mesh.GhostMode.
     fiat_cell = FIAT.ufc_cell(cell_name)
 
     # Initialize all mesh entities and connectivities
-    mesh.init()
+    mesh.create_connectivity_all()
 
     for cell in Cells(mesh):
         # Get mesh-global (MPI-local) indices of cell vertices

--- a/python/test/unit/mesh/test_mesh_iterator.py
+++ b/python/test/unit/mesh/test_mesh_iterator.py
@@ -16,7 +16,7 @@ def test_vertex_iterators():
 
     mesh = UnitCubeMesh(MPI.comm_world, 5, 5, 5)
     for i in range(4):
-        mesh.init(0, i)
+        mesh.create_connectivity(0, i)
 
     connectivities = [(i, mesh.topology.connectivity(0, i)) for i in range(4)]
 
@@ -41,7 +41,7 @@ def test_edge_iterators():
 
     mesh = UnitCubeMesh(MPI.comm_world, 5, 5, 5)
     for i in range(4):
-        mesh.init(1, i)
+        mesh.create_connectivity(1, i)
 
     connectivities = [(i, mesh.topology.connectivity(1, i)) for i in range(4)]
 
@@ -66,7 +66,7 @@ def test_face_iterator():
 
     mesh = UnitCubeMesh(MPI.comm_world, 5, 5, 5)
     for i in range(4):
-        mesh.init(2, i)
+        mesh.create_connectivity(2, i)
 
     connectivities = [(i, mesh.topology.connectivity(2, i)) for i in range(4)]
 
@@ -99,7 +99,7 @@ def test_cell_iterators():
     """Iterate over cells"""
     mesh = UnitCubeMesh(MPI.comm_world, 5, 5, 5)
     for i in range(4):
-        mesh.init(3, i)
+        mesh.create_connectivity(3, i)
 
     connectivities = [(i, mesh.topology.connectivity(3, i)) for i in range(4)]
 

--- a/python/test/unit/mesh/test_mesh_value_collection.py
+++ b/python/test/unit/mesh/test_mesh_value_collection.py
@@ -33,7 +33,7 @@ def test_assign_2D_cells():
 
 def test_assign_2D_facets():
     mesh = UnitSquareMesh(MPI.comm_world, 3, 3)
-    mesh.init(2, 1)
+    mesh.create_connectivity(2, 1)
     ncells = mesh.num_cells()
     f = MeshValueCollection("int", mesh, 1)
     all_new = True
@@ -56,7 +56,7 @@ def test_assign_2D_facets():
 
 def test_assign_2D_vertices():
     mesh = UnitSquareMesh(MPI.comm_world, 3, 3)
-    mesh.init(2, 0)
+    mesh.create_connectivity(2, 0)
     ncells = mesh.num_cells()
     f = MeshValueCollection("int", mesh, 0)
     all_new = True
@@ -115,7 +115,7 @@ def test_mesh_function_assign_2D_cells():
 
 def test_mesh_function_assign_2D_facets():
     mesh = UnitSquareMesh(MPI.comm_world, 3, 3)
-    mesh.init(1)
+    mesh.create_entities(1)
     tdim = mesh.topology.dim
     f = MeshFunction("int", mesh, tdim - 1, 25)
     for cell in Cells(mesh):
@@ -139,7 +139,7 @@ def test_mesh_function_assign_2D_facets():
 
 def test_mesh_function_assign_2D_vertices():
     mesh = UnitSquareMesh(MPI.comm_world, 3, 3)
-    mesh.init(0)
+    mesh.create_entities(0)
     f = MeshFunction("int", mesh, 0, 25)
     g = MeshValueCollection("int", mesh, 0)
     g.assign(f)

--- a/python/test/unit/mesh/test_sub_domain.py
+++ b/python/test/unit/mesh/test_sub_domain.py
@@ -35,7 +35,7 @@ def test_creation_and_marking():
         dim = ind + 1
         args = [10] * dim
         mesh = MeshClass(MPI.comm_world, *args)
-        mesh.init()
+        mesh.create_connectivity_all()
 
         for left, right in subdomain_pairs:
             for t_dim, f_dim in [(0, 0), (mesh.topology.dim - 1, dim - 1),


### PR DESCRIPTION
Change ambiguous 'init' method names to something descriptive.