### PR TITLE
Simplify MeshTag construction by requiring sorted and unique constructor arguments

### DIFF
--- a/cpp/dolfinx/common/utils.h
+++ b/cpp/dolfinx/common/utils.h
@@ -23,7 +23,8 @@ namespace common
 {
 
 /// Sort two arrays based on the values in array @p indices. Any
-/// duplicate indices and the corresponding value are removed.
+/// duplicate indices and the corresponding value are removed. In the
+/// case of duplicates, the entry with the smallest value is retained.
 /// @param[in] indices Array of indices
 /// @param[in] values Array of values
 /// @return Sorted (indices, values), with sorting based on indices
@@ -38,20 +39,19 @@ std::pair<U, V> sort_unique(const U& indices, const V& values)
   for (std::size_t i = 0; i < indices.size(); ++i)
     data[i] = {indices[i], values[i]};
 
-  // Sort, and remove any duplicate indices
+  // Sort make unique
   std::sort(data.begin(), data.end());
-  data.erase(std::unique(data.begin(), data.end(),
-                         [](auto& a, auto& b) { return a.first == b.first; }),
-             data.end());
+  auto it = std::unique(data.begin(), data.end(),
+                        [](auto& a, auto& b) { return a.first == b.first; });
 
   U indices_new;
   V values_new;
   indices_new.reserve(data.size());
   values_new.reserve(data.size());
-  for (auto& d : data)
+  for (auto d = data.begin(); d != it; ++d)
   {
-    indices_new.push_back(d.first);
-    indices_new.push_back(d.second);
+    indices_new.push_back(d->first);
+    values_new.push_back(d->second);
   }
 
   return {std::move(indices_new), std::move(values_new)};

--- a/cpp/dolfinx/common/utils.h
+++ b/cpp/dolfinx/common/utils.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <boost/functional/hash.hpp>
 #include <cstring>
 #include <dolfinx/common/MPI.h>
@@ -13,12 +14,48 @@
 #include <mpi.h>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace dolfinx
 {
 namespace common
 {
+
+/// Sort two arrays based on the values in array @p indices. Any
+/// duplicate indices and the corresponding value are removed.
+/// @param[in] indices Array of indices
+/// @param[in] values Array of values
+/// @return Sorted (indices, values), with sorting based on indices
+template <typename U, typename V>
+std::pair<U, V> sort_unique(const U& indices, const V& values)
+{
+  if (indices.size() != values.size())
+    throw std::runtime_error("Cannot sort two arrays of different lengths");
+
+  std::vector<std::pair<typename U::value_type, typename V::value_type>> data(
+      indices.size());
+  for (std::size_t i = 0; i < indices.size(); ++i)
+    data[i] = {indices[i], values[i]};
+
+  // Sort, and remove any duplicate indices
+  std::sort(data.begin(), data.end());
+  data.erase(std::unique(data.begin(), data.end(),
+                         [](auto& a, auto& b) { return a.first == b.first; }),
+             data.end());
+
+  U indices_new;
+  V values_new;
+  indices_new.reserve(data.size());
+  values_new.reserve(data.size());
+  for (auto& d : data)
+  {
+    indices_new.push_back(d.first);
+    indices_new.push_back(d.second);
+  }
+
+  return {std::move(indices_new), std::move(values_new)};
+}
 
 /// Indent string block
 std::string indent(std::string block);

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -54,12 +54,12 @@ public:
       throw std::runtime_error(
           "Indices and values arrays must have same size.");
     }
-    // #ifdef DEBUG
+#ifdef DEBUG
     if (!std::is_sorted(_indices.begin(), _indices.end()))
       throw std::runtime_error("MeshTag data is not sorted");
     if (std::adjacent_find(_indices.begin(), _indices.end()) != _indices.end())
       throw std::runtime_error("MeshTag data has duplicates");
-    // #endif
+#endif
   }
 
   /// Copy constructor

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -54,12 +54,12 @@ public:
       throw std::runtime_error(
           "Indices and values arrays must have same size.");
     }
-#ifdef DEBUG
-    if (!std::is_sorted(indices.begin(), indices.end()))
+// #ifdef DEBUG
+    if (!std::is_sorted(_indices.begin(), _indices.end()))
       throw std::runtime_error("MeshTag data is not sorted");
-    if (std::adjacent_find(indices.begin(), indices.end()) != indices.end())
+    if (std::adjacent_find(_indices.begin(), _indices.end()) != _indices.end())
       throw std::runtime_error("MeshTag data has duplicates");
