### PR TITLE
enable importing cffi_support from new or old numba versions

### DIFF
--- a/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
+++ b/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
@@ -12,7 +12,10 @@
 import os
 
 import numba
-import numba.core.typing.cffi_utils as cffi_support
+try:
+    import numba.core.typing.cffi_utils as cffi_support
+except ModuleNotFoundError: # numba 0.48 or earlier
+    from numba import cffi_support
 import numpy
 
 import cffi

--- a/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
+++ b/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
@@ -14,7 +14,7 @@ import os
 import numba
 try:
     import numba.core.typing.cffi_utils as cffi_support
-except ModuleNotFoundError: # numba 0.48 or earlier
+except ModuleNotFoundError:  # numba 0.48 or earlier
     from numba import cffi_support
 import numpy
 

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -14,7 +14,10 @@ import pathlib
 import time
 
 import numba
-import numba.core.typing.cffi_utils as cffi_support
+try:
+    import numba.core.typing.cffi_utils as cffi_support
+except ModuleNotFoundError: # numba 0.48 or earlier
+    from numba import cffi_support
 import numpy as np
 
 import cffi

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -16,7 +16,7 @@ import time
 import numba
 try:
     import numba.core.typing.cffi_utils as cffi_support
-except ModuleNotFoundError: # numba 0.48 or earlier
+except ModuleNotFoundError:  # numba 0.48 or earlier
     from numba import cffi_support
 import numpy as np
 


### PR DESCRIPTION
The latest numba 0.49 moved cffi_support to numba.core.typing.cffi_utils

Previously it was located at numba.cffi_support.

This patch enables tests and demos to work with both old and new
versions of numba.