### PR TITLE
Add time argument to Expression

### DIFF
--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -42,8 +42,7 @@ public:
   void eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
                                     Eigen::RowMajor>>
                 values,
-            Eigen::Ref<const EigenRowArrayXXd> x,
-            const dolfin::mesh::Cell& cell) const
+            Eigen::Ref<const EigenRowArrayXXd> x) const
   {
     for (int i = 0; i < x.rows(); ++i)
     {
@@ -63,8 +62,7 @@ public:
   void eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
                                     Eigen::RowMajor>>
                 values,
-            Eigen::Ref<const EigenRowArrayXXd> x,
-            const dolfin::mesh::Cell& cell) const
+            Eigen::Ref<const EigenRowArrayXXd> x) const
   {
     const double scale = 0.005;
 

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -110,8 +110,7 @@ public:
   void eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
                                     Eigen::RowMajor>>
                 values,
-            Eigen::Ref<const EigenRowArrayXXd> x,
-            const dolfin::mesh::Cell& cell) const
+            Eigen::Ref<const EigenRowArrayXXd> x) const
   {
     for (unsigned int i = 0; i != x.rows(); ++i)
     {
@@ -131,8 +130,7 @@ public:
   void eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
                                     Eigen::RowMajor>>
                 values,
-            Eigen::Ref<const EigenRowArrayXXd> x,
-            const dolfin::mesh::Cell& cell) const
+            Eigen::Ref<const EigenRowArrayXXd> x) const
   {
     for (unsigned int i = 0; i != x.rows(); ++i)
       values(i, 0) = sin(5 * x(i, 0));

--- a/cpp/dolfin/function/Expression.cpp
+++ b/cpp/dolfin/function/Expression.cpp
@@ -11,7 +11,6 @@
 #include <dolfin/mesh/Mesh.h>
 #include <dolfin/mesh/MeshIterator.h>
 #include <dolfin/mesh/Vertex.h>
-// #include <spdlog/spdlog.h>
 
 using namespace dolfin;
 using namespace dolfin::function;
@@ -26,7 +25,7 @@ Expression::Expression(std::vector<std::size_t> value_shape)
 Expression::Expression(
     std::function<void(PetscScalar* values, const double* x,
                        const int64_t* cell_idx, int num_points, int value_size,
-                       int gdim, int num_cells)>
+                       int gdim, int num_cells, double t)>
         eval_ptr,
     std::vector<std::size_t> value_shape)
     : _eval_ptr(eval_ptr), _value_shape(value_shape)
@@ -40,11 +39,11 @@ std::size_t Expression::value_dimension(std::size_t i) const
 {
   if (i >= _value_shape.size())
   {
-    // spdlog::error("Expression.cpp", "evaluate expression",
-    //               "Illegal axis %d for value dimension for value of rank %d",
-    //               i, _value_shape.size());
-    throw std::runtime_error("Value dimension axis");
+    throw std::runtime_error("Illegal axis " + std::to_string(i)
+                             + " for value dimension for value of rank "
+                             + std::to_string(_value_shape.size()));
   }
+
   return _value_shape[i];
 }
 //-----------------------------------------------------------------------------
@@ -139,6 +138,6 @@ void Expression::eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
   const int64_t cell_idx = cell.index();
   assert(_eval_ptr);
   _eval_ptr(values.data(), x.data(), &cell_idx, x.rows(), values.cols(),
-            x.cols(), 1);
+            x.cols(), 1, this->t);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/function/Expression.cpp
+++ b/cpp/dolfin/function/Expression.cpp
@@ -51,9 +51,9 @@ std::vector<std::size_t> Expression::value_shape() const
   return _value_shape;
 }
 //-----------------------------------------------------------------------------
