### PR TITLE
Use 32-bit index for DofMap

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        petsc_arch: [real]
+        petsc_arch: [real, complex]
         petsc_int_type: [32, 64]
 
     steps:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -29,8 +29,8 @@ jobs:
 
     strategy:
       matrix:
-        petsc_arch: [real, complex]
-        petsc_int_type: [32]
+        petsc_arch: [real]
+        petsc_int_type: [32, 64]
 
     steps:
       - uses: actions/checkout@v2

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -130,7 +130,7 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
     old_to_new[dof] = count++;
 
   // Build new dofmap
-  const graph::AdjacencyList<PetscInt>& dof_array_view = dofmap_view.list();
+  const graph::AdjacencyList<std::int32_t>& dof_array_view = dofmap_view.list();
   Eigen::Array<std::int32_t, Eigen::Dynamic, 1> dofmap
       = remap_dofs(old_to_new, dof_array_view);
 
@@ -155,7 +155,7 @@ DofMap::DofMap(std::shared_ptr<const ElementDofLayout> element_dof_layout,
                std::shared_ptr<const common::IndexMap> index_map,
                const graph::AdjacencyList<std::int32_t>& dofmap)
     : element_dof_layout(element_dof_layout), index_map(index_map),
-      _dofmap(dofmap.array().cast<PetscInt>(), dofmap.offsets())
+      _dofmap(dofmap)
 {
   // Dofmap data is copied as the types for dofmap and _dofmap may
   // differ, typically 32- vs 64-bit integers

--- a/cpp/dolfinx/fem/DofMap.h
+++ b/cpp/dolfinx/fem/DofMap.h
@@ -66,7 +66,7 @@ public:
   /// Local-to-global mapping of dofs on a cell
   /// @param[in] cell The cell index
   /// @return Local-global dof map for the cell (using process-local indices)
-  Eigen::Array<PetscInt, Eigen::Dynamic, 1>::ConstSegmentReturnType
+  Eigen::Array<std::int32_t, Eigen::Dynamic, 1>::ConstSegmentReturnType
   cell_dofs(int cell) const
   {
     return _dofmap.links(cell);
@@ -86,7 +86,7 @@ public:
 
   /// Get dofmap data
   /// @return The adjacency list with dof indices for each cell
-  const graph::AdjacencyList<PetscInt>& list() const { return _dofmap; }
+  const graph::AdjacencyList<std::int32_t>& list() const { return _dofmap; }
 
   /// Layout of dofs on an element
   std::shared_ptr<const ElementDofLayout> element_dof_layout;
@@ -96,7 +96,7 @@ public:
 
 private:
   // Cell-local-to-dof map (dofs for cell dofmap[i])
-  graph::AdjacencyList<PetscInt> _dofmap;
+  graph::AdjacencyList<std::int32_t> _dofmap;
 };
 } // namespace fem
 } // namespace dolfinx

--- a/cpp/dolfinx/fem/SparsityPatternBuilder.cpp
+++ b/cpp/dolfinx/fem/SparsityPatternBuilder.cpp
@@ -45,7 +45,7 @@ void SparsityPatternBuilder::interior_facets(
     throw std::runtime_error("Facet-cell connectivity has not been computed.");
 
   // Array to store macro-dofs, if required (for interior facets)
-  std::array<Eigen::Array<PetscInt, Eigen::Dynamic, 1>, 2> macro_dofs;
+  std::array<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>, 2> macro_dofs;
 
   // Loop over owned facets
   auto map = topology.index_map(D - 1);

--- a/cpp/dolfinx/fem/assemble_matrix_impl.cpp
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.cpp
@@ -87,16 +87,12 @@ void fem::impl::assemble_matrix(
   }
 }
 //-----------------------------------------------------------------------------
-// \cond doxygen should ignore
-
 // Explicit instantiation with PetscScalar
 template void fem::impl::assemble_matrix<PetscScalar>(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                             const std::int32_t*, const PetscScalar*)>&
         mat_set_values_local,
     const Form& a, const std::vector<bool>& bc0, const std::vector<bool>& bc1);
-
-// \endcond
 //-----------------------------------------------------------------------------
 template <typename ScalarType>
 void fem::impl::assemble_cells(

--- a/cpp/dolfinx/fem/assemble_matrix_impl.cpp
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.cpp
@@ -87,12 +87,14 @@ void fem::impl::assemble_matrix(
   }
 }
 //-----------------------------------------------------------------------------
+// @cond - protect from Doxygen
 // Explicit instantiation with PetscScalar
 template void fem::impl::assemble_matrix<PetscScalar>(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                             const std::int32_t*, const PetscScalar*)>&
         mat_set_values_local,
     const Form& a, const std::vector<bool>& bc0, const std::vector<bool>& bc1);
