### PR TITLE
Turn off two stage Docker image build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
           name: Push C++ API doc to fenicsproject.org
           command: cd /tmp/cpp/doc/html && scp -r * docs@fenicsproject.org:/var/www/vhosts/fenicsproject.org/docs/dolfinx/dev/cpp/
 
-  build-and-push-dev-env-docker-images:
+  build-and-push-complete-build-docker-images:
     machine:
       image: ubuntu-1604:201903-01
     steps:
@@ -235,36 +235,10 @@ jobs:
           docker-target: "dev-env-real"
       - build-and-push-target:
           docker-target: "dev-env-complex"
-
-  build-and-push-complete-build-docker-images:
-    machine:
-      image: ubuntu-1604:201903-01
-    steps:
-      - checkout
-      - run:
-          name: Update Docker
-          command: |
-            sudo apt-get -y remove docker docker-engine docker.io containerd runc
-            sudo apt-get -y update
-            sudo apt-get -y install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-            sudo add-apt-repository -y "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-            sudo apt-get -y install docker-ce docker-ce-cli containerd.io
-            sudo docker run hello-world
-      - run:
-          name: Login to quay.io
-          command: echo ${QUAYIO_TOKEN} | sudo docker login -u ${QUAYIO_USERNAME} --password-stdin quay.io
-      - run:
-          name: Pull dev-env images
-          command: |
-            sudo docker pull quay.io/fenicsproject/dolfinx:dev-env-real
-            sudo docker pull quay.io/fenicsproject/dolfinx:dev-env-complex
       - build-and-push-target:
           docker-target: "real-onbuild"
-          extra-args: "--cache-from quay.io/fenicsproject/dolfinx:dev-env-real"
       - build-and-push-target:
           docker-target: "complex-onbuild"
-          extra-args: "--cache-from quay.io/fenicsproject/dolfinx:dev-env-complex"
       - build-and-push-target:
           docker-target: "real"
       - build-and-push-target:
@@ -301,33 +275,13 @@ workflows:
               only:
                 - master
     jobs:
-      - build-and-push-dev-env-docker-images:
-          context: quay.io
-      - build-real:
-          requires:
-            - build-and-push-dev-env-docker-images
-      - build-complex:
-          requires:
-            - build-and-push-dev-env-docker-images
       - build-and-push-complete-build-docker-images:
-          requires:
-            - build-and-push-dev-env-docker-images
-            - build-real
-            - build-complex
           context: quay.io
 
   build-and-push-docker-images:
     when: << pipeline.parameters.build-and-push-docker-images >>
     jobs:
-      - build-and-push-dev-env-docker-images:
-          filters:
-            branches:
-              only:
-                - master
-          context: quay.io
       - build-and-push-complete-build-docker-images:
-          requires:
-            - build-and-push-dev-env-docker-images
           filters:
             branches:
               only:


### PR DESCRIPTION
Bit wasteful on CircleCI hours, but at least it should work. Multistage Dockerfiles and build caching seems to be work in progress at Docker HQ.