### PR TITLE
Few XDMFFile improvements

### DIFF
--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -189,9 +189,10 @@ mesh::Mesh XDMFFile::read_mesh(const std::string name,
   const fem::ElementDofLayout layout
       = fem::geometry_layout(cell_type, cells.cols());
 
-  // FIXME: Add ghostmode
-  return mesh::create(_mpi_comm.comm(), cells_adj, layout, x,
-                      mesh::GhostMode::none);
+  mesh::Mesh mesh = mesh::create(_mpi_comm.comm(), cells_adj, layout, x,
+                                 mesh::GhostMode::none);
+  mesh.name = name;
+  return mesh;
 }
 //-----------------------------------------------------------------------------
 std::tuple<

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -239,6 +239,11 @@ void XDMFFile::write_function(const function::Function& function,
   grid_node.append_attribute("Name") = function.name.c_str();
   grid_node.append_attribute("GridType") = "Uniform";
 
+  pugi::xml_node mesh_node = _xml_doc->select_node(mesh_xpath.c_str()).node();
+  if (!mesh_node)
+    LOG(WARNING) << "No mesh found at '" << mesh_xpath
+                 << "'. Write mesh before function!";
+
   const std::string ref_path
       = "xpointer(" + mesh_xpath + "/*[self::Topology or self::Geometry])";
 

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -197,6 +197,7 @@ void mesh(py::module& m)
           "topology", py::overload_cast<>(&dolfinx::mesh::Mesh::topology),
           "Mesh topology", py::return_value_policy::reference_internal)
       .def("ufl_id", &dolfinx::mesh::Mesh::id)
+      .def_readwrite("name", &dolfinx::mesh::Mesh::name)
       .def_property_readonly("id", &dolfinx::mesh::Mesh::id);
 
   // dolfinx::mesh::MeshEntity class

--- a/python/test/unit/io/test_xdmf_mesh.py
+++ b/python/test/unit/io/test_xdmf_mesh.py
@@ -20,7 +20,6 @@ if MPI.size(MPI.comm_world) > 1:
     encodings = (XDMFFile.Encoding.HDF5, )
 else:
     encodings = (XDMFFile.Encoding.HDF5, XDMFFile.Encoding.ASCII)
-    encodings = (XDMFFile.Encoding.HDF5, )
 
 celltypes_2D = [CellType.triangle, CellType.quadrilateral]
 celltypes_3D = [CellType.tetrahedron, CellType.hexahedron]
@@ -44,26 +43,10 @@ def worker_id(request):
         return 'master'
 
 
-# @pytest.mark.parametrize("encoding", encodings)
-# def test_save_and_load_1d_mesh(tempdir, encoding):
-#     filename = os.path.join(tempdir, "mesh.xdmf")
-#     mesh = UnitIntervalMesh(MPI.comm_world, 32)
-#     with XDMFFile(mesh.mpi_comm(), filename, "w", encoding=encoding) as file:
-#         file.write_mesh(mesh)
-
-#     with XDMFFile(MPI.comm_world, filename, "r") as file:
-#         mesh2 = file.read_mesh()
-
-#     assert mesh.topology.index_map(0).size_global == mesh2.topology.index_map(0).size_global
-#     dim = mesh.topology.dim
-#     assert mesh.topology.index_map(dim).size_global == mesh2.topology.index_map(dim).size_global
-
-
-@pytest.mark.parametrize("cell_type", celltypes_2D)
 @pytest.mark.parametrize("encoding", encodings)
-def test_save_and_load_mesh2D(tempdir, encoding, cell_type):
+def test_save_and_load_1d_mesh(tempdir, encoding):
     filename = os.path.join(tempdir, "mesh.xdmf")
