### PR TITLE
More doxygen compliance

### DIFF
--- a/cpp/doc/Doxyfile
+++ b/cpp/doc/Doxyfile
@@ -762,7 +762,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/cpp/doc/Doxyfile
+++ b/cpp/doc/Doxyfile
@@ -2083,7 +2083,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = protected=private DOXYGEN_IGNORE
+PREDEFINED             = protected=private
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/cpp/dolfin/common/MPI.cpp
+++ b/cpp/dolfin/common/MPI.cpp
@@ -24,8 +24,6 @@ dolfin::MPI::Comm::Comm(MPI_Comm comm)
   }
   else
     _comm = MPI_COMM_NULL;
-
-  std::vector<double> x = {{1.0, 3.0}};
 }
 //-----------------------------------------------------------------------------
 dolfin::MPI::Comm::Comm(const Comm& comm) : Comm(comm._comm)

--- a/cpp/dolfin/common/MPI.cpp
+++ b/cpp/dolfin/common/MPI.cpp
@@ -59,11 +59,6 @@ std::uint32_t dolfin::MPI::Comm::rank() const
   return dolfin::MPI::rank(_comm);
 }
 //-----------------------------------------------------------------------------
-MPI_Comm dolfin::MPI::Comm::SubsetComm(int num_processes) const
-{
-  return dolfin::MPI::SubsetComm(_comm, num_processes);
-}
-//-----------------------------------------------------------------------------
 std::uint32_t dolfin::MPI::Comm::size() const
 {
   int size;

--- a/cpp/dolfin/common/MPI.h
+++ b/cpp/dolfin/common/MPI.h
@@ -64,9 +64,6 @@ public:
     /// hasn't already been initialised.
     std::uint32_t size() const;
 
-    /// Create a new comm with a subset of processes
-    MPI_Comm SubsetComm(int num_processes) const;
-
     /// Set a barrier (synchronization point)
     void barrier() const;
 
@@ -233,8 +230,8 @@ public:
   };
   template <typename T>
 
-    /// MPI Type
-    static MPI_Datatype mpi_type()
+  /// MPI Type
+  static MPI_Datatype mpi_type()
   {
     static_assert(dependent_false<T>::value, "Unknown MPI type");
     throw std::runtime_error("MPI data type unknown");
@@ -245,7 +242,8 @@ public:
   static std::map<MPI_Op, std::string> operation_map;
 };
 
-#ifndef DOXYGEN_IGNORE
+// Turn off doxygen for these template specialisations
+/// @cond
 // Specialisations for MPI_Datatypes
 template <>
 inline MPI_Datatype MPI::mpi_type<float>()
@@ -292,7 +290,7 @@ inline MPI_Datatype MPI::mpi_type<long long>()
 {
   return MPI_LONG_LONG;
 }
