### PR TITLE
Fix issue 614 for refinement of 2D mesh resulting in 3D geometry

### DIFF
--- a/cpp/dolfin/refinement/ParallelRefinement.cpp
+++ b/cpp/dolfin/refinement/ParallelRefinement.cpp
@@ -282,7 +282,8 @@ mesh::Mesh ParallelRefinement::build_local() const
                                 Eigen::RowMajor>>
       topology(_new_cell_topology.data(), num_cells, num_cell_vertices);
 
-  mesh::Mesh mesh(_mesh.mpi_comm(), _mesh.cell_type(), geometry, topology, {},
+  mesh::Mesh mesh(_mesh.mpi_comm(), _mesh.cell_type(),
+                  geometry.leftCols(_mesh.geometry().dim()), topology, {},
                   _mesh.get_ghost_mode());
 
   return mesh;
@@ -314,11 +315,13 @@ mesh::Mesh ParallelRefinement::partition(bool redistribute) const
   if (redistribute)
   {
     return mesh::Partitioning::build_distributed_mesh(
-        _mesh.mpi_comm(), _mesh.cell_type(), points, cells, global_cell_indices,
+        _mesh.mpi_comm(), _mesh.cell_type(),
+        points.leftCols(_mesh.geometry().dim()), cells, global_cell_indices,
         _mesh.get_ghost_mode());
   }
 
-  mesh::Mesh mesh(_mesh.mpi_comm(), _mesh.cell_type(), points, cells,
+  mesh::Mesh mesh(_mesh.mpi_comm(), _mesh.cell_type(),
+                  points.leftCols(_mesh.geometry().dim()), cells,
                   global_cell_indices, _mesh.get_ghost_mode());
 
   mesh::DistributedMeshTools::init_facet_cell_connections(mesh);

--- a/python/test/unit/mesh/test_refinement.py
+++ b/python/test/unit/mesh/test_refinement.py
@@ -37,3 +37,10 @@ def test_RefineUnitCubeMesh_keep_partition():
     assert mesh.num_entities_global(3) == 15120
     Q = FunctionSpace(mesh, ("CG", 1))
     assert(Q)
+
+
+def test_refinement_gdim():
+    """Test that 2D refinement is still 2D"""
+    mesh = UnitSquareMesh(MPI.comm_world, 3, 4)
+    mesh2 = refine(mesh, True)
+    assert mesh.geometric_dimension() == mesh2.geometric_dimension()


### PR DESCRIPTION
Fixing issue #614 , using the information from the unrefined geometry in the mesh initializer.