### PR TITLE
Generate C++ demo and test files in build directory, rather than source directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,23 +37,26 @@ build-install-cpp: &build-install-cpp
 unit-tests-cpp: &unit-tests-cpp
   name: Build and run C++ unit tests (serial and MPI)
   command: |
-    cd build
-    ninja -j3 unittests
+    cd build/test/unit
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer .
+    ninja -j3
     ctest --output-on-failure -R unittests
     mpirun -np 3 ctest --output-on-failure -R unittests
 
 regression-tests-cpp: &regression-tests-cpp
   name: Build and run C++ regressions tests (serial)
   command: |
-    cd build
-    ninja -j3 demos
+    cd build/demo
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer .
+    ninja -j3
     ctest -j3 -R demo -R serial
 
 regression-tests-cpp-mpi: &regression-tests-cpp-mpi
   name: Run C++ regression tests (MPI)
   command: |
-    cd build
-    ninja -j3 demos
+    cd build/demo
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer .
+    ninja -j3
     ctest --verbose -R demo -R mpi_3
 
 build-python-interface: &build-python-interface

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -66,14 +66,16 @@ jobs:
 
       - name: Build and run C++ unit tests (serial and MPI)
         run: |
-          cmake --build ./build -t unittests
-          cd build/
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build/test/unit/ -S build/test/unit/
+          cmake --build build/test/unit
+          cd build/test/unit
           ctest --output-on-failure -R unittests
           mpiexec -np 2 ctest --output-on-failure -R unittests
       - name: Build and run C++ regression tests (serial and MPI (np=2))
         run: |
-          cmake --build ./build -t demos
-          cd build/
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build/demo/ -S build/demo/
+          cmake --build build/demo
+          cd build/demo
           ctest -R demo -R serial
           ctest -R demo -R mpi_2
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -252,74 +252,20 @@ install(FILES ${CMAKE_BINARY_DIR}/dolfinx.conf
         COMPONENT Development)
 
 #------------------------------------------------------------------------------
-# Generate form files for tests and demos and DOLFIN if not exists
-# FIXME: Generate files in Build directory instead, at least for demo
-#        and tests?
-
-set(COPY_DEMO_TEST_DEMO_DATA FALSE)
-if (PYTHONINTERP_FOUND AND NOT EXISTS ${DOLFINX_SOURCE_DIR}/demo/poisson/Poisson.h)
-  message(STATUS "")
-  message(STATUS "Generating form files in demo and test and directories. May take some time...")
-  message(STATUS "----------------------------------------------------------------------------------------")
-  execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} "-B" "-u" ${DOLFINX_SOURCE_DIR}/cmake/scripts/generate-form-files.py ${PETSC_SCALAR_COMPLEX}
-    WORKING_DIRECTORY ${DOLFINX_SOURCE_DIR}
-    RESULT_VARIABLE FORM_GENERATION_RESULT
-    OUTPUT_VARIABLE FORM_GENERATION_OUTPUT
-    ERROR_VARIABLE FORM_GENERATION_OUTPUT
-    )
-
-  if (FORM_GENERATION_RESULT)
-    # Cleanup so download is triggered next time we run cmake
-    if (EXISTS ${DOLFINX_SOURCE_DIR}/demo/poisson/Poisson.h)
-      file(REMOVE ${DOLFINX_SOURCE_DIR}/demo/poisson/Poisson.h)
-    endif()
-    message(FATAL_ERROR "Generation of form files failed: \n${FORM_GENERATION_OUTPUT}")
-  endif()
-  set(COPY_DEMO_TEST_DEMO_DATA TRUE)
-endif()
-
-#------------------------------------------------------------------------------
-# Generate CMakeLists.txt files for demos if needed
-
-# FIXME: Generate files in Build directory instead?
-# NOTE: We need to call this script after generate-formfiles
-
-if (PYTHONINTERP_FOUND AND NOT EXISTS ${DOLFINX_SOURCE_DIR}/demo/poisson/CMakeLists.txt)
-  message(STATUS "")
-  message(STATUS "Generating CMakeLists.txt files in demo and test directories")
-  message(STATUS "-------------------------------------------------------------------")
-  execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} ${DOLFINX_SOURCE_DIR}/cmake/scripts/generate-cmakefiles.py
-    WORKING_DIRECTORY ${DOLFINX_SOURCE_DIR}
-    RESULT_VARIABLE CMAKE_GENERATION_RESULT
-    OUTPUT_VARIABLE CMAKE_GENERATION_OUTPUT
-    ERROR_VARIABLE CMAKE_GENERATION_OUTPUT
-    )
-  if (CMAKE_GENERATION_RESULT)
-
-    # Cleanup so FFC rebuild is triggered next time we run cmake
-    if (EXISTS ${DOLFINX_SOURCE_DIR}/demo/poisson/CMakeLists.txt)
-      file(REMOVE ${DOLFINX_SOURCE_DIR}/demo/poisson/CMakeLists.txt)
-    endif()
-    message(FATAL_ERROR "Generation of CMakeLists.txt files failed: \n${CMAKE_GENERATION_OUTPUT}")
-  endif()
-
-  set(COPY_DEMO_TEST_DEMO_DATA TRUE)
-endif()
-
-#------------------------------------------------------------------------------
 # Copy data in demo/test direcories to the build directories
 