-    mesh = UnitSquareMesh(MPI.comm_world, 12, 12, cell_type)
+    mesh = UnitIntervalMesh(MPI.comm_world, 32)
     with XDMFFile(mesh.mpi_comm(), filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
 
@@ -75,9 +58,28 @@ def test_save_and_load_mesh2D(tempdir, encoding, cell_type):
     assert mesh.topology.index_map(dim).size_global == mesh2.topology.index_map(dim).size_global
 
 
+@pytest.mark.parametrize("cell_type", celltypes_2D)
+@pytest.mark.parametrize("encoding", encodings)
+def test_save_and_load_2d_mesh(tempdir, encoding, cell_type):
+    filename = os.path.join(tempdir, "mesh.xdmf")
+    mesh = UnitSquareMesh(MPI.comm_world, 12, 12, cell_type)
+    mesh.name = "square"
+
+    with XDMFFile(mesh.mpi_comm(), filename, "w", encoding=encoding) as file:
+        file.write_mesh(mesh)
+
+    with XDMFFile(MPI.comm_world, filename, "r") as file:
+        mesh2 = file.read_mesh("square")
+
+    assert mesh2.name == mesh.name
+    assert mesh.topology.index_map(0).size_global == mesh2.topology.index_map(0).size_global
+    dim = mesh.topology.dim
+    assert mesh.topology.index_map(dim).size_global == mesh2.topology.index_map(dim).size_global
+
+
 @pytest.mark.parametrize("cell_type", celltypes_3D)
 @pytest.mark.parametrize("encoding", encodings)
-def test_save_and_load_mesh3D(tempdir, encoding, cell_type):
+def test_save_and_load_3d_mesh(tempdir, encoding, cell_type):
     filename = os.path.join(tempdir, "mesh.xdmf")
     mesh = UnitCubeMesh(MPI.comm_world, 12, 12, 8, cell_type)
     with XDMFFile(mesh.mpi_comm(), filename, "w", encoding=encoding) as file:

--- a/python/test/unit/io/test_xdmf_mesh.py
+++ b/python/test/unit/io/test_xdmf_mesh.py
@@ -50,7 +50,7 @@ def test_save_and_load_1d_mesh(tempdir, encoding):
     with XDMFFile(mesh.mpi_comm(), filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
 
-    with XDMFFile(MPI.comm_world, filename, "r") as file:
+    with XDMFFile(MPI.comm_world, filename, "r", encoding=encoding) as file:
         mesh2 = file.read_mesh()
 
     assert mesh.topology.index_map(0).size_global == mesh2.topology.index_map(0).size_global
@@ -68,7 +68,7 @@ def test_save_and_load_2d_mesh(tempdir, encoding, cell_type):
     with XDMFFile(mesh.mpi_comm(), filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
 
-    with XDMFFile(MPI.comm_world, filename, "r") as file:
+    with XDMFFile(MPI.comm_world, filename, "r", encoding=encoding) as file:
         mesh2 = file.read_mesh("square")
 
     assert mesh2.name == mesh.name
@@ -85,7 +85,7 @@ def test_save_and_load_3d_mesh(tempdir, encoding, cell_type):
     with XDMFFile(mesh.mpi_comm(), filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
 
-    with XDMFFile(MPI.comm_world, filename, "r") as file:
+    with XDMFFile(MPI.comm_world, filename, "r", encoding=encoding) as file:
         mesh2 = file.read_mesh()
 
     assert mesh.topology.index_map(0).size_global == mesh2.topology.index_map(
@@ -105,7 +105,7 @@ def test_read_write_p2_mesh(tempdir, encoding):
     with XDMFFile(mesh.mpi_comm(), filename, "w", encoding=encoding) as xdmf:
         xdmf.write_mesh(mesh)
 
-    with XDMFFile(mesh.mpi_comm(), filename, "r") as xdmf:
+    with XDMFFile(mesh.mpi_comm(), filename, "r", encoding=encoding) as xdmf:
         mesh2 = xdmf.read_mesh()
 
     assert mesh.topology.index_map(0).size_global == mesh2.topology.index_map(


### PR DESCRIPTION
- set name to mesh on reading,
- test it,
- re-enable 1D mesh tests,
- add `LOG(WARNING)` for writing function to a non-existing mesh. This could cause tons of issues because of the old interface - users are used to write functions only. Doing so Paraview crashes.