-void Expression::restrict(
-    PetscScalar* w, const fem::FiniteElement& element, const mesh::Cell& cell,
-    const Eigen::Ref<const EigenRowArrayXXd>& coordinate_dofs) const
+void Expression::restrict(PetscScalar* w, const fem::FiniteElement& element,
+                          const mesh::Cell& cell,
+                          const EigenRowArrayXXd& coordinate_dofs) const
 {
   // Get evaluation points
   const std::size_t value_size = std::accumulate(

--- a/cpp/dolfin/function/Expression.cpp
+++ b/cpp/dolfin/function/Expression.cpp
@@ -23,8 +23,8 @@ Expression::Expression(std::vector<std::size_t> value_shape)
 }
 //-----------------------------------------------------------------------------
 Expression::Expression(
-    std::function<void(PetscScalar* values, const double* x, int num_points,
-                       int value_size, int gdim, double t)>
+    std::function<void(PetscScalar* values, int num_points, int value_size,
+                       const double* x, int gdim, double t)>
         eval_ptr,
     std::vector<std::size_t> value_shape)
     : _eval_ptr(eval_ptr), _value_shape(value_shape)
@@ -137,7 +137,8 @@ void Expression::eval(
         x) const
 {
   assert(_eval_ptr);
-  _eval_ptr(values.data(), x.data(), x.rows(), values.cols(), x.cols(),
+  assert(values.rows() == x.rows());
+  _eval_ptr(values.data(), values.rows(), values.cols(), x.data(), x.cols(),
             this->t);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/function/Expression.h
+++ b/cpp/dolfin/function/Expression.h
@@ -44,7 +44,7 @@ public:
   /// @param value_shape (std::vector<std::size_t>)
   ///         Shape of expression.
   Expression(
-      std::function<void(PetscScalar*, const double*, int, int, int, double)>
+      std::function<void(PetscScalar*, int, int, const double*, int, double)>
           eval_ptr,
       std::vector<std::size_t> value_shape);
 
@@ -128,22 +128,22 @@ private:
   //        Pointer to row major 2D C-style array of `PetscScalar`.
   //        The array has shape=(number of points, value size) and has to
   //        be filled with custom values in the function body.
+  // @param num_points
+  //        Number of points where expression is evaluated
+  // @param value_size
+  //        Size of expression value
   // @param x
   //        Pointer to a row major C-style 2D array of `double`.
   //        The array has shape=(number of points, geometrical dimension)
   //        and represents array of points in physical space at which the
   //        Expression is being evaluated.
-  // @param num_points
-  //        Number of points where expression is evaluated
-  // @param value_size
-  //        Size of expression value
   // @param gdim
   //        Geometrical dimension of physical point where expression
   //        is evaluated
   // @param t
   //        Time
-  std::function<void(PetscScalar* values, const double* x, int num_points,
-                     int value_size, int gdim, double t)>
+  std::function<void(PetscScalar* values, int num_points, int value_size,
+                     const double* x, int gdim, double t)>
       _eval_ptr;
 
   // Value shape

--- a/cpp/dolfin/function/Expression.h
+++ b/cpp/dolfin/function/Expression.h
@@ -44,7 +44,7 @@ public:
   /// @param value_shape (std::vector<std::size_t>)
   ///         Shape of expression.
   Expression(std::function<void(PetscScalar*, const double*, const int64_t*,
-                                int, int, int, int)>
+                                int, int, int, int, double)>
                  eval_ptr,
              std::vector<std::size_t> value_shape);
 
@@ -117,6 +117,9 @@ public:
                     const Eigen::Ref<const EigenRowArrayXXd> x,
                     const dolfin::mesh::Cell& cell) const;
 
+  /// Time
+double t = 0.0;
+
 private:
   // Evaluate method
   //
@@ -143,9 +146,11 @@ private:
   //        is evaluated
   // @param num_cells
   //        Number of cells
+  // @param t
+  //        Time
   std::function<void(PetscScalar* values, const double* x,
                      const int64_t* cell_idx, int num_points, int value_size,
-                     int gdim, int num_cells)>
+                     int gdim, int num_cells, double t)>
       _eval_ptr;
 
   // Value shape

--- a/cpp/dolfin/function/Expression.h
+++ b/cpp/dolfin/function/Expression.h
@@ -43,10 +43,10 @@ public:
   ///
   /// @param value_shape (std::vector<std::size_t>)
   ///         Shape of expression.
-  Expression(std::function<void(PetscScalar*, const double*, const int64_t*,
-                                int, int, int, int, double)>
-                 eval_ptr,
-             std::vector<std::size_t> value_shape);
+  Expression(
+      std::function<void(PetscScalar*, const double*, int, int, int, double)>
+          eval_ptr,
+      std::vector<std::size_t> value_shape);
 
   /// Copy constructor
   ///
@@ -109,16 +109,16 @@ public:
   ///         The values at the point.
   /// @param    x (Eigen::Ref<const Eigen::VectorXd>)
   ///         The coordinates of the point.
-  /// @param    cell (mesh::Cell)
-  ///         The cell which contains the given point.
-  virtual void eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
-                                            Eigen::Dynamic, Eigen::RowMajor>>
-                        values,
-                    const Eigen::Ref<const EigenRowArrayXXd> x,
-                    const dolfin::mesh::Cell& cell) const;
+  virtual void
+  eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
+                               Eigen::RowMajor>>
+           values,
+       const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,
+                                           Eigen::Dynamic, Eigen::RowMajor>>
+           x) const;
 
   /// Time
