### PR TITLE
Fix direction of VTK -> DOLFIN map 

### DIFF
--- a/cpp/demo/poisson/poisson.ufl
+++ b/cpp/demo/poisson/poisson.ufl
@@ -5,7 +5,7 @@
 # the variational problem in UFL terms in a separate form file
 # :download:`Poisson.ufl`.  We begin by defining the finite element::
 
-element = FiniteElement("Lagrange", triangle, 1)
+element = FiniteElement("Lagrange", hexahedron, 1)
 
 # The first argument to :py:class:`FiniteElement` is the finite element
 # family, the second argument specifies the domain, while the third
@@ -18,7 +18,7 @@ element = FiniteElement("Lagrange", triangle, 1)
 # (:math:`u` and :math:`v`) and the coefficient functions (:math:`f` and
 # :math:`g`)::
 
-coord_element = VectorElement("Lagrange", triangle, 1)
+coord_element = VectorElement("Lagrange", hexahedron, 1)
 mesh = Mesh(coord_element)
 
 V = FunctionSpace(mesh, element)

--- a/cpp/demo/poisson/poisson.ufl
+++ b/cpp/demo/poisson/poisson.ufl
@@ -5,7 +5,7 @@
 # the variational problem in UFL terms in a separate form file
 # :download:`Poisson.ufl`.  We begin by defining the finite element::
 
-element = FiniteElement("Lagrange", hexahedron, 1)
+element = FiniteElement("Lagrange", triangle, 1)
 
 # The first argument to :py:class:`FiniteElement` is the finite element
 # family, the second argument specifies the domain, while the third
@@ -18,7 +18,7 @@ element = FiniteElement("Lagrange", hexahedron, 1)
 # (:math:`u` and :math:`v`) and the coefficient functions (:math:`f` and
 # :math:`g`)::
 
-coord_element = VectorElement("Lagrange", hexahedron, 1)
+coord_element = VectorElement("Lagrange", triangle, 1)
 mesh = Mesh(coord_element)
 
 V = FunctionSpace(mesh, element)

