### PR TITLE
Add a partitioning to python interface and some tests 

### DIFF
--- a/cpp/dolfin/mesh/Partitioning.cpp
+++ b/cpp/dolfin/mesh/Partitioning.cpp
@@ -155,13 +155,13 @@ std::tuple<EigenRowArrayXXi64, std::vector<std::int64_t>, std::vector<int>,
 distribute_cells(const MPI_Comm mpi_comm,
                  const Eigen::Ref<const EigenRowArrayXXi64> cell_vertices,
                  const std::vector<std::int64_t>& global_cell_indices,
-                 const PartitionData& mp)
+                 const PartitionData& cell_partition)
 {
   // This function takes the partition computed by the partitioner
-  // stored in PartitionData mp. Some cells go to multiple destinations.
-  // Each cell is transmitted to its final destination(s) including its
-  // global index, and the cell owner (for ghost cells this will be
-  // different from the destination)
+  // stored in PartitionData cell_partition. Some cells go to multiple
+  // destinations. Each cell is transmitted to its final destination(s)
+  // including its global index, and the cell owner (for ghost cells this will
+  // be different from the destination)
 
   LOG(INFO) << "Distribute cells during distributed mesh construction";
 
@@ -178,7 +178,7 @@ distribute_cells(const MPI_Comm mpi_comm,
   // Get dimensions
   const std::int32_t num_local_cells = cell_vertices.rows();
   const std::int32_t num_cell_vertices = cell_vertices.cols();
-  assert(mp.size() == num_local_cells);
+  assert(cell_partition.size() == num_local_cells);
 
   // Send all cells to their destinations including their global
   // indices.  First element of vector is cell count of un-ghosted
@@ -186,10 +186,10 @@ distribute_cells(const MPI_Comm mpi_comm,
   std::vector<std::vector<std::size_t>> send_cell_vertices(
       mpi_size, std::vector<std::size_t>(2, 0));
 
-  for (std::int32_t i = 0; i < mp.size(); ++i)
+  for (std::int32_t i = 0; i < cell_partition.size(); ++i)
   {
-    std::int32_t num_procs = mp.num_procs(i);
-    const std::int32_t* sharing_procs = mp.procs(i);
+    std::int32_t num_procs = cell_partition.num_procs(i);
+    const std::int32_t* sharing_procs = cell_partition.procs(i);
     for (std::int32_t j = 0; j < num_procs; ++j)
     {
       // Create reference to destination vector

--- a/cpp/test/unit/mesh/DistributedMesh.cpp
+++ b/cpp/test/unit/mesh/DistributedMesh.cpp
@@ -48,7 +48,7 @@ void test_distributed_mesh()
   EigenRowArrayXXi64 cells;
   std::vector<std::int64_t> global_cell_indices;
 
-  // Save mesh in XDMF format
+  // Read in mesh in mesh data from XDMF file
   io::XDMFFile infile(MPI_COMM_WORLD, "mesh.xdmf");
   std::tie(cell_type, points, cells, global_cell_indices)
       = infile.read_mesh_data(subset_comm);

--- a/python/dolfin/io.py
+++ b/python/dolfin/io.py
@@ -206,6 +206,13 @@ class XDMFFile:
         mesh.geometry.coord_mapping = fem.create_coordinate_map(mesh)
         return mesh
 
+    def read_mesh_data(self, mpi_comm):
+        """
+        Read in mesh data:
+        Cell type, geometric points, topological cells and global cell indices.
+        """
+        return self._cpp_object.read_mesh_data(mpi_comm)
+
     def read_checkpoint(self, V, name: str,
                         counter: int = -1) -> function.Function:
         """Read finite element Function from checkpointing format

--- a/python/src/io.cpp
+++ b/python/src/io.cpp
@@ -228,6 +228,10 @@ void io(py::module& m)
               const dolfin::mesh::GhostMode ghost_mode) {
              return self.read_mesh(ghost_mode);
            })
+      .def("read_mesh_data",
+           [](dolfin::io::XDMFFile& self, const MPICommWrapper comm) {
+             return self.read_mesh_data(comm.get());
+           })
       // MeshFunction
       .def("read_mf_int", &dolfin::io::XDMFFile::read_mf_int, py::arg("mesh"),
            py::arg("name") = "")

--- a/python/src/mesh.cpp
+++ b/python/src/mesh.cpp
@@ -19,6 +19,7 @@
 #include <dolfin/mesh/MeshQuality.h>
 #include <dolfin/mesh/MeshValueCollection.h>
 #include <dolfin/mesh/Ordering.h>
+#include <dolfin/mesh/PartitionData.h>
 #include <dolfin/mesh/Partitioning.h>
 #include <dolfin/mesh/Topology.h>
 #include <dolfin/mesh/cell_types.h>
@@ -325,6 +326,34 @@ void mesh(py::module& m)
       .def_static("order_simplex", &dolfin::mesh::Ordering::order_simplex)
       .def_static("is_ordered_simplex",
                   &dolfin::mesh::Ordering::is_ordered_simplex);
+
+  // dolfin::mesh::PartitionData class
+  py::class_<dolfin::mesh::PartitionData,
+             std::shared_ptr<dolfin::mesh::PartitionData>>(
+      m, "PartitionData", "PartitionData object")
+      .def("num_procs", &dolfin::mesh::PartitionData::num_procs);
+
+  // dolfin::mesh::Partitioning::partition_cells
+  m.def("partition_cells",
+        [](const MPICommWrapper comm, int nparts,
+           dolfin::mesh::CellType cell_type,
+           const Eigen::Ref<const dolfin::EigenRowArrayXXi64> cells,
+           std::string partitioner) {
+          return dolfin::mesh::Partitioning::partition_cells(
+              comm.get(), nparts, cell_type, cells, partitioner);
+        });
+
+  m.def("build_from_partition",
+        [](const MPICommWrapper comm, dolfin::mesh::CellType cell_type,
+           const Eigen::Ref<const dolfin::EigenRowArrayXXi64> cells,
+           const Eigen::Ref<const dolfin::EigenRowArrayXXd> points,
+           const std::vector<std::int64_t>& global_cell_indices,
+           dolfin::mesh::GhostMode ghost_mode,
+           dolfin::mesh::PartitionData& cell_partition) {
+          return dolfin::mesh::Partitioning::build_from_partition(
+              comm.get(), cell_type, cells, points, global_cell_indices,
+              ghost_mode, cell_partition);
+        });
 
 } // namespace dolfin_wrappers
 } // namespace dolfin_wrappers

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -431,9 +431,12 @@ def test_small_mesh():
 
 
 @pytest.mark.parametrize("mesh_factory", mesh_factories)
-def test_distribute_mesh(mesh_factory):
+def test_distribute_mesh(tempdir, mesh_factory):
     func, args = mesh_factory
     mesh = func(*args)
+
+    if not is_simplex(mesh.cell_type):
+        return
 
     # Order mesh
     cpp.mesh.Ordering.order_simplex(mesh)

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -478,6 +478,7 @@ def test_distribute_mesh(tempdir, mesh_factory):
     dim = dist_mesh2.topology.dim
     assert mesh.num_entities_global(dim) == dist_mesh2.num_entities_global(dim)
 
+
 def test_coords():
     mesh = UnitCubeMesh(MPI.comm_world, 4, 4, 5)
     d = mesh.coordinate_dofs().entity_points()


### PR DESCRIPTION
 - Python interface for reading mesh data: `XDMFfile.read_mesh_data(comm)`
 - add test: `test_read_mesh_data`
 - add `partition_cells` and `build_from_partition` to cpp.mesh
 - add new test for partitioning with a subset of processors