### PR TITLE
Bump petsc/slepc to v3.13 in Dockerfile

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -179,6 +179,8 @@ RUN apt-get -qq update && \
     --with-64-bit-indices=yes \
     --with-debugging=yes \
     --with-fortran-bindings=no \
+    --with-scalapack=yes \
+    --with-scalapack-lib=-lscalapack-openmpi \
     --with-scalar-type=real \
     --with-shared-libraries && \
     make && \
@@ -216,6 +218,8 @@ RUN apt-get -qq update && \
     --with-64-bit-indices=yes \
     --with-debugging=yes \
     --with-fortran-bindings=no \
+    --with-scalapack=yes \
+    --with-scalapack-lib=-lscalapack-openmpi \
     --with-scalar-type=complex \
     --with-shared-libraries && \
     make && \

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -6,10 +6,10 @@
 
 ARG GMSH_VERSION=4.5.6
 ARG PYBIND11_VERSION=2.5.0
-ARG PETSC_VERSION=3.12.5
-ARG SLEPC_VERSION=3.12.2
-ARG PETSC4PY_VERSION=3.12.0
-ARG SLEPC4PY_VERSION=3.12.0
+ARG PETSC_VERSION=3.13.0
+ARG SLEPC_VERSION=3.13.0
+ARG PETSC4PY_VERSION=3.13.0
+ARG SLEPC4PY_VERSION=3.13.0
 
 # Should be updated upon a new KaHIP release
 ARG KAHIP_VERSION=14be06c
@@ -172,6 +172,7 @@ RUN apt-get -qq update && \
     --CXXOPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
     --FOPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
     --download-hypre \
+    --download-mumps \
     --download-ptscotch \
     --download-suitesparse \
     --download-superlu_dist \
@@ -208,6 +209,7 @@ RUN apt-get -qq update && \
     --CXXOPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
     --FOPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
     --download-hypre \
+    --download-mumps \
     --download-ptscotch \
     --download-suitesparse \
     --download-superlu_dist \

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -2,9 +2,9 @@ name: Build and push Docker CI test image
 
 on:
   # Uncomment the below to trigger 'docker build' on push
-  push:
-    branches:
-      - "**"
+  # push:
+  #   branches:
+  #     - "**"
   schedule:
     # '*' is a special character in YAML, so string must be quoted
     - cron: "0 2 * * MON"

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -2,9 +2,9 @@ name: Build and push Docker CI test image
 
 on:
   # Uncomment the below to trigger 'docker build' on push
-  # push:
-  #   branches:
-  #     - "**"
+  push:
+    branches:
+      - "**"
   schedule:
     # '*' is a special character in YAML, so string must be quoted
     - cron: "0 2 * * MON"


### PR DESCRIPTION
Makes MUMPS available in 64-bit index builds.