### PR TITLE
Improve nonlinear assembly tests

### DIFF
--- a/python/src/la.cpp
+++ b/python/src/la.cpp
@@ -104,6 +104,10 @@ void la(py::module& m)
         },
         py::return_value_policy::take_ownership,
         "Create a PETSc Mat from sparsity pattern.");
+  m.def("scatter_local_vectors", &dolfin::la::scatter_local_vectors,
+        "Scatter the (ordered) list of sub vectors into a block vector.");
+  m.def("get_local_vectors", &dolfin::la::get_local_vectors,
+        "Gather an (ordered) list of sub vectors from a block vector.");
   // NOTE: Enabling the below requires adding a C API for MatNullSpace to
   // petsc4py
   //   m.def("create_nullspace",

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -75,7 +75,10 @@ def test_matrix_assembly_block():
 
     # Monolithic blocked
     x0 = dolfin.fem.create_vector_block(L_block)
-    dolfin.cpp.la.scatter_local_vectors(x0, [u.vector.array_r, p.vector.array_r], [u.function_space.dofmap.index_map, p.function_space.dofmap.index_map])
+    dolfin.cpp.la.scatter_local_vectors(
+        x0, [u.vector.array_r, p.vector.array_r],
+        [u.function_space.dofmap.index_map, p.function_space.dofmap.index_map])
+    x0.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
     # Ghosts are updated inside assemble_vector_block
     A0 = dolfin.fem.assemble_matrix_block(a_block, [bc])
@@ -95,9 +98,9 @@ def test_matrix_assembly_block():
     A1 = dolfin.fem.assemble_matrix_nest(a_block, [bc])
     b1 = dolfin.fem.assemble_vector_nest(L_block, a_block, [bc], x0=x1, scale=-1.0)
 
-    # assert A1.getType() == "nest"
-    # assert nest_matrix_norm(A1) == pytest.approx(Anorm0, 1.0e-12)
-    # assert b1.norm() == pytest.approx(bnorm0, 1.0e-12)
+    assert A1.getType() == "nest"
+    assert nest_matrix_norm(A1) == pytest.approx(Anorm0, 1.0e-12)
+    assert b1.norm() == pytest.approx(bnorm0, 1.0e-12)
 
     # Monolithic version
     E = P0 * P1

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -95,9 +95,9 @@ def test_matrix_assembly_block():
     A1 = dolfin.fem.assemble_matrix_nest(a_block, [bc])
     b1 = dolfin.fem.assemble_vector_nest(L_block, a_block, [bc], x0=x1, scale=-1.0)
 
-    assert A1.getType() == "nest"
-    assert nest_matrix_norm(A1) == pytest.approx(Anorm0, 1.0e-12)
-    assert b1.norm() == pytest.approx(bnorm0, 1.0e-12)
+    # assert A1.getType() == "nest"
+    # assert nest_matrix_norm(A1) == pytest.approx(Anorm0, 1.0e-12)
+    # assert b1.norm() == pytest.approx(bnorm0, 1.0e-12)
 
     # Monolithic version
     E = P0 * P1

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -47,9 +47,14 @@ def test_matrix_assembly_block():
     def boundary(x):
         return numpy.logical_or(x[:, 0] < 1.0e-6, x[:, 0] > 1.0 - 1.0e-6)
 
-    initial_guess_u = lambda x: numpy.sin(x[:, 0])*numpy.sin(x[:, 1])
-    initial_guess_p = lambda x: -x[:, 0]**2 - x[:, 1]**3
-    bc_value = lambda x: numpy.cos(x[:, 0])*numpy.cos(x[:, 1])
+    def initial_guess_u(x):
+        return numpy.sin(x[:, 0]) * numpy.sin(x[:, 1])
+
+    def initial_guess_p(x):
+        return -x[:, 0]**2 - x[:, 1]**3
+
+    def bc_value(x):
+        return numpy.cos(x[:, 0]) * numpy.cos(x[:, 1])
 
     u_bc = dolfin.function.Function(V1)
     u_bc.interpolate(bc_value)
@@ -216,11 +221,17 @@ def test_assembly_solve_block():
     V0 = dolfin.function.functionspace.FunctionSpace(mesh, P0)
     V1 = dolfin.function.functionspace.FunctionSpace(mesh, P1)
 
-    bc_val_0 = lambda x: x[:, 0]**2 + x[:, 1]**2
-    bc_val_1 = lambda x: numpy.sin(x[:, 0]) * numpy.cos(x[:, 1])
+    def bc_val_0(x):
+        return x[:, 0]**2 + x[:, 1]**2
 
-    initial_guess_u = lambda x: numpy.sin(x[:, 0])*numpy.sin(x[:, 1])
-    initial_guess_p = lambda x: -x[:, 0]**2 - x[:, 1]**3
+    def bc_val_1(x):
+        return numpy.sin(x[:, 0]) * numpy.cos(x[:, 1])
+
+    def initial_guess_u(x):
+        return numpy.sin(x[:, 0]) * numpy.sin(x[:, 1])
+
+    def initial_guess_p(x):
+        return -x[:, 0]**2 - x[:, 1]**3
 
     def boundary(x):
         return numpy.logical_or(x[:, 0] < 1.0e-6, x[:, 0] > 1.0 - 1.0e-6)
@@ -411,12 +422,14 @@ def test_assembly_solve_taylor_hood(mesh):
     def initial_guess_u(x):
         d = x.shape[1]
         u_init = numpy.column_stack(
-            (numpy.sin(x[:, 0])*numpy.sin(x[:, 1]),
+            (numpy.sin(x[:, 0]) * numpy.sin(x[:, 1]),
              numpy.cos(x[:, 0]) * numpy.cos(x[:, 1])))
         if d == 3:
             u_init = numpy.column_stack((u_init, numpy.cos(x[:, 2])))
         return u_init
-    initial_guess_p = lambda x: -x[:, 0]**2 - x[:, 1]**3
+
+    def initial_guess_p(x):
+        return -x[:, 0]**2 - x[:, 1]**3
 
     u_bc_0 = dolfin.Function(P2)
     u_bc_0.interpolate(

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -47,9 +47,9 @@ def test_matrix_assembly_block():
     def boundary(x):
         return numpy.logical_or(x[:, 0] < 1.0e-6, x[:, 0] > 1.0 - 1.0e-6)
 
-    initial_guess_u = lambda x: numpy.sin(numpy.pi*x[:, 0])*numpy.sin(numpy.pi*x[:, 1])
+    initial_guess_u = lambda x: numpy.sin(x[:, 0])*numpy.sin(x[:, 1])
     initial_guess_p = lambda x: -x[:, 0]**2 - x[:, 1]**3
-    bc_value = lambda x: numpy.cos(numpy.pi*x[:, 0])*numpy.cos(numpy.pi*x[:, 1])
+    bc_value = lambda x: numpy.cos(x[:, 0])*numpy.cos(x[:, 1])
 
     u_bc = dolfin.function.Function(V1)
     u_bc.interpolate(bc_value)


### PR DESCRIPTION
The tests were not sufficient for ensuring ghost values were correctly set.

Simple changes introduce non-homogeneous BCs and initial guesses to the nonlinear tests.

Also adds blocked vector scatter and getter functions to the pybind layer.