### PR TITLE
Check that data has been created before returning

### DIFF
--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -301,12 +301,14 @@ size_t Topology::hash() const
 const Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>&
 Topology::get_cell_permutation_info() const
 {
+  assert(_cell_permutations.size() > 0);
   return _cell_permutations;
 }
 //-----------------------------------------------------------------------------
 const Eigen::Array<std::uint8_t, Eigen::Dynamic, Eigen::Dynamic>&
 Topology::get_facet_permutations() const
 {
+  assert(_cell_permutations.size() > 0);
   return _facet_permutations;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -302,7 +302,7 @@ const Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>&
 Topology::get_cell_permutation_info() const
 {
   if (_cell_permutations.size() == 0)
-    create_entity_permutations();
+    throw std::runtime_error("create_entity_permutations must be called before using this data.");
   return _cell_permutations;
 }
 //-----------------------------------------------------------------------------
@@ -310,7 +310,7 @@ const Eigen::Array<std::uint8_t, Eigen::Dynamic, Eigen::Dynamic>&
 Topology::get_facet_permutations() const
 {
   if (_cell_permutations.size() == 0)
-    create_entity_permutations();
+    throw std::runtime_error("create_entity_permutations must be called before using this data.");
   return _facet_permutations;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -301,14 +301,16 @@ size_t Topology::hash() const
 const Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>&
 Topology::get_cell_permutation_info() const
 {
-  assert(_cell_permutations.size() > 0);
+  if (_cell_permutations.size() == 0)
+    create_entity_permutations();
   return _cell_permutations;
 }
 //-----------------------------------------------------------------------------
 const Eigen::Array<std::uint8_t, Eigen::Dynamic, Eigen::Dynamic>&
 Topology::get_facet_permutations() const
 {
-  assert(_cell_permutations.size() > 0);
+  if (_cell_permutations.size() == 0)
+    create_entity_permutations();
   return _facet_permutations;
 }
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
These functions should check that the cell permutation data has been created instead of returning an empty list if it doesn't exist