### PR TITLE
Add mesh ordering test

### DIFF
--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -537,3 +537,36 @@ def test_UnitHexMesh_assemble():
     vol = assemble_scalar(1 * dx(mesh))
     vol = MPI.sum(mesh.mpi_comm(), vol)
     assert(vol == pytest.approx(1, rel=1e-9))
+
+
+def test_mesh_order_unchanged_triangle():
+    points = [[0, 0], [1, 0], [1, 1]]
+    cells = [[0, 1, 2]]
+    mesh = Mesh(MPI.comm_world, CellType.triangle, points,
+                cells, [], cpp.mesh.GhostMode.none)
+    assert (mesh.cells()[0] == cells[0]).all()
+
+
+def test_mesh_order_unchanged_quadrilateral():
+    points = [[0, 0], [1, 0], [0, 1], [1, 1]]
+    cells = [[0, 1, 2, 3]]
+    mesh = Mesh(MPI.comm_world, CellType.quadrilateral, points,
+                cells, [], cpp.mesh.GhostMode.none)
+    assert (mesh.cells()[0] == cells[0]).all()
+
+
+def test_mesh_order_unchanged_tetrahedron():
+    points = [[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 0, 1]]
+    cells = [[0, 1, 2, 3]]
+    mesh = Mesh(MPI.comm_world, CellType.tetrahedron, points,
+                cells, [], cpp.mesh.GhostMode.none)
+    assert (mesh.cells()[0] == cells[0]).all()
+
+
+def test_mesh_order_unchanged_hexahedron():
+    points = [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0],
+              [0, 0, 1], [1, 0, 1], [0, 1, 1], [1, 1, 1]]
+    cells = [[0, 1, 2, 3, 4, 5, 6, 7]]
+    mesh = Mesh(MPI.comm_world, CellType.hexahedron, points,
+                cells, [], cpp.mesh.GhostMode.none)
+    assert (mesh.cells()[0] == cells[0]).all()


### PR DESCRIPTION
@jorgensd: Should we add a test like this to make sure that the Mesh constructor leaves the mesh non-reorders?

(The quad version of this test currently fails in master, so I'm very happy it passes here.)