### PR TITLE
Simplify some namespacing with C++ 17 nested namespaces

### DIFF
--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -14,10 +14,7 @@
 #include <set>
 #include <vector>
 
-namespace dolfinx
-{
-
-namespace common
+namespace dolfinx::common
 {
 
 /// This class represents the distribution index arrays across
@@ -288,7 +285,7 @@ public:
   std::vector<std::int64_t> _all_ranges;
 
 private:
-  // Local-to-gl05obal map for ghost indices
+  // Local-to-global map for ghost indices
   Eigen::Array<std::int64_t, Eigen::Dynamic, 1> _ghosts;
 
   // Owning neighbour for each ghost index
@@ -310,5 +307,4 @@ private:
                         Mode op) const;
 };
 
-} // namespace common
-} // namespace dolfinx
+} // namespace dolfinx::common

--- a/cpp/dolfinx/common/SubSystemsManager.h
+++ b/cpp/dolfinx/common/SubSystemsManager.h
@@ -9,10 +9,7 @@
 #include <petscsys.h>
 #include <string>
 
-namespace dolfinx
-{
-
-namespace common
+namespace dolfinx::common
 {
 
 /// This is a singleton class which manages the initialisation and
@@ -94,5 +91,4 @@ private:
   bool petsc_initialized;
   bool control_mpi;
 };
-} // namespace common
-} // namespace dolfinx
+} // namespace dolfinx::common

--- a/cpp/dolfinx/common/TimeLogManager.h
+++ b/cpp/dolfinx/common/TimeLogManager.h
@@ -8,10 +8,7 @@
 
 #include "TimeLogger.h"
 
-namespace dolfinx
-{
-
-namespace common
+namespace dolfinx::common
 {
 
 /// Logger initialisation
@@ -22,5 +19,4 @@ public:
   /// Singleton instance of logger
   static TimeLogger& logger();
 };
-} // namespace common
-} // namespace dolfinx
+} // namespace dolfinx::common

--- a/cpp/dolfinx/common/TimeLogger.h
+++ b/cpp/dolfinx/common/TimeLogger.h
@@ -17,10 +17,7 @@
 #include <thread>
 #include <tuple>
 
-namespace dolfinx
-{
-
-namespace common
+namespace dolfinx::common
 {
 
 /// Timer logging
@@ -58,5 +55,4 @@ private:
   // total_wall_time, total_user_time, total_system_time)
   std::map<std::string, std::tuple<int, double, double, double>> _timings;
 };
-} // namespace common
-} // namespace dolfinx
+} // namespace dolfinx::common

--- a/cpp/dolfinx/common/Timer.h
+++ b/cpp/dolfinx/common/Timer.h
@@ -10,10 +10,7 @@
 #include <boost/timer/timer.hpp>
 #include <string>
 
-namespace dolfinx
-{
-
-namespace common
+namespace dolfinx::common
 {
 
 /// A timer can be used for timing tasks. The basic usage is
@@ -62,5 +59,4 @@ private:
   // Implementation of timer
   boost::timer::cpu_timer _timer;
 };
-} // namespace common
-} // namespace dolfinx
+} // namespace dolfinx::common

--- a/cpp/dolfinx/common/UniqueIdGenerator.h
+++ b/cpp/dolfinx/common/UniqueIdGenerator.h
@@ -8,10 +8,7 @@
 
 #include <cstddef>
 
-namespace dolfinx
-{
-
-namespace common
+namespace dolfinx::common
 {
 
 /// This is a singleton class that return IDs that are unique in the
@@ -32,5 +29,4 @@ private:
   // Next ID to be returned
   std::size_t _next_id;
 };
-} // namespace common
-} // namespace dolfinx
+} // namespace dolfinx::common

--- a/cpp/dolfinx/common/utils.h
+++ b/cpp/dolfinx/common/utils.h
@@ -17,9 +17,7 @@
 #include <utility>
 #include <vector>
 
