### PR TITLE
Replace tabulate signature and start on interior facet integrals

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ install-python-components: &install-python-components
             pip3 install git+https://bitbucket.org/fenics-project/fiat.git --upgrade
             pip3 install git+https://bitbucket.org/fenics-project/ufl.git --upgrade
             pip3 install git+https://bitbucket.org/fenics-project/dijitso.git --upgrade
-            pip3 install git+https://github.com/FEniCS/ffcx.git@chris/unify-facet-integral-sigs --upgrade
+            pip3 install git+https://github.com/FEniCS/ffcx.git --upgrade
             rm -rf /usr/local/include/dolfin /usr/local/include/dolfin.h
 
 flake8-python-code: &flake8-python-code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ install-python-components: &install-python-components
             pip3 install git+https://bitbucket.org/fenics-project/fiat.git --upgrade
             pip3 install git+https://bitbucket.org/fenics-project/ufl.git --upgrade
             pip3 install git+https://bitbucket.org/fenics-project/dijitso.git --upgrade
-            pip3 install git+https://github.com/FEniCS/ffcx.git --upgrade
+            pip3 install git+https://github.com/FEniCS/ffcx.git@chris/unify-facet-integral-sigs --upgrade
             rm -rf /usr/local/include/dolfin /usr/local/include/dolfin.h
 
 flake8-python-code: &flake8-python-code

