### PR TITLE
Avoid partitioning small meshes

### DIFF
--- a/cpp/dolfin/mesh/Partitioning.cpp
+++ b/cpp/dolfin/mesh/Partitioning.cpp
@@ -617,7 +617,8 @@ partition_cells(const MPI_Comm& mpi_comm, mesh::CellType::Type type,
   const std::size_t num_processes = MPI::size(mpi_comm);
 
   // At least two cells per processor are required for mesh partitioning
-  if (global_graph_size / num_processes < 2)
+  // in parallel
+  if (num_processes > 1 && global_graph_size / num_processes < 2)
     throw std::runtime_error("Cannot partition a graph of size "
                              + std::to_string(global_graph_size) + " into "
                              + std::to_string(num_processes) + " blocks.");

--- a/cpp/dolfin/mesh/Partitioning.cpp
+++ b/cpp/dolfin/mesh/Partitioning.cpp
@@ -613,6 +613,15 @@ partition_cells(const MPI_Comm& mpi_comm, mesh::CellType::Type type,
   std::tie(local_graph, graph_info) = graph::GraphBuilder::compute_dual_graph(
       mpi_comm, cell_vertices, *cell_type);
 
+  const std::size_t global_graph_size = MPI::sum(mpi_comm, local_graph.size());
+  const std::size_t num_processes = MPI::size(mpi_comm);
+
+  // At least two cells per processor are required for mesh partitioning
+  if (global_graph_size / num_processes < 2)
+    throw std::runtime_error("Cannot partition a graph of size "
+                             + std::to_string(global_size) + " into "
+                             + std::to_string(num_processes) + " blocks.");
+
   // Compute cell partition using partitioner from parameter system
   if (partitioner == "SCOTCH")
   {

--- a/cpp/dolfin/mesh/Partitioning.cpp
+++ b/cpp/dolfin/mesh/Partitioning.cpp
@@ -616,8 +616,9 @@ partition_cells(const MPI_Comm& mpi_comm, mesh::CellType::Type type,
   const std::size_t global_graph_size = MPI::sum(mpi_comm, local_graph.size());
   const std::size_t num_processes = MPI::size(mpi_comm);
 
-  // At least two cells per processor are required for mesh partitioning
-  // in parallel
+  // Require at least two cells per processor for mesh partitioning in
+  // parallel. Partitioning small graphs may lead to segaults or MPI
+  // processes with 0 cells.
   if (num_processes > 1 && global_graph_size / num_processes < 2)
     throw std::runtime_error("Cannot partition a graph of size "
                              + std::to_string(global_graph_size) + " into "

--- a/cpp/dolfin/mesh/Partitioning.cpp
+++ b/cpp/dolfin/mesh/Partitioning.cpp
@@ -619,7 +619,7 @@ partition_cells(const MPI_Comm& mpi_comm, mesh::CellType::Type type,
   // At least two cells per processor are required for mesh partitioning
   if (global_graph_size / num_processes < 2)
     throw std::runtime_error("Cannot partition a graph of size "
-                             + std::to_string(global_size) + " into "
+                             + std::to_string(global_graph_size) + " into "
                              + std::to_string(num_processes) + " blocks.");
 
   // Compute cell partition using partitioner from parameter system

--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -37,7 +37,7 @@ fe_3d_shapes = ["tetrahedron"]
 fe_families = ["CG", "DG"]
 fe_degrees = [0, 1, 3]
 mesh_tdims = [1, 2, 3]
-mesh_ns = [4, 7]
+mesh_ns = [6, 10]
 
 
 def mesh_factory(tdim, n):

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -463,3 +463,16 @@ def test_mesh_topology_lifetime():
     assert sys.getrefcount(mesh) == rc + 1
     del topology
     assert sys.getrefcount(mesh) == rc
+
+
+@pytest.mark.xfail(condition=MPI.size(MPI.comm_world) > 1,
+                   reason="Small meshes fail in parallel")
+def test_small_mesh(interval):
+    mesh3d = UnitCubeMesh(MPI.comm_world, 1, 1, 1)
+    assert mesh3d.num_cells() == 2
+
+    mesh2d = UnitSquareMesh(MPI.comm_world, 1, 1)
+    assert mesh2d.num_cells() == 2
+
+    mesh1d = UnitIntervalMesh(MPI.comm_world, 2)
+    assert mesh1d.num_cells() == 2

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -469,10 +469,13 @@ def test_mesh_topology_lifetime():
                    reason="Small meshes fail in parallel")
 def test_small_mesh(interval):
     mesh3d = UnitCubeMesh(MPI.comm_world, 1, 1, 1)
-    assert mesh3d.num_cells() == 6
+    gdim = mesh3d.geometric_dimension()
+    assert mesh3d.num_entities_global(gdim) == 6
 
     mesh2d = UnitSquareMesh(MPI.comm_world, 1, 1)
-    assert mesh2d.num_cells() == 2
+    gdim = mesh2d.geometric_dimension()
+    assert mesh2d.num_entities_global(gdim) == 2
 
     mesh1d = UnitIntervalMesh(MPI.comm_world, 2)
-    assert mesh1d.num_cells() == 2
+    gdim = mesh1d.geometric_dimension()
+    assert mesh1d.num_entities_global(gdim) == 2

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -469,7 +469,7 @@ def test_mesh_topology_lifetime():
                    reason="Small meshes fail in parallel")
 def test_small_mesh(interval):
     mesh3d = UnitCubeMesh(MPI.comm_world, 1, 1, 1)
-    assert mesh3d.num_cells() == 2
+    assert mesh3d.num_cells() == 6
 
     mesh2d = UnitSquareMesh(MPI.comm_world, 1, 1)
     assert mesh2d.num_cells() == 2


### PR DESCRIPTION
Throw an error if the expected local number of cells is less than 2.

This "fixes" [Issue 114](https://github.com/FEniCS/dolfinx/issues/114). It hangs when a process owns 0 cells, after the partitioning process.

Partitioning small graphs can lead to unexpected results, such as a different number of parts than requested (known Issue of Scotch and Parmetis, e.g.: [Issue](http://glaros.dtc.umn.edu/gkhome/node/786)), and segmentation fault when using k-way partitioning (eg.: [Issue](https://github.com/schulzchristian/KaHIP/issues/34)).