### PR TITLE
Change FormIntegrals domains marker type to MeshFunction<int> rather than MeshFunction<std::size_t>

### DIFF
--- a/cpp/dolfinx/fem/Form.cpp
+++ b/cpp/dolfinx/fem/Form.cpp
@@ -168,27 +168,27 @@ void Form::set_tabulate_tensor(
     _integrals.set_default_domains(*_mesh);
 }
 //-----------------------------------------------------------------------------
-void Form::set_cell_domains(const mesh::MeshFunction<std::size_t>& cell_domains)
+void Form::set_cell_domains(const mesh::MeshFunction<int>& cell_domains)
 {
   _integrals.set_domains(FormIntegrals::Type::cell, cell_domains);
 }
 //-----------------------------------------------------------------------------
 void Form::set_exterior_facet_domains(
-    const mesh::MeshFunction<std::size_t>& exterior_facet_domains)
+    const mesh::MeshFunction<int>& exterior_facet_domains)
 {
   _integrals.set_domains(FormIntegrals::Type::exterior_facet,
                          exterior_facet_domains);
 }
 //-----------------------------------------------------------------------------
 void Form::set_interior_facet_domains(
-    const mesh::MeshFunction<std::size_t>& interior_facet_domains)
+    const mesh::MeshFunction<int>& interior_facet_domains)
 {
   _integrals.set_domains(FormIntegrals::Type::interior_facet,
                          interior_facet_domains);
 }
 //-----------------------------------------------------------------------------
 void Form::set_vertex_domains(
-    const mesh::MeshFunction<std::size_t>& vertex_domains)
+    const mesh::MeshFunction<int>& vertex_domains)
 {
   _integrals.set_domains(FormIntegrals::Type::vertex, vertex_domains);
 }

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -180,22 +180,22 @@ public:
 
   /// Set cell domains
   /// @param[in] cell_domains The cell domains
-  void set_cell_domains(const mesh::MeshFunction<std::size_t>& cell_domains);
+  void set_cell_domains(const mesh::MeshFunction<int>& cell_domains);
 
   /// Set exterior facet domains
   /// @param[in] exterior_facet_domains The exterior facet domains
   void set_exterior_facet_domains(
-      const mesh::MeshFunction<std::size_t>& exterior_facet_domains);
+      const mesh::MeshFunction<int>& exterior_facet_domains);
 
   /// Set interior facet domains
   /// @param[in] interior_facet_domains The interior facet domains
   void set_interior_facet_domains(
-      const mesh::MeshFunction<std::size_t>& interior_facet_domains);
+      const mesh::MeshFunction<int>& interior_facet_domains);
 
   /// Set vertex domains
   /// @param[in] vertex_domains The vertex domains.
   void
-  set_vertex_domains(const mesh::MeshFunction<std::size_t>& vertex_domains);
+  set_vertex_domains(const mesh::MeshFunction<int>& vertex_domains);
 
   /// Access coefficients
   FormCoefficients& coefficients();

--- a/cpp/dolfinx/fem/FormIntegrals.cpp
+++ b/cpp/dolfinx/fem/FormIntegrals.cpp
@@ -85,7 +85,7 @@ FormIntegrals::integral_domains(FormIntegrals::Type type, int i) const
 }
 //-----------------------------------------------------------------------------
 void FormIntegrals::set_domains(FormIntegrals::Type type,
-                                const mesh::MeshFunction<std::size_t>& marker)
+                                const mesh::MeshFunction<int>& marker)
 {
   int type_index = static_cast<int>(type);
   std::vector<struct FormIntegrals::Integral>& integrals
@@ -123,7 +123,7 @@ void FormIntegrals::set_domains(FormIntegrals::Type type,
   }
 
   // Get  mesh function data array
-  const Eigen::Array<std::size_t, Eigen::Dynamic, 1>& mf_values
+  const Eigen::Array<int, Eigen::Dynamic, 1>& mf_values
       = marker.values();
 
   // Get number of mesh entities of dimension d owned by this process

--- a/cpp/dolfinx/fem/FormIntegrals.h
+++ b/cpp/dolfinx/fem/FormIntegrals.h
@@ -95,7 +95,7 @@ public:
   /// @param[in] type Integral type
   /// @param[in] marker Meshfunction mapping entities to integrals
   void set_domains(FormIntegrals::Type type,
-                   const mesh::MeshFunction<std::size_t>& marker);
+                   const mesh::MeshFunction<int>& marker);
 
   /// If there exists a default integral of any type, set the list of
   /// entities for those integrals from the mesh topology. For cell