-#endif
+// #endif
   }
 
   /// Copy constructor

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -26,10 +26,10 @@ namespace dolfinx
 namespace mesh
 {
 
-/// A MeshTags is a class used to associate mesh entities with values.
-/// The entity index (local to process) identifies the entity. MeshTags
-/// is a sparse data storage class; it allows tags to be associated with
-/// an arbitrary subset of mesh entities. An entity can have only one
+/// A MeshTags are used to associate mesh entities with values. The
+/// entity index (local to process) identifies the entity. MeshTags is a
+/// sparse data storage class; it allows tags to be associated with an
+/// arbitrary subset of mesh entities. An entity can have only one
 /// associated tag.
 /// @tparam Type
 template <typename T>
@@ -39,14 +39,13 @@ public:
   /// Create from entities of given dimension on a mesh
   /// @param[in] mesh The mesh associated with the tags
   /// @param[in] dim Topological dimension of mesh entities to tag
-  /// @param[in] indices std::vector<std::int32> of entity indices
-  ///   (indices local to the process)
+  /// @param[in] indices std::vector<std::int32> of sorted and unique
+  ///   entity indices (indices local to the process)
   /// @param[in] values std::vector<T> of values for each index in
-  ///   indices
-  /// @param[in] sorted_and_unique True if indices are sorted and unique
+  ///   indices. The size must be equal to the size of @p indices.
   template <typename U, typename V>
   MeshTags(const std::shared_ptr<const Mesh>& mesh, int dim, U&& indices,
-           V&& values, bool sorted_and_unique = false)
+           V&& values)
       : _mesh(mesh), _dim(dim), _indices(std::forward<U>(indices)),
         _values(std::forward<V>(values))
   {
@@ -54,14 +53,6 @@ public:
     {
       throw std::runtime_error(
           "Indices and values arrays must have same size.");
-    }
-
-    if (!sorted_and_unique)
-    {
-      auto [indices_sorted, values_sorted]
-          = common::sort_unique(_indices, _values);
-      _indices = std::move(indices_sorted);
-      _values = std::move(values_sorted);
     }
   }
 

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -9,6 +9,7 @@
 #include "Geometry.h"
 #include "Mesh.h"
 #include "Topology.h"
+#include <algorithm>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/UniqueIdGenerator.h>
 #include <dolfinx/common/utils.h>
@@ -17,7 +18,6 @@
 #include <dolfinx/io/cells.h>
 #include <map>
 #include <memory>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -54,12 +54,12 @@ public:
       throw std::runtime_error(
           "Indices and values arrays must have same size.");
     }
-// #ifdef DEBUG
+    // #ifdef DEBUG
     if (!std::is_sorted(_indices.begin(), _indices.end()))
       throw std::runtime_error("MeshTag data is not sorted");
     if (std::adjacent_find(_indices.begin(), _indices.end()) != _indices.end())
       throw std::runtime_error("MeshTag data has duplicates");
-// #endif
+    // #endif
   }
 
   /// Copy constructor
@@ -349,8 +349,10 @@ create_meshtags(MPI_Comm comm, const std::shared_ptr<const mesh::Mesh>& mesh,
   // -------------------
   // 5. Build MeshTags object
 
-  return mesh::MeshTags<T>(mesh, e_dim, std::move(indices_new),
-                           std::move(values_new));
+  auto [indices_sorted, values_sorted]
+      = common::sort_unique(indices_new, values_new);
+  return mesh::MeshTags<T>(mesh, e_dim, std::move(indices_sorted),
+                           std::move(values_sorted));
 }
 } // namespace mesh
 } // namespace dolfinx

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -54,6 +54,12 @@ public:
       throw std::runtime_error(
           "Indices and values arrays must have same size.");
     }
