### PR TITLE
Avoid const_cast for manipulating the cache-like members of a const object

### DIFF
--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -154,9 +154,8 @@ std::int32_t Mesh::create_entities(int dim) const
 {
   // This function is obviously not const since it may potentially
   // compute new connectivity. However, in a sense all connectivity of a
-  // mesh always exists, it just hasn't been computed yet. The
-  // const_cast is also needed to allow iterators over a const Mesh to
-  // create new connectivity.
+  // mesh always exists, it just hasn't been computed yet. This resembles the
+  // notion of a cache or lazy construction.
 
   // Skip if already computed (vertices (dim=0) should always exist)
   if (_topology.connectivity(dim, 0))
@@ -166,7 +165,6 @@ std::int32_t Mesh::create_entities(int dim) const
   const auto [cell_entity, entity_vertex, index_map]
       = TopologyComputation::compute_entities(_mpi_comm.comm(), _topology, dim);
 
-//  Topology& topology = const_cast<Topology&>(_topology);
   if (cell_entity)
     _topology.set_connectivity(cell_entity, _topology.dim(), dim);
   if (entity_vertex)
@@ -182,9 +180,8 @@ void Mesh::create_connectivity(int d0, int d1) const
 {
   // This function is obviously not const since it may potentially
   // compute new connectivity. However, in a sense all connectivity of a
-  // mesh always exists, it just hasn't been computed yet. The
-  // const_cast is also needed to allow iterators over a const Mesh to
-  // create new connectivity.
+  // mesh always exists, it just hasn't been computed yet. This resembles the
+  // notion of a cache or lazy construction.
 
   // Make sure entities exist
   create_entities(d0);
@@ -203,7 +200,6 @@ void Mesh::create_connectivity(int d0, int d1) const
   // connectivities are needed.
 
   // Attach connectivities
-//  Topology& topology = const_cast<Topology&>(_topology);
   if (c_d0_d1)
     _topology.set_connectivity(c_d0_d1, d0, d1);
   if (c_d1_d0)
@@ -229,7 +225,6 @@ void Mesh::create_entity_permutations() const
   for (int d = 0; d < tdim; ++d)
     this->create_entities(d);
 
-//  Topology& topology = const_cast<Topology&>(_topology);
   _topology.create_entity_permutations();
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -144,6 +144,8 @@ Topology& Mesh::topology() { return _topology; }
 //-----------------------------------------------------------------------------
 const Topology& Mesh::topology() const { return _topology; }
 //-----------------------------------------------------------------------------
+Topology& Mesh::topology_mutable() const { return _topology; }
+//-----------------------------------------------------------------------------
 Geometry& Mesh::geometry() { return _geometry; }
 //-----------------------------------------------------------------------------
 const Geometry& Mesh::geometry() const { return _geometry; }
@@ -164,14 +166,14 @@ std::int32_t Mesh::create_entities(int dim) const
   const auto [cell_entity, entity_vertex, index_map]
       = TopologyComputation::compute_entities(_mpi_comm.comm(), _topology, dim);
 
-  Topology& topology = const_cast<Topology&>(_topology);
+//  Topology& topology = const_cast<Topology&>(_topology);
   if (cell_entity)
-    topology.set_connectivity(cell_entity, _topology.dim(), dim);
+    _topology.set_connectivity(cell_entity, _topology.dim(), dim);
   if (entity_vertex)
-    topology.set_connectivity(entity_vertex, dim, 0);
+    _topology.set_connectivity(entity_vertex, dim, 0);
 
   assert(index_map);
-  topology.set_index_map(dim, index_map);
+  _topology.set_index_map(dim, index_map);
 
   return index_map->size_local();
 }
@@ -201,17 +203,17 @@ void Mesh::create_connectivity(int d0, int d1) const
   // connectivities are needed.
 
   // Attach connectivities
-  Topology& topology = const_cast<Topology&>(_topology);
+//  Topology& topology = const_cast<Topology&>(_topology);
   if (c_d0_d1)
-    topology.set_connectivity(c_d0_d1, d0, d1);
+    _topology.set_connectivity(c_d0_d1, d0, d1);
   if (c_d1_d0)
-    topology.set_connectivity(c_d1_d0, d1, d0);
+    _topology.set_connectivity(c_d1_d0, d1, d0);
 
   // Special facet handing
   if (d0 == (_topology.dim() - 1) and d1 == _topology.dim())
   {
     std::vector<bool> f = compute_interior_facets(_topology);
-    topology.set_interior_facets(f);
+    _topology.set_interior_facets(f);
   }
 }
 //-----------------------------------------------------------------------------
@@ -227,8 +229,8 @@ void Mesh::create_entity_permutations() const
   for (int d = 0; d < tdim; ++d)
     this->create_entities(d);
 
-  Topology& topology = const_cast<Topology&>(_topology);
-  topology.create_entity_permutations();
+//  Topology& topology = const_cast<Topology&>(_topology);
+  _topology.create_entity_permutations();
 }
 //-----------------------------------------------------------------------------
 void Mesh::create_connectivity_all() const

--- a/cpp/dolfinx/mesh/Mesh.h
+++ b/cpp/dolfinx/mesh/Mesh.h
@@ -112,6 +112,10 @@ public:
   /// @return The topology object associated with the mesh.
   const Topology& topology() const;
 
+  /// Get mutable mesh topology (internal library use)
+  /// @return The topology object associated with the mesh.
+  Topology& topology_mutable() const;
+
   /// Get mesh geometry
   /// @return The geometry object associated with the mesh
   Geometry& geometry();
@@ -184,7 +188,7 @@ public:
 
 private:
   // Mesh topology
-  Topology _topology;
+  mutable Topology _topology;
 
   // Mesh geometry
   Geometry _geometry;


### PR DESCRIPTION
The rationale of this draft pull request is to find a cleaner solution to the modification or lazy initialization of members of a const object through non-members. 
Such usages of `const_cast` appear in Mesh.cpp and also in graph partitioning functions.
One drawback of const_casts is that the object does not know that someone messes with it's internals, which may lead to errors that are difficult to track down.
As an alternative approach I suggest to use "mutable" for such members that need to be modified on const objects from outside together with a dedicated accessor. From here, one could go further
and for example set some kind of lock/flag if such an accessor to a mutable member is called. 
This could further indicate a temporarily "undefined" state of an object and/or the need for some recomputation.

What is beyond my knowledge is, why the "partition" functions 
`dolfinx::graph::*::partition`
actually have a const adj_graph as argument, which obviously is to be modified.

I am willing to spend some time on this and learn about the internals dolfin-X. So any feedback in this draft, also whether it actually has a reasonable objective or not, is welcome.
