### PR TITLE
Expose Mesh.name

### DIFF
--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -197,7 +197,8 @@ void mesh(py::module& m)
           "topology", py::overload_cast<>(&dolfinx::mesh::Mesh::topology),
           "Mesh topology", py::return_value_policy::reference_internal)
       .def("ufl_id", &dolfinx::mesh::Mesh::id)
-      .def_property_readonly("id", &dolfinx::mesh::Mesh::id);
+      .def_property_readonly("id", &dolfinx::mesh::Mesh::id)
+      .def_readwrite("name", &dolfinx::mesh::Mesh::name);
 
   // dolfinx::mesh::MeshEntity class
   py::class_<dolfinx::mesh::MeshEntity,


### PR DESCRIPTION
Name was not exposed in Python which didn't allow to change it - and save multiple meshes into one file.