### PR TITLE
Avoid copy in `create-vector`

### DIFF
--- a/cpp/dolfinx/function/Function.cpp
+++ b/cpp/dolfinx/function/Function.cpp
@@ -37,8 +37,8 @@ la::PETScVector create_vector(const function::FunctionSpace& V)
   common::Timer timer("Init dof vector");
 
   // Get dof map
-  assert(V.dofmap());
   std::shared_ptr<const fem::DofMap> dofmap = V.dofmap();
+  assert(dofmap);
 
   // Check that function space is not a subspace (view)
   assert(dofmap->element_dof_layout);

--- a/cpp/dolfinx/function/Function.cpp
+++ b/cpp/dolfinx/function/Function.cpp
@@ -38,11 +38,11 @@ la::PETScVector create_vector(const function::FunctionSpace& V)
 
   // Get dof map
   assert(V.dofmap());
-  const fem::DofMap& dofmap = *(V.dofmap());
+  std::shared_ptr<const fem::DofMap> dofmap = V.dofmap();
 
   // Check that function space is not a subspace (view)
-  assert(dofmap.element_dof_layout);
-  if (dofmap.element_dof_layout->is_view())
+  assert(dofmap->element_dof_layout);
+  if (dofmap->element_dof_layout->is_view())
   {
     throw std::runtime_error(
         "Cannot initialize vector of degrees of freedom for "
@@ -50,8 +50,8 @@ la::PETScVector create_vector(const function::FunctionSpace& V)
         "collapsing the function space");
   }
 
-  assert(dofmap.index_map);
-  la::PETScVector v = la::PETScVector(*dofmap.index_map);
+  assert(dofmap->index_map);
+  la::PETScVector v = la::PETScVector(*(dofmap->index_map));
   la::VecWrapper _v(v.vec());
   _v.x.setZero();
 


### PR DESCRIPTION
Here is a probably unintended copy of DofMap in create_vector (admittedly, that the getters returning shared_ptr are a tricky copy trap...). Also, I suppose that the "heavy" data member of DofMap, `_dofmap` could be turned into a shared_ptr<const>, which would make copies cheap.