### PR TITLE
Fix VTK Viusalization of facet functions

### DIFF
--- a/cpp/dolfinx/io/VTKWriter.cpp
+++ b/cpp/dolfinx/io/VTKWriter.cpp
@@ -216,7 +216,7 @@ void write_ascii_mesh(const mesh::Mesh& mesh, int cell_dim,
     const std::int32_t num_mesh_vertices = mesh.num_entities(0);
     std::vector<std::int32_t> topology_to_geometry(num_mesh_vertices);
     auto x_dofs = mesh.geometry().dofmap();
-    for (int j = 0; j < mesh.num_entities(tdim); ++j)
+    for (int j = 0; j < cell_connectivity->num_nodes(); ++j)
     {
       auto cell_vertices = cell_connectivity->links(j);
       const int num_cell_vertices = cell_vertices.size();
@@ -239,7 +239,7 @@ void write_ascii_mesh(const mesh::Mesh& mesh, int cell_dim,
         = vertex_connectivity->array();
     const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& pos_vertex
         = vertex_connectivity->offsets();
-    for (int j = 0; j < mesh.num_entities(cell_dim); ++j)
+    for (int j = 0; j < vertex_connectivity->num_nodes(); ++j)
     {
       for (int i = 0; i < num_vertices; ++i)
       {

--- a/cpp/dolfinx/io/VTKWriter.cpp
+++ b/cpp/dolfinx/io/VTKWriter.cpp
@@ -213,7 +213,11 @@ void write_ascii_mesh(const mesh::Mesh& mesh, int cell_dim,
 
     // Build a map from topology to geometry
     auto cell_connectivity = mesh.topology().connectivity(tdim, 0);
-    const std::int32_t num_mesh_vertices = mesh.num_entities(0);
+
+    auto map = mesh.topology().index_map(0);
+    const std::int32_t num_mesh_vertices
+        = map->size_local() + map->num_ghosts();
+
     std::vector<std::int32_t> topology_to_geometry(num_mesh_vertices);
     auto x_dofs = mesh.geometry().dofmap();
     for (int j = 0; j < cell_connectivity->num_nodes(); ++j)


### PR DESCRIPTION
After separation of Geometry and Topology, the topology vertex ordering is different from the geometry vertex ordering. Therefore we have to convert them to be able to visualize mesh functions properly.
Minimal example were visualization fails on master:
```
import dolfinx
import dolfinx.io
mesh = dolfinx.UnitSquareMesh(dolfinx.MPI.comm_world, 2, 2)
mf = dolfinx.MeshFunction("size_t", mesh, mesh.topology.dim-1, 0)
dolfinx.io.VTKFile("mf.pvd").write(mf)
```