+#ifdef DEBUG
+    if (!std::is_sorted(indices.begin(), indices.end()))
+      throw std::runtime_error("MeshTag data is not sorted");
+    if (std::adjacent_find(indices.begin(), indices.end()) != indices.end())
+      throw std::runtime_error("MeshTag data has duplicates");
+#endif
   }
 
   /// Copy constructor

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -70,7 +70,7 @@ def Mesh(comm, cell_type, x, cells, ghosts, degree=1, ghost_mode=cpp.mesh.GhostM
     return mesh
 
 
-def MeshTags(mesh, dim, indices, values, sorted=False, unique=False):
+def MeshTags(mesh, dim, indices, values):
 
     if isinstance(values, int):
         values = numpy.full(indices.shape, values, dtype=numpy.intc)
@@ -78,12 +78,11 @@ def MeshTags(mesh, dim, indices, values, sorted=False, unique=False):
         values = numpy.full(indices.shape, values, dtype=numpy.double)
 
     dtype = values.dtype.type
-
     if dtype not in _meshtags_types.keys():
         raise KeyError("Datatype {} of values array not recognised".format(dtype))
 
     fn = _meshtags_types[dtype]
-    return fn(mesh, dim, indices, values, sorted, unique)
+    return fn(mesh, dim, indices, values)
 
 
 # Functions to extend cpp.mesh.Mesh with

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -217,15 +217,13 @@ void mesh(py::module& m)
       m, "MeshTags_" #SCALAR_NAME, "MeshTags object")                          \
       .def(py::init([](const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh, \
                        int dim, const py::array_t<std::int32_t>& indices,      \
-                       const py::array_t<SCALAR>& values,                      \
-                       bool sorted_and_unique) {                               \
+                       const py::array_t<SCALAR>& values) {                    \
         std::vector<std::int32_t> indices_vec(                                 \
             indices.data(), indices.data() + indices.size());                  \
         std::vector<SCALAR> values_vec(values.data(),                          \
                                        values.data() + values.size());         \
         return std::make_unique<dolfinx::mesh::MeshTags<SCALAR>>(              \
-            mesh, dim, std::move(indices_vec), std::move(values_vec),          \
-            sorted_and_unique);                                                \
+            mesh, dim, std::move(indices_vec), std::move(values_vec));         \
       }))                                                                      \
       .def_readwrite("name", &dolfinx::mesh::MeshTags<SCALAR>::name)           \
       .def_property_readonly("dim", &dolfinx::mesh::MeshTags<SCALAR>::dim)     \

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -228,10 +228,7 @@ void mesh(py::module& m)
       .def_readwrite("name", &dolfinx::mesh::MeshTags<SCALAR>::name)           \
       .def_property_readonly("dim", &dolfinx::mesh::MeshTags<SCALAR>::dim)     \
       .def_property_readonly("mesh", &dolfinx::mesh::MeshTags<SCALAR>::mesh)   \
