### PR TITLE
remove Mesh.geometric_dimension()

### DIFF
--- a/python/dolfin/mesh.py
+++ b/python/dolfin/mesh.py
@@ -68,13 +68,6 @@ def ufl_domain(self):
     return self._ufl_domain
 
 
-# FIXME: find a way to remove this from public interface. Use gdim =
-# mesh.geometry.dim instead
-def geometric_dimension(self):
-    """Returns geometric dimension for UFL interface"""
-    return self.geometry.dim
-
-
 def num_cells(self):
     """Return number of mesh cells"""
     return self.num_entities(self.topology.dim)
@@ -84,7 +77,6 @@ def num_cells(self):
 cpp.mesh.Mesh.ufl_cell = ufl_cell
 cpp.mesh.Mesh.ufl_coordinate_element = ufl_coordinate_element
 cpp.mesh.Mesh.ufl_domain = ufl_domain
-cpp.mesh.Mesh.geometric_dimension = geometric_dimension
 cpp.mesh.Mesh.num_cells = num_cells
 
-del ufl_cell, ufl_coordinate_element, ufl_domain, geometric_dimension, num_cells
+del ufl_cell, ufl_coordinate_element, ufl_domain, num_cells

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -643,11 +643,11 @@ def test_higher_order_coordinate_map(points, celltype):
     x_g = mesh.geometry.points
 
     cmap = fem.create_coordinate_map(mesh.ufl_domain())
-    x_coord_new = np.zeros([len(points), mesh.geometric_dimension()])
+    x_coord_new = np.zeros([len(points), mesh.geometry.dim])
 
     i = 0
     for node in range(len(points)):
-        x_coord_new[i] = x_g[coord_dofs[0, node], :mesh.geometric_dimension()]
+        x_coord_new[i] = x_g[coord_dofs[0, node], :mesh.geometry.dim]
         i += 1
 
     x = np.zeros(X.shape)
@@ -656,7 +656,7 @@ def test_higher_order_coordinate_map(points, celltype):
     assert(np.allclose(x[:, 0], X[:, 0]))
     assert(np.allclose(x[:, 1], 2 * X[:, 1]))
 
-    if mesh.geometric_dimension() == 3:
+    if mesh.geometry.dim == 3:
         assert(np.allclose(x[:, 2], 3 * X[:, 2]))
 
 
@@ -692,11 +692,11 @@ def test_higher_order_tetra_coordinate_map(order):
     x_g = mesh.geometry.points
 
     cmap = fem.create_coordinate_map(mesh.ufl_domain())
-    x_coord_new = np.zeros([len(points), mesh.geometric_dimension()])
+    x_coord_new = np.zeros([len(points), mesh.geometry.dim])
 
     i = 0
     for node in range(len(points)):
-        x_coord_new[i] = x_g[coord_dofs[0, node], :mesh.geometric_dimension()]
+        x_coord_new[i] = x_g[coord_dofs[0, node], :mesh.geometry.dim]
         i += 1
 
     x = np.zeros(X.shape)

--- a/python/test/unit/mesh/test_refinement.py
+++ b/python/test/unit/mesh/test_refinement.py
@@ -43,4 +43,4 @@ def test_refinement_gdim():
     """Test that 2D refinement is still 2D"""
     mesh = UnitSquareMesh(MPI.comm_world, 3, 4)
     mesh2 = refine(mesh, True)
-    assert mesh.geometric_dimension() == mesh2.geometric_dimension()
+    assert mesh.geometry.dim == mesh2.geometry.dim


### PR DESCRIPTION
Simple cleanup. Remove `Mesh.geometric_dimension()` in the python layer in favour of `Mesh.geometry.dim`