### PR TITLE
Fixes for mesh re-ordering and geometry

### DIFF
--- a/cpp/dolfin/fem/DofMapBuilder.cpp
+++ b/cpp/dolfin/fem/DofMapBuilder.cpp
@@ -339,8 +339,6 @@ DofMapStructure build_basic_dofmap(const mesh::Mesh& mesh,
   // Build dofmaps from ElementDofmap
   for (auto& cell : mesh::MeshRange<mesh::Cell>(mesh, mesh::MeshRangeType::ALL))
   {
-    std::cout << "Cell index: " << cell.index() << std::endl;
-
     // Get local (process) and global cell entity indices
     get_cell_entities(entity_indices_local, entity_indices_global, cell,
                       needs_entities);
@@ -353,8 +351,6 @@ DofMapStructure build_basic_dofmap(const mesh::Mesh& mesh,
     {
       const std::int32_t d = std::distance(entity_dofs.begin(), e_dofs_d);
 
-      std::cout << "    dim: " << d << std::endl;
-
       // Iterate over each entity of current dimension d
       for (auto e_dofs = e_dofs_d->begin(); e_dofs != e_dofs_d->end(); ++e_dofs)
       {
@@ -363,9 +359,6 @@ DofMapStructure build_basic_dofmap(const mesh::Mesh& mesh,
         const std::int32_t e = std::distance(e_dofs_d->begin(), e_dofs);
         const std::int32_t e_index_local = entity_indices_local[d][e];
         const std::int64_t e_index_global = entity_indices_global[d][e];
-
-        std::cout << "      e: " << e << ", " << e_index_local << ", "
-                  << e_index_global << std::endl;
 
         // Loop over dofs belong to entity e of dimension d (d, e)
         // d: topological dimension
@@ -381,15 +374,6 @@ DofMapStructure build_basic_dofmap(const mesh::Mesh& mesh,
           dofmap.dof(cell.index(), *dof_local) = dof;
           dofmap.global_indices[dof]
               = offset_global + num_entity_dofs * e_index_global + count;
-          if (d == 1 and e_index_local == 1)
-          {
-            std::cout << "    local, dof: " << *dof_local << ", " << dof << std::endl;
-          }
-          // if (d == 1)
-          // {
-          //   std::cout << "    local, dof: " << *dof_local << ", " << dof << ",     " << e_index_local << std::endl;
-          // }
-
         }
       }
       offset_local += entity_dofs[d][0].size() * num_mesh_entities_local[d];

--- a/cpp/dolfin/fem/DofMapBuilder.cpp
+++ b/cpp/dolfin/fem/DofMapBuilder.cpp
@@ -339,6 +339,8 @@ DofMapStructure build_basic_dofmap(const mesh::Mesh& mesh,
   // Build dofmaps from ElementDofmap
   for (auto& cell : mesh::MeshRange<mesh::Cell>(mesh, mesh::MeshRangeType::ALL))
   {
+    std::cout << "Cell index: " << cell.index() << std::endl;
+
     // Get local (process) and global cell entity indices
     get_cell_entities(entity_indices_local, entity_indices_global, cell,
                       needs_entities);
@@ -351,6 +353,8 @@ DofMapStructure build_basic_dofmap(const mesh::Mesh& mesh,
     {
       const std::int32_t d = std::distance(entity_dofs.begin(), e_dofs_d);
 
+      std::cout << "    dim: " << d << std::endl;
+
       // Iterate over each entity of current dimension d
       for (auto e_dofs = e_dofs_d->begin(); e_dofs != e_dofs_d->end(); ++e_dofs)
       {
@@ -359,6 +363,9 @@ DofMapStructure build_basic_dofmap(const mesh::Mesh& mesh,
         const std::int32_t e = std::distance(e_dofs_d->begin(), e_dofs);
         const std::int32_t e_index_local = entity_indices_local[d][e];
         const std::int64_t e_index_global = entity_indices_global[d][e];
+
+        std::cout << "      e: " << e << ", " << e_index_local << ", "
+                  << e_index_global << std::endl;
 
         // Loop over dofs belong to entity e of dimension d (d, e)
         // d: topological dimension
@@ -374,6 +381,15 @@ DofMapStructure build_basic_dofmap(const mesh::Mesh& mesh,
           dofmap.dof(cell.index(), *dof_local) = dof;
           dofmap.global_indices[dof]
               = offset_global + num_entity_dofs * e_index_global + count;
+          if (d == 1 and e_index_local == 1)
+          {
+            std::cout << "    local, dof: " << *dof_local << ", " << dof << std::endl;
+          }
+          // if (d == 1)
+          // {
+          //   std::cout << "    local, dof: " << *dof_local << ", " << dof << ",     " << e_index_local << std::endl;
+          // }
+
         }
       }
       offset_local += entity_dofs[d][0].size() * num_mesh_entities_local[d];

--- a/cpp/dolfin/fem/PETScDMCollection.cpp
+++ b/cpp/dolfin/fem/PETScDMCollection.cpp
@@ -85,9 +85,8 @@ tabulate_coordinates_to_dofs(const function::FunctionSpace& V)
   const CoordinateMapping& cmap = *mesh.geometry().coord_mapping;
 
   // Prepare cell geometry
-  const int tdim = mesh.topology().dim();
   const mesh::Connectivity& connectivity_g
-      = mesh.coordinate_dofs().entity_points(tdim);
+      = mesh.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g
@@ -530,7 +529,7 @@ la::PETScMatrix PETScDMCollection::create_transfer_matrix(
 
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = meshc.coordinate_dofs().entity_points(tdim);
+      = meshc.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g

--- a/cpp/dolfin/fem/assemble_matrix_impl.cpp
+++ b/cpp/dolfin/fem/assemble_matrix_impl.cpp
@@ -89,11 +89,10 @@ void fem::impl::assemble_cells(
   assert(A);
 
   const int gdim = mesh.geometry().dim();
-  const int tdim = mesh.topology().dim();
 
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = mesh.coordinate_dofs().entity_points(tdim);
+      = mesh.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g
@@ -184,7 +183,7 @@ void fem::impl::assemble_exterior_facets(
 
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = mesh.coordinate_dofs().entity_points(tdim);
+      = mesh.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g

--- a/cpp/dolfin/fem/assemble_scalar_impl.cpp
+++ b/cpp/dolfin/fem/assemble_scalar_impl.cpp
@@ -72,7 +72,7 @@ PetscScalar fem::impl::assemble_cells(
 
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = mesh.coordinate_dofs().entity_points(tdim);
+      = mesh.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g
@@ -131,7 +131,7 @@ PetscScalar fem::impl::assemble_exterior_facets(
 
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = mesh.coordinate_dofs().entity_points(tdim);
+      = mesh.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -66,9 +66,8 @@ void _lift_bc_cells(
 
   // Prepare cell geometry
   const int gdim = mesh.geometry().dim();
-  const int tdim = mesh.topology().dim();
   const mesh::Connectivity& connectivity_g
-      = mesh.coordinate_dofs().entity_points(tdim);
+      = mesh.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g
@@ -199,7 +198,7 @@ void _lift_bc_exterior_facets(
 
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = mesh.coordinate_dofs().entity_points(tdim);
+      = mesh.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g
@@ -348,11 +347,10 @@ void fem::impl::assemble_cells(
     const std::vector<int>& offsets)
 {
   const int gdim = mesh.geometry().dim();
-  const int tdim = mesh.topology().dim();
 
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = mesh.coordinate_dofs().entity_points(tdim);
+      = mesh.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g
@@ -413,7 +411,7 @@ void fem::impl::assemble_exterior_facets(
 
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = mesh.coordinate_dofs().entity_points(tdim);
+      = mesh.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g

--- a/cpp/dolfin/function/Function.cpp
+++ b/cpp/dolfin/function/Function.cpp
@@ -224,7 +224,7 @@ void Function::eval(
   // Cell coordinates (re-allocated inside function for thread safety)
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = mesh.coordinate_dofs().entity_points(tdim);
+      = mesh.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g
@@ -372,13 +372,11 @@ Function::compute_point_values(const mesh::Mesh& mesh) const
       point_values(mesh.geometry().num_points(), value_size_loc);
 
   const int gdim = mesh.topology().dim();
-  const int tdim = mesh.topology().dim();
-  const mesh::Connectivity& cell_dofs
-      = mesh.coordinate_dofs().entity_points(tdim);
+  const mesh::Connectivity& cell_dofs = mesh.coordinate_dofs().entity_points();
 
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = mesh.coordinate_dofs().entity_points(tdim);
+      = mesh.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g

--- a/cpp/dolfin/function/Function.cpp
+++ b/cpp/dolfin/function/Function.cpp
@@ -355,8 +355,8 @@ Function::compute_point_values(const mesh::Mesh& mesh) const
   assert(_function_space);
   assert(_function_space->mesh());
 
-  // Check that the mesh matches. Notice that the hash is only
-  // compared if the pointers are not matching.
+  // Check that the mesh matches. Notice that the hash is only compared
+  // if the pointers are not matching.
   if (&mesh != _function_space->mesh().get()
       and mesh.hash() != _function_space->mesh()->hash())
   {

--- a/cpp/dolfin/function/FunctionSpace.cpp
+++ b/cpp/dolfin/function/FunctionSpace.cpp
@@ -106,7 +106,6 @@ void FunctionSpace::interpolate_from_any(
 {
   assert(_mesh);
   const int gdim = _mesh->geometry().dim();
-  const int tdim = _mesh->topology().dim();
 
   // Initialize local arrays
   std::vector<PetscScalar> cell_coefficients(_dofmap->max_element_dofs());
@@ -119,7 +118,7 @@ void FunctionSpace::interpolate_from_any(
 
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = _mesh->coordinate_dofs().entity_points(tdim);
+      = _mesh->coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g
@@ -166,14 +165,13 @@ void FunctionSpace::interpolate_from_any(
   assert(_mesh);
 
   const int gdim = _mesh->geometry().dim();
-  const int tdim = _mesh->topology().dim();
 
   // Initialize local arrays
   std::vector<PetscScalar> cell_coefficients(_dofmap->max_element_dofs());
 
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = _mesh->coordinate_dofs().entity_points(tdim);
+      = _mesh->coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g
@@ -354,7 +352,6 @@ EigenRowArrayXXd FunctionSpace::tabulate_dof_coordinates() const
   assert(_mesh);
   assert(_element);
   const int gdim = _mesh->geometry().dim();
-  const int tdim = _mesh->topology().dim();
 
   if (!_component.empty())
   {
@@ -384,7 +381,7 @@ EigenRowArrayXXd FunctionSpace::tabulate_dof_coordinates() const
   // Cell coordinates (re-allocated inside function for thread safety)
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = _mesh->coordinate_dofs().entity_points(tdim);
+      = _mesh->coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g
@@ -433,12 +430,11 @@ void FunctionSpace::set_x(
   assert(_element);
 
   const int gdim = _mesh->geometry().dim();
-  const int tdim = _mesh->topology().dim();
   std::vector<PetscScalar> x_values;
 
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = _mesh->coordinate_dofs().entity_points(tdim);
+      = _mesh->coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g

--- a/cpp/dolfin/io/xdmf_write.cpp
+++ b/cpp/dolfin/io/xdmf_write.cpp
@@ -530,7 +530,7 @@ void xdmf_write::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
 
     const auto& global_points = mesh.geometry().global_indices();
     const mesh::Connectivity& cell_points
-        = mesh.coordinate_dofs().entity_points(tdim);
+        = mesh.coordinate_dofs().entity_points();
 
     // Adjust num_nodes_per_cell to appropriate size
     num_nodes_per_cell = cell_points.size(0);

--- a/cpp/dolfin/mesh/Connectivity.cpp
+++ b/cpp/dolfin/mesh/Connectivity.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2006-2007 Anders Logg
+// Copyright (C) 2006-2019 Anders Logg and Garth N. Wells
 //
 // This file is part of DOLFIN (https://www.fenicsproject.org)
 //

--- a/cpp/dolfin/mesh/Connectivity.h
+++ b/cpp/dolfin/mesh/Connectivity.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2006-2007 Anders Logg
+// Copyright (C) 2006-2019 Anders Logg and Garth N. Wells
 //
 // This file is part of DOLFIN (https://www.fenicsproject.org)
 //

--- a/cpp/dolfin/mesh/CoordinateDofs.cpp
+++ b/cpp/dolfin/mesh/CoordinateDofs.cpp
@@ -22,6 +22,12 @@ mesh::CoordinateDofs::CoordinateDofs(
   // Do nothing
 }
 //-----------------------------------------------------------------------------
+mesh::Connectivity& mesh::CoordinateDofs::entity_points()
+{
+  assert(_coord_dofs);
+  return *_coord_dofs;
+}
+//-----------------------------------------------------------------------------
 const mesh::Connectivity& mesh::CoordinateDofs::entity_points() const
 {
   assert(_coord_dofs);

--- a/cpp/dolfin/mesh/CoordinateDofs.cpp
+++ b/cpp/dolfin/mesh/CoordinateDofs.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Chris N Richardson
+// Copyright (C) 2018 Chris N. Richardson
 //
 // This file is part of DOLFIN (https://www.fenicsproject.org)
 //
@@ -11,23 +11,21 @@ using namespace dolfin;
 
 //-----------------------------------------------------------------------------
 mesh::CoordinateDofs::CoordinateDofs(
-    int tdim,
     const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic,
                                         Eigen::Dynamic, Eigen::RowMajor>>
         point_dofs,
     const std::vector<std::uint8_t>& cell_permutation)
-    : _coord_dofs(tdim + 1), _cell_permutation(cell_permutation)
+    : _coord_dofs(new Connectivity(point_dofs)),
+      _cell_permutation(cell_permutation)
 
 {
-  _coord_dofs[tdim] = std::make_shared<Connectivity>(point_dofs);
+  // Do nothing
 }
 //-----------------------------------------------------------------------------
-const mesh::Connectivity&
-mesh::CoordinateDofs::entity_points(std::uint32_t dim) const
+const mesh::Connectivity& mesh::CoordinateDofs::entity_points() const
 {
-  assert(dim < _coord_dofs.size());
-  assert(_coord_dofs[dim]);
-  return *_coord_dofs[dim];
+  assert(_coord_dofs);
+  return *_coord_dofs;
 }
 //-----------------------------------------------------------------------------
 const std::vector<std::uint8_t>& mesh::CoordinateDofs::cell_permutation() const

--- a/cpp/dolfin/mesh/CoordinateDofs.h
+++ b/cpp/dolfin/mesh/CoordinateDofs.h
@@ -49,10 +49,14 @@ public:
   /// Move assignment
   CoordinateDofs& operator=(CoordinateDofs&& topology) = default;
 
-  /// Get the entity points associated with entities of dimension i
+  /// Get the entity points associated with cells (const version)
   ///
-  /// @param dim
-  ///   Entity dimension
+  /// @return Connectivity
+  ///   Connections from cells to points
+  Connectivity& entity_points();
+
+  /// Get the entity points associated with cells (const version)
+  ///
   /// @return Connectivity
   ///   Connections from cells to points
   const Connectivity& entity_points() const;

--- a/cpp/dolfin/mesh/CoordinateDofs.h
+++ b/cpp/dolfin/mesh/CoordinateDofs.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Chris N Richardson
+// Copyright (C) 2018 Chris N. Richardson
 //
 // This file is part of DOLFIN (https://www.fenicsproject.org)
 //
@@ -23,15 +23,12 @@ class CoordinateDofs
 {
 public:
   /// Constructor
-  /// @param tdim
-  ///   Topological dimension
   /// @param point_dofs
   ///   Array containing point dofs for each entity
   /// @param cell_permutation
   ///   Array containing permutation for cell_vertices required for higher order
   ///   elements which are input in gmsh/vtk order.
   CoordinateDofs(
-      int tdim,
       const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic,
                                           Eigen::Dynamic, Eigen::RowMajor>>
           point_dofs,
@@ -57,20 +54,20 @@ public:
   /// @param dim
   ///   Entity dimension
   /// @return Connectivity
-  ///   Connections from entities of given dimension to points
-  const Connectivity& entity_points(std::uint32_t dim) const;
+  ///   Connections from cells to points
+  const Connectivity& entity_points() const;
 
   const std::vector<std::uint8_t>& cell_permutation() const;
 
 private:
-  // Connectivity from entities to points. Initially only defined for
-  // cells
-  std::vector<std::shared_ptr<Connectivity>> _coord_dofs;
+  // Connectivity from cells to points
+  std::shared_ptr<Connectivity> _coord_dofs;
 
-  // Permutation required to transform to/from VTK/gmsh ordering to
-  // DOLFIN ordering needed for higher order elements
+
   // FIXME: ideally remove this, but would need to harmonise the dof
   // ordering between dolfin/ffc/gmsh
+  // Permutation required to transform to/from VTK/gmsh ordering to
+  // DOLFIN ordering needed for higher order elements
   std::vector<std::uint8_t> _cell_permutation;
 };
 } // namespace mesh

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -43,7 +43,7 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
         "Cannot create mesh. Wrong number of global cell indices");
   }
 
-  // Permutation from VTK to DOLFIN order for cell geometric points
+  // Permutation from VTK to DOLFIN order for cell geometric nodes
   // FIXME: should do this also for quad/hex
   // FIXME: remove duplication in CellType::vtk_mapping()
   std::vector<std::uint8_t> cell_permutation = {0, 1, 2, 3, 4, 5, 6, 7};
@@ -69,17 +69,18 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
     }
   }
 
-  // Get number of points (global) before distributing (which creates
-  // duplicates)
+  // Get number of nodes (global)
   const std::uint64_t num_points_global = MPI::sum(comm, points.rows());
 
-  // Number of cells, local (not ghost) and global.
+  // Number of local cells (not includign ghosts)
   const std::int32_t num_cells = cells.rows();
   assert((std::int32_t)num_ghost_cells <= num_cells);
   const std::int32_t num_local_cells = num_cells - num_ghost_cells;
-  const std::uint64_t num_cells_global = MPI::sum(comm, num_local_cells);
 
-  // Compute point local-to-global map from global indices, and compute
+  // Number of cells (global)
+  const std::int64_t num_cells_global = MPI::sum(comm, num_local_cells);
+
+  // Compute node local-to-global map from global indices, and compute
   // cell topology using new local indices.
   std::int32_t num_vertices;
   std::vector<std::int64_t> global_point_indices;

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -416,6 +416,12 @@ MPI_Comm Mesh::mpi_comm() const { return _mpi_comm.comm(); }
 //-----------------------------------------------------------------------------
 mesh::GhostMode Mesh::get_ghost_mode() const { return _ghost_mode; }
 //-----------------------------------------------------------------------------
+CoordinateDofs& Mesh::coordinate_dofs()
+{
+  assert(_coordinate_dofs);
+  return *_coordinate_dofs;
+}
+//-----------------------------------------------------------------------------
 const CoordinateDofs& Mesh::coordinate_dofs() const
 {
   assert(_coordinate_dofs);

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -69,7 +69,7 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
     }
   }
 
-  // Get number of global points before distributing (which creates
+  // Get number of points (global) before distributing (which creates
   // duplicates)
   const std::uint64_t num_points_global = MPI::sum(comm, points.rows());
 
@@ -83,12 +83,13 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType::Type type,
   // cell topology using new local indices.
   std::int32_t num_vertices;
   std::vector<std::int64_t> global_point_indices;
-  EigenRowArrayXXi32 coordinate_dofs;
+  Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+      coordinate_dofs;
   std::tie(num_vertices, global_point_indices, coordinate_dofs)
       = Partitioning::compute_point_mapping(num_vertices_per_cell, cells,
                                             cell_permutation);
-  _coordinate_dofs = std::make_unique<CoordinateDofs>(tdim, coordinate_dofs,
-                                                      cell_permutation);
+  _coordinate_dofs
+      = std::make_unique<CoordinateDofs>(coordinate_dofs, cell_permutation);
 
   // Distribute the points across processes and calculate shared points
   EigenRowArrayXXd distributed_points;

--- a/cpp/dolfin/mesh/Mesh.h
+++ b/cpp/dolfin/mesh/Mesh.h
@@ -95,7 +95,7 @@ public:
        const Eigen::Ref<const EigenRowArrayXXd> points,
        const Eigen::Ref<const EigenRowArrayXXi64> cells,
        const std::vector<std::int64_t>& global_cell_indices,
-       const GhostMode ghost_mode, std::uint32_t num_ghost_cells = 0);
+       const GhostMode ghost_mode, std::int32_t num_ghost_cells = 0);
 
   /// Copy constructor.
   ///

--- a/cpp/dolfin/mesh/Mesh.h
+++ b/cpp/dolfin/mesh/Mesh.h
@@ -272,6 +272,9 @@ public:
   mesh::GhostMode get_ghost_mode() const;
 
   /// Get coordinate dofs for all local cells
+  CoordinateDofs& coordinate_dofs();
+
+  /// Get coordinate dofs for all local cells (const version)
   const CoordinateDofs& coordinate_dofs() const;
 
   // FIXME: This should be with Geometry

--- a/cpp/dolfin/mesh/Mesh.h
+++ b/cpp/dolfin/mesh/Mesh.h
@@ -62,15 +62,16 @@ class Mesh
 public:
   /// Construct a Mesh from topological and geometric data.
   ///
-  /// In parallel, geometric points must be arranged in global index order
-  /// across processes, starting from 0 on process 0, and must not be
-  /// duplicated. The points will be redistributed to the processes that need
-  /// them.
+  /// In parallel, geometric points must be arranged in global index
+  /// order across processes, starting from 0 on process 0, and must not
+  /// be duplicated. The points will be redistributed to the processes
+  /// that need them.
   ///
-  /// Cells should be listed only on the processes they appear on, i.e. mesh
-  /// partitioning should be performed on the topology data before calling the
-  /// Mesh constructor. Ghost cells, if present, must be at the end of the list
-  /// of cells, and the number of ghost cells must be provided.
+  /// Cells should be listed only on the processes they appear on, i.e.
+  /// mesh partitioning should be performed on the topology data before
+  /// calling the Mesh constructor. Ghost cells, if present, must be at
+  /// the end of the list of cells, and the number of ghost cells must
+  /// be provided.
   ///
   /// @param comm (MPI_Comm)
   ///         MPI Communicator

--- a/cpp/dolfin/mesh/Ordering.cpp
+++ b/cpp/dolfin/mesh/Ordering.cpp
@@ -111,6 +111,15 @@ void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
 
   // Sort i - j for i > j: 1 - 0, 2 - 0, 2 - 1, 3 - 0, 3 - 1, 3 - 2
 
+  // Order 'coordinate' connectivity
+  mesh::Connectivity& connect_g = mesh.coordinate_dofs().entity_points();
+  if (tdim == 1)
+    sort_1_0(connect_g, cell, global_vertex_indices, num_edges);
+  else if (tdim == 2)
+    sort_2_0(connect_g, cell, global_vertex_indices, cell_type.num_entities(2));
+  else if (tdim == 3)
+    sort_3_0(connect_g, cell, global_vertex_indices);
+
   // Sort local vertices on edges in ascending order, connectivity 1 - 0
   std::shared_ptr<mesh::Connectivity> connect_1_0 = topology.connectivity(1, 0);
   if (connect_1_0)

--- a/cpp/dolfin/mesh/Ordering.cpp
+++ b/cpp/dolfin/mesh/Ordering.cpp
@@ -87,49 +87,6 @@ void sort_2_0(mesh::Connectivity& connect_2_0, const mesh::Cell& cell,
   }
 }
 //-----------------------------------------------------------------------------
-void sort_2_1(mesh::Connectivity& connect_2_1,
-              const mesh::Connectivity& connect_1_0, const mesh::Cell& cell,
-              const std::vector<std::int64_t>& global_vertex_indices,
-              const int num_faces)
-{
-  // Loop over faces on cell
-  const std::int32_t* cell_faces = cell.entities(2);
-  assert(cell_faces);
-  for (int i = 0; i < num_faces; ++i)
-  {
-    // For each face number get the global vertex numbers
-    const std::int32_t* face_vertices = connect_2_1.connections(cell_faces[i]);
-    assert(face_vertices);
-
-    // For each facet number get the global edge number
-    std::int32_t* cell_edges = connect_2_1.connections(cell_faces[i]);
-    assert(cell_edges);
-
-    // Loop over vertices on face
-    std::size_t m = 0;
-    for (int j = 0; j < 3; ++j)
-    {
-      // Loop edges on face
-      for (int k = m; k < 3; ++k)
-      {
-        // For each edge number get the global vertex numbers
-        const std::int32_t* edge_vertices
-            = connect_1_0.connections(cell_edges[k]);
-        assert(edge_vertices);
-
-        // Check if the jth vertex of facet i is non-incident on edge k
-        if (!std::count(edge_vertices, edge_vertices + 2, face_vertices[j]))
-        {
-          // Swap face numbers
-          std::swap(cell_edges[m], cell_edges[k]);
-          m++;
-          break;
-        }
-      }
-    }
-  }
-}
-//-----------------------------------------------------------------------------
 void sort_3_0(mesh::Connectivity& connect_3_0, const mesh::Cell& cell,
               const std::vector<std::int64_t>& global_vertex_indices)
 {
@@ -138,77 +95,6 @@ void sort_3_0(mesh::Connectivity& connect_3_0, const mesh::Cell& cell,
   std::sort(cell_vertices, cell_vertices + 4, [&](auto& a, auto& b) {
     return global_vertex_indices[a] < global_vertex_indices[b];
   });
-}
-//-----------------------------------------------------------------------------
-void sort_3_1(mesh::Connectivity& connect_3_1,
-              const mesh::Connectivity& connect_1_0, const mesh::Cell& cell,
-              const std::vector<std::int64_t>& global_vertex_indices)
-{
-  // Get cell vertices and edge numbers
-  const std::int32_t* cell_vertices = cell.entities(0);
-  assert(cell_vertices);
-  std::int32_t* cell_edges = connect_3_1.connections(cell.index());
-  assert(cell_edges);
-
-  // Loop two vertices on cell as a lexicographical tuple
-  // (i, j): (0,1) (0,2) (0,3) (1,2) (1,3) (2,3)
-  int m = 0;
-  for (int i = 0; i < 3; ++i)
-  {
-    for (int j = i + 1; j < 4; ++j)
-    {
-      // Loop edge numbers
-      for (int k = m; k < 6; ++k)
-      {
-        // Get local vertices on edge
-        const std::int32_t* edge_vertices
-            = connect_1_0.connections(cell_edges[k]);
-        assert(edge_vertices);
-
-        // Check if the ith and jth vertex of the cell are
-        // non-incident on edge k
-        if (!std::count(edge_vertices, edge_vertices + 2, cell_vertices[i])
-            and !std::count(edge_vertices, edge_vertices + 2, cell_vertices[j]))
-        {
-          // Swap edge numbers
-          std::swap(cell_edges[m], cell_edges[k]);
-          m++;
-          break;
-        }
-      }
-    }
-  }
-}
-//-----------------------------------------------------------------------------
-void sort_3_2(mesh::Connectivity& connect_3_2,
-              const mesh::Connectivity& connect_2_0, const mesh::Cell& cell,
-              const std::vector<std::int64_t>& global_vertex_indices)
-{
-  // Get cell vertices and facet numbers
-  const std::int32_t* cell_vertices = cell.entities(0);
-  assert(cell_vertices);
-  std::int32_t* cell_faces = connect_3_2.connections(cell.index());
-  assert(cell_faces);
-
-  // Loop vertices on cell
-  for (int i = 0; i < 4; ++i)
-  {
-    // Loop facets on cell
-    for (int j = i; j < 4; ++j)
-    {
-      const std::int32_t* face_vertices
-          = connect_2_0.connections(cell_faces[j]);
-      assert(face_vertices);
-
-      // Check if the ith vertex of the cell is non-incident on facet j
-      if (!std::count(face_vertices, face_vertices + 3, cell_vertices[i]))
-      {
-        // Swap facet numbers
-        std::swap(cell_faces[i], cell_faces[j]);
-        break;
-      }
-    }
-  }
 }
 //-----------------------------------------------------------------------------
 bool ordered_cell_simplex(
@@ -298,45 +184,34 @@ void mesh::Ordering::order_simplex(mesh::Mesh& mesh)
   if (tdim == 0)
     return;
 
-  if (mesh.degree() > 1)
-  {
-    throw std::runtime_error(
-        "Mesh re-ordering not yet working for high-order meshes");
-  }
-
-  mesh::Topology& topology = mesh.topology();
-
   // Get global vertex numbering
   if (!mesh.topology().have_global_indices(0))
     throw std::runtime_error("Mesh does not have global vertex indices.");
   const std::vector<std::int64_t>& global_vertex_indices
       = mesh.topology().global_indices(0);
 
-  mesh::Connectivity& connect_g = mesh.coordinate_dofs().entity_points();
-  const int num_edges = cell_type.num_entities(1);
-
-  // Get connectivities
-  std::shared_ptr<mesh::Connectivity> connect_1_0, connect_2_0, connect_3_0,
-      connect_2_1, connect_3_1, connect_3_2;
-  connect_1_0 = topology.connectivity(1, 0);
-  if (tdim > 1)
-  {
-   connect_2_0 = topology.connectivity(2, 0);
-   connect_2_1 = topology.connectivity(2, 1);
-  }
-  if (tdim > 2)
-  {
-   connect_3_0 = topology.connectivity(3, 0);
-   connect_3_1 = topology.connectivity(3, 1);
-   connect_3_2 = topology.connectivity(3, 2);
-  }
-
   // Iterate over all cells
   for (mesh::Cell& cell : mesh::MeshRange<mesh::Cell>(mesh))
   {
+    if (mesh.degree() > 1)
+    {
+      throw std::runtime_error(
+          "Mesh re-ordering not yet working for high-order meshes");
+    }
+
+    mesh::Topology& topology = mesh.topology();
+    const int tdim = topology.dim();
+
+    if (tdim < 1)
+      return;
+
+    const mesh::CellType& cell_type = cell.mesh().type();
+    const int num_edges = cell_type.num_entities(1);
+
     // Sort i - j for i > j: 1 - 0, 2 - 0, 2 - 1, 3 - 0, 3 - 1, 3 - 2
 
     // Order 'coordinate' connectivity
+    mesh::Connectivity& connect_g = mesh.coordinate_dofs().entity_points();
     if (tdim == 1)
       sort_1_0(connect_g, cell, global_vertex_indices, num_edges);
     else if (tdim == 2)
@@ -346,43 +221,152 @@ void mesh::Ordering::order_simplex(mesh::Mesh& mesh)
       sort_3_0(connect_g, cell, global_vertex_indices);
 
     // Sort local vertices on edges in ascending order, connectivity 1 - 0
+    std::shared_ptr<mesh::Connectivity> connect_1_0
+        = topology.connectivity(1, 0);
     if (connect_1_0)
       sort_1_0(*connect_1_0, cell, global_vertex_indices, num_edges);
 
     if (tdim < 2)
-      break;
+      return;
 
     const int num_faces = cell_type.num_entities(2);
 
     // Sort local vertices on faces in ascending order, connectivity 2 - 0
+    std::shared_ptr<mesh::Connectivity> connect_2_0
+        = topology.connectivity(2, 0);
     if (connect_2_0)
       sort_2_0(*connect_2_0, cell, global_vertex_indices, num_faces);
 
     // Sort local edges on local faces after non-incident vertex,
     // connectivity 2 - 1
+    std::shared_ptr<mesh::Connectivity> connect_2_1
+        = topology.connectivity(2, 1);
     if (connect_2_1)
     {
-      sort_2_1(*connect_2_1, *connect_1_0, cell, global_vertex_indices,
-               num_faces);
+      // Loop over faces on cell
+      const std::int32_t* cell_faces = cell.entities(2);
+      assert(cell_faces);
+      for (int i = 0; i < num_faces; ++i)
+      {
+        // For each face number get the global vertex numbers
+        const std::int32_t* face_vertices
+            = connect_2_0->connections(cell_faces[i]);
+        assert(face_vertices);
+
+        // For each facet number get the global edge number
+        std::int32_t* cell_edges = connect_2_1->connections(cell_faces[i]);
+        assert(cell_edges);
+
+        // Loop over vertices on face
+        std::size_t m = 0;
+        for (int j = 0; j < 3; ++j)
+        {
+          // Loop edges on face
+          for (int k = m; k < 3; ++k)
+          {
+            // For each edge number get the global vertex numbers
+            const std::int32_t* edge_vertices
+                = connect_1_0->connections(cell_edges[k]);
+            assert(edge_vertices);
+
+            // Check if the jth vertex of facet i is non-incident on edge k
+            if (!std::count(edge_vertices, edge_vertices + 2, face_vertices[j]))
+            {
+              // Swap face numbers
+              std::swap(cell_edges[m], cell_edges[k]);
+              m++;
+              break;
+            }
+          }
+        }
+      }
     }
 
     if (tdim < 3)
-      break;
+      return;
 
     // Sort local vertices on cell in ascending order, connectivity 3 - 0
+    std::shared_ptr<mesh::Connectivity> connect_3_0
+        = topology.connectivity(3, 0);
     if (connect_3_0)
       sort_3_0(*connect_3_0, cell, global_vertex_indices);
 
     // Sort local edges on cell after non-incident vertex tuble,
     // connectivity 3-1
+    std::shared_ptr<mesh::Connectivity> connect_3_1
+        = topology.connectivity(3, 1);
     if (connect_3_1)
-      sort_3_1(*connect_3_1, *connect_1_0, cell, global_vertex_indices);
+    {
+      // Get cell vertices and edge numbers
+      const std::int32_t* cell_vertices = cell.entities(0);
+      assert(cell_vertices);
+      std::int32_t* cell_edges = connect_3_1->connections(cell.index());
+      assert(cell_edges);
+
+      // Loop two vertices on cell as a lexicographical tuple
+      // (i, j): (0,1) (0,2) (0,3) (1,2) (1,3) (2,3)
+      int m = 0;
+      for (int i = 0; i < 3; ++i)
+      {
+        for (int j = i + 1; j < 4; ++j)
+        {
+          // Loop edge numbers
+          for (int k = m; k < 6; ++k)
+          {
+            // Get local vertices on edge
+            const std::int32_t* edge_vertices
+                = connect_1_0->connections(cell_edges[k]);
+            assert(edge_vertices);
+
+            // Check if the ith and jth vertex of the cell are
+            // non-incident on edge k
+            if (!std::count(edge_vertices, edge_vertices + 2, cell_vertices[i])
+                and !std::count(edge_vertices, edge_vertices + 2,
+                                cell_vertices[j]))
+            {
+              // Swap edge numbers
+              std::swap(cell_edges[m], cell_edges[k]);
+              m++;
+              break;
+            }
+          }
+        }
+      }
+    }
 
     // Sort local facets on cell after non-incident vertex, connectivity 3
     // - 2
+    std::shared_ptr<mesh::Connectivity> connect_3_2
+        = topology.connectivity(3, 2);
     if (connect_3_2)
-      sort_3_2(*connect_3_2, *connect_2_0, cell, global_vertex_indices);
+    {
+      // Get cell vertices and facet numbers
+      const std::int32_t* cell_vertices = cell.entities(0);
+      assert(cell_vertices);
+      std::int32_t* cell_faces = connect_3_2->connections(cell.index());
+      assert(cell_faces);
+
+      // Loop vertices on cell
+      for (int i = 0; i < 4; ++i)
+      {
+        // Loop facets on cell
+        for (int j = i; j < 4; ++j)
+        {
+          std::int32_t* face_vertices = connect_2_0->connections(cell_faces[j]);
+          assert(face_vertices);
+
+          // Check if the ith vertex of the cell is non-incident on facet j
+          if (!std::count(face_vertices, face_vertices + 3, cell_vertices[i]))
+          {
+            // Swap facet numbers
+            std::swap(cell_faces[i], cell_faces[j]);
+            break;
+          }
+        }
+      }
+    }
   }
+  // order_cell_simplex(global_vertex_indices, mesh, cell);
 }
 //-----------------------------------------------------------------------------
 bool mesh::Ordering::is_ordered_simplex(const mesh::Mesh& mesh)

--- a/cpp/dolfin/mesh/Ordering.cpp
+++ b/cpp/dolfin/mesh/Ordering.cpp
@@ -100,6 +100,12 @@ void sort_3_0(mesh::Connectivity& connect_3_0, const mesh::Cell& cell,
 void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
                         mesh::Mesh& mesh, mesh::Cell& cell)
 {
+  if (mesh.degree() > 1)
+  {
+    throw std::runtime_error(
+        "Mesh re-ordering not yet working for high-order meshes");
+  }
+
   mesh::Topology& topology = mesh.topology();
   const int tdim = topology.dim();
 

--- a/cpp/dolfin/mesh/Ordering.cpp
+++ b/cpp/dolfin/mesh/Ordering.cpp
@@ -87,6 +87,49 @@ void sort_2_0(mesh::Connectivity& connect_2_0, const mesh::Cell& cell,
   }
 }
 //-----------------------------------------------------------------------------
+void sort_2_1(mesh::Connectivity& connect_2_1,
+              const mesh::Connectivity& connect_1_0, const mesh::Cell& cell,
+              const std::vector<std::int64_t>& global_vertex_indices,
+              const int num_faces)
+{
+  // Loop over faces on cell
+  const std::int32_t* cell_faces = cell.entities(2);
+  assert(cell_faces);
+  for (int i = 0; i < num_faces; ++i)
+  {
+    // For each face number get the global vertex numbers
+    const std::int32_t* face_vertices = connect_2_1.connections(cell_faces[i]);
+    assert(face_vertices);
+
+    // For each facet number get the global edge number
+    std::int32_t* cell_edges = connect_2_1.connections(cell_faces[i]);
+    assert(cell_edges);
+
+    // Loop over vertices on face
+    std::size_t m = 0;
+    for (int j = 0; j < 3; ++j)
+    {
+      // Loop edges on face
+      for (int k = m; k < 3; ++k)
+      {
+        // For each edge number get the global vertex numbers
+        const std::int32_t* edge_vertices
+            = connect_1_0.connections(cell_edges[k]);
+        assert(edge_vertices);
+
+        // Check if the jth vertex of facet i is non-incident on edge k
+        if (!std::count(edge_vertices, edge_vertices + 2, face_vertices[j]))
+        {
+          // Swap face numbers
+          std::swap(cell_edges[m], cell_edges[k]);
+          m++;
+          break;
+        }
+      }
+    }
+  }
+}
+//-----------------------------------------------------------------------------
 void sort_3_0(mesh::Connectivity& connect_3_0, const mesh::Cell& cell,
               const std::vector<std::int64_t>& global_vertex_indices)
 {
@@ -97,171 +140,72 @@ void sort_3_0(mesh::Connectivity& connect_3_0, const mesh::Cell& cell,
   });
 }
 //-----------------------------------------------------------------------------
-void order_cell_simplex(const std::vector<std::int64_t>& global_vertex_indices,
-                        mesh::Mesh& mesh, mesh::Cell& cell)
+void sort_3_1(mesh::Connectivity& connect_3_1,
+              const mesh::Connectivity& connect_1_0, const mesh::Cell& cell,
+              const std::vector<std::int64_t>& global_vertex_indices)
 {
-  if (mesh.degree() > 1)
+  // Get cell vertices and edge numbers
+  const std::int32_t* cell_vertices = cell.entities(0);
+  assert(cell_vertices);
+  std::int32_t* cell_edges = connect_3_1.connections(cell.index());
+  assert(cell_edges);
+
+  // Loop two vertices on cell as a lexicographical tuple
+  // (i, j): (0,1) (0,2) (0,3) (1,2) (1,3) (2,3)
+  int m = 0;
+  for (int i = 0; i < 3; ++i)
   {
-    throw std::runtime_error(
-        "Mesh re-ordering not yet working for high-order meshes");
-  }
-
-  mesh::Topology& topology = mesh.topology();
-  const int tdim = topology.dim();
-
-  if (tdim < 1)
-    return;
-
-  const mesh::CellType& cell_type = cell.mesh().type();
-  const int num_edges = cell_type.num_entities(1);
-
-  // Sort i - j for i > j: 1 - 0, 2 - 0, 2 - 1, 3 - 0, 3 - 1, 3 - 2
-
-  // Order 'coordinate' connectivity
-  mesh::Connectivity& connect_g = mesh.coordinate_dofs().entity_points();
-  if (tdim == 1)
-    sort_1_0(connect_g, cell, global_vertex_indices, num_edges);
-  else if (tdim == 2)
-    sort_2_0(connect_g, cell, global_vertex_indices, cell_type.num_entities(2));
-  else if (tdim == 3)
-    sort_3_0(connect_g, cell, global_vertex_indices);
-
-  // Sort local vertices on edges in ascending order, connectivity 1 - 0
-  std::shared_ptr<mesh::Connectivity> connect_1_0 = topology.connectivity(1, 0);
-  if (connect_1_0)
-    sort_1_0(*connect_1_0, cell, global_vertex_indices, num_edges);
-
-  if (tdim < 2)
-    return;
-
-  const int num_faces = cell_type.num_entities(2);
-
-  // Sort local vertices on faces in ascending order, connectivity 2 - 0
-  std::shared_ptr<mesh::Connectivity> connect_2_0 = topology.connectivity(2, 0);
-  if (connect_2_0)
-    sort_2_0(*connect_2_0, cell, global_vertex_indices, num_faces);
-
-  // Sort local edges on local faces after non-incident vertex,
-  // connectivity 2 - 1
-  std::shared_ptr<mesh::Connectivity> connect_2_1 = topology.connectivity(2, 1);
-  if (connect_2_1)
-  {
-    // Loop over faces on cell
-    const std::int32_t* cell_faces = cell.entities(2);
-    assert(cell_faces);
-    for (int i = 0; i < num_faces; ++i)
+    for (int j = i + 1; j < 4; ++j)
     {
-      // For each face number get the global vertex numbers
-      const std::int32_t* face_vertices
-          = connect_2_0->connections(cell_faces[i]);
-      assert(face_vertices);
-
-      // For each facet number get the global edge number
-      std::int32_t* cell_edges = connect_2_1->connections(cell_faces[i]);
-      assert(cell_edges);
-
-      // Loop over vertices on face
-      std::size_t m = 0;
-      for (int j = 0; j < 3; ++j)
+      // Loop edge numbers
+      for (int k = m; k < 6; ++k)
       {
-        // Loop edges on face
-        for (int k = m; k < 3; ++k)
+        // Get local vertices on edge
+        const std::int32_t* edge_vertices
+            = connect_1_0.connections(cell_edges[k]);
+        assert(edge_vertices);
+
+        // Check if the ith and jth vertex of the cell are
+        // non-incident on edge k
+        if (!std::count(edge_vertices, edge_vertices + 2, cell_vertices[i])
+            and !std::count(edge_vertices, edge_vertices + 2, cell_vertices[j]))
         {
-          // For each edge number get the global vertex numbers
-          const std::int32_t* edge_vertices
-              = connect_1_0->connections(cell_edges[k]);
-          assert(edge_vertices);
-
-          // Check if the jth vertex of facet i is non-incident on edge k
-          if (!std::count(edge_vertices, edge_vertices + 2, face_vertices[j]))
-          {
-            // Swap face numbers
-            std::swap(cell_edges[m], cell_edges[k]);
-            m++;
-            break;
-          }
-        }
-      }
-    }
-  }
-
-  if (tdim < 3)
-    return;
-
-  // Sort local vertices on cell in ascending order, connectivity 3 - 0
-  std::shared_ptr<mesh::Connectivity> connect_3_0 = topology.connectivity(3, 0);
-  if (connect_3_0)
-    sort_3_0(*connect_3_0, cell, global_vertex_indices);
-
-  // Sort local edges on cell after non-incident vertex tuble,
-  // connectivity 3-1
-  std::shared_ptr<mesh::Connectivity> connect_3_1 = topology.connectivity(3, 1);
-  if (connect_3_1)
-  {
-    // Get cell vertices and edge numbers
-    const std::int32_t* cell_vertices = cell.entities(0);
-    assert(cell_vertices);
-    std::int32_t* cell_edges = connect_3_1->connections(cell.index());
-    assert(cell_edges);
-
-    // Loop two vertices on cell as a lexicographical tuple
-    // (i, j): (0,1) (0,2) (0,3) (1,2) (1,3) (2,3)
-    int m = 0;
-    for (int i = 0; i < 3; ++i)
-    {
-      for (int j = i + 1; j < 4; ++j)
-      {
-        // Loop edge numbers
-        for (int k = m; k < 6; ++k)
-        {
-          // Get local vertices on edge
-          const std::int32_t* edge_vertices
-              = connect_1_0->connections(cell_edges[k]);
-          assert(edge_vertices);
-
-          // Check if the ith and jth vertex of the cell are
-          // non-incident on edge k
-          if (!std::count(edge_vertices, edge_vertices + 2, cell_vertices[i])
-              and !std::count(edge_vertices, edge_vertices + 2,
-                              cell_vertices[j]))
-          {
-            // Swap edge numbers
-            std::swap(cell_edges[m], cell_edges[k]);
-            m++;
-            break;
-          }
-        }
-      }
-    }
-  }
-
-  // Sort local facets on cell after non-incident vertex, connectivity 3
-  // - 2
-  std::shared_ptr<mesh::Connectivity> connect_3_2 = topology.connectivity(3, 2);
-  if (connect_3_2)
-  {
-    // Get cell vertices and facet numbers
-    const std::int32_t* cell_vertices = cell.entities(0);
-    assert(cell_vertices);
-    std::int32_t* cell_faces = connect_3_2->connections(cell.index());
-    assert(cell_faces);
-
-    // Loop vertices on cell
-    for (int i = 0; i < 4; ++i)
-    {
-      // Loop facets on cell
-      for (int j = i; j < 4; ++j)
-      {
-        std::int32_t* face_vertices = connect_2_0->connections(cell_faces[j]);
-        assert(face_vertices);
-
-        // Check if the ith vertex of the cell is non-incident on facet j
-        if (!std::count(face_vertices, face_vertices + 3, cell_vertices[i]))
-        {
-          // Swap facet numbers
-          std::swap(cell_faces[i], cell_faces[j]);
+          // Swap edge numbers
+          std::swap(cell_edges[m], cell_edges[k]);
+          m++;
           break;
         }
+      }
+    }
+  }
+}
+//-----------------------------------------------------------------------------
+void sort_3_2(mesh::Connectivity& connect_3_2,
+              const mesh::Connectivity& connect_2_0, const mesh::Cell& cell,
+              const std::vector<std::int64_t>& global_vertex_indices)
+{
+  // Get cell vertices and facet numbers
+  const std::int32_t* cell_vertices = cell.entities(0);
+  assert(cell_vertices);
+  std::int32_t* cell_faces = connect_3_2.connections(cell.index());
+  assert(cell_faces);
+
+  // Loop vertices on cell
+  for (int i = 0; i < 4; ++i)
+  {
+    // Loop facets on cell
+    for (int j = i; j < 4; ++j)
+    {
+      const std::int32_t* face_vertices
+          = connect_2_0.connections(cell_faces[j]);
+      assert(face_vertices);
+
+      // Check if the ith vertex of the cell is non-incident on facet j
+      if (!std::count(face_vertices, face_vertices + 3, cell_vertices[i]))
+      {
+        // Swap facet numbers
+        std::swap(cell_faces[i], cell_faces[j]);
+        break;
       }
     }
   }
@@ -354,15 +298,91 @@ void mesh::Ordering::order_simplex(mesh::Mesh& mesh)
   if (tdim == 0)
     return;
 
+  if (mesh.degree() > 1)
+  {
+    throw std::runtime_error(
+        "Mesh re-ordering not yet working for high-order meshes");
+  }
+
+  mesh::Topology& topology = mesh.topology();
+
   // Get global vertex numbering
   if (!mesh.topology().have_global_indices(0))
     throw std::runtime_error("Mesh does not have global vertex indices.");
   const std::vector<std::int64_t>& global_vertex_indices
       = mesh.topology().global_indices(0);
 
+  mesh::Connectivity& connect_g = mesh.coordinate_dofs().entity_points();
+  const int num_edges = cell_type.num_entities(1);
+
+  // Get connectivities
+  std::shared_ptr<mesh::Connectivity> connect_1_0, connect_2_0, connect_3_0,
+      connect_2_1, connect_3_1, connect_3_2;
+  connect_1_0 = topology.connectivity(1, 0);
+  if (tdim > 1)
+  {
+   connect_2_0 = topology.connectivity(2, 0);
+   connect_2_1 = topology.connectivity(2, 1);
+  }
+  if (tdim > 2)
+  {
+   connect_3_0 = topology.connectivity(3, 0);
+   connect_3_1 = topology.connectivity(3, 1);
+   connect_3_2 = topology.connectivity(3, 2);
+  }
+
   // Iterate over all cells
   for (mesh::Cell& cell : mesh::MeshRange<mesh::Cell>(mesh))
-    order_cell_simplex(global_vertex_indices, mesh, cell);
+  {
+    // Sort i - j for i > j: 1 - 0, 2 - 0, 2 - 1, 3 - 0, 3 - 1, 3 - 2
+
+    // Order 'coordinate' connectivity
+    if (tdim == 1)
+      sort_1_0(connect_g, cell, global_vertex_indices, num_edges);
+    else if (tdim == 2)
+      sort_2_0(connect_g, cell, global_vertex_indices,
+               cell_type.num_entities(2));
+    else if (tdim == 3)
+      sort_3_0(connect_g, cell, global_vertex_indices);
+
+    // Sort local vertices on edges in ascending order, connectivity 1 - 0
+    if (connect_1_0)
+      sort_1_0(*connect_1_0, cell, global_vertex_indices, num_edges);
+
+    if (tdim < 2)
+      break;
+
+    const int num_faces = cell_type.num_entities(2);
+
+    // Sort local vertices on faces in ascending order, connectivity 2 - 0
+    if (connect_2_0)
+      sort_2_0(*connect_2_0, cell, global_vertex_indices, num_faces);
+
+    // Sort local edges on local faces after non-incident vertex,
+    // connectivity 2 - 1
+    if (connect_2_1)
+    {
+      sort_2_1(*connect_2_1, *connect_1_0, cell, global_vertex_indices,
+               num_faces);
+    }
+
+    if (tdim < 3)
+      break;
+
+    // Sort local vertices on cell in ascending order, connectivity 3 - 0
+    if (connect_3_0)
+      sort_3_0(*connect_3_0, cell, global_vertex_indices);
+
+    // Sort local edges on cell after non-incident vertex tuble,
+    // connectivity 3-1
+    if (connect_3_1)
+      sort_3_1(*connect_3_1, *connect_1_0, cell, global_vertex_indices);
+
+    // Sort local facets on cell after non-incident vertex, connectivity 3
+    // - 2
+    if (connect_3_2)
+      sort_3_2(*connect_3_2, *connect_2_0, cell, global_vertex_indices);
+  }
 }
 //-----------------------------------------------------------------------------
 bool mesh::Ordering::is_ordered_simplex(const mesh::Mesh& mesh)

--- a/cpp/dolfin/mesh/Partitioning.cpp
+++ b/cpp/dolfin/mesh/Partitioning.cpp
@@ -20,6 +20,7 @@
 #include <dolfin/common/MPI.h>
 #include <dolfin/common/Set.h>
 #include <dolfin/common/Timer.h>
+#include <dolfin/common/log.h>
 #include <dolfin/graph/CSRGraph.h>
 #include <dolfin/graph/GraphBuilder.h>
 #include <dolfin/graph/ParMETIS.h>
@@ -30,8 +31,6 @@
 #include <numeric>
 #include <set>
 
-#include <dolfin/common/log.h>
-
 using namespace dolfin;
 using namespace dolfin::mesh;
 
@@ -39,8 +38,8 @@ namespace
 {
 //-----------------------------------------------------------------------------
 // FIXME: Improve explanation
-// Utility to convert received_point_indices into
-// point sharing information
+// Utility to convert received_point_indices into point sharing
+// information
 std::map<std::int32_t, std::set<std::int32_t>> build_shared_points(
     MPI_Comm mpi_comm,
     const std::vector<std::vector<std::size_t>>& received_point_indices,
@@ -156,7 +155,7 @@ std::map<std::int32_t, std::set<std::int32_t>> build_shared_points(
 std::tuple<EigenRowArrayXXi64, std::vector<std::int64_t>, std::vector<int>,
            std::map<std::int32_t, std::set<std::int32_t>>, std::int32_t>
 distribute_cells(const MPI_Comm mpi_comm,
-                 const Eigen::Ref<const EigenRowArrayXXi64>& cell_vertices,
+                 const Eigen::Ref<const EigenRowArrayXXi64> cell_vertices,
                  const std::vector<std::int64_t>& global_cell_indices,
                  const PartitionData& mp)
 {
@@ -184,8 +183,8 @@ distribute_cells(const MPI_Comm mpi_comm,
   assert(mp.size() == num_local_cells);
 
   // Send all cells to their destinations including their global
-  // indices.  First element of vector is cell count of unghosted cells,
-  // second element is count of ghost cells.
+  // indices.  First element of vector is cell count of un-ghosted
+  // cells, second element is count of ghost cells.
   std::vector<std::vector<std::size_t>> send_cell_vertices(
       mpi_size, std::vector<std::size_t>(2, 0));
 
@@ -505,8 +504,8 @@ void distribute_cell_layer(
 // Build a distributed mesh from local mesh data with a computed
 // partition
 mesh::Mesh build(const MPI_Comm& comm, mesh::CellType::Type type,
-                 const Eigen::Ref<const EigenRowArrayXXi64>& cell_vertices,
-                 const Eigen::Ref<const EigenRowArrayXXd>& points,
+                 const Eigen::Ref<const EigenRowArrayXXi64> cell_vertices,
+                 const Eigen::Ref<const EigenRowArrayXXd> points,
                  const std::vector<std::int64_t>& global_cell_indices,
                  const mesh::GhostMode ghost_mode, const PartitionData& mp)
 {
@@ -599,7 +598,7 @@ mesh::Mesh build(const MPI_Comm& comm, mesh::CellType::Type type,
 // processes' to which ghost cells must be sent
 PartitionData
 partition_cells(const MPI_Comm& mpi_comm, mesh::CellType::Type type,
-                const Eigen::Ref<const EigenRowArrayXXi64>& cell_vertices,
+                const Eigen::Ref<const EigenRowArrayXXi64> cell_vertices,
                 const std::string partitioner)
 {
   LOG(INFO) << "Compute partition of cells across processes";
@@ -641,17 +640,19 @@ partition_cells(const MPI_Comm& mpi_comm, mesh::CellType::Type type,
 // // Reorder cells by Gibbs-Poole-Stockmeyer algorithm (via SCOTCH).
 // // Returns the tuple (reordered_shared_cells, reordered_cell_vertices,
 // // reordered_global_cell_indices)
-// std::tuple<std::map<std::int32_t, std::set<std::int32_t>>, EigenRowArrayXXi64,
+// std::tuple<std::map<std::int32_t, std::set<std::int32_t>>,
+// EigenRowArrayXXi64,
 //            std::vector<std::int64_t>>
 // reorder_cells_gps(
 //     MPI_Comm mpi_comm, const std::int32_t num_regular_cells,
 //     const CellType& cell_type,
 //     const std::map<std::int32_t, std::set<std::int32_t>>& shared_cells,
-//     const Eigen::Ref<const EigenRowArrayXXi64>& global_cell_vertices,
+//     const Eigen::Ref<const EigenRowArrayXXi64> global_cell_vertices,
 //     const std::vector<std::int64_t>& global_cell_indices)
 // {
 //   std::cout
-//       << "WARNING: this function is probably broken. It needs careful testing."
+//       << "WARNING: this function is probably broken. It needs careful
+//       testing."
 //       << std::endl;
 
 //   LOG(INFO) << "Re-order cells during distributed mesh construction";
@@ -729,14 +730,14 @@ partition_cells(const MPI_Comm& mpi_comm, mesh::CellType::Type type,
 
 //-----------------------------------------------------------------------------
 mesh::Mesh Partitioning::build_distributed_mesh(
-    const MPI_Comm& comm, mesh::CellType::Type type,
-    const Eigen::Ref<const EigenRowArrayXXd>& points,
-    const Eigen::Ref<const EigenRowArrayXXi64>& cells,
+    const MPI_Comm& comm, mesh::CellType::Type cell_type,
+    const Eigen::Ref<const EigenRowArrayXXd> points,
+    const Eigen::Ref<const EigenRowArrayXXi64> cells,
     const std::vector<std::int64_t>& global_cell_indices,
     const mesh::GhostMode ghost_mode, std::string graph_partitioner)
 {
   // Compute the cell partition
-  PartitionData mp = partition_cells(comm, type, cells, graph_partitioner);
+  PartitionData mp = partition_cells(comm, cell_type, cells, graph_partitioner);
 
   // Check that we have some ghost information.
   int all_ghosts = dolfin::MPI::sum(comm, mp.num_ghosts());
@@ -744,8 +745,8 @@ mesh::Mesh Partitioning::build_distributed_mesh(
     throw std::runtime_error("Ghost cell information not available");
 
   // Build mesh from local mesh data and provided cell partition
-  mesh::Mesh mesh
-      = build(comm, type, cells, points, global_cell_indices, ghost_mode, mp);
+  mesh::Mesh mesh = build(comm, cell_type, cells, points, global_cell_indices,
+                          ghost_mode, mp);
 
   // Initialise number of globally connected cells to each facet. This
   // is necessary to distinguish between facets on an exterior boundary
@@ -759,7 +760,7 @@ mesh::Mesh Partitioning::build_distributed_mesh(
 //-----------------------------------------------------------------------------
 std::pair<EigenRowArrayXXd, std::map<std::int32_t, std::set<std::int32_t>>>
 Partitioning::distribute_points(
-    const MPI_Comm mpi_comm, const Eigen::Ref<const EigenRowArrayXXd>& points,
+    const MPI_Comm mpi_comm, const Eigen::Ref<const EigenRowArrayXXd> points,
     const std::vector<std::int64_t>& global_point_indices)
 {
   // This function distributes all points (coordinates and

--- a/cpp/dolfin/mesh/Partitioning.cpp
+++ b/cpp/dolfin/mesh/Partitioning.cpp
@@ -864,7 +864,7 @@ Partitioning::distribute_points(
       const std::size_t local_index_0 = local_index;
       for (const auto& q : received_point_indices[p])
       {
-        assert(q >= local_point_range.first and q < local_point_range.second);ß
+        assert(q >= local_point_range.first and q < local_point_range.second);
         const std::size_t location = q - local_point_range.first;
         send_coord_data.row(local_index) = points.row(location);
         ++local_index;

--- a/cpp/dolfin/mesh/Partitioning.cpp
+++ b/cpp/dolfin/mesh/Partitioning.cpp
@@ -754,59 +754,6 @@ Partitioning::reorder_cells_gps(
                          std::move(reordered_global_cell_indices));
 }
 //-----------------------------------------------------------------------------
-std::tuple<std::uint64_t, std::vector<std::int64_t>, EigenRowArrayXXi32>
-Partitioning::compute_point_mapping(
-    std::int32_t num_vertices_per_cell,
-    const Eigen::Ref<const EigenRowArrayXXi64>& cell_nodes,
-    const std::vector<std::uint8_t>& cell_permutation)
-{
-  const std::int32_t num_cells = cell_nodes.rows();
-  const std::int32_t num_nodes_per_cell = cell_nodes.cols();
-
-  // Cell points in local indexing
-  EigenRowArrayXXi32 cell_nodes_local(num_cells, num_nodes_per_cell);
-
-  // Loop over cells to build local-to-global map for (i) vertices, and
-  // (ii) then other nodes
-  std::vector<std::int64_t> node_local_to_global;
-  std::map<std::int64_t, std::int32_t> node_global_to_local;
-  std::int32_t num_vertices_local = 0;
-  int v0(0), v1(num_vertices_per_cell);
-  for (std::int32_t pass = 0; pass < 2; ++pass)
-  {
-    for (std::int32_t c = 0; c < num_cells; ++c)
-    {
-      // Loop over cell points
-      for (std::int32_t v = v0; v < v1; ++v)
-      {
-        // Get global cell index
-        std::int64_t q = cell_nodes(c, v);
-
-        // Insert (global_vertex_index, local_vertex_index) into map. If
-        // global index seen for first time, add to local-to-global map.
-        auto map_it
-            = node_global_to_local.insert({q, node_local_to_global.size()});
-        if (map_it.second)
-          node_local_to_global.push_back(q);
-
-        // Set local index in cell vertex list (applying permutation)
-        cell_nodes_local(c, cell_permutation[v]) = map_it.first->second;
-      }
-    }
-
-    // Store number of local vertices
-    if (pass == 0)
-      num_vertices_local = node_local_to_global.size();
-
-    // Update loop range to loop over nodes
-    v0 = num_vertices_per_cell;
-    v1 = num_nodes_per_cell;
-  }
-
-  return std::make_tuple(num_vertices_local, std::move(node_local_to_global),
-                         std::move(cell_nodes_local));
-}
-//-----------------------------------------------------------------------------
 std::pair<EigenRowArrayXXd, std::map<std::int32_t, std::set<std::int32_t>>>
 Partitioning::distribute_points(
     const MPI_Comm mpi_comm, const Eigen::Ref<const EigenRowArrayXXd>& points,

--- a/cpp/dolfin/mesh/Partitioning.cpp
+++ b/cpp/dolfin/mesh/Partitioning.cpp
@@ -637,6 +637,94 @@ partition_cells(const MPI_Comm& mpi_comm, mesh::CellType::Type type,
   return PartitionData({}, {});
 }
 //-----------------------------------------------------------------------------
+// // FIXME: make clearer what goes in and what comes out
+// // Reorder cells by Gibbs-Poole-Stockmeyer algorithm (via SCOTCH).
+// // Returns the tuple (reordered_shared_cells, reordered_cell_vertices,
+// // reordered_global_cell_indices)
+// std::tuple<std::map<std::int32_t, std::set<std::int32_t>>, EigenRowArrayXXi64,
+//            std::vector<std::int64_t>>
+// reorder_cells_gps(
+//     MPI_Comm mpi_comm, const std::int32_t num_regular_cells,
+//     const CellType& cell_type,
+//     const std::map<std::int32_t, std::set<std::int32_t>>& shared_cells,
+//     const Eigen::Ref<const EigenRowArrayXXi64>& global_cell_vertices,
+//     const std::vector<std::int64_t>& global_cell_indices)
+// {
+//   std::cout
+//       << "WARNING: this function is probably broken. It needs careful testing."
+//       << std::endl;
+
+//   LOG(INFO) << "Re-order cells during distributed mesh construction";
+
+//   common::Timer timer("Reorder cells using GPS ordering");
+
+//   // FIXME: Should not use Graph private methods
+//   // Make dual graph from vertex indices, using GraphBuilder
+//   // FIXME: this should be reused later to add the facet-cell topology
+//   std::vector<std::vector<std::size_t>> local_graph;
+//   dolfin::graph::GraphBuilder::FacetCellMap facet_cell_map;
+//   std::tie(local_graph, facet_cell_map, std::ignore)
+//       = dolfin::graph::GraphBuilder::compute_local_dual_graph(
+//           mpi_comm, global_cell_vertices, cell_type);
+
+//   const std::size_t num_all_cells = global_cell_vertices.rows();
+//   const std::size_t local_cell_offset
+//       = dolfin::MPI::global_offset(mpi_comm, num_all_cells, true);
+
+//   // Convert between graph types, removing offset
+//   // FIXME: make all graphs the same type
+
+//   dolfin::graph::Graph g_dual;
+//   // Ignore the ghost cells - they will not be reordered
+//   // FIXME: reorder ghost cells too
+//   for (std::int32_t i = 0; i < num_regular_cells; ++i)
+//   {
+//     dolfin::common::Set<int> conn_set;
+//     for (auto q = local_graph[i].begin(); q != local_graph[i].end(); ++q)
+//     {
+//       assert(*q >= local_cell_offset);
+//       const int local_index = *q - local_cell_offset;
+
+//       // Ignore ghost cells in connectivity
+//       if (local_index < (int)num_regular_cells)
+//         conn_set.insert(local_index);
+//     }
+//     g_dual.push_back(conn_set);
+//   }
+//   std::vector<int> remap;
+//   std::tie(remap, std::ignore) = dolfin::graph::SCOTCH::compute_gps(g_dual);
+
+//   // Add direct mapping for any ghost cells (not reordered)
+//   for (unsigned int j = remap.size(); j < global_cell_indices.size(); ++j)
+//     remap.push_back(j);
+
+//   EigenRowArrayXXi64 reordered_cell_vertices(global_cell_vertices.rows(),
+//                                              global_cell_vertices.cols());
+//   std::vector<std::int64_t> reordered_global_cell_indices(g_dual.size());
+//   for (std::size_t i = 0; i < g_dual.size(); ++i)
+//   {
+//     // Remap data
+//     const int j = remap[i];
+//     reordered_cell_vertices.row(j) = global_cell_vertices.row(i);
+//     reordered_global_cell_indices[j] = global_cell_indices[i];
+//   }
+
+//   std::map<std::int32_t, std::set<std::int32_t>> reordered_shared_cells;
+//   for (auto p = shared_cells.begin(); p != shared_cells.end(); ++p)
+//   {
+//     const std::int32_t cell_index = p->first;
+//     if (cell_index < num_regular_cells)
+//       reordered_shared_cells.insert({remap[cell_index], p->second});
+//     else
+//       reordered_shared_cells.insert(*p);
+//   }
+
+//   return std::make_tuple(std::move(reordered_shared_cells),
+//                          std::move(reordered_cell_vertices),
+//                          std::move(reordered_global_cell_indices));
+// }
+//-----------------------------------------------------------------------------
+
 } // namespace
 
 //-----------------------------------------------------------------------------
@@ -652,10 +740,8 @@ mesh::Mesh Partitioning::build_distributed_mesh(
 
   // Check that we have some ghost information.
   int all_ghosts = dolfin::MPI::sum(comm, mp.num_ghosts());
-  if (all_ghosts == 0 && ghost_mode != mesh::GhostMode::none)
-  {
+  if (all_ghosts == 0 and ghost_mode != mesh::GhostMode::none)
     throw std::runtime_error("Ghost cell information not available");
-  }
 
   // Build mesh from local mesh data and provided cell partition
   mesh::Mesh mesh
@@ -669,89 +755,6 @@ mesh::Mesh Partitioning::build_distributed_mesh(
   DistributedMeshTools::init_facet_cell_connections(mesh);
 
   return mesh;
-}
-//-----------------------------------------------------------------------------
-std::tuple<std::map<std::int32_t, std::set<std::int32_t>>, EigenRowArrayXXi64,
-           std::vector<std::int64_t>>
-Partitioning::reorder_cells_gps(
-    MPI_Comm mpi_comm, const std::int32_t num_regular_cells,
-    const CellType& cell_type,
-    const std::map<std::int32_t, std::set<std::int32_t>>& shared_cells,
-    const Eigen::Ref<const EigenRowArrayXXi64>& global_cell_vertices,
-    const std::vector<std::int64_t>& global_cell_indices)
-{
-  std::cout
-      << "WARNING: this function is probably broken. It needs careful testing."
-      << std::endl;
-
-  LOG(INFO) << "Re-order cells during distributed mesh construction";
-
-  common::Timer timer("Reorder cells using GPS ordering");
-
-  // FIXME: Should not use Graph private methods
-  // Make dual graph from vertex indices, using GraphBuilder
-  // FIXME: this should be reused later to add the facet-cell topology
-  std::vector<std::vector<std::size_t>> local_graph;
-  dolfin::graph::GraphBuilder::FacetCellMap facet_cell_map;
-  std::tie(local_graph, facet_cell_map, std::ignore)
-      = dolfin::graph::GraphBuilder::compute_local_dual_graph(
-          mpi_comm, global_cell_vertices, cell_type);
-
-  const std::size_t num_all_cells = global_cell_vertices.rows();
-  const std::size_t local_cell_offset
-      = dolfin::MPI::global_offset(mpi_comm, num_all_cells, true);
-
-  // Convert between graph types, removing offset
-  // FIXME: make all graphs the same type
-
-  dolfin::graph::Graph g_dual;
-  // Ignore the ghost cells - they will not be reordered
-  // FIXME: reorder ghost cells too
-  for (std::int32_t i = 0; i < num_regular_cells; ++i)
-  {
-    dolfin::common::Set<int> conn_set;
-    for (auto q = local_graph[i].begin(); q != local_graph[i].end(); ++q)
-    {
-      assert(*q >= local_cell_offset);
-      const int local_index = *q - local_cell_offset;
-
-      // Ignore ghost cells in connectivity
-      if (local_index < (int)num_regular_cells)
-        conn_set.insert(local_index);
-    }
-    g_dual.push_back(conn_set);
-  }
-  std::vector<int> remap;
-  std::tie(remap, std::ignore) = dolfin::graph::SCOTCH::compute_gps(g_dual);
-
-  // Add direct mapping for any ghost cells (not reordered)
-  for (unsigned int j = remap.size(); j < global_cell_indices.size(); ++j)
-    remap.push_back(j);
-
-  EigenRowArrayXXi64 reordered_cell_vertices(global_cell_vertices.rows(),
-                                             global_cell_vertices.cols());
-  std::vector<std::int64_t> reordered_global_cell_indices(g_dual.size());
-  for (std::size_t i = 0; i < g_dual.size(); ++i)
-  {
-    // Remap data
-    const int j = remap[i];
-    reordered_cell_vertices.row(j) = global_cell_vertices.row(i);
-    reordered_global_cell_indices[j] = global_cell_indices[i];
-  }
-
-  std::map<std::int32_t, std::set<std::int32_t>> reordered_shared_cells;
-  for (auto p = shared_cells.begin(); p != shared_cells.end(); ++p)
-  {
-    const std::int32_t cell_index = p->first;
-    if (cell_index < num_regular_cells)
-      reordered_shared_cells.insert({remap[cell_index], p->second});
-    else
-      reordered_shared_cells.insert(*p);
-  }
-
-  return std::make_tuple(std::move(reordered_shared_cells),
-                         std::move(reordered_cell_vertices),
-                         std::move(reordered_global_cell_indices));
 }
 //-----------------------------------------------------------------------------
 std::pair<EigenRowArrayXXd, std::map<std::int32_t, std::set<std::int32_t>>>

--- a/cpp/dolfin/mesh/Partitioning.cpp
+++ b/cpp/dolfin/mesh/Partitioning.cpp
@@ -775,8 +775,7 @@ Partitioning::distribute_points(
   const int gdim = points.cols();
 
   // Create data structures that will be returned
-  EigenRowArrayXXd point_coordinates(global_point_indices.size(),
-                                     gdim;
+  EigenRowArrayXXd point_coordinates(global_point_indices.size(), gdim);
 
   LOG(INFO) << "Distribute points during distributed mesh construction";
   common::Timer timer("Distribute points");

--- a/cpp/dolfin/mesh/Partitioning.h
+++ b/cpp/dolfin/mesh/Partitioning.h
@@ -93,11 +93,9 @@ public:
                     const Eigen::Ref<const EigenRowArrayXXd>& points,
                     const std::vector<std::int64_t>& global_point_indices);
 
-  /// Compute mapping of globally indexed vertices to local indices
-  /// and remap topology accordingly
+  /// Compute map from global node indices to local (contiguous) node
+  /// indices, and remap cell node topology accordingly
   ///
-  /// @param mpi_comm
-  ///   MPI Communicator
   /// @param cell_vertices
   ///   Input cell topology (global indexing)
   /// @param cell_permutation
@@ -107,8 +105,8 @@ public:
   ///   topology in local indexing (EigenRowArrayXXi32)
   static std::tuple<std::uint64_t, std::vector<std::int64_t>,
                     EigenRowArrayXXi32>
-  compute_point_mapping(std::int32_t num_cell_vertices,
-                        const Eigen::Ref<const EigenRowArrayXXi64>& cell_points,
+  compute_point_mapping(std::int32_t num_vertices_per_cell,
+                        const Eigen::Ref<const EigenRowArrayXXi64>& cell_nodes,
                         const std::vector<std::uint8_t>& cell_permutation);
 
   // Utility to create global vertex indices, needed for higher

--- a/cpp/dolfin/mesh/Partitioning.h
+++ b/cpp/dolfin/mesh/Partitioning.h
@@ -93,22 +93,6 @@ public:
                     const Eigen::Ref<const EigenRowArrayXXd>& points,
                     const std::vector<std::int64_t>& global_point_indices);
 
-  /// Compute map from global node indices to local (contiguous) node
-  /// indices, and remap cell node topology accordingly
-  ///
-  /// @param cell_vertices
-  ///   Input cell topology (global indexing)
-  /// @param cell_permutation
-  ///   Permutation from VTK to DOLFIN index ordering
-  /// @return
-  ///   Local-to-global map for vertices (std::vector<std::int64_t>) and cell
-  ///   topology in local indexing (EigenRowArrayXXi32)
-  static std::tuple<std::uint64_t, std::vector<std::int64_t>,
-                    EigenRowArrayXXi32>
-  compute_point_mapping(std::int32_t num_vertices_per_cell,
-                        const Eigen::Ref<const EigenRowArrayXXi64>& cell_nodes,
-                        const std::vector<std::uint8_t>& cell_permutation);
-
   // Utility to create global vertex indices, needed for higher
   // order meshes, where there are geometric points which are not
   // at the vertex nodes

--- a/cpp/dolfin/mesh/Partitioning.h
+++ b/cpp/dolfin/mesh/Partitioning.h
@@ -20,11 +20,10 @@ namespace dolfin
 {
 namespace mesh
 {
-// Developer note: MeshFunction and MeshValueCollection cannot
-// appear in the implementations that appear in this file of the
-// templated functions as this leads to a circular
-// dependency. Therefore the functions are templated over these
-// types.
+// Developer note: MeshFunction and MeshValueCollection cannot appear in
+// the implementations that appear in this file of the templated
+// functions as this leads to a circular dependency. Therefore the
+// functions are templated over these types.
 
 class Mesh;
 template <typename T>
@@ -41,13 +40,12 @@ enum class GhostMode : int
   shared_vertex
 };
 
-/// This class partitions and distributes a mesh based on
-/// partitioned local mesh data.The local mesh data will also be
-/// repartitioned and redistributed during the computation of the
-/// mesh partitioning.
+/// This class partitions and distributes a mesh based on partitioned
+/// local mesh data.The local mesh data will also be repartitioned and
+/// redistributed during the computation of the mesh partitioning.
 ///
-/// After partitioning, each process has a local mesh and some data
-/// that couples the meshes together.
+/// After partitioning, each process has a local mesh and some data that
+/// couples the meshes together.
 
 class Partitioning
 {
@@ -93,28 +91,14 @@ public:
                     const Eigen::Ref<const EigenRowArrayXXd>& points,
                     const std::vector<std::int64_t>& global_point_indices);
 
-  // Utility to create global vertex indices, needed for higher
-  // order meshes, where there are geometric points which are not
-  // at the vertex nodes
+  // Utility to create global vertex indices, needed for higher order
+  // meshes, where there are geometric points which are not at the
+  // vertex nodes
   static std::pair<std::int64_t, std::vector<std::int64_t>>
   build_global_vertex_indices(
       MPI_Comm mpi_comm, std::int32_t num_vertices,
       const std::vector<std::int64_t>& global_point_indices,
       const std::map<std::int32_t, std::set<std::int32_t>>& shared_points);
-
-private:
-  // FIXME: make clearer what goes in and what comes out
-  // Reorder cells by Gibbs-Poole-Stockmeyer algorithm (via SCOTCH). Returns
-  // the tuple (reordered_shared_cells, reordered_cell_vertices,
-  // reordered_global_cell_indices)
-  static std::tuple<std::map<std::int32_t, std::set<std::int32_t>>,
-                    EigenRowArrayXXi64, std::vector<std::int64_t>>
-  reorder_cells_gps(
-      MPI_Comm mpi_comm, const std::int32_t num_regular_cells,
-      const mesh::CellType& cell_type,
-      const std::map<std::int32_t, std::set<std::int32_t>>& shared_cells,
-      const Eigen::Ref<const EigenRowArrayXXi64>& global_cell_vertices,
-      const std::vector<std::int64_t>& global_cell_indices);
 };
 } // namespace mesh
 } // namespace dolfin

--- a/cpp/dolfin/mesh/Partitioning.h
+++ b/cpp/dolfin/mesh/Partitioning.h
@@ -66,9 +66,9 @@ public:
   /// @param ghost_mode
   ///     Ghost mode
   static mesh::Mesh
-  build_distributed_mesh(const MPI_Comm& comm, mesh::CellType::Type type,
-                         const Eigen::Ref<const EigenRowArrayXXd>& points,
-                         const Eigen::Ref<const EigenRowArrayXXi64>& cells,
+  build_distributed_mesh(const MPI_Comm& comm, mesh::CellType::Type cell_type,
+                         const Eigen::Ref<const EigenRowArrayXXd> points,
+                         const Eigen::Ref<const EigenRowArrayXXi64> cells,
                          const std::vector<std::int64_t>& global_cell_indices,
                          const mesh::GhostMode ghost_mode,
                          std::string graph_partitioner = "SCOTCH");
@@ -88,7 +88,7 @@ public:
   static std::pair<EigenRowArrayXXd,
                    std::map<std::int32_t, std::set<std::int32_t>>>
   distribute_points(const MPI_Comm mpi_comm,
-                    const Eigen::Ref<const EigenRowArrayXXd>& points,
+                    const Eigen::Ref<const EigenRowArrayXXd> points,
                     const std::vector<std::int64_t>& global_point_indices);
 
   // Utility to create global vertex indices, needed for higher order

--- a/python/src/fem.cpp
+++ b/python/src/fem.cpp
@@ -177,7 +177,9 @@ void fem(py::module& m)
   // dolfin::fem::CoordinateMapping
   py::class_<dolfin::fem::CoordinateMapping,
              std::shared_ptr<dolfin::fem::CoordinateMapping>>(
-      m, "CoordinateMapping", "Coordinate mapping object");
+      m, "CoordinateMapping", "Coordinate mapping object")
+      .def("compute_physical_coordinates",
+           &dolfin::fem::CoordinateMapping::compute_physical_coordinates);
 
   // dolfin::fem::DirichletBC
   py::class_<dolfin::fem::DirichletBC,

--- a/python/src/mesh.cpp
+++ b/python/src/mesh.cpp
@@ -75,24 +75,22 @@ void mesh(py::module& m)
   py::class_<dolfin::mesh::CoordinateDofs,
              std::shared_ptr<dolfin::mesh::CoordinateDofs>>(
       m, "CoordinateDofs", "CoordinateDofs object")
-      .def("entity_points",
-           [](const dolfin::mesh::CoordinateDofs& self, std::size_t dim) {
-             const dolfin::mesh::Connectivity& connectivity
-                 = self.entity_points(dim);
-             Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
-                 connections = connectivity.connections();
-             const int num_entities = connectivity.entity_positions().size() - 1;
+      .def("entity_points", [](const dolfin::mesh::CoordinateDofs& self) {
+        const dolfin::mesh::Connectivity& connectivity = self.entity_points();
+        Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
+            connections = connectivity.connections();
+        const int num_entities = connectivity.entity_positions().size() - 1;
 
-             // FIXME: mesh::CoordinateDofs should know its dimension
-             // (entity_size) to handle empty case on a process.
-             int entity_size = 0;
-             if (num_entities > 0)
-             {
-               assert(connections.size() % num_entities == 0);
-               entity_size = connections.size() / num_entities;
-             }
-             return py::array({num_entities, entity_size}, connections.data());
-           });
+        // FIXME: mesh::CoordinateDofs should know its dimension
+        // (entity_size) to handle empty case on a process.
+        int entity_size = 0;
+        if (num_entities > 0)
+        {
+          assert(connections.size() % num_entities == 0);
+          entity_size = connections.size() / num_entities;
+        }
+        return py::array({num_entities, entity_size}, connections.data());
+      });
 
   // dolfin::mesh::Geometry class
   py::class_<dolfin::mesh::Geometry, std::shared_ptr<dolfin::mesh::Geometry>>(

--- a/python/src/mesh.cpp
+++ b/python/src/mesh.cpp
@@ -81,7 +81,7 @@ void mesh(py::module& m)
                  = self.entity_points(dim);
              Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
                  connections = connectivity.connections();
-             const int num_entities = connectivity.entity_positions().size();
+             const int num_entities = connectivity.entity_positions().size() - 1;
 
              // FIXME: mesh::CoordinateDofs should know its dimension
              // (entity_size) to handle empty case on a process.

--- a/python/src/mesh.cpp
+++ b/python/src/mesh.cpp
@@ -160,7 +160,9 @@ void mesh(py::module& m)
       .def_property_readonly("geometry",
                              py::overload_cast<>(&dolfin::mesh::Mesh::geometry),
                              "Mesh geometry")
-      .def("coordinate_dofs", &dolfin::mesh::Mesh::coordinate_dofs)
+      .def(
+          "coordinate_dofs",
+          py::overload_cast<>(&dolfin::mesh::Mesh::coordinate_dofs, py::const_))
       .def("degree", &dolfin::mesh::Mesh::degree)
       .def("hash", &dolfin::mesh::Mesh::hash)
       .def("hmax", &dolfin::mesh::Mesh::hmax)

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -13,7 +13,7 @@ import pytest
 
 from dolfin import (MPI, Cells, CellType, FunctionSpace, SubDomain,
                     UnitCubeMesh, UnitIntervalMesh, UnitSquareMesh,
-                    VectorFunctionSpace)
+                    VectorFunctionSpace, cpp, fem)
 from dolfin_utils.test.fixtures import fixture
 from dolfin_utils.test.skips import skip_in_parallel
 from ufl import FiniteElement, MixedElement, VectorElement
@@ -177,64 +177,6 @@ def test_tabulate_coord_periodic(mesh_factory):
 
 @pytest.mark.skip
 @pytest.mark.parametrize(
-    'mesh_factory', [(UnitSquareMesh, (MPI.comm_world, 5, 5)),
-                     (UnitSquareMesh,
-                      (MPI.comm_world, 5, 5, CellType.Type.quadrilateral))])
-def test_tabulate_dofs_periodic(mesh_factory):
-    class PeriodicBoundary2(SubDomain):
-        def inside(self, x, on_boundary):
-            return x[0] < np.finfo(float).eps
-
-        def map(self, x, y):
-            y[0] = x[0] - 1.0
-            y[1] = x[1]
-
-    func, args = mesh_factory
-    mesh = func(*args)
-
-    # Create periodic boundary
-    periodic_boundary = PeriodicBoundary2()
-
-    V = FiniteElement("Lagrange", mesh.ufl_cell(), 2)
-    Q = VectorElement("Lagrange", mesh.ufl_cell(), 2)
-    W = V * Q
-
-    V = FunctionSpace(mesh, V, constrained_domain=periodic_boundary)
-    Q = FunctionSpace(mesh, Q, constrained_domain=periodic_boundary)
-    W = FunctionSpace(mesh, W, constrained_domain=periodic_boundary)
-
-    L0 = W.sub(0)
-    L1 = W.sub(1)
-    L01 = L1.sub(0)
-    L11 = L1.sub(1)
-
-    # Check dimensions
-    assert V.dim == 110
-    assert Q.dim == 220
-    assert L0.dim == V.dim
-    assert L1.dim == Q.dim
-    assert L01.dim == V.dim
-    assert L11.dim == V.dim
-
-    for i, cell in enumerate(Cells(mesh)):
-        dofs0 = L0.dofmap().cell_dofs(cell.index())
-        dofs1 = L01.dofmap().cell_dofs(cell.index())
-        dofs2 = L11.dofmap().cell_dofs(cell.index())
-        dofs3 = L1.dofmap().cell_dofs(cell.index())
-
-        assert np.array_equal(dofs0, L0.dofmap().cell_dofs(i))
-        assert np.array_equal(dofs1, L01.dofmap().cell_dofs(i))
-        assert np.array_equal(dofs2, L11.dofmap().cell_dofs(i))
-        assert np.array_equal(dofs3, L1.dofmap().cell_dofs(i))
-
-        assert len(np.intersect1d(dofs0, dofs1)) == 0
-        assert len(np.intersect1d(dofs0, dofs2)) == 0
-        assert len(np.intersect1d(dofs1, dofs2)) == 0
-        assert np.array_equal(np.append(dofs1, dofs2), dofs3)
-
-
-@pytest.mark.skip
-@pytest.mark.parametrize(
     'mesh_factory', [(UnitSquareMesh, (MPI.comm_world, 3, 3)),
                      (UnitSquareMesh,
                       (MPI.comm_world, 3, 3, CellType.Type.quadrilateral))])
@@ -254,9 +196,7 @@ def test_global_dof_builder(mesh_factory):
 
 
 def test_entity_dofs(mesh):
-
-    # Test that num entity dofs is correctly wrapped to
-    # dolfin::DofMap
+    """Test that num entity dofs is correctly wrapped to dolfin::DofMap"""
     V = FunctionSpace(mesh, ("CG", 1))
     assert V.dofmap().num_entity_dofs(0) == 1
     assert V.dofmap().num_entity_dofs(1) == 0
@@ -290,8 +230,8 @@ def test_entity_dofs(mesh):
     V = VectorFunctionSpace(mesh, ("CG", 1))
 
     # Note this numbering is dependent on FFC and can change This test
-    # is here just to check that we get correct numbers mapped from
-    # ufc generated code to dolfin
+    # is here just to check that we get correct numbers mapped from ufc
+    # generated code to dolfin
     for i, cdofs in enumerate([[0, 3], [1, 4], [2, 5]]):
         dofs = V.dofmap().tabulate_entity_dofs(0, i)
         assert all(d == cd for d, cd in zip(dofs, cdofs))
@@ -538,3 +478,63 @@ def test_readonly_view_local_to_global_unwoned(mesh):
     assert all(l2gu < V.dofmap().global_dimension())
     del l2gu
     assert sys.getrefcount(index_map) == rc
+
+
+@skip_in_parallel
+def test_high_order_lagrange():
+    """Test simple P3 Lagrange dofmap. Checks that dofs on a shared edged match."""
+    def check(mesh, edges):
+        """Compute the physical coordinates of the dofs on the given local edges"""
+        V = FunctionSpace(mesh, ("Lagrange", 3))
+
+        assert len(edges) == 2
+        dofmap = V.dofmap()
+        dofs = [dofmap.cell_dofs(c) for c in range(len(edges))]
+        edge_dofs_local = [dofmap.tabulate_entity_dofs(1, e) for e in edges]
+        for edofs in edge_dofs_local:
+            assert len(edofs) == 2
+        edge_dofs = [dofs[0][edge_dofs_local[0]], dofs[1][edge_dofs_local[1]]]
+        assert set(edge_dofs[0]) == set(edge_dofs[1])
+
+        X = V.element().dof_reference_coordinates()
+        coord_dofs = mesh.coordinate_dofs().entity_points()
+        x_g = mesh.geometry.points
+        x_dofs = []
+        cmap = fem.create_coordinate_map(mesh.ufl_domain())
+        for c in range(len(edges)):
+            x_coord_new = np.zeros([3, 2])
+            for v in range(3):
+                x_coord_new[v] = x_g[coord_dofs[c, v], :2]
+            x = X.copy()
+            cmap.compute_physical_coordinates(x, X, x_coord_new)
+            x_dofs.append(x[edge_dofs_local[c]])
+
+        return x_dofs
+
+    # Create simple mesh
+    points = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+    cells = np.array([[0, 1, 2], [2, 3, 0], ])
+    mesh = cpp.mesh.Mesh(MPI.comm_world, CellType.Type.triangle, points,
+                         cells, [], cpp.mesh.GhostMode.none)
+    mesh.create_connectivity(2, 1)
+
+    c21 = mesh.topology.connectivity(2, 1)
+    e0 = c21.connections(0)[1]
+    e1 = c21.connections(1)[1]
+    assert e0 == e1
+
+    # Check un-ordered mesh
+    x0, x1 = check(mesh, [1, 1])
+    assert not np.allclose(x0, x1)
+    x0.sort(axis=0)
+    x1.sort(axis=0)
+    assert np.allclose(x0, x1)
+
+    # Check ordered mesh
+    cpp.mesh.Ordering.order_simplex(mesh)
+    c21 = mesh.topology.connectivity(2, 1)
+    e0 = c21.connections(0)[1]
+    e1 = c21.connections(1)[2]
+    assert e0 == e1
+    x0, x1 = check(mesh, [1, 2])
+    assert np.allclose(x0, x1)


### PR DESCRIPTION
Geometry 'dofs' were not being updated when re-ordering a mesh, leading to incorrect results.

This fixes the case of affine (P1) geometry. High-order geometry needs carefully consideration (refactoring, really) and does not work at present. Re-ordering a non-affine simplex mesh will throw an error.