### PR TITLE
Update MeshFunction ghost  values

### DIFF
--- a/cpp/dolfin/mesh/Mesh.h
+++ b/cpp/dolfin/mesh/Mesh.h
@@ -202,8 +202,7 @@ public:
   /// @return The communicator on which the mesh is distributed
   MPI_Comm mpi_comm() const;
 
-  /// Ghost mode used for partitioning. Possible values are same as
-  /// `parameters["ghost_mode"]`.
+  /// Ghost mode used for partitioning.
   /// @warning The interface may change in future without deprecation;
   ///          the method is now intended for internal library use.
   mesh::GhostMode get_ghost_mode() const;

--- a/cpp/dolfin/mesh/MeshFunction.h
+++ b/cpp/dolfin/mesh/MeshFunction.h
@@ -315,7 +315,7 @@ void MeshFunction<T>::update_ghosts()
     j++;
   }
 
-  // Distribute remote data as soon as each request is satisfied.
+  // Distribute remote data as soon as each request is satisfied
   for (int i = 0; i < recv_values.size(); i++)
   {
     int req_index;
@@ -326,7 +326,7 @@ void MeshFunction<T>::update_ghosts()
     std::vector<std::int32_t>::iterator it
         = std::find(entity_owner.begin(), entity_owner.end(), process);
 
-    // Update all ghost values with owned values from the current remote process
+    // Update all ghost values from onwning process values
     for (T& value : recv_values[process])
     {
       std::size_t local_entity_index = it - entity_owner.begin() + size_owned;

--- a/cpp/dolfin/mesh/Topology.h
+++ b/cpp/dolfin/mesh/Topology.h
@@ -93,9 +93,9 @@ public:
   const std::map<std::int32_t, std::set<std::int32_t>>&
   shared_entities(int dim) const;
 
-  /// Return mapping from local ghost cell index to owning process.
-  /// Since ghost cells are at the end of the range, this is just a vector
-  /// over those cells
+  /// Return mapping from local ghost entity index to owning process.
+  /// Since ghost entities are at the end of the range, this is just
+  /// a vector over those entities
   std::vector<std::int32_t>& entity_owner(int dim);
 
   /// Return mapping from local ghost cell index to owning process

--- a/python/src/mesh.cpp
+++ b/python/src/mesh.cpp
@@ -291,6 +291,8 @@ void mesh(py::module& m)
              return self.id;                                                   \
            })                                                                  \
       .def("mark", &dolfin::mesh::MeshFunction<SCALAR>::mark)                  \
+      .def("update_ghosts",                                                    \
+           &dolfin::mesh::MeshFunction<SCALAR>::update_ghosts)                 \
       .def_property_readonly(                                                  \
           "values",                                                            \
           py::overload_cast<>(&dolfin::mesh::MeshFunction<SCALAR>::values));

--- a/python/test/unit/mesh/test_mesh_function.py
+++ b/python/test/unit/mesh/test_mesh_function.py
@@ -9,6 +9,7 @@ import numpy.random
 import pytest
 
 from dolfin import MPI, MeshFunction, UnitCubeMesh
+from dolfin.cpp.mesh import GhostMode
 
 
 dtypes = (
@@ -36,3 +37,26 @@ def test_numpy_access(dtype, mesh):
     values = mf.values
     values[:] = numpy.random.rand(len(values))
     assert numpy.all(values == mf.values)
+
+
+@pytest.mark.xfail(MPI.size(MPI.comm_world) == 1,
+                   reason="Shared ghost modes fail in serial.")
+@pytest.mark.parametrize("ghost_mode",
+                         [GhostMode.none, GhostMode.shared_vertex, GhostMode.shared_facet])
+@pytest.mark.parametrize("dim",
+                         [0, pytest.param(1, marks=pytest.mark.skip),
+                          pytest.param(2, marks=pytest.mark.skip), 3])
+def test_update_ghosts(mesh, ghost_mode, dim):
+    comm = MPI.comm_world
+    mesh = UnitCubeMesh(comm, 5, 5, 5, ghost_mode=ghost_mode)
+    mf = MeshFunction('double', mesh, dim, 0)
+    mf.values[:] = comm.rank
+    mf.update_ghosts()
+
+    size_owned = mesh.topology.ghost_offset(dim)
+    size_local = mesh.topology.size(dim)
+    num_ghosts = size_local - size_owned
+    entity_owner = mesh.topology.entity_owner(dim)
+
+    assert(num_ghosts == len(entity_owner))
+    assert(numpy.all(mf.values[size_owned:] == entity_owner))


### PR DESCRIPTION
This is a proposal for updating MeshFunction ghost values. The ghost values are updated using non-blocking point-to-point communication.

Since the global numbering of mesh entities does not follow the same rules as dof numbering, `IndexMaps` could not be used directly .  Alternatively, we could work on global numbering and substitute `Topology::_shared_entities` and `Topology::_entity_owner` by an `IndexMap`.