### PR TITLE
Some fixes to allow setup.py to run in debug mode

### DIFF
--- a/python/src/mesh.cpp
+++ b/python/src/mesh.cpp
@@ -251,7 +251,7 @@ void mesh(py::module& m)
                return py::array(1, self.entities(dim));
              else
              {
-               assert(self.mesh.topology().connectivity(self.dim(), dim));
+               assert(self.mesh().topology().connectivity(self.dim(), dim));
                const int num_entities = self.mesh()
                                             .topology()
                                             .connectivity(self.dim(), dim)

--- a/python/src/nls.cpp
+++ b/python/src/nls.cpp
@@ -13,6 +13,13 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#ifdef DEBUG
+// Needed for typeid(_p_Mat) in debug mode
+#include <petsc/private/matimpl.h>
+// Needed for typeid(_p_Vec) in debug mode
+#include <petsc/private/vecimpl.h>
+#endif
+
 namespace py = pybind11;
 
 namespace dolfin_wrappers
@@ -46,7 +53,7 @@ void nls(py::module& m)
       PYBIND11_OVERLOAD_INT(void, dolfin::nls::NewtonSolver, "update_solution",
                             x, &dx, relaxation, &nonlinear_problem, iteration);
       return dolfin::nls::NewtonSolver::update_solution(
-              x, dx, relaxation, nonlinear_problem, iteration);
+          x, dx, relaxation, nonlinear_problem, iteration);
     }
   };
 


### PR DESCRIPTION
A workaround to allow `nls.cpp` to compile with `python3 setup.py build --debug`.
Without this, we can't compile in debug mode.