### PR TITLE
Document base permutations

### DIFF
--- a/cpp/dolfinx/fem/ElementDofLayout.cpp
+++ b/cpp/dolfinx/fem/ElementDofLayout.cpp
@@ -16,6 +16,34 @@
 using namespace dolfinx;
 using namespace dolfinx::fem;
 
+namespace
+{
+//-----------------------------------------------------------------------------
+int get_num_permutations(const mesh::CellType cell_type)
+{
+  // In general, this will return num_edges + 2*num_faces + 4*num_volumes
+  switch (cell_type)
+  {
+  case (mesh::CellType::point):
+    return 0;
+  case (mesh::CellType::interval):
+    return 1;
+  case (mesh::CellType::triangle):
+    return 5;
+  case (mesh::CellType::tetrahedron):
+    return 18;
+  case (mesh::CellType::quadrilateral):
+    return 6;
+  case (mesh::CellType::hexahedron):
+    return 28;
+  default:
+    LOG(WARNING) << "Dof permutations are not defined for this cell type. High "
+                    "order elements may be incorrect.";
+    return 0;
+  }
+}
+} // namespace
+
 //-----------------------------------------------------------------------------
 ElementDofLayout::ElementDofLayout(
     int block_size, const std::vector<std::vector<std::set<int>>>& entity_dofs_,
@@ -75,6 +103,10 @@ ElementDofLayout::ElementDofLayout(
       _num_dofs += entity_dofs_[dim][entity_index].size();
     }
   }
+
+  // Assert that base_permutations is the correct shape
+  assert (_base_permutations.rows() == get_num_permutations(cell_type));
+  assert (_base_permutations.cols() == _num_dofs);
 }
 //-----------------------------------------------------------------------------
 ElementDofLayout ElementDofLayout::copy() const

--- a/cpp/dolfinx/fem/ElementDofLayout.cpp
+++ b/cpp/dolfinx/fem/ElementDofLayout.cpp
@@ -18,32 +18,17 @@ using namespace dolfinx::fem;
 
 //-----------------------------------------------------------------------------
 ElementDofLayout::ElementDofLayout(
-    int block_size, const std::vector<std::vector<std::set<int>>>& entity_dofs_,
+    int block_size, const std::vector<std::vector<std::set<int>>>& entity_dofs,
     const std::vector<int>& parent_map,
     const std::vector<std::shared_ptr<const ElementDofLayout>>& sub_dofmaps,
     const mesh::CellType cell_type,
     const Eigen::Array<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
         base_permutations)
     : _block_size(block_size), _cell_type(cell_type), _parent_map(parent_map),