-# FIXME: We should probably just generate them directly in the build
-# directory...
+set(GENERATE_DEMO_TEST_DATA FALSE)
+if (PYTHONINTERP_FOUND AND (${DOLFINX_SOURCE_DIR}/demo IS_NEWER_THAN ${CMAKE_CURRENT_BINARY_DIR}/demo OR ${DOLFINX_SOURCE_DIR}/test IS_NEWER_THAN ${CMAKE_CURRENT_BINARY_DIR}/test))
+  file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/demo ${CMAKE_CURRENT_BINARY_DIR}/test)
+  set(GENERATE_DEMO_TEST_DATA TRUE)
+endif()
 
-if (PYTHONINTERP_FOUND AND COPY_DEMO_TEST_DEMO_DATA)
+if (GENERATE_DEMO_TEST_DATA)
   message(STATUS "")
   message(STATUS "Copying demo and test data to build directory.")
   message(STATUS "----------------------------------------------")
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} "-B" "-u" ${DOLFINX_SOURCE_DIR}/cmake/scripts/copy-test-demo-data.py ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND ${PYTHON_EXECUTABLE} "-B" "-u" ${DOLFINX_SOURCE_DIR}/cmake/scripts/copy-test-demo-data.py ${CMAKE_CURRENT_BINARY_DIR} ${PETSC_SCALAR_COMPLEX}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     RESULT_VARIABLE COPY_DEMO_DATA_RESULT
     OUTPUT_VARIABLE COPY_DEMO_DATA_OUTPUT
@@ -330,37 +276,63 @@ if (PYTHONINTERP_FOUND AND COPY_DEMO_TEST_DEMO_DATA)
 endif()
 
 #------------------------------------------------------------------------------
-# Add demos and install demo source files and mesh files
+# Generate form files for tests and demos
 
-# Set make program
-if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles")
-  set(MAKE_PROGRAM "$(MAKE)")
-else()
-  set(MAKE_PROGRAM "${CMAKE_MAKE_PROGRAM}")
+if (GENERATE_DEMO_TEST_DATA)
+  message(STATUS "")
+  message(STATUS "Generating form files in demo and test directories. May take some time...")
+  message(STATUS "----------------------------------------------------------------------------------------")
+  execute_process(
+    COMMAND ${PYTHON_EXECUTABLE} "-B" "-u" ${DOLFINX_SOURCE_DIR}/cmake/scripts/generate-form-files.py ${PETSC_SCALAR_COMPLEX}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    RESULT_VARIABLE FORM_GENERATION_RESULT
+    OUTPUT_VARIABLE FORM_GENERATION_OUTPUT
+    ERROR_VARIABLE FORM_GENERATION_OUTPUT
+    )
+
+  if (FORM_GENERATION_RESULT)
+    # Cleanup so that form generation is triggered next time we run cmake
+    file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/demo ${CMAKE_CURRENT_BINARY_DIR}/test)
+    message(FATAL_ERROR "Generation of form files failed: \n${FORM_GENERATION_OUTPUT}")
+  endif()
 endif()
 
