### PR TITLE
Avoid copies in Mesh construction

### DIFF
--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -1,4 +1,5 @@
-// Copyright (C) 2006-2019 Anders Logg, Chris Richardson, Jorgen S. Dokken
+// Copyright (C) 2006-2020 Anders Logg, Chris Richardson, Jorgen S.
+// Dokken and Garth N. Wells
 //
 // This file is part of DOLFINX (https://www.fenicsproject.org)
 //

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -126,10 +126,9 @@ Mesh mesh::create(MPI_Comm comm,
 
 //-----------------------------------------------------------------------------
 Mesh::Mesh(MPI_Comm comm, const Topology& topology, const Geometry& geometry)
-    : _mpi_comm(comm)
+    : _topology(topology), _geometry(geometry), _mpi_comm(comm)
 {
-  _topology = std::make_unique<Topology>(topology);
-  _geometry = std::make_unique<Geometry>(geometry);
+  // Do nothing
 }
 //-----------------------------------------------------------------------------
 Mesh::Mesh(
@@ -139,17 +138,19 @@ Mesh::Mesh(
     const Eigen::Ref<const Eigen::Array<
         std::int64_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>& cells,
     const std::vector<std::int64_t>&, const GhostMode ghost_mode, std::int32_t)
-    : _mpi_comm(comm)
+    : Mesh(mesh::create(comm, graph::AdjacencyList<std::int64_t>(cells),
+                        fem::geometry_layout(type, cells.cols()), x,
+                        ghost_mode))
 {
-  assert(cells.cols() > 0);
-  const fem::ElementDofLayout layout = fem::geometry_layout(type, cells.cols());
-  *this = mesh::create(comm, graph::AdjacencyList<std::int64_t>(cells), layout,
-                       x, ghost_mode);
+  // assert(cells.cols() > 0);
+  // *this = mesh::create(comm, graph::AdjacencyList<std::int64_t>(cells),
+  //                      fem::geometry_layout(type, cells.cols()), x,
+  //                      ghost_mode);
 }
 //-----------------------------------------------------------------------------
 Mesh::Mesh(const Mesh& mesh)
-    : _topology(new Topology(*mesh._topology)),
-      _geometry(new Geometry(*mesh._geometry)), _mpi_comm(mesh.mpi_comm())
+    : _topology(mesh._topology), _geometry(mesh._geometry),
+      _mpi_comm(mesh.mpi_comm())
 {
   // Do nothing
 }
@@ -159,29 +160,13 @@ Mesh::~Mesh()
   // Do nothing
 }
 //-----------------------------------------------------------------------------
-Topology& Mesh::topology()
-{
-  assert(_topology);
-  return *_topology;
-}
+Topology& Mesh::topology() { return _topology; }
 //-----------------------------------------------------------------------------
-const Topology& Mesh::topology() const
-{
-  assert(_topology);
-  return *_topology;
-}
+const Topology& Mesh::topology() const { return _topology; }
 //-----------------------------------------------------------------------------
-Geometry& Mesh::geometry()
-{
-  assert(_geometry);
-  return *_geometry;
-}
+Geometry& Mesh::geometry() { return _geometry; }
 //-----------------------------------------------------------------------------
-const Geometry& Mesh::geometry() const
-{
-  assert(_geometry);
-  return *_geometry;
-}
+const Geometry& Mesh::geometry() const { return _geometry; }
 //-----------------------------------------------------------------------------
 std::int32_t Mesh::create_entities(int dim) const
 {
@@ -191,24 +176,22 @@ std::int32_t Mesh::create_entities(int dim) const
   // const_cast is also needed to allow iterators over a const Mesh to
   // create new connectivity.
 
-  assert(_topology);
-
   // Skip if already computed (vertices (dim=0) should always exist)
-  if (_topology->connectivity(dim, 0))
+  if (_topology.connectivity(dim, 0))
     return -1;
 
   // Create local entities
   const auto [cell_entity, entity_vertex, index_map]
-      = TopologyComputation::compute_entities(_mpi_comm.comm(), *_topology,
-                                              dim);
+      = TopologyComputation::compute_entities(_mpi_comm.comm(), _topology, dim);
 
+  Topology& topology = const_cast<Topology&>(_topology);
   if (cell_entity)
-    _topology->set_connectivity(cell_entity, _topology->dim(), dim);
+    topology.set_connectivity(cell_entity, _topology.dim(), dim);
   if (entity_vertex)
-    _topology->set_connectivity(entity_vertex, dim, 0);
+    topology.set_connectivity(entity_vertex, dim, 0);
 
-  if (index_map)
-    _topology->set_index_map(dim, index_map);
+  assert(index_map);
+  topology.set_index_map(dim, index_map);
 
   return index_map->size_local();
 }
@@ -226,9 +209,8 @@ void Mesh::create_connectivity(int d0, int d1) const
   create_entities(d1);
 
   // Compute connectivity
-  assert(_topology);
   const auto [c_d0_d1, c_d1_d0]
-      = TopologyComputation::compute_connectivity(*_topology, d0, d1);
+      = TopologyComputation::compute_connectivity(_topology, d0, d1);
 
   // NOTE: that to compute the (d0, d1) connections is it sometimes
   // necessary to compute the (d1, d0) connections. We store the (d1,
@@ -239,17 +221,17 @@ void Mesh::create_connectivity(int d0, int d1) const
   // connectivities are needed.
 
   // Attach connectivities
-  Mesh* mesh = const_cast<Mesh*>(this);
+  Topology& topology = const_cast<Topology&>(_topology);
   if (c_d0_d1)
-    mesh->topology().set_connectivity(c_d0_d1, d0, d1);
+    topology.set_connectivity(c_d0_d1, d0, d1);
   if (c_d1_d0)
-    mesh->topology().set_connectivity(c_d1_d0, d1, d0);
+    topology.set_connectivity(c_d1_d0, d1, d0);
 
   // Special facet handing
-  if (d0 == (_topology->dim() - 1) and d1 == _topology->dim())
+  if (d0 == (_topology.dim() - 1) and d1 == _topology.dim())
   {
-    std::vector<bool> f = compute_interior_facets(*_topology);
-    _topology->set_interior_facets(f);
+    std::vector<bool> f = compute_interior_facets(_topology);
+    topology.set_interior_facets(f);
   }
 }
 //-----------------------------------------------------------------------------