-double t = 0.0;
+  double t = 0.0;
 
 private:
   // Evaluate method
@@ -133,10 +133,6 @@ private:
   //        The array has shape=(number of points, geometrical dimension)
   //        and represents array of points in physical space at which the
   //        Expression is being evaluated.
-  // @param cell_idx
-  //        Pointer to a 1D C-style array of `int`. It is an array
-  //        of indices of cells where points are evaluated. Value -1 represents
-  //        cell-independent eval function
   // @param num_points
   //        Number of points where expression is evaluated
   // @param value_size
@@ -144,13 +140,10 @@ private:
   // @param gdim
   //        Geometrical dimension of physical point where expression
   //        is evaluated
-  // @param num_cells
-  //        Number of cells
   // @param t
   //        Time
-  std::function<void(PetscScalar* values, const double* x,
-                     const int64_t* cell_idx, int num_points, int value_size,
-                     int gdim, int num_cells, double t)>
+  std::function<void(PetscScalar* values, const double* x, int num_points,
+                     int value_size, int gdim, double t)>
       _eval_ptr;
 
   // Value shape

--- a/cpp/dolfin/function/Expression.h
+++ b/cpp/dolfin/function/Expression.h
@@ -88,10 +88,9 @@ public:
   ///         The cell.
   /// @param  coordinate_dofs (double*)
   ///         The coordinates
-  virtual void
-  restrict(PetscScalar* w, const fem::FiniteElement& element,
-           const mesh::Cell& dolfin_cell,
-           const Eigen::Ref<const EigenRowArrayXXd>& coordinate_dofs) const;
+  virtual void restrict(PetscScalar* w, const fem::FiniteElement& element,
+                        const mesh::Cell& dolfin_cell,
+                        const EigenRowArrayXXd& coordinate_dofs) const;
 
   /// Compute values at all mesh vertices.
   ///

--- a/cpp/dolfin/function/SpecialFunctions.cpp
+++ b/cpp/dolfin/function/SpecialFunctions.cpp
@@ -21,37 +21,10 @@ void MeshCoordinates::eval(
     Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
                             Eigen::RowMajor>>
         values,
-    const Eigen::Ref<const EigenRowArrayXXd> x, const mesh::Cell& cell) const
+    const Eigen::Ref<const EigenRowArrayXXd> x) const
 {
   assert(_mesh);
   assert((unsigned int)x.cols() == _mesh->geometry().dim());
-
   values = x;
-}
-//-----------------------------------------------------------------------------
-FacetArea::FacetArea(std::shared_ptr<const mesh::Mesh> mesh)
-    : Expression({}), _mesh(mesh)
-{
-  // Do nothing
-}
-//-----------------------------------------------------------------------------
-void FacetArea::eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
-                                             Eigen::Dynamic, Eigen::RowMajor>>
-                         values,
-                     const Eigen::Ref<const EigenRowArrayXXd> x,
-                     const mesh::Cell& cell) const
-{
-  assert(_mesh);
-
-  for (unsigned int i = 0; i != x.rows(); ++i)
-  {
-    if (cell.local_facet >= 0)
-      values(i, 0) = cell.facet_area(cell.local_facet);
-    else
-    {
-      // not_on_boundary
-      values(i, 0) = 0.0;
-    }
-  }
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/function/SpecialFunctions.h
+++ b/cpp/dolfin/function/SpecialFunctions.h
@@ -33,32 +33,11 @@ public:
   void eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
                                     Eigen::RowMajor>>
                 values,
-            const Eigen::Ref<const EigenRowArrayXXd> x,
-            const mesh::Cell& cell) const override;
+            const Eigen::Ref<const EigenRowArrayXXd> x) const override;
 
 private:
-  // The mesh
   std::shared_ptr<const mesh::Mesh> _mesh;
 };
 
-/// This function represents the area/length of a cell facet on a
-/// given mesh.
-class FacetArea : public Expression
-{
-public:
-  /// Constructor
-  explicit FacetArea(std::shared_ptr<const mesh::Mesh> mesh);
-
-  /// Evaluate function
-  void eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
-                                    Eigen::RowMajor>>
-                values,
-            const Eigen::Ref<const EigenRowArrayXXd> x,
-            const mesh::Cell& cell) const override;
-
-private:
-  // The mesh
-  std::shared_ptr<const mesh::Mesh> _mesh;
-};
 } // namespace function
 } // namespace dolfin

