### PR TITLE
Avoid unintended copy

### DIFF
--- a/cpp/dolfinx/fem/DirichletBC.cpp
+++ b/cpp/dolfinx/fem/DirichletBC.cpp
@@ -311,35 +311,35 @@ _locate_dofs_topological(const function::FunctionSpace& V, const int entity_dim,
                          bool remote)
 {
   assert(V.dofmap());
-  const DofMap& dofmap = *V.dofmap();
+  std::shared_ptr<const DofMap> dofmap = V.dofmap();
   assert(V.mesh());
-  mesh::Mesh mesh = *V.mesh();
+  std::shared_ptr<const mesh::Mesh> mesh = V.mesh();
 
-  const int tdim = mesh.topology().dim();
+  const int tdim = mesh->topology().dim();
 
   // Initialise entity-cell connectivity
   // FIXME: cleanup these calls? Some of the happen internally again.
-  mesh.topology_mutable().create_entities(tdim);
-  mesh.topology_mutable().create_connectivity(entity_dim, tdim);
+  mesh->topology_mutable().create_entities(tdim);
+  mesh->topology_mutable().create_connectivity(entity_dim, tdim);
 
   // Prepare an element - local dof layout for dofs on entities of the
   // entity_dim
   const int num_cell_entities
-      = mesh::cell_num_entities(mesh.topology().cell_type(), entity_dim);
+      = mesh::cell_num_entities(mesh->topology().cell_type(), entity_dim);
   std::vector<Eigen::Array<int, Eigen::Dynamic, 1>> entity_dofs;
   for (int i = 0; i < num_cell_entities; ++i)
   {
     entity_dofs.push_back(
-        dofmap.element_dof_layout->entity_closure_dofs(entity_dim, i));
+        dofmap->element_dof_layout->entity_closure_dofs(entity_dim, i));
   }
 
-  auto e_to_c = mesh.topology().connectivity(entity_dim, tdim);
+  auto e_to_c = mesh->topology().connectivity(entity_dim, tdim);
   assert(e_to_c);
-  auto c_to_e = mesh.topology().connectivity(tdim, entity_dim);
+  auto c_to_e = mesh->topology().connectivity(tdim, entity_dim);
   assert(c_to_e);
 
   const int num_entity_closure_dofs
-      = dofmap.element_dof_layout->num_entity_closure_dofs(entity_dim);
+      = dofmap->element_dof_layout->num_entity_closure_dofs(entity_dim);
   std::vector<std::int32_t> dofs;
   for (Eigen::Index i = 0; i < entities.rows(); ++i)
   {
@@ -355,7 +355,7 @@ _locate_dofs_topological(const function::FunctionSpace& V, const int entity_dim,
     const int entity_local_index = std::distance(entities_d.data(), it);
 
     // Get cell dofmap
-    auto cell_dofs = dofmap.cell_dofs(cell);
+    auto cell_dofs = dofmap->cell_dofs(cell);
 
     // Loop over entity dofs
     for (int j = 0; j < num_entity_closure_dofs; j++)

--- a/cpp/dolfinx/mesh/Geometry.cpp
+++ b/cpp/dolfinx/mesh/Geometry.cpp
@@ -17,6 +17,12 @@ using namespace dolfinx;
 using namespace dolfinx::mesh;
 
 //-----------------------------------------------------------------------------
+Geometry Geometry::copy() const { return Geometry{*this}; }
+//-----------------------------------------------------------------------------
+Geometry& Geometry::copy_assign(const Geometry& other) {
+  return *this = other;
+}
+//-----------------------------------------------------------------------------
 int Geometry::dim() const { return _dim; }
 //-----------------------------------------------------------------------------
 const graph::AdjacencyList<std::int32_t>& Geometry::dofmap() const

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -64,7 +64,7 @@ public:
   }
 
   /// Copy constructor
-  Geometry(const Geometry&) = default;
+  Geometry(const Geometry&) = delete;
 
   /// Move constructor
   Geometry(Geometry&&) = default;

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -63,20 +63,29 @@ public:
     }
   }
 
-  /// Copy constructor
-  Geometry(const Geometry&) = delete;
-
   /// Move constructor
   Geometry(Geometry&&) = default;
 
   /// Destructor
   ~Geometry() = default;
 
-  /// Copy Assignment
-  Geometry& operator=(const Geometry&) = delete;
-
   /// Move Assignment
   Geometry& operator=(Geometry&&) = default;