-namespace dolfinx
-{
-namespace common
+namespace dolfinx::common
 {
 
 /// Sort two arrays based on the values in array @p indices. Any
@@ -121,5 +119,4 @@ std::int64_t hash_global(const MPI_Comm comm, const T& x)
 
   return global_hash;
 }
-} // namespace common
-} // namespace dolfinx
+} // namespace dolfinx::common

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -14,10 +14,7 @@
 #include <string>
 #include <unsupported/Eigen/CXX11/Tensor>
 
-namespace dolfinx
-{
-
-namespace fem
+namespace dolfinx::fem
 {
 
 // FIXME: A dof layout on a reference cell needs to be defined.
@@ -110,5 +107,4 @@ private:
                      const double*)>
       _compute_reference_geometry;
 };
-} // namespace fem
-} // namespace dolfinx
+} // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/ReferenceCellGeometry.h
+++ b/cpp/dolfinx/fem/ReferenceCellGeometry.h
@@ -9,10 +9,7 @@
 #include <Eigen/Dense>
 #include <dolfinx/mesh/cell_types.h>
 
-namespace dolfinx
-{
-
-namespace fem
+namespace dolfinx::fem
 {
 
 /// Tabulates the vertex positions for the reference cell
@@ -23,5 +20,4 @@ public:
   static Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
   get_vertices(mesh::CellType cell_type);
 };
-} // namespace fem
-} // namespace dolfinx
+} // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/SparsityPatternBuilder.cpp
+++ b/cpp/dolfinx/fem/SparsityPatternBuilder.cpp
@@ -6,7 +6,6 @@
 
 #include "SparsityPatternBuilder.h"
 #include <dolfinx/common/IndexMap.h>
-#include <dolfinx/common/MPI.h>
 #include <dolfinx/fem/DofMap.h>
 #include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/la/SparsityPattern.h>

--- a/cpp/dolfinx/function/Constant.h
+++ b/cpp/dolfinx/function/Constant.h
@@ -10,10 +10,7 @@
 #include <petscsys.h>
 #include <vector>
 
-namespace dolfinx
-{
-
-namespace function
+namespace dolfinx::function
 {
 
 /// A constant value which can be attached to a Form.
@@ -41,5 +38,4 @@ public:
   /// Values, stored as a flattened array.
   std::vector<PetscScalar> value;
 };
-} // namespace function
-} // namespace dolfinx
+} // namespace dolfinx::function

--- a/cpp/dolfinx/geometry/GeometryPredicates.h
+++ b/cpp/dolfinx/geometry/GeometryPredicates.h
@@ -9,10 +9,7 @@
 #include <Eigen/Dense>
 #include <vector>
 
-namespace dolfinx
-{
-
-namespace geometry
+namespace dolfinx::geometry
 {
 
 /// This class implements geometric predicates, i.e. function that
@@ -41,5 +38,4 @@ public:
   static bool convex_hull_is_degenerate(const std::vector<Eigen::Vector3d>& p,
                                         std::size_t gdim);
 };
-} // namespace geometry
-} // namespace dolfinx
+} // namespace dolfinx::geometry

--- a/cpp/dolfinx/geometry/predicates.h
+++ b/cpp/dolfinx/geometry/predicates.h
@@ -2,9 +2,7 @@
 
 #pragma once
 
-namespace dolfinx
-{
-namespace geometry
+namespace dolfinx::geometry
 {
 class Point;
 
@@ -43,5 +41,4 @@ double _orient2d(const double* a, const double* b, const double* c);
 double _orient3d(const double* a, const double* b, const double* c,
                  const double* d);
 
-} // namespace geometry
-} // namespace dolfinx
+} // namespace dolfinx::geometry

--- a/cpp/dolfinx/graph/AdjacencyList.h
+++ b/cpp/dolfinx/graph/AdjacencyList.h
@@ -14,9 +14,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace dolfinx
-{
-namespace graph
+namespace dolfinx::graph
 {
 
 /// This class provides a static adjacency list data structure. It is
@@ -206,5 +204,4 @@ private:
   // Position of first connection for each entity (using local index)
   Eigen::Array<std::int32_t, Eigen::Dynamic, 1> _offsets;
 }; // namespace graph
-} // namespace graph
-} // namespace dolfinx
+} // namespace dolfinx::graph

