### PR TITLE
Implement move assignment operator in MPI::Comm to make sure that previously held communicator is freed.

### DIFF
--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -51,6 +51,26 @@ dolfinx::MPI::Comm::~Comm()
   }
 }
 //-----------------------------------------------------------------------------
+dolfinx::MPI::Comm&
+dolfinx::MPI::Comm::operator=(dolfinx::MPI::Comm&& comm)
+{
+  // Free the currently held comm
+  if (this->_comm != MPI_COMM_NULL)
+  {
+    int err = MPI_Comm_free(&this->_comm);
+    if (err != MPI_SUCCESS)
+    {
+      std::cout << "Error when destroying communicator (MPI_Comm_free)."
+                << std::endl;
+    }
+  }
+  // Move comm from other object
+  this->_comm = comm._comm;
+  comm._comm = MPI_COMM_NULL;
+  // Return
+  return *this;
+}
+//-----------------------------------------------------------------------------
 MPI_Comm dolfinx::MPI::Comm::comm() const { return _comm; }
 //-----------------------------------------------------------------------------
 std::uint32_t dolfinx::MPI::rank(const MPI_Comm comm)

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -45,7 +45,7 @@ public:
     Comm& operator=(const Comm& comm) = delete;
 
     /// Move assignment operator
-    Comm& operator=(Comm&& comm) = default;
+    Comm& operator=(Comm&& comm);
 
     /// Destructor (frees wrapped communicator)
     ~Comm();


### PR DESCRIPTION
The following code

```
import gc
import numpy as np
from dolfinx import MPI, Mesh
from dolfinx.cpp.mesh import CellType, GhostMode

def unit_cell():
    points = np.array([[0.], [1.]])
    cells = np.array([list(range(len(points)))])
    mesh = Mesh(MPI.comm_world, CellType.interval, points, cells,
                [], GhostMode.none)
    return mesh

gc.disable()  # Manually control garbage collection

counter = 0
while True:
    print("Iteration", counter)
    unit_cell()
    counter += 1
    gc.collect()  # Force garbage collection
```

fails on master (on a dolfinx docker image) with
```
[...]
Iteration 2038
Iteration 2039
Iteration 2040
Iteration 2041
Traceback (most recent call last):
  File "tmp.py", line 18, in <module>
    unit_cell()
  File "tmp.py", line 10, in unit_cell
    [], GhostMode.none)
RuntimeError: Duplication of MPI communicator failed (MPI_Comm_dup)
```

This PR fixes the issue by making sure that the move assignment operator in MPI::Comm frees the previously held communicator.
