### PR TITLE
Connectivity may need to be initialized when reading in a lower dimensional MeshFunction

### DIFF
--- a/cpp/dolfinx/io/xdmf_mf.h
+++ b/cpp/dolfinx/io/xdmf_mf.h
@@ -143,10 +143,13 @@ remap_meshfunction_data(const mesh::Mesh& mesh, const int dim,
   }
   else
   {
+    mesh.create_connectivity(dim, tdim);
     auto e_to_c = mesh.topology().connectivity(dim, tdim);
     assert(e_to_c);
+    mesh.create_connectivity(dim, 0);
     auto e_to_v = mesh.topology().connectivity(dim, 0);
     assert(e_to_v);
+    mesh.create_connectivity(tdim, 0);
     auto c_to_v = mesh.topology().connectivity(tdim, 0);
     assert(c_to_v);
 


### PR DESCRIPTION
... otherwise assertion gets triggered.

Let me know if you want me to add a simple test.