--- a/cpp/dolfinx/io/cells.cpp
+++ b/cpp/dolfinx/io/cells.cpp
@@ -212,7 +212,8 @@ std::vector<std::uint8_t> io::cells::dolfin_to_vtk(mesh::CellType type,
 //     }
 //   }
 //   default:
-//     throw std::runtime_error("Simplicies can be expressed as TensorProduct.");
+//     throw std::runtime_error("Simplicies can be expressed as
+//     TensorProduct.");
 //   }
 // }
 //-----------------------------------------------------------------------------
@@ -227,7 +228,7 @@ io::cells::permute_ordering(
   for (Eigen::Index c = 0; c < cells_new.rows(); ++c)
   {
     for (Eigen::Index v = 0; v < cells_new.cols(); ++v)
-      cells_new(c, v) = cells(c, permutation[v]);
+      cells_new(c, permutation[v]) = cells(c, v);
   }
   return cells_new;
 }

--- a/cpp/dolfinx/io/cells.cpp
+++ b/cpp/dolfinx/io/cells.cpp
@@ -12,7 +12,7 @@
 using namespace dolfinx;
 
 //-----------------------------------------------------------------------------
-std::vector<std::uint8_t> io::cells::dolfin_to_vtk(mesh::CellType type,
+std::vector<std::uint8_t> io::cells::vtk_to_dolfin(mesh::CellType type,
                                                    int num_nodes)
 {
   switch (type)
@@ -139,10 +139,14 @@ std::vector<std::uint8_t> io::cells::dolfin_to_vtk(mesh::CellType type,
     case 8:
       return {0, 4, 6, 2, 1, 5, 7, 3};
     case 27:
-      // TODO: change permutation when paraview issue 19433 is resolved
-      // (https://gitlab.kitware.com/paraview/paraview/issues/19433)
-      return {0,  9, 12, 3,  1, 10, 13, 4,  18, 15, 21, 6,  19, 16,
-              22, 7, 2,  11, 5, 14, 8,  17, 20, 23, 24, 25, 26};
+      // // TODO: change permutation when paraview issue 19433 is resolved
+      // // (https://gitlab.kitware.com/paraview/paraview/issues/19433)
+      // return {0,  9, 12, 3,  1, 10, 13, 4,  18, 15, 21, 6,  19, 16,
+      //         22, 7, 2,  11, 5, 14, 8,  17, 20, 23, 24, 25, 26};
+
+      // This is the documented VTK ordering
+      return {0,  9, 12, 3,  1,  10, 13, 4,  18, 15, 21, 6,  19, 16,
+              22, 7, 2,  11, 14, 5,  8,  17, 20, 23, 24, 25, 26};
     default:
       throw std::runtime_error("Higher order hexahedron not supported.");
     }
@@ -152,121 +156,65 @@ std::vector<std::uint8_t> io::cells::dolfin_to_vtk(mesh::CellType type,
   }
 }
 //-----------------------------------------------------------------------------
-std::vector<std::uint8_t> io::cells::vtk_to_tp(mesh::CellType type,
-                                               int num_nodes)
-{
-  const std::vector<std::uint8_t> reversed
-      = io::cells::dolfin_to_vtk(type, num_nodes);
-  switch (type)
-  {
-  case mesh::CellType::quadrilateral:
-  {
-    std::vector<std::uint8_t> perm(num_nodes);
-    for (int i = 0; i < num_nodes; ++i)
-      perm[reversed[i]] = i;
-    return perm;
-  }
-  case mesh::CellType::hexahedron:
-  {
-    std::vector<std::uint8_t> perm(num_nodes);
-    for (int i = 0; i < num_nodes; ++i)
-      perm[reversed[i]] = i;
-    return perm;
-  }
-  default:
-    throw std::runtime_error("Simplicies can be expressed as TensorProduct");
-  }
-}
-//-----------------------------------------------------------------------------
-std::vector<std::uint8_t> io::cells::lex_to_tp(mesh::CellType type,
-                                               int num_nodes)
-{
-  switch (type)
-  {
-  case mesh::CellType::quadrilateral:
-  {
-    assert((std::sqrt(num_nodes) - std::floor(std::sqrt(num_nodes))) == 0);
-    // Number of nodes in each direction
-    const int n = sqrt(num_nodes);
-
-    std::vector<std::uint8_t> permutation(num_nodes);
-    std::vector<std::uint8_t> rows(n);
-    std::iota(std::next(rows.begin()), std::prev(rows.end()), 2);
-    rows.front() = 0;
-    rows.back() = 1;
-
-    int j = 0;
-    for (auto row : rows)
-    {
-      permutation[j] = row;
-      permutation[j + n - 1] = n + row;
-      j++;
-      for (int index = 0; index < n - 2; ++index)
-      {
-        permutation[j] = (2 + index) * n + row;
-        j++;
-      }
-      j++;
-    }
-    return permutation;
-  }
-  case mesh::CellType::hexahedron:
-  {
-    switch (num_nodes)
-    {
-    case 8:
-      return {0, 4, 2, 6, 1, 5, 3, 7};
-    default:
-      throw std::runtime_error("Higher order hexahedron not supported.");
-    }
-  }
-  default:
-    throw std::runtime_error("Simplicies can be expressed as TensorProduct.");
-  }
-}
-//-----------------------------------------------------------------------------
-std::vector<std::uint8_t> io::cells::vtk_to_dolfin(mesh::CellType type,
+std::vector<std::uint8_t> io::cells::dolfin_to_vtk(mesh::CellType type,
                                                    int num_nodes)
 {
-  switch (type)
-  {
-  case mesh::CellType::point:
-    return {0};
-  case mesh::CellType::interval:
-  {
-    const std::vector<std::uint8_t> reversed
-        = io::cells::dolfin_to_vtk(type, num_nodes);
-    std::vector<std::uint8_t> perm(num_nodes);
-    for (int i = 0; i < num_nodes; ++i)
-      perm[reversed[i]] = i;
-    return perm;
-  }
-  case mesh::CellType::triangle:
-  {
-    const std::vector<std::uint8_t> reversed
-        = io::cells::dolfin_to_vtk(type, num_nodes);
-    std::vector<std::uint8_t> perm(num_nodes);
-    for (int i = 0; i < num_nodes; ++i)
-      perm[reversed[i]] = i;
-    return perm;
-  }
-  case mesh::CellType::tetrahedron:
-  {
-    const std::vector<std::uint8_t> reversed
-        = io::cells::dolfin_to_vtk(type, num_nodes);
-    std::vector<std::uint8_t> perm(num_nodes);
-    for (int i = 0; i < num_nodes; ++i)
-      perm[reversed[i]] = i;
-    return perm;
-  }
-  case mesh::CellType::quadrilateral:
-    return io::cells::vtk_to_tp(type, num_nodes);
-  case mesh::CellType::hexahedron:
-    return io::cells::vtk_to_tp(type, num_nodes);
-  default:
-    throw std::runtime_error("Unknown cell type.");
-  }
+  // Transpose of vtk_to_dolfin
+  const std::vector<std::uint8_t> perm_r
+      = io::cells::vtk_to_dolfin(type, num_nodes);
+  assert(num_nodes == (int)perm_r.size());
+  std::vector<std::uint8_t> perm(perm_r.size());
+  for (std::size_t i = 0; i < perm.size(); ++i)
+    perm[perm_r[i]] = i;
+  return perm;
 }
+//-----------------------------------------------------------------------------
+// std::vector<std::uint8_t> io::cells::lex_to_tp(mesh::CellType type,
+//                                                int num_nodes)
+// {
+//   switch (type)
+//   {
+//   case mesh::CellType::quadrilateral:
+//   {
+//     assert((std::sqrt(num_nodes) - std::floor(std::sqrt(num_nodes))) == 0);
+//     // Number of nodes in each direction
+//     const int n = sqrt(num_nodes);
+
+//     std::vector<std::uint8_t> permutation(num_nodes);
+//     std::vector<std::uint8_t> rows(n);
+//     std::iota(std::next(rows.begin()), std::prev(rows.end()), 2);
+//     rows.front() = 0;
+//     rows.back() = 1;
+
+//     int j = 0;
+//     for (auto row : rows)
+//     {
+//       permutation[j] = row;
+//       permutation[j + n - 1] = n + row;
+//       j++;
+//       for (int index = 0; index < n - 2; ++index)
+//       {
+//         permutation[j] = (2 + index) * n + row;
+//         j++;
+//       }
+//       j++;
+//     }
+//     return permutation;
+//   }
+//   case mesh::CellType::hexahedron:
+//   {
+//     switch (num_nodes)
+//     {
+//     case 8:
+//       return {0, 4, 2, 6, 1, 5, 3, 7};
+//     default:
+//       throw std::runtime_error("Higher order hexahedron not supported.");
+//     }
+//   }
+//   default:
+//     throw std::runtime_error("Simplicies can be expressed as TensorProduct.");
+//   }
+// }
 //-----------------------------------------------------------------------------
 Eigen::Array<std::int64_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
 io::cells::permute_ordering(
@@ -275,12 +223,12 @@ io::cells::permute_ordering(
     const std::vector<std::uint8_t>& permutation)
 {
   Eigen::Array<std::int64_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
-      cells_dolfin(cells.rows(), cells.cols());
-  for (Eigen::Index c = 0; c < cells_dolfin.rows(); ++c)
+      cells_new(cells.rows(), cells.cols());
+  for (Eigen::Index c = 0; c < cells_new.rows(); ++c)
   {
-    for (Eigen::Index v = 0; v < cells_dolfin.cols(); ++v)
-      cells_dolfin(c, v) = cells(c, permutation[v]);
+    for (Eigen::Index v = 0; v < cells_new.cols(); ++v)
+      cells_new(c, v) = cells(c, permutation[v]);
   }
-  return cells_dolfin;
+  return cells_new;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/io/cells.h
+++ b/cpp/dolfinx/io/cells.h
@@ -19,20 +19,30 @@ namespace io
 namespace cells
 {
 
-/// Map from DOLFINX node ordering to VTK/XDMF ordering
+/// For simplices the FEniCS ordering is following the UFC-convention,
+/// see: https://fossies.org/linux/ufc/doc/manual/ufc-user-manual.pdf
+/// For non-simplices (Quadrilaterals and Hexahedrons) a TensorProduct
+/// ordering, as specified in FIAT.
+
+/// Map from DOLFINX to VTK ordering
 /// @param[in] type The cell shape
 /// @param[in] num_nodes The number of cell 'nodes'
-/// @return The map from local DOLFINX node ordering to the VTK ordering
-std::vector<std::uint8_t> dolfin_to_vtk(mesh::CellType type, int num_nodes);
+/// @return Map from local DOLFINX node index to the VTK node index,
+///     i.e. for node index i in the DOLFIN ordering, map[i] is the node
+///     index in VTK ordering
+std::vector<std::uint8_t> vtk_to_dolfin(mesh::CellType type, int num_nodes);
 
-/// Map from VTK ordering of a cell to tensor-product ordering. This map
-/// returns the identity map for all other cells than quadrilaterals and
-/// hexahedra.
+/// Map from VTK to DOLFINX ordering
 /// @param[in] type The cell shape
 /// @param[in] num_nodes The number of cell 'nodes'
 /// @return The map
-std::vector<std::uint8_t> vtk_to_tp(mesh::CellType type, int num_nodes);
+/// @return Map from local VTK node index to the DOLFINX node index,
+///     i.e. for node index i in the VTK ordering, map[i] is the node
+///     index in DOLFINX ordering
+std::vector<std::uint8_t> dolfin_to_vtk(mesh::CellType type, int num_nodes);
 
+/// @todo Check that direction of the map is correct
+///
 /// Map from the mapping of lexicographic nodes to a tensor product
 /// ordering. Convert Lexicographic cell ordering to FEniCS cell
 /// ordering. For simplices the FEniCS ordering is following the
@@ -59,17 +69,7 @@ std::vector<std::uint8_t> vtk_to_tp(mesh::CellType type, int num_nodes);
 /// @param[in] type The cell shape
 /// @param[in] num_nodes The number of cell 'nodes'
 /// @return The map
-std::vector<std::uint8_t> lex_to_tp(mesh::CellType type, int num_nodes);
-
-/// Permutation for VTK ordering to DOLFINX cell ordering. For simplices
-/// the FEniCS ordering is following the UFC-convention, see:
-/// https://fossies.org/linux/ufc/doc/manual/ufc-user-manual.pdf For
-/// non-simplices (Quadrilaterals and Hexahedrons) a TensorProduct
-/// ordering, as specified in FIAT.
-/// @param[in] type The cell shape
-/// @param[in] num_nodes The number of cell 'nodes'
-/// @return The map
-std::vector<std::uint8_t> vtk_to_dolfin(mesh::CellType type, int num_nodes);
+// std::vector<std::uint8_t> lex_to_tp(mesh::CellType type, int num_nodes);
 
 Eigen::Array<std::int64_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
 permute_ordering(

--- a/cpp/dolfinx/io/cells.h
+++ b/cpp/dolfinx/io/cells.h
@@ -27,18 +27,19 @@ namespace cells
 /// Map from DOLFINX to VTK ordering
 /// @param[in] type The cell shape
 /// @param[in] num_nodes The number of cell 'nodes'
-/// @return Map from local DOLFINX node index to the VTK node index,
-///     i.e. for node index i in the DOLFIN ordering, map[i] is the node
-///     index in VTK ordering
+/// @return Map from local DOLFINX node index to the corresponding VTK
+///     node index, i.e. for node index i in the DOLFIN ordering, map[i]
+///     is the node index in VTK ordering
 std::vector<std::uint8_t> vtk_to_dolfin(mesh::CellType type, int num_nodes);
 
-/// Map from VTK to DOLFINX ordering
+/// Map from VTK to DOLFINX ordering. Transpose of the DOLFINX to VTK
+/// map.
 /// @param[in] type The cell shape
 /// @param[in] num_nodes The number of cell 'nodes'
 /// @return The map
-/// @return Map from local VTK node index to the DOLFINX node index,
-///     i.e. for node index i in the VTK ordering, map[i] is the node
-///     index in DOLFINX ordering
+/// @return Map from local VTK node index to the corresponding DOLFINX
+///     node index, i.e. for node index i in the VTK ordering, map[i] is
+///     the node index in DOLFINX ordering
 std::vector<std::uint8_t> dolfin_to_vtk(mesh::CellType type, int num_nodes);
 
 /// @todo Check that direction of the map is correct

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -34,6 +34,7 @@ void io(py::module& m)
 
   // dolfinx::io::cell permutation functions
   m.def("permutation_vtk_to_dolfin", &dolfinx::io::cells::vtk_to_dolfin);
+  m.def("permutation_dolfin_to_vtk", &dolfinx::io::cells::dolfin_to_vtk);
   m.def("permute_cell_ordering", &dolfinx::io::cells::permute_ordering);
 
   // dolfinx::io::HDF5File
@@ -41,8 +42,8 @@ void io(py::module& m)
       m, "HDF5File", py::dynamic_attr())
       .def(py::init([](const MPICommWrapper comm, const std::string filename,
                        const std::string file_mode) {
-             return std::make_unique<dolfinx::io::HDF5File>(comm.get(), filename,
-                                                           file_mode);
+             return std::make_unique<dolfinx::io::HDF5File>(
+                 comm.get(), filename, file_mode);
            }),
            py::arg("comm"), py::arg("filename"), py::arg("file_mode"))
       .def("close", &dolfinx::io::HDF5File::close)
@@ -55,16 +56,17 @@ void io(py::module& m)
              return self.read_mesh(data_path, use_partition_from_file,
                                    ghost_mode);
            })
-      .def("read_vector",
-           [](dolfinx::io::HDF5File& self, const MPICommWrapper comm,
-              const std::string data_path, bool use_partition_from_file) {
-             auto x = self.read_vector(comm.get(), data_path,
-                                       use_partition_from_file);
-             Vec _x = x.vec();
-             PetscObjectReference((PetscObject)_x);
-             return _x;
-           },
-           py::return_value_policy::take_ownership)
+      .def(
+          "read_vector",
+          [](dolfinx::io::HDF5File& self, const MPICommWrapper comm,
+             const std::string data_path, bool use_partition_from_file) {
+            auto x = self.read_vector(comm.get(), data_path,
+                                      use_partition_from_file);
+            Vec _x = x.vec();
+            PetscObjectReference((PetscObject)_x);
+            return _x;
+          },
+          py::return_value_policy::take_ownership)
       .def("read_mf_int", &dolfinx::io::HDF5File::read_mf_int, py::arg("mesh"),
            py::arg("name"))
       .def("read_mf_size_t", &dolfinx::io::HDF5File::read_mf_size_t,
@@ -85,7 +87,7 @@ void io(py::module& m)
            py::arg("V"), py::arg("name"))
       // write
       .def("write", (void (dolfinx::io::HDF5File::*)(const dolfinx::mesh::Mesh&,
-                                                    std::string))
+                                                     std::string))
                         & dolfinx::io::HDF5File::write)
       .def("write",
            (void (dolfinx::io::HDF5File::*)(
@@ -118,20 +120,21 @@ void io(py::module& m)
                const dolfinx::mesh::MeshFunction<double>&, std::string))
                & dolfinx::io::HDF5File::write,
            py::arg("meshfunction"), py::arg("name"))
-      .def("write",
-           [](dolfinx::io::HDF5File& self, Vec x, std::string s) {
-             dolfinx::la::PETScVector _x(x, true);
-             self.write(_x, s);
-           },
-           py::arg("vector"), py::arg("name"))
+      .def(
+          "write",
+          [](dolfinx::io::HDF5File& self, Vec x, std::string s) {
+            dolfinx::la::PETScVector _x(x, true);
+            self.write(_x, s);
+          },
+          py::arg("vector"), py::arg("name"))
       .def("write",
            (void (dolfinx::io::HDF5File::*)(const dolfinx::function::Function&,
-                                           std::string))
+                                            std::string))
                & dolfinx::io::HDF5File::write,
            py::arg("u"), py::arg("name"))
       .def("write",
            (void (dolfinx::io::HDF5File::*)(const dolfinx::function::Function&,
-                                           std::string, double))
+                                            std::string, double))
                & dolfinx::io::HDF5File::write,
            py::arg("u"), py::arg("name"), py::arg("t"))
       .def("set_mpi_atomicity", &dolfinx::io::HDF5File::set_mpi_atomicity)
