### PR TITLE
Update URL to containers

### DIFF
--- a/python/doc/source/installation.rst
+++ b/python/doc/source/installation.rst
@@ -92,7 +92,7 @@ Docker container
 
 A Docker container is available at
 https://quay.io/repository/fenicsproject/dolfinx. The `Dockerfile
-<https://github.com/FEniCS/dolfinx/blob/master/Dockerfile>`_. Dockerfile
+<https://github.com/FEniCS/dolfinx/blob/master/Dockerfile>`_
 provides a definitive build recipe.
 
 

--- a/python/doc/source/installation.rst
+++ b/python/doc/source/installation.rst
@@ -91,7 +91,7 @@ Docker container
 ================
 
 A Docker container is available at
-https://hub.docker.com/r/fenicsproject/dolfinx/. The `Dockerfile
+https://quay.io/repository/fenicsproject/dolfinx. The `Dockerfile
 <https://github.com/FEniCS/dolfinx/blob/master/Dockerfile>`_. Dockerfile
 provides a definitive build recipe.
 


### PR DESCRIPTION
The [readthedocs page](https://fenicsproject.org/docs/dolfinx/dev/python/installation.html) still points to Docker Hub, not quay.io. This also removes a duplicate word in the documentation page.