### PR TITLE
Make test using cffi to expose PETSc thread-safe.

### DIFF
--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -108,9 +108,9 @@ else:
 MatSetValues_abi = petsc_lib_cffi.MatSetValuesLocal
 
 # Make MatSetValuesLocal from PETSc available via cffi in API mode
+worker = os.getenv('PYTEST_XDIST_WORKER', None)
+module_name = "_petsc_cffi_{}".format(worker)
 if dolfin.MPI.comm_world.Get_rank() == 0:
-    worker = os.getenv('PYTEST_XDIST_WORKER', None)
-    module_name = "_petsc_cffi_{}".format(worker)
     os.environ["CC"] = "mpicc"
     petsc_dir = os.environ.get('PETSC_DIR', None)
     ffibuilder = cffi.FFI()


### PR DESCRIPTION
Add pytest-xdist worker thread id to compiled module name.