--- a/cpp/dolfin/fem/Form.cpp
+++ b/cpp/dolfin/fem/Form.cpp
@@ -61,7 +61,7 @@ Form::Form(const ufc_form& ufc_form,
   ufc_form.get_cell_integral_ids(cell_integral_ids.data());
   for (int id : cell_integral_ids)
   {
-    ufc_cell_integral* cell_integral = ufc_form.create_cell_integral(id);
+    ufc_integral* cell_integral = ufc_form.create_cell_integral(id);
     assert(cell_integral);
     _integrals.register_tabulate_tensor_cell(id,
                                              cell_integral->tabulate_tensor);
@@ -73,7 +73,7 @@ Form::Form(const ufc_form& ufc_form,
   ufc_form.get_exterior_facet_integral_ids(exterior_facet_integral_ids.data());
   for (int id : exterior_facet_integral_ids)
   {
-    ufc_exterior_facet_integral* exterior_facet_integral
+    ufc_integral* exterior_facet_integral
         = ufc_form.create_exterior_facet_integral(id);
     assert(exterior_facet_integral);
     _integrals.register_tabulate_tensor_exterior_facet(
@@ -86,7 +86,7 @@ Form::Form(const ufc_form& ufc_form,
   ufc_form.get_interior_facet_integral_ids(interior_facet_integral_ids.data());
   for (int id : interior_facet_integral_ids)
   {
-    ufc_interior_facet_integral* interior_facet_integral
+    ufc_integral* interior_facet_integral
         = ufc_form.create_interior_facet_integral(id);
     assert(interior_facet_integral);
     _integrals.register_tabulate_tensor_interior_facet(

--- a/cpp/dolfin/fem/Form.cpp
+++ b/cpp/dolfin/fem/Form.cpp
@@ -187,9 +187,9 @@ Form::function_spaces() const
   return _function_spaces;
 }
 //-----------------------------------------------------------------------------
-void Form::register_tabulate_tensor_cell(int i, void (*fn)(PetscScalar*,
-                                                           const PetscScalar*,
-                                                           const double*, int))
+void Form::register_tabulate_tensor_cell(
+    int i, void (*fn)(PetscScalar*, const PetscScalar*, const double*,
+                      const int*, const int*))
 {
   _integrals.register_tabulate_tensor_cell(i, fn);
   if (i == -1 and _mesh)

--- a/cpp/dolfin/fem/Form.h
+++ b/cpp/dolfin/fem/Form.h
@@ -171,7 +171,8 @@ public:
   /// Register the function for 'tabulate_tensor' for cell integral i
   void register_tabulate_tensor_cell(int i, void (*fn)(PetscScalar*,
                                                        const PetscScalar*,
-                                                       const double*, int));
+                                                       const double*,
+                                                       const int*, const int*));
 
   /// Return exterior facet domains (zero pointer if no domains have
   /// been specified)

--- a/cpp/dolfin/fem/FormIntegrals.cpp
+++ b/cpp/dolfin/fem/FormIntegrals.cpp
@@ -29,8 +29,8 @@ FormIntegrals::get_tabulate_tensor_fn_cell(unsigned int i) const
   return _tabulate_tensor_cell[i];
 }
 //-----------------------------------------------------------------------------
-const std::function<void(PetscScalar*, const PetscScalar*, const double*, int,
-                         int)>&
+const std::function<void(PetscScalar*, const PetscScalar*, const double*,
+                         const int*, const int*)>&
 FormIntegrals::get_tabulate_tensor_fn_exterior_facet(unsigned int i) const
 {
   if (i > _tabulate_tensor_exterior_facet.size())
@@ -40,7 +40,7 @@ FormIntegrals::get_tabulate_tensor_fn_exterior_facet(unsigned int i) const
 }
 //-----------------------------------------------------------------------------
 const std::function<void(PetscScalar*, const PetscScalar* w, const double*,
-                         const double*, int, int, int, int)>&
+                         const int*, const int*)>&
 FormIntegrals::get_tabulate_tensor_fn_interior_facet(unsigned int i) const
 {
   if (i > _tabulate_tensor_interior_facet.size())
@@ -71,8 +71,8 @@ void FormIntegrals::register_tabulate_tensor_cell(
 }
 //-----------------------------------------------------------------------------
 void FormIntegrals::register_tabulate_tensor_exterior_facet(
-    int i,
-    void (*fn)(PetscScalar*, const PetscScalar*, const double*, int, int))
+    int i, void (*fn)(PetscScalar*, const PetscScalar*, const double*,
+                      const int*, const int*))
 {
 
   if (std::find(_exterior_facet_integral_ids.begin(),
@@ -100,7 +100,7 @@ void FormIntegrals::register_tabulate_tensor_exterior_facet(
 //-----------------------------------------------------------------------------
 void FormIntegrals::register_tabulate_tensor_interior_facet(
     int i, void (*fn)(PetscScalar*, const PetscScalar* w, const double*,
-                      const double*, int, int, int, int))
+                      const int*, const int*))
 {
   // At the moment, only accept one integral with index -1
   if (i != -1)

--- a/cpp/dolfin/fem/FormIntegrals.cpp
+++ b/cpp/dolfin/fem/FormIntegrals.cpp
@@ -20,7 +20,8 @@ FormIntegrals::FormIntegrals()
   // Do nothing
 }
 //-----------------------------------------------------------------------------
-const std::function<void(PetscScalar*, const PetscScalar*, const double*, int)>&
+const std::function<void(PetscScalar*, const PetscScalar*, const double*,
+                         const int*, const int*)>&
 FormIntegrals::get_tabulate_tensor_fn_cell(unsigned int i) const
 {
   if (i > _tabulate_tensor_cell.size())
@@ -50,7 +51,8 @@ FormIntegrals::get_tabulate_tensor_fn_interior_facet(unsigned int i) const
 }
 //-----------------------------------------------------------------------------
 void FormIntegrals::register_tabulate_tensor_cell(
-    int i, void (*fn)(PetscScalar*, const PetscScalar*, const double*, int))
+    int i, void (*fn)(PetscScalar*, const PetscScalar*, const double*,
+                      const int*, const int*))
 {
   if (std::find(_cell_integral_ids.begin(), _cell_integral_ids.end(), i)
       != _cell_integral_ids.end())

--- a/cpp/dolfin/fem/FormIntegrals.h
+++ b/cpp/dolfin/fem/FormIntegrals.h
@@ -49,7 +49,7 @@ public:
   /// @returns std::function
   ///    Function to call for tabulate_tensor on a cell
   const std::function<void(PetscScalar*, const PetscScalar*, const double*,
-                           int)>&
+                           const int*, const int*)>&
   get_tabulate_tensor_fn_cell(unsigned int i) const;
 
   /// Get the function for 'tabulate_tensor' for exterior facet integral i
@@ -73,7 +73,8 @@ public:
   /// Register the function for 'tabulate_tensor' for cell integral i
   void register_tabulate_tensor_cell(int i, void (*fn)(PetscScalar*,
                                                        const PetscScalar*,
-                                                       const double*, int));
+                                                       const double*,
+                                                       const int*, const int*));
 
   /// Register the function for 'tabulate_tensor' for exterior facet integral
   /// i
@@ -119,8 +120,8 @@ public:
 
 private:
   // Function pointers to tabulate_tensor functions
-  std::vector<
-      std::function<void(PetscScalar*, const PetscScalar*, const double*, int)>>
+  std::vector<std::function<void(PetscScalar*, const PetscScalar*,
+                                 const double*, const int*, const int*)>>
       _tabulate_tensor_cell;
 
   std::vector<std::function<void(PetscScalar*, const PetscScalar*,

--- a/cpp/dolfin/fem/FormIntegrals.h
+++ b/cpp/dolfin/fem/FormIntegrals.h
@@ -57,8 +57,8 @@ public:
   ///    Integral number
   /// @returns std::function
   ///    Function to call for tabulate_tensor on an exterior facet
-  const std::function<void(PetscScalar*, const PetscScalar*, const double*, int,
-                           int)>&
+  const std::function<void(PetscScalar*, const PetscScalar*, const double*,
+                           const int*, const int*)>&
   get_tabulate_tensor_fn_exterior_facet(unsigned int i) const;
 
   /// Get the function for 'tabulate_tensor' for interior facet integral i
@@ -67,7 +67,7 @@ public:
   /// @returns std::function
   ///    Function to call for tabulate_tensor on an interior facet
   const std::function<void(PetscScalar*, const PetscScalar* w, const double*,
-                           const double*, int, int, int, int)>&
+                           const int*, const int*)>&
   get_tabulate_tensor_fn_interior_facet(unsigned int i) const;
 
   /// Register the function for 'tabulate_tensor' for cell integral i
@@ -78,14 +78,14 @@ public:
   /// Register the function for 'tabulate_tensor' for exterior facet integral
   /// i
   void register_tabulate_tensor_exterior_facet(
-      int i,
-      void (*fn)(PetscScalar*, const PetscScalar*, const double*, int, int));
+      int i, void (*fn)(PetscScalar*, const PetscScalar*, const double*,
+                        const int*, const int*));
 
   /// Register the function for 'tabulate_tensor' for exterior facet integral
   /// i
   void register_tabulate_tensor_interior_facet(
       int i, void (*fn)(PetscScalar*, const PetscScalar* w, const double*,
-                        const double*, int, int, int, int));
+                        const int*, const int*));
 
   /// Number of integrals of given type
   int num_integrals(FormIntegrals::Type t) const;
