### PR TITLE
Remove the behind the scenes ksp.view()

### DIFF
--- a/python/dolfin/fem/solving.py
+++ b/python/dolfin/fem/solving.py
@@ -147,7 +147,6 @@ def _solve_varproblem(*args, **kwargs):
 
         ksp.setFromOptions()
         ksp.solve(b, u.vector)
-        ksp.view()
 
     # Solve nonlinear variational problem
     else:


### PR DESCRIPTION
This should be called as a PETSc option, i.e. `{"ksp_view": None}` and not forced on the user.