### PR TITLE
Fix bc lifting on ghosted mesh

### DIFF
--- a/cpp/dolfinx/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfinx/fem/assemble_vector_impl.cpp
@@ -225,7 +225,7 @@ void _lift_bc_exterior_facets(
   // Only need to consider shared facets when there are no ghost cells
   if (topology.index_map(tdim)->num_ghosts() == 0)
   {
-    fwd_shared_facets = std::set<std::int32_t>(
+    fwd_shared_facets.insert(
         topology.index_map(tdim - 1)->forward_indices().begin(),
         topology.index_map(tdim - 1)->forward_indices().end());
   }

--- a/cpp/dolfinx/fem/assemble_vector_impl.cpp
+++ b/cpp/dolfinx/fem/assemble_vector_impl.cpp
@@ -90,7 +90,7 @@ void _lift_bc_cells(
   const int tdim = mesh->topology().dim();
   auto map = mesh->topology().index_map(tdim);
   assert(map);
-  const int num_cells = map->size_local() + map->num_ghosts();
+  const int num_cells = map->size_local();
   for (int c = 0; c < num_cells; ++c)
   {
     // Get dof maps for cell

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -38,7 +38,7 @@ def nest_matrix_norm(A):
 
 @pytest.mark.parametrize("mode", [dolfinx.cpp.mesh.GhostMode.none, dolfinx.cpp.mesh.GhostMode.shared_facet])
 def test_assemble_functional_dx(mode):
-    mesh =UnitSquareMesh(MPI.COMM_WORLD, 12, 12, ghost_mode=mode)
+    mesh = UnitSquareMesh(MPI.COMM_WORLD, 12, 12, ghost_mode=mode)
     M = 1.0 * dx(domain=mesh)
     value = dolfinx.fem.assemble_scalar(M)
     value = mesh.mpi_comm().allreduce(value, op=MPI.SUM)
@@ -52,7 +52,7 @@ def test_assemble_functional_dx(mode):
 
 @pytest.mark.parametrize("mode", [dolfinx.cpp.mesh.GhostMode.none, dolfinx.cpp.mesh.GhostMode.shared_facet])
 def test_assemble_functional_ds(mode):
-    mesh =UnitSquareMesh(MPI.COMM_WORLD, 12, 12, ghost_mode=mode)
+    mesh = UnitSquareMesh(MPI.COMM_WORLD, 12, 12, ghost_mode=mode)
     M = 1.0 * ds(domain=mesh)
     value = dolfinx.fem.assemble_scalar(M)
     value = mesh.mpi_comm().allreduce(value, op=MPI.SUM)

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -36,12 +36,9 @@ def nest_matrix_norm(A):
     return math.sqrt(norm)
 
 
-@pytest.mark.parametrize('mesh', [UnitSquareMesh(MPI.COMM_WORLD, 12, 12),
-                                  UnitSquareMesh(MPI.COMM_WORLD, 12, 12,
-                                                 dolfinx.cpp.mesh.CellType.triangle,
-                                                 dolfinx.cpp.mesh.GhostMode.shared_facet)
-                                  ])
-def test_assemble_functional_dx(mesh):
+@pytest.mark.parametrize("mode", [dolfinx.cpp.mesh.GhostMode.none, dolfinx.cpp.mesh.GhostMode.shared_facet])
+def test_assemble_functional_dx(mode):
+    mesh =UnitSquareMesh(MPI.COMM_WORLD, 12, 12, ghost_mode=mode)
     M = 1.0 * dx(domain=mesh)
     value = dolfinx.fem.assemble_scalar(M)
     value = mesh.mpi_comm().allreduce(value, op=MPI.SUM)
@@ -53,12 +50,9 @@ def test_assemble_functional_dx(mesh):
     assert value == pytest.approx(0.5, 1e-12)
 
 
-@pytest.mark.parametrize('mesh', [UnitSquareMesh(MPI.COMM_WORLD, 12, 12),
-                                  UnitSquareMesh(MPI.COMM_WORLD, 12, 12,
-                                                 dolfinx.cpp.mesh.CellType.triangle,
-                                                 dolfinx.cpp.mesh.GhostMode.shared_facet)
-                                  ])
-def test_assemble_functional_ds(mesh):
+@pytest.mark.parametrize("mode", [dolfinx.cpp.mesh.GhostMode.none, dolfinx.cpp.mesh.GhostMode.shared_facet])
+def test_assemble_functional_ds(mode):
+    mesh =UnitSquareMesh(MPI.COMM_WORLD, 12, 12, ghost_mode=mode)
     M = 1.0 * ds(domain=mesh)
     value = dolfinx.fem.assemble_scalar(M)
     value = mesh.mpi_comm().allreduce(value, op=MPI.SUM)
@@ -123,8 +117,9 @@ def test_eigen_assembly():
     assert numpy.isclose(A1.norm(), scipy.sparse.linalg.norm(A2))
 
 
-def test_basic_assembly():
-    mesh = UnitSquareMesh(MPI.COMM_WORLD, 12, 12)
+@pytest.mark.parametrize("mode", [dolfinx.cpp.mesh.GhostMode.none, dolfinx.cpp.mesh.GhostMode.shared_facet])
+def test_basic_assembly(mode):
+    mesh = UnitSquareMesh(MPI.COMM_WORLD, 12, 12, ghost_mode=mode)
     V = dolfinx.FunctionSpace(mesh, ("Lagrange", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
 
@@ -170,8 +165,9 @@ def test_basic_assembly():
     assert 2.0 * normA == pytest.approx(A.norm())
 
 
-def test_assembly_bcs():
-    mesh = UnitSquareMesh(MPI.COMM_WORLD, 12, 12)
+@pytest.mark.parametrize("mode", [dolfinx.cpp.mesh.GhostMode.none, dolfinx.cpp.mesh.GhostMode.shared_facet])
+def test_assembly_bcs(mode):
+    mesh = UnitSquareMesh(MPI.COMM_WORLD, 12, 12, ghost_mode=mode)
     V = dolfinx.FunctionSpace(mesh, ("Lagrange", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = inner(u, v) * dx + inner(u, v) * ds


### PR DESCRIPTION
Fixes loop range for lifting on ghosted meshes, and enable more tests with ghosting.

Fixes some issues in #1003.