@@ -257,7 +239,7 @@ void Mesh::create_entity_permutations() const
 {
   // FIXME: This should be moved to topology or a TopologyPermutation class
 
-  const int tdim = _topology->dim();
+  const int tdim = _topology.dim();
 
   // FIXME: Is this always required? Could it be made cheaper by doing a
   // local version? This call does quite a lot of parallel work
@@ -265,18 +247,19 @@ void Mesh::create_entity_permutations() const
   for (int d = 0; d < tdim; ++d)
     this->create_entities(d);
 
-  _topology->create_entity_permutations();
+  Topology& topology = const_cast<Topology&>(_topology);
+  topology.create_entity_permutations();
 }
 //-----------------------------------------------------------------------------
 void Mesh::create_connectivity_all() const
 {
   // Compute all entities
-  for (int d = 0; d <= _topology->dim(); d++)
+  for (int d = 0; d <= _topology.dim(); d++)
     create_entities(d);
 
   // Compute all connectivity
-  for (int d0 = 0; d0 <= _topology->dim(); d0++)
-    for (int d1 = 0; d1 <= _topology->dim(); d1++)
+  for (int d0 = 0; d0 <= _topology.dim(); d0++)
+    for (int d1 = 0; d1 <= _topology.dim(); d1++)
       create_connectivity(d0, d1);
 }
 //-----------------------------------------------------------------------------
@@ -290,12 +273,9 @@ double Mesh::rmax() const { return cell_r(*this).maxCoeff(); }
 //-----------------------------------------------------------------------------
 std::size_t Mesh::hash() const
 {
-  assert(_topology);
-  assert(_geometry);
-
   // Get local hashes
-  const std::size_t kt_local = _topology->hash();
-  const std::size_t kg_local = _geometry->hash();
+  const std::size_t kt_local = _topology.hash();
+  const std::size_t kg_local = _geometry.hash();
 
   // Compute global hash
   const std::size_t kt = common::hash_global(_mpi_comm.comm(), kt_local);

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -117,19 +117,13 @@ Mesh mesh::create(MPI_Comm comm,
       topology.set_index_map(topology.dim() - 1, index_map1);
   }
 
-  const Geometry geometry
+  Geometry geometry
       = mesh::create_geometry(comm, topology, layout, cell_nodes, x);
 
-  return Mesh(comm, topology, geometry);
+  return Mesh(comm, std::move(topology), std::move(geometry));
 }
 //-----------------------------------------------------------------------------
 