+
+private:
+  /// Copy constructor: set private to avoid unintended copies. Use
+  /// Geometry::copy() instead.
+  Geometry(const Geometry&) = default;
+
+  /// Copy Assignment: set private to avoid unintended copies. Use
+  /// Geometry::copy_assign(const Geometry& other) instead.
+  Geometry& operator=(const Geometry&) = default;
+public:
+  /// Create a copy
+  Geometry copy() const;
+
+  /// Explicit copy assignment
+  Geometry& copy_assign(const Geometry& other);
 
   /// Return Euclidean dimension of coordinate system
   int dim() const;

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -134,6 +134,21 @@ Mesh::Mesh(
   // Do nothing
 }
 //-----------------------------------------------------------------------------
+Mesh::Mesh(const Mesh& other) : _topology{other._topology.copy()}, _geometry{other._geometry.copy()},
+                          _mpi_comm{other._mpi_comm} {}
+//-----------------------------------------------------------------------------
+Mesh& Mesh::operator=(const Mesh& other) {
+  Mesh tmp{other};
+  std::swap(*this, tmp);
+  return *this;
+}
+//-----------------------------------------------------------------------------
+Mesh Mesh::copy() const { return Mesh{*this}; }
+//-----------------------------------------------------------------------------
+Mesh& Mesh::copy_assign(const Mesh& other) {
+  return *this = other;
+}
+//-----------------------------------------------------------------------------
 Topology& Mesh::topology() { return _topology; }
 //-----------------------------------------------------------------------------
 const Topology& Mesh::topology() const { return _topology; }

--- a/cpp/dolfinx/mesh/Mesh.h
+++ b/cpp/dolfinx/mesh/Mesh.h
@@ -90,7 +90,7 @@ public:
 
   /// Copy constructor
   /// @param[in] mesh Mesh to be copied
-  Mesh(const Mesh& mesh) = default;
+  Mesh(const Mesh& mesh) = delete;
 
   /// Move constructor
   /// @param mesh Mesh to be moved.

--- a/cpp/dolfinx/mesh/Mesh.h
+++ b/cpp/dolfinx/mesh/Mesh.h
@@ -88,10 +88,6 @@ public:
       const std::vector<std::int64_t>& global_cell_indices,
       const GhostMode ghost_mode, std::int32_t num_ghost_cells = 0);
 
-  /// Copy constructor
-  /// @param[in] mesh Mesh to be copied
-  Mesh(const Mesh& mesh) = delete;
-
   /// Move constructor
   /// @param mesh Mesh to be moved.
   Mesh(Mesh&& mesh) = default;
@@ -99,12 +95,25 @@ public:
   /// Destructor
   ~Mesh() = default;
 
-  // Assignment operator
-  Mesh& operator=(const Mesh& mesh) = delete;
-
   /// Assignment move operator
   /// @param mesh Another Mesh object
   Mesh& operator=(Mesh&& mesh) = default;
+
+private:
+  /// Copy constructor: set private to avoid unnecessary copies.
+  /// Use Mesh::copy() instead.
+  /// @param[in] mesh Mesh to be copied
+  Mesh(const Mesh& mesh);
+
+  /// Assignment operator: set private to avoid unnecessary copies.
+  /// Use Mesh::copy_assign(const Mesh& mesh) instead.
+  Mesh& operator=(const Mesh& mesh);
+public:
+  /// Create a copy
+  Mesh copy() const;
+
+  /// Explicit copy assignment
+  Mesh& copy_assign(const Mesh& other);
 
   // TODO: Is there any use for this? In many situations one has to get the
   // topology of a const Mesh, which is done by Mesh::topology_mutable. Note

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -176,6 +176,18 @@ std::vector<bool> mesh::compute_interior_facets(const Topology& topology)
   return interior_facet;
 }
 //-----------------------------------------------------------------------------
+Topology Topology::copy() const { return Topology{*this}; }
+//-----------------------------------------------------------------------------
+Topology& Topology::operator=(const Topology& other) {
+  Topology tmp{other};
+  std::swap(*this, tmp);
+  return *this;
+}
+//-----------------------------------------------------------------------------
+Topology& Topology::copy_assign(const Topology& other) {
+  return *this = other;
+}
+//-----------------------------------------------------------------------------
 int Topology::dim() const { return _connectivity.rows() - 1; }
 //-----------------------------------------------------------------------------
 void Topology::set_index_map(int dim,

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -67,7 +67,7 @@ public:
   }
 
   /// Copy constructor
