### PR TITLE
[WIP] C++ unit testing might be broken in parallel on circleci

### DIFF
--- a/cpp/test/unit/CMakeLists.txt
+++ b/cpp/test/unit/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/common/SubSystemsManager.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/common/IndexMap.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mesh/DistributedMesh.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/common/CIFailure.cpp
   )
 
 add_executable(unittests ${TEST_SOURCES})

--- a/cpp/test/unit/common/CIFailure.cpp
+++ b/cpp/test/unit/common/CIFailure.cpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2019 Francesco Ballarin
+//
+// This file is part of DOLFIN (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+//
+// Unit tests for Distributed Meshes
+
+#include <catch.hpp>
+#include <dolfin.h>
+
+using namespace dolfin;
+
+namespace
+{
+void test_ci_failure()
+{
+  int argc = 0;
+  char** argv = nullptr;
+  PetscInitialize(&argc, &argv, nullptr, nullptr);
+
+  auto mpi_comm = dolfin::MPI::Comm(MPI_COMM_WORLD);
+  int mpi_rank = dolfin::MPI::rank(mpi_comm.comm());
+
+  CHECK(mpi_rank == 0);
+}
+} // namespace
+
+TEST_CASE("CI failure", "[ci_failure]")
+{
+  CHECK_NOTHROW(test_ci_failure());
+}


### PR DESCRIPTION
Associated to issue #576 .

The silly test should be failing in parallel, as not all processes have rank 0.

I marked this as WIP to prevent merge, as this PR is only supposed to try and reproduce the issue that occured while testing #573, but should be discarded without merge after fixing.