-# Install the demo source files
-install(DIRECTORY demo DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/dolfinx
-  FILES_MATCHING
-  PATTERN "CMakeLists.txt"
-  PATTERN "*.cpp"
-  PATTERN "*.ufl"
-  PATTERN "*.h"
-  PATTERN "*.py"
-  PATTERN "*.xml*"
-  PATTERN "CMakeFiles" EXCLUDE)
+#------------------------------------------------------------------------------
+# Generate CMakeLists.txt files for demos if needed
+
+# NOTE: We need to call this script after generate-formfiles
+
+if (GENERATE_DEMO_TEST_DATA)
+  message(STATUS "")
+  message(STATUS "Generating CMakeLists.txt files in demo and test directories")
+  message(STATUS "-------------------------------------------------------------------")
+  execute_process(
+    COMMAND ${PYTHON_EXECUTABLE} ${DOLFINX_SOURCE_DIR}/cmake/scripts/generate-cmakefiles.py
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    RESULT_VARIABLE CMAKE_GENERATION_RESULT
+    OUTPUT_VARIABLE CMAKE_GENERATION_OUTPUT
+    ERROR_VARIABLE CMAKE_GENERATION_OUTPUT
+    )
+  if (CMAKE_GENERATION_RESULT)
+    # Cleanup so FFCX rebuild is triggered next time we run cmake
+    file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/demo ${CMAKE_CURRENT_BINARY_DIR}/test)
+    message(FATAL_ERROR "Generation of CMakeLists.txt files failed: \n${CMAKE_GENERATION_OUTPUT}")
+  endif()
+endif()
 
 #------------------------------------------------------------------------------
-# Add tests
-
-enable_testing()
-
-# Add target "unittests", but do not add to default target
-add_subdirectory(test/unit EXCLUDE_FROM_ALL)
-
-# Add demos but do not add to default target
-set(CMAKE_MODULE_PATH "${DOLFINX_SOURCE_DIR}/cmake/modules")
-add_subdirectory(demo EXCLUDE_FROM_ALL)
+# Install the demo source files
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/demo DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/dolfinx
+  FILES_MATCHING
+  PATTERN "CMakeLists.txt"
+  PATTERN "*.h"
+  PATTERN "*.hpp"
+  PATTERN "*.c"
+  PATTERN "*.cpp"
+  PATTERN "*.ufl"
+  PATTERN "*.xdmf"
+  PATTERN "*.h5"
+  PATTERN "CMakeFiles" EXCLUDE)
 
 #------------------------------------------------------------------------------
 # Add "make uninstall" target

