### PR TITLE
Remove Mesh::num_entities

### DIFF
--- a/cpp/dolfinx/fem/FormIntegrals.cpp
+++ b/cpp/dolfinx/fem/FormIntegrals.cpp
@@ -222,7 +222,6 @@ void FormIntegrals::set_default_domains(const mesh::Mesh& mesh)
   {
     // If there is a default integral, define it only on interior facets
     inf_integrals[0].active_entities.clear();
-    inf_integrals[0].active_entities.reserve(mesh.num_entities(tdim - 1));
 
     // Get number of facets owned by this process
     mesh.create_connectivity(tdim - 1, tdim);
@@ -230,6 +229,7 @@ void FormIntegrals::set_default_domains(const mesh::Mesh& mesh)
 
     const int num_facets = topology.index_map(tdim - 1)->size_local();
     auto f_to_c = topology.connectivity(tdim - 1, tdim);
+    inf_integrals[0].active_entities.reserve(num_facets);
     for (int f = 0; f < num_facets; ++f)
     {
       if (f_to_c->num_links(f) == 2)

--- a/cpp/dolfinx/geometry/BoundingBoxTree.cpp
+++ b/cpp/dolfinx/geometry/BoundingBoxTree.cpp
@@ -45,8 +45,9 @@ compute_bbox_of_entity(const mesh::MeshEntity& entity)
 
   auto vertices = entity.entities(0);
   assert(vertices.rows() >= 2);
-  const auto *it = std::find(cell_vertices.data(),
-                      cell_vertices.data() + cell_vertices.rows(), vertices[0]);
+  const auto* it
+      = std::find(cell_vertices.data(),
+                  cell_vertices.data() + cell_vertices.rows(), vertices[0]);
   assert(it != (cell_vertices.data() + cell_vertices.rows()));
   const int local_vertex = std::distance(cell_vertices.data(), it);
 
@@ -58,7 +59,7 @@ compute_bbox_of_entity(const mesh::MeshEntity& entity)
   // Compute min and max over remaining vertices
   for (int i = 1; i < vertices.rows(); ++i)
   {
-    const auto *it
+    const auto* it
         = std::find(cell_vertices.data(),
                     cell_vertices.data() + cell_vertices.rows(), vertices[i]);
     assert(it != (cell_vertices.data() + cell_vertices.rows()));
@@ -277,7 +278,9 @@ BoundingBoxTree::BoundingBoxTree(const mesh::Mesh& mesh, int tdim) : _tdim(tdim)
   mesh.create_entities(tdim);
 
   // Create bounding boxes for all mesh entities (leaves)
-  const int num_leaves = mesh.num_entities(tdim);
+  auto map = mesh.topology().index_map(tdim);
+  assert(map);
+  const std::int32_t num_leaves = map->size_local() + map->num_ghosts();
   std::vector<double> leaf_bboxes(6 * num_leaves);
   Eigen::Map<Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>>
       _leaf_bboxes(leaf_bboxes.data(), 2 * num_leaves, 3);

--- a/cpp/dolfinx/geometry/utils.cpp
+++ b/cpp/dolfinx/geometry/utils.cpp
@@ -7,6 +7,7 @@
 #include "utils.h"
 #include "BoundingBoxTree.h"
 #include "CollisionPredicates.h"
+#include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/log.h>
 #include <dolfinx/mesh/Geometry.h>
 #include <dolfinx/mesh/Mesh.h>
@@ -344,7 +345,10 @@ geometry::BoundingBoxTree geometry::create_midpoint_tree(const mesh::Mesh& mesh)
 
   // Create list of midpoints for all cells
   const int dim = mesh.topology().dim();
-  Eigen::Array<int, Eigen::Dynamic, 1> entities(mesh.num_entities(dim));
+  auto map = mesh.topology().index_map(dim);
+  assert(map);
+  const std::int32_t num_cells = map->size_local() + map->num_ghosts();
+  Eigen::Array<int, Eigen::Dynamic, 1> entities(num_cells);
   std::iota(entities.data(), entities.data() + entities.rows(), 0);
   Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> midpoints
       = mesh::midpoints(mesh, dim, entities);
@@ -565,12 +569,12 @@ double geometry::squared_distance(const mesh::MeshEntity& entity,
   {
   case (mesh::CellType::interval):
   {
-    const auto *it0
+    const auto* it0
         = std::find(cell_vertices.data(),
                     cell_vertices.data() + cell_vertices.rows(), vertices[0]);
     assert(it0 != (cell_vertices.data() + cell_vertices.rows()));
     const int local_vertex0 = std::distance(cell_vertices.data(), it0);
-    const auto *it1
+    const auto* it1
         = std::find(cell_vertices.data(),
                     cell_vertices.data() + cell_vertices.rows(), vertices[1]);
     assert(it1 != (cell_vertices.data() + cell_vertices.rows()));
@@ -582,17 +586,17 @@ double geometry::squared_distance(const mesh::MeshEntity& entity,
   }
   case (mesh::CellType::triangle):
   {
-    const auto *it0
+    const auto* it0
         = std::find(cell_vertices.data(),
                     cell_vertices.data() + cell_vertices.rows(), vertices[0]);
     assert(it0 != (cell_vertices.data() + cell_vertices.rows()));
     const int local_vertex0 = std::distance(cell_vertices.data(), it0);
-    const auto *it1
+    const auto* it1
         = std::find(cell_vertices.data(),
                     cell_vertices.data() + cell_vertices.rows(), vertices[1]);
     assert(it1 != (cell_vertices.data() + cell_vertices.rows()));
     const int local_vertex1 = std::distance(cell_vertices.data(), it1);
-    const auto *it2
+    const auto* it2
         = std::find(cell_vertices.data(),
                     cell_vertices.data() + cell_vertices.rows(), vertices[2]);
     assert(it2 != (cell_vertices.data() + cell_vertices.rows()));
@@ -605,22 +609,22 @@ double geometry::squared_distance(const mesh::MeshEntity& entity,
   }
   case (mesh::CellType::tetrahedron):
   {
-    const auto *it0
+    const auto* it0
         = std::find(cell_vertices.data(),
                     cell_vertices.data() + cell_vertices.rows(), vertices[0]);
     assert(it0 != (cell_vertices.data() + cell_vertices.rows()));
     const int local_vertex0 = std::distance(cell_vertices.data(), it0);
-    const auto *it1
+    const auto* it1
         = std::find(cell_vertices.data(),
                     cell_vertices.data() + cell_vertices.rows(), vertices[1]);
     assert(it1 != (cell_vertices.data() + cell_vertices.rows()));
     const int local_vertex1 = std::distance(cell_vertices.data(), it1);
-    const auto *it2
+    const auto* it2
         = std::find(cell_vertices.data(),
                     cell_vertices.data() + cell_vertices.rows(), vertices[2]);
     assert(it2 != (cell_vertices.data() + cell_vertices.rows()));
     const int local_vertex2 = std::distance(cell_vertices.data(), it2);
-    const auto *it3
+    const auto* it3
         = std::find(cell_vertices.data(),
                     cell_vertices.data() + cell_vertices.rows(), vertices[3]);
     assert(it2 != (cell_vertices.data() + cell_vertices.rows()));

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -33,7 +33,9 @@ namespace
 Eigen::ArrayXd cell_h(const mesh::Mesh& mesh)
 {
   const int dim = mesh.topology().dim();
-  const int num_cells = mesh.num_entities(dim);
+  auto map = mesh.topology().index_map(dim);
+  assert(map);
+  const std::int32_t num_cells = map->size_local() + map->num_ghosts();
   if (num_cells == 0)
     throw std::runtime_error("Cannot compute h min/max. No cells.");
 
@@ -45,7 +47,9 @@ Eigen::ArrayXd cell_h(const mesh::Mesh& mesh)
 Eigen::ArrayXd cell_r(const mesh::Mesh& mesh)
 {
   const int dim = mesh.topology().dim();
-  const int num_cells = mesh.num_entities(dim);
+  auto map = mesh.topology().index_map(dim);
+  assert(map);
+  const std::int32_t num_cells = map->size_local() + map->num_ghosts();
   if (num_cells == 0)
     throw std::runtime_error("Cannnot compute inradius min/max. No cells.");
 
@@ -155,20 +159,6 @@ Mesh::Mesh(const Mesh& mesh)
 Mesh::~Mesh()
 {
   // Do nothing
-}
-//-----------------------------------------------------------------------------
-std::int32_t Mesh::num_entities(int d) const
-{
-  assert(_topology);
-  auto map = _topology->index_map(d);
-  if (!map)
-  {
-    throw std::runtime_error("Cannot get number of mesh entities. Have not "
-                             "been created for dimension "
-                             + std::to_string(d) + ".");
-  }
-  assert(map->block_size() == 1);
-  return map->size_local() + map->num_ghosts();
 }
 //-----------------------------------------------------------------------------
 Topology& Mesh::topology()

--- a/cpp/dolfinx/mesh/Mesh.h
+++ b/cpp/dolfinx/mesh/Mesh.h
@@ -104,13 +104,6 @@ public:
   /// @param mesh Another Mesh object
   Mesh& operator=(Mesh&& mesh) = default;
 
-  /// @todo Remove and work via Topology
-  ///
-  /// Get number of entities of given topological dimension
-  /// @param[in] d Topological dimension.
-  /// @return Number of entities of topological dimension d
-  std::int32_t num_entities(int d) const;
-
   /// Get mesh topology
   /// @return The topology object associated with the mesh.
   Topology& topology();

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -470,10 +470,11 @@ mesh::cell_normals(const mesh::Mesh& mesh, int dim)
   {
     if (gdim > 2)
       throw std::invalid_argument("Interval cell normal undefined in 3D");
-
-    Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> n(
-        mesh.num_entities(1), 3);
-    for (int i = 0; i < mesh.num_entities(1); ++i)
+    auto map = mesh.topology().index_map(1);
+    assert(map);
+    const std::int32_t num_cells = map->size_local() + map->num_ghosts();
+    Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> n(num_cells, 3);
+    for (int i = 0; i < num_cells; ++i)
     {
       // Get the two vertices as points
       const mesh::MeshEntity e(mesh, 1, i);
@@ -489,9 +490,11 @@ mesh::cell_normals(const mesh::Mesh& mesh, int dim)
   }
   case (mesh::CellType::triangle):
   {
-    Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> n(
-        mesh.num_entities(2), 3);
-    for (int i = 0; i < mesh.num_entities(2); ++i)
+    auto map = mesh.topology().index_map(2);
+    assert(map);
+    const std::int32_t num_cells = map->size_local() + map->num_ghosts();
+    Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> n(num_cells, 3);
+    for (int i = 0; i < num_cells; ++i)
     {
       // Get the three vertices as points
       const mesh::MeshEntity e(mesh, 2, i);
@@ -508,9 +511,11 @@ mesh::cell_normals(const mesh::Mesh& mesh, int dim)
   case (mesh::CellType::quadrilateral):
   {
     // TODO: check
-    Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> n(
-        mesh.num_entities(2), 3);
-    for (int i = 0; i < mesh.num_entities(2); ++i)
+    auto map = mesh.topology().index_map(2);
+    assert(map);
+    const std::int32_t num_cells = map->size_local() + map->num_ghosts();
+    Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> n(num_cells, 3);
+    for (int i = 0; i < num_cells; ++i)
     {
       // Get three vertices as points
       const mesh::MeshEntity e(mesh, 2, i);
@@ -718,8 +723,7 @@ Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> mesh::midpoints(
   return x_mid;
 }
 //-----------------------------------------------------------------------------
-Eigen::Array<std::int32_t, Eigen::Dynamic, 1>
-mesh::locate_entities_geometrical(
+Eigen::Array<std::int32_t, Eigen::Dynamic, 1> mesh::locate_entities_geometrical(
     const mesh::Mesh& mesh, const int dim,
     const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
@@ -788,7 +792,7 @@ mesh::locate_entities_geometrical(
       // Get first cell and find position
       const int c = v_to_c->links(i)[0];
       auto vertices = c_to_v->links(c);
-      const auto *it
+      const auto* it
           = std::find(vertices.data(), vertices.data() + vertices.rows(), i);
       assert(it != (vertices.data() + vertices.rows()));
       const int local_pos = std::distance(vertices.data(), it);

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -94,7 +94,8 @@ def ufl_domain(self):
 
 def num_cells(self):
     """Return number of mesh cells"""
-    return self.num_entities(self.topology.dim)
+    map = self.topology.index_map(self.topology.dim)
+    return map.size_local + map.num_ghosts
 
 
 # Extend cpp.mesh.Mesh class, and clean-up

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -96,6 +96,5 @@ def ufl_domain(self):
 cpp.mesh.Mesh.ufl_cell = ufl_cell
 cpp.mesh.Mesh.ufl_coordinate_element = ufl_coordinate_element
 cpp.mesh.Mesh.ufl_domain = ufl_domain
-cpp.mesh.Mesh.num_cells = num_cells
 
-del ufl_cell, ufl_coordinate_element, ufl_domain, num_cells
+del ufl_cell, ufl_coordinate_element, ufl_domain

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -92,12 +92,6 @@ def ufl_domain(self):
     return self._ufl_domain
 
 
-def num_cells(self):
-    """Return number of mesh cells"""
-    map = self.topology.index_map(self.topology.dim)
-    return map.size_local + map.num_ghosts
-
-
 # Extend cpp.mesh.Mesh class, and clean-up
 cpp.mesh.Mesh.ufl_cell = ufl_cell
 cpp.mesh.Mesh.ufl_coordinate_element = ufl_coordinate_element

--- a/python/dolfinx/plotting.py
+++ b/python/dolfinx/plotting.py
@@ -97,7 +97,9 @@ def mplot_function(ax, f, **kwargs):
             return
         fvec = fem.interpolate(f, fspace).vector
 
-    if fvec.getSize() == mesh.num_entities(tdim):
+    map_c = mesh.topology.index_map(tdim)
+    num_cells = map_c.size_local + map_c.num_ghosts
+    if fvec.getSize() == num_cells:
         # DG0 cellwise function
         C = fvec.get_local()
         if (C.dtype.type is np.complex128):
@@ -201,7 +203,8 @@ def mplot_function(ax, f, **kwargs):
         if (w0.dtype.type is np.complex128):
             warnings.warn("Plotting real part of complex data")
             w0 = np.real(w0)
-        nv = mesh.num_entities(0)
+        map_v = mesh.topology.index_map(0)
+        nv = map_v.size_local + map_v.num_ghosts
         if w0.shape[1] != gdim:
             raise AttributeError(
                 'Vector length must match geometric dimension.')

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -189,8 +189,6 @@ void mesh(py::module& m)
            [](dolfinx::mesh::Mesh& self) {
              return MPICommWrapper(self.mpi_comm());
            })
-      .def("num_entities", &dolfinx::mesh::Mesh::num_entities,
-           "Number of mesh entities")
       .def("rmax", &dolfinx::mesh::Mesh::rmax)
       .def("rmin", &dolfinx::mesh::Mesh::rmin)
       .def_property_readonly(

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -237,18 +237,17 @@ def test_entity_closure_dofs(mesh_factory):
     for degree in (1, 2, 3):
         V = FunctionSpace(mesh, ("CG", degree))
         for d in range(tdim + 1):
+            map = mesh.topology.index_map(d)
+            num_entities = map.size_local + map.num_ghosts
             covered = set()
             covered2 = set()
-            all_entities = np.array(
-                [entity for entity in range(mesh.num_entities(d))],
-                dtype=np.uintp)
+            all_entities = np.array([entity for entity in range(num_entities)], dtype=np.uintp)
             for entity in all_entities:
                 entities = np.array([entity], dtype=np.uintp)
                 dofs_on_this_entity = V.dofmap.entity_dofs(mesh, d, entities)
                 closure_dofs = V.dofmap.entity_closure_dofs(
                     mesh, d, entities)
-                assert len(dofs_on_this_entity) == V.dofmap.dof_layout.num_entity_dofs(
-                    d)
+                assert len(dofs_on_this_entity) == V.dofmap.dof_layout.num_entity_dofs(d)
                 assert len(dofs_on_this_entity) <= len(closure_dofs)
                 covered.update(dofs_on_this_entity)
                 covered2.update(closure_dofs)
@@ -256,15 +255,15 @@ def test_entity_closure_dofs(mesh_factory):
                 mesh, d, all_entities)
             closure_dofs_on_all_entities = V.dofmap.entity_closure_dofs(
                 mesh, d, all_entities)
-            assert len(dofs_on_all_entities) == V.dofmap.dof_layout.num_entity_dofs(
-                d) * mesh.num_entities(d)
+            assert len(dofs_on_all_entities) == V.dofmap.dof_layout.num_entity_dofs(d) * num_entities
             assert covered == set(dofs_on_all_entities)
             assert covered2 == set(closure_dofs_on_all_entities)
+
         d = tdim
-        all_cells = np.array(
-            [entity for entity in range(mesh.num_entities(d))], dtype=np.uintp)
-        assert set(V.dofmap.entity_closure_dofs(mesh, d, all_cells)) == set(
-            range(V.dim))
+        map = mesh.topology.index_map(d)
+        num_entities = map.size_local + map.num_ghosts
+        all_cells = np.array([entity for entity in range(num_entities)], dtype=np.uintp)
+        assert set(V.dofmap.entity_closure_dofs(mesh, d, all_cells)) == set(range(V.dim))
 
 
 @pytest.mark.skip

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -67,7 +67,9 @@ def test_tabulate_all_coordinates(mesh_factory):
     checked_W = [False] * local_size_W
 
     # Check that all coordinates are within the cell it should be
-    for i in range(mesh.num_cells()):
+    map = mesh.topology.index_map(mesh.topology.dim)
+    num_cells = map.size_local + map.num_ghosts
+    for i in range(num_cells):
         cell = MeshEntity(mesh, mesh.topology.dim, i)
         dofs_V = V_dofmap.cell_dofs(i)
         for di in dofs_V:
@@ -105,7 +107,9 @@ def test_tabulate_dofs(mesh_factory):
     L01 = L1.sub(0)
     L11 = L1.sub(1)
 
-    for i in range(mesh.num_cells()):
+    map = mesh.topology.index_map(mesh.topology.dim)
+    num_cells = map.size_local + map.num_ghosts
+    for i in range(num_cells):
         dofs0 = L0.dofmap.cell_dofs(i)
         dofs1 = L01.dofmap.cell_dofs(i)
         dofs2 = L11.dofmap.cell_dofs(i)
@@ -146,7 +150,9 @@ def test_tabulate_coord_periodic(mesh_factory):
     coord2 = np.zeros((sdim, 2), dtype="d")
     coord3 = np.zeros((sdim, 2), dtype="d")
 
-    for i in range(mesh.num_cells()):
+    map = mesh.topology.index_map(mesh.topology.dim)
+    num_cells = map.size_local + map.num_ghosts
+    for i in range(num_cells):
         cell = MeshEntity(mesh, mesh.topology.dim, i)
         coord0 = V.element.tabulate_dof_coordinates(cell)
         coord1 = L0.element.tabulate_dof_coordinates(cell)

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -5,18 +5,18 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Unit tests for the fem interface"""
 
-from random import shuffle
 from itertools import combinations, product
+from random import shuffle
 
 import numpy as np
 import pytest
 from dolfinx_utils.test.skips import skip_in_parallel
 
-from dolfinx import MPI, cpp, fem, Mesh, FunctionSpace, VectorFunctionSpace, FacetNormal, Function
-from dolfinx.mesh import MeshTags
-from ufl import inner, ds, dS, TestFunction, TrialFunction
+from dolfinx import (MPI, FacetNormal, Function, FunctionSpace, Mesh,
+                     VectorFunctionSpace, cpp, fem)
 from dolfinx.cpp.mesh import CellType
-
+from dolfinx.mesh import MeshTags
+from ufl import TestFunction, TrialFunction, ds, dS, inner
 
 parametrize_cell_types = pytest.mark.parametrize(
     "cell_type",
@@ -131,16 +131,16 @@ def test_facet_integral(cell_type):
     """Test that the integral of a function over a facet is correct"""
     for count in range(5):
         mesh = unit_cell(cell_type)
+        tdim = mesh.topology.dim
 
         V = FunctionSpace(mesh, ("Lagrange", 2))
-
-        num_facets = mesh.num_entities(mesh.topology.dim - 1)
-
         v = Function(V)
 
+        map_f = mesh.topology.index_map(tdim - 1)
+        num_facets = map_f.size_local + map_f.num_ghosts
         indices = np.arange(0, num_facets)
         values = np.arange(0, num_facets, dtype=np.intc)
-        marker = MeshTags(mesh, mesh.topology.dim - 1, indices, values, sorted=True, unique=True)
+        marker = MeshTags(mesh, tdim - 1, indices, values, sorted=True, unique=True)
 
         # Functions that will have the same integral over each facet
         if cell_type == CellType.triangle:
@@ -170,17 +170,17 @@ def test_facet_normals(cell_type):
     """Test that FacetNormal is outward facing"""
     for count in range(5):
         mesh = unit_cell(cell_type)
+        tdim = mesh.topology.dim
 
         V = VectorFunctionSpace(mesh, ("Lagrange", 1))
         normal = FacetNormal(mesh)
-
-        num_facets = mesh.num_entities(mesh.topology.dim - 1)
-
         v = Function(V)
 
+        map_f = mesh.topology.index_map(tdim - 1)
+        num_facets = map_f.size_local + map_f.num_ghosts
         indices = np.arange(0, num_facets)
         values = np.arange(0, num_facets, dtype=np.intc)
-        marker = MeshTags(mesh, mesh.topology.dim - 1, indices, values)
+        marker = MeshTags(mesh, tdim - 1, indices, values)
 
         # For each facet, check that the inner product of the normal and
         # the vector that has a positive normal component on only that facet

--- a/python/test/unit/function/test_function.py
+++ b/python/test/unit/function/test_function.py
@@ -292,15 +292,17 @@ def test_interpolation_old(V, W, mesh):
     def f1(x):
         return np.ones((mesh.geometry.dim, x.shape[1]))
 
+    num_vertices = mesh.topology.index_map(0).size_local
+
     # Scalar interpolation
     f = Function(V)
     f.interpolate(f0)
-    assert round(f.vector.norm(PETSc.NormType.N1) - mesh.num_entities(0), 7) == 0
+    assert round(f.vector.norm(PETSc.NormType.N1) - num_vertices, 7) == 0
 
     # Vector interpolation
     f = Function(W)
     f.interpolate(f1)
-    assert round(f.vector.norm(PETSc.NormType.N1) - 3 * mesh.num_entities(0), 7) == 0
+    assert round(f.vector.norm(PETSc.NormType.N1) - 3 * num_vertices, 7) == 0
 
 
 @skip_if_complex

--- a/python/test/unit/io/test_xdmf_meshdata.py
+++ b/python/test/unit/io/test_xdmf_meshdata.py
@@ -6,12 +6,13 @@
 
 import os
 
+import mpi4py
 import pytest
+from dolfinx_utils.test.fixtures import tempdir
 
 from dolfinx import MPI, UnitCubeMesh, UnitIntervalMesh, UnitSquareMesh
 from dolfinx.cpp.mesh import CellType
 from dolfinx.io import XDMFFile
-from dolfinx_utils.test.fixtures import tempdir
 
 assert (tempdir)
 
@@ -57,5 +58,5 @@ def test_read_mesh_data(tempdir, tdim, n):
         cell_type, x, cells = file.read_mesh_data()
 
     assert cell_type == mesh.topology.cell_type
-    assert mesh.topology.index_map(tdim).size_global == MPI.sum(mesh.mpi_comm(), cells.shape[0])
-    assert mesh.geometry.index_map().size_global == MPI.sum(mesh.mpi_comm(), x.shape[0])
+    assert mesh.topology.index_map(tdim).size_global == mesh.mpi_comm().allreduce(cells.shape[0], op=mpi4py.MPI.SUM)
+    assert mesh.geometry.index_map().size_global == mesh.mpi_comm().allreduce(x.shape[0], op=mpi4py.MPI.SUM)

--- a/python/test/unit/mesh/test_cell.py
+++ b/python/test/unit/mesh/test_cell.py
@@ -47,8 +47,10 @@ def test_distance_tetrahedron():
         UnitCubeMesh(MPI.comm_world, 8, 9, 5, CellType.tetrahedron)
     ])
 def test_volume_cells(mesh):
-    num_cells = mesh.num_entities(mesh.topology.dim)
-    v = cpp.mesh.volume_entities(mesh, range(num_cells), mesh.topology.dim)
+    tdim = mesh.topology.dim
+    map = mesh.topology.index_map(tdim)
+    num_cells = map.size_local + map.num_ghosts
+    v = cpp.mesh.volume_entities(mesh, range(num_cells), tdim)
     v = MPI.sum(mesh.mpi_comm(), v.sum())
     assert v == pytest.approx(1.0, rel=1e-9)
 

--- a/python/test/unit/mesh/test_face.py
+++ b/python/test/unit/mesh/test_face.py
@@ -30,6 +30,9 @@ def test_area(cube, square):
     # area = dolfinx.cpp.mesh.volume_entities(cube, range(cube.num_entities(2)), 2).sum()
     # assert area == pytest.approx(39.21320343559672494393)
 
+    map = square.topology.index_map(2)
+    num_faces = map.size_local + map.num_ghosts
+
     cube.create_entities(1)
-    area = dolfinx.cpp.mesh.volume_entities(square, range(square.num_entities(2)), 2).sum()
+    area = dolfinx.cpp.mesh.volume_entities(square, range(num_faces), 2).sum()
     assert area == pytest.approx(1.0)

--- a/python/test/unit/mesh/test_ghost_mesh.py
+++ b/python/test/unit/mesh/test_ghost_mesh.py
@@ -36,11 +36,11 @@ def test_ghost_facet_1d():
 def test_ghost_2d(mode):
     N = 8
     num_cells = N * N * 2
-
     mesh = UnitSquareMesh(MPI.comm_world, N, N, ghost_mode=mode)
     if MPI.size(mesh.mpi_comm()) > 1:
-        assert MPI.sum(mesh.mpi_comm(), mesh.num_cells()) > num_cells
-
+        map = mesh.topology.index_map(2)
+        num_cells_local = map.size_local + map.num_ghosts
+        assert MPI.sum(mesh.mpi_comm(), num_cells_local) > num_cells
     assert mesh.topology.index_map(0).size_global == 81
     assert mesh.topology.index_map(2).size_global == num_cells
 
@@ -54,11 +54,11 @@ def test_ghost_2d(mode):
 def test_ghost_3d(mode):
     N = 2
     num_cells = N * N * N * 6
-
     mesh = UnitCubeMesh(MPI.comm_world, N, N, N, ghost_mode=mode)
     if MPI.size(mesh.mpi_comm()) > 1:
-        assert MPI.sum(mesh.mpi_comm(), mesh.num_cells()) > num_cells
-
+        map = mesh.topology.index_map(3)
+        num_cells_local = map.size_local + map.num_ghosts
+        assert MPI.sum(mesh.mpi_comm(), num_cells_local) > num_cells
     assert mesh.topology.index_map(0).size_global == 27
     assert mesh.topology.index_map(3).size_global == num_cells
 

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -232,7 +232,7 @@ def test_UnitSquareMeshLocal():
     """Create mesh of unit square."""
     mesh = UnitSquareMesh(MPI.comm_self, 5, 7)
     assert mesh.topology.index_map(0).size_global == 48
-    assert mesh.num_cells() == 70
+    assert mesh.topology.index_map(2).size_global == 70
     assert mesh.geometry.dim == 2
 
 
@@ -248,8 +248,10 @@ def test_UnitCubeMeshDistributed():
 def test_UnitCubeMeshLocal():
     """Create mesh of unit cube."""
     mesh = UnitCubeMesh(MPI.comm_self, 5, 7, 9)
+    assert mesh.topology.index_map(0).size_global == 480
     assert mesh.topology.index_map(0).size_local == 480
-    assert mesh.num_cells() == 1890
+    assert mesh.topology.index_map(3).size_global == 1890
+    assert mesh.topology.index_map(3).size_local == 1890
     assert mesh.geometry.dim == 3
 
 
@@ -375,7 +377,9 @@ def test_mesh_topology_against_fiat(mesh_factory, ghost_mode=cpp.mesh.GhostMode.
     # Initialize all mesh entities and connectivities
     mesh.create_connectivity_all()
 
-    for i in range(mesh.num_cells()):
+    map = mesh.topology.index_map(mesh.topology.dim)
+    num_cells = map.size_local + map.num_ghosts
+    for i in range(num_cells):
         cell = MeshEntity(mesh, mesh.topology.dim, i)
         # Get mesh-global (MPI-local) indices of cell vertices
         vertex_global_indices = cell.entities(0)

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -231,7 +231,7 @@ def test_UnitSquareMeshDistributed():
 def test_UnitSquareMeshLocal():
     """Create mesh of unit square."""
     mesh = UnitSquareMesh(MPI.comm_self, 5, 7)
-    assert mesh.num_entities(0) == 48
+    assert mesh.topology.index_map(0).size_global == 48
     assert mesh.num_cells() == 70
     assert mesh.geometry.dim == 2
 
@@ -248,7 +248,7 @@ def test_UnitCubeMeshDistributed():
 def test_UnitCubeMeshLocal():
     """Create mesh of unit cube."""
     mesh = UnitCubeMesh(MPI.comm_self, 5, 7, 9)
-    assert mesh.num_entities(0) == 480
+    assert mesh.topology.index_map(0).size_local == 480
     assert mesh.num_cells() == 1890
     assert mesh.geometry.dim == 3
 


### PR DESCRIPTION
This fixes a long-standing ambiguity around what is the 'number of mesh entities' (global, local, with or without ghosts), and for topological dimension zero whether it is vertices or geometric 'nodes'.

The caller must now go via `topology` (resolving the vertex vs geometric node ambiguity) and use the `index_map` for the entity dimension. `index_map` distinguishes between global, local and ghost.

Making this changes shows up numerous locations where code is probably broken for ghosted meshes. This change forces the caller to think about ghosting.