### PR TITLE
Remove Function::restriction

### DIFF
--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -537,8 +537,9 @@ void fem::impl::assemble_exterior_facets(
     // Update coefficients
     for (std::size_t i = 0; i < coefficients.size(); ++i)
     {
-      coefficients[i]->restrict(cell, coordinate_dofs,
-                                coeff_array.data() + offsets[i]);
+      _restrict(*coefficients[i]->function_space()->dofmap(),
+                coefficients[i]->vector().vec(), cell.index(),
+                coeff_array.data() + offsets[i]);
     }
 
     // Tabulate element vector
@@ -632,11 +633,12 @@ void fem::impl::assemble_interior_facets(
                          gdim);
     for (std::size_t i = 0; i < coefficients.size(); ++i)
     {
-      coefficients[i]->restrict(cell0, coordinate_dofs0,
-                                coeff_array.data() + offsets[i]);
-      coefficients[i]->restrict(cell1, coordinate_dofs1,
-                                coeff_array.data() + offsets.back()
-                                    + offsets[i]);
+      _restrict(*coefficients[i]->function_space()->dofmap(),
+                coefficients[i]->vector().vec(), cell0.index(),
+                coeff_array.data() + offsets[i]);
+      _restrict(*coefficients[i]->function_space()->dofmap(),
+                coefficients[i]->vector().vec(), cell1.index(),
+                coeff_array.data() + offsets.back() + offsets[i]);
     }
 
     // Tabulate element vector

--- a/cpp/dolfin/function/Function.cpp
+++ b/cpp/dolfin/function/Function.cpp
@@ -191,7 +191,8 @@ void Function::eval(
   const int num_dofs_g = connectivity_g.size(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
-  Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> coordinate_dofs(num_dofs_g, gdim);
+  Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+      coordinate_dofs(num_dofs_g, gdim);
 
   // Get coordinate mapping
   std::shared_ptr<const fem::CoordinateMapping> cmap
@@ -213,7 +214,8 @@ void Function::eval(
   Eigen::Tensor<double, 3, Eigen::RowMajor> J(1, gdim, tdim);
   Eigen::Array<double, Eigen::Dynamic, 1> detJ(1);
   Eigen::Tensor<double, 3, Eigen::RowMajor> K(1, tdim, gdim);
-  Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> X(1, tdim);
+  Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> X(1,
+                                                                          tdim);
 
   // Prepare basis function data structures
   Eigen::Tensor<double, 3, Eigen::RowMajor> basis_reference_values(
@@ -316,28 +318,6 @@ std::vector<int> Function::value_shape() const
   for (std::size_t i = 0; i < _shape.size(); ++i)
     _shape[i] = this->value_dimension(i);
   return _shape;
-}
-//-----------------------------------------------------------------------------
-void Function::restrict(
-    const mesh::MeshEntity& cell,
-    const Eigen::Ref<const EigenRowArrayXXd>& coordinate_dofs,
-    PetscScalar* w) const
-{
-  assert(w);
-  assert(_function_space);
-  assert(_function_space->dofmap());
-  assert(_function_space->mesh());
-  assert(_function_space->mesh()->topology().dim() == cell.dim());
-
-  // Get dofmap for cell
-  const fem::DofMap& dofmap = *_function_space->dofmap();
-  auto dofs = dofmap.cell_dofs(cell.index());
-
-  // Pick values from vector(s)
-  la::VecReadWrapper v(_vector.vec());
-  Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> _v = v.x;
-  for (Eigen::Index i = 0; i < dofs.size(); ++i)
-    w[i] = _v[dofs[i]];
 }
 //-----------------------------------------------------------------------------
 Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>

--- a/cpp/dolfin/function/Function.h
+++ b/cpp/dolfin/function/Function.h
@@ -129,14 +129,6 @@ public:
                                Eigen::RowMajor>>
            u) const;
 
-  /// Restrict function to local cell (compute expansion coefficients w)
-  /// @param[in] cell The cell
-  /// @param[in] coordinate_dofs The coordinate dofs
-  /// @param[in,out] w Expansion coefficients.
-  void restrict(const mesh::MeshEntity& cell,
-                const Eigen::Ref<const EigenRowArrayXXd>& coordinate_dofs,
-                PetscScalar* w) const;
-
   /// Compute values at all mesh points
   /// @return The values at all geometric points
   Eigen::Array<PetscScalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>

--- a/cpp/dolfin/function/FunctionSpace.cpp
+++ b/cpp/dolfin/function/FunctionSpace.cpp
@@ -110,8 +110,14 @@ void FunctionSpace::interpolate_from_any(
       for (int j = 0; j < gdim; ++j)
         coordinate_dofs(i, j) = x_g(cell_g[pos_g[cell_index] + i], j);
 
+    // FIXME: This is all very circular.Clean up.
     // Restrict function to cell
-    v.restrict(cell, coordinate_dofs, cell_coefficients.data());
+    auto dofs = v.function_space()->dofmap()->cell_dofs(cell_index);
+    la::VecReadWrapper v_wrap(v.vector().vec());
+    Eigen::Map<const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> _v
+        = v_wrap.x;
+    for (Eigen::Index i = 0; i < dofs.size(); ++i)
+      cell_coefficients[i] = _v[dofs[i]];
 
     // Tabulate dofs
     auto cell_dofs = _dofmap->cell_dofs(cell.index());


### PR DESCRIPTION
Remove `Function::restriction`, which obfuscated a simple operation and involved  a number of operations that should be taken outside of tight loops.

This PR improves the code in `Function` and `FunctionSpace`, and adds placeholder functions in the assembly code that can be removed later with more re-factoring of coefficients in the assembly code.