### PR TITLE
Rename dolfin to dolfinx in flake8 check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,8 @@ install-python-components: &install-python-components
 flake8-python-code: &flake8-python-code
   name: Flake8 checks on Python code
   command: |
-    python3 -m flake8 python/dolfin
-    python3 -m flake8 python/dolfin_utils
+    python3 -m flake8 python/dolfinx
+    python3 -m flake8 python/dolfinx_utils
     python3 -m flake8 python/demo
     python3 -m flake8 python/test
 

--- a/python/dolfinx/fem/__init__.py
+++ b/python/dolfinx/fem/__init__.py
@@ -30,7 +30,7 @@ __all__ = [
     "apply_lifting", "apply_lifting_nest", "assemble_scalar", "assemble_vector",
     "assemble_vector_block", "assemble_vector_nest",
     "assemble_matrix_block", "assemble_matrix_nest",
-    "assemble_matrix", "set_bc", "set_bc_nest", "create_coordinate_map",
+    "assemble_matrix", "assemble_csr_matrix", "set_bc", "set_bc_nest", "create_coordinate_map",
     "DirichletBC", "DofMap", "Form", "FormIntegrals",
     "derivative", "adjoint", "increase_order",
     "tear", "project", "solve", "locate_dofs_geometrical", "locate_dofs_topological"

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -198,9 +198,9 @@ def assemble_csr_matrix(a: typing.Union[Form, cpp.fem.Form],
     if _a.function_space(0).id == _a.function_space(1).id:
         for bc in bcs:
             if _a.function_space(0).contains(bc.function_space):
-                 bc_dofs = bc.dof_indices[:,0]
-                 for i in bc_dofs:
-                     A[i, i] = 1.0
+                bc_dofs = bc.dof_indices[:, 0]
+                for i in bc_dofs:
+                    A[i, i] = 1.0
     return A
 
 


### PR DESCRIPTION
We forgot to rename this when changing dolfin to dolfinx. CI is now failing, but upon merging #895 CI will run correctly.