### PR TITLE
Fix get_remote_bcs1

### DIFF
--- a/cpp/dolfinx/fem/DirichletBC.cpp
+++ b/cpp/dolfinx/fem/DirichletBC.cpp
@@ -80,7 +80,7 @@ get_remote_bcs1(const common::IndexMap& map,
 
   // Build vector of local dof indicies that have been marked by another
   // process
-  std::vector<std::int32_t> dofs = map.global_to_local(dofs_global, false);
+  std::vector<std::int32_t> dofs = map.global_to_local(dofs_received, false);
   dofs.erase(std::remove(dofs.begin(), dofs.end(), -1), dofs.end());
 
   return dofs;


### PR DESCRIPTION
Failixing example:
`mpirun -n 2 python3 file.py`
```
import dolfinx
import numpy
from dolfinx.fem import locate_dofs_topological

comm = dolfinx.MPI.comm_world
mesh = dolfinx.UnitSquareMesh(comm, 2, 2)
mesh.create_connectivity_all()

V = dolfinx.FunctionSpace(mesh, ("CG", 1))
facets = numpy.where(mesh.topology.on_boundary(1))[0]

# Remove  top facet
if comm.rank == 0:
    facets = facets[:-1]

marker = locate_dofs_topological(V, 1, facets)
assert(marker.size == 5)
```

In a next PR, I'll add some tests and use `MPI_Neighbor_alltoallv` .