### PR TITLE
allow MPIEXEC_PARAMS to be added to test parameters

### DIFF
--- a/cpp/cmake/scripts/generate-cmakefiles.py
+++ b/cpp/cmake/scripts/generate-cmakefiles.py
@@ -39,7 +39,7 @@ CHECK_CXX_COMPILER_FLAG("-Wno-comment" HAVE_NO_MULTLINE)
 target_compile_options(${{PROJECT_NAME}} PRIVATE $<$<BOOL:${{HAVE_NO_MULTLINE}}>:-Wno-comment>)
 
 # Test targets
-set(TEST_PARAMETERS -np 3 "./${{PROJECT_NAME}}")
+set(TEST_PARAMETERS -np 3 ${{MPIEXEC_PARAMS}} "./${{PROJECT_NAME}}")
 add_test(NAME ${{PROJECT_NAME}}_mpi COMMAND "mpirun" ${{TEST_PARAMETERS}})
 add_test(NAME ${{PROJECT_NAME}}_serial COMMAND ${{PROJECT_NAME}})
 """


### PR DESCRIPTION
When MPIEXEC_PARAMS is defined at configure time
(cmake -DMPIEXEC_PARAMS=...) it allows flags like --oversubscribe
to be added where desirable
(e.g. to enable build tests on 2-cpu machines, where tests
use 3 processes via -np 3)

Applies commit d6c8cf8 from dolfin-old PR#519