### PR TITLE
Reduce dynamic eigen memory

### DIFF
--- a/cpp/dolfin/fem/PETScDMCollection.cpp
+++ b/cpp/dolfin/fem/PETScDMCollection.cpp
@@ -94,7 +94,7 @@ tabulate_coordinates_to_dofs(const function::FunctionSpace& V)
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
       x_g
       = mesh.geometry().points();
 
@@ -537,7 +537,7 @@ la::PETScMatrix PETScDMCollection::create_transfer_matrix(
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
       x_g
       = meshc.geometry().points();
   EigenRowArrayXXd coordinate_dofs(num_dofs_g, gdim);

--- a/cpp/dolfin/fem/assemble_matrix_impl.cpp
+++ b/cpp/dolfin/fem/assemble_matrix_impl.cpp
@@ -100,7 +100,7 @@ void fem::impl::assemble_cells(
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
       x_g
       = mesh.geometry().points();
 
@@ -191,7 +191,7 @@ void fem::impl::assemble_exterior_facets(
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
       x_g
       = mesh.geometry().points();
 

--- a/cpp/dolfin/fem/assemble_scalar_impl.cpp
+++ b/cpp/dolfin/fem/assemble_scalar_impl.cpp
@@ -79,7 +79,7 @@ PetscScalar fem::impl::assemble_cells(
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
       x_g
       = mesh.geometry().points();
 
@@ -138,7 +138,7 @@ PetscScalar fem::impl::assemble_exterior_facets(
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
       x_g
       = mesh.geometry().points();
 

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -75,7 +75,7 @@ void _lift_bc_cells(
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
       x_g
       = mesh.geometry().points();
 
@@ -206,7 +206,7 @@ void _lift_bc_exterior_facets(
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
       x_g
       = mesh.geometry().points();
 
@@ -359,7 +359,7 @@ void fem::impl::assemble_cells(
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
       x_g
       = mesh.geometry().points();
 
@@ -420,7 +420,7 @@ void fem::impl::assemble_exterior_facets(
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
       x_g
       = mesh.geometry().points();
 

--- a/cpp/dolfin/function/Function.cpp
+++ b/cpp/dolfin/function/Function.cpp
@@ -229,7 +229,7 @@ void Function::eval(
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
       x_g
       = mesh.geometry().points();
   EigenRowArrayXXd coordinate_dofs(num_dofs_g, gdim);
@@ -384,7 +384,7 @@ Function::compute_point_values(const mesh::Mesh& mesh) const
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
       x_g
       = mesh.geometry().points();
 

--- a/cpp/dolfin/generation/BoxMesh.cpp
+++ b/cpp/dolfin/generation/BoxMesh.cpp
@@ -27,9 +27,9 @@ mesh::Mesh build_tet(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
   // Receive mesh if not rank 0
   if (dolfin::MPI::rank(comm) != 0)
   {
-    Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> geom(
+    Eigen::Array<double, 0, 3, Eigen::RowMajor> geom(
         0, 3);
-    Eigen::Array<std::int64_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+    Eigen::Array<std::int64_t, 0, 4, Eigen::RowMajor>
         topo(0, 4);
 
     return mesh::Partitioning::build_distributed_mesh(

--- a/cpp/dolfin/io/HDF5File.cpp
+++ b/cpp/dolfin/io/HDF5File.cpp
@@ -271,7 +271,7 @@ void HDF5File::write(const mesh::Mesh& mesh, int cell_dim,
     }
 
     Eigen::Map<
-        Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>
+        Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>>
         varray(_vertex_coords.data(), _vertex_coords.size() / 3, 3);
 
     Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>


### PR DESCRIPTION
Some dynamic memory allocation could be reduced now, after fixed geometry width.
Probably, a good compiler could deduce this from returned values, but anyway...