### PR TITLE
Avoid some MPI calls for mesh in serial

### DIFF
--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -163,6 +163,23 @@ compute_point_distribution(
         points,
     mesh::CellType type)
 {
+  int mpi_size = dolfin::MPI::size(mpi_comm);
+
+  if (mpi_size == 1)
+  {
+    std::map<std::int32_t, std::set<int>> shared_points;
+    std::vector<std::int64_t> local_to_global(points.rows());
+    std::iota(local_to_global.begin(), local_to_global.end(), 0);
+    std::array<int, 4> num_vertices_local;
+    num_vertices_local.fill(points.rows());
+    Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+        cells_local = cell_nodes.cast <std::int32_t> ();
+
+    return std::tuple(std::move(local_to_global), std::move(shared_points),
+                      std::move(cells_local), std::move(points),
+                      num_vertices_local);
+  }
+
   // Get set of global point indices, which exist on this process
   std::vector<std::int64_t> global_index_set
       = compute_global_index_set(cell_nodes);

--- a/cpp/dolfin/mesh/Mesh.cpp
+++ b/cpp/dolfin/mesh/Mesh.cpp
@@ -173,7 +173,7 @@ compute_point_distribution(
     std::array<int, 4> num_vertices_local;
     num_vertices_local.fill(points.rows());
     Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
-        cells_local = cell_nodes.cast <std::int32_t> ();
+        cells_local = cell_nodes.cast<std::int32_t>();
 
     return std::tuple(std::move(local_to_global), std::move(shared_points),
                       std::move(cells_local), std::move(points),

--- a/cpp/dolfin/mesh/Partitioning.cpp
+++ b/cpp/dolfin/mesh/Partitioning.cpp
@@ -721,6 +721,9 @@ mesh::Mesh Partitioning::build_distributed_mesh(
 
   if (nparts == 1)
   {
+    if (ghost_mode != mesh::GhostMode::none)
+      throw std::runtime_error(
+          "Ghost cell information not available in serial");
 
     mesh::Mesh mesh(comm, cell_type, points, cells, global_cell_indices,
                     ghost_mode);

--- a/cpp/dolfin/mesh/Partitioning.cpp
+++ b/cpp/dolfin/mesh/Partitioning.cpp
@@ -724,6 +724,13 @@ mesh::Mesh Partitioning::build_distributed_mesh(
 
     mesh::Mesh mesh(comm, cell_type, points, cells,
                     global_cell_indices, ghost_mode);
+
+    // Initialise number of globally connected cells to each facet. This
+    // is necessary to distinguish between facets on an exterior boundary
+    // and facets on a partition boundary (see
+    // https://bugs.launchpad.net/dolfin/+bug/733834).
+    DistributedMeshTools::init_facet_cell_connections(mesh);
+
     return mesh;
   }
 

--- a/cpp/dolfin/mesh/Partitioning.cpp
+++ b/cpp/dolfin/mesh/Partitioning.cpp
@@ -722,13 +722,14 @@ mesh::Mesh Partitioning::build_distributed_mesh(
   if (nparts == 1)
   {
 
-    mesh::Mesh mesh(comm, cell_type, points, cells,
-                    global_cell_indices, ghost_mode);
+    mesh::Mesh mesh(comm, cell_type, points, cells, global_cell_indices,
+                    ghost_mode);
 
     // Initialise number of globally connected cells to each facet. This
     // is necessary to distinguish between facets on an exterior boundary
     // and facets on a partition boundary (see
     // https://bugs.launchpad.net/dolfin/+bug/733834).
+
     DistributedMeshTools::init_facet_cell_connections(mesh);
 
     return mesh;

--- a/cpp/dolfin/mesh/Partitioning.cpp
+++ b/cpp/dolfin/mesh/Partitioning.cpp
@@ -719,6 +719,14 @@ mesh::Mesh Partitioning::build_distributed_mesh(
   // nparts = MPI size
   const int nparts = dolfin::MPI::size(comm);
 
+  if (nparts == 1)
+  {
+
+    mesh::Mesh mesh(comm, cell_type, points, cells,
+                    global_cell_indices, ghost_mode);
+    return mesh;
+  }
+
   // Compute the cell partition
   PartitionData cell_partition
       = partition_cells(comm, nparts, cell_type, cells, graph_partitioner);


### PR DESCRIPTION
Proposal to fix Issue #101 .

```
from dolfin.common import list_timings, TimingType
from dolfin import *

mesh = UnitCubeMesh(MPI.comm_world, 100, 100, 100)
list_timings([TimingType.wall])
```
Time to build UnitCubeMesh in serial:
- Dolfin-x (computing facet-cell connections):  25.31 s
- This branch (computing facet-cell connections): 7.6271 s
- This branch  (without computing facet-cell connections): 0.54866 s
- Dolfin (without computing facet-cell connections):  0.55464 s

Should we initialize facet-cell connections by default?



