### PR TITLE
Avoid hiding ufl.Coefficient.__call__

### DIFF
--- a/cpp/dolfin/fem/assemble_matrix_impl.cpp
+++ b/cpp/dolfin/fem/assemble_matrix_impl.cpp
@@ -148,8 +148,8 @@ void fem::impl::assemble_cells(
     // Update coefficients
     for (std::size_t i = 0; i < coefficients.size(); ++i)
     {
-      coefficients[i]->restrict(coeff_array.data() + offsets[i], cell,
-                                coordinate_dofs);
+      coefficients[i]->restrict(cell, coordinate_dofs,
+                                coeff_array.data() + offsets[i]);
     }
 
     // Tabulate tensor
@@ -253,8 +253,8 @@ void fem::impl::assemble_exterior_facets(
     // Update coefficients
     for (std::size_t i = 0; i < coefficients.size(); ++i)
     {
-      coefficients[i]->restrict(coeff_array.data() + offsets[i], cell,
-                                coordinate_dofs);
+      coefficients[i]->restrict(cell, coordinate_dofs,
+                                coeff_array.data() + offsets[i]);
     }
 
     // Tabulate tensor
@@ -389,11 +389,11 @@ void fem::impl::assemble_interior_facets(
                          gdim);
     for (std::size_t i = 0; i < coefficients.size(); ++i)
     {
-      coefficients[i]->restrict(coeff_array.data() + offsets[i], cell0,
-                                coordinate_dofs0);
-      coefficients[i]->restrict(coeff_array.data() + offsets.back()
-                                    + offsets[i],
-                                cell1, coordinate_dofs1);
+      coefficients[i]->restrict(cell0, coordinate_dofs0,
+                                coeff_array.data() + offsets[i]);
+      coefficients[i]->restrict(cell1, coordinate_dofs1,
+                                coeff_array.data() + offsets.back()
+                                    + offsets[i]);
     }
 
     // Tabulate tensor

--- a/cpp/dolfin/fem/assemble_scalar_impl.cpp
+++ b/cpp/dolfin/fem/assemble_scalar_impl.cpp
@@ -127,8 +127,8 @@ PetscScalar fem::impl::assemble_cells(
     // Update coefficients
     for (std::size_t i = 0; i < coefficients.size(); ++i)
     {
-      coefficients[i]->restrict(coeff_array.data() + offsets[i], cell,
-                                coordinate_dofs);
+      coefficients[i]->restrict(cell, coordinate_dofs,
+                                coeff_array.data() + offsets[i]);
     }
 
     fn(&value, coeff_array.data(), constant_values.data(),
@@ -193,8 +193,8 @@ PetscScalar fem::impl::assemble_exterior_facets(
     // Update coefficients
     for (std::size_t i = 0; i < coefficients.size(); ++i)
     {
-      coefficients[i]->restrict(coeff_array.data() + offsets[i], cell,
-                                coordinate_dofs);
+      coefficients[i]->restrict(cell, coordinate_dofs,
+                                coeff_array.data() + offsets[i]);
     }
 
     fn(&value, coeff_array.data(), constant_values.data(),
@@ -273,11 +273,11 @@ PetscScalar fem::impl::assemble_interior_facets(
                          gdim);
     for (std::size_t i = 0; i < coefficients.size(); ++i)
     {
-      coefficients[i]->restrict(coeff_array.data() + offsets[i], cell0,
-                                coordinate_dofs0);
-      coefficients[i]->restrict(coeff_array.data() + offsets.back()
-                                    + offsets[i],
-                                cell1, coordinate_dofs1);
+      coefficients[i]->restrict(cell0, coordinate_dofs0,
+                                coeff_array.data() + offsets[i]);
+      coefficients[i]->restrict(cell1, coordinate_dofs1,
+                                coeff_array.data() + offsets.back()
+                                    + offsets[i]);
     }
 
     fn(&value, coeff_array.data(), constant_values.data(),

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -139,8 +139,8 @@ void _lift_bc_cells(
     // Update coefficients
     for (int i = 0; i < coefficients.size(); ++i)
     {
-      coefficients_ptr[i]->restrict(coeff_array.data() + n[i], cell,
-                                    coordinate_dofs);
+      coefficients_ptr[i]->restrict(cell, coordinate_dofs,
+                                    coeff_array.data() + n[i]);
     }
 
     Ae.setZero(dmap0.size(), dmap1.size());
@@ -298,8 +298,8 @@ void _lift_bc_exterior_facets(
     // Update coefficients
     for (int i = 0; i < coefficients.size(); ++i)
     {
-      coefficients_ptr[i]->restrict(coeff_array.data() + n[i], cell,
-                                    coordinate_dofs);
+      coefficients_ptr[i]->restrict(cell, coordinate_dofs,
+                                    coeff_array.data() + n[i]);
     }
 
     Ae.setZero(dmap0.size(), dmap1.size());
@@ -445,8 +445,8 @@ void fem::impl::assemble_cells(
     // Update coefficients
     for (std::size_t i = 0; i < coefficients.size(); ++i)
     {
-      coefficients[i]->restrict(coeff_array.data() + offsets[i], cell,
-                                coordinate_dofs);
+      coefficients[i]->restrict(cell, coordinate_dofs,
+                                coeff_array.data() + offsets[i]);
     }
 
     // Tabulate vector for cell
@@ -520,8 +520,8 @@ void fem::impl::assemble_exterior_facets(
     // Update coefficients
     for (std::size_t i = 0; i < coefficients.size(); ++i)
     {
-      coefficients[i]->restrict(coeff_array.data() + offsets[i], cell,
-                                coordinate_dofs);
+      coefficients[i]->restrict(cell, coordinate_dofs,
+                                coeff_array.data() + offsets[i]);
     }
 
     // Tabulate element vector
@@ -615,11 +615,11 @@ void fem::impl::assemble_interior_facets(
                          gdim);
     for (std::size_t i = 0; i < coefficients.size(); ++i)
     {
-      coefficients[i]->restrict(coeff_array.data() + offsets[i], cell0,
-                                coordinate_dofs0);
-      coefficients[i]->restrict(coeff_array.data() + offsets.back()
-                                    + offsets[i],
-                                cell1, coordinate_dofs1);
+      coefficients[i]->restrict(cell0, coordinate_dofs0,
+                                coeff_array.data() + offsets[i]);
+      coefficients[i]->restrict(cell1, coordinate_dofs1,
+                                coeff_array.data() + offsets.back()
+                                    + offsets[i]);
     }
 
     // Tabulate element vector

--- a/cpp/dolfin/function/Function.cpp
+++ b/cpp/dolfin/function/Function.cpp
@@ -149,11 +149,11 @@ la::PETScVector& Function::vector()
 //-----------------------------------------------------------------------------
 const la::PETScVector& Function::vector() const { return _vector; }
 //-----------------------------------------------------------------------------
-void Function::eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
+void Function::eval(const Eigen::Ref<const EigenRowArrayXXd> x,
+                    const geometry::BoundingBoxTree& bb_tree,
+                    Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
                                             Eigen::Dynamic, Eigen::RowMajor>>
-                        values,
-                    const Eigen::Ref<const EigenRowArrayXXd> x,
-                    const geometry::BoundingBoxTree& bb_tree) const
+                        u) const
 {
   assert(_function_space);
   assert(_function_space->mesh);
@@ -191,18 +191,18 @@ void Function::eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
     const mesh::MeshEntity cell(mesh, tdim, id);
 
     // Call evaluate function
-    eval(values.row(i), x.row(i), cell);
+    eval(x.row(i), cell, u.row(i));
   }
 }
 //-----------------------------------------------------------------------------
 void Function::eval(
-    Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
-                            Eigen::RowMajor>>
-        values,
     const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
                                         Eigen::RowMajor>>
         x,
-    const mesh::MeshEntity& cell) const
+    const mesh::MeshEntity& cell,
+    Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
+                            Eigen::RowMajor>>
+        u) const
 {
   // FIXME: This function needs to be changed to handle an arbitrary
   // number of points for efficiency
@@ -220,7 +220,7 @@ void Function::eval(
   const int tdim = mesh.topology().dim();
   assert(cell.dim() == tdim);
 
-  assert(x.rows() == values.rows());
+  assert(x.rows() == u.rows());
   assert(_function_space->element);
   const fem::FiniteElement& element = *_function_space->element;
 
@@ -247,7 +247,7 @@ void Function::eval(
     for (int j = 0; j < gdim; ++j)
       coordinate_dofs(i, j) = x_g(cell_g[pos_g[cell_index] + i], j);
 
-  restrict(coefficients.data(), cell, coordinate_dofs);
+  restrict(cell, coordinate_dofs, coefficients.data());
 
   // Get coordinate mapping
   std::shared_ptr<const fem::CoordinateMapping> cmap
@@ -285,7 +285,7 @@ void Function::eval(
                                     detJ, K);
 
   // Compute expansion
-  values.setZero();
+  u.setZero();
   for (std::size_t p = 0; p < num_points; ++p)
   {
     for (std::size_t i = 0; i < space_dimension; ++i)
@@ -293,7 +293,7 @@ void Function::eval(
       for (std::size_t j = 0; j < value_size; ++j)
       {
         // TODO: Find an Eigen shortcut fot this operation
-        values.row(p)[j] += coefficients[i] * basis_values(p, i, j);
+        u.row(p)[j] += coefficients[i] * basis_values(p, i, j);
       }
     }
   }
@@ -351,8 +351,9 @@ std::vector<int> Function::value_shape() const
 }
 //-----------------------------------------------------------------------------
 void Function::restrict(
-    PetscScalar* w, const mesh::MeshEntity& cell,
-    const Eigen::Ref<const EigenRowArrayXXd>& coordinate_dofs) const
+    const mesh::MeshEntity& cell,
+    const Eigen::Ref<const EigenRowArrayXXd>& coordinate_dofs,
+    PetscScalar* w) const
 {
   assert(w);
   assert(_function_space);
@@ -418,7 +419,7 @@ Function::compute_point_values() const
     values.resize(x.rows(), value_size_loc);
 
     // Call evaluate function
-    eval(values, x, cell);
+    eval(x, cell, values);
 
     // Copy values to array of point values
     const std::int32_t* dofs = cell_dofs.connections(cell.index());
@@ -427,6 +428,5 @@ Function::compute_point_values() const
   }
 
   return point_values;
-
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfin/function/Function.h
+++ b/cpp/dolfin/function/Function.h
@@ -147,49 +147,49 @@ public:
 
   /// Evaluate at given point in given cell
   ///
-  /// @param    values (Eigen::Ref<Eigen::VectorXd>)
-  ///         The values at the point.
   /// @param   x (Eigen::Ref<const Eigen::VectorXd>
   ///         The coordinates of the point.
   /// @param    cell (mesh::Cell)
   ///         The cell which contains the given point.
+  /// @param    u (Eigen::Ref<Eigen::VectorXd>)
+  ///         The values at the point.
   void
-  eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
-                               Eigen::RowMajor>>
-           values,
-       const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,
+  eval(const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,
                                            Eigen::Dynamic, Eigen::RowMajor>>
            x,
-       const mesh::MeshEntity& cell) const;
+       const mesh::MeshEntity& cell,
+       Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
+                               Eigen::RowMajor>>
+           u) const;
 
   /// Evaluate function at given coordinates
   ///
-  /// @param    values (Eigen::Ref<Eigen::VectorXd> values)
-  ///         The values.
   /// @param    x (Eigen::Ref<const Eigen::VectorXd> x)
   ///         The coordinates.
+  /// @param    u (Eigen::Ref<Eigen::VectorXd> u)
+  ///         The values.
   void
-  eval(Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
-                               Eigen::RowMajor>>
-           values,
-       const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,
+  eval(const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,
                                            Eigen::Dynamic, Eigen::RowMajor>>
            x,
-       const geometry::BoundingBoxTree& bb_tree) const;
+       const geometry::BoundingBoxTree& bb_tree,
+       Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
+                               Eigen::RowMajor>>
+           u) const;
 
   /// Restrict function to local cell (compute expansion coefficients w)
   ///
-  /// @param    w (list of PetscScalars)
-  ///         Expansion coefficients.
   /// @param    element (_FiniteElement_)
   ///         The element.
   /// @param    cell (_Cell_)
   ///         The cell.
   /// @param  coordinate_dofs (double *)
   ///         The coordinates
-  void
-  restrict(PetscScalar* w, const mesh::MeshEntity& cell,
-           const Eigen::Ref<const EigenRowArrayXXd>& coordinate_dofs) const;
+  /// @param    w (list of PetscScalars)
+  ///         Expansion coefficients.
+  void restrict(const mesh::MeshEntity& cell,
+                const Eigen::Ref<const EigenRowArrayXXd>& coordinate_dofs,
+                PetscScalar* w) const;
 
   /// Compute values at all mesh points
   ///

--- a/cpp/dolfin/function/FunctionSpace.cpp
+++ b/cpp/dolfin/function/FunctionSpace.cpp
@@ -111,7 +111,7 @@ void FunctionSpace::interpolate_from_any(
         coordinate_dofs(i, j) = x_g(cell_g[pos_g[cell_index] + i], j);
 
     // Restrict function to cell
-    v.restrict(cell_coefficients.data(), cell, coordinate_dofs);
+    v.restrict(cell, coordinate_dofs, cell_coefficients.data());
 
     // Tabulate dofs
     auto cell_dofs = dofmap->cell_dofs(cell.index());

--- a/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
+++ b/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
@@ -153,7 +153,7 @@ bb_tree = dolfin.cpp.geometry.BoundingBoxTree(mesh, 2)
 
 # Check against standard table value
 if bb_tree.collides([48.0, 52.0, 0.0]):
-    value = uc([48.0, 52.0], bb_tree)
+    value = uc.eval([48.0, 52.0], bb_tree)
     assert(numpy.isclose(value[1], 23.95, rtol=1.e-2))
 
 # Check the equality of displacement based and mixed condensed

--- a/python/demo/stokes-taylor-hood/demo_stokes-taylor-hood.py
+++ b/python/demo/stokes-taylor-hood/demo_stokes-taylor-hood.py
@@ -203,8 +203,7 @@ print("Norm of velocity coefficient vector: %.15g" % u.vector.norm())
 print("Norm of pressure coefficient vector: %.15g" % p.vector.norm())
 
 # Check pressure norm
-pnorm = p.vector.norm()
-assert np.isclose(pnorm, 4147.69457577)
+assert np.isclose(p.vector.norm(), 4147.69457577)
 
 # Finally, we can save and plot the solutions::
 

--- a/python/dolfin/function/function.py
+++ b/python/dolfin/function/function.py
@@ -83,32 +83,28 @@ class Function(ufl.Coefficient):
             # Scalar evaluation
             return self(*x)
 
-    # def __call__(self, x: np.ndarray, bb_tree: cpp.geometry.BoundingBoxTree) -> np.ndarray:
-    #     """Evaluate Function at points x, where x has shape (num_points, gdim)"""
-    #     _x = np.asarray(x, dtype=np.float)
-    #     num_points = _x.shape[0] if len(_x.shape) > 1 else 1
-    #     _x = np.reshape(_x, (num_points, -1))
-    #     if _x.shape[1] != self.geometric_dimension():
-    #         raise ValueError("Wrong geometric dimension for coordinate(s).")
-
-    #     value_size = ufl.product(self.ufl_element().value_shape())
-    #     if common.has_petsc_complex:
-    #         values = np.empty((num_points, value_size), dtype=np.complex128)
-    #     else:
-    #         values = np.empty((num_points, value_size))
-
-    #     # Call the evaluation
-    #     self._cpp_object.eval(values, _x, bb_tree)
-    #     if num_points == 1:
-    #         values = np.reshape(values, (-1, ))
-
-    #     return values
-
-    def eval_cell(self, u, x, cell):
+    def eval_cell(self, x, cell, u):
         return self._cpp_object.eval(u, x, cell)
 
-    def eval(self, u, x, bb_tree: cpp.geometry.BoundingBoxTree):
-        return self._cpp_object.eval(u, x, bb_tree)
+    def eval(self, x: np.ndarray, bb_tree: cpp.geometry.BoundingBoxTree, u=None) -> np.ndarray:
+        """Evaluate Function at points x, where x has shape (num_points, gdim)"""
+        _x = np.asarray(x, dtype=np.float)
+        num_points = _x.shape[0] if len(_x.shape) > 1 else 1
+        _x = np.reshape(_x, (num_points, -1))
+        if _x.shape[1] != self.geometric_dimension():
+            raise ValueError("Wrong geometric dimension for coordinate(s).")
+
+        if u is None:
+            value_size = ufl.product(self.ufl_element().value_shape())
+            if common.has_petsc_complex:
+                u = np.empty((num_points, value_size), dtype=np.complex128)
+            else:
+                u = np.empty((num_points, value_size))
+
+        self._cpp_object.eval(u, _x, bb_tree)
+        if num_points == 1:
+            u = np.reshape(u, (-1, ))
+        return u
 
     def interpolate(self, u) -> None:
         """Interpolate an expression"""

--- a/python/dolfin/function/function.py
+++ b/python/dolfin/function/function.py
@@ -84,12 +84,13 @@ class Function(ufl.Coefficient):
             return self(*x)
 
     def eval_cell(self, x: np.ndarray, cell, u):
-        return self._cpp_object.eval(u, x, cell)
+        u = self._cpp_object.eval_cell(x, cell, u)
+        return u
 
     def eval(self, x: np.ndarray, bb_tree: cpp.geometry.BoundingBoxTree, u=None) -> np.ndarray:
         """Evaluate Function at points x, where x has shape (num_points, gdim)"""
 
-        # Make sure input coordinate are a NumPy array
+        # Make sure input coordinates are a NumPy array
         x = np.asarray(x, dtype=np.float)
         assert x.ndim < 2
         num_points = x.shape[0] if x.ndim > 1 else 1
@@ -105,7 +106,7 @@ class Function(ufl.Coefficient):
             else:
                 u = np.empty((num_points, value_size))
 
-        self._cpp_object.eval(u, x, bb_tree)
+        self._cpp_object.eval(x, bb_tree, u)
         if num_points == 1:
             u = np.reshape(u, (-1, ))
         return u

--- a/python/dolfin/function/function.py
+++ b/python/dolfin/function/function.py
@@ -83,26 +83,26 @@ class Function(ufl.Coefficient):
             # Scalar evaluation
             return self(*x)
 
-    def __call__(self, x: np.ndarray, bb_tree: cpp.geometry.BoundingBoxTree) -> np.ndarray:
-        """Evaluate Function at points x, where x has shape (num_points, gdim)"""
-        _x = np.asarray(x, dtype=np.float)
-        num_points = _x.shape[0] if len(_x.shape) > 1 else 1
-        _x = np.reshape(_x, (num_points, -1))
-        if _x.shape[1] != self.geometric_dimension():
-            raise ValueError("Wrong geometric dimension for coordinate(s).")
+    # def __call__(self, x: np.ndarray, bb_tree: cpp.geometry.BoundingBoxTree) -> np.ndarray:
+    #     """Evaluate Function at points x, where x has shape (num_points, gdim)"""
+    #     _x = np.asarray(x, dtype=np.float)
+    #     num_points = _x.shape[0] if len(_x.shape) > 1 else 1
+    #     _x = np.reshape(_x, (num_points, -1))
+    #     if _x.shape[1] != self.geometric_dimension():
+    #         raise ValueError("Wrong geometric dimension for coordinate(s).")
 
-        value_size = ufl.product(self.ufl_element().value_shape())
-        if common.has_petsc_complex:
-            values = np.empty((num_points, value_size), dtype=np.complex128)
-        else:
-            values = np.empty((num_points, value_size))
+    #     value_size = ufl.product(self.ufl_element().value_shape())
+    #     if common.has_petsc_complex:
+    #         values = np.empty((num_points, value_size), dtype=np.complex128)
+    #     else:
+    #         values = np.empty((num_points, value_size))
 
-        # Call the evaluation
-        self._cpp_object.eval(values, _x, bb_tree)
-        if num_points == 1:
-            values = np.reshape(values, (-1, ))
+    #     # Call the evaluation
+    #     self._cpp_object.eval(values, _x, bb_tree)
+    #     if num_points == 1:
+    #         values = np.reshape(values, (-1, ))
 
-        return values
+    #     return values
 
     def eval_cell(self, u, x, cell):
         return self._cpp_object.eval(u, x, cell)

--- a/python/src/function.cpp
+++ b/python/src/function.cpp
@@ -89,22 +89,23 @@ void function(py::module& m)
                              &dolfin::function::Function::value_rank)
       .def_property_readonly("value_shape",
                              &dolfin::function::Function::value_shape)
-      .def("eval",
-           [](const dolfin::function::Function& self,
-              Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
-                                      Eigen::Dynamic, Eigen::RowMajor>>
-                  u,
-              const Eigen::Ref<const dolfin::EigenRowArrayXXd> x,
-              const dolfin::mesh::MeshEntity& cell) { self.eval(u, x, cell); },
+      .def("eval_cell",
+           py::overload_cast<
+               const Eigen::Ref<const dolfin::EigenRowArrayXXd>,
+               const dolfin::mesh::MeshEntity&,
+               Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
+                                       Eigen::Dynamic, Eigen::RowMajor>>>(
+               &dolfin::function::Function::eval, py::const_),
+           py::arg("x"), py::arg("cell"), py::arg("values"),
            "Evaluate Function (cell version)")
       .def("eval",
            py::overload_cast<
-               Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
-                                       Eigen::Dynamic, Eigen::RowMajor>>,
                const Eigen::Ref<const dolfin::EigenRowArrayXXd>,
-               const dolfin::geometry::BoundingBoxTree&>(
+               const dolfin::geometry::BoundingBoxTree&,
+               Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
+                                       Eigen::Dynamic, Eigen::RowMajor>>>(
                &dolfin::function::Function::eval, py::const_),
-           py::arg("values"), py::arg("x"), py::arg("bb_tree"),
+           py::arg("x"), py::arg("bb_tree"), py::arg("values"),
            "Evaluate Function")
       .def("compute_point_values",
            &dolfin::function::Function::compute_point_values,

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -133,7 +133,7 @@ def test_assign(V, W):
                 uu.assign(4 * u * u1)
 
 
-def test_call(R, V, W, Q, mesh):
+def test_eval(R, V, W, Q, mesh):
     u0 = Function(R)
     u1 = Function(V)
     u2 = Function(W)
@@ -165,12 +165,12 @@ def test_call(R, V, W, Q, mesh):
 
     x0 = (mesh.geometry.x(0) + mesh.geometry.x(1)) / 2.0
     tree = cpp.geometry.BoundingBoxTree(mesh, mesh.geometry.dim)
-    assert np.allclose(u3(x0, tree)[:3], u2(x0, tree), rtol=1e-15, atol=1e-15)
+    assert np.allclose(u3.eval(x0, tree)[:3], u2.eval(x0, tree), rtol=1e-15, atol=1e-15)
 
     with pytest.raises(ValueError):
-        u0([0, 0, 0, 0], tree)
+        u0.eval([0, 0, 0, 0], tree)
     with pytest.raises(ValueError):
-        u0([0, 0], tree)
+        u0.eval([0, 0], tree)
 
 
 def test_scalar_conditions(R):
@@ -246,12 +246,12 @@ def test_near_evaluations(R, mesh):
     offset = 0.99 * np.finfo(float).eps
 
     a_shift_x = np.array([a[0] - offset, a[1], a[2]])
-    assert round(u0(a, bb_tree)[0] - u0(a_shift_x, bb_tree)[0], 7) == 0
+    assert u0.eval(a, bb_tree)[0] == pytest.approx(u0.eval(a_shift_x, bb_tree)[0])
 
     a_shift_xyz = np.array([a[0] - offset / math.sqrt(3),
                             a[1] - offset / math.sqrt(3),
                             a[2] - offset / math.sqrt(3)])
-    assert round(u0(a, bb_tree)[0] - u0(a_shift_xyz, bb_tree)[0], 7) == 0
+    assert u0.eval(a, bb_tree)[0] == pytest.approx(u0.eval(a_shift_xyz, bb_tree)[0])
 
 
 def test_interpolation_rank1(W):


### PR DESCRIPTION
`ufl.Coefficient.__call__` was being hidden in the subclass `dolfin.Function`, and this messed up DG restrictions.

This change requires user to call the method `eval` to evaluate a Function at points.