### PR TITLE
Fix coefficient offsets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ install-python-components: &install-python-components
   command: |
             pip3 install git+https://github.com/FEniCS/fiat.git --upgrade
             pip3 install git+https://github.com/FEniCS/ufl.git --upgrade
-            pip3 install git+https://github.com/FEniCS/ffcx.git@michal/fix-coeff-offsets --upgrade
+            pip3 install git+https://github.com/FEniCS/ffcx.git --upgrade
             rm -rf /usr/local/include/dolfin /usr/local/include/dolfin.h
 
 flake8-python-code: &flake8-python-code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ install-python-components: &install-python-components
   command: |
             pip3 install git+https://github.com/FEniCS/fiat.git --upgrade
             pip3 install git+https://github.com/FEniCS/ufl.git --upgrade
-            pip3 install git+https://github.com/FEniCS/ffcx.git --upgrade
+            pip3 install git+https://github.com/FEniCS/ffcx.git@michal/fix-coeff-offsets --upgrade
             rm -rf /usr/local/include/dolfin /usr/local/include/dolfin.h
 
 flake8-python-code: &flake8-python-code

--- a/cpp/dolfin/fem/assemble_matrix_impl.cpp
+++ b/cpp/dolfin/fem/assemble_matrix_impl.cpp
@@ -410,12 +410,18 @@ void fem::impl::assemble_interior_facets(
                          gdim);
     for (std::size_t i = 0; i < coefficients.size(); ++i)
     {
+      // Layout for the restricted coefficients is flattened
+      // w[coefficient][restriction][dof]
+
+      // Prepare restriction to cell 0
       _restrict(*coefficients[i]->function_space()->dofmap(),
                 coefficients[i]->vector().vec(), cell0.index(),
-                coeff_array.data() + offsets[i]);
+                coeff_array.data() + 2 * offsets[i]);
+
+      // Prepare restriction to cell 1
       _restrict(*coefficients[i]->function_space()->dofmap(),
                 coefficients[i]->vector().vec(), cell1.index(),
-                coeff_array.data() + offsets.back() + offsets[i]);
+                coeff_array.data() + offsets[i + 1] + offsets[i]);
     }
 
     // Tabulate tensor

--- a/cpp/dolfin/fem/assemble_scalar_impl.cpp
+++ b/cpp/dolfin/fem/assemble_scalar_impl.cpp
@@ -295,12 +295,18 @@ PetscScalar fem::impl::assemble_interior_facets(
                          gdim);
     for (std::size_t i = 0; i < coefficients.size(); ++i)
     {
+      // Layout for the restricted coefficients is flattened
+      // w[coefficient][restriction][dof]
+
+      // Prepare restriction to cell 0
       _restrict(*coefficients[i]->function_space()->dofmap(),
                 coefficients[i]->vector().vec(), cell0.index(),
-                coeff_array.data() + offsets[i]);
+                coeff_array.data() + 2 * offsets[i]);
+
+      // Prepare restriction to cell 1
       _restrict(*coefficients[i]->function_space()->dofmap(),
                 coefficients[i]->vector().vec(), cell1.index(),
-                coeff_array.data() + offsets.back() + offsets[i]);
+                coeff_array.data() + offsets[i + 1] + offsets[i]);
     }
 
     fn(&value, coeff_array.data(), constant_values.data(),

--- a/cpp/dolfin/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfin/fem/assemble_vector_impl.cpp
@@ -633,12 +633,18 @@ void fem::impl::assemble_interior_facets(
                          gdim);
     for (std::size_t i = 0; i < coefficients.size(); ++i)
     {
+      // Layout for the restricted coefficients is flattened
+      // w[coefficient][restriction][dof]
+
+      // Prepare restriction to cell 0
       _restrict(*coefficients[i]->function_space()->dofmap(),
                 coefficients[i]->vector().vec(), cell0.index(),
-                coeff_array.data() + offsets[i]);
+                coeff_array.data() + 2 * offsets[i]);
+
+      // Prepare restriction to cell 1
       _restrict(*coefficients[i]->function_space()->dofmap(),
                 coefficients[i]->vector().vec(), cell1.index(),
-                coeff_array.data() + offsets.back() + offsets[i]);
+                coeff_array.data() + offsets[i + 1] + offsets[i]);
     }
 
     // Tabulate element vector

--- a/python/test/unit/fem/test_assemble_domains.py
+++ b/python/test/unit/fem/test_assemble_domains.py
@@ -18,16 +18,16 @@ def mesh():
     return dolfin.generation.UnitSquareMesh(dolfin.MPI.comm_world, 10, 10)
 
 
-parametrize_ghost_mode = pytest.mark.parametrize("mode",
-    [pytest.param(dolfin.cpp.mesh.GhostMode.none,
-                marks=pytest.mark.skipif(condition=dolfin.MPI.size(dolfin.MPI.comm_world) > 1,
-                                        reason="Unghosted interior facets fail in parallel")),
+parametrize_ghost_mode = pytest.mark.parametrize("mode", [
+    pytest.param(dolfin.cpp.mesh.GhostMode.none,
+                 marks=pytest.mark.skipif(condition=dolfin.MPI.size(dolfin.MPI.comm_world) > 1,
+                                          reason="Unghosted interior facets fail in parallel")),
     pytest.param(dolfin.cpp.mesh.GhostMode.shared_facet,
-                marks=pytest.mark.skipif(condition=dolfin.MPI.size(dolfin.MPI.comm_world) == 1,
-                                        reason="Shared ghost modes fail in serial")),
+                 marks=pytest.mark.skipif(condition=dolfin.MPI.size(dolfin.MPI.comm_world) == 1,
+                                          reason="Shared ghost modes fail in serial")),
     pytest.param(dolfin.cpp.mesh.GhostMode.shared_vertex,
-                marks=pytest.mark.skipif(condition=dolfin.MPI.size(dolfin.MPI.comm_world) == 1,
-                                        reason="Shared ghost modes fail in serial"))])
+                 marks=pytest.mark.skipif(condition=dolfin.MPI.size(dolfin.MPI.comm_world) == 1,
+                                          reason="Shared ghost modes fail in serial"))])
 
 
 def test_assembly_dx_domains(mesh):


### PR DESCRIPTION
Fixes issue #545 , see also FFCx https://github.com/FEniCS/ffcx/pull/154

However, current approach is still suboptimal. We fetch all coefficients for the whole form for each integral - even though if the integral is using only one of them. Improvement will come as additional PR, this is mainly to fix the bugs discovered by @francesco-ballarin .