+// @endcond
 //-----------------------------------------------------------------------------
 template <typename ScalarType>
 void fem::impl::assemble_cells(

--- a/cpp/dolfinx/fem/assemble_matrix_impl.cpp
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.cpp
@@ -87,7 +87,8 @@ void fem::impl::assemble_matrix(
   }
 }
 //-----------------------------------------------------------------------------
-// @cond - protect from Doxygen
+// @cond
+// protect from Doxygen
 // Explicit instantiation with PetscScalar
 template void fem::impl::assemble_matrix<PetscScalar>(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,

--- a/cpp/dolfinx/fem/assemble_matrix_impl.cpp
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.cpp
@@ -20,10 +20,10 @@
 using namespace dolfinx;
 
 //-----------------------------------------------------------------------------
-template <typename IndexType, typename ScalarType>
+template <typename ScalarType>
 void fem::impl::assemble_matrix(
-    const std::function<int(IndexType, const IndexType*, IndexType,
-                            const IndexType*, const ScalarType*)>&
+    const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
+                            const std::int32_t*, const ScalarType*)>&
         mat_set_values_local,
     const Form& a, const std::vector<bool>& bc0, const std::vector<bool>& bc1)
 {
@@ -33,8 +33,8 @@ void fem::impl::assemble_matrix(
   // Get dofmap data
   const fem::DofMap& dofmap0 = *a.function_space(0)->dofmap();
   const fem::DofMap& dofmap1 = *a.function_space(1)->dofmap();
-  const graph::AdjacencyList<PetscInt>& dofs0 = dofmap0.list();
-  const graph::AdjacencyList<PetscInt>& dofs1 = dofmap1.list();
+  const graph::AdjacencyList<std::int32_t>& dofs0 = dofmap0.list();
+  const graph::AdjacencyList<std::int32_t>& dofs1 = dofmap1.list();
 
   assert(dofmap0.element_dof_layout);
   assert(dofmap1.element_dof_layout);
@@ -56,21 +56,21 @@ void fem::impl::assemble_matrix(
   using type = fem::FormIntegrals::Type;
   for (int i = 0; i < integrals.num_integrals(type::cell); ++i)
   {
-    const auto & fn = integrals.get_tabulate_tensor(type::cell, i);
+    const auto& fn = integrals.get_tabulate_tensor(type::cell, i);
     const std::vector<std::int32_t>& active_cells
         = integrals.integral_domains(type::cell, i);
 
-    fem::impl::assemble_cells<IndexType, ScalarType>(
+    fem::impl::assemble_cells<ScalarType>(
         mat_set_values_local, mesh, active_cells, dofs0, num_dofs_per_cell0,
         dofs1, num_dofs_per_cell1, bc0, bc1, fn, coeffs, constant_values);
   }
 
   for (int i = 0; i < integrals.num_integrals(type::exterior_facet); ++i)
   {
-    const auto & fn = integrals.get_tabulate_tensor(type::exterior_facet, i);
+    const auto& fn = integrals.get_tabulate_tensor(type::exterior_facet, i);
     const std::vector<std::int32_t>& active_facets
         = integrals.integral_domains(type::exterior_facet, i);
-    fem::impl::assemble_exterior_facets<IndexType, ScalarType>(
+    fem::impl::assemble_exterior_facets<ScalarType>(
         mat_set_values_local, mesh, active_facets, dofmap0, dofmap1, bc0, bc1,
         fn, coeffs, constant_values);
   }
@@ -78,10 +78,10 @@ void fem::impl::assemble_matrix(
   for (int i = 0; i < integrals.num_integrals(type::interior_facet); ++i)
   {
     const std::vector<int> c_offsets = a.coefficients().offsets();
-    const auto & fn = integrals.get_tabulate_tensor(type::interior_facet, i);
+    const auto& fn = integrals.get_tabulate_tensor(type::interior_facet, i);
     const std::vector<std::int32_t>& active_facets
         = integrals.integral_domains(type::interior_facet, i);
-    fem::impl::assemble_interior_facets<IndexType, ScalarType>(
+    fem::impl::assemble_interior_facets<ScalarType>(
         mat_set_values_local, mesh, active_facets, dofmap0, dofmap1, bc0, bc1,
         fn, coeffs, c_offsets, constant_values);
   }
@@ -89,23 +89,23 @@ void fem::impl::assemble_matrix(
 //-----------------------------------------------------------------------------
 // \cond doxygen should ignore
 
-// Explicit instantiation with PetscInt and PetscScalar
-template void fem::impl::assemble_matrix<PetscInt, PetscScalar>(
-    const std::function<int(PetscInt, const PetscInt*, PetscInt,
-                            const PetscInt*, const PetscScalar*)>&
+// Explicit instantiation with PetscScalar
+template void fem::impl::assemble_matrix<PetscScalar>(
+    const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
+                            const std::int32_t*, const PetscScalar*)>&
         mat_set_values_local,
     const Form& a, const std::vector<bool>& bc0, const std::vector<bool>& bc1);
 
 // \endcond
 //-----------------------------------------------------------------------------
-template <typename IndexType, typename ScalarType>
+template <typename ScalarType>
 void fem::impl::assemble_cells(
-    const std::function<int(IndexType, const IndexType*, IndexType,
-                            const IndexType*, const ScalarType*)>&
+    const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
+                            const std::int32_t*, const ScalarType*)>&
         mat_set_values_local,
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_cells,
-    const graph::AdjacencyList<IndexType>& dofmap0, int num_dofs_per_cell0,
-    const graph::AdjacencyList<IndexType>& dofmap1, int num_dofs_per_cell1,
+    const graph::AdjacencyList<std::int32_t>& dofmap0, int num_dofs_per_cell0,
+    const graph::AdjacencyList<std::int32_t>& dofmap1, int num_dofs_per_cell1,
     const std::vector<bool>& bc0, const std::vector<bool>& bc1,
     const std::function<void(ScalarType*, const ScalarType*, const ScalarType*,
                              const double*, const int*, const std::uint8_t*,
@@ -175,10 +175,10 @@ void fem::impl::assemble_cells(
   }
 }
 //-----------------------------------------------------------------------------
-template <typename IndexType, typename ScalarType>
+template <typename ScalarType>
 void fem::impl::assemble_exterior_facets(
-    const std::function<int(IndexType, const IndexType*, IndexType,
-                            const IndexType*, const ScalarType*)>&
+    const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
+                            const std::int32_t*, const ScalarType*)>&
         mat_set_values_local,
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
     const DofMap& dofmap0, const DofMap& dofmap1, const std::vector<bool>& bc0,
@@ -226,7 +226,7 @@ void fem::impl::assemble_exterior_facets(
 
     // Get local index of facet with respect to the cell
     auto facets = c_to_f->links(cells[0]);
-    const auto *it = std::find(facets.data(), facets.data() + facets.rows(), f);
+    const auto* it = std::find(facets.data(), facets.data() + facets.rows(), f);
     assert(it != (facets.data() + facets.rows()));
     const int local_facet = std::distance(facets.data(), it);
 
@@ -269,10 +269,10 @@ void fem::impl::assemble_exterior_facets(
   }
 }
 //-----------------------------------------------------------------------------
-template <typename IndexType, typename ScalarType>
+template <typename ScalarType>
 void fem::impl::assemble_interior_facets(
-    const std::function<int(IndexType, const IndexType*, IndexType,
-                            const IndexType*, const ScalarType*)>&
+    const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
+                            const std::int32_t*, const ScalarType*)>&
         mat_set_values_local,
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
     const DofMap& dofmap0, const DofMap& dofmap1, const std::vector<bool>& bc0,
@@ -308,7 +308,7 @@ void fem::impl::assemble_interior_facets(
   assert(offsets.back() == coeffs.cols());
 
   // Temporaries for joint dofmaps
-  Eigen::Array<IndexType, Eigen::Dynamic, 1> dmapjoint0, dmapjoint1;
+  Eigen::Array<std::int32_t, Eigen::Dynamic, 1> dmapjoint0, dmapjoint1;
 
   const Eigen::Array<std::uint8_t, Eigen::Dynamic, Eigen::Dynamic>& perms
       = mesh.topology().get_facet_permutations();
@@ -330,13 +330,13 @@ void fem::impl::assemble_interior_facets(
 
     // Get local index of facet with respect to the cell
     auto facets0 = c_to_f->links(cells[0]);
-    const auto *it0 = std::find(facets0.data(), facets0.data() + facets0.rows(),
-                         facet_index);
+    const auto* it0 = std::find(facets0.data(), facets0.data() + facets0.rows(),
+                                facet_index);
     assert(it0 != (facets0.data() + facets0.rows()));
     const int local_facet0 = std::distance(facets0.data(), it0);
     auto facets1 = c_to_f->links(cells[1]);
-    const auto *it1 = std::find(facets1.data(), facets1.data() + facets1.rows(),
-                         facet_index);
+    const auto* it1 = std::find(facets1.data(), facets1.data() + facets1.rows(),
+                                facet_index);
     assert(it1 != (facets1.data() + facets1.rows()));
     const int local_facet1 = std::distance(facets1.data(), it1);
 

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -45,22 +45,22 @@ namespace impl
 /// conditions are zeroed. Markers (bc0 and bc1) can be empty if not bcs
 /// are applied. Matrix is not finalised.
 
-template <typename IndexType, typename ScalarType>
+template <typename ScalarType>
 void assemble_matrix(
-    const std::function<int(IndexType, const IndexType*, IndexType,
-                            const IndexType*, const ScalarType*)>&
+    const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
+                            const std::int32_t*, const ScalarType*)>&
         mat_set_values_local,
     const Form& a, const std::vector<bool>& bc0, const std::vector<bool>& bc1);
 
 /// Execute kernel over cells and accumulate result in Mat
-template <typename IndexType, typename ScalarType>
+template <typename ScalarType>
 void assemble_cells(
-    const std::function<int(IndexType, const IndexType*, IndexType,
-                            const IndexType*, const ScalarType*)>&
+    const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
+                            const std::int32_t*, const ScalarType*)>&
         mat_set_values_local,
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_cells,
-    const graph::AdjacencyList<IndexType>& dofmap0, int num_dofs_per_cell0,
-    const graph::AdjacencyList<IndexType>& dofmap1, int num_dofs_per_cell1,
+    const graph::AdjacencyList<std::int32_t>& dofmap0, int num_dofs_per_cell0,
+    const graph::AdjacencyList<std::int32_t>& dofmap1, int num_dofs_per_cell1,
     const std::vector<bool>& bc0, const std::vector<bool>& bc1,
     const std::function<void(ScalarType*, const ScalarType*, const ScalarType*,
                              const double*, const int*, const std::uint8_t*,
@@ -70,10 +70,10 @@ void assemble_cells(
     const Eigen::Array<ScalarType, Eigen::Dynamic, 1>& constant_values);
 
 /// Execute kernel over exterior facets and  accumulate result in Mat
-template <typename IndexType, typename ScalarType>
+template <typename ScalarType>
 void assemble_exterior_facets(
-    const std::function<int(IndexType, const IndexType*, IndexType,
-                            const IndexType*, const ScalarType*)>&
+    const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
+                            const std::int32_t*, const ScalarType*)>&
         mat_set_values_local,
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
     const DofMap& dofmap0, const DofMap& dofmap1, const std::vector<bool>& bc0,
@@ -86,10 +86,10 @@ void assemble_exterior_facets(
     const Eigen::Array<ScalarType, Eigen::Dynamic, 1> constant_values);
 
 /// Execute kernel over interior facets and  accumulate result in Mat
-template <typename IndexType, typename ScalarType>
+template <typename ScalarType>
 void assemble_interior_facets(
-    const std::function<int(IndexType, const IndexType*, IndexType,
-                            const IndexType*, const ScalarType*)>&
+    const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
+                            const std::int32_t*, const ScalarType*)>&
         mat_set_values_local,
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
     const DofMap& dofmap0, const DofMap& dofmap1, const std::vector<bool>& bc0,

--- a/cpp/dolfinx/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfinx/fem/assemble_vector_impl.cpp
@@ -228,7 +228,7 @@ void _lift_bc_exterior_facets(
 
     // Get local index of facet with respect to the cell
     auto facets = c_to_f->links(cell);
-    const auto *it = std::find(facets.data(), facets.data() + facets.rows(), f);
+    const auto* it = std::find(facets.data(), facets.data() + facets.rows(), f);
     assert(it != (facets.data() + facets.rows()));
     const int local_facet = std::distance(facets.data(), it);
 
@@ -297,7 +297,7 @@ void fem::impl::assemble_vector(
 
   // Get dofmap data
   const fem::DofMap& dofmap = *L.function_space(0)->dofmap();
-  const graph::AdjacencyList<PetscInt>& dofs = dofmap.list();
+  const graph::AdjacencyList<std::int32_t>& dofs = dofmap.list();
 
   assert(dofmap.element_dof_layout);
   const int num_dofs_per_cell = dofmap.element_dof_layout->num_dofs();
@@ -317,7 +317,8 @@ void fem::impl::assemble_vector(
   using type = fem::FormIntegrals::Type;
   for (int i = 0; i < integrals.num_integrals(type::cell); ++i)
   {
-    const auto & fn = integrals.get_tabulate_tensor(FormIntegrals::Type::cell, i);
+    const auto& fn
+        = integrals.get_tabulate_tensor(FormIntegrals::Type::cell, i);
     const std::vector<std::int32_t>& active_cells
         = integrals.integral_domains(type::cell, i);
     fem::impl::assemble_cells(b, mesh, active_cells, dofs, num_dofs_per_cell,
@@ -349,7 +350,7 @@ void fem::impl::assemble_vector(
 void fem::impl::assemble_cells(
     Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_cells,
-    const graph::AdjacencyList<PetscInt>& dofmap, int num_dofs_per_cell,
+    const graph::AdjacencyList<std::int32_t>& dofmap, int num_dofs_per_cell,
     const std::function<void(PetscScalar*, const PetscScalar*,
                              const PetscScalar*, const double*, const int*,
                              const std::uint8_t*, const std::uint32_t)>& kernel,
@@ -445,7 +446,7 @@ void fem::impl::assemble_exterior_facets(
 
     // Get local index of facet with respect to the cell
     auto facets = c_to_f->links(cell);
-    const auto *it = std::find(facets.data(), facets.data() + facets.rows(), f);
+    const auto* it = std::find(facets.data(), facets.data() + facets.rows(), f);
     assert(it != (facets.data() + facets.rows()));
     const int local_facet = std::distance(facets.data(), it);
     const std::uint8_t perm = perms(local_facet, cell);
@@ -523,7 +524,8 @@ void fem::impl::assemble_interior_facets(
     for (int i = 0; i < 2; ++i)
     {
       auto facets = c_to_f->links(cells[i]);
-      const auto *it = std::find(facets.data(), facets.data() + facets.rows(), f);
+      const auto* it
+          = std::find(facets.data(), facets.data() + facets.rows(), f);
       assert(it != (facets.data() + facets.rows()));
       local_facet[i] = std::distance(facets.data(), it);
     }

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -53,7 +53,7 @@ void assemble_vector(
 void assemble_cells(
     Eigen::Ref<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> b,
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_cells,
-    const graph::AdjacencyList<PetscInt>& dofmap, int num_dofs_per_cell,
+    const graph::AdjacencyList<std::int32_t>& dofmap, int num_dofs_per_cell,
     const std::function<void(PetscScalar*, const PetscScalar*,
                              const PetscScalar*, const double*, const int*,
                              const std::uint8_t*, const std::uint32_t)>& kernel,

--- a/cpp/dolfinx/fem/assembler.cpp
+++ b/cpp/dolfinx/fem/assembler.cpp
@@ -166,16 +166,17 @@ void fem::assemble_matrix(
     }
   }
 
+  std::array<std::vector<PetscInt>, 2> sp;
   const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                           const std::int32_t*, const PetscScalar*)>
       mat_set_values_local
-      = [&A](std::int32_t nrow, const std::int32_t* rows, std::int32_t ncol,
-             const std::int32_t* cols, const PetscScalar* y) {
+      = [&A, &sp](std::int32_t nrow, const std::int32_t* rows,
+                  std::int32_t ncol, const std::int32_t* cols,
+                  const PetscScalar* y) {
 #ifdef PETSC_USE_64BIT_INDICES
-          PetscInt rows1[nrow];
-          PetscInt cols1[ncol];
-          std::copy(rows, rows + nrow, rows1);
-          std::copy(cols, cols + ncol, cols1);
+          sp[0].assign(rows, rows + nrow);
+          sp[1].assign(cols, cols + ncol);
+          const PetscInt *rows1 = sp[0].data(), *cols1 = sp[1].data();
 #else
           const PetscInt *rows1 = rows, *cols1 = cols;
 #endif
@@ -196,16 +197,17 @@ void fem::assemble_matrix(
 void fem::assemble_matrix(Mat A, const Form& a, const std::vector<bool>& bc0,
                           const std::vector<bool>& bc1)
 {
+  std::array<std::vector<PetscInt>, 2> sp;
   const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                           const std::int32_t*, const PetscScalar*)>
       mat_set_values_local
-      = [&A](std::int32_t nrow, const std::int32_t* rows, std::int32_t ncol,
-             const std::int32_t* cols, const PetscScalar* y) {
+      = [&A, &sp](std::int32_t nrow, const std::int32_t* rows,
+                  std::int32_t ncol, const std::int32_t* cols,
+                  const PetscScalar* y) {
 #ifdef PETSC_USE_64BIT_INDICES
-          PetscInt rows1[nrow];
-          PetscInt cols1[ncol];
-          std::copy(rows, rows + nrow, rows1);
-          std::copy(cols, cols + ncol, cols1);
+          sp[0].assign(rows, rows + nrow);
+          sp[1].assign(cols, cols + ncol);
+          const PetscInt *rows1 = sp[0].data(), *cols1 = sp[1].data();
 #else
           const PetscInt *rows1 = rows, *cols1 = cols;
 #endif
@@ -250,16 +252,17 @@ void fem::add_diagonal(
   // NOTE: MatSetValuesLocal uses ADD_VALUES, hence it requires that the
   //       diagonal is zero before this function is called.
 
+  std::array<std::vector<PetscInt>, 2> sp;
   const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                           const std::int32_t*, const PetscScalar*)>
       mat_set_values_local
-      = [&A](std::int32_t nrow, const std::int32_t* rows, std::int32_t ncol,
-             const std::int32_t* cols, const PetscScalar* y) {
+      = [&A, &sp](std::int32_t nrow, const std::int32_t* rows,
+                  std::int32_t ncol, const std::int32_t* cols,
+                  const PetscScalar* y) {
 #ifdef PETSC_USE_64BIT_INDICES
-          PetscInt rows1[nrow];
-          PetscInt cols1[ncol];
-          std::copy(rows, rows + nrow, rows1);
-          std::copy(cols, cols + ncol, cols1);
+          sp[0].assign(rows, rows + nrow);
+          sp[1].assign(cols, cols + ncol);
+          const PetscInt *rows1 = sp[0].data(), *cols1 = sp[1].data();
 #else
           const PetscInt *rows1 = rows, *cols1 = cols;
 #endif

--- a/cpp/dolfinx/fem/assembler.cpp
+++ b/cpp/dolfinx/fem/assembler.cpp
@@ -29,18 +29,18 @@ namespace
 #ifdef PETSC_USE_64BIT_INDICES
 const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                         const std::int32_t*, const PetscScalar*)>
-make_petsc_lambda(Mat& A, std::vector<PetscInt>& storage_p)
+make_petsc_lambda(Mat A, std::vector<PetscInt>& tmp_dofs_petsc64)
 {
 
   const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                           const std::int32_t*, const PetscScalar*)>
-      f = [&A, &storage_p](std::int32_t nrow, const std::int32_t* rows,
-                           std::int32_t ncol, const std::int32_t* cols,
-                           const PetscScalar* y) {
-        storage_p.resize(nrow + ncol);
-        std::copy(rows, rows + nrow, storage_p.begin());
-        std::copy(cols, cols + ncol, storage_p.begin() + nrow);
-        const PetscInt *rows1 = storage_p.data(), *cols1 = rows1 + nrow;
+      f = [A, &tmp_dofs_petsc64](std::int32_t nrow, const std::int32_t* rows,
+                                 std::int32_t ncol, const std::int32_t* cols,
+                                 const PetscScalar* y) {
+        tmp_dofs_petsc64.resize(nrow + ncol);
+        std::copy(rows, rows + nrow, tmp_dofs_petsc64.begin());
+        std::copy(cols, cols + ncol, tmp_dofs_petsc64.begin() + nrow);
+        const PetscInt *rows1 = tmp_dofs_petsc64.data(), *cols1 = rows1 + nrow;
         PetscErrorCode ierr
             = MatSetValuesLocal(A, nrow, rows1, ncol, cols1, y, ADD_VALUES);
 #ifdef DEBUG
@@ -54,12 +54,12 @@ make_petsc_lambda(Mat& A, std::vector<PetscInt>& storage_p)
 #else
 const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                         const std::int32_t*, const PetscScalar*)>
-make_petsc_lambda(Mat& A, std::vector<PetscInt>&)
+make_petsc_lambda(Mat A, std::vector<PetscInt>&)
 {
   const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                           const std::int32_t*, const PetscScalar*)>
-      f = [&A](std::int32_t nrow, const std::int32_t* rows, std::int32_t ncol,
-               const std::int32_t* cols, const PetscScalar* y) {
+      f = [A](std::int32_t nrow, const std::int32_t* rows, std::int32_t ncol,
+              const std::int32_t* cols, const PetscScalar* y) {
         PetscErrorCode ierr
             = MatSetValuesLocal(A, nrow, rows, ncol, cols, y, ADD_VALUES);
 #ifdef DEBUG
@@ -217,10 +217,10 @@ void fem::assemble_matrix(
     }
   }
 
-  std::vector<PetscInt> sp;
+  std::vector<PetscInt> tmp_dofs_petsc64;
   const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                           const std::int32_t*, const PetscScalar*)>
-      mat_set_values_local = make_petsc_lambda(A, sp);
+      mat_set_values_local = make_petsc_lambda(A, tmp_dofs_petsc64);
 
   // Assemble
   impl::assemble_matrix(mat_set_values_local, a, dof_marker0, dof_marker1);
@@ -229,10 +229,10 @@ void fem::assemble_matrix(
 void fem::assemble_matrix(Mat A, const Form& a, const std::vector<bool>& bc0,
                           const std::vector<bool>& bc1)
 {
-  std::vector<PetscInt> sp;
+  std::vector<PetscInt> tmp_dofs_petsc64;
   const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                           const std::int32_t*, const PetscScalar*)>
-      mat_set_values_local = make_petsc_lambda(A, sp);
+      mat_set_values_local = make_petsc_lambda(A, tmp_dofs_petsc64);
 
   impl::assemble_matrix(mat_set_values_local, a, bc0, bc1);
 }
@@ -266,10 +266,10 @@ void fem::add_diagonal(
   // NOTE: MatSetValuesLocal uses ADD_VALUES, hence it requires that the
   //       diagonal is zero before this function is called.
 
-  std::vector<PetscInt> sp;
+  std::vector<PetscInt> tmp_dofs_petsc64;
   const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                           const std::int32_t*, const PetscScalar*)>
-      mat_set_values_local = make_petsc_lambda(A, sp);
+      mat_set_values_local = make_petsc_lambda(A, tmp_dofs_petsc64);
 
   for (Eigen::Index i = 0; i < rows.size(); ++i)
   {

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -242,7 +242,7 @@ void SparsityPattern::insert(
 }
 //-----------------------------------------------------------------------------
 void SparsityPattern::insert_diagonal(
-    const Eigen::Ref<const Eigen::Array<PetscInt, Eigen::Dynamic, 1>>& rows)
+    const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>& rows)
 {
   if (_diagonal)
   {

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -103,7 +103,7 @@ SparsityPattern::SparsityPattern(
     for (std::size_t col = 0; col < patterns[row].size(); ++col)
     {
       // Get pattern for this block
-      const auto *p = patterns[row][col];
+      const auto* p = patterns[row][col];
       assert(p);
 
       // Check that
@@ -160,7 +160,7 @@ SparsityPattern::SparsityPattern(
   // FIXME: Need to add unowned entries?
 
   // Initialise common::IndexMaps for merged pattern
-  const auto *p00 = patterns[0][0];
+  const auto* p00 = patterns[0][0];
   assert(p00);
   Eigen::Array<std::int64_t, Eigen::Dynamic, 1> ghosts;
   _index_maps[0] = std::make_shared<common::IndexMap>(
@@ -200,8 +200,8 @@ SparsityPattern::index_map(int dim) const
 }
 //-----------------------------------------------------------------------------
 void SparsityPattern::insert(
-    const Eigen::Ref<const Eigen::Array<PetscInt, Eigen::Dynamic, 1>>& rows,
-    const Eigen::Ref<const Eigen::Array<PetscInt, Eigen::Dynamic, 1>>& cols)
+    const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>& rows,
+    const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>& cols)
 {
   if (_diagonal)
   {

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -78,7 +78,8 @@ public:
   /// @param[in] rows The rows in local (process-wise) indices. The
   ///   indices must exist in the row IndexMap.
   void insert_diagonal(
-      const Eigen::Ref<const Eigen::Array<PetscInt, Eigen::Dynamic, 1>>& rows);
+      const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>&
+          rows);
 
   /// Finalize sparsity pattern and communicate off-process entries
   void assemble();

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -68,9 +68,11 @@ public:
   std::shared_ptr<const common::IndexMap> index_map(int dim) const;
 
   /// Insert non-zero locations using local (process-wise) indices
-  void insert(
-      const Eigen::Ref<const Eigen::Array<PetscInt, Eigen::Dynamic, 1>>& rows,
-      const Eigen::Ref<const Eigen::Array<PetscInt, Eigen::Dynamic, 1>>& cols);
+  void
+  insert(const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>&
+             rows,
+         const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>&
+             cols);
 
   /// Insert non-zero locations on the diagonal
   /// @param[in] rows The rows in local (process-wise) indices. The

--- a/python/demo/stokes-taylor-hood/demo_stokes-taylor-hood.py
+++ b/python/demo/stokes-taylor-hood/demo_stokes-taylor-hood.py
@@ -362,7 +362,7 @@ ksp = PETSc.KSP().create(mesh.mpi_comm())
 ksp.setOperators(A)
 ksp.setType("preonly")
 ksp.getPC().setType("lu")
-ksp.getPC().setFactorSolverType("mumps")
+ksp.getPC().setFactorSolverType("superlu_dist")
 
 # We also need to create a block vector,``x``, to store the (full)
 # solution, which we initialize using the block RHS form ``L``.
@@ -447,7 +447,7 @@ ksp = PETSc.KSP().create(mesh.mpi_comm())
 ksp.setOperators(A)
 ksp.setType("preonly")
 ksp.getPC().setType("lu")
-ksp.getPC().setFactorSolverType("mumps")
+ksp.getPC().setFactorSolverType("superlu_dist")
 
 # Compute the solution
 U = Function(W)

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -547,7 +547,7 @@ def test_assembly_solve_taylor_hood(mesh):
     ksp_u, ksp_p = pc.getFieldSplitSubKSP()
     ksp_u.setType("preonly")
     ksp_u.getPC().setType('lu')
-    ksp_u.getPC().setFactorSolverType('mumps')
+    ksp_u.getPC().setFactorSolverType('superlu_dist')
     ksp_p.setType("preonly")
 
     def monitor(ksp, its, rnorm):
@@ -581,7 +581,7 @@ def test_assembly_solve_taylor_hood(mesh):
     ksp.setType("minres")
     pc = ksp.getPC()
     pc.setType('lu')
-    pc.setFactorSolverType('mumps')
+    pc.setFactorSolverType('superlu_dist')
     ksp.setTolerances(rtol=1.0e-8, max_it=50)
     ksp.setFromOptions()
     x1 = A1.createVecRight()
@@ -638,7 +638,7 @@ def test_assembly_solve_taylor_hood(mesh):
     ksp.setType("minres")
     pc = ksp.getPC()
     pc.setType('lu')
-    pc.setFactorSolverType('mumps')
+    pc.setFactorSolverType('superlu_dist')
 
     def monitor(ksp, its, rnorm):
         # print("Num it, rnorm:", its, rnorm)

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -340,7 +340,7 @@ def test_custom_mesh_loop_ctypes_rank2():
     pos = mesh.geometry.dofmap().offsets()
     x_dofs = mesh.geometry.dofmap().array()
     x = mesh.geometry.x
-    dofs = V.dofmap.list.array()
+    dofs = np.array(V.dofmap.list.array(), dtype=np.dtype(PETSc.IntType))
 
     # Generated case with general assembler
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
@@ -393,7 +393,7 @@ def test_custom_mesh_loop_cffi_rank2(set_vals):
     pos = mesh.geometry.dofmap().offsets()
     x_dofs = mesh.geometry.dofmap().array()
     x = mesh.geometry.x
-    dofs = V.dofmap.list.array()
+    dofs = np.array(V.dofmap.list.array(), dtype=np.dtype(PETSc.IntType))
 
     A1 = A0.copy()
     for i in range(2):

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -301,7 +301,7 @@ def test_assembly_solve_block():
 
     snes.getKSP().setType("preonly")
     snes.getKSP().getPC().setType("lu")
-    snes.getKSP().getPC().setFactorSolverType("mumps")
+    snes.getKSP().getPC().setFactorSolverType("superlu_dist")
 
     problem = NonlinearPDE_SNESProblem(F, J, [u, p], bcs)
     snes.setFunction(problem.F_block, Fvec0)
@@ -342,10 +342,10 @@ def test_assembly_solve_block():
     ksp_u, ksp_p = snes.getKSP().getPC().getFieldSplitSubKSP()
     ksp_u.setType("preonly")
     ksp_u.getPC().setType('lu')
-    ksp_u.getPC().setFactorSolverType('mumps')
+    ksp_u.getPC().setFactorSolverType('superlu_dist')
     ksp_p.setType("preonly")
     ksp_p.getPC().setType('lu')
-    ksp_p.getPC().setFactorSolverType('mumps')
+    ksp_p.getPC().setFactorSolverType('superlu_dist')
 
     problem = NonlinearPDE_SNESProblem(F, J, [u, p], bcs)
     snes.setFunction(problem.F_nest, Fvec1)
@@ -409,7 +409,7 @@ def test_assembly_solve_block():
 
     snes.getKSP().setType("preonly")
     snes.getKSP().getPC().setType("lu")
-    snes.getKSP().getPC().setFactorSolverType("mumps")
+    snes.getKSP().getPC().setFactorSolverType("superlu_dist")
 
     problem = NonlinearPDE_SNESProblem(F, J, U, bcs)
     snes.setFunction(problem.F_mono, Fvec2)
@@ -500,7 +500,7 @@ def test_assembly_solve_taylor_hood(mesh):
 
     snes.getKSP().setType("minres")
     snes.getKSP().getPC().setType("lu")
-    snes.getKSP().getPC().setFactorSolverType("mumps")
+    snes.getKSP().getPC().setFactorSolverType("superlu_dist")
 
     problem = NonlinearPDE_SNESProblem(F, J, [u, p], bcs, P=P)
     snes.setFunction(problem.F_block, Fvec0)
@@ -539,10 +539,10 @@ def test_assembly_solve_taylor_hood(mesh):
     ksp_u, ksp_p = snes.getKSP().getPC().getFieldSplitSubKSP()
     ksp_u.setType("preonly")
     ksp_u.getPC().setType('lu')
-    ksp_u.getPC().setFactorSolverType('mumps')
+    ksp_u.getPC().setFactorSolverType('superlu_dist')
     ksp_p.setType("preonly")
     ksp_p.getPC().setType('lu')
-    ksp_p.getPC().setFactorSolverType('mumps')
+    ksp_p.getPC().setFactorSolverType('superlu_dist')
 
     problem = NonlinearPDE_SNESProblem(F, J, [u, p], bcs, P=P)
     snes.setFunction(problem.F_nest, Fvec1)
@@ -598,7 +598,7 @@ def test_assembly_solve_taylor_hood(mesh):
 
     snes.getKSP().setType("minres")
     snes.getKSP().getPC().setType("lu")
-    snes.getKSP().getPC().setFactorSolverType("mumps")
+    snes.getKSP().getPC().setFactorSolverType("superlu_dist")
 
     problem = NonlinearPDE_SNESProblem(F, J, U, bcs, P=P)
     snes.setFunction(problem.F_mono, Fvec2)

--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -198,7 +198,7 @@ def test_nonlinear_pde_snes():
     snes.getKSP().setTolerances(rtol=1.0e-9)
 
     snes.getKSP().getPC().setType("lu")
-    snes.getKSP().getPC().setFactorSolverType("mumps")
+    snes.getKSP().getPC().setFactorSolverType("superlu_dist")
 
     snes.solve(None, u.vector)
     assert snes.getConvergedReason() > 0


### PR DESCRIPTION
Remove PetscInt from DofMap and assembly, copying dofs to 64-bit on-the-fly if PETSc is configured with 64-bit-indices.