@@ -124,12 +124,11 @@ private:
       _tabulate_tensor_cell;
 
   std::vector<std::function<void(PetscScalar*, const PetscScalar*,
-                                 const double*, int, int)>>
+                                 const double*, const int*, const int*)>>
       _tabulate_tensor_exterior_facet;
 
-  std::vector<
-      std::function<void(PetscScalar*, const PetscScalar* w, const double*,
-                         const double*, int, int, int, int)>>
+  std::vector<std::function<void(PetscScalar*, const PetscScalar* w,
+                                 const double*, const int*, const int*)>>
       _tabulate_tensor_interior_facet;
 
   // ID codes for each stored integral sorted numerically (-1 for default

--- a/cpp/dolfin/fem/assemble_matrix_impl.cpp
+++ b/cpp/dolfin/fem/assemble_matrix_impl.cpp
@@ -322,8 +322,7 @@ void fem::impl::assemble_interior_facets(
     const mesh::Cell cell1(mesh, facet.entities(tdim)[1]);
 
     // Get local index of facet with respect to the cell
-    const int local_facet[2]
-        = {(int)cell0.index(facet), (int)cell1.index(facet)};
+    const int local_facet[2] = {cell0.index(facet), cell1.index(facet)};
     const int orient[2] = {1, 1};
 
     // Get cell vertex coordinates

--- a/cpp/dolfin/fem/assemble_matrix_impl.cpp
+++ b/cpp/dolfin/fem/assemble_matrix_impl.cpp
@@ -287,7 +287,7 @@ void fem::impl::assemble_interior_facets(
 
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = mesh.coordinate_dofs().entity_points(tdim);
+      = mesh.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g

--- a/cpp/dolfin/fem/assemble_matrix_impl.cpp
+++ b/cpp/dolfin/fem/assemble_matrix_impl.cpp
@@ -303,7 +303,7 @@ void fem::impl::assemble_interior_facets(
       coordinate_dofs1(num_dofs_g, gdim);
   Eigen::Matrix<PetscScalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
       Ae;
-  Eigen::Array<PetscScalar, Eigen::Dynamic, 1> coeff_array(offsets.back());
+  Eigen::Array<PetscScalar, Eigen::Dynamic, 1> coeff_array(2 * offsets.back());
 
   // Temporaries for joint dofmaps
   std::vector<PetscInt> dmapjoint0, dmapjoint1;
@@ -362,6 +362,9 @@ void fem::impl::assemble_interior_facets(
     {
       coefficients[i]->restrict(coeff_array.data() + offsets[i], cell0,
                                 coordinate_dofs0);
+      coefficients[i]->restrict(coeff_array.data() + offsets.back()
+                                    + offsets[i],
+                                cell1, coordinate_dofs1);
     }
 
     // Tabulate tensor

--- a/cpp/dolfin/fem/assemble_matrix_impl.cpp
+++ b/cpp/dolfin/fem/assemble_matrix_impl.cpp
@@ -86,7 +86,7 @@ void fem::impl::assemble_cells(
     int num_dofs_per_cell1, const std::vector<bool>& bc0,
     const std::vector<bool>& bc1,
     const std::function<void(PetscScalar*, const PetscScalar*, const double*,
-                             int)>& kernel,
+                             const int*, const int*)>& kernel,
     std::vector<const function::Function*> coefficients,
     const std::vector<int>& offsets)
 {
@@ -137,7 +137,7 @@ void fem::impl::assemble_cells(
 
     // Tabulate tensor
     Ae.setZero(num_dofs_per_cell0, num_dofs_per_cell1);
-    kernel(Ae.data(), coeff_array.data(), coordinate_dofs.data(), 1);
+    kernel(Ae.data(), coeff_array.data(), coordinate_dofs.data(), NULL, NULL);
 
     // Zero rows/columns for essential bcs
     if (!bc0.empty())

--- a/cpp/dolfin/fem/assemble_matrix_impl.h
+++ b/cpp/dolfin/fem/assemble_matrix_impl.h
@@ -66,6 +66,16 @@ void assemble_exterior_facets(
     std::vector<const function::Function*> coefficients,
     const std::vector<int>& offsets);
 
+void assemble_interior_facets(
+    Mat A, const mesh::Mesh& mesh,
+    const std::vector<std::int32_t>& active_facets,
+    const GenericDofMap& dofmap0, const GenericDofMap& dofmap1,
+    const std::vector<bool>& bc0, const std::vector<bool>& bc1,
+    const std::function<void(PetscScalar*, const PetscScalar*, const double*,
+                             const double*, int, int, int, int)>& fn,
+    std::vector<const function::Function*> coefficients,
+    const std::vector<int>& offsets);
+
 } // namespace impl
 } // namespace fem
 } // namespace dolfin

--- a/cpp/dolfin/fem/assemble_matrix_impl.h
+++ b/cpp/dolfin/fem/assemble_matrix_impl.h
@@ -62,7 +62,7 @@ void assemble_exterior_facets(
     const GenericDofMap& dofmap0, const GenericDofMap& dofmap1,
     const std::vector<bool>& bc0, const std::vector<bool>& bc1,
     const std::function<void(PetscScalar*, const PetscScalar*, const double*,
-                             int, int)>& fn,
+                             const int*, const int*)>& fn,
     std::vector<const function::Function*> coefficients,
     const std::vector<int>& offsets);
 
@@ -72,7 +72,7 @@ void assemble_interior_facets(
     const GenericDofMap& dofmap0, const GenericDofMap& dofmap1,
     const std::vector<bool>& bc0, const std::vector<bool>& bc1,
     const std::function<void(PetscScalar*, const PetscScalar*, const double*,
-                             const double*, int, int, int, int)>& fn,
+                             const int*, const int*)>& fn,
     std::vector<const function::Function*> coefficients,
     const std::vector<int>& offsets);
 

