### PR TITLE
Remove pybind11 mesh.cell helper

### DIFF
--- a/python/dolfinx/plotting.py
+++ b/python/dolfinx/plotting.py
@@ -32,7 +32,8 @@ def _has_matplotlib():
 def mesh2triang(mesh):
     import matplotlib.tri as tri
     xy = mesh.geometry.x
-    return tri.Triangulation(xy[:, 0], xy[:, 1], mesh.cells())
+    cells = mesh.geometry.dofmap().array().reshape((-1, mesh.topology.dim + 1))
+    return tri.Triangulation(xy[:, 0], xy[:, 1], cells)
 
 
 def mplot_mesh(ax, mesh, **kwargs):
@@ -46,8 +47,9 @@ def mplot_mesh(ax, mesh, **kwargs):
         mplot_mesh(ax, bmesh, **kwargs)
     elif gdim == 3 and tdim == 2:
         xy = mesh.geometry.x
+        cells = mesh.geometry.dofmap().array().reshape((-1, mesh.topology.dim + 1))
         return ax.plot_trisurf(
-            *[xy[:, i] for i in range(gdim)], triangles=mesh.cells(), **kwargs)
+            *[xy[:, i] for i in range(gdim)], triangles=cells, **kwargs)
     elif tdim == 1:
         x = [mesh.geometry.x[:, i] for i in range(gdim)]
         if gdim == 1:
@@ -228,7 +230,8 @@ def mplot_function(ax, f, **kwargs):
             import matplotlib.tri as tri
             if gdim == 2 and tdim == 2:
                 # FIXME: Not tested
-                triang = tri.Triangulation(Xdef[0], Xdef[1], mesh.cells())
+                cells = mesh.geometry.dofmap().array().reshape((-1, mesh.topology.dim + 1))
+                triang = tri.Triangulation(Xdef[0], Xdef[1], cells)
                 shading = kwargs.pop("shading", "flat")
                 return ax.tripcolor(triang, C, shading=shading, **kwargs)
             else:

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -172,20 +172,6 @@ void mesh(py::module& m)
                   comm.get(), type, geometry, topology, global_cell_indices,
                   ghost_mode);
             }))
-      .def(
-          "cells",
-          [](const dolfinx::mesh::Mesh& self) {
-            const int tdim = self.topology().dim();
-            auto map = self.topology().index_map(tdim);
-            assert(map);
-            const std::int32_t size = map->size_local() + map->num_ghosts();
-            return py::array(
-                {size, (std::int32_t)dolfinx::mesh::num_cell_vertices(
-                           self.topology().cell_type())},
-                self.topology().connectivity(tdim, 0)->array().data(),
-                py::none());
-          },
-          py::return_value_policy::reference_internal)
       .def_property_readonly(
           "geometry", py::overload_cast<>(&dolfinx::mesh::Mesh::geometry),
           "Mesh geometry")

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -290,12 +290,6 @@ def test_GetCoordinates():
     assert len(mesh.geometry.x) == 36
 
 
-def test_GetCells():
-    """Get cells of mesh"""
-    mesh = UnitSquareMesh(MPI.comm_world, 5, 5)
-    assert MPI.sum(mesh.mpi_comm(), len(mesh.cells())) == 50
-
-
 @skip_in_parallel
 def xtest_cell_inradius(c0, c1, c5):
     assert cpp.mesh.inradius(c0.mesh(), [c0.index()]) == pytest.approx((3.0 - math.sqrt(3.0)) / 6.0)


### PR DESCRIPTION
Mixed geometry and topology. Get data from mesh.topology or mesh.geometry to make it unambiguous. 