### PR TITLE
Reintroduced parts of the XDMF IO of write_checkpoint to take over for write

### DIFF
--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -44,8 +44,7 @@ std::string get_hdf5_filename(std::string filename)
 } // namespace
 
 //-----------------------------------------------------------------------------
-XDMFFile::XDMFFile(MPI_Comm comm, const std::string filename,
-                         Encoding encoding)
+XDMFFile::XDMFFile(MPI_Comm comm, const std::string filename, Encoding encoding)
     : _mpi_comm(comm), _filename(filename), _xml_doc(new pugi::xml_document),
       _encoding(encoding)
 {
@@ -208,7 +207,7 @@ void XDMFFile::write(const mesh::MeshFunction<int>& meshfunction)
 //-----------------------------------------------------------------------------
 mesh::MeshFunction<int>
 XDMFFile::read_mf_int(std::shared_ptr<const mesh::Mesh> mesh,
-                         std::string name) const
+                      std::string name) const
 {
   // Load XML doc from file
   pugi::xml_document xml_doc;
@@ -270,6 +269,7 @@ void XDMFFile::write(const function::Function& u, double t)
   }
 
   xdmf_function::write(u, t, _counter, *_xml_doc, h5_id);
+  _counter++;
 
   // Save XML file (on process 0 only)
   if (MPI::rank(_mpi_comm.comm()) == 0)
@@ -281,7 +281,5 @@ void XDMFFile::write(const function::Function& u, double t)
   //   assert(_hdf5_file);
   //   _hdf5_file.reset();
   // }
-
-  ++_counter;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -264,11 +264,11 @@ void xdmf_function::write(const function::Function& u, double t, int counter,
       else if (component == "imag")
         component_data_values[i] = local_data[i].imag();
     }
-    const std::size_t offset = MPI::global_offset(
+    const std::size_t value_offset = MPI::global_offset(
         mesh->mpi_comm(), component_data_values.size(), true);
     xdmf_utils::add_data_item(
         fe_attribute_node, h5_id, h5_path + "/vector", component_data_values,
-        offset{(std::int64_t)u_vector.size(), 1}, "Float", use_mpi_io);
+        value_offset, {(std::int64_t)u_vector.size(), 1}, "Float", use_mpi_io);
 #else
     const std::size_t offset_data
         = MPI::global_offset(mesh->mpi_comm(), local_data.size(), true);


### PR DESCRIPTION
Replacing write(function, t), which computed vertex values of the function, with one recognizing finite elements, similar to what @michalhabera had in write_checkpoint. The main difference is that the last two DataItem's as they are not required for visualization.

An issue I can see with changing the IO to this, is that we can no longer visualize on lines and hexes, as they are not supported by paraview (but supported by XDMF). Could add an if statement which checks if it can be visualized or not, and does the old code path if it cant be visualized.