@@ -147,8 +150,8 @@ void io(py::module& m)
   xdmf_file
       .def(py::init([](const MPICommWrapper comm, std::string filename,
                        dolfinx::io::XDMFFile::Encoding encoding) {
-             return std::make_unique<dolfinx::io::XDMFFile>(comm.get(), filename,
-                                                           encoding);
+             return std::make_unique<dolfinx::io::XDMFFile>(comm.get(),
+                                                            filename, encoding);
            }),
            py::arg("comm"), py::arg("filename"), py::arg("encoding"))
       .def("close", &dolfinx::io::XDMFFile::close)
@@ -220,13 +223,14 @@ void io(py::module& m)
                &dolfinx::io::XDMFFile::write),
            py::arg("points"), py::arg("values"))
       // Checkpoints
-      .def("write_checkpoint",
-           [](dolfinx::io::XDMFFile& instance,
-              const dolfinx::function::Function& u, std::string function_name,
-              double time_step) {
-             instance.write_checkpoint(u, function_name, time_step);
-           },
-           py::arg("u"), py::arg("function_name"), py::arg("time_step") = 0.0);
+      .def(
+          "write_checkpoint",
+          [](dolfinx::io::XDMFFile& instance,
+             const dolfinx::function::Function& u, std::string function_name,
+             double time_step) {
+            instance.write_checkpoint(u, function_name, time_step);
+          },
+          py::arg("u"), py::arg("function_name"), py::arg("time_step") = 0.0);
 
   // dolfinx::io::VTKFile
   py::class_<dolfinx::io::VTKFile, std::shared_ptr<dolfinx::io::VTKFile>>