-//-----------------------------------------------------------------------------
-Mesh::Mesh(MPI_Comm comm, const Topology& topology, const Geometry& geometry)
-    : _topology(topology), _geometry(geometry), _mpi_comm(comm)
-{
-  // Do nothing
-}
 //-----------------------------------------------------------------------------
 Mesh::Mesh(
     MPI_Comm comm, mesh::CellType type,
@@ -141,21 +135,6 @@ Mesh::Mesh(
     : Mesh(mesh::create(comm, graph::AdjacencyList<std::int64_t>(cells),
                         fem::geometry_layout(type, cells.cols()), x,
                         ghost_mode))
-{
-  // assert(cells.cols() > 0);
-  // *this = mesh::create(comm, graph::AdjacencyList<std::int64_t>(cells),
-  //                      fem::geometry_layout(type, cells.cols()), x,
-  //                      ghost_mode);
-}
-//-----------------------------------------------------------------------------
-Mesh::Mesh(const Mesh& mesh)
-    : _topology(mesh._topology), _geometry(mesh._geometry),
-      _mpi_comm(mesh.mpi_comm())
-{
-  // Do nothing
-}
-//-----------------------------------------------------------------------------
-Mesh::~Mesh()
 {
   // Do nothing
 }

--- a/cpp/dolfinx/mesh/Mesh.h
+++ b/cpp/dolfinx/mesh/Mesh.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "Geometry.h"
+#include "Topology.h"
 #include "cell_types.h"
 #include <Eigen/Dense>
 #include <dolfinx/common/MPI.h>
@@ -185,10 +187,10 @@ public:
 
 private:
   // Mesh topology
-  std::unique_ptr<Topology> _topology;
+  Topology _topology;
 
   // Mesh geometry
-  std::unique_ptr<Geometry> _geometry;
+  Geometry _geometry;
 
   // MPI communicator
   dolfinx::MPI::Comm _mpi_comm;

--- a/cpp/dolfinx/mesh/Mesh.h
+++ b/cpp/dolfinx/mesh/Mesh.h
@@ -12,8 +12,6 @@
 #include <Eigen/Dense>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/UniqueIdGenerator.h>
-#include <dolfinx/common/types.h>
-#include <memory>
 #include <string>
 #include <utility>
 
@@ -25,11 +23,6 @@ namespace fem
 class ElementDofLayout;
 }
 
-namespace function
-{
-class Function;
-}
-
 namespace graph
 {
 template <typename T>
@@ -38,8 +31,6 @@ class AdjacencyList;
 
 namespace mesh
 {
-class Geometry;
-class Topology;
 
 /// Enum for different partitioning ghost modes
 enum class GhostMode : int
@@ -59,7 +50,13 @@ public:
   /// @param[in] comm MPI Communicator
   /// @param[in] topology Mesh topology
   /// @param[in] geometry Mesh geometry
-  Mesh(MPI_Comm comm, const Topology& topology, const Geometry& geometry);
+  template <typename Topology, typename Geometry>
+  Mesh(MPI_Comm comm, Topology&& topology, Geometry&& geometry)
+      : _topology(std::forward<Topology>(topology)),
+        _geometry(std::forward<Geometry>(geometry)), _mpi_comm(comm)
+  {
+    // Do nothing
+  }
 
   /// @todo Remove this constructor once the creation of
   /// ElementDofLayout and coordinate maps is make straightforward
@@ -91,14 +88,14 @@ public:
 
   /// Copy constructor
   /// @param[in] mesh Mesh to be copied
-  Mesh(const Mesh& mesh);
+  Mesh(const Mesh& mesh) = default;
 
   /// Move constructor
   /// @param mesh Mesh to be moved.
   Mesh(Mesh&& mesh) = default;
 
   /// Destructor
-  ~Mesh();
+  ~Mesh() = default;
 
   // Assignment operator
   Mesh& operator=(const Mesh& mesh) = delete;

--- a/cpp/dolfinx/mesh/Mesh.h
+++ b/cpp/dolfinx/mesh/Mesh.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2006-2019 Anders Logg, Chris Richardson
+// Copyright (C) 2006-2020 Anders Logg, Chris Richardson and Garth N. Wells
 //
 // This file is part of DOLFINX (https://www.fenicsproject.org)
 //

--- a/cpp/dolfinx/refinement/ParallelRefinement.cpp
+++ b/cpp/dolfinx/refinement/ParallelRefinement.cpp
@@ -425,7 +425,7 @@ mesh::Mesh ParallelRefinement::partition(bool redistribute) const
   const mesh::Geometry geometry = mesh::create_geometry(
       comm, topology, layout, my_cells, _new_vertex_coordinates);
 
-  return mesh::Mesh(comm, topology, geometry);
+  return mesh::Mesh(comm, std::move(topology), std::move(geometry));
 }
 //-----------------------------------------------------------------------------
 void ParallelRefinement::new_cells(const std::vector<std::int64_t>& idx)

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -216,7 +216,7 @@ void mesh(py::module& m)
 #define MESHTAGS_MACRO(SCALAR, SCALAR_NAME)                                    \
   py::class_<dolfinx::mesh::MeshTags<SCALAR>,                                  \
              std::shared_ptr<dolfinx::mesh::MeshTags<SCALAR>>>(                \
-      m, "MeshTags_" #SCALAR_NAME, "MeshTags object")                   \
+      m, "MeshTags_" #SCALAR_NAME, "MeshTags object")                          \
       .def(py::init([](const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh, \
                        int dim, const py::array_t<std::int32_t>& indices,      \
                        const py::array_t<SCALAR>& values, bool sorted,         \


### PR DESCRIPTION
Store actual topology/geometry objects (rather than pointers) and add move semantics to constructor.