### PR TITLE
Remove unnecessary include in assemble_vector_impl.h

### DIFF
--- a/cpp/dolfin/fem/assemble_vector_impl.h
+++ b/cpp/dolfin/fem/assemble_vector_impl.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include "assembler.h"
 #include <Eigen/Dense>
 #include <dolfin/common/types.h>
 #include <memory>


### PR DESCRIPTION
I caught this while being lazy with the `using` directive in `.cpp` files, getting errors like
```
error: call of overloaded ‘assemble_vector(Eigen::Map<Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> >&, const dolfin::fem::Form&)’ is ambiguous

dolfin/fem/assemble_vector_impl.h:44:5: note: candidate: void dolfin::fem::impl::assemble_vector(Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const dolfin::fem::Form&)
     assemble_vector(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
     ^~~~~~~~~~~~~~~

dolfin/fem/assembler.h:55:5: note: candidate: void dolfin::fem::assemble_vector(Eigen::Ref<Eigen::Matrix<double, -1, 1> >, const dolfin::fem::Form&)
     assemble_vector(Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
     ^~~~~~~~~~~~~~~
```
when including `dolfin/fem/assemble_vector_impl.h` after #611.

This can of course be easily fixed on my side by proper namespacing, but I'd still argue in favor of this PR since (it is ridiculously small and) the leftover include might be misleading to a new user who is scrolling through the source files (as assembler.h uses the implementation in assemble_vector_impl.h, not the other way around).