### PR TITLE
Restore in-place generation of CMakeLists.txt files for demos

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -304,8 +304,9 @@ endif()
 
 if (GENERATE_DEMO_TEST_DATA)
   message(STATUS "")
-  message(STATUS "Generating CMakeLists.txt files in demo and test directories")
+  message(STATUS "Generating CMakeLists.txt files in demo directory")
   message(STATUS "-------------------------------------------------------------------")
+  # Generate CMakeLists.txt files in build directory
   execute_process(
     COMMAND ${PYTHON_EXECUTABLE} ${DOLFINX_SOURCE_DIR}/cmake/scripts/generate-cmakefiles.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -316,7 +317,20 @@ if (GENERATE_DEMO_TEST_DATA)
   if (CMAKE_GENERATION_RESULT)
     # Cleanup so FFCX rebuild is triggered next time we run cmake
     file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/demo ${CMAKE_CURRENT_BINARY_DIR}/test)
-    message(FATAL_ERROR "Generation of CMakeLists.txt files failed: \n${CMAKE_GENERATION_OUTPUT}")
+    message(FATAL_ERROR "Generation of CMakeLists.txt files in build directory failed: \n${CMAKE_GENERATION_OUTPUT}")
+  else()
+    # Generate CMakeLists.txt files in source directory as well, as developers might find it
+    # easier to run in-place demo builds while preparing new demos or modifying existing ones
+    execute_process(
+      COMMAND ${PYTHON_EXECUTABLE} ${DOLFINX_SOURCE_DIR}/cmake/scripts/generate-cmakefiles.py
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      RESULT_VARIABLE CMAKE_GENERATION_RESULT
+      OUTPUT_VARIABLE CMAKE_GENERATION_OUTPUT
+      ERROR_VARIABLE CMAKE_GENERATION_OUTPUT
+      )
+    if (CMAKE_GENERATION_RESULT)
+      message(FATAL_ERROR "Generation of CMakeLists.txt files in source directory failed: \n${CMAKE_GENERATION_OUTPUT}")
+    endif()
   endif()
 endif()
 

--- a/cpp/cmake/scripts/generate-cmakefiles.py
+++ b/cpp/cmake/scripts/generate-cmakefiles.py
@@ -88,8 +88,10 @@ def generate_cmake_files(subdirectory, generated_files):
             filename, extension = os.path.splitext(f)
             if extension == ".cpp":
                 cpp_files.add(f)
-            if extension == ".c":
+            elif extension == ".c":
                 c_files.add(f)
+            elif extension == ".ufl":
+                c_files.add(f.replace(".ufl", ".c"))
             if ".cpp.rst" in f:
                 cpp_files.add(filename)
 


### PR DESCRIPTION
This is a follow up to #897, that restores the capability to have automatically generated CMakeLists.txt in the demos source directory, as per @garth-wells request.

The changes introduced in #897 to accommodate the packaging pipeline by @RizzerOnGitHub are still in place (please @RizzerOnGitHub confirm by running your pipeline again, if possibile). This PR only fixes the non-backward compatible change that was introduced in #897: end users (and CI) are still supposed to configure and build demos in the build (or install directory), but CMakeLists.txt files are generated in the source tree as well (as it used to be before #897) to ensure better backward compatibility and easier development of new demos.