### PR TITLE
Require MPI-3

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -105,7 +105,7 @@ endforeach()
 # Check for MPI
 
 # FIXME: Should we set CMake to use the discovered MPI compiler wrappers?
-find_package(MPI REQUIRED)
+find_package(MPI 3 REQUIRED)
 
 #------------------------------------------------------------------------------
 # Compiler flags


### PR DESCRIPTION
Neighbourhood collective operations were introduced in MPI 3.0, and they are currently being used in `IndexMap`, should dolfinx require MPI 3?