--- a/cpp/dolfin/fem/assemble_matrix_impl.h
+++ b/cpp/dolfin/fem/assemble_matrix_impl.h
@@ -51,7 +51,7 @@ void assemble_cells(
     int num_dofs_per_cell1, const std::vector<bool>& bc0,
     const std::vector<bool>& bc1,
     const std::function<void(PetscScalar*, const PetscScalar*, const double*,
-                             int)>& kernel,
+                             const int *, const int*)>& kernel,
     std::vector<const function::Function*> coefficients,
     const std::vector<int>& offsets);
 

--- a/cpp/dolfin/fem/assemble_scalar_impl.cpp
+++ b/cpp/dolfin/fem/assemble_scalar_impl.cpp
@@ -233,8 +233,7 @@ PetscScalar fem::impl::assemble_interior_facets(
     const mesh::Cell cell1(mesh, facet.entities(tdim)[1]);
 
     // Get local index of facet with respect to the cell
-    const int local_facet[2]
-        = {(int)cell0.index(facet), (int)cell1.index(facet)};
+    const int local_facet[2] = {cell0.index(facet), cell1.index(facet)};
     const int orient[2] = {1, 1};
 
     // Get cell vertex coordinates

--- a/cpp/dolfin/fem/assemble_scalar_impl.cpp
+++ b/cpp/dolfin/fem/assemble_scalar_impl.cpp
@@ -53,8 +53,14 @@ PetscScalar dolfin::fem::impl::assemble_scalar(const dolfin::fem::Form& M)
                                                  coeff_fn, c_offsets);
   }
 
-  if (integrals.num_integrals(type::interior_facet) > 0)
-    value += fem::impl::assemble_interior_facets(M);
+  for (int i = 0; i < integrals.num_integrals(type::interior_facet); ++i)
+  {
+    auto& fn = integrals.get_tabulate_tensor_fn_interior_facet(i);
+    const std::vector<std::int32_t>& active_facets = integrals.integral_domains(
+        fem::FormIntegrals::Type::interior_facet, i);
+    value += fem::impl::assemble_interior_facets(mesh, active_facets, fn,
+                                                 coeff_fn, c_offsets);
+  }
 
   return value;
 }
