### PR TITLE
Simplify Function::eval interface

### DIFF
--- a/cpp/dolfin/function/Function.cpp
+++ b/cpp/dolfin/function/Function.cpp
@@ -202,7 +202,7 @@ void Function::eval(
         "fem::CoordinateMapping has not been attached to mesh.");
   }
 
-  // Get elemet
+  // Get element
   assert(_function_space->element());
   const fem::FiniteElement& element = *_function_space->element();
   const int reference_value_size = element.reference_value_size();
@@ -259,7 +259,7 @@ void Function::eval(
     {
       for (int j = 0; j < value_size; ++j)
       {
-        // TODO: Find an Eigen shortcut fot this operation
+        // TODO: Find an Eigen shortcut for this operation
         u.row(p)[j] += coefficients[i] * basis_values(0, i, j);
       }
     }

--- a/cpp/dolfin/function/Function.cpp
+++ b/cpp/dolfin/function/Function.cpp
@@ -161,10 +161,15 @@ void Function::eval(
   // FIXME: This function needs to be changed to handle an arbitrary
   // number of points for efficiency
 
+  if (x.rows() != cells.rows())
+  {
+    throw std::runtime_error(
+        "Number of points and number of cells must be equal.");
+  }
+
   assert(_function_space);
   assert(_function_space->mesh());
   const mesh::Mesh& mesh = *_function_space->mesh();
-
   const int gdim = mesh.geometry().dim();
   const int tdim = mesh.topology().dim();
 
@@ -176,14 +181,14 @@ void Function::eval(
   Eigen::Matrix<PetscScalar, 1, Eigen::Dynamic> coefficients(
       element.space_dimension());
 
-  // Cell coordinates (re-allocated inside function for thread safety)
-  // Prepare cell geometry
+  // Get geometry data
   const mesh::Connectivity& connectivity_g
       = mesh.coordinate_dofs().entity_points();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g
       = connectivity_g.connections();
+
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = connectivity_g.size(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
@@ -199,41 +204,36 @@ void Function::eval(
         "fem::CoordinateMapping has not been attached to mesh.");
   }
 
-  // -- here
-  if (x.rows() != cells.rows())
-  {
-    throw std::runtime_error(
-        "Number of points and number of cells must be equal.");
-  }
+  const std::size_t reference_value_size = element.reference_value_size();
+  const std::size_t value_size = element.value_size();
+  const std::size_t space_dimension = element.space_dimension();
 
-  // std::size_t num_points = x.rows();
-  std::size_t reference_value_size = element.reference_value_size();
-  std::size_t value_size = element.value_size();
-  std::size_t space_dimension = element.space_dimension();
-
+  // Prepare geometry data structures
   Eigen::Tensor<double, 3, Eigen::RowMajor> J(1, gdim, tdim);
   EigenArrayXd detJ(1);
   Eigen::Tensor<double, 3, Eigen::RowMajor> K(1, tdim, gdim);
   EigenRowArrayXXd X(1, tdim);
 
+  // Prepare basis function data structures
   Eigen::Tensor<double, 3, Eigen::RowMajor> basis_reference_values(
       1, space_dimension, reference_value_size);
   Eigen::Tensor<double, 3, Eigen::RowMajor> basis_values(1, space_dimension,
                                                          value_size);
 
+  // Loop over points
   u.setZero();
   for (int p = 0; p < cells.rows(); ++p)
   {
     const int cell_index = cells(p);
+
+    // Skip negative cell indices
     if (cell_index < 0)
       break;
 
+    // Get cell geometry (coordinate dofs)
     for (int i = 0; i < num_dofs_g; ++i)
       for (int j = 0; j < gdim; ++j)
         coordinate_dofs(i, j) = x_g(cell_g[pos_g[cell_index] + i], j);
-
-    const mesh::MeshEntity cell(mesh, tdim, cell_index);
-    restrict(cell, coordinate_dofs, coefficients.data());
 
     // Compute reference coordinates X, and J, detJ and K
     cmap->compute_reference_geometry(X, J, detJ, K, x.row(p), coordinate_dofs);
@@ -245,67 +245,20 @@ void Function::eval(
     element.transform_reference_basis(basis_values, basis_reference_values, X,
                                       J, detJ, K);
 
+    // Get degrees of freedom for current cell
+    const mesh::MeshEntity cell(mesh, tdim, cell_index);
+    restrict(cell, coordinate_dofs, coefficients.data());
+
     // Compute expansion
     for (std::size_t i = 0; i < space_dimension; ++i)
     {
       for (std::size_t j = 0; j < value_size; ++j)
       {
         // TODO: Find an Eigen shortcut fot this operation
-        u.row(p)[j] += coefficients[i] * basis_values(p, i, j);
+        u.row(p)[j] += coefficients[i] * basis_values(0, i, j);
       }
     }
   }
-
-  // const int cell_index = cell.index();
-  // for (int i = 0; i < num_dofs_g; ++i)
-  //   for (int j = 0; j < gdim; ++j)
-  //     coordinate_dofs(i, j) = x_g(cell_g[pos_g[cell_index] + i], j);
-
-  // restrict(cell, coordinate_dofs, coefficients.data());
-
-  // Get coordinate mapping
-  // std::shared_ptr<const fem::CoordinateMapping> cmap
-  //     = mesh.geometry().coord_mapping;
-  // if (!cmap)
-  // {
-  //   throw std::runtime_error(
-  //       "fem::CoordinateMapping has not been attached to mesh.");
-  // }
-
-  // Eigen::Tensor<double, 3, Eigen::RowMajor> J(num_points, gdim, tdim);
-  // EigenArrayXd detJ(num_points);
-  // Eigen::Tensor<double, 3, Eigen::RowMajor> K(num_points, tdim, gdim);
-
-  // EigenRowArrayXXd X(x.rows(), tdim);
-  // Eigen::Tensor<double, 3, Eigen::RowMajor> basis_reference_values(
-  //     num_points, space_dimension, reference_value_size);
-
-  // Eigen::Tensor<double, 3, Eigen::RowMajor> basis_values(
-  //     num_points, space_dimension, value_size);
-
-  // Compute reference coordinates X, and J, detJ and K
-  // cmap->compute_reference_geometry(X, J, detJ, K, x, coordinate_dofs);
-
-  // // Compute basis on reference element
-  // element.evaluate_reference_basis(basis_reference_values, X);
-
-  // // Push basis forward to physical element
-  // element.transform_reference_basis(basis_values, basis_reference_values, X,
-  // J,
-  //                                   detJ, K);
-
-  // // Compute expansion
-  // // for (std::size_t p = 0; p < num_points; ++p)
-  // // {
-  // for (std::size_t i = 0; i < space_dimension; ++i)
-  // {
-  //   for (std::size_t j = 0; j < value_size; ++j)
-  //   {
-  //     // TODO: Find an Eigen shortcut fot this operation
-  //     u.row(p)[j] += coefficients[i] * basis_values(p, i, j);
-  //   }
-  // }
-  // // }
 }
 //-----------------------------------------------------------------------------
 void Function::interpolate(const Function& v)

--- a/cpp/dolfin/function/Function.cpp
+++ b/cpp/dolfin/function/Function.cpp
@@ -253,9 +253,9 @@ void Function::eval(
     restrict(cell, coordinate_dofs, coefficients.data());
 
     // Compute expansion
-    for (std::size_t i = 0; i < space_dimension; ++i)
+    for (int i = 0; i < space_dimension; ++i)
     {
-      for (std::size_t j = 0; j < value_size; ++j)
+      for (int j = 0; j < value_size; ++j)
       {
         // TODO: Find an Eigen shortcut fot this operation
         u.row(p)[j] += coefficients[i] * basis_values(0, i, j);

--- a/cpp/dolfin/function/Function.h
+++ b/cpp/dolfin/function/Function.h
@@ -112,7 +112,7 @@ public:
 
   /// Evaluate at given point in given cell
   /// @param[in] x The coordinates of the points
-  /// @param[in] cell The cell which contains the given point
+  /// @param[in] cells The cell which contains the given point
   /// @param[in,out] u The values at the points
   void
   eval(const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,

--- a/cpp/dolfin/function/Function.h
+++ b/cpp/dolfin/function/Function.h
@@ -111,11 +111,14 @@ public:
   std::vector<int> value_shape() const;
 
   /// Evaluate the Function at points
-  /// @param[in] x The coordinates of the points
-  /// @param[in] cells The index of the cell which contains each point.
-  ///            Negative indices are ignored.
+  /// @param[in] x The coordinates of the points. It has shape
+  ///              (num_points, gdim).
+  /// @param[in] cells An array of cell indices. cells[i] is the index
+  ///                  of the cell that contains the point x(i).
+  ///                  Negative cell indices can be passed, and the
+  ///                  corresponding point will be ignored.
   /// @param[in,out] u The values at the points. Values are not computed
-  ///                  for points with a negative cel index. This
+  ///                  for points with a negative cell index. This
   ///                  argument must be passed with the corrext size.
   void
   eval(const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,

--- a/cpp/dolfin/function/Function.h
+++ b/cpp/dolfin/function/Function.h
@@ -110,10 +110,13 @@ public:
   /// Return value shape
   std::vector<int> value_shape() const;
 
-  /// Evaluate at given point in given cell
+  /// Evaluate the Function at points
   /// @param[in] x The coordinates of the points
-  /// @param[in] cells The cell which contains the given point
-  /// @param[in,out] u The values at the points
+  /// @param[in] cells The index of the cell which contains each point.
+  ///            Negative indices are ignored.
+  /// @param[in,out] u The values at the points. Values are not computed
+  ///                  for points with a negative cel index. This
+  ///                  argument must be passed with the corrext size.
   void
   eval(const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,
                                            Eigen::Dynamic, Eigen::RowMajor>>

--- a/cpp/dolfin/function/Function.h
+++ b/cpp/dolfin/function/Function.h
@@ -118,20 +118,7 @@ public:
   eval(const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,
                                            Eigen::Dynamic, Eigen::RowMajor>>
            x,
-       const mesh::MeshEntity& cell,
-       Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
-                               Eigen::RowMajor>>
-           u) const;
-
-  /// Evaluate function at given coordinates
-  /// @param[in] x The coordinates of the points
-  /// @param[in] bb_tree Bounding box tree for the mesh
-  /// @param[in,out] u The values at the points
-  void
-  eval(const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,
-                                           Eigen::Dynamic, Eigen::RowMajor>>
-           x,
-       const geometry::BoundingBoxTree& bb_tree,
+       const Eigen::Ref<const Eigen::Array<int, Eigen::Dynamic, 1>> cells,
        Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic,
                                Eigen::RowMajor>>
            u) const;

--- a/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
+++ b/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
@@ -152,8 +152,9 @@ A.assemble()
 bb_tree = dolfin.cpp.geometry.BoundingBoxTree(mesh, 2)
 
 # Check against standard table value
-if dolfin.cpp.geometry.compute_first_collision(bb_tree, [48.0, 52.0, 0.0]) >= 0:
-    value = uc.eval([48.0, 52.0], bb_tree)
+cell = dolfin.cpp.geometry.compute_first_collision(bb_tree, [48.0, 52.0, 0.0])
+if cell  >= 0:
+    value = uc.eval([48.0, 52.0], numpy.asarray(cell))
     assert numpy.isclose(value[1], 23.95, rtol=1.e-2)
 
 # Check the equality of displacement based and mixed condensed global

--- a/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
+++ b/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
@@ -153,7 +153,7 @@ bb_tree = dolfin.cpp.geometry.BoundingBoxTree(mesh, 2)
 
 # Check against standard table value
 cell = dolfin.cpp.geometry.compute_first_collision(bb_tree, [48.0, 52.0, 0.0])
-if cell  >= 0:
+if cell >= 0:
     value = uc.eval([48.0, 52.0], numpy.asarray(cell))
     assert numpy.isclose(value[1], 23.95, rtol=1.e-2)
 

--- a/python/dolfin/function.py
+++ b/python/dolfin/function.py
@@ -82,7 +82,10 @@ class Function(ufl.Coefficient):
             return self(*x)
 
     def eval(self, x: np.ndarray, cells: np.ndarray, u=None) -> np.ndarray:
-        """Evaluate Function at points x, where x has shape (num_points, gdim)"""
+        """Evaluate Function at points x, where x has shape (num_points, gdim),
+        and cells has shape (num_points,) and cell[i] is the index of the
+        cell containing point x[i]. If the cell index is negative the
+        point is ignored."""
 
         # Make sure input coordinates are a NumPy array
         x = np.asarray(x, dtype=np.float)

--- a/python/dolfin/function.py
+++ b/python/dolfin/function.py
@@ -12,8 +12,7 @@ import numpy as np
 from petsc4py import PETSc
 
 import ufl
-from dolfin import common, cpp, function
-from dolfin import functionspace
+from dolfin import common, cpp, function, functionspace
 
 
 class Function(ufl.Coefficient):
@@ -64,8 +63,8 @@ class Function(ufl.Coefficient):
 
     def ufl_evaluate(self, x, component, derivatives):
         """Function used by ufl to evaluate the Expression"""
-        # FIXME: same as dolfin.expression.Expression version. Find
-        # way to re-use.
+        # FIXME: same as dolfin.expression.Expression version. Find way
+        # to re-use.
         assert derivatives == ()  # TODO: Handle derivatives
 
         if component:
@@ -82,11 +81,7 @@ class Function(ufl.Coefficient):
             # Scalar evaluation
             return self(*x)
 
-    # def eval_cell(self, x: np.ndarray, cells, u):
-    #     u = self._cpp_object.eval_cell(x, cells, u)
-    #     return u
-
-    def eval(self, x: np.ndarray, cells, u=None) -> np.ndarray:
+    def eval(self, x: np.ndarray, cells: np.ndarray, u=None) -> np.ndarray:
         """Evaluate Function at points x, where x has shape (num_points, gdim)"""
 
         # Make sure input coordinates are a NumPy array

--- a/python/dolfin/function.py
+++ b/python/dolfin/function.py
@@ -92,7 +92,7 @@ class Function(ufl.Coefficient):
         if x.shape[1] != self.geometric_dimension():
             raise ValueError("Wrong geometric dimension for coordinate(s).")
 
-        # Allocate memory for return value is not provided
+        # Allocate memory for return value if not provided
         if u is None:
             value_size = ufl.product(self.ufl_element().value_shape())
             if common.has_petsc_complex:

--- a/python/dolfin/function.py
+++ b/python/dolfin/function.py
@@ -82,11 +82,11 @@ class Function(ufl.Coefficient):
             # Scalar evaluation
             return self(*x)
 
-    def eval_cell(self, x: np.ndarray, cell, u):
-        u = self._cpp_object.eval_cell(x, cell, u)
-        return u
+    # def eval_cell(self, x: np.ndarray, cells, u):
+    #     u = self._cpp_object.eval_cell(x, cells, u)
+    #     return u
 
-    def eval(self, x: np.ndarray, bb_tree: cpp.geometry.BoundingBoxTree, u=None) -> np.ndarray:
+    def eval(self, x: np.ndarray, cells, u=None) -> np.ndarray:
         """Evaluate Function at points x, where x has shape (num_points, gdim)"""
 
         # Make sure input coordinates are a NumPy array
@@ -105,7 +105,7 @@ class Function(ufl.Coefficient):
             else:
                 u = np.empty((num_points, value_size))
 
-        self._cpp_object.eval(x, bb_tree, u)
+        self._cpp_object.eval(x, [cells], u)
         if num_points == 1:
             u = np.reshape(u, (-1, ))
         return u

--- a/python/dolfin/function.py
+++ b/python/dolfin/function.py
@@ -89,11 +89,17 @@ class Function(ufl.Coefficient):
 
         # Make sure input coordinates are a NumPy array
         x = np.asarray(x, dtype=np.float)
-        assert x.ndim < 2
-        num_points = x.shape[0] if x.ndim > 1 else 1
+        assert x.ndim < 3
+        num_points = x.shape[0] if x.ndim == 2 else 1
         x = np.reshape(x, (num_points, -1))
         if x.shape[1] != self.geometric_dimension():
             raise ValueError("Wrong geometric dimension for coordinate(s).")
+
+        # Make sure cells are a NumPy array
+        cells = np.asarray(cells)
+        assert cells.ndim < 2
+        num_points_c = cells.shape[0] if cells.ndim == 1 else 1
+        cells = np.reshape(cells, num_points_c)
 
         # Allocate memory for return value if not provided
         if u is None:
@@ -103,7 +109,7 @@ class Function(ufl.Coefficient):
             else:
                 u = np.empty((num_points, value_size))
 
-        self._cpp_object.eval(x, [cells], u)
+        self._cpp_object.eval(x, cells, u)
         if num_points == 1:
             u = np.reshape(u, (-1, ))
         return u

--- a/python/src/function.cpp
+++ b/python/src/function.cpp
@@ -89,24 +89,8 @@ void function(py::module& m)
                              &dolfin::function::Function::value_rank)
       .def_property_readonly("value_shape",
                              &dolfin::function::Function::value_shape)
-      .def("eval_cell",
-           py::overload_cast<
-               const Eigen::Ref<const dolfin::EigenRowArrayXXd>,
-               const dolfin::mesh::MeshEntity&,
-               Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
-                                       Eigen::Dynamic, Eigen::RowMajor>>>(
-               &dolfin::function::Function::eval, py::const_),
-           py::arg("x"), py::arg("cell"), py::arg("values"),
-           "Evaluate Function (cell version)")
-      .def("eval",
-           py::overload_cast<
-               const Eigen::Ref<const dolfin::EigenRowArrayXXd>,
-               const dolfin::geometry::BoundingBoxTree&,
-               Eigen::Ref<Eigen::Array<PetscScalar, Eigen::Dynamic,
-                                       Eigen::Dynamic, Eigen::RowMajor>>>(
-               &dolfin::function::Function::eval, py::const_),
-           py::arg("x"), py::arg("bb_tree"), py::arg("values"),
-           "Evaluate Function")
+      .def("eval", &dolfin::function::Function::eval, py::arg("x"),
+           py::arg("cells"), py::arg("values"), "Evaluate Function")
       .def("compute_point_values",
            &dolfin::function::Function::compute_point_values,
            "Compute values at all mesh points")
@@ -135,7 +119,8 @@ void function(py::module& m)
       .def("collapse", &dolfin::function::FunctionSpace::collapse)
       .def("component", &dolfin::function::FunctionSpace::component)
       .def("contains", &dolfin::function::FunctionSpace::contains)
-      .def_property_readonly("element", &dolfin::function::FunctionSpace::element)
+      .def_property_readonly("element",
+                             &dolfin::function::FunctionSpace::element)
       .def_property_readonly("mesh", &dolfin::function::FunctionSpace::mesh)
       .def_property_readonly("dofmap", &dolfin::function::FunctionSpace::dofmap)
       .def("set_x", &dolfin::function::FunctionSpace::set_x)

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -182,7 +182,7 @@ def test_eval_multiple(W):
     x = np.array([x0, x0 + 1.0e8])
     tree = geometry.BoundingBoxTree(mesh, W.mesh.geometry.dim)
     cells = geometry.compute_first_entity_collision(tree, mesh, x)
-    f = u.eval(x[0], 0)
+    u.eval(x[0], cells[0])
 
 
 def test_scalar_conditions(R):

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -166,8 +166,8 @@ def test_eval(R, V, W, Q, mesh):
 
     x0 = (mesh.geometry.x(0) + mesh.geometry.x(1)) / 2.0
     tree = geometry.BoundingBoxTree(mesh, mesh.geometry.dim)
-    cells = geometry.compute_first_entity_collision(tree, mesh)
-    assert np.allclose(u3.eval(x0, tree)[:3], u2.eval(x0, tree), rtol=1e-15, atol=1e-15)
+    cells = geometry.compute_first_entity_collisions(tree, mesh)
+    assert np.allclose(u3.eval(x0, cells)[:3], u2.eval(x0, cells), rtol=1e-15, atol=1e-15)
 
     with pytest.raises(ValueError):
         u0.eval([0, 0, 0, 0], tree)

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -166,9 +166,8 @@ def test_eval(R, V, W, Q, mesh):
 
     x0 = (mesh.geometry.x(0) + mesh.geometry.x(1)) / 2.0
     tree = geometry.BoundingBoxTree(mesh, mesh.geometry.dim)
-    cells = geometry.compute_first_entity_collisions(tree, mesh)
+    cells = geometry.compute_first_entity_collision(tree, mesh, x0)
     assert np.allclose(u3.eval(x0, cells)[:3], u2.eval(x0, cells), rtol=1e-15, atol=1e-15)
-
     with pytest.raises(ValueError):
         u0.eval([0, 0, 0, 0], tree)
     with pytest.raises(ValueError):

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -15,7 +15,8 @@ from petsc4py import PETSc
 
 import ufl
 from dolfin import (MPI, Function, FunctionSpace, TensorFunctionSpace,
-                    UnitCubeMesh, VectorFunctionSpace, cpp, interpolate)
+                    UnitCubeMesh, VectorFunctionSpace, cpp, geometry,
+                    interpolate)
 from dolfin_utils.test.fixtures import fixture
 from dolfin_utils.test.skips import skip_if_complex, skip_in_parallel
 
@@ -164,7 +165,8 @@ def test_eval(R, V, W, Q, mesh):
     u3.interpolate(e3)
 
     x0 = (mesh.geometry.x(0) + mesh.geometry.x(1)) / 2.0
-    tree = cpp.geometry.BoundingBoxTree(mesh, mesh.geometry.dim)
+    tree = geometry.BoundingBoxTree(mesh, mesh.geometry.dim)
+    cells = geometry.compute_first_entity_collision(tree, mesh)
     assert np.allclose(u3.eval(x0, tree)[:3], u2.eval(x0, tree), rtol=1e-15, atol=1e-15)
 
     with pytest.raises(ValueError):

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -169,9 +169,20 @@ def test_eval(R, V, W, Q, mesh):
     cells = geometry.compute_first_entity_collision(tree, mesh, x0)
     assert np.allclose(u3.eval(x0, cells)[:3], u2.eval(x0, cells), rtol=1e-15, atol=1e-15)
     with pytest.raises(ValueError):
-        u0.eval([0, 0, 0, 0], tree)
+        u0.eval([0, 0, 0, 0], 0)
     with pytest.raises(ValueError):
-        u0.eval([0, 0], tree)
+        u0.eval([0, 0], 0)
+
+
+def test_eval_multiple(W):
+    u = Function(W)
+    u.vector.set(1.0)
+    mesh = W.mesh
+    x0 = (mesh.geometry.x(0) + mesh.geometry.x(1)) / 2.0
+    x = np.array([x0, x0 + 1.0e8])
+    tree = geometry.BoundingBoxTree(mesh, W.mesh.geometry.dim)
+    cells = geometry.compute_first_entity_collision(tree, mesh, x)
+    f = u.eval(x[0], 0)
 
 
 def test_scalar_conditions(R):


### PR DESCRIPTION
This changes the `Function` `eval` interface to take (i) a list of points and (ii) a list of cells indices that contain each point. Points with negative cell indices are ignored (the bounding box search now returns a negative index when the cell containing a point is not found). This makes point evaluations in parallel much simpler.

The change makes what is happening behind `eval` explicit and removes a ton of opaque magic behind the scenes, e.g. cell searches, assumptions on what to do when a point is 'close' to a cell but not within it, etc. Now allowing an arbitrary number of points to be processed permits a number of performance optimisations and minimises dynamics memory allocations.

Example usage:
```
x = numpy.array(......)
tree = geometry.BoundingBoxTree(mesh, mesh.geometry.dim)
cells = geometry.compute_first_entity_collision(tree, mesh, x)
f = u.eval(x, cells)
```

The is scope for a further optimisation is the user passes in points that are groups by the cell that contains them.