### PR TITLE
Do not use "new" for singleton, since the destructor will never be called

### DIFF
--- a/cpp/dolfinx/common/TimeLogManager.cpp
+++ b/cpp/dolfinx/common/TimeLogManager.cpp
@@ -6,14 +6,12 @@
 
 #include "TimeLogManager.h"
 
-// Initialise static data
-// FIXME : Logger singleton is initialised here on the first call to logger()
-// to avoid "static initialisation order fiasco". Logger's destructor
-// may therefore never be called.
+// Initialise static data to avoid "static initialisation order fiasco".
+// See also Meyers' singleton.
 
 dolfinx::common::TimeLogger& dolfinx::common::TimeLogManager::logger()
 {
   // NB static - this only allocates a new Logger on the first call to logger()
-  static auto* lg = new (dolfinx::common::TimeLogger);
-  return *lg;
+  static dolfinx::common::TimeLogger lg{};
+  return lg;
 }

--- a/cpp/dolfinx/common/TimeLogger.h
+++ b/cpp/dolfinx/common/TimeLogger.h
@@ -28,6 +28,12 @@ public:
   /// Constructor
   TimeLogger() = default;
 
+  // This class is used as a singleton and thus should not allow copies.
+  TimeLogger(const TimeLogger&) = delete;
+
+  // This class is used as a singleton and thus should not allow copies.
+  TimeLogger& operator=(const TimeLogger&) = delete;
+
   /// Destructor
   ~TimeLogger() = default;
 


### PR DESCRIPTION
Bring the implementation close to the canonical "Meyers'" singleton.