### PR TITLE
Pad input point to 3d

### DIFF
--- a/cpp/dolfin/function/Function.cpp
+++ b/cpp/dolfin/function/Function.cpp
@@ -154,13 +154,14 @@ void Function::eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
   assert(_function_space->mesh());
   const mesh::Mesh& mesh = *_function_space->mesh();
 
+  Eigen::Vector3d point = Eigen::Vector3d::Zero();
+
   // Find the cell that contains x
   for (unsigned int i = 0; i < x.rows(); ++i)
   {
     // Pad the input point to size 3
     // Bounding box requires 3d point
-    Eigen::Vector3d point;
-    point.head(x.row(i).size()) = x.row(i);
+    point.head(x.cols()) = x.row(i);
 
     // Get index of first cell containing point
     unsigned int id = bb_tree.compute_first_entity_collision(point, mesh);

--- a/cpp/dolfin/function/Function.cpp
+++ b/cpp/dolfin/function/Function.cpp
@@ -157,7 +157,10 @@ void Function::eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
   // Find the cell that contains x
   for (unsigned int i = 0; i < x.rows(); ++i)
   {
-    const Eigen::Vector3d point = x.row(i).matrix().transpose();
+    // Pad the input point to size 3
+    // Bounding box requires 3d point
+    Eigen::Vector3d point;
+    point.head(x.row(i).size()) = x.row(i);
 
     // Get index of first cell containing point
     unsigned int id = bb_tree.compute_first_entity_collision(point, mesh);

--- a/cpp/dolfin/function/Function.cpp
+++ b/cpp/dolfin/function/Function.cpp
@@ -154,14 +154,13 @@ void Function::eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
   assert(_function_space->mesh());
   const mesh::Mesh& mesh = *_function_space->mesh();
 
-  Eigen::Vector3d point = Eigen::Vector3d::Zero();
-
   // Find the cell that contains x
+  const int gdim = x.cols();
+  Eigen::Vector3d point = Eigen::Vector3d::Zero();
   for (unsigned int i = 0; i < x.rows(); ++i)
   {
-    // Pad the input point to size 3
-    // Bounding box requires 3d point
-    point.head(x.cols()) = x.row(i);
+    // Pad the input point to size 3 (bounding box requires 3d point)
+    point.head(gdim) = x.row(i);
 
     // Get index of first cell containing point
     unsigned int id = bb_tree.compute_first_entity_collision(point, mesh);
@@ -173,7 +172,6 @@ void Function::eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
       // allow without _allow_extrapolation
       std::pair<unsigned int, double> close
           = bb_tree.compute_closest_entity(point, mesh);
-
       if (close.second < 2.0 * DBL_EPSILON)
         id = close.first;
       else
@@ -233,8 +231,7 @@ void Function::eval(
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
-      x_g
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
   EigenRowArrayXXd coordinate_dofs(num_dofs_g, gdim);
 
@@ -388,8 +385,7 @@ Function::compute_point_values(const mesh::Mesh& mesh) const
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
-      x_g
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 
   // Interpolate point values on each cell (using last computed value


### PR DESCRIPTION
Function evaluation takes a point with true geometrical dimensions,
e.g. for mesh with gdim=2  we call `f([0.5, 0.5])`, thus the point needs padding for use in bounding box tree cell computation.