### PR TITLE
Fix issue #959: use vector.data() instead of &vector[0]

### DIFF
--- a/cpp/dolfinx/graph/SCOTCH.cpp
+++ b/cpp/dolfinx/graph/SCOTCH.cpp
@@ -65,7 +65,7 @@ dolfinx::graph::SCOTCH::compute_reordering(
   SCOTCH_Num edgenbr = verttab.back();
   common::Timer timer1("SCOTCH: call SCOTCH_graphBuild");
   if (SCOTCH_graphBuild(&scotch_graph, baseval, vertnbr, &verttab[0],
-                        &verttab[1], nullptr, nullptr, edgenbr, &edgetab[0],
+                        &verttab[1], nullptr, nullptr, edgenbr, edgetab.data(),
                         nullptr))
   {
     throw std::runtime_error("Error building SCOTCH graph");


### PR DESCRIPTION
`&vector[0]` is as an out-of-bounds access that is caught some platforms (an assertion inside
vector.h has to be active), e.g. Fedora 31, on others it is not, e.g. Ubuntu 20.04.
`vector.data()` will return a `nullptr` in this case with any failure.