@@ -265,10 +269,11 @@ void io(py::module& m)
            py::overload_cast<const dolfinx::mesh::MeshFunction<double>&>(
                &dolfinx::io::VTKFile::write),
            py::arg("mf"))
-      .def("write",
-           py::overload_cast<const dolfinx::mesh::MeshFunction<double>&, double>(
-               &dolfinx::io::VTKFile::write),
-           py::arg("mf"), py::arg("t"))
+      .def(
+          "write",
+          py::overload_cast<const dolfinx::mesh::MeshFunction<double>&, double>(
+              &dolfinx::io::VTKFile::write),
+          py::arg("mf"), py::arg("t"))
       .def("write",
            py::overload_cast<const dolfinx::mesh::MeshFunction<int>&>(
                &dolfinx::io::VTKFile::write),
@@ -298,8 +303,8 @@ void io(py::module& m)
       .def("read_mf_double", &dolfinx::io::XDMFFile::read_mf_double,
            py::arg("mesh"), py::arg("name") = "")
       // MeshValueCollection
-      .def("read_mvc_int", &dolfinx::io::XDMFFile::read_mvc_int, py::arg("mesh"),
-           py::arg("name") = "")
+      .def("read_mvc_int", &dolfinx::io::XDMFFile::read_mvc_int,
+           py::arg("mesh"), py::arg("name") = "")
       .def("read_mvc_size_t", &dolfinx::io::XDMFFile::read_mvc_size_t,
            py::arg("mesh"), py::arg("name") = "")
       .def("read_mvc_double", &dolfinx::io::XDMFFile::read_mvc_double,

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -69,13 +69,15 @@ def sympy_scipy(points, nodes, L, H):
 
 @skip_in_parallel
 @pytest.mark.parametrize("vtk,dolfin,cell_type", [
-    ([0, 1, 2, 3, 4, 5], [0, 1, 2, 5, 3, 4], CellType.triangle),
-    ([0, 1, 2, 3], [0, 2, 3, 1], CellType.quadrilateral),
-    ([0, 1, 2, 3, 4, 5, 6, 7], [0, 4, 6, 2, 1, 5, 7, 3], CellType.hexahedron)
+    ([0, 1, 2, 3, 4, 5], [0, 1, 2, 4, 5, 3], CellType.triangle),
+    ([0, 1, 2, 3], [0, 3, 1, 2], CellType.quadrilateral),
+    ([0, 1, 2, 3, 4, 5, 6, 7], [0, 4, 3, 7, 1, 5, 2, 6], CellType.hexahedron)
 ])
 def test_permute_vtk_to_dolfin(vtk, dolfin, cell_type):
     p = permutation_vtk_to_dolfin(cell_type, len(vtk))
     cell_p = permute_cell_ordering([vtk], p)
+    print(cell_p)
+    print(dolfin)
     assert (cell_p == dolfin).all()
 
     p = permutation_dolfin_to_vtk(cell_type, len(vtk))

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -15,7 +15,8 @@ from dolfinx_utils.test.skips import skip_in_parallel
 from sympy.vector import CoordSys3D, matrix_to_vector
 
 from dolfinx import MPI, Function, FunctionSpace, Mesh, fem
-from dolfinx.cpp.io import permutation_vtk_to_dolfin, permute_cell_ordering
+from dolfinx.cpp.io import (permutation_dolfin_to_vtk,
+                            permutation_vtk_to_dolfin, permute_cell_ordering)
 from dolfinx.cpp.mesh import CellType, GhostMode
 from dolfinx.fem import assemble_scalar
 from dolfinx.io import XDMFFile
@@ -64,6 +65,22 @@ def sympy_scipy(points, nodes, L, H):
     # ex = integral.evalf()
 
     return ref
+
+
+@skip_in_parallel
+@pytest.mark.parametrize("vtk,dolfin,cell_type", [
+    ([0, 1, 2, 3, 4, 5], [0, 1, 2, 5, 3, 4], CellType.triangle),
+    ([0, 1, 2, 3], [0, 2, 3, 1], CellType.quadrilateral),
+    ([0, 1, 2, 3, 4, 5, 6, 7], [0, 4, 6, 2, 1, 5, 7, 3], CellType.hexahedron)
+])
+def test_permute_vtk_to_dolfin(vtk, dolfin, cell_type):
+    p = permutation_vtk_to_dolfin(cell_type, len(vtk))
+    cell_p = permute_cell_ordering([vtk], p)
+    assert (cell_p == dolfin).all()
+
+    p = permutation_dolfin_to_vtk(cell_type, len(vtk))
+    cell_p = permute_cell_ordering([dolfin], p)
+    assert (cell_p == vtk).all()
 
 
 @skip_in_parallel


### PR DESCRIPTION
Was the transpose (VTK <- DOLFIN), which was compensated for by another transpose in `permute_ordering`.

Also fixes permutation for HEX27