### PR TITLE
Remove unused comm parameter from read_mesh

### DIFF
--- a/cpp/dolfin/io/HDF5File.cpp
+++ b/cpp/dolfin/io/HDF5File.cpp
@@ -1321,7 +1321,7 @@ HDF5File::read_mesh_value_collection(std::shared_ptr<const mesh::Mesh> mesh,
   return mvc;
 }
 //-----------------------------------------------------------------------------
-mesh::Mesh HDF5File::read_mesh(MPI_Comm comm, const std::string data_path,
+mesh::Mesh HDF5File::read_mesh(const std::string data_path,
                                bool use_partition_from_file,
                                const mesh::GhostMode ghost_mode) const
 {
@@ -1377,11 +1377,11 @@ mesh::Mesh HDF5File::read_mesh(MPI_Comm comm, const std::string data_path,
   int gdim = coords_shape[1];
 
   // Build mesh from data in HDF5 file
-  return read_mesh(comm, topology_path, geometry_path, gdim, *cell_type, -1,
+  return read_mesh(topology_path, geometry_path, gdim, *cell_type, -1,
                    coords_shape[0], use_partition_from_file, ghost_mode);
 }
 //-----------------------------------------------------------------------------
-mesh::Mesh HDF5File::read_mesh(MPI_Comm comm, const std::string topology_path,
+mesh::Mesh HDF5File::read_mesh(const std::string topology_path,
                                const std::string geometry_path, const int gdim,
                                const mesh::CellType& cell_type,
                                const std::int64_t expected_num_global_cells,

--- a/cpp/dolfin/io/HDF5File.h
+++ b/cpp/dolfin/io/HDF5File.h
@@ -104,7 +104,7 @@ public:
   /// stored in the HDF5 file. Optionally re-use any partition data
   /// in the file. This function requires all necessary data for
   /// constructing a mesh::Mesh to be present in the HDF5 file.
-  mesh::Mesh read_mesh(MPI_Comm, const std::string data_path,
+  mesh::Mesh read_mesh(const std::string data_path,
                        bool use_partition_from_file,
                        const mesh::GhostMode ghost_mode) const;
 
@@ -117,7 +117,7 @@ public:
   /// This function is typically called when using the XDMF format,
   /// in which case the meta data has already been read from an XML
   /// file
-  mesh::Mesh read_mesh(MPI_Comm comm, const std::string topology_path,
+  mesh::Mesh read_mesh(const std::string topology_path,
                        const std::string geometry_path, const int gdim,
                        const mesh::CellType& cell_type,
                        const std::int64_t expected_num_global_cells,

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -1316,8 +1316,7 @@ XDMFFile::read_mf_double(std::shared_ptr<const mesh::Mesh> mesh,
   return read_mesh_function<double>(mesh, name);
 }
 //----------------------------------------------------------------------------
-mesh::Mesh XDMFFile::read_mesh(MPI_Comm comm,
-                               const mesh::GhostMode ghost_mode) const
+mesh::Mesh XDMFFile::read_mesh(const mesh::GhostMode ghost_mode) const
 {
   // Extract parent filepath (required by HDF5 when XDMF stores relative
   // path of the HDF5 files(s) and the XDMF is not opened from its own

--- a/cpp/dolfin/io/XDMFFile.h
+++ b/cpp/dolfin/io/XDMFFile.h
@@ -269,7 +269,7 @@ public:
   ///        Ghost mode for mesh partition
   /// @returns mesh::Mesh
   ///        Mesh
-  mesh::Mesh read_mesh(MPI_Comm comm, const mesh::GhostMode ghost_mode) const;
+  mesh::Mesh read_mesh(const mesh::GhostMode ghost_mode) const;
 
   /// Read a function from the XDMF file. Supplied function must
   /// come with already initialized and compatible function space.

--- a/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
+++ b/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
@@ -27,7 +27,7 @@ filedir = os.path.dirname(__file__)
 infile = dolfin.io.XDMFFile(dolfin.MPI.comm_world,
                             os.path.join(filedir, "cooks_tri_mesh.xdmf"),
                             encoding=dolfin.cpp.io.XDMFFile.Encoding.ASCII)
-mesh = infile.read_mesh(dolfin.MPI.comm_world, dolfin.cpp.mesh.GhostMode.none)
+mesh = infile.read_mesh(dolfin.cpp.mesh.GhostMode.none)
 infile.close()
 
 # Stress (Se) and displacement (Ue) elements

--- a/python/demo/stokes-taylor-hood/demo_stokes-taylor-hood.py
+++ b/python/demo/stokes-taylor-hood/demo_stokes-taylor-hood.py
@@ -95,7 +95,7 @@ from ufl import FiniteElement, VectorElement, div, dx, grad, inner
 
 # Load mesh and subdomains
 xdmf = XDMFFile(MPI.comm_world, "../dolfin_fine.xdmf")
-mesh = xdmf.read_mesh(MPI.comm_world, dolfin.cpp.mesh.GhostMode.none)
+mesh = xdmf.read_mesh(dolfin.cpp.mesh.GhostMode.none)
 
 sub_domains = xdmf.read_mf_size_t(mesh)
 

--- a/python/dolfin/io.py
+++ b/python/dolfin/io.py
@@ -83,10 +83,10 @@ class HDF5File:
         return self._cpp_object.read_vector(mpi_comm, data_path,
                                             use_partition_from_file)
 
-    def read_mesh(self, mpi_comm, data_path: str,
+    def read_mesh(self, data_path: str,
                   use_partition_from_file: bool, ghost_mode):
-        mesh = self._cpp_object.read_mesh(mpi_comm, data_path,
-                                          use_partition_from_file, ghost_mode)
+        mesh = self._cpp_object.read_mesh(data_path, use_partition_from_file,
+                                          ghost_mode)
         mesh.geometry.coord_mapping = fem.create_coordinate_map(mesh)
         return mesh
 

--- a/python/dolfin/io.py
+++ b/python/dolfin/io.py
@@ -205,8 +205,8 @@ class XDMFFile:
 
     # ----------------------------------------------------------
 
-    def read_mesh(self, mpi_comm, ghost_mode):
-        mesh = self._cpp_object.read_mesh(mpi_comm, ghost_mode)
+    def read_mesh(self, ghost_mode):
+        mesh = self._cpp_object.read_mesh(ghost_mode)
         mesh.geometry.coord_mapping = fem.create_coordinate_map(mesh)
         return mesh
 

--- a/python/src/io.cpp
+++ b/python/src/io.cpp
@@ -232,9 +232,9 @@ void io(py::module& m)
   xdmf_file
       // Mesh
       .def("read_mesh",
-           [](dolfin::io::XDMFFile& self, const MPICommWrapper comm,
+           [](dolfin::io::XDMFFile& self,
               const dolfin::mesh::GhostMode ghost_mode) {
-             return self.read_mesh(comm.get(), ghost_mode);
+             return self.read_mesh(ghost_mode);
            })
       // MeshFunction
       .def("read_mf_int", &dolfin::io::XDMFFile::read_mf_int, py::arg("mesh"),

--- a/python/src/io.cpp
+++ b/python/src/io.cpp
@@ -40,11 +40,11 @@ void io(py::module& m)
       .def("flush", &dolfin::io::HDF5File::flush)
       // read
       .def("read_mesh",
-           [](dolfin::io::HDF5File& self, const MPICommWrapper comm,
-              const std::string data_path, bool use_partition_from_file,
+           [](dolfin::io::HDF5File& self, const std::string data_path,
+              bool use_partition_from_file,
               const dolfin::mesh::GhostMode ghost_mode) {
-             return self.read_mesh(comm.get(), data_path,
-                                   use_partition_from_file, ghost_mode);
+             return self.read_mesh(data_path, use_partition_from_file,
+                                   ghost_mode);
            })
       .def("read_vector",
            [](dolfin::io::HDF5File& self, const MPICommWrapper comm,

--- a/python/test/unit/io/test_HDF5.py
+++ b/python/test/unit/io/test_HDF5.py
@@ -193,8 +193,7 @@ def test_save_and_read_mesh_2D(tempdir):
 
     # Read from file
     mesh_file = HDF5File(mesh0.mpi_comm(), filename, "r")
-    mesh1 = mesh_file.read_mesh(MPI.comm_world, "/my_mesh", False,
-                                cpp.mesh.GhostMode.none)
+    mesh1 = mesh_file.read_mesh("/my_mesh", False, cpp.mesh.GhostMode.none)
     mesh_file.close()
 
     assert mesh0.num_entities_global(0) == mesh1.num_entities_global(0)
@@ -213,8 +212,7 @@ def test_save_and_read_mesh_3D(tempdir):
 
     # Read from file
     mesh_file = HDF5File(mesh0.mpi_comm(), filename, "r")
-    mesh1 = mesh_file.read_mesh(MPI.comm_world, "/my_mesh", False,
-                                cpp.mesh.GhostMode.none)
+    mesh1 = mesh_file.read_mesh("/my_mesh", False, cpp.mesh.GhostMode.none)
     mesh_file.close()
 
     assert mesh0.num_entities_global(0) == mesh1.num_entities_global(0)

--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -75,7 +75,7 @@ def test_multiple_datasets(tempdir, encoding):
         xdmf.write(cf0)
         xdmf.write(cf1)
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-        mesh = xdmf.read_mesh(MPI.comm_world, cpp.mesh.GhostMode.none)
+        mesh = xdmf.read_mesh(cpp.mesh.GhostMode.none)
         cf0 = xdmf.read_mf_size_t(mesh, "cf0")
         cf1 = xdmf.read_mf_size_t(mesh, "cf1")
     assert (cf0[0] == 11 and cf1[0] == 22)
@@ -88,7 +88,7 @@ def test_save_and_load_1d_mesh(tempdir, encoding):
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         file.write(mesh)
     with XDMFFile(MPI.comm_world, filename) as file:
-        mesh2 = file.read_mesh(MPI.comm_world, cpp.mesh.GhostMode.none)
+        mesh2 = file.read_mesh(cpp.mesh.GhostMode.none)
     assert mesh.num_entities_global(0) == mesh2.num_entities_global(0)
     dim = mesh.topology.dim
     assert mesh.num_entities_global(dim) == mesh2.num_entities_global(dim)
@@ -101,7 +101,7 @@ def test_save_and_load_2d_mesh(tempdir, encoding):
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         file.write(mesh)
     with XDMFFile(MPI.comm_world, filename) as file:
-        mesh2 = file.read_mesh(MPI.comm_world, cpp.mesh.GhostMode.none)
+        mesh2 = file.read_mesh(cpp.mesh.GhostMode.none)
     assert mesh.num_entities_global(0) == mesh2.num_entities_global(0)
     dim = mesh.topology.dim
     assert mesh.num_entities_global(dim) == mesh2.num_entities_global(dim)
@@ -114,7 +114,7 @@ def test_save_and_load_2d_quad_mesh(tempdir, encoding):
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         file.write(mesh)
     with XDMFFile(MPI.comm_world, filename) as file:
-        mesh2 = file.read_mesh(MPI.comm_world, cpp.mesh.GhostMode.none)
+        mesh2 = file.read_mesh(cpp.mesh.GhostMode.none)
     assert mesh.num_entities_global(0) == mesh2.num_entities_global(0)
     dim = mesh.topology.dim
     assert mesh.num_entities_global(dim) == mesh2.num_entities_global(dim)
@@ -127,7 +127,7 @@ def test_save_and_load_3d_mesh(tempdir, encoding):
     with XDMFFile(mesh.mpi_comm(), filename, encoding=encoding) as file:
         file.write(mesh)
     with XDMFFile(MPI.comm_world, filename) as file:
-        mesh2 = file.read_mesh(MPI.comm_world, cpp.mesh.GhostMode.none)
+        mesh2 = file.read_mesh(cpp.mesh.GhostMode.none)
     assert mesh.num_entities_global(0) == mesh2.num_entities_global(0)
     dim = mesh.topology.dim
     assert mesh.num_entities_global(dim) == mesh2.num_entities_global(dim)

--- a/python/test/unit/io/test_XDMF_P2.py
+++ b/python/test/unit/io/test_XDMF_P2.py
@@ -25,7 +25,7 @@ def test_read_write_p2_mesh(tempdir):
         xdmf.write(mesh)
 
     with XDMFFile(mesh.mpi_comm(), filename) as xdmf:
-        mesh2 = xdmf.read_mesh(mesh.mpi_comm(), cpp.mesh.GhostMode.none)
+        mesh2 = xdmf.read_mesh(cpp.mesh.GhostMode.none)
 
     assert mesh2.num_entities_global(
         mesh.topology.dim) == mesh.num_entities_global(mesh.topology.dim)


### PR DESCRIPTION
`HDF5File` and `XDMFFile` already have their communicator (passed for the constructor).
In `XXXXX::read_mesh` the communicator parameter was not used.

Removing the comm parameter avoids ambiguity if one uses more than 1 communicator for other tasks.