--- a/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
+++ b/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
@@ -50,7 +50,7 @@ with u_bc.vector.localForm() as loc:
     loc.set(0.0)
 
 facetdim = mesh.topology.dim - 1
-mf = dolfinx.MeshFunction("size_t", mesh, facetdim, 0)
+mf = dolfinx.MeshFunction("int", mesh, facetdim, 0)
 mf.mark(lambda x: numpy.isclose(x[0], 0.0), 1)
 bndry_facets = numpy.where(mf.values == 1)[0]
 
@@ -65,7 +65,7 @@ def free_end(x):
 
 
 # Mark free end facets as 1
-mf = dolfinx.mesh.MeshFunction("size_t", mesh, 1, 0)
+mf = dolfinx.mesh.MeshFunction("int", mesh, 1, 0)
 mf.mark(free_end, 1)
 
 ds = ufl.Measure("ds", subdomain_data=mf)

--- a/python/test/unit/fem/test_assemble_domains.py
+++ b/python/test/unit/fem/test_assemble_domains.py
@@ -34,7 +34,7 @@ def test_assembly_dx_domains(mesh):
     V = dolfinx.FunctionSpace(mesh, ("CG", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
 
-    marker = dolfinx.MeshFunction("size_t", mesh, mesh.topology.dim, 0)
+    marker = dolfinx.MeshFunction("int", mesh, mesh.topology.dim, 0)
     values = marker.values
     # Mark first, second and all other
     # Their union is the whole domain
@@ -99,7 +99,7 @@ def test_assembly_ds_domains(mesh):
     V = dolfinx.FunctionSpace(mesh, ("CG", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
 
-    marker = dolfinx.MeshFunction("size_t", mesh, mesh.topology.dim - 1, 0)
+    marker = dolfinx.MeshFunction("int", mesh, mesh.topology.dim - 1, 0)
 
     def bottom(x):
         return numpy.isclose(x[1], 0.0)

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -219,7 +219,7 @@ def test_matrix_assembly_block():
 
     # Prepare a MeshFunction used for boundary conditions
     facetdim = mesh.topology.dim - 1
-    mf = dolfinx.MeshFunction("size_t", mesh, facetdim, 0)
+    mf = dolfinx.MeshFunction("int", mesh, facetdim, 0)
     mf.mark(boundary, 1)
     bndry_facets = numpy.where(mf.values == 1)[0]
 
@@ -309,7 +309,7 @@ def test_assembly_solve_block():
         return numpy.logical_or(x[0] < 1.0e-6, x[0] > 1.0 - 1.0e-6)
 
     facetdim = mesh.topology.dim - 1
-    mf = dolfinx.MeshFunction("size_t", mesh, facetdim, 0)
+    mf = dolfinx.MeshFunction("int", mesh, facetdim, 0)
     mf.mark(boundary, 1)
     bndry_facets = numpy.where(mf.values == 1)[0]
 
@@ -460,7 +460,7 @@ def test_assembly_solve_taylor_hood(mesh):
         return x[0] > (1.0 - 10 * numpy.finfo(float).eps)
 
     facetdim = mesh.topology.dim - 1
-    mf = dolfinx.MeshFunction("size_t", mesh, facetdim, 0)
+    mf = dolfinx.MeshFunction("int", mesh, facetdim, 0)
     mf.mark(boundary0, 1)
     mf.mark(boundary1, 2)
     bndry_facets0 = numpy.where(mf.values == 1)[0]

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -136,7 +136,7 @@ def test_facet_integral(cell_type):
         num_facets = mesh.num_entities(mesh.topology.dim - 1)
 
         v = Function(V)
-        facet_function = MeshFunction("size_t", mesh, mesh.topology.dim - 1, 1)
+        facet_function = MeshFunction("int", mesh, mesh.topology.dim - 1, 1)
         facet_function.values[:] = range(num_facets)
 
         # Functions that will have the same integral over each facet
@@ -174,7 +174,7 @@ def test_facet_normals(cell_type):
         num_facets = mesh.num_entities(mesh.topology.dim - 1)
 
         v = Function(V)
-        facet_function = MeshFunction("size_t", mesh, mesh.topology.dim - 1, 1)
+        facet_function = MeshFunction("int", mesh, mesh.topology.dim - 1, 1)
         facet_function.values[:] = range(num_facets)
 
         # For each facet, check that the inner product of the normal and

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -57,7 +57,7 @@ def test_matrix_assembly_block():
         return numpy.cos(x[0]) * numpy.cos(x[1])
 
     facetdim = mesh.topology.dim - 1
-    mf = dolfinx.MeshFunction("size_t", mesh, facetdim, 0)
+    mf = dolfinx.MeshFunction("int", mesh, facetdim, 0)
     mf.mark(boundary, 1)
     bndry_facets = numpy.where(mf.values == 1)[0]
 
@@ -266,7 +266,7 @@ def test_assembly_solve_block():
         return numpy.logical_or(x[0] < 1.0e-6, x[0] > 1.0 - 1.0e-6)
 
     facetdim = mesh.topology.dim - 1
-    mf = dolfinx.MeshFunction("size_t", mesh, facetdim, 0)
+    mf = dolfinx.MeshFunction("int", mesh, facetdim, 0)
     mf.mark(boundary, 1)
     bndry_facets = numpy.where(mf.values == 1)[0]
 
@@ -472,7 +472,7 @@ def test_assembly_solve_taylor_hood(mesh):
     u_bc_1.interpolate(lambda x: numpy.row_stack(tuple(numpy.sin(x[j]) for j in range(gdim))))
 
     facetdim = mesh.topology.dim - 1
-    mf = dolfinx.MeshFunction("size_t", mesh, facetdim, 0)
+    mf = dolfinx.MeshFunction("int", mesh, facetdim, 0)
     mf.mark(boundary0, 1)
     mf.mark(boundary1, 2)
     bndry_facets0 = numpy.where(mf.values == 1)[0]

--- a/python/test/unit/fem/xtest_ghost_mesh_assembly.py
+++ b/python/test/unit/fem/xtest_ghost_mesh_assembly.py
@@ -21,7 +21,7 @@ def dx_from_ufl(mesh):
 
 
 def dx_from_measure(mesh):
-    subdomains = MeshFunction("size_t", mesh, mesh.topology.dim, 1)
+    subdomains = MeshFunction("int", mesh, mesh.topology.dim, 1)
     dx = Measure("dx")(subdomain_data=subdomains, domain=mesh)
     dx = dx(1)
     return dx
@@ -37,7 +37,7 @@ def ds_from_ufl(mesh):
 
 
 def ds_from_measure(mesh):
-    boundaries = MeshFunction("size_t", mesh, mesh.topology.dim - 1, 1)
+    boundaries = MeshFunction("int", mesh, mesh.topology.dim - 1, 1)
     ds = Measure("ds")(subdomain_data=boundaries, domain=mesh)
     return ds
 
@@ -52,7 +52,7 @@ def dS_from_ufl(mesh):
 
 
 def dS_from_measure(mesh):
-    boundaries = MeshFunction("size_t", mesh, mesh.topology.dim - 1, 1)
+    boundaries = MeshFunction("int", mesh, mesh.topology.dim - 1, 1)
     dS = Measure("dS")(subdomain_data=boundaries, domain=mesh)
     return dS
 

--- a/python/test/unit/la/test_krylov_solver.py
+++ b/python/test/unit/la/test_krylov_solver.py
@@ -100,7 +100,7 @@ def test_krylov_samg_solver_elasticity():
             return np.full(x.shape[1], True)
 
         facetdim = mesh.topology.dim - 1
-        mf = MeshFunction("size_t", mesh, facetdim, 0)
+        mf = MeshFunction("int", mesh, facetdim, 0)
         mf.mark(boundary, 1)
         bndry_facets = np.where(mf.values == 1)[0]
 


### PR DESCRIPTION
Recent changes to `XDMFFile` have limited to int only the `MeshFunction` types for I/O. Thus, in order to be able to use markers imported from file when assembling forms, I propose in this PR to change the domain marker type to use `int`, rather than `size_t`.

I will close this if you want me to do it the other way around (allow `XDMFFile` to read in `MeshFunction<size_t>` as well, and do not change `FormIntegrals` marker type).

I realize that whichever of the two options is chosen, it will probably be a short term solution (until `MeshValueCollection` is used instead of `MeshFunction`).