### PR TITLE
Rename AdjacencyList methods and update pybind11 wrappers 

### DIFF
--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -297,7 +297,7 @@ DofMap::dofs(const mesh::Topology& topology, std::size_t dim) const
 
     // Loop over all entities of dimension dim belonging to cell
     int local_index = 0;
-    auto entities = c_tdim_dim->edges(c);
+    auto entities = c_tdim_dim->links(c);
     for (int e = 0; e < entities.rows(); ++e)
     {
       // Get dof index and add to list

--- a/cpp/dolfinx/fem/DofMapBuilder.cpp
+++ b/cpp/dolfinx/fem/DofMapBuilder.cpp
@@ -130,7 +130,7 @@ build_basic_dofmap(const mesh::Topology& topology,
         const std::vector<std::int64_t>& global_indices
             = topology.global_indices(d);
         assert(global_indices.size() > 0);
-        auto entities = connectivity[d]->edges(c);
+        auto entities = connectivity[d]->links(c);
         for (int i = 0; i < entities.rows(); ++i)
         {
           entity_indices_local[d][i] = entities[i];
@@ -247,7 +247,7 @@ std::pair<std::vector<std::int32_t>, std::int32_t> compute_reordering_map(
   {
     // Loop over nodes collecting valid local nodes
     local_old.clear();
-    auto nodes = dofmap.edges(cell);
+    auto nodes = dofmap.links(cell);
     for (std::int32_t i = 0; i < nodes.rows(); ++i)
     {
       // Add to graph if node is owned
@@ -549,7 +549,7 @@ DofMapBuilder::build(MPI_Comm comm, const mesh::Topology& topology,
   for (std::int32_t cell = 0; cell < node_graph0.num_nodes(); ++cell)
   {
     const std::int32_t local_dim0 = node_graph0.num_links(cell);
-    auto old_nodes = node_graph0.edges(cell);
+    auto old_nodes = node_graph0.links(cell);
     for (std::int32_t j = 0; j < local_dim0; ++j)
     {
       const std::int32_t old_node = old_nodes[j];

--- a/cpp/dolfinx/fem/DofMapBuilder.cpp
+++ b/cpp/dolfinx/fem/DofMapBuilder.cpp
@@ -548,7 +548,7 @@ DofMapBuilder::build(MPI_Comm comm, const mesh::Topology& topology,
                                                    * block_size);
   for (std::int32_t cell = 0; cell < node_graph0.num_nodes(); ++cell)
   {
-    const std::int32_t local_dim0 = node_graph0.num_edges(cell);
+    const std::int32_t local_dim0 = node_graph0.num_links(cell);
     auto old_nodes = node_graph0.edges(cell);
     for (std::int32_t j = 0; j < local_dim0; ++j)
     {

--- a/cpp/dolfinx/fem/FormIntegrals.cpp
+++ b/cpp/dolfinx/fem/FormIntegrals.cpp
@@ -160,7 +160,7 @@ void FormIntegrals::set_domains(FormIntegrals::Type type,
 
     for (Eigen::Index i = 0; i < num_entities; ++i)
     {
-      if (connectivity->num_edges(i) == 2)
+      if (connectivity->num_links(i) == 2)
       {
         auto it = id_to_integral.find(mf_values[i]);
         if (it != id_to_integral.end())

--- a/cpp/dolfinx/fem/PETScDMCollection.cpp
+++ b/cpp/dolfinx/fem/PETScDMCollection.cpp
@@ -97,7 +97,7 @@ tabulate_coordinates_to_dofs(const function::FunctionSpace& V)
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 
@@ -541,7 +541,7 @@ la::PETScMatrix PETScDMCollection::create_transfer_matrix(
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = meshc.geometry().points();
   Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>

--- a/cpp/dolfinx/fem/SparsityPatternBuilder.cpp
+++ b/cpp/dolfinx/fem/SparsityPatternBuilder.cpp
@@ -95,7 +95,7 @@ void SparsityPatternBuilder::exterior_facets(
 
     // FIXME: sort out ghosting
 
-    assert(connectivity->num_edges(f) == 1);
+    assert(connectivity->num_links(f) == 1);
     auto cells = connectivity->edges(f);
     const int cell = cells[0];
 

--- a/cpp/dolfinx/fem/SparsityPatternBuilder.cpp
+++ b/cpp/dolfinx/fem/SparsityPatternBuilder.cpp
@@ -54,7 +54,7 @@ void SparsityPatternBuilder::interior_facets(
     // FIXME: sort out ghosting
 
     // Get cells incident with facet
-    auto cells = connectivity->edges(f);
+    auto cells = connectivity->links(f);
     assert(cells.rows() == 0);
     const int cell0 = cells[0];
     const int cell1 = cells[1];
@@ -96,7 +96,7 @@ void SparsityPatternBuilder::exterior_facets(
     // FIXME: sort out ghosting
 
     assert(connectivity->num_links(f) == 1);
-    auto cells = connectivity->edges(f);
+    auto cells = connectivity->links(f);
     const int cell = cells[0];
 
     pattern.insert_local(dofmaps[0]->cell_dofs(cell),

--- a/cpp/dolfinx/fem/assemble_matrix_impl.cpp
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.cpp
@@ -120,7 +120,7 @@ void fem::impl::assemble_cells(
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 
@@ -202,7 +202,7 @@ void fem::impl::assemble_exterior_facets(
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 
@@ -295,7 +295,7 @@ void fem::impl::assemble_interior_facets(
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 

--- a/cpp/dolfinx/fem/assemble_scalar_impl.cpp
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.cpp
@@ -106,7 +106,7 @@ PetscScalar fem::impl::assemble_cells(
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 
@@ -156,7 +156,7 @@ PetscScalar fem::impl::assemble_exterior_facets(
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 
@@ -216,7 +216,7 @@ PetscScalar fem::impl::assemble_interior_facets(
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 

--- a/cpp/dolfinx/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfinx/fem/assemble_vector_impl.cpp
@@ -67,7 +67,7 @@ void _lift_bc_cells(
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 
@@ -194,7 +194,7 @@ void _lift_bc_exterior_facets(
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 
@@ -382,7 +382,7 @@ void fem::impl::assemble_cells(
   const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>> cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 
@@ -436,7 +436,7 @@ void fem::impl::assemble_exterior_facets(
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 
@@ -502,7 +502,7 @@ void fem::impl::assemble_interior_facets(
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 

--- a/cpp/dolfinx/fem/dofs_permutation.cpp
+++ b/cpp/dolfinx/fem/dofs_permutation.cpp
@@ -445,7 +445,7 @@ compute_ordering_triangle(const mesh::Topology& topology,
   // Set orders for each cell
   for (int cell_n = 0; cell_n < num_cells; ++cell_n)
   {
-    auto vertices = cells->edges(cell_n);
+    auto vertices = cells->links(cell_n);
     const std::int64_t v0 = global_indices[vertices[0]];
     const std::int64_t v1 = global_indices[vertices[1]];
     const std::int64_t v2 = global_indices[vertices[2]];
@@ -481,7 +481,7 @@ compute_ordering_interval(const mesh::Topology& topology,
   const std::vector<std::int64_t>& global_indices = topology.global_indices(0);
   for (int cell_n = 0; cell_n < num_cells; ++cell_n)
   {
-    auto vertices = cells->edges(cell_n);
+    auto vertices = cells->links(cell_n);
     const std::int64_t v0 = global_indices[vertices[0]];
     const std::int64_t v1 = global_indices[vertices[1]];
 
@@ -508,7 +508,7 @@ compute_ordering_quadrilateral(const mesh::Topology& topology,
   const std::vector<std::int64_t>& global_indices = topology.global_indices(0);
   for (int cell_n = 0; cell_n < num_cells; ++cell_n)
   {
-    auto vertices = cells->edges(cell_n);
+    auto vertices = cells->links(cell_n);
     const std::int64_t v0 = global_indices[vertices[0]];
     const std::int64_t v1 = global_indices[vertices[1]];
     const std::int64_t v2 = global_indices[vertices[2]];
@@ -546,7 +546,7 @@ compute_ordering_tetrahedron(const mesh::Topology& topology,
   const std::vector<std::int64_t>& global_indices = topology.global_indices(0);
   for (int cell_n = 0; cell_n < num_cells; ++cell_n)
   {
-    auto vertices = cells->edges(cell_n);
+    auto vertices = cells->links(cell_n);
     const std::int64_t v0 = global_indices[vertices[0]];
     const std::int64_t v1 = global_indices[vertices[1]];
     const std::int64_t v2 = global_indices[vertices[2]];
@@ -606,7 +606,7 @@ compute_ordering_hexahedron(const mesh::Topology& topology,
   const std::vector<std::int64_t>& global_indices = topology.global_indices(0);
   for (int cell_n = 0; cell_n < num_cells; ++cell_n)
   {
-    auto vertices = cells->edges(cell_n);
+    auto vertices = cells->links(cell_n);
     const std::int64_t v0 = global_indices[vertices[0]];
     const std::int64_t v1 = global_indices[vertices[1]];
     const std::int64_t v2 = global_indices[vertices[2]];

--- a/cpp/dolfinx/function/Function.cpp
+++ b/cpp/dolfinx/function/Function.cpp
@@ -376,7 +376,7 @@ Function::compute_point_values() const
     eval(x, cells, values);
 
     // Copy values to array of point values
-    auto dofs = cell_dofs.edges(cell.index());
+    auto dofs = cell_dofs.links(cell.index());
     for (int i = 0; i < x.rows(); ++i)
       point_values.row(dofs[i]) = values.row(i);
   }

--- a/cpp/dolfinx/function/Function.cpp
+++ b/cpp/dolfinx/function/Function.cpp
@@ -185,7 +185,7 @@ void Function::eval(
       = connectivity_g.array();
 
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
   Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
@@ -352,7 +352,7 @@ Function::compute_point_values() const
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>& x_g
       = mesh.geometry().points();
 

--- a/cpp/dolfinx/function/FunctionSpace.cpp
+++ b/cpp/dolfinx/function/FunctionSpace.cpp
@@ -320,7 +320,7 @@ FunctionSpace::tabulate_dof_coordinates() const
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
       x_g
       = _mesh->geometry().points();
@@ -382,7 +382,7 @@ void FunctionSpace::set_x(
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& cell_g
       = connectivity_g.array();
   // FIXME: Add proper interface for num coordinate dofs
-  const int num_dofs_g = connectivity_g.num_edges(0);
+  const int num_dofs_g = connectivity_g.num_links(0);
   const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
       x_g
       = _mesh->geometry().points();

--- a/cpp/dolfinx/graph/AdjacencyList.h
+++ b/cpp/dolfinx/graph/AdjacencyList.h
@@ -122,34 +122,34 @@ public:
     return _offsets[node + 1] - _offsets[node];
   }
 
-  /// Edges for given node
+  /// Links (edges) for given node
   /// @param [in] node Node index
-  /// @return Array of outgoing edges for the node. The length will be
-  ///   AdjacencyList:num_edges(node).
-  auto edges(int node)
+  /// @return Array of outgoing links for the node. The length will be
+  ///   AdjacencyList:num_links(node).
+  auto links(int node)
   {
     return _array.segment(_offsets[node], _offsets[node + 1] - _offsets[node]);
   }
 
-  /// Edges for given node (const version)
+  /// Links (edges) for given node (const version)
   /// @param [in] node Node index
-  /// @return Array of outgoing edges for the node. The length will be
-  ///   AdjacencyList:num_edges(node).
-  auto edges(int node) const
+  /// @return Array of outgoing links for the node. The length will be
+  ///   AdjacencyList:num_links(node).
+  auto links(int node) const
   {
     return _array.segment(_offsets[node], _offsets[node + 1] - _offsets[node]);
   }
 
   /// TODO: attempt to remove
-  const std::int32_t* edges_ptr(int node) const
+  const std::int32_t* links_ptr(int node) const
   {
     return &_array[_offsets[node]];
   }
 
-  /// Return contiguous array of edges for all nodes
+  /// Return contiguous array of links for all nodes
   Eigen::Array<T, Eigen::Dynamic, 1>& array() { return _array; }
 
-  /// Return contiguous array of edges for all nodes (const version)
+  /// Return contiguous array of links for all nodes (const version)
   const Eigen::Array<T, Eigen::Dynamic, 1>& array() const { return _array; }
 
   /// Offset for each node in array()
@@ -199,5 +199,5 @@ private:
   // // computed)
   // Eigen::Array<std::int32_t, Eigen::Dynamic, 1> _num_global_connections;
 };
-} // namespace mesh
+} // namespace graph
 } // namespace dolfinx

--- a/cpp/dolfinx/graph/AdjacencyList.h
+++ b/cpp/dolfinx/graph/AdjacencyList.h
@@ -146,14 +146,8 @@ public:
     return &_array[_offsets[node]];
   }
 
-  /// Return contiguous array of links for all nodes
-  Eigen::Array<T, Eigen::Dynamic, 1>& array() { return _array; }
-
   /// Return contiguous array of links for all nodes (const version)
   const Eigen::Array<T, Eigen::Dynamic, 1>& array() const { return _array; }
-
-  /// Offset for each node in array()
-  Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& offsets() { return _offsets; }
 
   /// Offset for each node in array() (const version)
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& offsets() const
@@ -194,10 +188,6 @@ private:
 
   // Position of first connection for each entity (using local index)
   Eigen::Array<std::int32_t, Eigen::Dynamic, 1> _offsets;
-
-  // // Global number of connections for each entity (possibly not
-  // // computed)
-  // Eigen::Array<std::int32_t, Eigen::Dynamic, 1> _num_global_connections;
 };
 } // namespace graph
 } // namespace dolfinx

--- a/cpp/dolfinx/graph/AdjacencyList.h
+++ b/cpp/dolfinx/graph/AdjacencyList.h
@@ -51,7 +51,7 @@ public:
   }
 
   /// Construct adjacency list for a problem with a fixed number of
-  /// edges for each node
+  /// links (edges) for each node
   /// @param [in] matrix Two-dimensional array of adjacency data where
   ///   matrix(i, j) is the jth neighbor of the ith node
   AdjacencyList(
@@ -59,14 +59,14 @@ public:
                                           Eigen::RowMajor>>& matrix)
       : _array(matrix.rows() * matrix.cols()), _offsets(matrix.rows() + 1)
   {
-    const std::int32_t num_edges = matrix.cols();
+    const std::int32_t num_links = matrix.cols();
     for (Eigen::Index e = 0; e < _offsets.rows(); e++)
-      _offsets[e] = e * num_edges;
+      _offsets[e] = e * num_links;
 
     // NOTE: Do not directly copy data from matrix because it may be a
     // view into a larger array
     for (Eigen::Index i = 0; i < matrix.rows(); ++i)
-      _array.segment(_offsets(i), num_edges) = matrix.row(i);
+      _array.segment(_offsets(i), num_links) = matrix.row(i);
   }
 
   /// Set all connections for all entities (T is a '2D' container, e.g.
@@ -115,8 +115,8 @@ public:
 
   /// Number of connections for given node
   /// @param [in] Node index
-  /// @return The number of outgoing edges from the node
-  int num_edges(int node) const
+  /// @return The number of outgoing links (edges) from the node
+  int num_links(int node) const
   {
     assert((node + 1) < _offsets.rows());
     return _offsets[node + 1] - _offsets[node];

--- a/cpp/dolfinx/io/HDF5File.cpp
+++ b/cpp/dolfinx/io/HDF5File.cpp
@@ -261,7 +261,7 @@ void HDF5File::write(const mesh::Mesh& mesh, int cell_dim,
   // Allowing for higher order meshes to be written to file
   std::size_t num_cell_points;
   if (cell_dim == tdim)
-    num_cell_points = cell_points.num_edges(0);
+    num_cell_points = cell_points.num_links(0);
   else
     num_cell_points = mesh::cell_num_entities(cell_type, 0);
 
@@ -306,10 +306,10 @@ void HDF5File::write(const mesh::Mesh& mesh, int cell_dim,
       const auto& global_points = mesh.geometry().global_indices();
 
       // Adjust num_nodes_per_cell to appropriate size
-      int num_nodes_per_cell = cell_points.num_edges(0);
+      int num_nodes_per_cell = cell_points.num_links(0);
       topological_data.reserve(num_nodes_per_cell * mesh.num_entities(tdim));
 
-      int num_nodes = mesh.coordinate_dofs().entity_points().num_edges(0);
+      int num_nodes = mesh.coordinate_dofs().entity_points().num_links(0);
       const std::vector<std::uint8_t> perm
           = io::cells::dolfin_to_vtk(mesh.cell_type(), num_nodes);
 
@@ -329,7 +329,7 @@ void HDF5File::write(const mesh::Mesh& mesh, int cell_dim,
       const auto& global_vertices = mesh.topology().global_indices(0);
 
       // Permutation to VTK ordering
-      int num_nodes = mesh.coordinate_dofs().entity_points().num_edges(0);
+      int num_nodes = mesh.coordinate_dofs().entity_points().num_links(0);
       const std::vector<std::uint8_t> perm
           = io::cells::dolfin_to_vtk(mesh.cell_type(), num_nodes);
 

--- a/cpp/dolfinx/io/HDF5File.cpp
+++ b/cpp/dolfinx/io/HDF5File.cpp
@@ -315,7 +315,7 @@ void HDF5File::write(const mesh::Mesh& mesh, int cell_dim,
 
       for (std::int32_t c = 0; c < mesh.num_entities(tdim); ++c)
       {
-        auto points = cell_points.edges(c);
+        auto points = cell_points.links(c);
         for (std::int32_t i = 0; i < num_nodes_per_cell; ++i)
         {
           topological_data.push_back(global_points[points[perm[i]]]);

--- a/cpp/dolfinx/io/VTKWriter.cpp
+++ b/cpp/dolfinx/io/VTKWriter.cpp
@@ -190,7 +190,7 @@ void write_ascii_mesh(const mesh::Mesh& mesh, int cell_dim,
         = connectivity_g.array();
     const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& pos_g
         = connectivity_g.offsets();
-    num_nodes = connectivity_g.num_edges(0);
+    num_nodes = connectivity_g.num_links(0);
 
     const std::vector<std::uint8_t> perm
         = io::cells::dolfin_to_vtk(mesh.cell_type(), num_nodes);

--- a/cpp/dolfinx/io/xdmf_write.cpp
+++ b/cpp/dolfinx/io/xdmf_write.cpp
@@ -571,7 +571,7 @@ void xdmf_write::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
 
     for (std::int32_t c = 0; c < mesh.num_entities(tdim); ++c)
     {
-      auto points = cell_points.edges(c);
+      auto points = cell_points.links(c);
       for (std::int32_t i = 0; i < num_nodes_per_cell; ++i)
         topology_data.push_back(global_points[points[perm[i]]]);
     }

--- a/cpp/dolfinx/io/xdmf_write.cpp
+++ b/cpp/dolfinx/io/xdmf_write.cpp
@@ -212,7 +212,7 @@ std::vector<std::int64_t> compute_topology_data(const mesh::Mesh& mesh,
   // Get mesh communicator
   MPI_Comm comm = mesh.mpi_comm();
 
-  int num_nodes = mesh.coordinate_dofs().entity_points().num_edges(0);
+  int num_nodes = mesh.coordinate_dofs().entity_points().num_links(0);
   std::vector<std::uint8_t> perm;
   if (cell_dim == mesh.topology().dim())
     perm = io::cells::dolfin_to_vtk(mesh.cell_type(), num_nodes);
@@ -562,10 +562,10 @@ void xdmf_write::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
         = mesh.coordinate_dofs().entity_points();
 
     // Adjust num_nodes_per_cell to appropriate size
-    num_nodes_per_cell = cell_points.num_edges(0);
+    num_nodes_per_cell = cell_points.num_links(0);
     topology_data.reserve(num_nodes_per_cell * mesh.num_entities(tdim));
 
-    int num_nodes = mesh.coordinate_dofs().entity_points().num_edges(0);
+    int num_nodes = mesh.coordinate_dofs().entity_points().num_links(0);
     const std::vector<std::uint8_t> perm
         = io::cells::dolfin_to_vtk(mesh.cell_type(), num_nodes);
 

--- a/cpp/dolfinx/mesh/DistributedMeshTools.cpp
+++ b/cpp/dolfinx/mesh/DistributedMeshTools.cpp
@@ -93,7 +93,7 @@ compute_entity_numbering(MPI_Comm comm, const Topology& topology,
 
     for (int e = 0; e < size; ++e)
     {
-      auto v = c_d_0->edges(e);
+      auto v = c_d_0->links(e);
 
       // Entity can only be shared if all vertices are shared but this
       // is not a sufficient condition
@@ -503,7 +503,7 @@ void DistributedMeshTools::init_facet_cell_connections(MPI_Comm comm,
       {
         // Singly attached ghost facet - check with owner of attached
         // cell
-        auto c = connectivity->edges(f);
+        auto c = connectivity->links(f);
         assert(c[0] >= ghost_offset_c);
         const int owner = cell_owners[c[0] - ghost_offset_c];
         send_facet[owner].push_back(global_facets[f]);

--- a/cpp/dolfinx/mesh/DistributedMeshTools.cpp
+++ b/cpp/dolfinx/mesh/DistributedMeshTools.cpp
@@ -462,7 +462,7 @@ void DistributedMeshTools::init_facet_cell_connections(MPI_Comm comm,
     assert(topology.connectivity(D - 1, D));
     auto connectivity = topology.connectivity(D - 1, D);
     for (int f = 0; f < num_facets; ++f)
-      num_global_neighbors[f] = connectivity->num_edges(f);
+      num_global_neighbors[f] = connectivity->num_links(f);
 
     // All shared facets must have two cells, if no ghost cells
     for (const auto& f_it : shared_facets)
@@ -496,7 +496,7 @@ void DistributedMeshTools::init_facet_cell_connections(MPI_Comm comm,
         global_to_local_facet.insert({global_facets[f], f});
 
       // Copy local values
-      const int n_cells = connectivity->num_edges(f);
+      const int n_cells = connectivity->num_links(f);
       num_global_neighbors[f] = n_cells;
 
       if ((f >= ghost_offset_f) and n_cells == 1)
@@ -521,7 +521,7 @@ void DistributedMeshTools::init_facet_cell_connections(MPI_Comm comm,
       {
         auto map_it = global_to_local_facet.find(*r);
         assert(map_it != global_to_local_facet.end());
-        const int n_cells = connectivity->num_edges(map_it->second);
+        const int n_cells = connectivity->num_links(map_it->second);
         send_response[p].push_back(n_cells);
       }
     }

--- a/cpp/dolfinx/mesh/MeshEntity.cpp
+++ b/cpp/dolfinx/mesh/MeshEntity.cpp
@@ -24,7 +24,7 @@ int MeshEntity::index(const MeshEntity& entity) const
 
   // Get list of entities for given topological dimension
   auto entities
-      = _mesh->topology().connectivity(_dim, entity._dim)->edges(_local_index);
+      = _mesh->topology().connectivity(_dim, entity._dim)->links(_local_index);
   const int num_entities = _mesh->topology()
                                .connectivity(_dim, entity._dim)
                                ->num_links(_local_index);

--- a/cpp/dolfinx/mesh/MeshEntity.cpp
+++ b/cpp/dolfinx/mesh/MeshEntity.cpp
@@ -27,7 +27,7 @@ int MeshEntity::index(const MeshEntity& entity) const
       = _mesh->topology().connectivity(_dim, entity._dim)->edges(_local_index);
   const int num_entities = _mesh->topology()
                                .connectivity(_dim, entity._dim)
-                               ->num_edges(_local_index);
+                               ->num_links(_local_index);
 
   // Check if any entity matches
   for (int i = 0; i < num_entities; ++i)

--- a/cpp/dolfinx/mesh/MeshEntity.h
+++ b/cpp/dolfinx/mesh/MeshEntity.h
@@ -81,7 +81,7 @@ public:
   auto entities(int dim) const
   {
     assert(_mesh->topology().connectivity(_dim, dim));
-    return _mesh->topology().connectivity(_dim, dim)->edges(_local_index);
+    return _mesh->topology().connectivity(_dim, dim)->links(_local_index);
   }
 
   /// Return array of indices for incident mesh entities of given
@@ -93,7 +93,7 @@ public:
     {
       assert(_mesh->topology().connectivity(_dim, dim));
       const std::int32_t* initialized_mesh_entities
-          = _mesh->topology().connectivity(_dim, dim)->edges_ptr(_local_index);
+          = _mesh->topology().connectivity(_dim, dim)->links_ptr(_local_index);
       assert(initialized_mesh_entities);
       return initialized_mesh_entities;
     }

--- a/cpp/dolfinx/mesh/MeshFunction.h
+++ b/cpp/dolfinx/mesh/MeshFunction.h
@@ -172,7 +172,7 @@ MeshFunction<T>::MeshFunction(std::shared_ptr<const Mesh> mesh,
     {
       // Get global (local to to process) entity index
       assert(cell_index < _mesh->num_entities(D));
-      entity_index = connectivity.edges(cell_index)[local_entity];
+      entity_index = connectivity.links(cell_index)[local_entity];
     }
     else
     {

--- a/cpp/dolfinx/mesh/MeshIterator.h
+++ b/cpp/dolfinx/mesh/MeshIterator.h
@@ -102,7 +102,7 @@ public:
         = *e.mesh().topology().connectivity(e.dim(), _entity.dim());
 
     // Pointer to array of connections
-    _connections = c.edges_ptr(e.index()) + pos;
+    _connections = c.links_ptr(e.index()) + pos;
   }
 
   /// Copy constructor

--- a/cpp/dolfinx/mesh/MeshIterator.h
+++ b/cpp/dolfinx/mesh/MeshIterator.h
@@ -252,7 +252,7 @@ public:
                                          : _entity.mesh()
                                                .topology()
                                                .connectivity(_entity._dim, _dim)
-                                               ->num_edges(_entity.index());
+                                               ->num_links(_entity.index());
     return MeshEntityIterator(_entity, _dim, n);
   }
 

--- a/cpp/dolfinx/mesh/MeshValueCollection.h
+++ b/cpp/dolfinx/mesh/MeshValueCollection.h
@@ -185,7 +185,7 @@ MeshValueCollection<T>::MeshValueCollection(
       {
         // Create cell
         const mesh::MeshEntity cell(*_mesh, D,
-                                    connectivity.edges(entity_index)[i]);
+                                    connectivity.links(entity_index)[i]);
 
         // Find the local entity index
         const std::size_t local_entity = cell.index(entity);
@@ -239,7 +239,7 @@ MeshValueCollection<T>::operator=(const MeshFunction<T>& mesh_function)
       {
         // Create cell
         const mesh::MeshEntity cell(*_mesh, D,
-                                    connectivity.edges(entity_index)[i]);
+                                    connectivity.links(entity_index)[i]);
 
         // Find the local entity index
         const std::size_t local_entity = cell.index(entity);
@@ -345,7 +345,7 @@ bool MeshValueCollection<T>::set_value(std::size_t entity_index, const T& value)
   assert(connectivity.num_links(entity_index) > 0);
   const MeshEntity entity(*_mesh, _dim, entity_index);
   const mesh::MeshEntity cell(
-      *_mesh, D, connectivity.edges(entity_index)[0]); // choose first
+      *_mesh, D, connectivity.links(entity_index)[0]); // choose first
 
   // Find the local entity index
   const std::size_t local_entity = cell.index(entity);

--- a/cpp/dolfinx/mesh/MeshValueCollection.h
+++ b/cpp/dolfinx/mesh/MeshValueCollection.h
@@ -179,9 +179,9 @@ MeshValueCollection<T>::MeshValueCollection(
          ++entity_index)
     {
       // Find the cell
-      assert(connectivity.num_edges(entity_index) > 0);
+      assert(connectivity.num_links(entity_index) > 0);
       const MeshEntity entity(*_mesh, _dim, entity_index);
-      for (int i = 0; i < connectivity.num_edges(entity_index); ++i)
+      for (int i = 0; i < connectivity.num_links(entity_index); ++i)
       {
         // Create cell
         const mesh::MeshEntity cell(*_mesh, D,
@@ -233,9 +233,9 @@ MeshValueCollection<T>::operator=(const MeshFunction<T>& mesh_function)
          ++entity_index)
     {
       // Find the cell
-      assert(connectivity.num_edges(entity_index) > 0);
+      assert(connectivity.num_links(entity_index) > 0);
       const MeshEntity entity(*_mesh, _dim, entity_index);
-      for (int i = 0; i < connectivity.num_edges(entity_index); ++i)
+      for (int i = 0; i < connectivity.num_links(entity_index); ++i)
       {
         // Create cell
         const mesh::MeshEntity cell(*_mesh, D,
@@ -342,7 +342,7 @@ bool MeshValueCollection<T>::set_value(std::size_t entity_index, const T& value)
   const graph::AdjacencyList<std::int32_t>& connectivity = *_mesh->topology().connectivity(_dim, D);
 
   // Find the cell
-  assert(connectivity.num_edges(entity_index) > 0);
+  assert(connectivity.num_links(entity_index) > 0);
   const MeshEntity entity(*_mesh, _dim, entity_index);
   const mesh::MeshEntity cell(
       *_mesh, D, connectivity.edges(entity_index)[0]); // choose first

--- a/cpp/dolfinx/mesh/Ordering.cpp
+++ b/cpp/dolfinx/mesh/Ordering.cpp
@@ -65,7 +65,7 @@ void sort_1_0(graph::AdjacencyList<std::int32_t>& connect_1_0,
   assert(cell_edges);
   for (int i = 0; i < num_edges; ++i)
   {
-    auto edge_vertices = connect_1_0.edges(cell_edges[i]);
+    auto edge_vertices = connect_1_0.links(cell_edges[i]);
     std::sort(edge_vertices.data(), edge_vertices.data() + 2,
               [&](auto& a, auto& b) {
                 return global_vertex_indices[a] < global_vertex_indices[b];
@@ -83,7 +83,7 @@ void sort_2_0(graph::AdjacencyList<std::int32_t>& connect_2_0,
   assert(cell_faces);
   for (int i = 0; i < num_faces; ++i)
   {
-    auto face_vertices = connect_2_0.edges(cell_faces[i]);
+    auto face_vertices = connect_2_0.links(cell_faces[i]);
     std::sort(face_vertices.data(), face_vertices.data() + 3,
               [&](auto& a, auto& b) {
                 return global_vertex_indices[a] < global_vertex_indices[b];
@@ -104,10 +104,10 @@ void sort_2_1(graph::AdjacencyList<std::int32_t>& connect_2_1,
   for (int i = 0; i < num_faces; ++i)
   {
     // For each face number get the global vertex numbers
-    auto face_vertices = connect_2_0.edges(cell_faces[i]);
+    auto face_vertices = connect_2_0.links(cell_faces[i]);
 
     // For each facet number get the global edge number
-    auto cell_edges = connect_2_1.edges(cell_faces[i]);
+    auto cell_edges = connect_2_1.links(cell_faces[i]);
 
     // Loop over vertices on face
     std::size_t m = 0;
@@ -117,7 +117,7 @@ void sort_2_1(graph::AdjacencyList<std::int32_t>& connect_2_1,
       for (int k = m; k < 3; ++k)
       {
         // For each edge number get the global vertex numbers
-        auto edge_vertices = connect_1_0.edges(cell_edges[k]);
+        auto edge_vertices = connect_1_0.links(cell_edges[k]);
 
         // Check if the jth vertex of facet i is non-incident on edge k
         if (!std::count(edge_vertices.data(), edge_vertices.data() + 2,
@@ -137,7 +137,7 @@ void sort_3_0(graph::AdjacencyList<std::int32_t>& connect_3_0,
               const mesh::MeshEntity& cell,
               const std::vector<std::int64_t>& global_vertex_indices)
 {
-  auto cell_vertices = connect_3_0.edges(cell.index());
+  auto cell_vertices = connect_3_0.links(cell.index());
   std::sort(cell_vertices.data(), cell_vertices.data() + 4,
             [&](auto& a, auto& b) {
               return global_vertex_indices[a] < global_vertex_indices[b];
@@ -152,7 +152,7 @@ void sort_3_1(graph::AdjacencyList<std::int32_t>& connect_3_1,
   // Get cell vertices and edge numbers
   const std::int32_t* cell_vertices = cell.entities_ptr(0);
   assert(cell_vertices);
-  auto cell_edges = connect_3_1.edges(cell.index());
+  auto cell_edges = connect_3_1.links(cell.index());
 
   // Loop two vertices on cell as a lexicographical tuple
   // (i, j): (0,1) (0,2) (0,3) (1,2) (1,3) (2,3)
@@ -165,7 +165,7 @@ void sort_3_1(graph::AdjacencyList<std::int32_t>& connect_3_1,
       for (int k = m; k < 6; ++k)
       {
         // Get local vertices on edge
-        auto edge_vertices = connect_1_0.edges(cell_edges[k]);
+        auto edge_vertices = connect_1_0.links(cell_edges[k]);
 
         // Check if the ith and jth vertex of the cell are
         // non-incident on edge k
@@ -192,7 +192,7 @@ void sort_3_2(graph::AdjacencyList<std::int32_t>& connect_3_2,
   // Get cell vertices and facet numbers
   const std::int32_t* cell_vertices = cell.entities_ptr(0);
   assert(cell_vertices);
-  auto cell_faces = connect_3_2.edges(cell.index());
+  auto cell_faces = connect_3_2.links(cell.index());
 
   // Loop vertices on cell
   for (int i = 0; i < 4; ++i)
@@ -200,7 +200,7 @@ void sort_3_2(graph::AdjacencyList<std::int32_t>& connect_3_2,
     // Loop facets on cell
     for (int j = i; j < 4; ++j)
     {
-      auto face_vertices = connect_2_0.edges(cell_faces[j]);
+      auto face_vertices = connect_2_0.links(cell_faces[j]);
 
       // Check if the ith vertex of the cell is non-incident on facet j
       if (!std::count(face_vertices.data(), face_vertices.data() + 3,
@@ -229,7 +229,7 @@ bool ordered_cell_simplex(
   assert(connect_tdim_0);
 
   const int num_vertices = connect_tdim_0->num_links(c);
-  auto vertices = connect_tdim_0->edges(c);
+  auto vertices = connect_tdim_0->links(c);
 
   // Check that vertices are in ascending order
   if (!std::is_sorted(vertices.data(), vertices.data() + num_vertices,
@@ -257,7 +257,7 @@ bool ordered_cell_simplex(
         = topology.connectivity(tdim, d);
     assert(connect_tdim_d);
     const int num_entities = connect_tdim_d->num_links(c);
-    auto entities = connect_tdim_d->edges(c);
+    auto entities = connect_tdim_d->links(c);
 
     // Iterate over entities
     for (int e = 1; e < num_entities; ++e)
@@ -265,12 +265,12 @@ bool ordered_cell_simplex(
       // Get vertices for first entity
       const int e0 = entities[e - 1];
       const int n0 = connect_d_0->num_links(e0);
-      auto v0 = connect_d_0->edges(e0);
+      auto v0 = connect_d_0->links(e0);
 
       // Get vertices for second entity
       const int e1 = entities[e];
       const int n1 = connect_d_0->num_links(e1);
-      auto v1 = connect_d_0->edges(e1);
+      auto v1 = connect_d_0->links(e1);
 
       // Check ordering of entities
       assert(n0 == n1);

--- a/cpp/dolfinx/mesh/Ordering.cpp
+++ b/cpp/dolfinx/mesh/Ordering.cpp
@@ -228,7 +228,7 @@ bool ordered_cell_simplex(
       = topology.connectivity(tdim, 0);
   assert(connect_tdim_0);
 
-  const int num_vertices = connect_tdim_0->num_edges(c);
+  const int num_vertices = connect_tdim_0->num_links(c);
   auto vertices = connect_tdim_0->edges(c);
 
   // Check that vertices are in ascending order
@@ -256,7 +256,7 @@ bool ordered_cell_simplex(
     std::shared_ptr<const graph::AdjacencyList<std::int32_t>> connect_tdim_d
         = topology.connectivity(tdim, d);
     assert(connect_tdim_d);
-    const int num_entities = connect_tdim_d->num_edges(c);
+    const int num_entities = connect_tdim_d->num_links(c);
     auto entities = connect_tdim_d->edges(c);
 
     // Iterate over entities
@@ -264,12 +264,12 @@ bool ordered_cell_simplex(
     {
       // Get vertices for first entity
       const int e0 = entities[e - 1];
-      const int n0 = connect_d_0->num_edges(e0);
+      const int n0 = connect_d_0->num_links(e0);
       auto v0 = connect_d_0->edges(e0);
 
       // Get vertices for second entity
       const int e1 = entities[e];
-      const int n1 = connect_d_0->num_edges(e1);
+      const int n1 = connect_d_0->num_links(e1);
       auto v1 = connect_d_0->edges(e1);
 
       // Check ordering of entities

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -135,7 +135,7 @@ public:
   int size_global(std::array<int, 2> d, std::int32_t entity) const
   {
     if (_num_global_connections(d[0], d[1]).size() == 0)
-      return _connectivity(d[0], d[1])->num_edges(entity);
+      return _connectivity(d[0], d[1])->num_links(entity);
     else
       return _num_global_connections(d[0], d[1])[entity];
   }

--- a/cpp/dolfinx/mesh/TopologyComputation.cpp
+++ b/cpp/dolfinx/mesh/TopologyComputation.cpp
@@ -321,7 +321,7 @@ compute_entities_by_key_matching(
   for (int c = 0; c < num_cells; ++c)
   {
     // Get vertices from cell
-    auto vertices = cells.edges(c);
+    auto vertices = cells.links(c);
 
     // Iterate over entities of cell
     for (int i = 0; i < num_entities_per_cell; ++i)
@@ -416,7 +416,7 @@ compute_from_transpose(const graph::AdjacencyList<std::int32_t>& c_d1_d0,
 
   for (int e1 = 0; e1 < num_entities_d1; ++e1)
   {
-    auto e = c_d1_d0.edges(e1);
+    auto e = c_d1_d0.links(e1);
     for (int i = 0; i < e.rows(); ++i)
       num_connections[e[i]]++;
   }
@@ -431,7 +431,7 @@ compute_from_transpose(const graph::AdjacencyList<std::int32_t>& c_d1_d0,
 
   for (int e1 = 0; e1 < num_entities_d1; ++e1)
   {
-    auto e = c_d1_d0.edges(e1);
+    auto e = c_d1_d0.links(e1);
     for (int e0 = 0; e0 < e.rows(); ++e0)
       connections[offsets[e[e0]] + counter[e[e0]]++] = e1;
   }
@@ -459,7 +459,7 @@ compute_from_map(const graph::AdjacencyList<std::int32_t>& c_d0_0,
   std::vector<std::int32_t> key(num_verts_d1);
   for (int e = 0; e < c_d1_0.num_nodes(); ++e)
   {
-    const std::int32_t* v = c_d1_0.edges_ptr(e);
+    const std::int32_t* v = c_d1_0.links_ptr(e);
     std::partial_sort_copy(v, v + num_verts_d1, key.begin(), key.end());
     entity_to_index.insert({key, e});
   }
@@ -477,7 +477,7 @@ compute_from_map(const graph::AdjacencyList<std::int32_t>& c_d0_0,
   for (int e = 0; e < c_d0_0.num_nodes(); ++e)
   {
     entities.clear();
-    auto e0 = c_d0_0.edges(e);
+    auto e0 = c_d0_0.links(e);
     for (Eigen::Index i = 0; i < e_vertices_ref.rows(); ++i)
       for (Eigen::Index j = 0; j < e_vertices_ref.cols(); ++j)
         keys(i, j) = e0[e_vertices_ref(i, j)];

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -34,7 +34,7 @@ T volume_interval(const mesh::Mesh& mesh,
   for (Eigen::Index i = 0; i < entities.rows(); ++i)
   {
     // Get the coordinates of the two vertices
-    auto vertices = connectivity.edges(entities[i]);
+    auto vertices = connectivity.links(entities[i]);
     const Eigen::Vector3d x0 = geometry.x(vertices[0]);
     const Eigen::Vector3d x1 = geometry.x(vertices[1]);
     v[i] = (x1 - x0).norm();
@@ -60,7 +60,7 @@ T volume_triangle(const mesh::Mesh& mesh,
   {
     for (Eigen::Index i = 0; i < entities.rows(); ++i)
     {
-      auto vertices = connectivity.edges(entities[i]);
+      auto vertices = connectivity.links(entities[i]);
       const Eigen::Vector3d x0 = geometry.x(vertices[0]);
       const Eigen::Vector3d x1 = geometry.x(vertices[1]);
       const Eigen::Vector3d x2 = geometry.x(vertices[2]);
@@ -77,7 +77,7 @@ T volume_triangle(const mesh::Mesh& mesh,
   {
     for (Eigen::Index i = 0; i < entities.rows(); ++i)
     {
-      auto vertices = connectivity.edges(entities[i]);
+      auto vertices = connectivity.links(entities[i]);
       const Eigen::Vector3d x0 = geometry.x(vertices[0]);
       const Eigen::Vector3d x1 = geometry.x(vertices[1]);
       const Eigen::Vector3d x2 = geometry.x(vertices[2]);
@@ -114,7 +114,7 @@ T volume_tetrahedron(const mesh::Mesh& mesh,
   for (Eigen::Index i = 0; i < entities.rows(); ++i)
   {
     // Get the coordinates of the four vertices
-    auto vertices = connectivity.edges(entities[i]);
+    auto vertices = connectivity.links(entities[i]);
     const Eigen::Vector3d x0 = geometry.x(vertices[0]);
     const Eigen::Vector3d x1 = geometry.x(vertices[1]);
     const Eigen::Vector3d x2 = geometry.x(vertices[2]);
@@ -156,7 +156,7 @@ T volume_quadrilateral(const mesh::Mesh& mesh,
   for (Eigen::Index i = 0; i < entities.rows(); ++i)
   {
     // Get the coordinates of the four vertices
-    auto vertices = connectivity.edges(entities[i]);
+    auto vertices = connectivity.links(entities[i]);
     const Eigen::Vector3d p0 = geometry.x(vertices[0]);
     const Eigen::Vector3d p1 = geometry.x(vertices[1]);
     const Eigen::Vector3d p2 = geometry.x(vertices[2]);
@@ -236,7 +236,7 @@ T circumradius_triangle(const mesh::Mesh& mesh,
   T cr(entities.rows());
   for (Eigen::Index e = 0; e < entities.rows(); ++e)
   {
-    auto vertices = connectivity.edges(entities[e]);
+    auto vertices = connectivity.links(entities[e]);
     const Eigen::Vector3d p0 = geometry.x(vertices[0]);
     const Eigen::Vector3d p1 = geometry.x(vertices[1]);
     const Eigen::Vector3d p2 = geometry.x(vertices[2]);
@@ -269,7 +269,7 @@ T circumradius_tetrahedron(const mesh::Mesh& mesh,
   T cr(entities.rows());
   for (Eigen::Index e = 0; e < entities.rows(); ++e)
   {
-    auto vertices = connectivity.edges(entities[e]);
+    auto vertices = connectivity.links(entities[e]);
     const Eigen::Vector3d p0 = geometry.x(vertices[0]);
     const Eigen::Vector3d p1 = geometry.x(vertices[1]);
     const Eigen::Vector3d p2 = geometry.x(vertices[2]);
@@ -358,7 +358,7 @@ Eigen::ArrayXd mesh::h(const Mesh& mesh,
   for (Eigen::Index e = 0; e < entities.rows(); ++e)
   {
     // Get the coordinates  of the vertices
-    auto vertices = connectivity.edges(entities[e]);
+    auto vertices = connectivity.links(entities[e]);
     for (int i = 0; i < num_vertices; ++i)
       points[i] = geometry.x(vertices[i]);
 
@@ -412,7 +412,7 @@ Eigen::ArrayXd mesh::inradius(const mesh::Mesh& mesh,
       continue;
     }
 
-    auto facets = connectivity.edges(entities[c]);
+    auto facets = connectivity.links(entities[c]);
     for (int i = 0; i <= d; i++)
       facet_list[i] = facets[i];
     const double A = volume_entities_tmpl<Eigen::Array<double, 4, 1>>(
@@ -666,7 +666,7 @@ Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> mesh::midpoints(
         = mesh::cell_num_entities(cell_entity_type(mesh.cell_type(), dim), 0);
     for (Eigen::Index e = 0; e < entities.rows(); ++e)
     {
-      auto vertices = connectivity->edges(entities[e]);
+      auto vertices = connectivity->links(entities[e]);
       x.row(e) = 0.0;
       for (int i = 0; i < num_vertices; ++i)
         x.row(e) += points.row(vertices[i]);

--- a/python/dolfinx/wrappers/graph.cpp
+++ b/python/dolfinx/wrappers/graph.cpp
@@ -4,9 +4,11 @@
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
+#include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/graph/Graph.h>
 #include <dolfinx/graph/GraphBuilder.h>
 #include <dolfinx/mesh/Mesh.h>
+#include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <vector>
@@ -20,6 +22,25 @@ void graph(py::module& m)
   // dolfinx::Set
   py::class_<dolfinx::common::Set<int>>(m, "DOLFINIntSet");
 
+  // dolfinx::graph::AdjacencyList class
+  py::class_<dolfinx::graph::AdjacencyList<std::int32_t>,
+             std::shared_ptr<dolfinx::graph::AdjacencyList<std::int32_t>>>(
+      m, "AdjacencyList", "Adjacency list")
+      .def(
+          "links",
+          [](const dolfinx::graph::AdjacencyList<std::int32_t>& self, int i) {
+            return self.links(i);
+          },
+          "Links (edges) of a node",
+          py::return_value_policy::reference_internal)
+      .def("array", &dolfinx::graph::AdjacencyList<std::int32_t>::array,
+           "All edges", py::return_value_policy::reference_internal)
+      .def("offsets", &dolfinx::graph::AdjacencyList<std::int32_t>::offsets,
+           "Index to each node in the links array",
+           py::return_value_policy::reference_internal)
+      .def_property_readonly(
+          "num_nodes", &dolfinx::graph::AdjacencyList<std::int32_t>::num_nodes);
+
   // dolfinx::Graph
   py::class_<dolfinx::graph::Graph>(m, "Graph");
 
@@ -29,7 +50,7 @@ void graph(py::module& m)
                   [](const dolfinx::mesh::Mesh& mesh,
                      const std::vector<std::size_t>& coloring) {
                     return dolfinx::graph::GraphBuilder::local_graph(mesh,
-                                                                    coloring);
+                                                                     coloring);
                   })
       .def_static("local_graph", [](const dolfinx::mesh::Mesh& mesh,
                                     std::size_t dim0, std::size_t dim1) {

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -9,7 +9,6 @@
 #include <cfloat>
 #include <dolfinx/common/types.h>
 #include <dolfinx/fem/CoordinateElement.h>
-#include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/mesh/CoordinateDofs.h>
 #include <dolfinx/mesh/Geometry.h>
 #include <dolfinx/mesh/Mesh.h>
@@ -213,28 +212,6 @@ void mesh(py::module& m)
       .def("cell_name", [](const dolfinx::mesh::Mesh& self) {
         return dolfinx::mesh::to_string(self.cell_type());
       });
-
-  // dolfinx::graph::AdjacencyList class
-  py::class_<dolfinx::graph::AdjacencyList<std::int32_t>,
-             std::shared_ptr<dolfinx::graph::AdjacencyList<std::int32_t>>>(
-      m, "Connectivity", "Connectivity object")
-      .def(
-          "connections",
-          [](dolfinx::graph::AdjacencyList<std::int32_t>& self, int i) {
-            return self.links(i);
-          },
-          "Connections for a single mesh entity",
-          py::return_value_policy::reference_internal)
-      .def("connections",
-           py::overload_cast<>(
-               &dolfinx::graph::AdjacencyList<std::int32_t>::array),
-           "Connections for all mesh entities")
-      .def("pos",
-           py::overload_cast<>(
-               &dolfinx::graph::AdjacencyList<std::int32_t>::offsets),
-           "Index to each entity in the connectivity array")
-      .def("size", &dolfinx::graph::AdjacencyList<std::int32_t>::num_nodes)
-      .def("size", &dolfinx::graph::AdjacencyList<std::int32_t>::num_links);
 
   // dolfinx::mesh::MeshEntity class
   py::class_<dolfinx::mesh::MeshEntity,

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -221,7 +221,7 @@ void mesh(py::module& m)
       .def(
           "connections",
           [](dolfinx::graph::AdjacencyList<std::int32_t>& self, int i) {
-            return self.edges(i);
+            return self.links(i);
           },
           "Connections for a single mesh entity",
           py::return_value_policy::reference_internal)

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -234,7 +234,7 @@ void mesh(py::module& m)
                &dolfinx::graph::AdjacencyList<std::int32_t>::offsets),
            "Index to each entity in the connectivity array")
       .def("size", &dolfinx::graph::AdjacencyList<std::int32_t>::num_nodes)
-      .def("size", &dolfinx::graph::AdjacencyList<std::int32_t>::num_edges);
+      .def("size", &dolfinx::graph::AdjacencyList<std::int32_t>::num_links);
 
   // dolfinx::mesh::MeshEntity class
   py::class_<dolfinx::mesh::MeshEntity,

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -264,8 +264,8 @@ def test_custom_mesh_loop_rank1():
     V = dolfinx.FunctionSpace(mesh, ("Lagrange", 1))
 
     # Unpack mesh and dofmap data
-    c = mesh.topology.connectivity(2, 0).connections()
-    pos = mesh.topology.connectivity(2, 0).pos()
+    c = mesh.topology.connectivity(2, 0).array()
+    pos = mesh.topology.connectivity(2, 0).offsets()
     geom = mesh.geometry.points
     dofs = V.dofmap.dof_array
 
@@ -325,8 +325,8 @@ def test_custom_mesh_loop_ctypes_rank2():
     V = dolfinx.FunctionSpace(mesh, ("Lagrange", 1))
 
     # Extract mesh and dofmap data
-    c = mesh.topology.connectivity(2, 0).connections()
-    pos = mesh.topology.connectivity(2, 0).pos()
+    c = mesh.topology.connectivity(2, 0).array()
+    pos = mesh.topology.connectivity(2, 0).offsets()
     geom = mesh.geometry.points
     dofs = V.dofmap.dof_array
 
@@ -378,8 +378,8 @@ def test_custom_mesh_loop_cffi_rank2(set_vals):
     A0.assemble()
 
     # Unpack mesh and dofmap data
-    c = mesh.topology.connectivity(2, 0).connections()
-    pos = mesh.topology.connectivity(2, 0).pos()
+    c = mesh.topology.connectivity(2, 0).array()
+    pos = mesh.topology.connectivity(2, 0).offsets()
     geom = mesh.geometry.points
     dofs = V.dofmap.dof_array
 

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -436,7 +436,7 @@ def test_dofs_dim(space):
     for dim in range(0, topology.dim):
         edofs = dofmap.dofs(topology, dim)
         if topology.connectivity(dim, 0) is not None:
-            num_mesh_entities = topology.connectivity(dim, 0).size()
+            num_mesh_entities = topology.connectivity(dim, 0).num_nodes
             dofs_per_entity = dofmap.dof_layout.num_entity_dofs(dim)
             assert len(edofs) == dofs_per_entity * num_mesh_entities
 

--- a/python/test/unit/fem/test_expression_evaluation.py
+++ b/python/test/unit/fem/test_expression_evaluation.py
@@ -73,8 +73,8 @@ def test_rank0():
                 b[dofmap[i * 6 + j]] = b_local[j]
 
     # Prepare mesh and dofmap data
-    c = mesh.topology.connectivity(2, 0).connections()
-    pos = mesh.topology.connectivity(2, 0).pos()
+    c = mesh.topology.connectivity(2, 0).array()
+    pos = mesh.topology.connectivity(2, 0).offsets()
     geom = mesh.geometry.points
     coeff_dofmap = P2.dofmap.dof_array
     dofmap = vP1.dofmap.dof_array

--- a/python/test/unit/mesh/test_mesh_value_collection.py
+++ b/python/test/unit/mesh/test_mesh_value_collection.py
@@ -126,7 +126,7 @@ def test_mesh_function_assign_2D_facets():
     f = MeshFunction("int", mesh, tdim - 1, 25)
     connectivity = mesh.topology.connectivity(tdim, tdim - 1)
     for c in range(mesh.num_cells()):
-        facets = connectivity.connections(c)
+        facets = connectivity.links(c)
         for i in range(num_cell_facets):
             assert 25 == f.values[facets[i]]
 
@@ -142,7 +142,7 @@ def test_mesh_function_assign_2D_facets():
 
     connectivity = mesh.topology.connectivity(tdim, tdim - 1)
     for c in range(mesh.num_cells()):
-        facets = connectivity.connections(c)
+        facets = connectivity.links(c)
         for i in range(num_cell_facets):
             assert f2.values[facets[i]] == g.get_value(c, i)
 
@@ -162,7 +162,7 @@ def test_mesh_function_assign_2D_vertices():
     tdim = mesh.topology.dim
     connectivity = mesh.topology.connectivity(tdim, 0)
     for c in range(mesh.num_cells()):
-        vertices = connectivity.connections(c)
+        vertices = connectivity.links(c)
         for i in range(num_cell_vertices):
             assert 25 == g.get_value(c, i)
             assert f2.values[vertices[i]] == g.get_value(c, i)

--- a/python/test/unit/mesh/xtest_ghost_mesh.py
+++ b/python/test/unit/mesh/xtest_ghost_mesh.py
@@ -88,7 +88,7 @@ def test_ghost_connectivities(mode):
     cell_mp = cpp.mesh.midpoints(meshR, tdim, range(meshR.num_entities(tdim)))
     reference = dict.fromkeys([tuple(row) for row in facet_mp], [])
     for i in range(meshR.num_entities(tdim - 1)):
-        for cidx in meshR.topology.connectivity(1, 2).connections(i):
+        for cidx in meshR.topology.connectivity(1, 2).links(i):
             reference[tuple(facet_mp[i])].append(cell_mp[cidx].tolist())
 
     # Loop through ghosted mesh and check connectivities
@@ -99,6 +99,6 @@ def test_ghost_connectivities(mode):
     cell_mp = cpp.mesh.midpoints(meshG, tdim, range(meshG.num_entities(tdim)))
     for i in range(num_facets):
         assert tuple(facet_mp[i]) in reference
-        for cidx in meshG.topology.connectivity(1, 2).connections(i):
+        for cidx in meshG.topology.connectivity(1, 2).links(i):
             assert cidx in allowable_cell_indices
             assert cell_mp[cidx].tolist() in reference[tuple(facet_mp[i])]


### PR DESCRIPTION
Renames AdjacencyList::edges -> AdjacencyList::links. Fixes #748.