@@ -79,8 +85,7 @@ PetscScalar fem::impl::assemble_cells(
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
-      x_g
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 
   // Create data structures used in assembly
@@ -120,7 +125,7 @@ PetscScalar fem::impl::assemble_cells(
 PetscScalar fem::impl::assemble_exterior_facets(
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
     const std::function<void(PetscScalar*, const PetscScalar*, const double*,
-                             int, int)>& fn,
+                             const int*, const int*)>& fn,
     std::vector<const function::Function*> coefficients,
     const std::vector<int>& offsets)
 {
@@ -138,8 +143,7 @@ PetscScalar fem::impl::assemble_exterior_facets(
       = connectivity_g.connections();
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
-  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>&
-      x_g
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 
   // Creat data structures used in assembly
@@ -162,6 +166,7 @@ PetscScalar fem::impl::assemble_exterior_facets(
 
     // Get local index of facet with respect to the cell
     const int local_facet = cell.index(facet);
+    const int orient = 1;
 
     // Get cell vertex coordinates
     const int cell_index = cell.index();
@@ -176,16 +181,96 @@ PetscScalar fem::impl::assemble_exterior_facets(
                                 coordinate_dofs);
     }
 
-    fn(&cell_value, coeff_array.data(), coordinate_dofs.data(), local_facet, 1);
+    fn(&cell_value, coeff_array.data(), coordinate_dofs.data(), &local_facet,
+       &orient);
     value += cell_value;
   }
 
   return value;
 }
 //-----------------------------------------------------------------------------
-PetscScalar fem::impl::assemble_interior_facets(const Form& M)
+PetscScalar fem::impl::assemble_interior_facets(
+    const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
+    const std::function<void(PetscScalar*, const PetscScalar*, const double*,
+                             const int*, const int*)>& fn,
+    std::vector<const function::Function*> coefficients,
+    const std::vector<int>& offsets)
 {
-  throw std::runtime_error("Interior facet integrals not supported yet.");
-  return 0.0;
+  const int gdim = mesh.geometry().dim();
+  const int tdim = mesh.topology().dim();
+  mesh.create_entities(tdim - 1);
+  mesh.create_connectivity(tdim - 1, tdim);
+
+  // Prepare cell geometry
+  const mesh::Connectivity& connectivity_g
+      = mesh.coordinate_dofs().entity_points(tdim);
+  const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
+      = connectivity_g.entity_positions();
+  const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g
+      = connectivity_g.connections();
+  // FIXME: Add proper interface for num coordinate dofs
+  const int num_dofs_g = connectivity_g.size(0);
+  const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
+      = mesh.geometry().points();
+
+  // Creat data structures used in assembly
+  Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+      coordinate_dofs(2 * num_dofs_g, gdim);
+  Eigen::Array<PetscScalar, Eigen::Dynamic, 1> coeff_array(2 * offsets.back());
+
+  // Iterate over all facets
+  PetscScalar cell_value, value(0);
+  for (const auto& facet_index : active_facets)
+  {
+    const mesh::Facet facet(mesh, facet_index);
+
+    assert(facet.num_global_entities(tdim) == 2);
+
+    // TODO: check ghosting sanity?
+
+    // Create attached cell
+    const mesh::Cell cell0(mesh, facet.entities(tdim)[0]);
+    const mesh::Cell cell1(mesh, facet.entities(tdim)[1]);
+
+    // Get local index of facet with respect to the cell
+    const int local_facet[2]
+        = {(int)cell0.index(facet), (int)cell1.index(facet)};
+    const int orient[2] = {1, 1};
+
+    // Get cell vertex coordinates
+    const int cell0_index = cell0.index();
+    const int cell1_index = cell1.index();
+    for (int i = 0; i < num_dofs_g; ++i)
+      for (int j = 0; j < gdim; ++j)
+      {
+        coordinate_dofs(i, j) = x_g(cell_g[pos_g[cell0_index] + i], j);
+        coordinate_dofs(i + num_dofs_g, j)
+            = x_g(cell_g[pos_g[cell1_index] + i], j);
+      }
+
+    // Update coefficients
+    Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                  Eigen::RowMajor>>
+        coordinate_dofs0(coordinate_dofs.data(), num_dofs_g, gdim);
+
+    Eigen::Map<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                  Eigen::RowMajor>>
+        coordinate_dofs1(coordinate_dofs.data() + num_dofs_g * gdim, num_dofs_g,
+                         gdim);
+    for (std::size_t i = 0; i < coefficients.size(); ++i)
+    {
+      coefficients[i]->restrict(coeff_array.data() + offsets[i], cell0,
+                                coordinate_dofs0);
+      coefficients[i]->restrict(coeff_array.data() + offsets.back()
+                                    + offsets[i],
+                                cell1, coordinate_dofs1);
+    }
+
+    fn(&cell_value, coeff_array.data(), coordinate_dofs.data(), local_facet,
+       orient);
+    value += cell_value;
+  }
+
+  return value;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/fem/assemble_scalar_impl.cpp
+++ b/cpp/dolfin/fem/assemble_scalar_impl.cpp
@@ -203,7 +203,7 @@ PetscScalar fem::impl::assemble_interior_facets(
 
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = mesh.coordinate_dofs().entity_points(tdim);
+      = mesh.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g

--- a/cpp/dolfin/fem/assemble_scalar_impl.cpp
+++ b/cpp/dolfin/fem/assemble_scalar_impl.cpp
@@ -68,7 +68,7 @@ PetscScalar dolfin::fem::impl::assemble_scalar(const dolfin::fem::Form& M)
 PetscScalar fem::impl::assemble_cells(
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_cells,
     const std::function<void(PetscScalar*, const PetscScalar*, const double*,
-                             int)>& fn,
+                             const int*, const int*)>& fn,
     std::vector<const function::Function*> coefficients,
     const std::vector<int>& offsets)
 {
@@ -115,7 +115,7 @@ PetscScalar fem::impl::assemble_cells(
                                 coordinate_dofs);
     }
 
-    fn(&cell_value, coeff_array.data(), coordinate_dofs.data(), 1);
+    fn(&cell_value, coeff_array.data(), coordinate_dofs.data(), NULL, NULL);
     value += cell_value;
   }
 

--- a/cpp/dolfin/fem/assemble_scalar_impl.h
+++ b/cpp/dolfin/fem/assemble_scalar_impl.h
@@ -50,12 +50,17 @@ assemble_cells(const mesh::Mesh& mesh,
 PetscScalar assemble_exterior_facets(
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_cells,
     const std::function<void(PetscScalar*, const PetscScalar*, const double*,
-                             int, int)>& fn,
+                             const int*, const int*)>& fn,
     std::vector<const function::Function*> coefficients,
     const std::vector<int>& offsets);
 
 /// Assemble functional over interior facets
-PetscScalar assemble_interior_facets(const Form& M);
+PetscScalar assemble_interior_facets(
+    const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_cells,
+    const std::function<void(PetscScalar*, const PetscScalar*, const double*,
+                             const int*, const int*)>& fn,
+    std::vector<const function::Function*> coefficients,
+    const std::vector<int>& offsets);
 
 } // namespace impl
 } // namespace fem

