### PR TITLE
Incompatibility of MeshFunction.mark and PR #563

### DIFF
--- a/cpp/dolfin/mesh/MeshFunction.h
+++ b/cpp/dolfin/mesh/MeshFunction.h
@@ -230,7 +230,7 @@ void MeshFunction<T>::mark(
 
   // Iterate over all mesh entities of the dimension of this
   // MeshFunction
-  for (const auto& entity : mesh::MeshRange(*_mesh.get(), _dim))
+  for (const auto& entity : mesh::MeshRange(*_mesh.get(), _dim, mesh::MeshRangeType::ALL))
   {
 
     // By default, assume maker is 'true' at all vertices of this entity

--- a/cpp/test/unit/CMakeLists.txt
+++ b/cpp/test/unit/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TEST_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/common/IndexMap.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mesh/DistributedMesh.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/common/CIFailure.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/mesh/MeshFunction.cpp
   )
 
 add_executable(unittests ${TEST_SOURCES})

--- a/cpp/test/unit/mesh/MeshFunction.cpp
+++ b/cpp/test/unit/mesh/MeshFunction.cpp
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 Francesco Ballarin
+//
+// This file is part of DOLFIN (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+//
+// Unit tests for Distributed Meshes
+
+#include <catch.hpp>
+#include <dolfin.h>
+
+using namespace dolfin;
+
+namespace
+{
+Eigen::Array<bool, Eigen::Dynamic, 1>
+marking_function(const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>>& x)
+{
+  Eigen::Array<bool, Eigen::Dynamic, 1> inside(x.rows());
+  inside.fill(true);
+  return inside;
+}
+
+void test_mesh_function()
+{
+  int argc = 0;
+  char** argv = nullptr;
+  PetscInitialize(&argc, &argv, nullptr, nullptr);
+
+  // Create mesh using all processes
+  std::array<Eigen::Vector3d, 2> pt{Eigen::Vector3d(0.0, 0.0, 0.0),
+                                    Eigen::Vector3d(1.0, 1.0, 0.0)};
+  auto mesh = std::make_shared<mesh::Mesh>(generation::RectangleMesh::create(
+      MPI_COMM_WORLD, pt, {{16, 16}}, mesh::CellType::triangle,
+      mesh::GhostMode::none));
+
+  // Loop over entity dimension
+  for (int d = 0; d <= mesh->geometry().dim(); ++d)
+  {
+    mesh::MeshFunction<std::size_t> mesh_function(mesh, d, 0.0);
+    mesh_function.mark(marking_function, 1.0);
+    for (const auto& e : mesh::MeshRange(*mesh, d, mesh::MeshRangeType::ALL))
+    {
+      CHECK(mesh_function.values()[e.index()] == 1.0);
+    }
+  }
+}
+} // namespace
+
+TEST_CASE("Mesh Function", "[mesh_function]")
+{
+  CHECK_NOTHROW(test_mesh_function());
+}


### PR DESCRIPTION
This PR introduces a new test case for the issue I highlighted in the discussion of #563.
I believe that, after #563 and the forthcoming changes to the remaining mesh entities, MeshFunction's values for shared entities are currently out of sync between sharing processes after MeshFunction::mark.

I believe that a fix would be to add a third argument `MeshRangeType::ALL` to `mesh::MeshRange` on line 233 of MeshFunction.h. Please advise if that is indeed the correct fix, and I will apply in a commit to this branch.