-#endif
+/// @endcond
 //---------------------------------------------------------------------------
 template <typename T>
 void dolfin::MPI::broadcast(MPI_Comm comm, std::vector<T>& value,
@@ -456,49 +454,6 @@ void dolfin::MPI::all_to_all(MPI_Comm comm,
   all_to_all_common(comm, in_values, out_values, offsets);
 }
 //---------------------------------------------------------------------------
-#ifndef DOXYGEN_IGNORE
-template <>
-inline void
-dolfin::MPI::all_to_all(MPI_Comm comm,
-                        const std::vector<std::vector<bool>>& in_values,
-                        std::vector<std::vector<bool>>& out_values)
-{
-  // Copy to short int
-  std::vector<std::vector<short int>> send(in_values.size());
-  for (std::size_t i = 0; i < in_values.size(); ++i)
-    send[i].assign(in_values[i].begin(), in_values[i].end());
-
-  // Communicate data
-  std::vector<std::vector<short int>> recv;
-  all_to_all(comm, send, recv);
-
-  // Copy back to bool
-  out_values.resize(recv.size());
-  for (std::size_t i = 0; i < recv.size(); ++i)
-    out_values[i].assign(recv[i].begin(), recv[i].end());
-}
-
-template <>
-inline void
-dolfin::MPI::all_to_all(MPI_Comm comm,
-                        const std::vector<std::vector<bool>>& in_values,
-                        std::vector<bool>& out_values)
-{
-  // Copy to short int
-  std::vector<std::vector<short int>> send(in_values.size());
-  for (std::size_t i = 0; i < in_values.size(); ++i)
-    send[i].assign(in_values[i].begin(), in_values[i].end());
-
-  // Communicate data
-  std::vector<short int> recv;
-  all_to_all(comm, send, recv);
-
-  // Copy back to bool
-  out_values.assign(recv.begin(), recv.end());
-}
-
-#endif
-//---------------------------------------------------------------------------
 template <typename T>
 void dolfin::MPI::scatter(MPI_Comm comm,
                           const std::vector<std::vector<T>>& in_values,
@@ -545,25 +500,6 @@ void dolfin::MPI::scatter(MPI_Comm comm,
                offsets.data(), mpi_type<T>(), out_value.data(), my_num_values,
                mpi_type<T>(), sending_process, comm);
 }
-//---------------------------------------------------------------------------
-#ifndef DOXYGEN_IGNORE
-template <>
-inline void dolfin::MPI::scatter(
-    MPI_Comm comm, const std::vector<std::vector<bool>>& in_values,
-    std::vector<bool>& out_value, std::uint32_t sending_process)
-{
-  // Copy data
-  std::vector<std::vector<short int>> in(in_values.size());
-  for (std::size_t i = 0; i < in_values.size(); ++i)
-    in[i] = std::vector<short int>(in_values[i].begin(), in_values[i].end());
-
-  std::vector<short int> out;
-  scatter(comm, in, out, sending_process);
-
-  out_value.resize(out.size());
-  std::copy(out.begin(), out.end(), out_value.begin());
-}
-#endif
 //---------------------------------------------------------------------------
 template <typename T>
 void dolfin::MPI::scatter(MPI_Comm comm, const std::vector<T>& in_values,

--- a/cpp/dolfin/common/MPI.h
+++ b/cpp/dolfin/common/MPI.h
@@ -227,13 +227,14 @@ public:
   /// all_reduce(MPI_Comm, Table&, MPI_Op)
   static MPI_Op MPI_AVG();
 
-  /// Return MPI data type
   template <typename T>
   struct dependent_false : std::false_type
   {
   };
   template <typename T>
-  static MPI_Datatype mpi_type()
+
+    /// MPI Type
+    static MPI_Datatype mpi_type()
   {
     static_assert(dependent_false<T>::value, "Unknown MPI type");
     throw std::runtime_error("MPI data type unknown");
@@ -244,6 +245,7 @@ public:
   static std::map<MPI_Op, std::string> operation_map;
 };
 
+#ifndef DOXYGEN_IGNORE
 // Specialisations for MPI_Datatypes
 template <>
 inline MPI_Datatype MPI::mpi_type<float>()
@@ -290,6 +292,7 @@ inline MPI_Datatype MPI::mpi_type<long long>()
 {
   return MPI_LONG_LONG;
 }
+#endif
 //---------------------------------------------------------------------------
 template <typename T>
 void dolfin::MPI::broadcast(MPI_Comm comm, std::vector<T>& value,
@@ -715,6 +718,7 @@ void dolfin::MPI::all_gather(MPI_Comm comm, const T in_value,
                 1, mpi_type<T>(), comm);
 }
 //---------------------------------------------------------------------------
+/// All reduce table
 template <typename T, typename X>
 T dolfin::MPI::all_reduce(MPI_Comm comm, const T& value, X op)
 {
@@ -783,14 +787,14 @@ void dolfin::MPI::send_recv(MPI_Comm comm, const std::vector<T>& send_value,
   MPI::send_recv(comm, send_value, dest, 0, recv_value, source, 0);
 }
 //---------------------------------------------------------------------------
-// Specialization for dolfin::log::Table class
-// NOTE: This function is not truly "all_reduce", it reduces to rank 0
-//       and returns zero Table on other ranks.
+/// Specialization for dolfin::log::Table class
+/// NOTE: This function is not truly "all_reduce", it reduces to rank 0
+///       and returns zero Table on other ranks.
 template <>
-Table dolfin::MPI::all_reduce(MPI_Comm, const Table&, MPI_Op);
+dolfin::Table dolfin::MPI::all_reduce(MPI_Comm, const Table&, MPI_Op);
 //---------------------------------------------------------------------------
-// Specialization for dolfin::log::Table class
+/// Specialization for dolfin::log::Table class
 template <>
-Table dolfin::MPI::avg(MPI_Comm, const Table&);
+dolfin::Table dolfin::MPI::avg(MPI_Comm, const Table&);
 //---------------------------------------------------------------------------
 } // namespace dolfin

--- a/cpp/dolfin/common/MPI.h
+++ b/cpp/dolfin/common/MPI.h
@@ -228,9 +228,9 @@ public:
   struct dependent_false : std::false_type
   {
   };
-  template <typename T>
 
   /// MPI Type
+  template <typename T>
   static MPI_Datatype mpi_type()
   {
     static_assert(dependent_false<T>::value, "Unknown MPI type");

--- a/cpp/dolfin/function/Function.h
+++ b/cpp/dolfin/function/Function.h
@@ -68,7 +68,7 @@ public:
   Function& operator=(const Function& v) = delete;
 
   /// Extract subfunction (view into the Function)
-  /// @param[i] i Index of subfunction
+  /// @param[in] i Index of subfunction
   /// @return The subfunction
   Function sub(int i) const;
 

--- a/cpp/dolfin/io/HDF5Interface.h
+++ b/cpp/dolfin/io/HDF5Interface.h
@@ -175,7 +175,7 @@ private:
     return 0;
   }
 };
-#ifndef DOXYGEN_IGNORE
+/// @cond
 //---------------------------------------------------------------------------
 template <>
 inline hid_t HDF5Interface::hdf5_type<float>()
@@ -652,6 +652,6 @@ inline void HDF5Interface::get_attribute_value(const hid_t attr_type,
   assert(status != HDF5_FAIL);
 }
 //---------------------------------------------------------------------------
-#endif
+/// @endcond
 } // namespace io
 } // namespace dolfin


### PR DESCRIPTION
* Final clean-up required to run doxygen with warn=error
* Removes some outdated MPI wrappers
* Uses doxygen `@cond` command to comment out regions (template specialisations) 