--- a/cpp/dolfin/fem/assemble_scalar_impl.h
+++ b/cpp/dolfin/fem/assemble_scalar_impl.h
@@ -38,13 +38,12 @@ namespace impl
 PetscScalar assemble_scalar(const fem::Form& M);
 
 /// Assemble functional over cells
-PetscScalar
-assemble_cells(const mesh::Mesh& mesh,
-               const std::vector<std::int32_t>& active_cells,
-               const std::function<void(PetscScalar*, const PetscScalar*,
-                                        const double*, int)>& fn,
-               std::vector<const function::Function*> coefficients,
-               const std::vector<int>& offsets);
+PetscScalar assemble_cells(
+    const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_cells,
+    const std::function<void(PetscScalar*, const PetscScalar*, const double*,
+                             const int*, const int*)>& fn,
+    std::vector<const function::Function*> coefficients,
+    const std::vector<int>& offsets);
 
 /// Execute kernel over exterior facets and accumulate result
 PetscScalar assemble_exterior_facets(

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -493,7 +493,7 @@ void fem::impl::assemble_interior_facets(
 
   // Prepare cell geometry
   const mesh::Connectivity& connectivity_g
-      = mesh.coordinate_dofs().entity_points(tdim);
+      = mesh.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -61,7 +61,7 @@ void _lift_bc_cells(
   Eigen::Array<PetscScalar, Eigen::Dynamic, 1> coeff_array(n.back());
 
   const std::function<void(PetscScalar*, const PetscScalar*, const double*,
-                           int)>& fn
+                           const int*, const int*)>& fn
       = a.integrals().get_tabulate_tensor_fn_cell(0);
 
   // Prepare cell geometry
@@ -129,7 +129,7 @@ void _lift_bc_cells(
     }
 
     Ae.setZero(dmap0.size(), dmap1.size());
-    fn(Ae.data(), coeff_array.data(), coordinate_dofs.data(), 1);
+    fn(Ae.data(), coeff_array.data(), coordinate_dofs.data(), NULL, NULL);
 
     // Size data structure for assembly
     be.setZero(dmap0.size());
@@ -349,7 +349,7 @@ void fem::impl::assemble_cells(
     const Eigen::Ref<const Eigen::Array<PetscInt, Eigen::Dynamic, 1>> dofmap,
     int num_dofs_per_cell,
     const std::function<void(PetscScalar*, const PetscScalar*, const double*,
-                             int)>& kernel,
+                             const int*, const int*)>& kernel,
     std::vector<const function::Function*> coefficients,
     const std::vector<int>& offsets)
 {
@@ -394,7 +394,7 @@ void fem::impl::assemble_cells(
     }
 
     // Tabulate vector for cell
-    kernel(be.data(), coeff_array.data(), coordinate_dofs.data(), 1);
+    kernel(be.data(), coeff_array.data(), coordinate_dofs.data(), NULL, NULL);
 
     // Add local cell vector to global vector
     for (Eigen::Index i = 0; i < num_dofs_per_cell; ++i)

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -524,8 +524,7 @@ void fem::impl::assemble_interior_facets(
     const mesh::Cell cell1(mesh, facet.entities(tdim)[1]);
 
     // Get local index of facet with respect to the cell
-    const int local_facet[2]
-        = {(int)cell0.index(facet), (int)cell1.index(facet)};
+    const int local_facet[2] = {cell0.index(facet), cell1.index(facet)};
     const int orient[2] = {1, 1};
 
     // Get cell vertex coordinates

--- a/cpp/dolfin/fem/assemble_vector_impl.h
+++ b/cpp/dolfin/fem/assemble_vector_impl.h
@@ -62,7 +62,14 @@ void assemble_exterior_facets(
 
 /// Assemble linear form interior facet integrals into an Eigen vector
 void assemble_interior_facets(
-    Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b, const Form& L);
+    Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
+    const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
+    const fem::GenericDofMap& dofmap,
+    const std::function<void(PetscScalar*, const PetscScalar*, const double*,
+                             const double*, int, int, int, int)>& fn,
+    std::vector<const function::Function*> coefficients,
+    const std::vector<int>& offsets);
+
 
 /// Modify b such that:
 ///

--- a/cpp/dolfin/fem/assemble_vector_impl.h
+++ b/cpp/dolfin/fem/assemble_vector_impl.h
@@ -56,7 +56,7 @@ void assemble_exterior_facets(
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
     const fem::GenericDofMap& dofmap,
     const std::function<void(PetscScalar*, const PetscScalar*, const double*,
-                             int, int)>& fn,
+                             const int*, const int*)>& fn,
     std::vector<const function::Function*> coefficients,
     const std::vector<int>& offsets);
 
@@ -66,7 +66,7 @@ void assemble_interior_facets(
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
     const fem::GenericDofMap& dofmap,
     const std::function<void(PetscScalar*, const PetscScalar*, const double*,
-                             const double*, int, int, int, int)>& fn,
+                             const int*, const int*)>& fn,
     std::vector<const function::Function*> coefficients,
     const std::vector<int>& offsets);
 

--- a/cpp/dolfin/fem/assemble_vector_impl.h
+++ b/cpp/dolfin/fem/assemble_vector_impl.h
@@ -46,7 +46,7 @@ void assemble_cells(
     const Eigen::Ref<const Eigen::Array<PetscInt, Eigen::Dynamic, 1>> dofmap,
     int num_dofs_per_cell,
     const std::function<void(PetscScalar*, const PetscScalar*, const double*,
-                             int)>& kernel,
+                             const int*, const int*)>& kernel,
     std::vector<const function::Function*> coefficients,
     const std::vector<int>& offsets);
 

