### PR TITLE
Add ghost assembly tests

### DIFF
--- a/cpp/dolfin/fem/FormIntegrals.cpp
+++ b/cpp/dolfin/fem/FormIntegrals.cpp
@@ -146,9 +146,11 @@ void FormIntegrals::set_default_domains(const mesh::Mesh& mesh)
       = _integrals[static_cast<int>(FormIntegrals::Type::cell)];
 
   // If there is a default integral, define it on all cells
+  // (excluding ghost cells)
   if (cell_integrals.size() > 0 and cell_integrals[0].id == -1)
   {
-    cell_integrals[0].active_entities.resize(mesh.num_entities(tdim));
+    const int num_regular_cells = mesh.topology().ghost_offset(tdim);
+    cell_integrals[0].active_entities.resize(num_regular_cells);
     std::iota(cell_integrals[0].active_entities.begin(),
               cell_integrals[0].active_entities.end(), 0);
   }
@@ -159,7 +161,8 @@ void FormIntegrals::set_default_domains(const mesh::Mesh& mesh)
   {
     // If there is a default integral, define it only on surface facets
     exf_integrals[0].active_entities.clear();
-    for (const mesh::Facet& facet : mesh::MeshRange<mesh::Facet>(mesh))
+    for (const mesh::Facet& facet :
+         mesh::MeshRange<mesh::Facet>(mesh, mesh::MeshRangeType::REGULAR))
     {
       if (facet.num_global_entities(tdim) == 1)
         exf_integrals[0].active_entities.push_back(facet.index());
@@ -173,7 +176,8 @@ void FormIntegrals::set_default_domains(const mesh::Mesh& mesh)
     // If there is a default integral, define it only on interior facets
     inf_integrals[0].active_entities.clear();
     inf_integrals[0].active_entities.reserve(mesh.num_entities(tdim - 1));
-    for (const mesh::Facet& facet : mesh::MeshRange<mesh::Facet>(mesh))
+    for (const mesh::Facet& facet :
+         mesh::MeshRange<mesh::Facet>(mesh, mesh::MeshRangeType::REGULAR))
     {
       if (facet.num_global_entities(tdim) != 1)
         inf_integrals[0].active_entities.push_back(facet.index());

--- a/cpp/dolfin/fem/assemble_matrix_impl.cpp
+++ b/cpp/dolfin/fem/assemble_matrix_impl.cpp
@@ -214,7 +214,8 @@ void fem::impl::assemble_exterior_facets(
     const mesh::Facet facet(mesh, facet_index);
     assert(facet.num_global_entities(tdim) == 1);
 
-    // TODO: check ghosting sanity?
+    // Check that facet is not a ghost (will be assembled on another process)
+    assert(!facet.is_ghost());
 
     // Create attached cell
     const mesh::Cell cell(mesh, facet.entities(tdim)[0]);

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -447,7 +447,8 @@ void fem::impl::assemble_exterior_facets(
 
     assert(facet.num_global_entities(tdim) == 1);
 
-    // TODO: check ghosting sanity?
+    // Check that facet is not a ghost (will be assembled on another process)
+    assert(!facet.is_ghost());
 
     // Create attached cell
     const mesh::Cell cell(mesh, facet.entities(tdim)[0]);

--- a/cpp/dolfin/mesh/MeshEntity.cpp
+++ b/cpp/dolfin/mesh/MeshEntity.cpp
@@ -88,7 +88,7 @@ Eigen::Vector3d MeshEntity::midpoint() const
   return x;
 }
 //-----------------------------------------------------------------------------
-std::uint32_t MeshEntity::owner() const
+std::int32_t MeshEntity::owner() const
 {
   if (_dim != _mesh->topology().dim())
   {

--- a/cpp/dolfin/mesh/MeshEntity.h
+++ b/cpp/dolfin/mesh/MeshEntity.h
@@ -233,7 +233,7 @@ public:
   /// Get ownership of this entity - only really valid for cells
   /// @return std::uint32_t
   ///    Owning process
-  std::uint32_t owner() const;
+  std::int32_t owner() const;
 
   /// Return informal string representation (pretty-print)
   ///

--- a/python/test/unit/fem/test_ghost_mesh_assembly.py
+++ b/python/test/unit/fem/test_ghost_mesh_assembly.py
@@ -17,13 +17,14 @@ from petsc4py import PETSc
 from ufl import ds, dx, dS, inner, avg
 
 
-@pytest.mark.parametrize("mode", [pytest.param(GhostMode.none),
-                                  pytest.param(GhostMode.shared_facet,
-                                               marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
-                                                                       reason="Shared ghost modes fail in serial")),
-                                  pytest.param(GhostMode.shared_vertex,
-                                               marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
-                                                                       reason="Shared ghost modes fail in serial"))])
+@pytest.mark.parametrize("mode",
+                         [pytest.param(GhostMode.none),
+                          pytest.param(GhostMode.shared_facet,
+                                       marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
+                                                               reason="Shared ghost modes fail in serial")),
+                          pytest.param(GhostMode.shared_vertex,
+                                       marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
+                                                               reason="Shared ghost modes fail in serial"))])
 def test_ghost_mesh_assembly(mode):
     mesh = UnitSquareMesh(MPI.comm_world, 12, 12, ghost_mode=mode)
     V = FunctionSpace(mesh, ("Lagrange", 1))
@@ -51,15 +52,16 @@ def test_ghost_mesh_assembly(mode):
     assert normb == pytest.approx(1.582294032953906, rel=1.e-6, abs=1.e-12)
 
 
-@pytest.mark.parametrize("mode", [pytest.param(GhostMode.none,
-                                               marks=pytest.mark.skipif(condition=MPI.size(MPI.comm_world) > 1,
-                                                                        reason="Unghosted interior facets fail in parallel")),
-                                  pytest.param(GhostMode.shared_facet,
-                                               marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
-                                                                       reason="Shared ghost modes fail in serial")),
-                                  pytest.param(GhostMode.shared_vertex,
-                                               marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
-                                                                       reason="Shared ghost modes fail in serial"))])
+@pytest.mark.parametrize("mode",
+                         [pytest.param(GhostMode.none,
+                                       marks=pytest.mark.skipif(condition=MPI.size(MPI.comm_world) > 1,
+                                                                reason="Unghosted interior facets fail in parallel")),
+                          pytest.param(GhostMode.shared_facet,
+                                       marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
+                                                               reason="Shared ghost modes fail in serial")),
+                          pytest.param(GhostMode.shared_vertex,
+                                       marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
+                                                               reason="Shared ghost modes fail in serial"))])
 def test_ghost_mesh_dS_assembly(mode):
     mesh = UnitSquareMesh(MPI.comm_world, 12, 12, ghost_mode=mode)
     V = FunctionSpace(mesh, ("Lagrange", 1))