--- a/cpp/dolfinx/graph/BoostGraphOrdering.h
+++ b/cpp/dolfinx/graph/BoostGraphOrdering.h
@@ -10,10 +10,7 @@
 #include <utility>
 #include <vector>
 
-namespace dolfinx
-{
-
-namespace graph
+namespace dolfinx::graph
 {
 
 template <typename T>
@@ -37,5 +34,4 @@ public:
       const std::set<std::pair<std::size_t, std::size_t>>& edges,
       std::size_t size, bool reverse = false);
 };
-} // namespace graph
-} // namespace dolfinx
+} // namespace dolfinx::graph

--- a/cpp/dolfinx/graph/ParMETIS.h
+++ b/cpp/dolfinx/graph/ParMETIS.h
@@ -17,10 +17,7 @@
 #include <parmetis.h>
 #endif
 
-namespace dolfinx
-{
-
-namespace graph
+namespace dolfinx::graph
 {
 
 /// This class provides an interface to ParMETIS
@@ -36,5 +33,4 @@ public:
 
 #endif
 };
-} // namespace graph
-} // namespace dolfinx
+} // namespace dolfinx::graph

--- a/cpp/dolfinx/graph/Partitioning.h
+++ b/cpp/dolfinx/graph/Partitioning.h
@@ -15,10 +15,7 @@
 #include <utility>
 #include <vector>
 
-namespace dolfinx
-{
-
-namespace graph
+namespace dolfinx::graph
 {
 
 /// Tools for distributed graphs
@@ -295,5 +292,4 @@ Partitioning::distribute_data(
   return my_x;
 }
 
-} // namespace graph
-} // namespace dolfinx
+} // namespace dolfinx::graph

--- a/cpp/dolfinx/graph/SCOTCH.h
+++ b/cpp/dolfinx/graph/SCOTCH.h
@@ -21,10 +21,7 @@ extern "C"
 #include <ptscotch.h>
 }
 
-namespace dolfinx
-{
-
-namespace graph
+namespace dolfinx::graph
 {
 
 /// This class provides an interface to SCOTCH-PT (parallel version)
@@ -66,5 +63,4 @@ public:
   compute_reordering(const AdjacencyList<std::int32_t>& graph,
                      std::string scotch_strategy = "");
 };
-} // namespace graph
-} // namespace dolfinx
+} // namespace dolfinx::graph

--- a/cpp/dolfinx/io/HDF5File.h
+++ b/cpp/dolfinx/io/HDF5File.h
@@ -14,10 +14,7 @@
 #include <utility>
 #include <vector>
 
-namespace dolfinx
-{
-
-namespace io
+namespace dolfinx::io
 {
 
 /// Interface to HDF5 files
@@ -139,5 +136,4 @@ void HDF5File::write_data(
                                global_size, use_mpi_io, chunking);
 }
 //---------------------------------------------------------------------------
-} // namespace io
-} // namespace dolfinx
+} // namespace dolfinx::io

--- a/cpp/dolfinx/io/cells.h
+++ b/cpp/dolfinx/io/cells.h
@@ -11,12 +11,7 @@
 #include <dolfinx/mesh/cell_types.h>
 #include <vector>
 
-namespace dolfinx
-{
-namespace io
-{
-
-namespace cells
+namespace dolfinx::io::cells
 {
 /// For simplices the FEniCS ordering follows the UFC convention, see:
 /// https://fossies.org/linux/ufc/doc/manual/ufc-user-manual.pdf For
@@ -51,6 +46,4 @@ permute_ordering(
         std::int64_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>& cells,
     const std::vector<std::uint8_t>& permutation);
 
-} // namespace cells
-} // namespace io
-} // namespace dolfinx
+} // namespace dolfinx::io::cells

--- a/cpp/dolfinx/io/xdmf_mesh.h
+++ b/cpp/dolfinx/io/xdmf_mesh.h
@@ -29,10 +29,8 @@ class Mesh;
 class Topology;
 } // namespace mesh
 
