### PR TITLE
Strict FFCX JIT compiler in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ build-documentation-python: &build-documentation-python
 unit-tests-python: &unit-tests-python
   name: Run unit tests (Python, serial)
   environment:
-    DOLFINX_JIT_CFLAGS: -g0 -O0
+    DOLFINX_JIT_CFLAGS: -g0 -O0 -Wall -Werror
   command: |
     mkdir -p ~/junit
     cd python/test/unit
@@ -80,7 +80,7 @@ unit-tests-python: &unit-tests-python
 unit-tests-python-mpi: &unit-tests-python-mpi
   name: Run unit tests (Python, MPI)
   environment:
-    DOLFINX_JIT_CFLAGS: -g0 -O0
+    DOLFINX_JIT_CFLAGS: -g0 -O0 -Wall -Werror
   command: |
     cd python/test/unit
     mpirun -np 3 python3 -m pytest .
@@ -88,7 +88,7 @@ unit-tests-python-mpi: &unit-tests-python-mpi
 demos-python: &demos-python
   name: Run demos (Python, serial)
   environment:
-    DOLFINX_JIT_CFLAGS: -g0 -O2
+    DOLFINX_JIT_CFLAGS: -g0 -O2 -Wall -Werror
   command: |
     mkdir -p ~/junit
     cd python/demo
@@ -98,7 +98,7 @@ demos-python: &demos-python
 demos-python-mpi: &demos-python-mpi
   name: Run demos (Python, MPI)
   environment:
-    DOLFINX_JIT_CFLAGS: -g0 -O2
+    DOLFINX_JIT_CFLAGS: -g0 -O2 -Wall -Werror
   command: |
     cd python/demo
     python3 ./generate-demo-files.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ install-python-components: &install-python-components
   command: |
     pip3 install git+https://github.com/FEniCS/fiat.git --upgrade
     pip3 install git+https://github.com/FEniCS/ufl.git --upgrade
-    pip3 install git+https://github.com/FEniCS/ffcx.git --upgrade
+    pip3 install git+https://github.com/FEniCS/ffcx.git@michal/fix-expression-werror --upgrade
     rm -rf /usr/local/include/dolfin /usr/local/include/dolfin.h
 
 flake8-python-code: &flake8-python-code


### PR DESCRIPTION
Enable `-Wall -Werror` for FFCX JIT compilation in all tests.