### PR TITLE
Consolidate mesh entity creation and numbering

### DIFF
--- a/cpp/dolfin/fem/DofMapBuilder.cpp
+++ b/cpp/dolfin/fem/DofMapBuilder.cpp
@@ -80,9 +80,10 @@ void get_cell_entities(
   {
     if (needs_mesh_entities[d])
     {
-      assert(topology.connectivity(d, 0));
       const std::vector<std::int64_t>& global_indices
           = topology.global_indices(d);
+      assert(global_indices.size() > 0);
+
       const int cell_num_entities
           = mesh::cell_num_entities(cell.mesh().cell_type(), d);
       const std::int32_t* entities = cell.entities(d);

--- a/cpp/dolfin/fem/DofMapBuilder.cpp
+++ b/cpp/dolfin/fem/DofMapBuilder.cpp
@@ -80,7 +80,7 @@ void get_cell_entities(
   {
     if (needs_mesh_entities[d])
     {
-      assert(topology.have_global_indices(d));
+      assert(topology.connectivity(d, 0));
       const std::vector<std::int64_t>& global_indices
           = topology.global_indices(d);
       const int cell_num_entities

--- a/cpp/dolfin/fem/DofMapBuilder.cpp
+++ b/cpp/dolfin/fem/DofMapBuilder.cpp
@@ -305,7 +305,6 @@ DofMapStructure build_basic_dofmap(const mesh::Mesh& mesh,
     {
       needs_entities[d] = true;
       mesh.create_entities(d);
-      mesh::DistributedMeshTools::number_entities(mesh, d);
       num_mesh_entities_local[d] = mesh.num_entities(d);
       num_mesh_entities_global[d] = mesh.num_entities_global(d);
     }

--- a/cpp/dolfin/io/HDF5File.cpp
+++ b/cpp/dolfin/io/HDF5File.cpp
@@ -323,7 +323,7 @@ void HDF5File::write(const mesh::Mesh& mesh, int cell_dim,
     else
     {
       // If not already numbered, number entities of order cell_dim
-      mesh::DistributedMeshTools::number_entities(mesh, cell_dim);
+      // mesh::DistributedMeshTools::number_entities(mesh, cell_dim);
 
       // Drop duplicate topology for shared entities of less than mesh
       // dimension
@@ -526,7 +526,7 @@ HDF5File::read_mesh_function(std::shared_ptr<const mesh::Mesh> mesh,
   const std::size_t dim = vertices_per_cell - 1;
 
   // Ensure num_entities_global(cell_dim) is set
-  mesh::DistributedMeshTools::number_entities(*mesh, dim);
+  // mesh::DistributedMeshTools::number_entities(*mesh, dim);
 
   if (num_global_cells != mesh->num_entities_global(dim))
   {

--- a/cpp/dolfin/io/HDF5File.cpp
+++ b/cpp/dolfin/io/HDF5File.cpp
@@ -322,9 +322,6 @@ void HDF5File::write(const mesh::Mesh& mesh, int cell_dim,
     }
     else
     {
-      // If not already numbered, number entities of order cell_dim
-      // mesh::DistributedMeshTools::number_entities(mesh, cell_dim);
-
       // Drop duplicate topology for shared entities of less than mesh
       // dimension
 
@@ -524,9 +521,6 @@ HDF5File::read_mesh_function(std::shared_ptr<const mesh::Mesh> mesh,
   const std::int64_t num_global_cells = topology_shape[0];
   const std::size_t vertices_per_cell = topology_shape[1];
   const std::size_t dim = vertices_per_cell - 1;
-
-  // Ensure num_entities_global(cell_dim) is set
-  // mesh::DistributedMeshTools::number_entities(*mesh, dim);
 
   if (num_global_cells != mesh->num_entities_global(dim))
   {

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -1727,7 +1727,7 @@ XDMFFile::read_mesh_function(std::shared_ptr<const mesh::Mesh> mesh,
       = xdmf_utils::get_num_cells(topology_node);
 
   // Ensure num_entities_global(cell_dim) is set and check dataset matches
-  mesh::DistributedMeshTools::number_entities(*mesh, dim);
+  //  mesh::DistributedMeshTools::number_entities(*mesh, dim);
   assert(mesh->num_entities_global(dim) == num_entities_global);
 
   boost::filesystem::path xdmf_filename(_filename);
@@ -1850,7 +1850,7 @@ void XDMFFile::write_mesh_function(const mesh::MeshFunction<T>& meshfunction)
     // Make sure entities are numbered - only needed for  mesh::Edge in 3D in
     // parallel
     // FIXME: remove this once  mesh::Edge in 3D in parallel works properly
-    mesh::DistributedMeshTools::number_entities(*mesh, cell_dim);
+    //    mesh::DistributedMeshTools::number_entities(*mesh, cell_dim);
 
     xdmf_write::add_topology_data(_mpi_comm.comm(), grid_node, h5_id, mf_name,
                                   *mesh, cell_dim);

--- a/cpp/dolfin/io/XDMFFile.cpp
+++ b/cpp/dolfin/io/XDMFFile.cpp
@@ -29,7 +29,6 @@
 #include <dolfin/la/PETScVector.h>
 #include <dolfin/la/utils.h>
 #include <dolfin/mesh/Connectivity.h>
-#include <dolfin/mesh/DistributedMeshTools.h>
 #include <dolfin/mesh/Mesh.h>
 #include <dolfin/mesh/MeshEntity.h>
 #include <dolfin/mesh/MeshIterator.h>
@@ -1726,8 +1725,6 @@ XDMFFile::read_mesh_function(std::shared_ptr<const mesh::Mesh> mesh,
   const std::int64_t num_entities_global
       = xdmf_utils::get_num_cells(topology_node);
 
-  // Ensure num_entities_global(cell_dim) is set and check dataset matches
-  //  mesh::DistributedMeshTools::number_entities(*mesh, dim);
   assert(mesh->num_entities_global(dim) == num_entities_global);
 
   boost::filesystem::path xdmf_filename(_filename);
@@ -1846,11 +1843,6 @@ void XDMFFile::write_mesh_function(const mesh::MeshFunction<T>& meshfunction)
     assert(grid_node);
     grid_node.append_attribute("Name") = "mesh";
     grid_node.append_attribute("GridType") = "Uniform";
-
-    // Make sure entities are numbered - only needed for  mesh::Edge in 3D in
-    // parallel
-    // FIXME: remove this once  mesh::Edge in 3D in parallel works properly
-    //    mesh::DistributedMeshTools::number_entities(*mesh, cell_dim);
 
     xdmf_write::add_topology_data(_mpi_comm.comm(), grid_node, h5_id, mf_name,
                                   *mesh, cell_dim);

--- a/cpp/dolfin/io/xdmf_write.cpp
+++ b/cpp/dolfin/io/xdmf_write.cpp
@@ -434,10 +434,6 @@ std::string to_string(X x, Y y)
 std::set<std::uint32_t>
 xdmf_write::compute_nonlocal_entities(const mesh::Mesh& mesh, int cell_dim)
 {
-  // If not already numbered, number entities of
-  // order cell_dim so we can get shared_entities
-  //  mesh::DistributedMeshTools::number_entities(mesh, cell_dim);
-
   const int mpi_rank = dolfin::MPI::rank(mesh.mpi_comm());
   const mesh::Topology& topology = mesh.topology();
   const std::map<std::int32_t, std::set<std::int32_t>>& shared_entities

--- a/cpp/dolfin/io/xdmf_write.cpp
+++ b/cpp/dolfin/io/xdmf_write.cpp
@@ -436,7 +436,7 @@ xdmf_write::compute_nonlocal_entities(const mesh::Mesh& mesh, int cell_dim)
 {
   // If not already numbered, number entities of
   // order cell_dim so we can get shared_entities
-  mesh::DistributedMeshTools::number_entities(mesh, cell_dim);
+  //  mesh::DistributedMeshTools::number_entities(mesh, cell_dim);
 
   const int mpi_rank = dolfin::MPI::rank(mesh.mpi_comm());
   const mesh::Topology& topology = mesh.topology();

--- a/cpp/dolfin/mesh/DistributedMeshTools.cpp
+++ b/cpp/dolfin/mesh/DistributedMeshTools.cpp
@@ -432,9 +432,6 @@ void DistributedMeshTools::init_facet_cell_connections(Mesh& mesh)
   // Initialise local facet-cell connections.
   mesh.create_connectivity(D - 1, D);
 
-  // Global numbering
-  number_entities(mesh, D - 1);
-
   // Calculate the number of global cells attached to each facet
   // essentially defining the exterior surface
   // FIXME: should this be done earlier, e.g. at partitioning stage

--- a/cpp/dolfin/mesh/DistributedMeshTools.cpp
+++ b/cpp/dolfin/mesh/DistributedMeshTools.cpp
@@ -24,6 +24,288 @@ using namespace dolfin::mesh;
 //-----------------------------------------------------------------------------
 namespace
 {
+std::tuple<std::vector<std::int64_t>,
+           std::map<std::int32_t, std::set<std::int32_t>>, std::size_t>
+compute_entity_numbering(const Mesh& mesh, int d)
+{
+  LOG(INFO)
+      << "Number mesh entities for distributed mesh (for specified vertex ids)."
+      << d;
+  common::Timer timer(
+      "Number mesh entities for distributed mesh (for specified vertex ids)");
+
+  std::vector<std::int64_t> global_entity_indices;
+  std::map<std::int32_t, std::set<std::int32_t>> shared_entities;
+
+  // Check that we're not re-numbering vertices (these are fixed at mesh
+  // construction)
+  if (d == 0)
+  {
+    throw std::runtime_error(
+        "Global vertex indices exist at input. Cannot be renumbered");
+  }
+
+  if (d == mesh.topology().dim())
+  {
+    // Numbering cells.
+    // FIXME: Should be redundant?
+    shared_entities.clear();
+    global_entity_indices = mesh.topology().global_indices(d);
+    return std::make_tuple(std::move(global_entity_indices),
+                           std::move(shared_entities),
+                           mesh.num_entities_global(d));
+  }
+
+  // MPI communicator
+  const MPI_Comm mpi_comm = mesh.mpi_comm();
+
+  // Get number of processes and process number
+  const int mpi_size = dolfin::MPI::size(mpi_comm);
+  const int mpi_rank = dolfin::MPI::rank(mpi_comm);
+
+  // Initialize entities of dimension d locally
+  mesh.create_entities(d);
+
+  // Get vertex global indices
+  const std::vector<std::int64_t>& global_vertex_indices
+      = mesh.topology().global_indices(0);
+
+  // Get shared vertices (local index, [sharing processes])
+  // already determined in Mesh distribution
+  const std::map<std::int32_t, std::set<std::int32_t>>& shared_vertices_local
+      = mesh.topology().shared_entities(0);
+
+  // Send and receive shared entities.
+  // In order to communicate with remote processes, the entities are sent
+  // and received as blocks of global vertex indices, since these are the same
+  // on all processes. However, is more convenient to use the local index, so
+  // translate before and after sending.
+  std::vector<std::vector<std::int32_t>> send_local_entities(mpi_size);
+  std::vector<std::vector<std::int32_t>> recv_local_entities(mpi_size);
+
+  {
+    // Scoped region
+
+    // Entities to send/recv, as blocks of global vertex indices.
+    std::vector<std::vector<std::int64_t>> send_entities(mpi_size);
+    std::vector<std::vector<std::int64_t>> recv_entities(mpi_size);
+
+    // Mapping from the global vertex indices of an entity, back to its local
+    // index. Used after receiving, to translate back to local index.
+    std::map<std::vector<std::int64_t>, std::int32_t> entity_to_local_index;
+
+    // Get number of vertices in this entity type
+    const mesh::CellType& ct = mesh.cell_type();
+    const mesh::CellType& et = mesh::cell_entity_type(ct, d);
+    const int num_entity_vertices = mesh::num_cell_vertices(et);
+
+    // Make a mask listing all shared vertices (true if shared)
+    std::vector<bool> vertex_shared(mesh.num_entities(0), false);
+    for (const auto& v : shared_vertices_local)
+      vertex_shared[v.first] = true;
+
+    for (auto& e : mesh::MeshRange(mesh, d, mesh::MeshRangeType::ALL))
+    {
+      const std::size_t local_index = e.index();
+      const std::int32_t* v = e.entities(0);
+
+      // Entity can only be shared if all vertices are shared
+      // but this is not a sufficient condition
+      bool may_be_shared = true;
+      for (int i = 0; i < num_entity_vertices; ++i)
+        may_be_shared &= vertex_shared[v[i]];
+
+      if (may_be_shared)
+      {
+        // Get the set of processes which share all the vertices of this entity
+
+        // First vertex, and its sharing processes
+        const std::set<std::int32_t>& shared_vertices_v0
+            = shared_vertices_local.find(v[0])->second;
+        std::vector<std::int32_t> sharing_procs(shared_vertices_v0.begin(),
+                                                shared_vertices_v0.end());
+
+        for (int i = 1; i < num_entity_vertices; ++i)
+        {
+          // Sharing processes for subsequent vertices of this entity
+          const std::set<std::int32_t>& shared_vertices_v
+              = shared_vertices_local.find(v[i])->second;
+
+          std::vector<std::int32_t> v_sharing_procs;
+          std::set_intersection(sharing_procs.begin(), sharing_procs.end(),
+                                shared_vertices_v.begin(),
+                                shared_vertices_v.end(),
+                                std::back_inserter(v_sharing_procs));
+          sharing_procs = v_sharing_procs;
+        }
+
+        if (!sharing_procs.empty())
+        {
+          // If there are still processes that share all the vertices,
+          // send the entity to the sharing processes.
+
+          // Sort global vertex indices into order
+          std::vector<std::int64_t> g_index;
+          for (int i = 0; i < num_entity_vertices; ++i)
+            g_index.push_back(global_vertex_indices[v[i]]);
+          std::sort(g_index.begin(), g_index.end());
+
+          // Record processes this entity belongs to (possibly)
+          shared_entities.insert(
+              {local_index,
+               std::set<int>(sharing_procs.begin(), sharing_procs.end())});
+
+          // Record mapping from vertex global indices to local entity index
+          entity_to_local_index.insert({g_index, local_index});
+
+          // Send all possible entities to remote processes
+          for (auto p : sharing_procs)
+          {
+            send_local_entities[p].push_back(local_index);
+            send_entities[p].insert(send_entities[p].end(), g_index.begin(),
+                                    g_index.end());
+          }
+        }
+      }
+    }
+
+    dolfin::MPI::all_to_all(mpi_comm, send_entities, recv_entities);
+
+    // Check off received entities against sent entities
+    // (any which don't match need to be revised).
+    // For every shared entity that is sent to another process, the same entity
+    // should be returned. If not, it does not exist on the remote process... On
+    // the other hand, if an entity is received which has not been sent, then it
+    // can be safely ignored.
+
+    // Convert received data back to local index (where possible, otherwise put
+    // -1 to ignore)
+    for (int p = 0; p < mpi_size; ++p)
+    {
+      const std::vector<std::int64_t>& recv_p = recv_entities[p];
+      for (std::size_t i = 0; i < recv_p.size(); i += num_entity_vertices)
+      {
+        std::vector<std::int64_t> q(recv_p.begin() + i,
+                                    recv_p.begin() + i + num_entity_vertices);
+
+        const auto map_it = entity_to_local_index.find(q);
+        if (map_it != entity_to_local_index.end())
+          recv_local_entities[p].push_back(map_it->second);
+        else
+          recv_local_entities[p].push_back(-1);
+      }
+    }
+
+    // End of scoped region
+  }
+
+  // Compare sent and received entities
+  for (int p = 0; p < mpi_size; ++p)
+  {
+    std::vector<std::int32_t> send_p = send_local_entities[p];
+    std::vector<std::int32_t> recv_p = recv_local_entities[p];
+    std::sort(send_p.begin(), send_p.end());
+    std::sort(recv_p.begin(), recv_p.end());
+
+    // If received and sent are identical, there is nothing to do here.
+    if (send_p == recv_p)
+      continue;
+
+    // Get list of items in send_p, but not in recv_p
+    std::vector<std::int32_t> diff;
+    std::set_difference(send_p.begin(), send_p.end(), recv_p.begin(),
+                        recv_p.end(), std::back_inserter(diff));
+
+    // any entities listed in diff do not exist on process 'p'
+    for (auto& q : diff)
+    {
+      const auto emap_it = shared_entities.find(q);
+      assert(emap_it != shared_entities.end());
+      int n = emap_it->second.erase(p);
+      assert(n == 1);
+
+      // If this was the last sharing process, then this is no longer a shared
+      // entity
+      if (emap_it->second.empty())
+        shared_entities.erase(emap_it);
+    }
+  }
+
+  // We now know which entities are shared (and with which processes).
+  // Three categories: owned, owned+shared, remote+shared=ghost
+
+  global_entity_indices.resize(mesh.num_entities(d), -1);
+
+  // Start numbering
+
+  // Calculate all locally owned entities, and get a local offset
+  std::int64_t num_local = mesh.num_entities(d) - shared_entities.size();
+  for (const auto& q : shared_entities)
+  {
+    if (*q.second.begin() > mpi_rank)
+      ++num_local;
+  }
+
+  const std::int64_t local_offset
+      = dolfin::MPI::global_offset(mpi_comm, num_local, true);
+  const std::int64_t num_global = dolfin::MPI::sum(mpi_comm, num_local);
+  std::int64_t n = local_offset;
+
+  // Owned
+  for (int i = 0; i < mesh.num_entities(d); ++i)
+  {
+    const auto it = shared_entities.find(i);
+    if (it == shared_entities.end())
+    {
+      global_entity_indices[i] = n;
+      ++n;
+    }
+  }
+
+  // Owned and shared
+  for (const auto& q : shared_entities)
+  {
+    if (*q.second.begin() > mpi_rank)
+    {
+      global_entity_indices[q.first] = n;
+      ++n;
+    }
+  }
+
+  assert(n == local_offset + num_local);
+
+  // Now send/recv global indices to/from remotes
+  std::vector<std::vector<std::int64_t>> send_indices(mpi_size);
+  std::vector<std::vector<std::int64_t>> recv_indices(mpi_size);
+
+  // Revisit the entities we sent out before, sending out our
+  // new global indices (only to higher rank processes)
+  for (int p = mpi_rank + 1; p < mpi_size; ++p)
+  {
+    const std::vector<std::int32_t>& send_p = send_local_entities[p];
+    for (auto q : send_p)
+      send_indices[p].push_back(global_entity_indices[q]);
+  }
+
+  dolfin::MPI::all_to_all(mpi_comm, send_indices, recv_indices);
+
+  // Revisit the entities we received before, now with the global
+  // index from remote
+  for (int p = 0; p < mpi_rank; ++p)
+  {
+    const std::vector<std::int32_t>& recv_p = recv_local_entities[p];
+    for (std::size_t i = 0; i < recv_p.size(); ++i)
+    {
+      const std::int32_t local_index = recv_p[i];
+      // Make sure this is a valid entity, and coming from the owner
+      if (local_index != -1 and p == *shared_entities[local_index].begin())
+        global_entity_indices[local_index] = recv_indices[p][i];
+    }
+  }
+
+  return std::make_tuple(std::move(global_entity_indices),
+                         std::move(shared_entities), num_global);
+}
 //-----------------------------------------------------------------------------
 template <typename T>
 Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
@@ -136,289 +418,6 @@ void DistributedMeshTools::number_entities(const Mesh& mesh, int d)
   // Set global entity numbers in mesh
   _mesh.topology().set_num_entities_global(d, num_global_entities);
   _mesh.topology().set_global_indices(d, global_entity_indices);
-}
-//-----------------------------------------------------------------------------
-std::tuple<std::vector<std::int64_t>,
-           std::map<std::int32_t, std::set<std::int32_t>>, std::size_t>
-DistributedMeshTools::compute_entity_numbering(const Mesh& mesh, int d)
-{
-  LOG(INFO)
-      << "Number mesh entities for distributed mesh (for specified vertex ids)."
-      << d;
-  common::Timer timer(
-      "Number mesh entities for distributed mesh (for specified vertex ids)");
-
-  std::vector<std::int64_t> global_entity_indices;
-  std::map<std::int32_t, std::set<std::int32_t>> shared_entities;
-
-  // Check that we're not re-numbering vertices (these are fixed at mesh
-  // construction)
-  if (d == 0)
-  {
-    throw std::runtime_error(
-        "Global vertex indices exist at input. Cannot be renumbered");
-  }
-
-  if (d == mesh.topology().dim())
-  {
-    // Numbering cells.
-    // FIXME: Should be redundant?
-    shared_entities.clear();
-    global_entity_indices = mesh.topology().global_indices(d);
-    return std::make_tuple(std::move(global_entity_indices),
-                           std::move(shared_entities),
-                           mesh.num_entities_global(d));
-  }
-
-  // MPI communicator
-  const MPI_Comm mpi_comm = mesh.mpi_comm();
-
-  // Get number of processes and process number
-  const int mpi_size = MPI::size(mpi_comm);
-  const int mpi_rank = MPI::rank(mpi_comm);
-
-  // Initialize entities of dimension d locally
-  mesh.create_entities(d);
-
-  // Get vertex global indices
-  const std::vector<std::int64_t>& global_vertex_indices
-      = mesh.topology().global_indices(0);
-
-  // Get shared vertices (local index, [sharing processes])
-  // already determined in Mesh distribution
-  const std::map<std::int32_t, std::set<std::int32_t>>& shared_vertices_local
-      = mesh.topology().shared_entities(0);
-
-  // Send and receive shared entities.
-  // In order to communicate with remote processes, the entities are sent
-  // and received as blocks of global vertex indices, since these are the same
-  // on all processes. However, is more convenient to use the local index, so
-  // translate before and after sending.
-  std::vector<std::vector<std::int32_t>> send_local_entities(mpi_size);
-  std::vector<std::vector<std::int32_t>> recv_local_entities(mpi_size);
-
-  {
-    // Scoped region
-
-    // Entities to send/recv, as blocks of global vertex indices.
-    std::vector<std::vector<std::int64_t>> send_entities(mpi_size);
-    std::vector<std::vector<std::int64_t>> recv_entities(mpi_size);
-
-    // Mapping from the global vertex indices of an entity, back to its local
-    // index. Used after receiving, to translate back to local index.
-    std::map<std::vector<std::int64_t>, std::int32_t> entity_to_local_index;
-
-    // Get number of vertices in this entity type
-    const mesh::CellType& ct = mesh.cell_type();
-    const mesh::CellType& et = mesh::cell_entity_type(ct, d);
-    const int num_entity_vertices = mesh::num_cell_vertices(et);
-
-    // Make a mask listing all shared vertices (true if shared)
-    std::vector<bool> vertex_shared(mesh.num_entities(0), false);
-    for (const auto& v : shared_vertices_local)
-      vertex_shared[v.first] = true;
-
-    for (auto& e : mesh::MeshRange(mesh, d, mesh::MeshRangeType::ALL))
-    {
-      const std::size_t local_index = e.index();
-      const std::int32_t* v = e.entities(0);
-
-      // Entity can only be shared if all vertices are shared
-      // but this is not a sufficient condition
-      bool may_be_shared = true;
-      for (int i = 0; i < num_entity_vertices; ++i)
-        may_be_shared &= vertex_shared[v[i]];
-
-      if (may_be_shared)
-      {
-        // Get the set of processes which share all the vertices of this entity
-
-        // First vertex, and its sharing processes
-        const std::set<std::int32_t>& shared_vertices_v0
-            = shared_vertices_local.find(v[0])->second;
-        std::vector<std::int32_t> sharing_procs(shared_vertices_v0.begin(),
-                                                shared_vertices_v0.end());
-
-        for (int i = 1; i < num_entity_vertices; ++i)
-        {
-          // Sharing processes for subsequent vertices of this entity
-          const std::set<std::int32_t>& shared_vertices_v
-              = shared_vertices_local.find(v[i])->second;
-
-          std::vector<std::int32_t> v_sharing_procs;
-          std::set_intersection(sharing_procs.begin(), sharing_procs.end(),
-                                shared_vertices_v.begin(),
-                                shared_vertices_v.end(),
-                                std::back_inserter(v_sharing_procs));
-          sharing_procs = v_sharing_procs;
-        }
-
-        if (!sharing_procs.empty())
-        {
-          // If there are still processes that share all the vertices,
-          // send the entity to the sharing processes.
-
-          // Sort global vertex indices into order
-          std::vector<std::int64_t> g_index;
-          for (int i = 0; i < num_entity_vertices; ++i)
-            g_index.push_back(global_vertex_indices[v[i]]);
-          std::sort(g_index.begin(), g_index.end());
-
-          // Record processes this entity belongs to (possibly)
-          shared_entities.insert(
-              {local_index,
-               std::set<int>(sharing_procs.begin(), sharing_procs.end())});
-
-          // Record mapping from vertex global indices to local entity index
-          entity_to_local_index.insert({g_index, local_index});
-
-          // Send all possible entities to remote processes
-          for (auto p : sharing_procs)
-          {
-            send_local_entities[p].push_back(local_index);
-            send_entities[p].insert(send_entities[p].end(), g_index.begin(),
-                                    g_index.end());
-          }
-        }
-      }
-    }
-
-    MPI::all_to_all(mpi_comm, send_entities, recv_entities);
-
-    // Check off received entities against sent entities
-    // (any which don't match need to be revised).
-    // For every shared entity that is sent to another process, the same entity
-    // should be returned. If not, it does not exist on the remote process... On
-    // the other hand, if an entity is received which has not been sent, then it
-    // can be safely ignored.
-
-    // Convert received data back to local index (where possible, otherwise put
-    // -1 to ignore)
-    for (int p = 0; p < mpi_size; ++p)
-    {
-      const std::vector<std::int64_t>& recv_p = recv_entities[p];
-      for (std::size_t i = 0; i < recv_p.size(); i += num_entity_vertices)
-      {
-        std::vector<std::int64_t> q(recv_p.begin() + i,
-                                    recv_p.begin() + i + num_entity_vertices);
-
-        const auto map_it = entity_to_local_index.find(q);
-        if (map_it != entity_to_local_index.end())
-          recv_local_entities[p].push_back(map_it->second);
-        else
-          recv_local_entities[p].push_back(-1);
-      }
-    }
-
-    // End of scoped region
-  }
-
-  // Compare sent and received entities
-  for (int p = 0; p < mpi_size; ++p)
-  {
-    std::vector<std::int32_t> send_p = send_local_entities[p];
-    std::vector<std::int32_t> recv_p = recv_local_entities[p];
-    std::sort(send_p.begin(), send_p.end());
-    std::sort(recv_p.begin(), recv_p.end());
-
-    // If received and sent are identical, there is nothing to do here.
-    if (send_p == recv_p)
-      continue;
-
-    // Get list of items in send_p, but not in recv_p
-    std::vector<std::int32_t> diff;
-    std::set_difference(send_p.begin(), send_p.end(), recv_p.begin(),
-                        recv_p.end(), std::back_inserter(diff));
-
-    // any entities listed in diff do not exist on process 'p'
-    for (auto& q : diff)
-    {
-      const auto emap_it = shared_entities.find(q);
-      assert(emap_it != shared_entities.end());
-      int n = emap_it->second.erase(p);
-      assert(n == 1);
-
-      // If this was the last sharing process, then this is no longer a shared
-      // entity
-      if (emap_it->second.empty())
-        shared_entities.erase(emap_it);
-    }
-  }
-
-  // We now know which entities are shared (and with which processes).
-  // Three categories: owned, owned+shared, remote+shared=ghost
-
-  global_entity_indices.resize(mesh.num_entities(d), -1);
-
-  // Start numbering
-
-  // Calculate all locally owned entities, and get a local offset
-  std::int64_t num_local = mesh.num_entities(d) - shared_entities.size();
-  for (const auto& q : shared_entities)
-  {
-    if (*q.second.begin() > mpi_rank)
-      ++num_local;
-  }
-
-  const std::int64_t local_offset
-      = MPI::global_offset(mpi_comm, num_local, true);
-  const std::int64_t num_global = MPI::sum(mpi_comm, num_local);
-  std::int64_t n = local_offset;
-
-  // Owned
-  for (int i = 0; i < mesh.num_entities(d); ++i)
-  {
-    const auto it = shared_entities.find(i);
-    if (it == shared_entities.end())
-    {
-      global_entity_indices[i] = n;
-      ++n;
-    }
-  }
-
-  // Owned and shared
-  for (const auto& q : shared_entities)
-  {
-    if (*q.second.begin() > mpi_rank)
-    {
-      global_entity_indices[q.first] = n;
-      ++n;
-    }
-  }
-
-  assert(n == local_offset + num_local);
-
-  // Now send/recv global indices to/from remotes
-  std::vector<std::vector<std::int64_t>> send_indices(mpi_size);
-  std::vector<std::vector<std::int64_t>> recv_indices(mpi_size);
-
-  // Revisit the entities we sent out before, sending out our
-  // new global indices (only to higher rank processes)
-  for (int p = mpi_rank + 1; p < mpi_size; ++p)
-  {
-    const std::vector<std::int32_t>& send_p = send_local_entities[p];
-    for (auto q : send_p)
-      send_indices[p].push_back(global_entity_indices[q]);
-  }
-
-  MPI::all_to_all(mpi_comm, send_indices, recv_indices);
-
-  // Revisit the entities we received before, now with the global
-  // index from remote
-  for (int p = 0; p < mpi_rank; ++p)
-  {
-    const std::vector<std::int32_t>& recv_p = recv_local_entities[p];
-    for (std::size_t i = 0; i < recv_p.size(); ++i)
-    {
-      const std::int32_t local_index = recv_p[i];
-      // Make sure this is a valid entity, and coming from the owner
-      if (local_index != -1 and p == *shared_entities[local_index].begin())
-        global_entity_indices[local_index] = recv_indices[p][i];
-    }
-  }
-
-  return std::make_tuple(std::move(global_entity_indices),
-                         std::move(shared_entities), num_global);
 }
 //-----------------------------------------------------------------------------
 void DistributedMeshTools::init_facet_cell_connections(Mesh& mesh)

--- a/cpp/dolfin/mesh/DistributedMeshTools.cpp
+++ b/cpp/dolfin/mesh/DistributedMeshTools.cpp
@@ -388,7 +388,7 @@ void DistributedMeshTools::number_entities(const Mesh& mesh, int d)
   common::Timer timer("Number distributed mesh entities");
 
   // Return if global entity indices have already been calculated
-  if (mesh.topology().have_global_indices(d))
+  if (mesh.topology().global_indices(d).size() > 0)
     return;
 
   // Const-cast to allow data to be attached

--- a/cpp/dolfin/mesh/DistributedMeshTools.cpp
+++ b/cpp/dolfin/mesh/DistributedMeshTools.cpp
@@ -63,9 +63,6 @@ compute_entity_numbering(const Mesh& mesh, int d)
   const int mpi_size = dolfin::MPI::size(mpi_comm);
   const int mpi_rank = dolfin::MPI::rank(mpi_comm);
 
-  // Initialize entities of dimension d locally
-  mesh.create_entities(d);
-
   // Get vertex global indices
   const std::vector<std::int64_t>& global_vertex_indices
       = mesh.topology().global_indices(0);

--- a/cpp/dolfin/mesh/DistributedMeshTools.h
+++ b/cpp/dolfin/mesh/DistributedMeshTools.h
@@ -34,16 +34,6 @@ public:
   /// Create global entity indices for entities of dimension d
   static void number_entities(const Mesh& mesh, int d);
 
-  /// Create global entity indices for entities of dimension d for given
-  /// global vertex indices
-  /// @param[in] mesh The mesh
-  /// @param[in] d The dimension
-  /// @return (global_entity_indices, shared_entities,
-  ///          number_of_global_entities)
-  static std::tuple<std::vector<std::int64_t>,
-                    std::map<std::int32_t, std::set<std::int32_t>>, std::size_t>
-  compute_entity_numbering(const Mesh& mesh, int d);
-
   /// Compute number of cells connected to each facet (globally). Facets
   /// on internal boundaries will be connected to two cells (with the
   /// cells residing on neighboring processes)

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -414,7 +414,9 @@ std::size_t Mesh::create_entities(int dim) const
   // Compute connectivity to vertices
   Mesh* mesh = const_cast<Mesh*>(this);
 
+  // Create local entities
   TopologyComputation::compute_entities(*mesh, dim);
+  // Number globally
   DistributedMeshTools::number_entities(*mesh, dim);
 
   return _topology->size(dim);

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -414,7 +414,6 @@ std::size_t Mesh::create_entities(int dim) const
   // Compute connectivity
   Mesh* mesh = const_cast<Mesh*>(this);
   TopologyComputation::compute_entities(*mesh, dim);
-
   DistributedMeshTools::number_entities(*mesh, dim);
 
   return _topology->size(dim);
@@ -428,9 +427,9 @@ void Mesh::create_connectivity(std::size_t d0, std::size_t d1) const
   // const_cast is also needed to allow iterators over a const Mesh to
   // create new connectivity.
 
-  // Skip if already computed
-  if (_topology->connectivity(d0, d1))
-    return;
+  // Make sure entities exist
+  create_entities(d0);
+  create_entities(d1);
 
   // Compute connectivity
   Mesh* mesh = const_cast<Mesh*>(this);

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -415,6 +415,8 @@ std::size_t Mesh::create_entities(int dim) const
   Mesh* mesh = const_cast<Mesh*>(this);
   TopologyComputation::compute_entities(*mesh, dim);
 
+  DistributedMeshTools::number_entities(*mesh, dim);
+
   return _topology->size(dim);
 }
 //-----------------------------------------------------------------------------
@@ -445,12 +447,6 @@ void Mesh::create_connectivity_all() const
   for (int d0 = 0; d0 <= _topology->dim(); d0++)
     for (int d1 = 0; d1 <= _topology->dim(); d1++)
       create_connectivity(d0, d1);
-}
-//-----------------------------------------------------------------------------
-void Mesh::create_global_indices(std::size_t dim) const
-{
-  create_entities(dim);
-  DistributedMeshTools::number_entities(*this, dim);
 }
 //-----------------------------------------------------------------------------
 void Mesh::clean()

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -411,8 +411,9 @@ std::size_t Mesh::create_entities(int dim) const
   if (_topology->connectivity(dim, 0) or dim == 0)
     return _topology->size(dim);
 
-  // Compute connectivity
+  // Compute connectivity to vertices
   Mesh* mesh = const_cast<Mesh*>(this);
+
   TopologyComputation::compute_entities(*mesh, dim);
   DistributedMeshTools::number_entities(*mesh, dim);
 

--- a/cpp/dolfin/mesh/Mesh.h
+++ b/cpp/dolfin/mesh/Mesh.h
@@ -156,9 +156,6 @@ public:
   /// Compute all entities and connectivity
   void create_connectivity_all() const;
 
-  /// Compute global indices for entity dimension dim
-  void create_global_indices(std::size_t dim) const;
-
   /// Clean out all auxiliary topology data. This clears all topological
   /// data, except the connectivity between cells and vertices.
   void clean();

--- a/cpp/dolfin/mesh/Ordering.cpp
+++ b/cpp/dolfin/mesh/Ordering.cpp
@@ -313,8 +313,6 @@ void mesh::Ordering::order_simplex(mesh::Mesh& mesh)
   mesh::Connectivity& connect_g = mesh.coordinate_dofs().entity_points();
 
   // Get global vertex numbering
-  if (!mesh.topology().have_global_indices(0))
-    throw std::runtime_error("Mesh does not have global vertex indices.");
   const std::vector<std::int64_t>& global_vertex_indices
       = mesh.topology().global_indices(0);
 
@@ -395,8 +393,6 @@ bool mesh::Ordering::is_ordered_simplex(const mesh::Mesh& mesh)
     return true;
 
   // Get global vertex numbering
-  if (!mesh.topology().have_global_indices(0))
-    throw std::runtime_error("Mesh does not have global vertex indices.");
   const std::vector<std::int64_t>& global_vertex_indices
       = mesh.topology().global_indices(0);
 

--- a/cpp/dolfin/mesh/Topology.cpp
+++ b/cpp/dolfin/mesh/Topology.cpp
@@ -103,12 +103,6 @@ const std::vector<std::int64_t>& Topology::global_indices(std::size_t d) const
   return _global_indices[d];
 }
 //-----------------------------------------------------------------------------
-bool Topology::have_global_indices(std::size_t dim) const
-{
-  assert(dim < _global_indices.size());
-  return !_global_indices[dim].empty();
-}
-//-----------------------------------------------------------------------------
 std::map<std::int32_t, std::set<std::int32_t>>&
 Topology::shared_entities(int dim)
 {

--- a/cpp/dolfin/mesh/Topology.cpp
+++ b/cpp/dolfin/mesh/Topology.cpp
@@ -58,13 +58,8 @@ std::int64_t Topology::size_global(int dim) const
 //-----------------------------------------------------------------------------
 std::int32_t Topology::ghost_offset(int dim) const
 {
-  if (_ghost_offset_index.empty())
-    return 0;
-  else
-  {
-    assert(dim < (int)_ghost_offset_index.size());
-    return _ghost_offset_index[dim];
-  }
+  assert(dim < (int)_ghost_offset_index.size());
+  return _ghost_offset_index[dim];
 }
 //-----------------------------------------------------------------------------
 void Topology::clear(int d0, int d1)

--- a/cpp/dolfin/mesh/Topology.h
+++ b/cpp/dolfin/mesh/Topology.h
@@ -133,8 +133,9 @@ private:
   // Number of mesh vertices
   std::int32_t _num_vertices;
 
-  // Number of ghost indices for each topological dimension (local
-  // or global??)
+  // Local index of first ghost entity, for each topological dimension.
+  // Since ghost entities come after non-ghost entities, this is
+  // also the number of local non-ghost entities for each dimension.
   std::vector<std::size_t> _ghost_offset_index;
 
   // Global number of mesh entities for each topological dimension

--- a/cpp/dolfin/mesh/Topology.h
+++ b/cpp/dolfin/mesh/Topology.h
@@ -100,12 +100,12 @@ public:
   const std::vector<std::int32_t>& entity_owner(int dim) const;
 
   /// Marker for entities of dimension dim on the boundary. An entity of
-  /// co-dimension < 0 is on the boundary if it is connected to boundary
-  /// facet. It i not defined for codimension 0.
+  /// co-dimension < 0 is on the boundary if it is connected to a boundary
+  /// facet. It is not defined for codimension 0.
   /// @param[in] dim Toplogical dimension of the entities to check. It
   /// must be less than the topological dimension.
   /// @return Vector of length equal to number of local entities, with
-  ///          'true' for enties on the boundary and otherwise 'false'.
+  ///          'true' for entities on the boundary and otherwise 'false'.
   std::vector<bool> on_boundary(int dim) const;
 
   /// Return connectivity for given pair of topological dimensions

--- a/cpp/dolfin/mesh/Topology.h
+++ b/cpp/dolfin/mesh/Topology.h
@@ -141,7 +141,7 @@ private:
   // Global number of mesh entities for each topological dimension
   std::vector<std::int64_t> _global_num_entities;
 
-  // Global indices for mesh entities (empty if not set)
+  // Global indices for mesh entities
   std::vector<std::vector<std::int64_t>> _global_indices;
 
   // TODO: Could IndexMap be used here in place of std::map?

--- a/cpp/dolfin/mesh/Topology.h
+++ b/cpp/dolfin/mesh/Topology.h
@@ -80,10 +80,6 @@ public:
   /// dimension d
   const std::vector<std::int64_t>& global_indices(std::size_t d) const;
 
-  /// Check if global indices are available for entities of
-  /// dimension dim
-  bool have_global_indices(std::size_t dim) const;
-
   /// Return map from shared entities (local index) to processes
   /// that share the entity
   std::map<std::int32_t, std::set<std::int32_t>>& shared_entities(int dim);

--- a/cpp/dolfin/mesh/TopologyComputation.cpp
+++ b/cpp/dolfin/mesh/TopologyComputation.cpp
@@ -396,19 +396,15 @@ void TopologyComputation::compute_connectivity(Mesh& mesh, int d0, int d1)
   // Get mesh topology and connectivity
   Topology& topology = mesh.topology();
 
-  // Return connectivity has already been computed
+  // Return if connectivity has already been computed
   if (topology.connectivity(d0, d1))
     return;
 
-  // Compute entities if they don't exist
-  if (!topology.connectivity(d0, 0))
-    compute_entities(mesh, d0);
-  if (!topology.connectivity(d1, 0))
-    compute_entities(mesh, d1);
-
-  // Check if connectivity still needs to be computed
-  if (topology.connectivity(d0, d1))
-    return;
+  // Make sure entities exist
+  if (d0 > 0)
+    assert(topology.connectivity(d0, 0));
+  if (d1 > 0)
+    assert(topology.connectivity(d1, 0));
 
   // Start timer
   common::Timer timer("Compute connectivity " + std::to_string(d0) + "-"

--- a/cpp/dolfin/refinement/ParallelRefinement.cpp
+++ b/cpp/dolfin/refinement/ParallelRefinement.cpp
@@ -26,7 +26,8 @@ ParallelRefinement::ParallelRefinement(const mesh::Mesh& mesh)
     : _mesh(mesh), _marked_edges(mesh.num_entities(1), false),
       _marked_for_update(MPI::size(mesh.mpi_comm()))
 {
-  _mesh.create_global_indices(1);
+  if (!_mesh.topology().have_global_indices(1))
+    throw std::runtime_error("Edges must be initialised");
 
   // Create a global-to-local map for shared edges
   const std::map<std::int32_t, std::set<std::int32_t>>& shared_edges

--- a/cpp/dolfin/refinement/ParallelRefinement.cpp
+++ b/cpp/dolfin/refinement/ParallelRefinement.cpp
@@ -26,7 +26,7 @@ ParallelRefinement::ParallelRefinement(const mesh::Mesh& mesh)
     : _mesh(mesh), _marked_edges(mesh.num_entities(1), false),
       _marked_for_update(MPI::size(mesh.mpi_comm()))
 {
-  if (!_mesh.topology().have_global_indices(1))
+  if (!_mesh.topology().connectivity(1, 0))
     throw std::runtime_error("Edges must be initialised");
 
   // Create a global-to-local map for shared edges

--- a/python/src/mesh.cpp
+++ b/python/src/mesh.cpp
@@ -137,7 +137,6 @@ void mesh(py::module& m)
                &dolfin::mesh::Topology::connectivity, py::const_))
       .def("size", &dolfin::mesh::Topology::size)
       .def("hash", &dolfin::mesh::Topology::hash)
-      .def("have_global_indices", &dolfin::mesh::Topology::have_global_indices)
       .def("ghost_offset", &dolfin::mesh::Topology::ghost_offset)
       .def("entity_owner",
            py::overload_cast<int>(&dolfin::mesh::Topology::entity_owner,

--- a/python/src/mesh.cpp
+++ b/python/src/mesh.cpp
@@ -80,27 +80,27 @@ void mesh(py::module& m)
   py::class_<dolfin::mesh::CoordinateDofs,
              std::shared_ptr<dolfin::mesh::CoordinateDofs>>(
       m, "CoordinateDofs", "CoordinateDofs object")
-      .def(
-          "entity_points",
-          [](const dolfin::mesh::CoordinateDofs& self) {
-            const dolfin::mesh::Connectivity& connectivity
-                = self.entity_points();
-            Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
-                connections = connectivity.connections();
-            const int num_entities = connectivity.entity_positions().size() - 1;
+      .def("entity_points",
+           [](const dolfin::mesh::CoordinateDofs& self) {
+             const dolfin::mesh::Connectivity& connectivity
+                 = self.entity_points();
+             Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
+                 connections = connectivity.connections();
+             const int num_entities
+                 = connectivity.entity_positions().size() - 1;
 
-            // FIXME: mesh::CoordinateDofs should know its dimension
-            // (entity_size) to handle empty case on a process.
-            int entity_size = 0;
-            if (num_entities > 0)
-            {
-              assert(connections.size() % num_entities == 0);
-              entity_size = connections.size() / num_entities;
-            }
-            return py::array({num_entities, entity_size}, connections.data(),
-                             py::none());
-          },
-          py::return_value_policy::reference_internal);
+             // FIXME: mesh::CoordinateDofs should know its dimension
+             // (entity_size) to handle empty case on a process.
+             int entity_size = 0;
+             if (num_entities > 0)
+             {
+               assert(connections.size() % num_entities == 0);
+               entity_size = connections.size() / num_entities;
+             }
+             return py::array({num_entities, entity_size}, connections.data(),
+                              py::none());
+           },
+           py::return_value_policy::reference_internal);
 
   // dolfin::mesh::Geometry class
   py::class_<dolfin::mesh::Geometry, std::shared_ptr<dolfin::mesh::Geometry>>(
@@ -143,14 +143,13 @@ void mesh(py::module& m)
            py::overload_cast<int>(&dolfin::mesh::Topology::entity_owner,
                                   py::const_))
       .def("on_boundary", &dolfin::mesh::Topology::on_boundary)
-      .def(
-          "global_indices",
-          [](const dolfin::mesh::Topology& self, int dim) {
-            auto& indices = self.global_indices(dim);
-            return py::array_t<std::int64_t>(indices.size(), indices.data(),
-                                             py::none());
-          },
-          py::return_value_policy::reference_internal)
+      .def("global_indices",
+           [](const dolfin::mesh::Topology& self, int dim) {
+             auto& indices = self.global_indices(dim);
+             return py::array_t<std::int64_t>(indices.size(), indices.data(),
+                                              py::none());
+           },
+           py::return_value_policy::reference_internal)
       .def("shared_entities",
            py::overload_cast<int>(&dolfin::mesh::Topology::shared_entities))
       .def("str", &dolfin::mesh::Topology::str);
@@ -193,7 +192,6 @@ void mesh(py::module& m)
       .def("hash", &dolfin::mesh::Mesh::hash)
       .def("hmax", &dolfin::mesh::Mesh::hmax)
       .def("hmin", &dolfin::mesh::Mesh::hmin)
-      .def("create_global_indices", &dolfin::mesh::Mesh::create_global_indices)
       .def("create_entities", &dolfin::mesh::Mesh::create_entities)
       .def("create_connectivity", &dolfin::mesh::Mesh::create_connectivity)
       .def("create_connectivity_all",
@@ -221,15 +219,14 @@ void mesh(py::module& m)
   py::class_<dolfin::mesh::Connectivity,
              std::shared_ptr<dolfin::mesh::Connectivity>>(m, "Connectivity",
                                                           "Connectivity object")
-      .def(
-          "connections",
-          [](const dolfin::mesh::Connectivity& self, std::size_t i) {
-            return Eigen::Map<
-                const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>(
-                self.connections(i), self.size(i));
-          },
-          "Connections for a single mesh entity",
-          py::return_value_policy::reference_internal)
+      .def("connections",
+           [](const dolfin::mesh::Connectivity& self, std::size_t i) {
+             return Eigen::Map<
+                 const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>(
+                 self.connections(i), self.size(i));
+           },
+           "Connections for a single mesh entity",
+           py::return_value_policy::reference_internal)
       .def("connections",
            py::overload_cast<>(&dolfin::mesh::Connectivity::connections),
            "Connections for all mesh entities")
@@ -249,22 +246,21 @@ void mesh(py::module& m)
       .def("index",
            py::overload_cast<>(&dolfin::mesh::MeshEntity::index, py::const_),
            "Entity index")
-      .def(
-          "entities",
-          [](dolfin::mesh::MeshEntity& self, std::size_t dim) {
-            if (self.dim() == dim)
-              return py::array(1, self.entities(dim));
-            else
-            {
-              assert(self.mesh.topology().connectivity(self.dim(), dim));
-              const int num_entities = self.mesh()
-                                           .topology()
-                                           .connectivity(self.dim(), dim)
-                                           ->size(self.index());
-              return py::array(num_entities, self.entities(dim));
-            }
-          },
-          py::return_value_policy::reference_internal)
+      .def("entities",
+           [](dolfin::mesh::MeshEntity& self, std::size_t dim) {
+             if (self.dim() == dim)
+               return py::array(1, self.entities(dim));
+             else
+             {
+               assert(self.mesh.topology().connectivity(self.dim(), dim));
+               const int num_entities = self.mesh()
+                                            .topology()
+                                            .connectivity(self.dim(), dim)
+                                            ->size(self.index());
+               return py::array(num_entities, self.entities(dim));
+             }
+           },
+           py::return_value_policy::reference_internal)
       .def("__str__",
            [](dolfin::mesh::MeshEntity& self) { return self.str(false); });
 

--- a/python/test/unit/io/test_XDMF.py
+++ b/python/test/unit/io/test_XDMF.py
@@ -654,8 +654,6 @@ def test_append_and_load_mesh_value_collections(tempdir, encoding, data_type):
     dtype_str, dtype = data_type
     mesh = UnitCubeMesh(MPI.comm_world, 2, 2, 2)
     mesh.create_connectivity_all()
-    for d in range(mesh.geometry.dim + 1):
-        mesh.create_global_indices(d)
 
     mvc_v = MeshValueCollection(dtype_str, mesh, 0)
     mvc_v.name = "vertices"

--- a/python/test/unit/mesh/test_refinement.py
+++ b/python/test/unit/mesh/test_refinement.py
@@ -11,6 +11,7 @@ from dolfin.cpp.refinement import refine
 def test_RefineUnitSquareMesh():
     """Refine mesh of unit square."""
     mesh = UnitSquareMesh(MPI.comm_world, 5, 7)
+    mesh.create_entities(1)
     mesh = refine(mesh, False)
     assert mesh.num_entities_global(0) == 165
     assert mesh.num_entities_global(2) == 280
@@ -19,6 +20,7 @@ def test_RefineUnitSquareMesh():
 def test_RefineUnitCubeMesh_repartition():
     """Refine mesh of unit cube."""
     mesh = UnitCubeMesh(MPI.comm_world, 5, 7, 9)
+    mesh.create_entities(1)
     mesh = refine(mesh, True)
     assert mesh.num_entities_global(0) == 3135
     assert mesh.num_entities_global(3) == 15120
@@ -29,6 +31,7 @@ def test_RefineUnitCubeMesh_repartition():
 def test_RefineUnitCubeMesh_keep_partition():
     """Refine mesh of unit cube."""
     mesh = UnitCubeMesh(MPI.comm_world, 5, 7, 9)
+    mesh.create_entities(1)
     mesh = refine(mesh, False)
     assert mesh.num_entities_global(0) == 3135
     assert mesh.num_entities_global(3) == 15120


### PR DESCRIPTION
This pulls together the entity creation and numbering for edges and facets. 
Now, when they are created on demand, they are also given global indexing.

Future work will refactor `TopologyComputation::compute_entities()` and `DistributedMeshTools::number_entities()` so that the ghosting scheme can be updated.