### PR TITLE
Fixes bug introduced in PR 532

### DIFF
--- a/cpp/dolfin/io/HDF5File.cpp
+++ b/cpp/dolfin/io/HDF5File.cpp
@@ -292,8 +292,9 @@ void HDF5File::write(const mesh::Mesh& mesh, int cell_dim,
     const auto& global_vertices = mesh.topology().global_indices(0);
 
     // Permutation to VTK ordering
+    int num_nodes = mesh.coordinate_dofs().cell_permutation().size();
     const std::vector<std::uint8_t> perm
-        = mesh::vtk_mapping(cell_type, mesh.degree());
+        = mesh::vtk_mapping(mesh.cell_type(), num_nodes);
 
     if (cell_dim == tdim or !mpi_io)
     {

--- a/cpp/dolfin/io/HDF5File.cpp
+++ b/cpp/dolfin/io/HDF5File.cpp
@@ -293,7 +293,7 @@ void HDF5File::write(const mesh::Mesh& mesh, int cell_dim,
 
     // Permutation to VTK ordering
     const std::vector<std::uint8_t> perm
-        = mesh.coordinate_dofs().cell_permutation();
+        = mesh::vtk_mapping(cell_type, mesh.degree());
 
     if (cell_dim == tdim or !mpi_io)
     {

--- a/cpp/dolfin/io/VTKWriter.cpp
+++ b/cpp/dolfin/io/VTKWriter.cpp
@@ -163,9 +163,8 @@ void write_ascii_mesh(const mesh::Mesh& mesh, std::size_t cell_dim,
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
   int num_nodes = mesh.coordinate_dofs().cell_permutation().size();
-  mesh::CellType cell_type = mesh::cell_entity_type(mesh.cell_type(), cell_dim);
   const std::vector<std::uint8_t> perm
-      = mesh::vtk_mapping(cell_type, num_nodes);
+      = mesh::vtk_mapping(mesh.cell_type(), num_nodes);
 
   for (int j = 0; j < mesh.num_entities(mesh.topology().dim()); ++j)
   {

--- a/cpp/dolfin/io/VTKWriter.cpp
+++ b/cpp/dolfin/io/VTKWriter.cpp
@@ -162,9 +162,10 @@ void write_ascii_mesh(const mesh::Mesh& mesh, std::size_t cell_dim,
       cell_connections = connectivity_g.connections();
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> pos_g
       = connectivity_g.entity_positions();
+  int num_nodes = mesh.coordinate_dofs().cell_permutation().size();
+  mesh::CellType cell_type = mesh::cell_entity_type(mesh.cell_type(), cell_dim);
   const std::vector<std::uint8_t> perm
-      = mesh.coordinate_dofs().cell_permutation();
-  int num_nodes = perm.size();
+      = mesh::vtk_mapping(cell_type, num_nodes);
 
   for (int j = 0; j < mesh.num_entities(mesh.topology().dim()); ++j)
   {

--- a/cpp/dolfin/io/xdmf_write.cpp
+++ b/cpp/dolfin/io/xdmf_write.cpp
@@ -211,9 +211,8 @@ std::vector<std::int64_t> compute_topology_data(const mesh::Mesh& mesh,
   MPI_Comm comm = mesh.mpi_comm();
 
   int num_nodes = mesh.coordinate_dofs().cell_permutation().size();
-  mesh::CellType cell_type = mesh::cell_entity_type(mesh.cell_type(), cell_dim);
   const std::vector<std::uint8_t> perm
-      = mesh::vtk_mapping(cell_type, num_nodes);
+      = mesh::vtk_mapping(mesh.cell_type(), num_nodes);
 
   const int tdim = mesh.topology().dim();
   const auto& global_vertices = mesh.topology().global_indices(0);
@@ -562,10 +561,8 @@ void xdmf_write::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
     num_nodes_per_cell = cell_points.size(0);
     topology_data.reserve(num_nodes_per_cell * mesh.num_entities(tdim));
     int num_nodes = mesh.coordinate_dofs().cell_permutation().size();
-    mesh::CellType cell_type
-        = mesh::cell_entity_type(mesh.cell_type(), cell_dim);
     const std::vector<std::uint8_t> perm
-        = mesh::vtk_mapping(cell_type, num_nodes);
+        = mesh::vtk_mapping(mesh.cell_type(), num_nodes);
 
     for (std::int32_t c = 0; c < mesh.num_entities(tdim); ++c)
     {

--- a/cpp/dolfin/io/xdmf_write.cpp
+++ b/cpp/dolfin/io/xdmf_write.cpp
@@ -210,8 +210,11 @@ std::vector<std::int64_t> compute_topology_data(const mesh::Mesh& mesh,
   // Get mesh communicator
   MPI_Comm comm = mesh.mpi_comm();
 
+  int num_nodes = mesh.coordinate_dofs().cell_permutation().size();
+  mesh::CellType cell_type = mesh::cell_entity_type(mesh.cell_type(), cell_dim);
   const std::vector<std::uint8_t> perm
-      = mesh.coordinate_dofs().cell_permutation();
+      = mesh::vtk_mapping(cell_type, num_nodes);
+
   const int tdim = mesh.topology().dim();
   const auto& global_vertices = mesh.topology().global_indices(0);
   if (dolfin::MPI::size(comm) == 1 or cell_dim == tdim)
@@ -558,8 +561,11 @@ void xdmf_write::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
     // Adjust num_nodes_per_cell to appropriate size
     num_nodes_per_cell = cell_points.size(0);
     topology_data.reserve(num_nodes_per_cell * mesh.num_entities(tdim));
-    const std::vector<std::uint8_t>& perm
-        = mesh.coordinate_dofs().cell_permutation();
+    int num_nodes = mesh.coordinate_dofs().cell_permutation().size();
+    mesh::CellType cell_type
+        = mesh::cell_entity_type(mesh.cell_type(), cell_dim);
+    const std::vector<std::uint8_t> perm
+        = mesh::vtk_mapping(cell_type, num_nodes);
 
     for (std::int32_t c = 0; c < mesh.num_entities(tdim); ++c)
     {

--- a/cpp/dolfin/io/xdmf_write.cpp
+++ b/cpp/dolfin/io/xdmf_write.cpp
@@ -560,6 +560,7 @@ void xdmf_write::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
     // Adjust num_nodes_per_cell to appropriate size
     num_nodes_per_cell = cell_points.size(0);
     topology_data.reserve(num_nodes_per_cell * mesh.num_entities(tdim));
+
     int num_nodes = mesh.coordinate_dofs().cell_permutation().size();
     const std::vector<std::uint8_t> perm
         = mesh::vtk_mapping(mesh.cell_type(), num_nodes);

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -142,7 +142,18 @@ Mesh::Mesh(MPI_Comm comm, mesh::CellType type,
 
   // Permutation from VTK to DOLFIN order for cell geometric nodes
   std::vector<std::uint8_t> cell_permutation;
-  cell_permutation = mesh::vtk_mapping(type, cells.cols());
+  if (type == mesh::CellType::quadrilateral)
+  {
+    // Quadrilateral cells does not follow counter clockwise
+    // order (cc), but lexiographic order (LG). This breaks the assumptions
+    // that the cell permutation is the same as the VTK-map.
+    if (num_vertices_per_cell == cells.cols())
+      cell_permutation = {0, 1, 2, 3};
+    else
+      throw std::runtime_error("Higher order quadrilateral not supported");
+  }
+  else
+    cell_permutation = mesh::vtk_mapping(type, cells.cols());
 
   // Find degree of mesh
   // FIXME: degree should probably be in MeshGeometry

--- a/cpp/dolfin/mesh/cell_types.cpp
+++ b/cpp/dolfin/mesh/cell_types.cpp
@@ -515,10 +515,8 @@ std::vector<std::uint8_t> mesh::vtk_mapping(mesh::CellType type, int num_nodes)
     {
     case 4:
     {
-      // FIXME: Note that this is not counter clockwise ordering (CC),
-      // as performed by vtk (used by gmsh and other mesh generators),
-      // but lexicographic (LG). A convert function from (CC) to (LG) will
-      // be created in a future PR.
+      // Assumes mapping from lexiographic ordering, not counter-clockwise
+      // which is the VTK format
       return {0, 1, 3, 2};
     }
     default:

--- a/cpp/dolfin/mesh/utils.cpp
+++ b/cpp/dolfin/mesh/utils.cpp
@@ -158,7 +158,7 @@ T volume_quadrilateral(const mesh::Mesh& mesh,
     const Eigen::Vector3d p2 = geometry.x(vertices[2]);
     const Eigen::Vector3d p3 = geometry.x(vertices[3]);
 
-    const Eigen::Vector3d c = (p0 - p2).cross(p1 - p3);
+    const Eigen::Vector3d c = (p0 - p3).cross(p1 - p2);
     const double volume = 0.5 * c.norm();
 
     if (gdim == 3)


### PR DESCRIPTION
 Assumed that the VTK mapping and cell_permutation always matches, which is not the case for quadrilaterals, using Lexiographic ordering (when we use built in meshes). 
Support for reading gmsh-quad meshes are still not there, as a flag needs to be introduced to tell the constructor which ordering the input data has.

Reverting assumptions in mesh/utils, and decoupling cell_permutation from visualization, as the assumption I made there clearly does not hold in general