--- a/python/test/unit/fem/test_ghost_mesh_assembly.py
+++ b/python/test/unit/fem/test_ghost_mesh_assembly.py
@@ -17,9 +17,7 @@ from petsc4py import PETSc
 from ufl import ds, dx, dS, inner, avg
 
 
-@pytest.mark.parametrize("mode", [pytest.param(GhostMode.none,
-                                               marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
-                                                                       reason="Shared ghost modes fail in serial")),
+@pytest.mark.parametrize("mode", [pytest.param(GhostMode.none),
                                   pytest.param(GhostMode.shared_facet,
                                                marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
                                                                        reason="Shared ghost modes fail in serial")),

--- a/python/test/unit/fem/test_ghost_mesh_assembly.py
+++ b/python/test/unit/fem/test_ghost_mesh_assembly.py
@@ -5,46 +5,43 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Unit tests for assembly"""
 
-import math
-
-import numpy
 import pytest
 
-import dolfin
-from dolfin import MPI, Facets
-import ufl
+from dolfin import fem
+from dolfin import MPI
+from dolfin.function import FunctionSpace, TrialFunction, TestFunction, Function
+from dolfin.generation import UnitSquareMesh
+from dolfin.cpp.mesh import GhostMode
 
 from petsc4py import PETSc
 from ufl import ds, dx, dS, inner, avg
 
 
-@pytest.mark.parametrize("mode", [pytest.param(dolfin.cpp.mesh.GhostMode.none,
+@pytest.mark.parametrize("mode", [pytest.param(GhostMode.none,
                                                marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
                                                                        reason="Shared ghost modes fail in serial")),
-                                  pytest.param(dolfin.cpp.mesh.GhostMode.shared_facet,
+                                  pytest.param(GhostMode.shared_facet,
                                                marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
                                                                        reason="Shared ghost modes fail in serial")),
-                                  pytest.param(dolfin.cpp.mesh.GhostMode.shared_vertex,
+                                  pytest.param(GhostMode.shared_vertex,
                                                marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
                                                                        reason="Shared ghost modes fail in serial"))])
 def test_ghost_mesh_assembly(mode):
-    mesh = dolfin.generation.UnitSquareMesh(dolfin.MPI.comm_world, 12, 12,
-                                            dolfin.cpp.mesh.CellType.Type.triangle,
-                                            mode)
-    V = dolfin.FunctionSpace(mesh, ("Lagrange", 1))
-    u, v = dolfin.TrialFunction(V), dolfin.TestFunction(V)
+    mesh = UnitSquareMesh(MPI.comm_world, 12, 12, ghost_mode=mode)
+    V = FunctionSpace(mesh, ("Lagrange", 1))
+    u, v = TrialFunction(V), TestFunction(V)
 
-    f = dolfin.Function(V)
+    f = Function(V)
     with f.vector().localForm() as f_local:
         f_local.set(10.0)
     a = inner(f * u, v) * dx + inner(u, v) * ds
     L = inner(f, v) * dx + inner(2.0, v) * ds
 
     # Initial assembly
-    A = dolfin.fem.assemble_matrix(a)
+    A = fem.assemble_matrix(a)
     A.assemble()
     assert isinstance(A, PETSc.Mat)
-    b = dolfin.fem.assemble_vector(L)
+    b = fem.assemble_vector(L)
     b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
     assert isinstance(b, PETSc.Vec)
 
@@ -56,26 +53,24 @@ def test_ghost_mesh_assembly(mode):
     assert normb == pytest.approx(1.582294032953906, rel=1.e-6, abs=1.e-12)
 
 
-@pytest.mark.parametrize("mode", [pytest.param(dolfin.cpp.mesh.GhostMode.none,
+@pytest.mark.parametrize("mode", [pytest.param(GhostMode.none,
                                                marks=pytest.mark.skipif(condition=MPI.size(MPI.comm_world) > 1,
-                                                                       reason="Unghosted interior facets fail in parallel")),
-                                  pytest.param(dolfin.cpp.mesh.GhostMode.shared_facet,
+                                                                        reason="Unghosted interior facets fail in parallel")),
+                                  pytest.param(GhostMode.shared_facet,
                                                marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
                                                                        reason="Shared ghost modes fail in serial")),
-                                  pytest.param(dolfin.cpp.mesh.GhostMode.shared_vertex,
+                                  pytest.param(GhostMode.shared_vertex,
                                                marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
                                                                        reason="Shared ghost modes fail in serial"))])
 def test_ghost_mesh_dS_assembly(mode):
-    mesh = dolfin.generation.UnitSquareMesh(dolfin.MPI.comm_world, 12, 12,
-                                            dolfin.cpp.mesh.CellType.Type.triangle,
-                                            mode)
-    V = dolfin.FunctionSpace(mesh, ("Lagrange", 1))
-    u, v = dolfin.TrialFunction(V), dolfin.TestFunction(V)
+    mesh = UnitSquareMesh(MPI.comm_world, 12, 12, ghost_mode=mode)
+    V = FunctionSpace(mesh, ("Lagrange", 1))
+    u, v = TrialFunction(V), TestFunction(V)
 
     a = inner(avg(u), avg(v)) * dS
 
     # Initial assembly
-    A = dolfin.fem.assemble_matrix(a)
+    A = fem.assemble_matrix(a)
     A.assemble()
     assert isinstance(A, PETSc.Mat)
 

--- a/python/test/unit/fem/test_ghost_mesh_assembly.py
+++ b/python/test/unit/fem/test_ghost_mesh_assembly.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2018-2019 Garth N. Wells
+#
+# This file is part of DOLFIN (https://www.fenicsproject.org)
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+"""Unit tests for assembly"""
+
+import math
+
+import numpy
+import pytest
+
+import dolfin
+from dolfin import MPI, Facets
+import ufl
+
+from petsc4py import PETSc
+from ufl import ds, dx, dS, inner, avg
+
+
+@pytest.mark.parametrize("mode", [pytest.param(dolfin.cpp.mesh.GhostMode.none,
+                                               marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
+                                                                       reason="Shared ghost modes fail in serial")),
+                                  pytest.param(dolfin.cpp.mesh.GhostMode.shared_facet,
+                                               marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
+                                                                       reason="Shared ghost modes fail in serial")),
+                                  pytest.param(dolfin.cpp.mesh.GhostMode.shared_vertex,
+                                               marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
+                                                                       reason="Shared ghost modes fail in serial"))])
+def test_ghost_mesh_assembly(mode):
+    mesh = dolfin.generation.UnitSquareMesh(dolfin.MPI.comm_world, 12, 12,
+                                            dolfin.cpp.mesh.CellType.Type.triangle,
+                                            mode)
+    V = dolfin.FunctionSpace(mesh, ("Lagrange", 1))
+    u, v = dolfin.TrialFunction(V), dolfin.TestFunction(V)
+
+    f = dolfin.Function(V)
+    with f.vector().localForm() as f_local:
+        f_local.set(10.0)
+    a = inner(f * u, v) * dx + inner(u, v) * ds
+    L = inner(f, v) * dx + inner(2.0, v) * ds
+
+    # Initial assembly
+    A = dolfin.fem.assemble_matrix(a)
+    A.assemble()
+    assert isinstance(A, PETSc.Mat)
+    b = dolfin.fem.assemble_vector(L)
+    b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
+    assert isinstance(b, PETSc.Vec)
+
+    # Check that the norms are the same for all three modes
+    normA = A.norm()
+    assert normA == pytest.approx(0.6713621455570528, rel=1.e-6, abs=1.e-12)
+
+    normb = b.norm()
+    assert normb == pytest.approx(1.582294032953906, rel=1.e-6, abs=1.e-12)
+
+
+@pytest.mark.parametrize("mode", [pytest.param(dolfin.cpp.mesh.GhostMode.none,
+                                               marks=pytest.mark.skipif(condition=MPI.size(MPI.comm_world) > 1,
+                                                                       reason="Unghosted interior facets fail in parallel")),
+                                  pytest.param(dolfin.cpp.mesh.GhostMode.shared_facet,
+                                               marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
+                                                                       reason="Shared ghost modes fail in serial")),
+                                  pytest.param(dolfin.cpp.mesh.GhostMode.shared_vertex,
+                                               marks=pytest.mark.xfail(condition=MPI.size(MPI.comm_world) == 1,
+                                                                       reason="Shared ghost modes fail in serial"))])
+def test_ghost_mesh_dS_assembly(mode):
+    mesh = dolfin.generation.UnitSquareMesh(dolfin.MPI.comm_world, 12, 12,
+                                            dolfin.cpp.mesh.CellType.Type.triangle,
+                                            mode)
+    V = dolfin.FunctionSpace(mesh, ("Lagrange", 1))
+    u, v = dolfin.TrialFunction(V), dolfin.TestFunction(V)
+
+    a = inner(avg(u), avg(v)) * dS
+
+    # Initial assembly
+    A = dolfin.fem.assemble_matrix(a)
+    A.assemble()
+    assert isinstance(A, PETSc.Mat)
+
+    # Check that the norms are the same for all three modes
+    normA = A.norm()
+    print(normA)
+
+    assert normA == pytest.approx(2.1834054713561906, rel=1.e-6, abs=1.e-12)


### PR DESCRIPTION
Adds some unit tests for integrals with ghost cells, and fixes some resulting issues in assembler.
* mostly resolved by adjusting the list of `active_entities` in `FormIntegrals`
* Integrals on `dx`, `ds`, and `dS`
* Compares serial and parallel results for equality