--- a/python/dolfin/function/expression.py
+++ b/python/dolfin/function/expression.py
@@ -59,26 +59,21 @@ def numba_eval(*args,
     # Decomaker pattern see PEP 318
     def decorator(f: typing.Callable):
         scalar_type = numba.typeof(PETSc.ScalarType())
-        c_signature = numba.types.void(
-            numba.types.CPointer(scalar_type),
-            numba.types.CPointer(numba.types.double),
-            numba.types.CPointer(numba.types.int32), numba.types.intc,
-            numba.types.intc, numba.types.intc, numba.types.intc, numba.types.float64)
+        c_signature = numba.types.void(numba.types.CPointer(scalar_type), numba.types.CPointer(
+            numba.types.double), numba.types.intc, numba.types.intc, numba.types.intc, numba.types.float64)
 
         # Compile the user function
         f_jit = numba.jit(**numba_jit_options)(f)
 
         # Wrap the user function in a function with a C interface
         @numba.cfunc(c_signature, **numba_cfunc_options)
-        def eval(values, x, cell_idx, num_points, value_size, gdim, num_cells, t):
+        def eval(values, x, num_points, value_size, gdim, t):
             np_values = numba.carray(
                 values, (num_points, value_size), dtype=scalar_type)
             np_x = numba.carray(
                 x, (num_points, gdim), dtype=numba.types.double)
-            np_cell_idx = numba.carray(
-                cell_idx, (num_cells, ), dtype=numba.types.int32)
 
-            f_jit(np_values, np_x, np_cell_idx, t)
+            f_jit(np_values, np_x, t)
 
         return eval
 

--- a/python/src/function.cpp
+++ b/python/src/function.cpp
@@ -48,12 +48,12 @@ void function(py::module& m)
              std::shared_ptr<dolfin::function::Expression>>(m, "Expression")
       .def(py::init([](std::uintptr_t addr,
                        std::vector<std::size_t> value_size) {
-        std::function<void(PetscScalar*, const double*, int, int, int, double)>
-            f = reinterpret_cast<void (*)(PetscScalar*, const double*, int, int,
+        std::function<void(PetscScalar*, int, int, const double*, int, double)>
+            f = reinterpret_cast<void (*)(PetscScalar*, int, int, const double*,
                                           int, double)>(addr);
         return std::make_unique<dolfin::function::Expression>(f, value_size);
       }))
-      .def(py::init<std::function<void(PetscScalar*, const double*, int, int,
+      .def(py::init<std::function<void(PetscScalar*, int, int, const double*,
                                        int, double)>,
                     std::vector<std::size_t>>())
       .def("eval", &dolfin::function::Expression::eval)

--- a/python/src/function.cpp
+++ b/python/src/function.cpp
@@ -48,19 +48,17 @@ void function(py::module& m)
              std::shared_ptr<dolfin::function::Expression>>(m, "Expression")
       .def(py::init([](std::uintptr_t addr,
                        std::vector<std::size_t> value_size) {
-        std::function<void(PetscScalar*, const double*, const std::int64_t*,
-                           int, int, int, int, double)>
-            f = reinterpret_cast<void (*)(PetscScalar*, const double*,
-                                          const std::int64_t*, int, int, int,
+        std::function<void(PetscScalar*, const double*, int, int, int, double)>
+            f = reinterpret_cast<void (*)(PetscScalar*, const double*, int, int,
                                           int, double)>(addr);
         return std::make_unique<dolfin::function::Expression>(f, value_size);
       }))
-      .def(py::init<
-           std::function<void(PetscScalar*, const double*, const std::int64_t*,
-                              int, int, int, int, double)>,
-           std::vector<std::size_t>>())
+      .def(py::init<std::function<void(PetscScalar*, const double*, int, int,
+                                       int, double)>,
+                    std::vector<std::size_t>>())
       .def("eval", &dolfin::function::Expression::eval)
-      .def_property_readonly("value_rank", &dolfin::function::Expression::value_rank)
+      .def_property_readonly("value_rank",
+                             &dolfin::function::Expression::value_rank)
       .def("value_dimension", &dolfin::function::Expression::value_dimension)
       .def_readwrite("t", &dolfin::function::Expression::t);
 

--- a/python/src/function.cpp
+++ b/python/src/function.cpp
@@ -34,15 +34,14 @@ void function(py::module& m)
 {
 
   // Create dolfin::function::Expression from a JIT pointer
-  m.def(
-      "make_dolfin_expression",
-      [](std::uintptr_t addr) {
-        dolfin::function::Expression* p
-            = reinterpret_cast<dolfin::function::Expression*>(addr);
-        return std::shared_ptr<const dolfin::function::Expression>(p);
-      },
-      "Create a dolfin::function::Expression object from a pointer integer, "
-      "typically returned by a just-in-time compiler");
+  m.def("make_dolfin_expression",
+        [](std::uintptr_t addr) {
+          dolfin::function::Expression* p
+              = reinterpret_cast<dolfin::function::Expression*>(addr);
+          return std::shared_ptr<const dolfin::function::Expression>(p);
+        },
+        "Create a dolfin::function::Expression object from a pointer integer, "
+        "typically returned by a just-in-time compiler");
 
   // dolfin:Expression
   py::class_<dolfin::function::Expression,
@@ -50,18 +49,20 @@ void function(py::module& m)
       .def(py::init([](std::uintptr_t addr,
                        std::vector<std::size_t> value_size) {
         std::function<void(PetscScalar*, const double*, const std::int64_t*,
-                           int, int, int, int)>
+                           int, int, int, int, double)>
             f = reinterpret_cast<void (*)(PetscScalar*, const double*,
                                           const std::int64_t*, int, int, int,
-                                          int)>(addr);
+                                          int, double)>(addr);
         return std::make_unique<dolfin::function::Expression>(f, value_size);
       }))
-      .def(
-          py::init<std::function<void(PetscScalar*, const double*,
-                                      const std::int64_t*, int, int, int, int)>,
-                   std::vector<std::size_t>>())
+      .def(py::init<
+           std::function<void(PetscScalar*, const double*, const std::int64_t*,
+                              int, int, int, int, double)>,
+           std::vector<std::size_t>>())
       .def("eval", &dolfin::function::Expression::eval)
-      .def("value_dimension", &dolfin::function::Expression::value_dimension);
+      .def_property_readonly("value_rank", &dolfin::function::Expression::value_rank)
+      .def("value_dimension", &dolfin::function::Expression::value_dimension)
+      .def_readwrite("t", &dolfin::function::Expression::t);
 
   // dolfin::function::Function
   py::class_<dolfin::function::Function,
@@ -83,26 +84,24 @@ void function(py::module& m)
            py::overload_cast<const dolfin::function::Expression&>(
                &dolfin::function::Function::interpolate),
            py::arg("expr"))
-      .def(
-          "vector",
-          [](const dolfin::function::Function& self) {
-            return self.vector().vec();
-          },
-          "Return the vector associated with the finite element Function")
+      .def("vector",
+           [](const dolfin::function::Function& self) {
+             return self.vector().vec();
+           },
+           "Return the vector associated with the finite element Function")
       .def("value_dimension", &dolfin::function::Function::value_dimension)
       .def("value_size", &dolfin::function::Function::value_size)
       .def("value_rank", &dolfin::function::Function::value_rank)
       .def_property_readonly("value_shape",
                              &dolfin::function::Function::value_shape)
-      .def(
-          "eval",
-          [](const dolfin::function::Function& self,
-             Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
-                                     Eigen::Dynamic, Eigen::RowMajor>>
-                 u,
-             const Eigen::Ref<const dolfin::EigenRowArrayXXd> x,
-             const dolfin::mesh::Cell& cell) { self.eval(u, x, cell); },
-          "Evaluate Function (cell version)")
+      .def("eval",
+           [](const dolfin::function::Function& self,
+              Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
+                                      Eigen::Dynamic, Eigen::RowMajor>>
+                  u,
+              const Eigen::Ref<const dolfin::EigenRowArrayXXd> x,
+              const dolfin::mesh::Cell& cell) { self.eval(u, x, cell); },
+           "Evaluate Function (cell version)")
       .def("eval",
            py::overload_cast<
                Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
@@ -116,21 +115,20 @@ void function(py::module& m)
            py::overload_cast<const dolfin::mesh::Mesh&>(
                &dolfin::function::Function::compute_point_values, py::const_),
            "Compute values at all mesh points")
-      .def(
-          "compute_point_values",
-          [](dolfin::function::Function& self) {
-            auto V = self.function_space();
-            if (!V)
-              throw py::value_error("Function has no function space. "
-                                    "You must supply a mesh.");
-            auto mesh = V->mesh();
-            if (!mesh)
-              throw py::value_error("Function has no function space "
-                                    "mesh. You must supply a mesh.");
-            return self.compute_point_values(*mesh);
-          },
-          "Compute values at all mesh points by using the mesh "
-          "function.function_space().mesh()")
+      .def("compute_point_values",
+           [](dolfin::function::Function& self) {
+             auto V = self.function_space();
+             if (!V)
+               throw py::value_error("Function has no function space. "
+                                     "You must supply a mesh.");
+             auto mesh = V->mesh();
+             if (!mesh)
+               throw py::value_error("Function has no function space "
+                                     "mesh. You must supply a mesh.");
+             return self.compute_point_values(*mesh);
+           },
+           "Compute values at all mesh points by using the mesh "
+           "function.function_space().mesh()")
       .def("function_space", &dolfin::function::Function::function_space);
 
   // FIXME: why is this floating here?

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -372,12 +372,11 @@ def test_numba_expression_address(V):
 @skip_if_complex
 def test_cffi_expression(V):
     code_h = """
-    void eval(double* values, const double* x, int num_points, int value_size,
-              int gdim, double t);
+    void eval(double* values, int num_points, int value_size, const double* x, int gdim, double t);
     """
 
     code_c = """
-    void eval(double* values, const double* x, int num_points, int value_size, int gdim, double t)
+    void eval(double* values, int num_points, int value_size, const double* x, int gdim, double t)
     {
       for (int i = 0; i < num_points; ++i)
       {

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -406,7 +406,7 @@ def test_cffi_expression(V):
     f1.interpolate(ex1)
 
     @function.expression.numba_eval
-    def expr_eval2(values, x,  t):
+    def expr_eval2(values, x, t):
         values[:, 0] = x[:, 0] + x[:, 1]
 
     ex2 = Expression(expr_eval2)

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -135,7 +135,7 @@ def test_assign(V, W):
         uu = Function(V1)
 
         @function.expression.numba_eval
-        def expr_eval(values, x, cell_idx, t):
+        def expr_eval(values, x, t):
             values[:, 0] = 1.0
 
         f = Expression(expr_eval)
@@ -161,13 +161,13 @@ def test_call(R, V, W, Q, mesh):
     u3 = Function(Q)
 
     @function.expression.numba_eval
-    def expr_eval1(values, x, cell_idx, t):
+    def expr_eval1(values, x, t):
         values[:, 0] = x[:, 0] + x[:, 1] + x[:, 2]
 
     e1 = Expression(expr_eval1)
 
     @function.expression.numba_eval
-    def expr_eval2(values, x, cell_idx, t):
+    def expr_eval2(values, x, t):
         values[:, 0] = x[:, 0] + x[:, 1] + x[:, 2]
         values[:, 1] = x[:, 0] - x[:, 1] - x[:, 2]
         values[:, 2] = x[:, 0] + x[:, 1] + x[:, 2]
@@ -175,7 +175,7 @@ def test_call(R, V, W, Q, mesh):
     e2 = Expression(expr_eval2, shape=(3, ))
 
     @function.expression.numba_eval
-    def expr_eval3(values, x, cell_idx, t):
+    def expr_eval3(values, x, t):
         values[:, 0] = x[:, 0] + x[:, 1] + x[:, 2]
         values[:, 1] = x[:, 0] - x[:, 1] - x[:, 2]
         values[:, 2] = x[:, 0] + x[:, 1] + x[:, 2]
@@ -245,7 +245,7 @@ def test_scalar_conditions(R):
 
 def test_interpolation_mismatch_rank0(W):
     @function.expression.numba_eval
-    def expr_eval(values, x, cell_idx, t):
+    def expr_eval(values, x, t):
         values[:, 0] = 1.0
 
     f = Expression(expr_eval, shape=())
@@ -255,7 +255,7 @@ def test_interpolation_mismatch_rank0(W):
 
 def test_interpolation_mismatch_rank1(W):
     @function.expression.numba_eval
-    def expr_eval(values, x, cell_idx, t):
+    def expr_eval(values, x, t):
         values[:, 0] = 1.0
         values[:, 1] = 1.0
 
@@ -266,7 +266,7 @@ def test_interpolation_mismatch_rank1(W):
 
 def test_interpolation_rank0(V):
     @function.expression.numba_eval
-    def expr_eval(values, x, cell_idx, t):
+    def expr_eval(values, x, t):
         values[:, 0] = 1.0 * t
 
     f = Expression(expr_eval, shape=())
@@ -300,7 +300,7 @@ def test_near_evaluations(R, mesh):
 
 def test_interpolation_rank1(W):
     @function.expression.numba_eval
-    def expr_eval(values, x, cell_idx, t):
+    def expr_eval(values, x, t):
         values[:, 0] = 1.0
         values[:, 1] = 1.0
         values[:, 2] = 1.0
@@ -316,7 +316,7 @@ def test_interpolation_rank1(W):
 def test_numba_expression_jit_objmode_fails(W):
     # numba cfunc cannot call into objmode jit function
     @function.expression.numba_eval(numba_jit_options={"forceobj": True})
-    def expr_eval(values, x, cell_idx, t):
+    def expr_eval(values, x, t):
         values[0] = 1.0
 
 
@@ -324,18 +324,18 @@ def test_numba_expression_jit_objmode_fails(W):
 def test_numba_expression_cfunc_objmode_fails(W):
     # numba does not support cfuncs built in objmode
     @function.expression.numba_eval(numba_cfunc_options={"forceobj": True})
-    def expr_eval(values, x, cell_idx, t):
+    def expr_eval(values, x, t):
         values[0] = 1.0
 
 
 @skip_in_parallel
 def test_interpolation_old(V, W, mesh):
     @function.expression.numba_eval
-    def expr_eval0(values, x, cell_idx, t):
+    def expr_eval0(values, x, t):
         values[:, 0] = 1.0
 
     @function.expression.numba_eval
-    def expr_eval1(values, x, cell_idx, t):
+    def expr_eval1(values, x, t):
         values[:, 0] = 1.0
         values[:, 1] = 1.0
         values[:, 2] = 1.0
@@ -357,7 +357,7 @@ def test_interpolation_old(V, W, mesh):
 
 def test_numba_expression_address(V):
     @function.expression.numba_eval
-    def expr_eval(values, x, cell_idx, t):
+    def expr_eval(values, x, t):
         values[:, :] = 1.0
 
     # Handle C func address by hand
@@ -372,18 +372,17 @@ def test_numba_expression_address(V):
 @skip_if_complex
 def test_cffi_expression(V):
     code_h = """
-    void eval(double* values, const double* x, const int64_t* cell_idx,
-            int num_points, int value_size, int gdim, int num_cells);
+    void eval(double* values, const double* x, int num_points, int value_size,
+              int gdim, double t);
     """
 
     code_c = """
-    void eval(double* values, const double* x, const int64_t* cell_idx,
-            int num_points, int value_size, int gdim, int num_cells)
+    void eval(double* values, const double* x, int num_points, int value_size, int gdim, double t)
     {
-        for (int i = 0; i < num_points; ++i)
-        {
-            values[i*value_size + 0] = x[i*gdim + 0] + x[i*gdim + 1];
-        }
+      for (int i = 0; i < num_points; ++i)
+      {
+        values[i*value_size + 0] = x[i*gdim + 0] + x[i*gdim + 1];
+      }
     }
     """
     module = "_expr_eval" + str(MPI.comm_world.rank)
@@ -407,7 +406,7 @@ def test_cffi_expression(V):
     f1.interpolate(ex1)
 
     @function.expression.numba_eval
-    def expr_eval2(values, x, cell_idx, t):
+    def expr_eval2(values, x,  t):
         values[:, 0] = x[:, 0] + x[:, 1]
 
     ex2 = Expression(expr_eval2)

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -135,7 +135,7 @@ def test_assign(V, W):
         uu = Function(V1)
 
         @function.expression.numba_eval
-        def expr_eval(values, x, cell_idx):
+        def expr_eval(values, x, cell_idx, t):
             values[:, 0] = 1.0
 
         f = Expression(expr_eval)
@@ -161,13 +161,13 @@ def test_call(R, V, W, Q, mesh):
     u3 = Function(Q)
 
     @function.expression.numba_eval
-    def expr_eval1(values, x, cell_idx):
+    def expr_eval1(values, x, cell_idx, t):
         values[:, 0] = x[:, 0] + x[:, 1] + x[:, 2]
 
     e1 = Expression(expr_eval1)
 
     @function.expression.numba_eval
-    def expr_eval2(values, x, cell_idx):
+    def expr_eval2(values, x, cell_idx, t):
         values[:, 0] = x[:, 0] + x[:, 1] + x[:, 2]
         values[:, 1] = x[:, 0] - x[:, 1] - x[:, 2]
         values[:, 2] = x[:, 0] + x[:, 1] + x[:, 2]
@@ -175,7 +175,7 @@ def test_call(R, V, W, Q, mesh):
     e2 = Expression(expr_eval2, shape=(3, ))
 
     @function.expression.numba_eval
-    def expr_eval3(values, x, cell_idx):
+    def expr_eval3(values, x, cell_idx, t):
         values[:, 0] = x[:, 0] + x[:, 1] + x[:, 2]
         values[:, 1] = x[:, 0] - x[:, 1] - x[:, 2]
         values[:, 2] = x[:, 0] + x[:, 1] + x[:, 2]
@@ -245,7 +245,7 @@ def test_scalar_conditions(R):
 
 def test_interpolation_mismatch_rank0(W):
     @function.expression.numba_eval
-    def expr_eval(values, x, cell_idx):
+    def expr_eval(values, x, cell_idx, t):
         values[:, 0] = 1.0
 
     f = Expression(expr_eval, shape=())
@@ -255,7 +255,7 @@ def test_interpolation_mismatch_rank0(W):
 
 def test_interpolation_mismatch_rank1(W):
     @function.expression.numba_eval
-    def expr_eval(values, x, cell_idx):
+    def expr_eval(values, x, cell_idx, t):
         values[:, 0] = 1.0
         values[:, 1] = 1.0
 
@@ -266,14 +266,18 @@ def test_interpolation_mismatch_rank1(W):
 
 def test_interpolation_rank0(V):
     @function.expression.numba_eval
-    def expr_eval(values, x, cell_idx):
-        values[:, 0] = 1.0
+    def expr_eval(values, x, cell_idx, t):
+        values[:, 0] = 1.0 * t
 
     f = Expression(expr_eval, shape=())
+    f.t = 1.0
     w = interpolate(f, V)
-    x = w.vector()
-    assert MPI.max(MPI.comm_world, abs(x.max()[1])) == 1
-    assert MPI.min(MPI.comm_world, abs(x.min()[1])) == 1
+    with w.vector().localForm() as x:
+        assert (x[:] == 1.0).all()
+    f.t = 2.0
+    w = interpolate(f, V)
+    with w.vector().localForm() as x:
+        assert (x[:] == 2.0).all()
 
 
 @skip_in_parallel
@@ -296,7 +300,7 @@ def test_near_evaluations(R, mesh):
 
 def test_interpolation_rank1(W):
     @function.expression.numba_eval
-    def expr_eval(values, x, cell_idx):
+    def expr_eval(values, x, cell_idx, t):
         values[:, 0] = 1.0
         values[:, 1] = 1.0
         values[:, 2] = 1.0
@@ -312,7 +316,7 @@ def test_interpolation_rank1(W):
 def test_numba_expression_jit_objmode_fails(W):
     # numba cfunc cannot call into objmode jit function
     @function.expression.numba_eval(numba_jit_options={"forceobj": True})
-    def expr_eval(values, x, cell_idx):
+    def expr_eval(values, x, cell_idx, t):
         values[0] = 1.0
 
 
@@ -320,18 +324,18 @@ def test_numba_expression_jit_objmode_fails(W):
 def test_numba_expression_cfunc_objmode_fails(W):
     # numba does not support cfuncs built in objmode
     @function.expression.numba_eval(numba_cfunc_options={"forceobj": True})
-    def expr_eval(values, x, cell_idx):
+    def expr_eval(values, x, cell_idx, t):
         values[0] = 1.0
 
 
 @skip_in_parallel
 def test_interpolation_old(V, W, mesh):
     @function.expression.numba_eval
-    def expr_eval0(values, x, cell_idx):
+    def expr_eval0(values, x, cell_idx, t):
         values[:, 0] = 1.0
 
     @function.expression.numba_eval
-    def expr_eval1(values, x, cell_idx):
+    def expr_eval1(values, x, cell_idx, t):
         values[:, 0] = 1.0
         values[:, 1] = 1.0
         values[:, 2] = 1.0
@@ -353,7 +357,7 @@ def test_interpolation_old(V, W, mesh):
 
 def test_numba_expression_address(V):
     @function.expression.numba_eval
-    def expr_eval(values, x, cell_idx):
+    def expr_eval(values, x, cell_idx, t):
         values[:, :] = 1.0
 
     # Handle C func address by hand
@@ -403,7 +407,7 @@ def test_cffi_expression(V):
     f1.interpolate(ex1)
 
     @function.expression.numba_eval
-    def expr_eval2(values, x, cell_idx):
+    def expr_eval2(values, x, cell_idx, t):
         values[:, 0] = x[:, 0] + x[:, 1]
 
     ex2 = Expression(expr_eval2)


### PR DESCRIPTION
When using Numba expressions, it was not possible to get a 'time' parameter. This adds a time parameter to Expression that a user can update outside of an eval function.

Also remove the `cell` argument. The design was inconsistent w.r.t evaluation at an arbitrary number of points. E.g., for multiple cells it was not defined which cell a point belonged to. Moreover, it was not used in any tests or demos. Can be re-designed later if needed.