-      _num_dofs(0), _entity_dofs(entity_dofs_), _sub_dofmaps(sub_dofmaps),
+      _num_dofs(0), _entity_dofs(entity_dofs), _sub_dofmaps(sub_dofmaps),
       _base_permutations(base_permutations)
 {
   // TODO: Handle global support dofs
-
-  // Check that base_permutations has the correct shape
-  int perm_count = 0;
-  std::array<int, 4> perms_per_dim = {0, 1, 2, 4};
-  for (std::size_t dim = 0; dim < entity_dofs_.size(); ++dim)
-    perm_count += perms_per_dim[dim] * entity_dofs_[dim].size();
-  if (base_permutations.rows() != perm_count
-      or _base_permutations.cols() != _num_dofs)
-  {
-    throw std::runtime_error("Permutation array has wrong shape. Expected "
-                             + std::to_string(perm_count) + " x "
-                             + std::to_string(_num_dofs) + " but got "
-                             + std::to_string(_base_permutations.rows()) + " x "
-                             + std::to_string(_base_permutations.cols()) + ".");
-  }
 
   // Compute closure entities
   // [dim, entity] -> closure{sub_dim, (sub_entities)}
@@ -51,23 +36,23 @@ ElementDofLayout::ElementDofLayout(
       = mesh::cell_entity_closure(cell_type);
 
   // dof = _entity_dofs[dim][entity_index][i]
-  _entity_closure_dofs = entity_dofs_;
+  _entity_closure_dofs = entity_dofs;
   for (auto entity : entity_closure)
   {
     const int dim = entity.first[0];
     const int index = entity.first[1];
-    assert(dim < (int)entity_dofs_.size());
-    assert(index < (int)entity_dofs_[dim].size());
+    assert(dim < (int)entity_dofs.size());
+    assert(index < (int)entity_dofs[dim].size());
     int subdim = 0;
     for (auto sub_entity : entity.second)
     {
-      assert(subdim < (int)entity_dofs_.size());
+      assert(subdim < (int)entity_dofs.size());
       for (auto sub_index : sub_entity)
       {
-        assert(sub_index < (int)entity_dofs_[subdim].size());
+        assert(sub_index < (int)entity_dofs[subdim].size());
         _entity_closure_dofs[dim][index].insert(
-            entity_dofs_[subdim][sub_index].begin(),
-            entity_dofs_[subdim][sub_index].end());
+            entity_dofs[subdim][sub_index].begin(),
+            entity_dofs[subdim][sub_index].end());
       }
       ++subdim;
     }
@@ -76,19 +61,37 @@ ElementDofLayout::ElementDofLayout(
   // dof = _entity_dofs[dim][entity_index][i]
   _num_entity_dofs.fill(0);
   _num_entity_closure_dofs.fill(0);
-  assert(entity_dofs_.size() == _entity_closure_dofs.size());
-  for (std::size_t dim = 0; dim < entity_dofs_.size(); ++dim)
+  assert(entity_dofs.size() == _entity_closure_dofs.size());
+  for (std::size_t dim = 0; dim < entity_dofs.size(); ++dim)
   {
-    assert(!entity_dofs_[dim].empty());
+    assert(!entity_dofs[dim].empty());
     assert(!_entity_closure_dofs[dim].empty());
-    _num_entity_dofs[dim] = entity_dofs_[dim][0].size();
+    _num_entity_dofs[dim] = entity_dofs[dim][0].size();
     _num_entity_closure_dofs[dim] = _entity_closure_dofs[dim][0].size();
-
-    for (std::size_t entity_index = 0; entity_index < entity_dofs_[dim].size();
+    for (std::size_t entity_index = 0; entity_index < entity_dofs[dim].size();
          ++entity_index)
     {
-      _num_dofs += entity_dofs_[dim][entity_index].size();
+      _num_dofs += entity_dofs[dim][entity_index].size();
     }
+  }
+
+  // Check that base_permutations has the correct shape
+  int perm_count = 0;
+  const std::array<int, 4> perms_per_dim = {0, 1, 2, 4};
+  for (std::size_t dim = 0; dim < entity_dofs.size(); ++dim)
+  {
+    assert(dim < perms_per_dim.size());
+    assert(dim < entity_dofs.size());
+    perm_count += perms_per_dim[dim] * entity_dofs[dim].size();
+  }
+  if (base_permutations.rows() != perm_count
+      or _base_permutations.cols() != _num_dofs)
+  {
+    throw std::runtime_error("Permutation array has wrong shape. Expected "
+                             + std::to_string(perm_count) + " x "
+                             + std::to_string(_num_dofs) + " but got "
+                             + std::to_string(_base_permutations.rows()) + " x "
+                             + std::to_string(_base_permutations.cols()) + ".");
   }
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/ElementDofLayout.cpp
+++ b/cpp/dolfinx/fem/ElementDofLayout.cpp
@@ -16,34 +16,6 @@
 using namespace dolfinx;
 using namespace dolfinx::fem;
 
-namespace
-{
-//-----------------------------------------------------------------------------
-int get_num_permutations(const mesh::CellType cell_type)
-{
-  // In general, this will return num_edges + 2*num_faces + 4*num_volumes
-  switch (cell_type)
-  {
-  case (mesh::CellType::point):
-    return 0;
-  case (mesh::CellType::interval):
-    return 1;
-  case (mesh::CellType::triangle):
-    return 5;
-  case (mesh::CellType::tetrahedron):
-    return 18;
-  case (mesh::CellType::quadrilateral):
-    return 6;
-  case (mesh::CellType::hexahedron):
-    return 28;
-  default:
-    LOG(WARNING) << "Dof permutations are not defined for this cell type. High "
-                    "order elements may be incorrect.";
-    return 0;
-  }
-}
-} // namespace
-
 //-----------------------------------------------------------------------------
 ElementDofLayout::ElementDofLayout(
     int block_size, const std::vector<std::vector<std::set<int>>>& entity_dofs_,
@@ -105,7 +77,13 @@ ElementDofLayout::ElementDofLayout(
   }
 
   // Assert that base_permutations is the correct shape
-  assert (_base_permutations.rows() == get_num_permutations(cell_type));
+#ifdef DEBUG
+  int perm_count = 0;
+  std::array<int, 4> perms_per_dim = {0, 1, 2, 4};
+  for (std::size_t dim = 0; dim < entity_dofs_.size(); ++dim)
+    perm_count += perms_per_dim[dim] * entity_dofs_[dim].size();
+#endif
+  assert(_base_permutations.rows() == perm_count);
   assert (_base_permutations.cols() == _num_dofs);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/ElementDofLayout.cpp
+++ b/cpp/dolfinx/fem/ElementDofLayout.cpp
@@ -30,6 +30,21 @@ ElementDofLayout::ElementDofLayout(
 {
   // TODO: Handle global support dofs
 
+  // Check that base_permutations has the correct shape
+  int perm_count = 0;
+  std::array<int, 4> perms_per_dim = {0, 1, 2, 4};
+  for (std::size_t dim = 0; dim < entity_dofs_.size(); ++dim)
+    perm_count += perms_per_dim[dim] * entity_dofs_[dim].size();
+  if (base_permutations.rows() != perm_count
+      or _base_permutations.cols() != _num_dofs)
+  {
+    throw std::runtime_error("Permutation array has wrong shape. Expected "
+                             + std::to_string(perm_count) + " x "
+                             + std::to_string(_num_dofs) + " but got "
+                             + std::to_string(_base_permutations.rows()) + " x "
+                             + std::to_string(_base_permutations.cols()) + ".");
+  }
+
   // Compute closure entities
   // [dim, entity] -> closure{sub_dim, (sub_entities)}
   std::map<std::array<int, 2>, std::vector<std::set<int>>> entity_closure
@@ -75,16 +90,6 @@ ElementDofLayout::ElementDofLayout(
       _num_dofs += entity_dofs_[dim][entity_index].size();
     }
   }
-
-  // Assert that base_permutations is the correct shape
-#ifdef DEBUG
-  int perm_count = 0;
-  std::array<int, 4> perms_per_dim = {0, 1, 2, 4};
-  for (std::size_t dim = 0; dim < entity_dofs_.size(); ++dim)
-    perm_count += perms_per_dim[dim] * entity_dofs_[dim].size();
-  assert(_base_permutations.rows() == perm_count);
-#endif
-  assert(_base_permutations.cols() == _num_dofs);
 }
 //-----------------------------------------------------------------------------
 ElementDofLayout ElementDofLayout::copy() const

--- a/cpp/dolfinx/fem/ElementDofLayout.cpp
+++ b/cpp/dolfinx/fem/ElementDofLayout.cpp
@@ -82,9 +82,9 @@ ElementDofLayout::ElementDofLayout(
   std::array<int, 4> perms_per_dim = {0, 1, 2, 4};
   for (std::size_t dim = 0; dim < entity_dofs_.size(); ++dim)
     perm_count += perms_per_dim[dim] * entity_dofs_[dim].size();
-#endif
   assert(_base_permutations.rows() == perm_count);
-  assert (_base_permutations.cols() == _num_dofs);
+#endif
+  assert(_base_permutations.cols() == _num_dofs);
 }
 //-----------------------------------------------------------------------------
 ElementDofLayout ElementDofLayout::copy() const

--- a/cpp/dolfinx/fem/ElementDofLayout.h
+++ b/cpp/dolfinx/fem/ElementDofLayout.h
@@ -34,6 +34,7 @@ class ElementDofLayout
 {
 public:
   /// Constructor
+  /// @param[in] block_size The number of dofs co-located at each point.
   /// @param[in] entity_dofs The dofs on each entity, in the format:
   ///            entity_dofs[entity_dim][entity_number] = [dof0, dof1, ...]
   /// @param[in] parent_map TODO

--- a/cpp/dolfinx/fem/ElementDofLayout.h
+++ b/cpp/dolfinx/fem/ElementDofLayout.h
@@ -34,6 +34,26 @@ class ElementDofLayout
 {
 public:
   /// Constructor
+  /// @param[in] entity_dofs The dofs on each entity, in the format:
+  ///            entity_dofs[entity_dim][entity_number] = [dof0, dof1, ...]
+  /// @param[in] parent_map TODO
+  /// @param[in] sub_dofmaps TODO
+  /// @param[in] cell_type The cell type of the mesh.
+  /// @param[in] base_permutations The base permutations for the dofs on the
+  ///            cell. These will be used to permute the dofs on the cell. Each
+  ///            row of this array is one base permutation, and the number of
+  ///            columns should be the number of (local) dofs on each cell.
+  ///              Points (dim 0 entities) have no permutations.
+  ///              Lines (dim 1 entities) have one permutation each to represent
+  ///                the line being reversed.
+  ///              Faces (dim 2 entities) have two permutations each to
+  ///                represent the face being rotated (one vertex anticlockwise)
+  ///                and reflected.
+  ///              Volumes (dim 3 entities) have four permutations each to
+  ///                represent the volume being rotated (by one vertex) in three
+  ///                directions and reflected. It would be possible to represent
+  ///                a volume with 3 base permutations (2 rotations and 1
+  ///                reflection), but the implementation with 3 is simpler.
   ElementDofLayout(
       int block_size,
       const std::vector<std::vector<std::set<int>>>& entity_dofs,

--- a/cpp/dolfinx/fem/ElementDofLayout.h
+++ b/cpp/dolfinx/fem/ElementDofLayout.h
@@ -36,25 +36,23 @@ public:
   /// Constructor
   /// @param[in] block_size The number of dofs co-located at each point.
   /// @param[in] entity_dofs The dofs on each entity, in the format:
-  ///            entity_dofs[entity_dim][entity_number] = [dof0, dof1, ...]
+  ///   entity_dofs[entity_dim][entity_number] = [dof0, dof1, ...]
   /// @param[in] parent_map TODO
   /// @param[in] sub_dofmaps TODO
   /// @param[in] cell_type The cell type of the mesh.
-  /// @param[in] base_permutations The base permutations for the dofs on the
-  ///            cell. These will be used to permute the dofs on the cell. Each
-  ///            row of this array is one base permutation, and the number of
-  ///            columns should be the number of (local) dofs on each cell.
-  ///              Points (dim 0 entities) have no permutations.
-  ///              Lines (dim 1 entities) have one permutation each to represent
-  ///                the line being reversed.
-  ///              Faces (dim 2 entities) have two permutations each to
-  ///                represent the face being rotated (one vertex anticlockwise)
-  ///                and reflected.
-  ///              Volumes (dim 3 entities) have four permutations each to
-  ///                represent the volume being rotated (by one vertex) in three
-  ///                directions and reflected. It would be possible to represent
-  ///                a volume with 3 base permutations (2 rotations and 1
-  ///                reflection), but the implementation with 3 is simpler.
+  /// @param[in] base_permutations The base permutations for the dofs on
+  ///   the cell. These will be used to permute the dofs on the cell.
+  ///   Each row of this array is one base permutation, and the number
+  ///   of columns should be the number of (local) dofs on each cell.
+  ///   Points (dim 0 entities) have no permutations. Lines (dim 1
+  ///   entities) have one permutation each to represent the line being
+  ///   reversed. Faces (dim 2 entities) have two permutations each to
+  ///   represent the face being rotated (one vertex anticlockwise) and
+  ///   reflected. Volumes (dim 3 entities) have four permutations each
+  ///   to represent the volume being rotated (by one vertex) in three
+  ///   directions and reflected. It would be possible to represent a
+  ///   volume with 3 base permutations (2 rotations and 1 reflection),
+  ///   but the implementation with 3 is simpler.
   ElementDofLayout(
       int block_size,
       const std::vector<std::vector<std::set<int>>>& entity_dofs,
@@ -99,7 +97,7 @@ public:
   /// Return the number of closure dofs for a given entity dimension
   /// @param[in] dim Entity dimension
   /// @return Number of dofs associated with closure of given entity
-  ///         dimension
+  ///   dimension
   int num_entity_closure_dofs(int dim) const;
 
   /// Local-local mapping of dofs on entity of cell
@@ -141,9 +139,8 @@ public:
 
   /// True iff dof map is a view into another map
   ///
-  /// @returns bool
-  ///         True if the dof map is a sub-dof map (a view into
-  ///         another map).
+  /// @returns bool True if the dof map is a sub-dof map (a view into
+  ///   another map).
   bool is_view() const;
 
   /// Returns the base permutations of the DoFs, as computed by FFCx

--- a/python/test/unit/mesh/test_mesh_utils.py
+++ b/python/test/unit/mesh/test_mesh_utils.py
@@ -33,6 +33,8 @@ def test_extract_topology():
     assert np.array_equal(cells0.array(), cells_filtered0.array())
 
     # Create element dof layout for P2 element
+    perms = np.zeros([5, 6], dtype=np.int8)
+    perms[:] = [0, 1, 2, 3, 4, 5]
     entity_dofs = [[set([0]), set([1]), set([2])], [set([3]), set([4]), set([5])], [set()]]
     layout = cpp.fem.ElementDofLayout(1, entity_dofs, [], [],
                                       cpp.mesh.CellType.triangle, perms)


### PR DESCRIPTION
 - Added some documentation for base permutations input of `ElementDofLayout`.
 - Added asserts in the `ElementDofLayout` to check the shape of the base permutations, so that the assertion is hit rather than a segfault later.