### PR TITLE
Remove numba requirement in setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -18,7 +18,6 @@ RESTRICT_REQUIREMENTS = ">=2019.2.0.dev0,<2019.3"
 
 REQUIREMENTS = [
     "numpy",
-    "numba",
     "mpi4py",
     "petsc4py",
     "fenics-ffc",


### PR DESCRIPTION
Not used in DOLFIN, but is used in tests.