### PR TITLE
Predicates cleanup

### DIFF
--- a/cpp/dolfinx/geometry/predicates.cpp
+++ b/cpp/dolfinx/geometry/predicates.cpp
@@ -1,4 +1,9 @@
 #include "predicates.h"
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <sys/time.h>
+
 namespace dolfinx::geometry{
 //-----------------------------------------------------------------------------
 double orient1d(double a, double b, double x)
@@ -125,11 +130,6 @@ double orient3d(const Eigen::Vector3d& a,
 /*    have questions.                                                        */
 /*                                                                           */
 /*****************************************************************************/
-
-#include <cmath>
-#include <cstdio>
-#include <cstdlib>
-#include <sys/time.h>
 
 /* On some machines, the exact arithmetic routines might be defeated by the  */
 /*   use of internal extended precision floating-point registers.  Sometimes */

--- a/cpp/dolfinx/geometry/predicates.cpp
+++ b/cpp/dolfinx/geometry/predicates.cpp
@@ -29,7 +29,7 @@ double orient3d(const Eigen::Vector3d& a,
 {
   return _orient3d(a.data(), b.data(), c.data(), d.data());
 }
-
+} // namespace dolfinx::geometry
 //-----------------------------------------------------------------------------
 
 /*****************************************************************************/
@@ -716,7 +716,7 @@ REAL orient2dadapt(const REAL* pa, const REAL* pb, const REAL* pc,
 
   return (D[Dlength - 1]);
 }
-
+namespace dolfinx::geometry {
 double _orient2d(const double* pa, const double* pb,
                                     const double* pc)
 /* REAL *pa; */
@@ -765,6 +765,8 @@ double _orient2d(const double* pa, const double* pb,
 
   return orient2dadapt(pa, pb, pc, detsum);
 }
+} // namespace dolfinx::geometry
+
 
 /*****************************************************************************/
 /*                                                                           */
@@ -1296,7 +1298,7 @@ REAL orient3dadapt(const REAL* pa, const REAL* pb, const REAL* pc,
 
   return finnow[finlength - 1];
 }
-
+namespace dolfinx::geometry{
 double _orient3d(const double* pa, const double* pb,
                                     const double* pc, const double* pd)
 /* REAL *pa; */

--- a/cpp/dolfinx/geometry/predicates.cpp
+++ b/cpp/dolfinx/geometry/predicates.cpp
@@ -394,7 +394,7 @@ REAL *e;
 /*  Don't change this routine unless you fully understand it.                */
 /*                                                                           */
 /*****************************************************************************/
-
+namespace dolfinx::geometry {
 void exactinit()
 {
   REAL half;
@@ -432,7 +432,7 @@ void exactinit()
   o3derrboundB = (3.0 + 28.0 * epsilon) * epsilon;
   o3derrboundC = (26.0 + 288.0 * epsilon) * epsilon * epsilon;
 }
-
+} // dolfinx::geometry
 
 /*****************************************************************************/
 /*                                                                           */


### PR DESCRIPTION
This is an initial start of trying to make sense of collision detection in dolfinx.

I have removed all the code that I can see that is unused. 
Please let me know if things should be done differently (for instance not wrapping all function in the dolfinx::geometry namespace), or if there are any functions there are worth keeping as of now. To me, this code is just a massive mess, and it would be good to remove ~1300 lines.

We could also think about moving to a newer version of the code like: https://github.com/danshapero/predicates.
For reference, the orignal code can be found at: http://www.cs.cmu.edu/~quake/robust.html