### PR TITLE
Expose petsc-vector from C++

### DIFF
--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -27,6 +27,14 @@ namespace dolfinx_wrappers
 
 void la(py::module& m)
 {
+  // dolfinx::la::PETScVector
+  py::class_<dolfinx::la::PETScVector,
+             std::shared_ptr<dolfinx::la::PETScVector>>(m, "PETScVector")
+      .def(py::init([](const dolfinx::common::IndexMap& map) {
+        return dolfinx::la::PETScVector(map);
+      }))
+      .def("vec", &dolfinx::la::PETScVector::vec);
+
   // dolfinx::la::SparsityPattern
   py::class_<dolfinx::la::SparsityPattern,
              std::shared_ptr<dolfinx::la::SparsityPattern>>(m,


### PR DESCRIPTION
Exposed with initializer from IndexMap, so that one does not have to go through a Function with an appropriate function space to get a vector (used in MPC).