-namespace io
-{
 /// Low-level methods for reading XDMF files
-namespace xdmf_mesh
+namespace io::xdmf_mesh
 {
 
 /// Add Mesh to xml node
@@ -72,6 +70,5 @@ std::tuple<
     Eigen::Array<std::int64_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>
 read_mesh_data(MPI_Comm comm, const hid_t h5_id, const pugi::xml_node& node);
 
-} // namespace xdmf_mesh
-} // namespace io
+} // namespace io::xdmf_mesh
 } // namespace dolfinx

--- a/cpp/dolfinx/io/xdmf_read.h
+++ b/cpp/dolfinx/io/xdmf_read.h
@@ -17,13 +17,8 @@
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/Topology.h>
 
-namespace dolfinx
-{
-
-namespace io
-{
 /// Low-level methods for reading XDMF files
-namespace xdmf_read
+namespace dolfinx::io::xdmf_read
 {
 
 /// Return data associated with a data set node
@@ -158,6 +153,4 @@ std::vector<T> get_dataset(MPI_Comm comm, const pugi::xml_node& dataset_node,
 }
 //----------------------------------------------------------------------------
 
-} // namespace xdmf_read
-} // namespace io
-} // namespace dolfinx
+} // namespace dolfinx::io::xdmf_read

--- a/cpp/dolfinx/io/xdmf_utils.h
+++ b/cpp/dolfinx/io/xdmf_utils.h
@@ -30,9 +30,7 @@ namespace function
 class Function;
 } // namespace function
 
-namespace io
-{
-namespace xdmf_utils
+namespace io::xdmf_utils
 {
 
 // Get DOLFINX cell type string from XML topology node
@@ -135,6 +133,5 @@ void add_data_item(pugi::xml_node& xml_node, const hid_t h5_id,
 } // namespace
 //----------------------------------------------------------------------------
 
-} // namespace xdmf_utils
-} // namespace io
+} // namespace io::xdmf_utils
 } // namespace dolfinx

--- a/cpp/dolfinx/la/PETScMatrix.h
+++ b/cpp/dolfinx/la/PETScMatrix.h
@@ -13,10 +13,7 @@
 #include <petscmat.h>
 #include <string>
 
-namespace dolfinx
-{
-
-namespace la
+namespace dolfinx::la
 {
 class SparsityPattern;
 class VectorSpaceBasis;
@@ -102,5 +99,4 @@ public:
   /// such as smoothed aggregation algerbraic multigrid)
   void set_near_nullspace(const la::VectorSpaceBasis& nullspace);
 };
-} // namespace la
-} // namespace dolfinx
+} // namespace dolfinx::la

--- a/cpp/dolfinx/la/PETScOperator.h
+++ b/cpp/dolfinx/la/PETScOperator.h
@@ -12,9 +12,7 @@
 #include <petscmat.h>
 #include <string>
 
-namespace dolfinx
-{
-namespace la
+namespace dolfinx::la
 {
 class PETScVector;
 
@@ -60,5 +58,4 @@ protected:
   // PETSc Mat pointer
   Mat _matA;
 };
-} // namespace la
-} // namespace dolfinx
+} // namespace dolfinx::la

--- a/cpp/dolfinx/la/PETScOptions.h
+++ b/cpp/dolfinx/la/PETScOptions.h
@@ -11,9 +11,7 @@
 #include <petscoptions.h>
 #include <string>
 
-namespace dolfinx
-{
-namespace la
+namespace dolfinx::la
 {
 
 /// These class provides static functions that permit users to set and
@@ -49,5 +47,4 @@ public:
   /// Clear PETSc global options database
   static void clear();
 };
-} // namespace la
-} // namespace dolfinx
+} // namespace dolfinx::la

--- a/cpp/dolfinx/la/VectorSpaceBasis.h
+++ b/cpp/dolfinx/la/VectorSpaceBasis.h
@@ -10,9 +10,7 @@
 #include <petscmat.h>
 #include <vector>
 
-namespace dolfinx
-{
-namespace la
+namespace dolfinx::la
 {
 class PETScVector;
 
@@ -61,5 +59,4 @@ public:
 private:
   const std::vector<std::shared_ptr<PETScVector>> _basis;
 };
-} // namespace la
-} // namespace dolfinx
+} // namespace dolfinx::la

