### PR TITLE
Improve parallel boxmesh

### DIFF
--- a/cpp/dolfin/generation/BoxMesh.cpp
+++ b/cpp/dolfin/generation/BoxMesh.cpp
@@ -18,25 +18,20 @@ using namespace dolfin::generation;
 namespace
 {
 //-----------------------------------------------------------------------------
-mesh::Mesh build_tet(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
-                     std::array<std::size_t, 3> n,
-                     const mesh::GhostMode ghost_mode,
-                     mesh::Partitioner partitioner)
+Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>
+create_geom(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
+            std::array<std::size_t, 3> n)
 {
-  common::Timer timer("Build BoxMesh");
-
-  const std::int64_t n_points = (n[0] + 1) * (n[1] + 1) * (n[2] + 1);
-  const std::int64_t n_cells = n[0] * n[1] * n[2];
-  std::array<std::int64_t, 2> range_p
-      = dolfin::MPI::local_range(comm, n_points);
-  std::array<std::int64_t, 2> range_c = dolfin::MPI::local_range(comm, n_cells);
-
   // Extract data
   const Eigen::Vector3d& p0 = p[0];
   const Eigen::Vector3d& p1 = p[1];
-  std::size_t nx = n[0];
-  std::size_t ny = n[1];
-  std::size_t nz = n[2];
+  std::int64_t nx = n[0];
+  std::int64_t ny = n[1];
+  std::int64_t nz = n[2];
+
+  const std::int64_t n_points = (nx + 1) * (ny + 1) * (nz + 1);
+  std::array<std::int64_t, 2> range_p
+      = dolfin::MPI::local_range(comm, n_points);
 
   // Extract minimum and maximum coordinates
   const double x0 = std::min(p0[0], p1[0]);
@@ -72,8 +67,6 @@ mesh::Mesh build_tet(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
 
   Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> geom(
       range_p[1] - range_p[0], 3);
-  Eigen::Array<std::int64_t, Eigen::Dynamic, 4, Eigen::RowMajor> topo(
-      6 * (range_c[1] - range_c[0]), 4);
 
   const std::int64_t sqxy = (nx + 1) * (ny + 1);
   for (std::int64_t v = range_p[0]; v < range_p[1]; ++v)
@@ -88,23 +81,44 @@ mesh::Mesh build_tet(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
     geom.row(v - range_p[0]) << x, y, z;
   }
 
-  // Create tetrahedra
-  std::size_t cell = 0;
-  for (std::int64_t cct = range_c[0]; cct < range_c[1]; ++cct)
-  {
-    const int iz = cct / (nx * ny);
-    const int p = cct % (nx * ny);
-    const int iy = p / nx;
-    const int ix = p % nx;
+  return geom;
+}
+//-----------------------------------------------------------------------------
+mesh::Mesh build_tet(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
+                     std::array<std::size_t, 3> n,
+                     const mesh::GhostMode ghost_mode,
+                     mesh::Partitioner partitioner)
+{
+  common::Timer timer("Build BoxMesh");
 
-    const std::size_t v0 = iz * (nx + 1) * (ny + 1) + iy * (nx + 1) + ix;
-    const std::size_t v1 = v0 + 1;
-    const std::size_t v2 = v0 + (nx + 1);
-    const std::size_t v3 = v1 + (nx + 1);
-    const std::size_t v4 = v0 + (nx + 1) * (ny + 1);
-    const std::size_t v5 = v1 + (nx + 1) * (ny + 1);
-    const std::size_t v6 = v2 + (nx + 1) * (ny + 1);
-    const std::size_t v7 = v3 + (nx + 1) * (ny + 1);
+  Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> geom
+      = create_geom(comm, p, n);
+
+  std::int64_t nx = n[0];
+  std::int64_t ny = n[1];
+  std::int64_t nz = n[2];
+  const std::int64_t n_cells = nx * ny * nz;
+  std::array<std::int64_t, 2> range_c = dolfin::MPI::local_range(comm, n_cells);
+  Eigen::Array<std::int64_t, Eigen::Dynamic, 4, Eigen::RowMajor> topo(
+      6 * (range_c[1] - range_c[0]), 4);
+
+  // Create tetrahedra
+  std::int64_t cell = 0;
+  for (std::int64_t i = range_c[0]; i < range_c[1]; ++i)
+  {
+    const int iz = i / (nx * ny);
+    const int j = i % (nx * ny);
+    const int iy = j / nx;
+    const int ix = j % nx;
+
+    const std::int64_t v0 = iz * (nx + 1) * (ny + 1) + iy * (nx + 1) + ix;
+    const std::int64_t v1 = v0 + 1;
+    const std::int64_t v2 = v0 + (nx + 1);
+    const std::int64_t v3 = v1 + (nx + 1);
+    const std::int64_t v4 = v0 + (nx + 1) * (ny + 1);
+    const std::int64_t v5 = v1 + (nx + 1) * (ny + 1);
+    const std::int64_t v6 = v2 + (nx + 1) * (ny + 1);
+    const std::int64_t v7 = v3 + (nx + 1) * (ny + 1);
 
     // Note that v0 < v1 < v2 < v3 < vmid.
     topo.row(cell) << v0, v1, v3, v7;
@@ -126,84 +140,45 @@ mesh::Mesh build_tet(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
       partitioner);
 }
 //-----------------------------------------------------------------------------
-mesh::Mesh build_hex(MPI_Comm comm, std::array<std::size_t, 3> n,
+mesh::Mesh build_hex(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
+                     std::array<std::size_t, 3> n,
                      const mesh::GhostMode ghost_mode,
                      mesh::Partitioner partitioner)
 {
-  // Receive mesh if not rank 0
-  if (dolfin::MPI::rank(comm) != 0)
-  {
-    Eigen::Array<double, 0, 3, Eigen::RowMajor> geom(0, 3);
-    Eigen::Array<std::int64_t, 0, 8, Eigen::RowMajor> topo(0, 8);
+  Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> geom
+      = create_geom(comm, p, n);
 
-    return mesh::Partitioning::build_distributed_mesh(
-        comm, mesh::CellType::hexahedron, geom, topo, {}, ghost_mode);
-  }
-
-  const std::size_t nx = n[0];
-  const std::size_t ny = n[1];
-  const std::size_t nz = n[2];
-
-  const double a = 0.0;
-  const double b = 1.0;
-  const double c = 0.0;
-  const double d = 1.0;
-  const double e = 0.0;
-  const double f = 1.0;
-
-  // Create main vertices
-  Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> geom(
-      (nx + 1) * (ny + 1) * (nz + 1), 3);
-  std::size_t vertex = 0;
-  for (std::size_t iz = 0; iz <= nz; ++iz)
-  {
-    const double z
-        = e + ((static_cast<double>(iz)) * (f - e) / static_cast<double>(nz));
-    for (std::size_t iy = 0; iy <= ny; ++iy)
-    {
-      const double y
-          = c + ((static_cast<double>(iy)) * (d - c) / static_cast<double>(ny));
-      for (std::size_t ix = 0; ix <= nx; ix++)
-      {
-        const double x
-            = a
-              + ((static_cast<double>(ix)) * (b - a) / static_cast<double>(nx));
-        geom.row(vertex) << x, y, z;
-        ++vertex;
-      }
-    }
-  }
+  const std::int64_t nx = n[0];
+  const std::int64_t ny = n[1];
+  const std::int64_t nz = n[2];
+  const std::int64_t n_cells = nx * ny * nz;
+  std::array<std::int64_t, 2> range_c = dolfin::MPI::local_range(comm, n_cells);
+  Eigen::Array<std::int64_t, Eigen::Dynamic, 4, Eigen::RowMajor> topo(
+      range_c[1] - range_c[0], 8);
 
   // Create cuboids
-  Eigen::Array<std::int64_t, Eigen::Dynamic, 8, Eigen::RowMajor> topo(
-      nx * ny * nz, 8);
-  std::size_t cell = 0;
-  for (std::size_t iz = 0; iz < nz; ++iz)
+  std::int64_t cell = 0;
+  for (std::int64_t i = range_c[0]; i < range_c[1]; ++i)
   {
-    for (std::size_t iy = 0; iy < ny; ++iy)
-    {
-      for (std::size_t ix = 0; ix < nx; ++ix)
-      {
-        const std::size_t v0 = (iz * (ny + 1) + iy) * (nx + 1) + ix;
-        const std::size_t v1 = v0 + 1;
-        const std::size_t v2 = v0 + (nx + 1);
-        const std::size_t v3 = v1 + (nx + 1);
-        const std::size_t v4 = v0 + (nx + 1) * (ny + 1);
-        const std::size_t v5 = v1 + (nx + 1) * (ny + 1);
-        const std::size_t v6 = v2 + (nx + 1) * (ny + 1);
-        const std::size_t v7 = v3 + (nx + 1) * (ny + 1);
-        topo.row(cell) << v0, v1, v2, v3, v4, v5, v6, v7;
-        ++cell;
-      }
-    }
+    const std::int64_t iz = i / (nx * ny);
+    const std::int64_t j = i % (nx * ny);
+    const std::int64_t iy = j / nx;
+    const std::int64_t ix = j % nx;
+
+    const std::int64_t v0 = (iz * (ny + 1) + iy) * (nx + 1) + ix;
+    const std::int64_t v1 = v0 + 1;
+    const std::int64_t v2 = v0 + (nx + 1);
+    const std::int64_t v3 = v1 + (nx + 1);
+    const std::int64_t v4 = v0 + (nx + 1) * (ny + 1);
+    const std::int64_t v5 = v1 + (nx + 1) * (ny + 1);
+    const std::int64_t v6 = v2 + (nx + 1) * (ny + 1);
+    const std::int64_t v7 = v3 + (nx + 1) * (ny + 1);
+    topo.row(cell) << v0, v4, v2, v6, v1, v5, v3, v7;
+    ++cell;
   }
 
-  const Eigen::Array<std::int64_t, Eigen::Dynamic, 8, Eigen::RowMajor>
-      topo_reordered = io::cells::permute_ordering(
-          topo, io::cells::lex_to_tp(mesh::CellType::hexahedron, topo.cols()));
-
   return mesh::Partitioning::build_distributed_mesh(
-      comm, mesh::CellType::hexahedron, geom, topo_reordered, {}, ghost_mode,
+      comm, mesh::CellType::hexahedron, geom, topo, {}, ghost_mode,
       partitioner);
 }
 //-----------------------------------------------------------------------------
@@ -219,7 +194,7 @@ BoxMesh::create(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
   if (cell_type == mesh::CellType::tetrahedron)
     return build_tet(comm, p, n, ghost_mode, partitioner);
   else if (cell_type == mesh::CellType::hexahedron)
-    return build_hex(comm, n, ghost_mode, partitioner);
+    return build_hex(comm, p, n, ghost_mode, partitioner);
   else
     throw std::runtime_error("Generate rectangle mesh. Wrong cell type");
 

--- a/cpp/dolfin/generation/BoxMesh.cpp
+++ b/cpp/dolfin/generation/BoxMesh.cpp
@@ -153,7 +153,7 @@ mesh::Mesh build_hex(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
   const std::int64_t nz = n[2];
   const std::int64_t n_cells = nx * ny * nz;
   std::array<std::int64_t, 2> range_c = dolfin::MPI::local_range(comm, n_cells);
-  Eigen::Array<std::int64_t, Eigen::Dynamic, 4, Eigen::RowMajor> topo(
+  Eigen::Array<std::int64_t, Eigen::Dynamic, 8, Eigen::RowMajor> topo(
       range_c[1] - range_c[0], 8);
 
   // Create cuboids

--- a/cpp/dolfin/generation/BoxMesh.cpp
+++ b/cpp/dolfin/generation/BoxMesh.cpp
@@ -90,7 +90,7 @@ mesh::Mesh build_tet(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
 
   // Create tetrahedra
   std::size_t cell = 0;
-  for (std::size_t cct = range_c[0]; cct < range_c[1]; ++cct)
+  for (std::int64_t cct = range_c[0]; cct < range_c[1]; ++cct)
   {
     const int iz = cct / (nx * ny);
     const int p = cct % (nx * ny);

--- a/cpp/dolfin/generation/BoxMesh.h
+++ b/cpp/dolfin/generation/BoxMesh.h
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <dolfin/common/MPI.h>
 #include <dolfin/mesh/Mesh.h>
+#include <dolfin/mesh/Partitioning.h>
 
 namespace dolfin
 {
@@ -35,12 +36,14 @@ public:
   /// @param[in] n Number of cells in each direction.
   /// @param[in] cell_type Tetrahedron or hexahedron
   /// @param[in] ghost_mode Ghost mode
+  /// @param[in] partitioner Partitioner (scotch, parmetis or kahip)
   /// @return Mesh
   static mesh::Mesh create(MPI_Comm comm,
                            const std::array<Eigen::Vector3d, 2>& p,
                            std::array<std::size_t, 3> n,
                            mesh::CellType cell_type,
-                           const mesh::GhostMode ghost_mode);
+                           const mesh::GhostMode ghost_mode,
+			   mesh::Partitioner partitioner=mesh::Partitioner::scotch);
 };
 } // namespace generation
 } // namespace dolfin

--- a/cpp/dolfin/generation/BoxMesh.h
+++ b/cpp/dolfin/generation/BoxMesh.h
@@ -38,12 +38,11 @@ public:
   /// @param[in] ghost_mode Ghost mode
   /// @param[in] partitioner Partitioner (scotch, parmetis or kahip)
   /// @return Mesh
-  static mesh::Mesh create(MPI_Comm comm,
-                           const std::array<Eigen::Vector3d, 2>& p,
-                           std::array<std::size_t, 3> n,
-                           mesh::CellType cell_type,
-                           const mesh::GhostMode ghost_mode,
-			   mesh::Partitioner partitioner=mesh::Partitioner::scotch);
+  static mesh::Mesh
+  create(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
+         std::array<std::size_t, 3> n, mesh::CellType cell_type,
+         const mesh::GhostMode ghost_mode,
+         mesh::Partitioner partitioner = mesh::Partitioner::scotch);
 };
 } // namespace generation
 } // namespace dolfin


### PR DESCRIPTION
Improves the creation of `BoxMesh` in parallel, by distributing the cells and vertices across processes during creation.
* Allows the use of ParMETIS (which failed before, due to empty data on some processes)
* Removes an unnecessary permutation call for hex mesh.
* Consolidates code for hex/tet geometry creation which is the same.
* Should reduce runtime when running scaling benchmarks.