-  Topology(const Topology& topology) = default;
+  Topology(const Topology& topology) = delete;
 
   /// Move constructor
   Topology(Topology&& topology) = default;

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -66,9 +66,6 @@ public:
     // Do nothing
   }
 
-  /// Copy constructor
-  Topology(const Topology& topology) = delete;
-
   /// Move constructor
   Topology(Topology&& topology) = default;
 
@@ -76,10 +73,23 @@ public:
   ~Topology() = default;
 
   /// Assignment
-  Topology& operator=(const Topology& topology) = delete;
-
-  /// Assignment
   Topology& operator=(Topology&& topology) = default;
+
+private:
+  /// Copy constructor: set private to avoid unintended copies.
+  /// Use Topology::copy() instead
+  Topology(const Topology& topology) = default;
+
+  /// Assignment: set private to avoid unintended copies
+  /// Use Topology::copy_assign(const Topology& other) instead.
+  Topology& operator=(const Topology& topology);
+
+public:
+  /// Create a copy
+  Topology copy() const;
+
+  /// Explicit copy assignment
+  Topology& copy_assign(const Topology& other);
 
   /// Return topological dimension
   int dim() const;
@@ -181,7 +191,6 @@ public:
   MPI_Comm mpi_comm() const;
 
 private:
-
   // MPI communicator
   dolfinx::MPI::Comm _mpi_comm;
 

--- a/cpp/dolfinx/refinement/ParallelRefinement.cpp
+++ b/cpp/dolfinx/refinement/ParallelRefinement.cpp
@@ -447,7 +447,7 @@ ParallelRefinement::partition(const std::vector<std::int64_t>& cell_topology,
     topology.set_connectivity(_cells_d, tdim, 0);
   }
 
-  const mesh::Geometry geometry
+  mesh::Geometry geometry
       = mesh::create_geometry(comm, topology, _mesh.geometry().cmap(), my_cells,
                               _new_vertex_coordinates);
 

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -94,6 +94,7 @@ void mesh(py::module& m)
                     const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
                                        Eigen::RowMajor>&,
                     const std::vector<std::int64_t>&>())
+      .def("copy", &dolfinx::mesh::Geometry::copy)
       .def_property_readonly("dim", &dolfinx::mesh::Geometry::dim,
                              "Geometric dimension")
       .def_property_readonly("dofmap", &dolfinx::mesh::Geometry::dofmap)
@@ -130,6 +131,7 @@ void mesh(py::module& m)
                        const dolfinx::mesh::CellType cell_type) {
         return std::make_unique<dolfinx::mesh::Topology>(comm.get(), cell_type);
       }))
+      .def("copy", &dolfinx::mesh::Topology::copy)
       .def("set_connectivity", &dolfinx::mesh::Topology::set_connectivity)
       .def("set_index_map", &dolfinx::mesh::Topology::set_index_map)
       .def("set_interior_facets", &dolfinx::mesh::Topology::set_interior_facets)
@@ -166,8 +168,8 @@ void mesh(py::module& m)
       .def(py::init([](const MPICommWrapper comm,
                        const dolfinx::mesh::Topology& topology,
                        dolfinx::mesh::Geometry& geometry) {
-        return std::make_unique<dolfinx::mesh::Mesh>(comm.get(), topology,
-                                                     geometry);
+        return std::make_unique<dolfinx::mesh::Mesh>(comm.get(), topology.copy(),
+                                                     geometry.copy());
       }))
       .def(py::init(
           [](const MPICommWrapper comm, dolfinx::mesh::CellType type,
@@ -184,6 +186,7 @@ void mesh(py::module& m)
                 comm.get(), type, geometry, topology, element,
                 global_cell_indices, ghost_mode);
           }))
+      .def("copy", &dolfinx::mesh::Mesh::copy)
       .def_property_readonly(
           "geometry", py::overload_cast<>(&dolfinx::mesh::Mesh::geometry),
           "Mesh geometry")


### PR DESCRIPTION
Mesh, Topology and Geometry have copy construction but no copy assignment. I propose to also "delete" the copy constructors, which are probably anyway not supposed to be called. Deleting them revealed possible unintended copies. The first commit of this PR deals with the unintended copies, the second with the deletion of constructors. I chose that order because I do not know whether copy construction is totally unwanted. Note however, that I did not find any intended copy in the code.