--- a/cpp/dolfin/mesh/MeshEntity.cpp
+++ b/cpp/dolfin/mesh/MeshEntity.cpp
@@ -38,7 +38,7 @@ bool MeshEntity::incident(const MeshEntity& entity) const
   return false;
 }
 //-----------------------------------------------------------------------------
-std::size_t MeshEntity::index(const MeshEntity& entity) const
+int MeshEntity::index(const MeshEntity& entity) const
 {
   // Must be in the same mesh to be incident
   if (_mesh != entity._mesh)
@@ -50,11 +50,11 @@ std::size_t MeshEntity::index(const MeshEntity& entity) const
   const std::int32_t* entities = _mesh->topology()
                                      .connectivity(_dim, entity._dim)
                                      ->connections(_local_index);
-  const std::size_t num_entities
+  const int num_entities
       = _mesh->topology().connectivity(_dim, entity._dim)->size(_local_index);
 
   // Check if any entity matches
-  for (std::size_t i = 0; i < num_entities; ++i)
+  for (int i = 0; i < num_entities; ++i)
     if (entities[i] == entity._local_index)
       return i;
 

--- a/cpp/dolfin/mesh/MeshEntity.h
+++ b/cpp/dolfin/mesh/MeshEntity.h
@@ -185,7 +185,7 @@ public:
   ///
   /// @return     std::size_t
   ///         The local index of given entity.
-  std::size_t index(const MeshEntity& entity) const;
+  int index(const MeshEntity& entity) const;
 
   /// Compute midpoint of cell
   ///

--- a/python/src/fem.cpp
+++ b/python/src/fem.cpp
@@ -288,8 +288,9 @@ void fem(py::module& m)
       .def("set_vertex_domains", &dolfin::fem::Form::set_vertex_domains)
       .def("set_tabulate_cell",
            [](dolfin::fem::Form& self, int i, std::intptr_t addr) {
-             auto tabulate_tensor_ptr = (void (*)(
-                 PetscScalar*, const PetscScalar*, const double*, int))addr;
+             auto tabulate_tensor_ptr
+                 = (void (*)(PetscScalar*, const PetscScalar*, const double*,
+                             const int*, const int*))addr;
              self.register_tabulate_tensor_cell(i, tabulate_tensor_ptr);
            })
       .def_property_readonly("rank", &dolfin::fem::Form::rank)

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -532,7 +532,7 @@ def test_basic_interior_facet_assembly():
     V = dolfin.function.FunctionSpace(mesh, ("DG", 1))
     u, v = dolfin.TrialFunction(V), dolfin.TestFunction(V)
 
-    a = ufl.avg(u) * ufl.avg(v) * ufl.dS
+    a = innert(ufl.avg(u), ufl.avg(v)) * ufl.dS
 
     A = dolfin.fem.assemble_matrix(a)
     A.assemble()

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -516,3 +516,15 @@ def test_projection():
 
     integral_analytic = 1.0 / 3
     assert integral == pytest.approx(integral_analytic, rel=1.e-6, abs=1.e-12)
+
+
+def test_interior_facets():
+    mesh = dolfin.UnitCubeMesh(dolfin.MPI.comm_world, 4, 4, 4)
+    V = dolfin.function.FunctionSpace(mesh, ("DG", 1))
+    u, v = dolfin.TrialFunction(V), dolfin.TestFunction(V)
+
+    a = ufl.avg(u) * ufl.avg(v) * ufl.dS
+
+    A = dolfin.fem.assemble_matrix(a)
+    A.assemble()
+    assert isinstance(A, PETSc.Mat)

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -532,7 +532,7 @@ def test_basic_interior_facet_assembly():
     V = dolfin.function.FunctionSpace(mesh, ("DG", 1))
     u, v = dolfin.TrialFunction(V), dolfin.TestFunction(V)
 
-    a = innert(ufl.avg(u), ufl.avg(v)) * ufl.dS
+    a = ufl.inner(ufl.avg(u), ufl.avg(v)) * ufl.dS
 
     A = dolfin.fem.assemble_matrix(a)
     A.assemble()

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -538,7 +538,7 @@ def test_basic_interior_facet_assembly():
     A.assemble()
     assert isinstance(A, PETSc.Mat)
 
-    L = ufl.avg(v) * ufl.dS
+    L = ufl.conj(ufl.avg(v)) * ufl.dS
 
     b = dolfin.fem.assemble_vector(L)
     b.assemble()

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -186,7 +186,9 @@ def assemble_vector_ufc(b, kernel, mesh, x, dofmap):
         for j in range(3):
             for k in range(2):
                 geometry[j, k] = x[c[j], k]
-        kernel(ffi.from_buffer(b_local), ffi.from_buffer(coeffs), ffi.from_buffer(geometry), ffi.from_buffer(orientation), ffi.from_buffer(orientation))
+        kernel(ffi.from_buffer(b_local), ffi.from_buffer(coeffs),
+               ffi.from_buffer(geometry), ffi.from_buffer(orientation),
+               ffi.from_buffer(orientation))
         for j in range(3):
             b[dofmap[i * 3 + j]] += b_local[j]
 

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -176,6 +176,7 @@ def assemble_vector(b, mesh, x, dofmap):
 def assemble_vector_ufc(b, kernel, mesh, x, dofmap):
     """Assemble provided FFC/UFC kernel over a mesh into the array b"""
     connections, pos = mesh
+    orientation = np.array([0], dtype=np.int32)
     geometry = np.zeros((3, 2))
     coeffs = np.zeros(1, dtype=PETSc.ScalarType)
     b_local = np.zeros(3, dtype=PETSc.ScalarType)
@@ -185,7 +186,7 @@ def assemble_vector_ufc(b, kernel, mesh, x, dofmap):
         for j in range(3):
             for k in range(2):
                 geometry[j, k] = x[c[j], k]
-        kernel(ffi.from_buffer(b_local), ffi.from_buffer(coeffs), ffi.from_buffer(geometry), 0)
+        kernel(ffi.from_buffer(b_local), ffi.from_buffer(coeffs), ffi.from_buffer(geometry), ffi.from_buffer(orientation), ffi.from_buffer(orientation))
         for j in range(3):
             b[dofmap[i * 3 + j]] += b_local[j]
 

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -18,11 +18,13 @@ from dolfin_utils.test.skips import skip_if_complex
 c_signature = numba.types.void(
     numba.types.CPointer(numba.typeof(PETSc.ScalarType())),
     numba.types.CPointer(numba.typeof(PETSc.ScalarType())),
-    numba.types.CPointer(numba.types.double), numba.types.intc)
+    numba.types.CPointer(numba.types.double),
+    numba.types.CPointer(numba.types.int32),
+    numba.types.CPointer(numba.types.int32))
 
 
 @numba.cfunc(c_signature, nopython=True)