--- a/cpp/cmake/scripts/generate-cmakefiles.py
+++ b/cpp/cmake/scripts/generate-cmakefiles.py
@@ -47,13 +47,12 @@ add_test(NAME ${{PROJECT_NAME}}_serial COMMAND ${{PROJECT_NAME}})
 """
 
 # Subdirectories
-sub_directories = ['demo', 'bench']
+sub_directories = ["demo"]
 # Prefix map for subdirectories
-executable_prefixes = dict(demo="demo_", bench="bench_")
+executable_prefixes = dict(demo="demo_")
 
 # Main file name map for subdirectories
-main_file_names = dict(
-    demo=set(["main.cpp", "main.cpp.rst"]), bench=set(["main.cpp"]))
+main_file_names = dict(demo=set(["main.cpp"]))
 
 # Projects that use custom CMakeLists.txt (shouldn't overwrite)
 exclude_projects = []

--- a/cpp/cmake/scripts/generate-form-files.py
+++ b/cpp/cmake/scripts/generate-form-files.py
@@ -24,11 +24,6 @@ import ffcx
 # Call with "./generate-form-files.py 1" for PETSc complex mode
 complex_mode = (sys.argv[-1] == "1")
 
-# UFL files to skip
-skip = set()
-if complex_mode is True:
-    skip.update(["hyperelasticity.ufl"])
-
 # Directories to scan
 subdirs = ["demo", "test"]
 
@@ -45,7 +40,7 @@ for subdir in subdirs:
         # Compile files
         os.chdir(root)
         print("Compiling %d forms in %s..." % (len(formfiles), root))
-        for f in set(formfiles) - skip:
+        for f in set(formfiles):
             args = []
             if complex_mode:
                 args += ["--scalar_type", "double complex"]

--- a/cpp/demo/CMakeLists.txt
+++ b/cpp/demo/CMakeLists.txt
@@ -1,28 +1,20 @@
 cmake_minimum_required(VERSION 3.9)
 project(dolfinx-demos)
 
-# Find DOLFIN config file (not used here, but check that the demo will
-# be able to find it
-if (NOT TARGET dolfinx)
-  find_package(DOLFINX REQUIRED)
-endif()
+# Find DOLFINX config file
+find_package(DOLFINX REQUIRED)
 
-# Demos that run in real and complex modes
-add_subdirectory(poisson)
+# Enable testing
+enable_testing()
 
-# Demos that run only in real mode
-if (NOT PETSC_SCALAR_COMPLEX)
-  add_subdirectory(hyperelasticity)
-endif()
+# Macro to add demos. Some subdirectories might be skipped because demos may
+# not be running in both real and complex modes.
+macro(add_demo_subdirectory subdir)
+  if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${subdir})
+    add_subdirectory(${subdir})
+  endif()
+endmacro(add_demo_subdirectory)
 
-# Demos that run only in complex mode
-if (PETSC_SCALAR_COMPLEX)
-  # Add here
-endif()
-
-# FIXME: do this programatically. Can we get a list of all targets?
-if (NOT PETSC_SCALAR_COMPLEX)
-  add_custom_target(demos DEPENDS demo_poisson demo_hyperelasticity)
-else()
-  add_custom_target(demos DEPENDS demo_poisson)
-endif()
+# Add demos
+add_demo_subdirectory(poisson)
+add_demo_subdirectory(hyperelasticity)

--- a/cpp/test/unit/CMakeLists.txt
+++ b/cpp/test/unit/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(dolfinx-tests)
 
-if (NOT TARGET dolfinx)
-  find_package(DOLFINX REQUIRED)
-endif()
+# Find DOLFINX config file
+find_package(DOLFINX REQUIRED)
 
 # Make test executable
 set(TEST_SOURCES
@@ -15,7 +14,7 @@ set(TEST_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/mesh/mesh_function.cpp
   )
 
-  # Prepare "Catch" library for other executables
+# Prepare "Catch" library for other executables
 set(CATCH_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/catch)
 
 add_library(Catch INTERFACE)
@@ -24,6 +23,9 @@ target_include_directories(Catch INTERFACE ${CATCH_INCLUDE_DIR})
 add_executable(unittests ${TEST_SOURCES})
 target_link_libraries(unittests PRIVATE Catch dolfinx)
 target_compile_features(unittests PRIVATE cxx_std_17)
+
+# Enable testing
+enable_testing()
 
 # Test target
 add_test(unittests unittests)


### PR DESCRIPTION
This PR changes CMakeLists.txt and form generation stages for C++ demos and tests so that the files are generated in the build directory and not in the source tree.

@RizzerOnGitHub I believe this will fix both #888 and #893. If possible start from a clean repo and a clean build dir.

The changes included here are not fully backward compatible. In particular, the demos and unittests target are not added anymore to the main makefile. Instead, demos and tests should be configured as standalone projects after the core library has been installed. CI has been updated to reflect this change. I believe that this separation is beneficial for CI testing, because these standalone projects (especially demos) were previously not covered, but could have been used by end users.

The only remaining build file to still be generated in the source dir is now dolfinx/common/version.h.