### PR TITLE
Fix UFC JIT objects memory management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ install-python-components: &install-python-components
   command: |
     pip3 install git+https://github.com/FEniCS/fiat.git --upgrade
     pip3 install git+https://github.com/FEniCS/ufl.git --upgrade
-    pip3 install git+https://github.com/FEniCS/ffcx.git --upgrade
+    pip3 install git+https://github.com/FEniCS/ffcx.git@michal/cffi-free --upgrade
     rm -rf /usr/local/include/dolfin /usr/local/include/dolfin.h
 
 flake8-python-code: &flake8-python-code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ install-python-components: &install-python-components
   command: |
     pip3 install git+https://github.com/FEniCS/fiat.git --upgrade
     pip3 install git+https://github.com/FEniCS/ufl.git --upgrade
-    pip3 install git+https://github.com/FEniCS/ffcx.git@michal/cffi-free --upgrade
+    pip3 install git+https://github.com/FEniCS/ffcx.git --upgrade
     rm -rf /usr/local/include/dolfin /usr/local/include/dolfin.h
 
 flake8-python-code: &flake8-python-code

--- a/python/dolfinx/fem/coordinatemapping.py
+++ b/python/dolfinx/fem/coordinatemapping.py
@@ -8,7 +8,7 @@
 import ufl
 
 from dolfinx import jit
-from dolfinx import fem
+from dolfinx import cpp
 from cffi import FFI
 
 
@@ -35,5 +35,5 @@ def create_coordinate_map(o):
 
     # Wrap compiled coordinate map and return
     ffi = FFI()
-    cmap = fem.dofmap.make_coordinate_map(ffi.cast("uintptr_t", cmap_ptr))
+    cmap = cpp.fem.create_coordinate_map(ffi.cast("uintptr_t", cmap_ptr))
     return cmap

--- a/python/dolfinx/fem/dofmap.py
+++ b/python/dolfinx/fem/dofmap.py
@@ -8,21 +8,6 @@
 from dolfinx import cpp
 
 
-def make_ufc_finite_element(ufc_finite_element):
-    """Returns ufc finite element from a pointer"""
-    return cpp.fem.make_ufc_finite_element(ufc_finite_element)
-
-
-def make_ufc_dofmap(ufc_dofmap):
-    """Returns ufc dofmap from a pointer"""
-    return cpp.fem.make_ufc_dofmap(ufc_dofmap)
-
-
-def make_ufc_form(ufc_form):
-    """Returns ufc form from a pointer"""
-    return cpp.fem.make_ufc_form(ufc_form)
-
-
 def make_coordinate_map(ufc_coordinate_mapping):
     """Returns CoordinateElement from a pointer to a ufc_coordinate_mapping"""
     return cpp.fem.make_coordinate_map(ufc_coordinate_mapping)

--- a/python/dolfinx/fem/dofmap.py
+++ b/python/dolfinx/fem/dofmap.py
@@ -8,11 +8,6 @@
 from dolfinx import cpp
 
 
