### PR TITLE
Define MeshFunction and MeshValueCollection as functions rather than classes in python layer

### DIFF
--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -54,23 +54,21 @@ _meshvaluecollection_types = {
 }
 
 
-class MeshFunction:
-    def __new__(cls, value_type, mesh, dim, value):
-        if value_type not in _meshfunction_types.keys():
-            raise KeyError("MeshFunction type not recognised")
-        fn = _meshfunction_types[value_type]
-        return fn(mesh, dim, value)
+def MeshFunction(value_type, mesh, dim, value):
+    if value_type not in _meshfunction_types.keys():
+        raise KeyError("MeshFunction type not recognised")
+    fn = _meshfunction_types[value_type]
+    return fn(mesh, dim, value)
 
 
-class MeshValueCollection:
-    def __new__(cls, value_type, mesh, dim=None):
-        if value_type not in _meshvaluecollection_types.keys():
-            raise KeyError("MeshValueCollection type not recognised")
-        mvc = _meshvaluecollection_types[value_type]
-        if dim is not None:
-            return mvc(mesh, dim)
-        else:
-            return mvc(mesh)
+def MeshValueCollection(value_type, mesh, dim=None):
+    if value_type not in _meshvaluecollection_types.keys():
+        raise KeyError("MeshValueCollection type not recognised")
+    mvc = _meshvaluecollection_types[value_type]
+    if dim is not None:
+        return mvc(mesh, dim)
+    else:
+        return mvc(mesh)
 
 
 # Functions to extend cpp.mesh.Mesh with


### PR DESCRIPTION
I find the old definition to be confusing, especially in a code like the following
```
from dolfinx import *
mesh = UnitSquareMesh(MPI.comm_world, 3, 3)
mf = MeshFunction("size_t", mesh, 2, 0)
assert isinstance(mf, MeshFunction) # fails
```