-      .def("ufl_id",                                                           \
-           [](const dolfinx::mesh::MeshTags<SCALAR>& self) {                   \
-             return self.id();                                                 \
-           })                                                                  \
+      .def("ufl_id", &dolfinx::mesh::MeshTags<SCALAR>::id)                     \
       .def_property_readonly("values",                                         \
                              [](dolfinx::mesh::MeshTags<SCALAR>& self) {       \
                                return py::array_t<SCALAR>(                     \

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -217,15 +217,15 @@ void mesh(py::module& m)
       m, "MeshTags_" #SCALAR_NAME, "MeshTags object")                          \
       .def(py::init([](const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh, \
                        int dim, const py::array_t<std::int32_t>& indices,      \
-                       const py::array_t<SCALAR>& values, bool sorted,         \
-                       bool unique) {                                          \
+                       const py::array_t<SCALAR>& values,                      \
+                       bool sorted_and_unique) {                               \
         std::vector<std::int32_t> indices_vec(                                 \
             indices.data(), indices.data() + indices.size());                  \
         std::vector<SCALAR> values_vec(values.data(),                          \
                                        values.data() + values.size());         \
         return std::make_unique<dolfinx::mesh::MeshTags<SCALAR>>(              \
-            mesh, dim, std::move(indices_vec), std::move(values_vec), sorted,  \
-            unique);                                                           \
+            mesh, dim, std::move(indices_vec), std::move(values_vec),          \
+            sorted_and_unique);                                                \
       }))                                                                      \
       .def_readwrite("name", &dolfinx::mesh::MeshTags<SCALAR>::name)           \
       .def_property_readonly("dim", &dolfinx::mesh::MeshTags<SCALAR>::dim)     \

--- a/python/test/unit/fem/test_assemble_domains.py
+++ b/python/test/unit/fem/test_assemble_domains.py
@@ -122,7 +122,8 @@ def test_assembly_ds_domains(mesh):
     indices = numpy.hstack((bottom_facets, top_facets, left_facets, right_facets))
     values = numpy.hstack((bottom_vals, top_vals, left_vals, right_vals))
 
-    marker = dolfinx.mesh.MeshTags(mesh, mesh.topology.dim - 1, indices, values)
+    indices, pos = numpy.unique(indices, return_index=True)
+    marker = dolfinx.mesh.MeshTags(mesh, mesh.topology.dim - 1, indices, values[pos])
 
     ds = ufl.Measure('ds', subdomain_data=marker, domain=mesh)
 

--- a/python/test/unit/fem/test_assemble_domains.py
+++ b/python/test/unit/fem/test_assemble_domains.py
@@ -45,18 +45,13 @@ def test_assembly_dx_domains(mesh):
     values = numpy.full(indices.shape, 3, dtype=numpy.intc)
     values[0] = 1
     values[1] = 2
-
-    marker = dolfinx.mesh.MeshTags(mesh, mesh.topology.dim, indices, values, sorted=True, unique=True)
-
+    marker = dolfinx.mesh.MeshTags(mesh, mesh.topology.dim, indices, values)
     dx = ufl.Measure('dx', subdomain_data=marker, domain=mesh)
-
     w = dolfinx.Function(V)
     with w.vector.localForm() as w_local:
         w_local.set(0.5)
 
-    #
     # Assemble matrix
-    #
 
     a = w * ufl.inner(u, v) * (dx(1) + dx(2) + dx(3))
 

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -137,7 +137,7 @@ def test_facet_integral(cell_type):
         num_facets = map_f.size_local + map_f.num_ghosts
         indices = np.arange(0, num_facets)
         values = np.arange(0, num_facets, dtype=np.intc)
-        marker = MeshTags(mesh, tdim - 1, indices, values, sorted=True, unique=True)
+        marker = MeshTags(mesh, tdim - 1, indices, values)
 
         # Functions that will have the same integral over each facet
         if cell_type == CellType.triangle:

--- a/python/test/unit/io/test_xdmf_meshtags.py
+++ b/python/test/unit/io/test_xdmf_meshtags.py
@@ -6,15 +6,15 @@
 
 import os
 
-import numpy
+import numpy as np
 import pytest
 from mpi4py import MPI
-from dolfinx_utils.test.fixtures import tempdir
 
 from dolfinx.cpp.mesh import CellType
 from dolfinx.generation import UnitCubeMesh
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import MeshTags, locate_entities_geometrical
+from dolfinx_utils.test.fixtures import tempdir
 
 assert (tempdir)
 
@@ -34,22 +34,22 @@ def test_3d(tempdir, cell_type, encoding):
     comm = MPI.COMM_WORLD
     mesh = UnitCubeMesh(comm, 4, 4, 4, cell_type)
 
-    bottom_facets = locate_entities_geometrical(mesh, 2, lambda x: numpy.isclose(x[1], 0.0))
-    left_facets = locate_entities_geometrical(mesh, 2, lambda x: numpy.isclose(x[0], 0.0))
+    bottom_facets = locate_entities_geometrical(mesh, 2, lambda x: np.isclose(x[1], 0.0))
+    bottom_values = np.full(bottom_facets.shape, 1, dtype=np.intc)
+    left_facets = locate_entities_geometrical(mesh, 2, lambda x: np.isclose(x[0], 0.0))
+    left_values = np.full(left_facets.shape, 2, dtype=np.intc)
 
-    bottom_values = numpy.full(bottom_facets.shape, 1, dtype=numpy.intc)
-    left_values = numpy.full(left_facets.shape, 2, dtype=numpy.intc)
-
-    mt = MeshTags(mesh, 2, numpy.hstack((bottom_facets, left_facets)), numpy.hstack((bottom_values, left_values)))
+    indices, pos = np.unique(np.hstack((bottom_facets, left_facets)), return_index=True)
+    mt = MeshTags(mesh, 2, indices, np.hstack((bottom_values, left_values))[pos])
     mt.name = "facets"
 
-    top_lines = locate_entities_geometrical(mesh, 1, lambda x: numpy.isclose(x[2], 1.0))
-    right_lines = locate_entities_geometrical(mesh, 1, lambda x: numpy.isclose(x[0], 1.0))
+    top_lines = locate_entities_geometrical(mesh, 1, lambda x: np.isclose(x[2], 1.0))
+    top_values = np.full(top_lines.shape, 3, dtype=np.intc)
+    right_lines = locate_entities_geometrical(mesh, 1, lambda x: np.isclose(x[0], 1.0))
+    right_values = np.full(right_lines.shape, 4, dtype=np.intc)
 
-    top_values = numpy.full(top_lines.shape, 3, dtype=numpy.intc)
-    right_values = numpy.full(right_lines.shape, 4, dtype=numpy.intc)
-
-    mt_lines = MeshTags(mesh, 1, numpy.hstack((top_lines, right_lines)), numpy.hstack((top_values, right_values)))
+    indices, pos = np.unique(np.hstack((top_lines, right_lines)), return_index=True)
+    mt_lines = MeshTags(mesh, 1, indices, np.hstack((top_values, right_values))[pos])
     mt_lines.name = "lines"
 
     with XDMFFile(comm, filename, "w", encoding=encoding) as file:
@@ -63,7 +63,6 @@ def test_3d(tempdir, cell_type, encoding):
         mesh_in.create_connectivity_all()
         mt_in = file.read_meshtags(mesh_in, "facets")
         mt_lines_in = file.read_meshtags(mesh_in, "lines")
-
         assert mt_in.name == "facets"
         assert mt_lines_in.name == "lines"
 


### PR DESCRIPTION
- Makes implementation less implicit
- Move algorithms out of MeshTags
- Remove the bug-prone "double default arguments" of the same type in `MeshTags` constructor 
- Remove non-pure private functions