-def make_coordinate_map(ufc_coordinate_mapping):
-    """Returns CoordinateElement from a pointer to a ufc_coordinate_mapping"""
-    return cpp.fem.make_coordinate_map(ufc_coordinate_mapping)
-
-
 class DofMap:
     """Degree-of-freedom map
 

--- a/python/dolfinx/fem/form.py
+++ b/python/dolfinx/fem/form.py
@@ -8,7 +8,7 @@
 import cffi
 
 import ufl
-from dolfinx import cpp, fem, jit
+from dolfinx import cpp, jit
 
 
 class Form:
@@ -42,7 +42,7 @@ class Form:
             form_compiler_parameters=self.form_compiler_parameters,
             mpi_comm=mesh.mpi_comm())
 
-        # Cast compiled library to pointer to ufc_form
+        # Dereference compiled pointer
         ffi = cffi.FFI()
         ufc_form = cpp.fem.make_ufc_form(ffi.cast("uintptr_t", ufc_form))
 

--- a/python/dolfinx/fem/form.py
+++ b/python/dolfinx/fem/form.py
@@ -42,17 +42,14 @@ class Form:
             form_compiler_parameters=self.form_compiler_parameters,
             mpi_comm=mesh.mpi_comm())
 
-        # Dereference compiled pointer
-        ffi = cffi.FFI()
-        ufc_form = cpp.fem.make_ufc_form(ffi.cast("uintptr_t", ufc_form))
-
         # For every argument in form extract its function space
         function_spaces = [
             func.ufl_function_space()._cpp_object for func in form.arguments()
         ]
 
         # Prepare dolfinx.Form and hold it as a member
-        self._cpp_object = cpp.fem.create_form(ufc_form, function_spaces)
+        ffi = cffi.FFI()
+        self._cpp_object = cpp.fem.create_form(ffi.cast("uintptr_t", ufc_form), function_spaces)
 
         # Need to fill the form with coefficients data
         # For every coefficient in form take its C++ object

--- a/python/dolfinx/fem/form.py
+++ b/python/dolfinx/fem/form.py
@@ -44,7 +44,7 @@ class Form:
 
         # Cast compiled library to pointer to ufc_form
         ffi = cffi.FFI()
-        ufc_form = fem.dofmap.make_ufc_form(ffi.cast("uintptr_t", ufc_form))
+        ufc_form = cpp.fem.make_ufc_form(ffi.cast("uintptr_t", ufc_form))
 
         # For every argument in form extract its function space
         function_spaces = [

--- a/python/dolfinx/function.py
+++ b/python/dolfinx/function.py
@@ -256,10 +256,10 @@ class FunctionSpace(ufl.FunctionSpace):
             self.ufl_element(), form_compiler_parameters=None, mpi_comm=mesh.mpi_comm())
 
         ffi = cffi.FFI()
-        ufc_element = fem.dofmap.make_ufc_finite_element(ffi.cast("uintptr_t", ufc_element))
+        ufc_element = cpp.fem.make_ufc_finite_element(ffi.cast("uintptr_t", ufc_element))
         cpp_element = cpp.fem.FiniteElement(ufc_element)
 
-        ufc_dofmap = fem.dofmap.make_ufc_dofmap(ffi.cast("uintptr_t", ufc_dofmap_ptr))
+        ufc_dofmap = cpp.fem.make_ufc_dofmap(ffi.cast("uintptr_t", ufc_dofmap_ptr))
         cpp_dofmap = cpp.fem.create_dofmap(mesh.mpi_comm(), ufc_dofmap, mesh.topology)
 
         # Initialize the cpp.FunctionSpace

--- a/python/dolfinx/function.py
+++ b/python/dolfinx/function.py
@@ -256,11 +256,8 @@ class FunctionSpace(ufl.FunctionSpace):
             self.ufl_element(), form_compiler_parameters=None, mpi_comm=mesh.mpi_comm())
 
         ffi = cffi.FFI()
-        ufc_element = cpp.fem.make_ufc_finite_element(ffi.cast("uintptr_t", ufc_element))
-        cpp_element = cpp.fem.FiniteElement(ufc_element)
-
-        ufc_dofmap = cpp.fem.make_ufc_dofmap(ffi.cast("uintptr_t", ufc_dofmap_ptr))
-        cpp_dofmap = cpp.fem.create_dofmap(mesh.mpi_comm(), ufc_dofmap, mesh.topology)
+        cpp_element = cpp.fem.FiniteElement(ffi.cast("uintptr_t", ufc_element))
+        cpp_dofmap = cpp.fem.create_dofmap(mesh.mpi_comm(), ffi.cast("uintptr_t", ufc_dofmap_ptr), mesh.topology)
 
         # Initialize the cpp.FunctionSpace
         self._cpp_object = cpp.function.FunctionSpace(mesh, cpp_element, cpp_dofmap)

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -74,50 +74,8 @@ namespace dolfinx_wrappers
 void fem(py::module& m)
 {
 
-  // UFC objects
-  py::class_<ufc_finite_element, std::shared_ptr<ufc_finite_element>>(
-      m, "ufc_finite_element", "UFC finite element object");
-  py::class_<ufc_dofmap, std::shared_ptr<ufc_dofmap>>(m, "ufc_dofmap",
-                                                      "UFC dofmap object");
-  py::class_<ufc_form, std::shared_ptr<ufc_form>>(m, "ufc_form",
-                                                  "UFC form object");
   py::class_<ufc_coordinate_mapping, std::shared_ptr<ufc_coordinate_mapping>>(
       m, "ufc_coordinate_mapping", "UFC coordinate_mapping object");
-
-  // Functions to convert pointers (from JIT usually) to UFC objects
-  m.def(
-      "make_ufc_finite_element",
-      [](std::uintptr_t e) {
-        ufc_finite_element* p = reinterpret_cast<ufc_finite_element*>(e);
-        return *p;
-      },
-      "Create a ufc_finite_element object from a pointer.");
-
-  m.def(
-      "make_ufc_dofmap",
-      [](std::uintptr_t e) {
-        ufc_dofmap* p = reinterpret_cast<ufc_dofmap*>(e);
-        return *p;
-      },
-      "Create a ufc_dofmap object from a pointer.");
-
-  m.def(
-      "make_ufc_form",
-      [](std::uintptr_t e) {
-        ufc_form* p = reinterpret_cast<ufc_form*>(e);
-        return *p;
-      },
-      "Create a ufc_form object from a pointer.");
-
-  m.def(
-      "make_coordinate_map",
-      [](std::uintptr_t e) {
-        ufc_coordinate_mapping* p
-            = reinterpret_cast<ufc_coordinate_mapping*>(e);
-        return dolfinx::fem::create_coordinate_map(*p);
-      },
-      "Create a CoordinateElement object from a pointer to a "
-      "ufc_coordinate_map.");
 
   // utils
   m.def("block_function_spaces",
@@ -187,18 +145,29 @@ void fem(py::module& m)
         "Create ElementDofLayout object from a ufc dofmap.");
   m.def(
       "create_dofmap",
-      [](const MPICommWrapper comm, const ufc_dofmap& dofmap,
+      [](const MPICommWrapper comm, const std::uintptr_t dofmap,
          dolfinx::mesh::Topology& topology) {
-        return dolfinx::fem::create_dofmap(comm.get(), dofmap, topology);
+        const ufc_dofmap* p = reinterpret_cast<const ufc_dofmap*>(dofmap);
+        return dolfinx::fem::create_dofmap(comm.get(), *p, topology);
       },
-      "Create DOLFIN DofMap object from a ufc dofmap.");
-  m.def("create_form",
-        py::overload_cast<const ufc_form&,
-                          const std::vector<std::shared_ptr<
-                              const dolfinx::function::FunctionSpace>>&>(
-            &dolfinx::fem::create_form),
-        "Create DOLFIN form from a ufc form.");
-
+      "Create DofMap object from a pointer to ufc_dofmap.");
+  m.def(
+      "create_form",
+      [](const std::uintptr_t form,
+         const std::vector<
+             std::shared_ptr<const dolfinx::function::FunctionSpace>>& spaces) {
+        const ufc_form* p = reinterpret_cast<const ufc_form*>(form);
+        return dolfinx::fem::create_form(*p, spaces);
+      },
+      "Create Form from a pointer to ufc_form.");
+  m.def(
+      "create_coordinate_map",
+      [](std::uintptr_t cmap) {
+        const ufc_coordinate_mapping* p
+            = reinterpret_cast<const ufc_coordinate_mapping*>(cmap);
+        return dolfinx::fem::create_coordinate_map(*p);
+      },
+      "Create CoordinateElement from a pointer to ufc_coordinate_map.");
   m.def(
       "build_dofmap",
       [](const dolfinx::mesh::Mesh& mesh,
@@ -226,7 +195,11 @@ void fem(py::module& m)
   py::class_<dolfinx::fem::FiniteElement,
              std::shared_ptr<dolfinx::fem::FiniteElement>>(
       m, "FiniteElement", "Finite element object")
-      .def(py::init<const ufc_finite_element&>())
+      .def(py::init([](const std::uintptr_t ufc_element) {
+        const ufc_finite_element* p
+            = reinterpret_cast<const ufc_finite_element*>(ufc_element);
+        return std::make_unique<dolfinx::fem::FiniteElement>(*p);
+      }))
       .def("num_sub_elements", &dolfinx::fem::FiniteElement::num_sub_elements)
       .def("dof_reference_coordinates",
            &dolfinx::fem::FiniteElement::dof_reference_coordinates)

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -89,7 +89,7 @@ void fem(py::module& m)
       "make_ufc_finite_element",
       [](std::uintptr_t e) {
         ufc_finite_element* p = reinterpret_cast<ufc_finite_element*>(e);
-        return std::shared_ptr<const ufc_finite_element>(p);
+        return *p;
       },
       "Create a ufc_finite_element object from a pointer.");
 
@@ -97,7 +97,7 @@ void fem(py::module& m)
       "make_ufc_dofmap",
       [](std::uintptr_t e) {
         ufc_dofmap* p = reinterpret_cast<ufc_dofmap*>(e);
-        return std::shared_ptr<const ufc_dofmap>(p);
+        return *p;
       },
       "Create a ufc_dofmap object from a pointer.");
 
@@ -105,7 +105,7 @@ void fem(py::module& m)
       "make_ufc_form",
       [](std::uintptr_t e) {
         ufc_form* p = reinterpret_cast<ufc_form*>(e);
-        return std::shared_ptr<const ufc_form>(p);
+        return *p;
       },
       "Create a ufc_form object from a pointer.");
 

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -73,10 +73,6 @@ namespace dolfinx_wrappers
 {
 void fem(py::module& m)
 {
-
-  py::class_<ufc_coordinate_mapping, std::shared_ptr<ufc_coordinate_mapping>>(
-      m, "ufc_coordinate_mapping", "UFC coordinate_mapping object");
-
   // utils
   m.def("block_function_spaces",
         [](const std::vector<std::vector<const dolfinx::fem::Form*>>& a) {


### PR DESCRIPTION
An attempt to fix #966

**Update 1:**
Helpers `make_ufc_foo` now removed, pybind11 layer takes `uintptr_t`, dereferences and calls C++ helpers directly with ufc objects.

--- 

This fix changes `make_ufc_foo` to return from `uintptr_t` an actual `ufc_foo` object.

This has the advantage in lifetime management, because anyone calling `make_ufc_foo` makes a copy of an actual ufc object pointed to. It defaults to pybind11 `return_value_policy::copy` so new returned object has lifetime now managed on Python side, while the "old" cdata structure returned directly by FFCx JIT is usually garbage collected (we do not store a reference to it, e.g. in form.py).