--- a/cpp/dolfinx/mesh/DistributedMeshTools.h
+++ b/cpp/dolfinx/mesh/DistributedMeshTools.h
@@ -10,10 +10,7 @@
 #include <dolfinx/common/MPI.h>
 #include <vector>
 
-namespace dolfinx
-{
-
-namespace mesh
+namespace dolfinx::mesh
 {
 
 /// This class provides various functionality for working with
@@ -33,7 +30,5 @@ public:
       const Eigen::Ref<const Eigen::Array<
           double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>& values,
       const std::vector<std::int64_t>& global_indices);
-
 };
-} // namespace mesh
-} // namespace dolfinx
+} // namespace dolfinx::mesh

--- a/cpp/dolfinx/mesh/MeshEntity.h
+++ b/cpp/dolfinx/mesh/MeshEntity.h
@@ -10,10 +10,7 @@
 #include "Topology.h"
 #include <dolfinx/graph/AdjacencyList.h>
 
-namespace dolfinx
-{
-
-namespace mesh
+namespace dolfinx::mesh
 {
 
 /// A MeshEntity represents a mesh entity associated with a specific
@@ -114,5 +111,4 @@ protected:
   std::int32_t _local_index;
 }; // namespace mesh
 
-} // namespace mesh
-} // namespace dolfinx
+} // namespace dolfinx::mesh

--- a/cpp/dolfinx/mesh/MeshIterator.h
+++ b/cpp/dolfinx/mesh/MeshIterator.h
@@ -13,10 +13,7 @@
 #include <dolfinx/graph/AdjacencyList.h>
 #include <iterator>
 
-namespace dolfinx
-{
-
-namespace mesh
+namespace dolfinx::mesh
 {
 // Developer note: This code is performance critical as it appears in
 // tight assembly loops. Any changes should be carefully profiled.
@@ -263,5 +260,4 @@ private:
   // Dimension of incident entities
   const int _dim;
 };
-} // namespace mesh
-} // namespace dolfinx
+} // namespace dolfinx::mesh

--- a/cpp/dolfinx/mesh/MeshQuality.h
+++ b/cpp/dolfinx/mesh/MeshQuality.h
@@ -10,9 +10,7 @@
 #include <utility>
 #include <vector>
 
-namespace dolfinx
-{
-namespace mesh
+namespace dolfinx::mesh
 {
 class Mesh;
 class MeshEntity;
@@ -42,5 +40,4 @@ public:
   static std::pair<std::vector<double>, std::vector<std::int64_t>>
   dihedral_angle_histogram_data(const Mesh& mesh, int num_bins);
 };
-} // namespace mesh
-} // namespace dolfinx
+} // namespace dolfinx::mesh

--- a/cpp/dolfinx/mesh/PermutationComputation.h
+++ b/cpp/dolfinx/mesh/PermutationComputation.h
@@ -10,9 +10,7 @@
 #include <cstdint>
 #include <utility>
 
-namespace dolfinx
-{
-namespace mesh
+namespace dolfinx::mesh
 {
 class Topology;
 
@@ -79,5 +77,4 @@ public:
   compute_entity_permutations(const Topology& topology);
 };
 
-} // namespace mesh
-} // namespace dolfinx
+} // namespace dolfinx::mesh

--- a/cpp/dolfinx/nls/NonlinearProblem.h
+++ b/cpp/dolfinx/nls/NonlinearProblem.h
@@ -9,10 +9,7 @@
 #include <petscmat.h>
 #include <petscvec.h>
 
-namespace dolfinx
-{
-
-namespace nls
+namespace dolfinx::nls
 {
 
 /// This is a base class for nonlinear problems which can return the
@@ -47,5 +44,4 @@ public:
   /// to construct preconditioner.
   virtual Mat P(const Vec) { return nullptr; }
 };
-} // namespace nls
-} // namespace dolfinx
+} // namespace dolfinx::nls


### PR DESCRIPTION
Nested namespaces are available since C++ 17:
https://en.cppreference.com/w/cpp/language/namespace

It is equivalent to the previous definitions, but I think it improves readability.