-def tabulate_tensor_A(A_, w_, coords_, cell_orientation):
+def tabulate_tensor_A(A_, w_, coords_, entity_local_index, cell_orientation):
     A = numba.carray(A_, (3, 3), dtype=PETSc.ScalarType)
     coordinate_dofs = numba.carray(coords_, (3, 2), dtype=np.float64)
 
@@ -40,7 +42,7 @@ def tabulate_tensor_A(A_, w_, coords_, cell_orientation):
 
 
 @numba.cfunc(c_signature, nopython=True)
-def tabulate_tensor_b(b_, w_, coords_, cell_orientation):
+def tabulate_tensor_b(b_, w_, coords_, local_index, orientation):
     b = numba.carray(b_, (3), dtype=PETSc.ScalarType)
     coordinate_dofs = numba.carray(coords_, (3, 2), dtype=np.float64)
     x0, y0 = coordinate_dofs[0, :]
@@ -53,7 +55,7 @@ def tabulate_tensor_b(b_, w_, coords_, cell_orientation):
 
 
 @numba.cfunc(c_signature, nopython=True)
-def tabulate_tensor_b_coeff(b_, w_, coords_, cell_orientation):
+def tabulate_tensor_b_coeff(b_, w_, coords_, local_index, orientation):
     b = numba.carray(b_, (3), dtype=PETSc.ScalarType)
     w = numba.carray(w_, (1), dtype=PETSc.ScalarType)
     coordinate_dofs = numba.carray(coords_, (3, 2), dtype=np.float64)
@@ -123,7 +125,8 @@ def test_cffi_assembly():
         #include <stdalign.h>
         void tabulate_tensor_poissonA(double* restrict A, const double* w,
                                     const double* restrict coordinate_dofs,
-                                    int cell_orientation)
+                                    const int* entity_local_index,
+                                    const int* cell_orientation)
         {
         // Precomputed values of basis functions and precomputations
         // FE* dimensions: [entities][points][dofs]
@@ -170,7 +173,8 @@ def test_cffi_assembly():
 
         void tabulate_tensor_poissonL(double* restrict A, const double* w,
                                      const double* restrict coordinate_dofs,
-                                     int cell_orientation)
+                                     const int* entity_local_index,
+                                     const int* cell_orientation)
         {
         // Precomputed values of basis functions and precomputations
         // FE* dimensions: [entities][points][dofs]
@@ -196,10 +200,12 @@ def test_cffi_assembly():
         ffibuilder.cdef("""
         void tabulate_tensor_poissonA(double* restrict A, const double* w,
                                     const double* restrict coordinate_dofs,
-                                    int cell_orientation);
+                                    const int* entity_local_index,
+                                    const int* cell_orientation);
         void tabulate_tensor_poissonL(double* restrict A, const double* w,
                                     const double* restrict coordinate_dofs,
-                                    int cell_orientation);
+                                    const int* entity_local_index,
+                                    const int* cell_orientation);
         """)
 
         ffibuilder.compile(verbose=True)


### PR DESCRIPTION
This replaces the tabulate_tensor signature for all integrals (except custom) to the same signature.

* will lead to further simplifications in `FormIntegrals`
* needs ffcx branch https://github.com/FEniCS/ffcx/tree/chris/unify-facet-integral-sigs
