### PR TITLE
Prevent crash during HDF5File::read_mesh with quad/hex elements in parallel

### DIFF
--- a/cpp/dolfin/io/HDF5File.cpp
+++ b/cpp/dolfin/io/HDF5File.cpp
@@ -410,7 +410,7 @@ void HDF5File::write(const mesh::Mesh& mesh, int cell_dim,
     // Add partitioning attribute to dataset
     std::vector<std::size_t> partitions;
     const std::size_t topology_offset = MPI::global_offset(
-        _mpi_comm.comm(), topological_data.size() / (cell_dim + 1), true);
+        _mpi_comm.comm(), topological_data.size() / num_cell_points, true);
 
     std::vector<std::size_t> topology_offset_tmp(1, topology_offset);
     MPI::gather(_mpi_comm.comm(), topology_offset_tmp, partitions);


### PR DESCRIPTION
This fixes the problem identified in Issue 1000 from the Bitbucket tracker and prevents `read_mesh` from crashing in parallel with quad/hex meshes (for certain combinations of meshes and numbers of processors).  

However, unlike in the current stable version of DOLFIN on Bitbucket, this fix **does not** lead to correct behavior of `read_mesh` with with the parameter `use_partition_from_file=true`, due to the orthogonal issue that, in DOLFIN-X, `build_distributed_mesh` no longer checks whether an existing partition exists, and always re-partitions the mesh.  (I will open an issue for discussion of this separate problem.)