### PR TITLE
Fix for hex meshes

### DIFF
--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -229,19 +229,26 @@ Mesh::Mesh(
 
   // Permutation from VTK to DOLFIN order for cell geometric nodes
   std::vector<std::uint8_t> cell_permutation;
-  if (type == mesh::CellType::quadrilateral)
+  switch (type)
   {
+  case mesh::CellType::quadrilateral:
     // Quadrilateral cells does not follow counter clockwise
     // order (cc), but lexiographic order (LG). This breaks the assumptions
     // that the cell permutation is the same as the VTK-map.
-    if (num_vertices_per_cell == cells.cols())
+    if (cells.cols() == 4)
       cell_permutation = {0, 1, 2, 3};
     else
-      throw std::runtime_error("Higher order quadrilateral not supported");
-  }
-  else
+      cell_permutation = mesh::vtk_mapping(type, cells.cols());
+    break;
+  case mesh::CellType::hexahedron:
+    if (cells.cols() == 8)
+      cell_permutation = {0, 1, 2, 3, 4, 5, 6, 7};
+    else
+      throw std::runtime_error("Higher order hexahedron not supported");
+    break;
+  default:
     cell_permutation = mesh::vtk_mapping(type, cells.cols());
-
+  }
   // Find degree of mesh
   // FIXME: degree should probably be in MeshGeometry
   _degree = mesh::cell_degree(type, cells.cols());

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -13,12 +13,14 @@ import pytest
 
 import dolfin
 import FIAT
-from dolfin import (MPI, BoxMesh, MeshEntity, MeshFunction, RectangleMesh,
+from dolfin import (MPI, BoxMesh, Constant, MeshEntity, MeshFunction, RectangleMesh,
                     UnitCubeMesh, UnitIntervalMesh, UnitSquareMesh, cpp)
 from dolfin.cpp.mesh import CellType, is_simplex
+from dolfin.fem import assemble_scalar
 from dolfin.io import XDMFFile
 from dolfin_utils.test.fixtures import tempdir
 from dolfin_utils.test.skips import skip_in_parallel
+from ufl import dx
 
 assert (tempdir)
 
@@ -536,3 +538,10 @@ def test_coords():
     d = mesh.coordinate_dofs().entity_points()
     d += 2
     assert numpy.array_equal(d, mesh.coordinate_dofs().entity_points())
+
+
+def test_UnitHexMesh_assemble():
+    mesh = UnitCubeMesh(MPI.comm_world, 6, 7, 5, CellType.hexahedron)
+    vol = assemble_scalar(Constant(mesh, 1) * dx)
+    vol = MPI.sum(mesh.mpi_comm(), vol)
+    assert(vol == pytest.approx(1, rel=1e-9))

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -13,7 +13,7 @@ import pytest
 
 import dolfin
 import FIAT
-from dolfin import (MPI, BoxMesh, Constant, MeshEntity, MeshFunction, RectangleMesh,
+from dolfin import (MPI, BoxMesh, MeshEntity, MeshFunction, RectangleMesh,
                     UnitCubeMesh, UnitIntervalMesh, UnitSquareMesh, cpp)
 from dolfin.cpp.mesh import CellType, is_simplex
 from dolfin.fem import assemble_scalar

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -542,6 +542,6 @@ def test_coords():
 
 def test_UnitHexMesh_assemble():
     mesh = UnitCubeMesh(MPI.comm_world, 6, 7, 5, CellType.hexahedron)
-    vol = assemble_scalar(Constant(mesh, 1) * dx)
+    vol = assemble_scalar(1 * dx(mesh))
     vol = MPI.sum(mesh.mpi_comm(), vol)
     assert(vol == pytest.approx(1, rel=1e-9))


### PR DESCRIPTION
Yet another error introduced when I tried to remove "duplicate code". 
As hexes follow the same structure as quads, a lexiographic ordering, they need to use a separate map, which is not the same as the VTK map in the cell_permutations. 

Added additional test to test this for future rewrites.