### PR TITLE
IndexMap: Remove _all_ranges and MPI_Allgather calls

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -334,7 +334,7 @@ IndexMap::IndexMap(
 //-----------------------------------------------------------------------------
 std::array<std::int64_t, 2> IndexMap::local_range() const
 {
-  return {{_local_range[0], _local_range[1]}};
+  return _local_range;
 }
 //-----------------------------------------------------------------------------
 int IndexMap::block_size() const { return _block_size; }

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -310,7 +310,7 @@ IndexMap::IndexMap(
     _ghost_owners[j] = np;
 
     // Local on owning process
-    out_indices[disp[np]] = _ghosts[j] - _local_range[0];
+    out_indices[disp[np]] = _ghosts[j];
     disp[np] += 1;
   }
 
@@ -322,6 +322,8 @@ IndexMap::IndexMap(
       in_edges_num.data(), disp_in.data(), MPI_INT, neighbour_comm);
 
   _forward_indices = std::move(indices_in);
+  for (auto& value : _forward_indices)
+    value -= offset;
   _forward_sizes = std::move(in_edges_num);
 
   MPI_Comm_free(&neighbour_comm);

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -213,21 +213,21 @@ IndexMap::IndexMap(
     MPI_Comm mpi_comm, std::int32_t local_size,
     const Eigen::Ref<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>&
         ghosts,
-    int block_size, std::vector<int> ghost_owner_global1)
+    int block_size, std::vector<int> ghost_owner_global)
     : _block_size(block_size), _mpi_comm(mpi_comm),
       _myrank(MPI::rank(mpi_comm)), _ghosts(ghosts),
       _ghost_owners(ghosts.size())
 {
 
+  assert(size_t(ghosts.size()) == ghost_owner_global.size());
+
   int mpi_size = -1;
   MPI_Comm_size(_mpi_comm.comm(), &mpi_size);
 
-  // if (ghost_owner_global.empty())
-  auto ghost_owner_global
-      = get_global_ghost_owners(_mpi_comm, local_size, _ghosts);
-
-  if (!ghost_owner_global1.empty())
-    assert(ghost_owner_global1 == ghost_owner_global);
+#ifdef DEBUG
+  assert(ghost_owner_global
+         == get_global_ghost_owners(_mpi_comm, local_size, _ghosts));
+#endif
 
   std::vector<std::int32_t> num_edges_out_per_proc(mpi_size, 0);
   for (int i = 0; i < ghosts.size(); ++i)

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -207,7 +207,7 @@ IndexMap::IndexMap(
     MPI_Comm mpi_comm, std::int32_t local_size,
     const Eigen::Ref<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>&
         ghosts,
-    int block_size, std::vector<int> ghost_owner_global)
+    int block_size, std::vector<int> ghost_owner_global1)
     : _block_size(block_size), _mpi_comm(mpi_comm),
       _myrank(MPI::rank(mpi_comm)), _ghosts(ghosts),
       _ghost_owners(ghosts.size())
@@ -216,9 +216,11 @@ IndexMap::IndexMap(
   int mpi_size = -1;
   MPI_Comm_size(_mpi_comm.comm(), &mpi_size);
 
-  if (ghost_owner_global.empty())
-    ghost_owner_global
-        = get_global_ghost_owners(_mpi_comm, local_size, _ghosts);
+  // if (ghost_owner_global.empty())
+  auto ghost_owner_global = get_global_ghost_owners(_mpi_comm, local_size, _ghosts);
+
+  if (!ghost_owner_global1.empty())
+    assert(ghost_owner_global1 == ghost_owner_global);
 
   std::vector<std::int32_t> num_edges_out_per_proc(mpi_size, 0);
   for (int i = 0; i < ghosts.size(); ++i)

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -199,12 +199,12 @@ common::stack_index_maps(
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 IndexMap::IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
-                   const std::vector<std::int64_t>& ghosts, int block_size,
-                   std::vector<int> ghost_owner_global)
+                   const std::vector<std::int64_t>& ghosts,
+                   std::vector<int> ghost_owner_global, int block_size)
     : IndexMap(mpi_comm, local_size,
                Eigen::Map<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>(
                    ghosts.data(), ghosts.size()),
-               block_size, ghost_owner_global)
+               ghost_owner_global, block_size)
 {
   // Do nothing
 }
@@ -213,7 +213,7 @@ IndexMap::IndexMap(
     MPI_Comm mpi_comm, std::int32_t local_size,
     const Eigen::Ref<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>&
         ghosts,
-    int block_size, std::vector<int> ghost_owner_global)
+    std::vector<int> ghost_owner_global, int block_size)
     : _block_size(block_size), _mpi_comm(mpi_comm),
       _myrank(MPI::rank(mpi_comm)), _ghosts(ghosts),
       _ghost_owners(ghosts.size())

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -161,8 +161,7 @@ public:
   std::int64_t local_to_global(std::int32_t local_index) const
   {
     assert(local_index >= 0);
-    const std::int32_t local_size
-        = static_cast<const int32_t>(_local_range[1] - _local_range[0]);
+    const std::int32_t local_size = (_local_range[1] - _local_range[0]);
     if (local_index < local_size)
     {
       const std::int64_t global_offset = _local_range[0];

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -30,7 +30,8 @@ class IndexMap;
 ///   local offset for each submap in the stacked map, and (2) new
 ///   indices for the ghosts for each submap.
 std::tuple<std::int64_t, std::vector<std::int32_t>,
-           std::vector<std::vector<std::int64_t>>>
+           std::vector<std::vector<std::int64_t>>,
+           std::vector<std::vector<int>>>
 stack_index_maps(
     const std::vector<std::reference_wrapper<const common::IndexMap>>& maps);
 
@@ -283,7 +284,7 @@ private:
   int _block_size;
 
   // Range of indices (global) owned by this process
-  std::array<std::int64_t , 2> _local_range{{0, 0}};
+  std::array<std::int64_t, 2> _local_range{{0, 0}};
 
   // Number indices across communicator
   std::int64_t _size_global;

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -60,6 +60,7 @@ public:
   ///   of owned entries
   /// @param[in] ghosts The global indices of ghost entries
   /// @param[in] block_size The block size of the IndexMap
+  /// @param[in] ghost_owner_global
   IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
            const std::vector<std::int64_t>& ghosts, int block_size,
            std::vector<int> ghost_owner_global = {});
@@ -73,6 +74,7 @@ public:
   ///   of owned entries
   /// @param[in] ghosts The global indices of ghost entries
   /// @param[in] block_size The block size of the IndexMap
+  /// @param[in] ghost_owner_global
   IndexMap(
       MPI_Comm mpi_comm, std::int32_t local_size,
       const Eigen::Ref<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>&

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -61,7 +61,8 @@ public:
   /// @param[in] ghosts The global indices of ghost entries
   /// @param[in] block_size The block size of the IndexMap
   IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
-           const std::vector<std::int64_t>& ghosts, int block_size);
+           const std::vector<std::int64_t>& ghosts, int block_size,
+           std::vector<int> ghost_owner_global = {});
 
   /// Create Index map with local_size owned blocks on this process, and
   /// blocks have size block_size.
@@ -76,7 +77,7 @@ public:
       MPI_Comm mpi_comm, std::int32_t local_size,
       const Eigen::Ref<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>&
           ghosts,
-      int block_size);
+      int block_size, std::vector<int> ghost_owner_global = {});
 
   /// Copy constructor
   IndexMap(const IndexMap& map) = delete;
@@ -279,11 +280,13 @@ public:
 private:
   int _block_size;
 
+  // Range of indices (global) owned by this process
   std::array<std::int64_t , 2> _local_range{{0, 0}};
 
+  // Number indices across communicator
   std::int64_t _size_global;
 
-    // MPI Communicator
+  // MPI Communicator
   dolfinx::MPI::Comm _mpi_comm;
 
   // MPI Communicator for neighbourhood only

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -28,7 +28,8 @@ class IndexMap;
 /// @param[in] maps List of index maps
 /// @returns The (0) global offset of a stacked map for this rank, (1)
 ///   local offset for each submap in the stacked map, and (2) new
-///   indices for the ghosts for each submap.
+///   indices for the ghosts for each submap (3) owner rank of each ghost
+///   entry for each submap
 std::tuple<std::int64_t, std::vector<std::int32_t>,
            std::vector<std::vector<std::int64_t>>,
            std::vector<std::vector<int>>>
@@ -61,10 +62,11 @@ public:
   ///   of owned entries
   /// @param[in] ghosts The global indices of ghost entries
   /// @param[in] block_size The block size of the IndexMap
-  /// @param[in] ghost_owner_global
+  /// @param[in] ghost_ranks Owner rank (on global communicator) of each ghost
+  ///   entry
   IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
            const std::vector<std::int64_t>& ghosts,
-           std::vector<int> ghost_owner_global, int block_size);
+           const std::vector<int>& ghost_ranks, int block_size);
 
   /// Create Index map with local_size owned blocks on this process, and
   /// blocks have size block_size.
@@ -75,12 +77,13 @@ public:
   ///   of owned entries
   /// @param[in] ghosts The global indices of ghost entries
   /// @param[in] block_size The block size of the IndexMap
-  /// @param[in] ghost_owner_global
+  /// @param[in] ghost_ranks Owner rank (on global communicator) of each ghost
+  ///   entry
   IndexMap(
       MPI_Comm mpi_comm, std::int32_t local_size,
       const Eigen::Ref<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>&
           ghosts,
-      std::vector<int> ghost_owner_global, int block_size);
+      const std::vector<int>& ghost_ranks, int block_size);
 
   /// Copy constructor
   IndexMap(const IndexMap& map) = delete;
@@ -284,7 +287,7 @@ private:
   int _block_size;
 
   // Range of indices (global) owned by this process
-  std::array<std::int64_t, 2> _local_range{{0, 0}};
+  std::array<std::int64_t, 2> _local_range;
 
   // Number indices across communicator
   std::int64_t _size_global;

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -63,7 +63,7 @@ public:
   /// @param[in] ghost_owner_global
   IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
            const std::vector<std::int64_t>& ghosts, int block_size,
-           std::vector<int> ghost_owner_global = {});
+           std::vector<int> ghost_owner_global);
 
   /// Create Index map with local_size owned blocks on this process, and
   /// blocks have size block_size.
@@ -79,7 +79,7 @@ public:
       MPI_Comm mpi_comm, std::int32_t local_size,
       const Eigen::Ref<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>&
           ghosts,
-      int block_size, std::vector<int> ghost_owner_global = {});
+      int block_size, std::vector<int> ghost_owner_global);
 
   /// Copy constructor
   IndexMap(const IndexMap& map) = delete;

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -63,8 +63,8 @@ public:
   /// @param[in] block_size The block size of the IndexMap
   /// @param[in] ghost_owner_global
   IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
-           const std::vector<std::int64_t>& ghosts, int block_size,
-           std::vector<int> ghost_owner_global);
+           const std::vector<std::int64_t>& ghosts,
+           std::vector<int> ghost_owner_global, int block_size);
 
   /// Create Index map with local_size owned blocks on this process, and
   /// blocks have size block_size.
@@ -80,7 +80,7 @@ public:
       MPI_Comm mpi_comm, std::int32_t local_size,
       const Eigen::Ref<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>&
           ghosts,
-      int block_size, std::vector<int> ghost_owner_global);
+      std::vector<int> ghost_owner_global, int block_size);
 
   /// Copy constructor
   IndexMap(const IndexMap& map) = delete;

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -108,7 +108,7 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
   // receive new global indices from owner
   std::vector<std::int64_t> global_index_remote
       = dofmap_view.index_map->scatter_fwd(global_index, 1);
-  auto ghost_onwer_old = dofmap_view.index_map->ghost_owners();
+  auto ghost_owner_old = dofmap_view.index_map->ghost_owners();
 
   // Compute ghosts for collapsed dofmap
   Eigen::Array<std::int64_t, Eigen::Dynamic, 1> ghosts(num_unowned);
@@ -119,7 +119,7 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
     const std::int32_t index_old = *it / bs_view - num_owned_view;
     assert(global_index_remote[index_old] >= 0);
     ghosts[index] = global_index_remote[index_old];
-    ghost_owners[index] = ghost_onwer_old[index_old];
+    ghost_owners[index] = ghost_owner_old[index_old];
   }
 
   // Create new index map

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -121,7 +121,8 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
 
   // Create new index map
   auto index_map
-      = std::make_shared<common::IndexMap>(comm, num_owned, ghosts, bs);
+      = std::make_shared<common::IndexMap>(comm, num_owned, ghosts, bs,
+                                           std::vector<int>());
 
   // Create array from dofs in view to new dof indices
   std::vector<std::int32_t> old_to_new(dofs_view.back() + 1, -1);

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -108,21 +108,23 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
   // receive new global indices from owner
   std::vector<std::int64_t> global_index_remote
       = dofmap_view.index_map->scatter_fwd(global_index, 1);
+  auto ghost_onwer_old = dofmap_view.index_map->ghost_owners();
 
   // Compute ghosts for collapsed dofmap
   Eigen::Array<std::int64_t, Eigen::Dynamic, 1> ghosts(num_unowned);
+  std::vector<int> ghost_owners(num_unowned);
   for (auto it = it_unowned0; it != dofs_view.end(); ++it)
   {
     const std::int32_t index = std::distance(it_unowned0, it) / bs;
     const std::int32_t index_old = *it / bs_view - num_owned_view;
     assert(global_index_remote[index_old] >= 0);
     ghosts[index] = global_index_remote[index_old];
+    ghost_owners[index] = ghost_onwer_old[index_old];
   }
 
   // Create new index map
-  auto index_map
-      = std::make_shared<common::IndexMap>(comm, num_owned, ghosts, bs,
-                                           std::vector<int>());
+  auto index_map = std::make_shared<common::IndexMap>(comm, num_owned, ghosts,
+                                                      bs, ghost_owners);
 
   // Create array from dofs in view to new dof indices
   std::vector<std::int32_t> old_to_new(dofs_view.back() + 1, -1);

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -124,7 +124,7 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
 
   // Create new index map
   auto index_map = std::make_shared<common::IndexMap>(comm, num_owned, ghosts,
-                                                      bs, ghost_owners);
+                                                      ghost_owners, bs);
 
   // Create array from dofs in view to new dof indices
   std::vector<std::int32_t> old_to_new(dofs_view.back() + 1, -1);

--- a/cpp/dolfinx/fem/DofMapBuilder.cpp
+++ b/cpp/dolfinx/fem/DofMapBuilder.cpp
@@ -6,6 +6,7 @@
 
 #include "DofMapBuilder.h"
 #include "ElementDofLayout.h"
+#include <algorithm>
 #include <cstdlib>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/MPI.h>
@@ -16,6 +17,7 @@
 #include <dolfinx/graph/BoostGraphOrdering.h>
 #include <dolfinx/graph/SCOTCH.h>
 #include <dolfinx/mesh/Topology.h>
+#include <iterator>
 #include <memory>
 #include <random>
 #include <unordered_map>
@@ -332,7 +334,7 @@ std::pair<std::vector<std::int32_t>, std::int32_t> compute_reordering_map(
 /// @param [in] dof_entity The ith entry gives (topological dim, local
 ///   index) of the mesh entity to which node i (old local index) is
 ///   associated
-std::vector<std::int64_t> get_global_indices(
+std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
     const mesh::Topology& topology, const std::int32_t num_owned,
     const std::int64_t process_offset,
     const std::vector<std::int64_t>& global_indices_old,
@@ -381,6 +383,7 @@ std::vector<std::int64_t> get_global_indices(
   std::vector<MPI_Request> requests(D + 1);
   std::vector<MPI_Comm> comm(D + 1, MPI_COMM_NULL);
   std::vector<std::vector<std::int64_t>> all_dofs_received(D + 1);
+  std::vector<std::vector<int>> recv_offsets(D + 1);
   for (int d = 0; d <= D; ++d)
   {
     // FIXME: This should check which dimension are needed by the dofmap
@@ -407,7 +410,8 @@ std::vector<std::int64_t> get_global_indices(
 
       // Compute displacements for data to receive. Last entry has total
       // number of received items.
-      std::vector<int> disp(num_neighbours + 1, 0);
+      std::vector<int>& disp = recv_offsets[d];
+      disp.resize(num_neighbours + 1);
       std::partial_sum(num_indices_recv.begin(), num_indices_recv.end(),
                        disp.begin() + 1);
 
@@ -438,17 +442,27 @@ std::vector<std::int64_t> get_global_indices(
   }
 
   std::vector<std::int64_t> local_to_global_new(old_to_new.size() - num_owned);
+  std::vector<int> local_to_global_new_owner(old_to_new.size() - num_owned);
   for (std::size_t i = 0; i < requests_dim.size(); ++i)
   {
     int idx, d;
     MPI_Waitany(requests_dim.size(), requests.data(), &idx, MPI_STATUS_IGNORE);
     d = requests_dim[idx];
 
+    auto map = topology.index_map(d);
+    const std::vector<std::int32_t>& neighbours = map->neighbours();
+
     // Build (global old, global new) map for dofs of dimension d
-    std::unordered_map<std::int64_t, std::int64_t> global_old_new;
+    std::unordered_map<std::int64_t, std::pair<int64_t, int>> global_old_new;
     std::vector<std::int64_t>& dofs_received = all_dofs_received[d];
+    std::vector<int>& offsets = recv_offsets[d];
     for (std::size_t j = 0; j < dofs_received.size(); j += 2)
-      global_old_new.insert({dofs_received[j], dofs_received[j + 1]});
+    {
+      const auto pos = std::upper_bound(offsets.begin(), offsets.end(), int(j));
+      const int owner = std::distance(offsets.begin(), pos) - 1;
+      global_old_new.insert(
+          {dofs_received[j], {dofs_received[j + 1], neighbours[owner]}});
+    }
 
     // Build the dimension d part of local_to_global_new vector
     std::vector<std::int64_t>& local_new_to_global_old_d
@@ -457,7 +471,9 @@ std::vector<std::int64_t> get_global_indices(
     {
       auto it = global_old_new.find(local_new_to_global_old_d[i]);
       assert(it != global_old_new.end());
-      local_to_global_new[local_new_to_global_old_d[i + 1]] = it->second;
+      local_to_global_new[local_new_to_global_old_d[i + 1]] = it->second.first;
+      local_to_global_new_owner[local_new_to_global_old_d[i + 1]]
+          = it->second.second;
     }
   }
 
@@ -468,7 +484,7 @@ std::vector<std::int64_t> get_global_indices(
       MPI_Comm_free(&comm[d]);
   }
 
-  return local_to_global_new;
+  return {local_to_global_new, local_to_global_new_owner};
 }
 //-----------------------------------------------------------------------------
 
@@ -537,13 +553,15 @@ DofMapBuilder::build(MPI_Comm comm, const mesh::Topology& topology,
       = dolfinx::MPI::global_offset(comm, num_owned, true);
 
   // Get global indices for unowned dofs
-  const std::vector<std::int64_t> local_to_global_unowned
+  const auto [local_to_global_unowned, local_to_global_owner]
       = get_global_indices(topology, num_owned, process_offset,
                            local_to_global0, old_to_new, dof_entity0);
+  assert(local_to_global_unowned.size() == local_to_global_owner.size());
 
   // Create IndexMap for dofs range on this process
   auto index_map = std::make_unique<common::IndexMap>(
-      comm, num_owned, local_to_global_unowned, block_size, std::vector<int>());
+      comm, num_owned, local_to_global_unowned, block_size,
+      local_to_global_owner);
   assert(index_map);
 
   // FIXME: There is an assumption here on the dof order for an element.

--- a/cpp/dolfinx/fem/DofMapBuilder.cpp
+++ b/cpp/dolfinx/fem/DofMapBuilder.cpp
@@ -560,8 +560,8 @@ DofMapBuilder::build(MPI_Comm comm, const mesh::Topology& topology,
 
   // Create IndexMap for dofs range on this process
   auto index_map = std::make_unique<common::IndexMap>(
-      comm, num_owned, local_to_global_unowned, block_size,
-      local_to_global_owner);
+      comm, num_owned, local_to_global_unowned, local_to_global_owner,
+      block_size);
   assert(index_map);
 
   // FIXME: There is an assumption here on the dof order for an element.

--- a/cpp/dolfinx/fem/DofMapBuilder.cpp
+++ b/cpp/dolfinx/fem/DofMapBuilder.cpp
@@ -543,7 +543,7 @@ DofMapBuilder::build(MPI_Comm comm, const mesh::Topology& topology,
 
   // Create IndexMap for dofs range on this process
   auto index_map = std::make_unique<common::IndexMap>(
-      comm, num_owned, local_to_global_unowned, block_size);
+      comm, num_owned, local_to_global_unowned, block_size, std::vector<int>());
   assert(index_map);
 
   // FIXME: There is an assumption here on the dof order for an element.

--- a/cpp/dolfinx/fem/DofMapBuilder.cpp
+++ b/cpp/dolfinx/fem/DofMapBuilder.cpp
@@ -334,6 +334,8 @@ std::pair<std::vector<std::int32_t>, std::int32_t> compute_reordering_map(
 /// @param [in] dof_entity The ith entry gives (topological dim, local
 ///   index) of the mesh entity to which node i (old local index) is
 ///   associated
+/// @returns The (0) global indices for unowned dofs, (1) onwer rank of each
+///   unowned dof
 std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
     const mesh::Topology& topology, const std::int32_t num_owned,
     const std::int64_t process_offset,

--- a/cpp/dolfinx/fem/DofMapBuilder.cpp
+++ b/cpp/dolfinx/fem/DofMapBuilder.cpp
@@ -458,7 +458,7 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
     std::vector<int>& offsets = recv_offsets[d];
     for (std::size_t j = 0; j < dofs_received.size(); j += 2)
     {
-      const auto pos = std::upper_bound(offsets.begin(), offsets.end(), int(j));
+      const auto pos = std::upper_bound(offsets.begin(), offsets.end(), j);
       const int owner = std::distance(offsets.begin(), pos) - 1;
       global_old_new.insert(
           {dofs_received[j], {dofs_received[j + 1], neighbours[owner]}});

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -271,12 +271,12 @@ la::PETScMatrix fem::create_matrix_block(
       maps[d].push_back(*space->dofmap()->index_map.get());
   }
 
-
   // FIXME: This is computed again inside the SparsityPattern
   // constructor, but we also need to outside to build the PETSc
   // local-to-global map. Compute outside and pass into SparsityPattern
   // constructor.
-  auto [rank_offset, local_offset, ghosts] = common::stack_index_maps(maps[0]);
+  auto [rank_offset, local_offset, ghosts, owner]
+      = common::stack_index_maps(maps[0]);
 
   // Create merged sparsity pattern
   std::vector<std::vector<const la::SparsityPattern*>> p(V[0].size());
@@ -285,7 +285,6 @@ la::PETScMatrix fem::create_matrix_block(
       p[row].push_back(patterns[row][col].get());
   la::SparsityPattern pattern(mesh->mpi_comm(), p, maps);
   pattern.assemble();
-
 
   // FIXME: Add option to pass customised local-to-global map to PETSc
   // Mat constructor.
@@ -373,17 +372,20 @@ la::PETScVector fem::create_vector_block(
 {
   // FIXME: handle constant block size > 1
 
-  auto [rank_offset, local_offset, ghosts_new] = common::stack_index_maps(maps);
+  auto [rank_offset, local_offset, ghosts_new, ghost_new_owners]
+      = common::stack_index_maps(maps);
   std::int32_t local_size = local_offset.back();
   std::vector<std::int64_t> ghosts;
   for (auto& sub_ghost : ghosts_new)
     ghosts.insert(ghosts.end(), sub_ghost.begin(), sub_ghost.end());
 
+  std::vector<int> ghost_owners;
+  for (auto& sub_owner : ghost_new_owners)
+    ghost_owners.insert(ghost_owners.end(), sub_owner.begin(), sub_owner.end());
+
   // Create map for combined problem, and create vector
-  Eigen::Map<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>> _ghosts(
-      ghosts.data(), ghosts.size());
-  common::IndexMap index_map(maps[0].get().mpi_comm(), local_size, _ghosts, 1,
-                             std::vector<int>());
+  common::IndexMap index_map(maps[0].get().mpi_comm(), local_size, ghosts, 1,
+                             ghost_owners);
 
   return la::PETScVector(index_map);
 }

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -384,8 +384,8 @@ la::PETScVector fem::create_vector_block(
     ghost_owners.insert(ghost_owners.end(), sub_owner.begin(), sub_owner.end());
 
   // Create map for combined problem, and create vector
-  common::IndexMap index_map(maps[0].get().mpi_comm(), local_size, ghosts, 1,
-                             ghost_owners);
+  common::IndexMap index_map(maps[0].get().mpi_comm(), local_size, ghosts,
+                             ghost_owners, 1);
 
   return la::PETScVector(index_map);
 }

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -382,7 +382,8 @@ la::PETScVector fem::create_vector_block(
   // Create map for combined problem, and create vector
   Eigen::Map<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>> _ghosts(
       ghosts.data(), ghosts.size());
-  common::IndexMap index_map(maps[0].get().mpi_comm(), local_size, _ghosts, 1);
+  common::IndexMap index_map(maps[0].get().mpi_comm(), local_size, _ghosts, 1,
+                             std::vector<int>());
 
   return la::PETScVector(index_map);
 }

--- a/cpp/dolfinx/graph/Partitioning.cpp
+++ b/cpp/dolfinx/graph/Partitioning.cpp
@@ -397,7 +397,8 @@ Partitioning::create_distributed_adjacency_list(
   const int num_owned_vertices = local_to_local_new.size() - ghosts.size();
   return {graph::AdjacencyList<std::int32_t>(std::move(data_new),
                                              list_local.offsets()),
-          common::IndexMap(comm, num_owned_vertices, ghosts, 1)};
+          common::IndexMap(comm, num_owned_vertices, ghosts, 1,
+                           std::vector<int>())};
 }
 //-----------------------------------------------------------------------------
 std::tuple<graph::AdjacencyList<std::int64_t>, std::vector<int>,

--- a/cpp/dolfinx/graph/Partitioning.cpp
+++ b/cpp/dolfinx/graph/Partitioning.cpp
@@ -407,7 +407,7 @@ Partitioning::create_distributed_adjacency_list(
   const int num_owned_vertices = local_to_local_new.size() - ghosts.size();
   return {graph::AdjacencyList<std::int32_t>(std::move(data_new),
                                              list_local.offsets()),
-          common::IndexMap(comm, num_owned_vertices, ghosts, 1, ghost_owners)};
+          common::IndexMap(comm, num_owned_vertices, ghosts, ghost_owners, 1)};
 }
 //-----------------------------------------------------------------------------
 std::tuple<graph::AdjacencyList<std::int64_t>, std::vector<int>,

--- a/cpp/dolfinx/graph/Partitioning.cpp
+++ b/cpp/dolfinx/graph/Partitioning.cpp
@@ -17,7 +17,8 @@ using namespace dolfinx;
 using namespace dolfinx::graph;
 
 //-----------------------------------------------------------------------------
-std::pair<std::vector<std::int32_t>, std::vector<std::int64_t>>
+std::tuple<std::vector<std::int32_t>, std::vector<std::int64_t>,
+           std::vector<int>>
 Partitioning::reorder_global_indices(
     MPI_Comm comm, const std::vector<std::int64_t>& global_indices,
     const std::vector<bool>& shared_indices)
@@ -318,16 +319,23 @@ Partitioning::reorder_global_indices(
   MPI_Comm_free(&comm_n);
 
   // Unpack received (global old, global new) pairs
-  std::map<std::int64_t, std::int64_t> global_old_new;
+  std::map<std::int64_t, std::pair<std::int64_t, int>> global_old_new;
   for (std::size_t i = 0; i < data_recv_neigh.size(); i += 2)
   {
     if (data_recv_neigh[i + 1] >= 0)
-      global_old_new.insert({data_recv_neigh[i], data_recv_neigh[i + 1]});
+    {
+      const auto pos = std::upper_bound(disp_recv_neigh.begin(),
+                                        disp_recv_neigh.end(), i + 1);
+      const int owner = std::distance(disp_recv_neigh.begin(), pos) - 1;
+      global_old_new.insert(
+          {data_recv_neigh[i], {data_recv_neigh[i + 1], neighbours[owner]}});
+    }
   }
 
   // Build array of ghost indices (indices owned and numbered by another
   // process)
   std::vector<std::int64_t> ghosts;
+  std::vector<int> ghost_owners;
   for (auto it = global_to_local_unowned.begin();
        it != global_to_local_unowned.end(); ++it)
   {
@@ -337,11 +345,13 @@ Partitioning::reorder_global_indices(
       assert(it->second < (int)local_to_local_new.size());
       local_to_original.push_back(it->first);
       local_to_local_new[it->second] = p++;
-      ghosts.push_back(pair->second);
+      ghosts.push_back(pair->second.first);
+      ghost_owners.push_back(pair->second.second);
     }
   }
 
-  return {std::move(local_to_local_new), std::move(ghosts)};
+  return {std::move(local_to_local_new), std::move(ghosts),
+          std::move(ghost_owners)};
 }
 //-----------------------------------------------------------------------------
 std::pair<graph::AdjacencyList<std::int32_t>, std::vector<std::int64_t>>
@@ -385,7 +395,7 @@ Partitioning::create_distributed_adjacency_list(
   common::Timer timer("Create distributed AdjacencyList");
 
   // Compute new local and global indices
-  const auto [local_to_local_new, ghosts]
+  const auto [local_to_local_new, ghosts, ghost_owners]
       = reorder_global_indices(comm, local_to_global_links, shared_links);
 
   const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& data_old
@@ -397,8 +407,7 @@ Partitioning::create_distributed_adjacency_list(
   const int num_owned_vertices = local_to_local_new.size() - ghosts.size();
   return {graph::AdjacencyList<std::int32_t>(std::move(data_new),
                                              list_local.offsets()),
-          common::IndexMap(comm, num_owned_vertices, ghosts, 1,
-                           std::vector<int>())};
+          common::IndexMap(comm, num_owned_vertices, ghosts, 1, ghost_owners)};
 }
 //-----------------------------------------------------------------------------
 std::tuple<graph::AdjacencyList<std::int64_t>, std::vector<int>,
@@ -555,8 +564,8 @@ std::vector<std::int64_t> Partitioning::compute_ghost_indices(
   }
 
   // NB - this assumes a symmetry, i.e. that if one process shares an index
-  // owned by another process, then the same is true vice versa. This assumption
-  // is valid for meshes with cells shared via facet or vertex.
+  // owned by another process, then the same is true vice versa. This
+  // assumption is valid for meshes with cells shared via facet or vertex.
   MPI_Comm neighbour_comm;
   MPI_Dist_graph_create_adjacent(comm, neighbours.size(), neighbours.data(),
                                  MPI_UNWEIGHTED, neighbours.size(),

--- a/cpp/dolfinx/graph/Partitioning.h
+++ b/cpp/dolfinx/graph/Partitioning.h
@@ -46,7 +46,8 @@ public:
   ///   computed from a process scan. Indices [n0, ..., N) are owned by
   ///   a remote process and the ghosts return vector maps [n0, ..., N)
   ///   to global indices.
-  static std::pair<std::vector<std::int32_t>, std::vector<std::int64_t>>
+  static std::tuple<std::vector<std::int32_t>, std::vector<std::int64_t>,
+                    std::vector<int>>
   reorder_global_indices(MPI_Comm comm,
                          const std::vector<std::int64_t>& global_indices,
                          const std::vector<bool>& shared_indices);

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -69,9 +69,9 @@ SparsityPattern::SparsityPattern(
 
   // Create new IndexMaps
   _index_maps[0] = std::make_shared<common::IndexMap>(
-      comm, local_offset0.back(), ghosts0, 1);
+      comm, local_offset0.back(), ghosts0, 1, std::vector<int>());
   _index_maps[1] = std::make_shared<common::IndexMap>(
-      comm, local_offset1.back(), ghosts1, 1);
+      comm, local_offset1.back(), ghosts1, 1, std::vector<int>());
 
   // Size cache arrays
   const std::int32_t size_row = local_offset0.back() + ghosts0.size();

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -77,9 +77,9 @@ SparsityPattern::SparsityPattern(
 
   // Create new IndexMaps
   _index_maps[0] = std::make_shared<common::IndexMap>(
-      comm, local_offset0.back(), ghosts0, 1, ghost_owners0);
+      comm, local_offset0.back(), ghosts0, ghost_owners0, 1);
   _index_maps[1] = std::make_shared<common::IndexMap>(
-      comm, local_offset1.back(), ghosts1, 1, ghost_owners1);
+      comm, local_offset1.back(), ghosts1, ghost_owners1, 1);
 
   // Size cache arrays
   const std::int32_t size_row = local_offset0.back() + ghosts0.size();

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -77,9 +77,9 @@ SparsityPattern::SparsityPattern(
 
   // Create new IndexMaps
   _index_maps[0] = std::make_shared<common::IndexMap>(
-      comm, local_offset0.back(), ghosts0, 1, std::vector<int>());
+      comm, local_offset0.back(), ghosts0, 1, ghost_owners0);
   _index_maps[1] = std::make_shared<common::IndexMap>(
-      comm, local_offset1.back(), ghosts1, 1, std::vector<int>());
+      comm, local_offset1.back(), ghosts1, 1, ghost_owners1);
 
   // Size cache arrays
   const std::int32_t size_row = local_offset0.back() + ghosts0.size();

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -51,9 +51,9 @@ SparsityPattern::SparsityPattern(
   // FIXME: - Add range/bound checks for each block
   //        - Check for compatible block sizes for each block
 
-  auto [rank_offset0, local_offset0, ghosts_new0]
+  auto [rank_offset0, local_offset0, ghosts_new0, onwers0]
       = common::stack_index_maps(maps[0]);
-  auto [rank_offset1, local_offset1, ghosts_new1]
+  auto [rank_offset1, local_offset1, ghosts_new1, onwers1]
       = common::stack_index_maps(maps[1]);
 
   std::vector<std::int64_t> ghosts0;
@@ -66,6 +66,14 @@ SparsityPattern::SparsityPattern(
   }
   for (auto& ghosts : ghosts_new1)
     ghosts1.insert(ghosts1.end(), ghosts.begin(), ghosts.end());
+
+  std::vector<int> ghost_owners0;
+  std::vector<int> ghost_owners1;
+  for (auto& owners : onwers0)
+    ghost_owners0.insert(ghost_owners0.end(), owners.begin(), owners.end());
+
+  for (auto& owners : onwers1)
+    ghost_owners1.insert(ghost_owners1.end(), owners.begin(), owners.end());
 
   // Create new IndexMaps
   _index_maps[0] = std::make_shared<common::IndexMap>(

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -56,8 +56,7 @@ SparsityPattern::SparsityPattern(
   auto [rank_offset1, local_offset1, ghosts_new1, onwers1]
       = common::stack_index_maps(maps[1]);
 
-  std::vector<std::int64_t> ghosts0;
-  std::vector<std::int64_t> ghosts1;
+  std::vector<std::int64_t> ghosts0, ghosts1;
   std::vector<std::int32_t> ghost_offsets0(1, 0);
   for (auto& ghosts : ghosts_new0)
   {
@@ -67,8 +66,7 @@ SparsityPattern::SparsityPattern(
   for (auto& ghosts : ghosts_new1)
     ghosts1.insert(ghosts1.end(), ghosts.begin(), ghosts.end());
 
-  std::vector<int> ghost_owners0;
-  std::vector<int> ghost_owners1;
+  std::vector<int> ghost_owners0, ghost_owners1;
   for (auto& owners : onwers0)
     ghost_owners0.insert(ghost_owners0.end(), owners.begin(), owners.end());
 

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -323,7 +323,8 @@ mesh::create_topology(MPI_Comm comm,
   if (ghost_mode == mesh::GhostMode::none)
   {
     index_map_c = std::make_shared<common::IndexMap>(
-        comm, num_local_cells, std::vector<std::int64_t>(), 1);
+        comm, num_local_cells, std::vector<std::int64_t>(), 1,
+        std::vector<int>());
   }
   else
   {
@@ -332,7 +333,8 @@ mesh::create_topology(MPI_Comm comm,
         = graph::Partitioning::compute_ghost_indices(comm, original_cell_index,
                                                      ghost_owners);
     index_map_c = std::make_shared<common::IndexMap>(comm, num_local_cells,
-                                                     cell_ghost_indices, 1);
+                                                     cell_ghost_indices, 1,
+                                                     ghost_owners);
   }
 
   // Create map from existing global vertex index to local index,

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -323,8 +323,8 @@ mesh::create_topology(MPI_Comm comm,
   if (ghost_mode == mesh::GhostMode::none)
   {
     index_map_c = std::make_shared<common::IndexMap>(
-        comm, num_local_cells, std::vector<std::int64_t>(), 1,
-        std::vector<int>());
+        comm, num_local_cells, std::vector<std::int64_t>(), std::vector<int>(),
+        1);
   }
   else
   {
@@ -333,7 +333,7 @@ mesh::create_topology(MPI_Comm comm,
         = graph::Partitioning::compute_ghost_indices(comm, original_cell_index,
                                                      ghost_owners);
     index_map_c = std::make_shared<common::IndexMap>(
-        comm, num_local_cells, cell_ghost_indices, 1, ghost_owners);
+        comm, num_local_cells, cell_ghost_indices, ghost_owners, 1);
   }
 
   // Create map from existing global vertex index to local index,
@@ -551,7 +551,8 @@ mesh::create_topology(MPI_Comm comm,
   }
 
   // Get global onwers of ghost vertices
-  // TODO: Get vertice owner from cell owner? Can use neighborhood communication?
+  // TODO: Get vertice owner from cell owner? Can use neighborhood
+  // communication?
   int mpi_size = -1;
   MPI_Comm_size(neighbour_comm, &mpi_size);
   std::vector<std::int32_t> local_sizes(mpi_size);
@@ -605,7 +606,7 @@ mesh::create_topology(MPI_Comm comm,
 
   // Vertex IndexMap
   auto index_map_v = std::make_shared<common::IndexMap>(
-      comm, nlocal, ghost_vertices, 1, ghost_vertices_owners);
+      comm, nlocal, ghost_vertices, ghost_vertices_owners, 1);
   topology.set_index_map(0, index_map_v);
   auto c0 = std::make_shared<graph::AdjacencyList<std::int32_t>>(
       index_map_v->size_local() + index_map_v->num_ghosts());

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -582,7 +582,8 @@ mesh::create_topology(MPI_Comm comm,
 
   // Vertex IndexMap
   auto index_map_v
-      = std::make_shared<common::IndexMap>(comm, nlocal, ghost_vertices, 1);
+      = std::make_shared<common::IndexMap>(comm, nlocal, ghost_vertices, 1,
+                                           std::vector<int>());
   topology.set_index_map(0, index_map_v);
   auto c0 = std::make_shared<graph::AdjacencyList<std::int32_t>>(
       index_map_v->size_local() + index_map_v->num_ghosts());

--- a/cpp/dolfinx/mesh/TopologyComputation.cpp
+++ b/cpp/dolfinx/mesh/TopologyComputation.cpp
@@ -357,7 +357,8 @@ get_local_indexing(
   MPI_Comm_free(&neighbour_comm);
 
   std::shared_ptr<common::IndexMap> index_map
-      = std::make_shared<common::IndexMap>(comm, num_local, ghost_indices, 1);
+      = std::make_shared<common::IndexMap>(comm, num_local, ghost_indices, 1,
+                                           std::vector<int>());
 
   // Map from initial numbering to new local indices
   std::vector<std::int32_t> new_entity_index(entity_index.size());

--- a/cpp/dolfinx/mesh/TopologyComputation.cpp
+++ b/cpp/dolfinx/mesh/TopologyComputation.cpp
@@ -336,8 +336,11 @@ get_local_indexing(
         = dolfinx::MPI::neighbor_all_to_all(
             neighbour_comm, send_global_index_offsets, send_global_index_data);
 
-    auto& recv_global_index_data = recv_data.array();
-    auto& recv_offsets = recv_data.offsets();
+    const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>& recv_global_index_data
+        = recv_data.array();
+    const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& recv_offsets
+        = recv_data.offsets();
+
     assert(recv_global_index_data.size() == (int)recv_index.size());
 
     // Map back received indices
@@ -361,9 +364,8 @@ get_local_indexing(
 
   MPI_Comm_free(&neighbour_comm);
 
-  std::shared_ptr<common::IndexMap> index_map
-      = std::make_shared<common::IndexMap>(comm, num_local, ghost_indices,
-                                           ghost_owners, 1);
+  auto index_map = std::make_shared<common::IndexMap>(
+      comm, num_local, ghost_indices, ghost_owners, 1);
 
   // Map from initial numbering to new local indices
   std::vector<std::int32_t> new_entity_index(entity_index.size());

--- a/cpp/dolfinx/mesh/TopologyComputation.cpp
+++ b/cpp/dolfinx/mesh/TopologyComputation.cpp
@@ -363,7 +363,7 @@ get_local_indexing(
 
   std::shared_ptr<common::IndexMap> index_map
       = std::make_shared<common::IndexMap>(comm, num_local, ghost_indices, 1,
-                                           std::vector<int>());
+                                           ghost_owners);
 
   // Map from initial numbering to new local indices
   std::vector<std::int32_t> new_entity_index(entity_index.size());

--- a/cpp/dolfinx/mesh/TopologyComputation.cpp
+++ b/cpp/dolfinx/mesh/TopologyComputation.cpp
@@ -362,8 +362,8 @@ get_local_indexing(
   MPI_Comm_free(&neighbour_comm);
 
   std::shared_ptr<common::IndexMap> index_map
-      = std::make_shared<common::IndexMap>(comm, num_local, ghost_indices, 1,
-                                           ghost_owners);
+      = std::make_shared<common::IndexMap>(comm, num_local, ghost_indices,
+                                           ghost_owners, 1);
 
   // Map from initial numbering to new local indices
   std::vector<std::int32_t> new_entity_index(entity_index.size());

--- a/cpp/dolfinx/mesh/TopologyComputation.cpp
+++ b/cpp/dolfinx/mesh/TopologyComputation.cpp
@@ -306,6 +306,7 @@ get_local_indexing(
 
   //---------
   // Communicate global indices to other processes
+  std::vector<int> ghost_owners(entity_count - num_local, -1);
   std::vector<std::int64_t> ghost_indices(entity_count - num_local, -1);
   {
     const std::int64_t local_offset
@@ -331,12 +332,12 @@ get_local_indexing(
 
       send_global_index_offsets.push_back(send_global_index_data.size());
     }
-
-    const Eigen::Array<std::int64_t, Eigen::Dynamic, 1> recv_global_index_data
+    const graph::AdjacencyList<std::int64_t> recv_data
         = dolfinx::MPI::neighbor_all_to_all(
-              neighbour_comm, send_global_index_offsets, send_global_index_data)
-              .array();
+            neighbour_comm, send_global_index_offsets, send_global_index_data);
 
+    auto& recv_global_index_data = recv_data.array();
+    auto& recv_offsets = recv_data.offsets();
     assert(recv_global_index_data.size() == (int)recv_index.size());
 
     // Map back received indices
@@ -348,6 +349,10 @@ get_local_indexing(
       {
         assert(local_index[idx] >= num_local);
         ghost_indices[local_index[idx] - num_local] = gi;
+        const auto pos = std::upper_bound(
+            recv_offsets.data(), recv_offsets.data() + recv_offsets.rows(), j);
+        const int owner = std::distance(recv_offsets.data(), pos) - 1;
+        ghost_owners[local_index[idx] - num_local] = neighbours[owner];
       }
     }
     for (std::int64_t idx : ghost_indices)

--- a/cpp/dolfinx/refinement/ParallelRefinement.cpp
+++ b/cpp/dolfinx/refinement/ParallelRefinement.cpp
@@ -385,18 +385,17 @@ ParallelRefinement::partition(const std::vector<std::int64_t>& cell_topology,
     // set cell-vertex topology
     mesh::Topology topology_local(comm, _mesh.geometry().cmap().cell_shape());
     const int tdim = topology_local.dim();
-    auto map = std::make_shared<common::IndexMap>(
-        comm, cells_local.num_nodes(), std::vector<std::int64_t>(), 1,
-        std::vector<int>());
+    auto map = std::make_shared<common::IndexMap>(comm, cells_local.num_nodes(),
+                                                  std::vector<std::int64_t>(),
+                                                  std::vector<int>(), 1);
     topology_local.set_index_map(tdim, map);
     auto _cells_local
         = std::make_shared<graph::AdjacencyList<std::int32_t>>(cells_local);
     topology_local.set_connectivity(_cells_local, tdim, 0);
 
     const int n = local_to_global_vertices.size();
-    map = std::make_shared<common::IndexMap>(comm, n,
-                                             std::vector<std::int64_t>(), 1,
-                                             std::vector<int>());
+    map = std::make_shared<common::IndexMap>(
+        comm, n, std::vector<std::int64_t>(), std::vector<int>(), 1);
     topology_local.set_index_map(0, map);
     auto _vertices_local
         = std::make_shared<graph::AdjacencyList<std::int32_t>>(n);
@@ -440,8 +439,8 @@ ParallelRefinement::partition(const std::vector<std::int64_t>& cell_topology,
 
     // Set cell IndexMap and cell-vertex connectivity
     auto index_map_c = std::make_shared<common::IndexMap>(
-        comm, cells_d.num_nodes(), std::vector<std::int64_t>(), 1,
-        std::vector<int>());
+        comm, cells_d.num_nodes(), std::vector<std::int64_t>(),
+        std::vector<int>(), 1);
     topology.set_index_map(tdim, index_map_c);
     auto _cells_d
         = std::make_shared<graph::AdjacencyList<std::int32_t>>(cells_d);

--- a/cpp/dolfinx/refinement/ParallelRefinement.cpp
+++ b/cpp/dolfinx/refinement/ParallelRefinement.cpp
@@ -386,7 +386,8 @@ ParallelRefinement::partition(const std::vector<std::int64_t>& cell_topology,
     mesh::Topology topology_local(comm, _mesh.geometry().cmap().cell_shape());
     const int tdim = topology_local.dim();
     auto map = std::make_shared<common::IndexMap>(
-        comm, cells_local.num_nodes(), std::vector<std::int64_t>(), 1);
+        comm, cells_local.num_nodes(), std::vector<std::int64_t>(), 1,
+        std::vector<int>());
     topology_local.set_index_map(tdim, map);
     auto _cells_local
         = std::make_shared<graph::AdjacencyList<std::int32_t>>(cells_local);
@@ -394,7 +395,8 @@ ParallelRefinement::partition(const std::vector<std::int64_t>& cell_topology,
 
     const int n = local_to_global_vertices.size();
     map = std::make_shared<common::IndexMap>(comm, n,
-                                             std::vector<std::int64_t>(), 1);
+                                             std::vector<std::int64_t>(), 1,
+                                             std::vector<int>());
     topology_local.set_index_map(0, map);
     auto _vertices_local
         = std::make_shared<graph::AdjacencyList<std::int32_t>>(n);
@@ -438,7 +440,8 @@ ParallelRefinement::partition(const std::vector<std::int64_t>& cell_topology,
 
     // Set cell IndexMap and cell-vertex connectivity
     auto index_map_c = std::make_shared<common::IndexMap>(
-        comm, cells_d.num_nodes(), std::vector<std::int64_t>(), 1);
+        comm, cells_d.num_nodes(), std::vector<std::int64_t>(), 1,
+        std::vector<int>());
     topology.set_index_map(tdim, index_map_c);
     auto _cells_d
         = std::make_shared<graph::AdjacencyList<std::int32_t>>(cells_d);

--- a/cpp/test/unit/common/index_map.cpp
+++ b/cpp/test/unit/common/index_map.cpp
@@ -30,9 +30,11 @@ void test_scatter_fwd()
   for (int i = 0; i < num_ghosts; ++i)
     ghosts[i] = (mpi_rank + 1) % mpi_size * size_local + i;
 
+  std::vector<int> global_ghost_owner(ghosts.size(), (mpi_rank + 1) % mpi_size);
+
   // Create an IndexMap
   common::IndexMap idx_map(MPI_COMM_WORLD, size_local, ghosts, 1,
-                           std::vector<int>());
+                           global_ghost_owner);
 
   // Create some data to scatter
   const std::int64_t val = 11;
@@ -62,9 +64,11 @@ void test_scatter_rev()
   for (int i = 0; i < num_ghosts; ++i)
     ghosts[i] = (mpi_rank + 1) % mpi_size * size_local + i;
 
+  std::vector<int> global_ghost_owner(ghosts.size(), (mpi_rank + 1) % mpi_size);
+
   // Create an IndexMap
   common::IndexMap idx_map(MPI_COMM_WORLD, size_local, ghosts, 1,
-                           std::vector<int>());
+                           global_ghost_owner);
 
   // Create some data, setting ghost values
   std::int64_t value = 15;

--- a/cpp/test/unit/common/index_map.cpp
+++ b/cpp/test/unit/common/index_map.cpp
@@ -33,8 +33,8 @@ void test_scatter_fwd()
   std::vector<int> global_ghost_owner(ghosts.size(), (mpi_rank + 1) % mpi_size);
 
   // Create an IndexMap
-  common::IndexMap idx_map(MPI_COMM_WORLD, size_local, ghosts, 1,
-                           global_ghost_owner);
+  common::IndexMap idx_map(MPI_COMM_WORLD, size_local, ghosts,
+                           global_ghost_owner, 1);
 
   // Create some data to scatter
   const std::int64_t val = 11;
@@ -67,8 +67,8 @@ void test_scatter_rev()
   std::vector<int> global_ghost_owner(ghosts.size(), (mpi_rank + 1) % mpi_size);
 
   // Create an IndexMap
-  common::IndexMap idx_map(MPI_COMM_WORLD, size_local, ghosts, 1,
-                           global_ghost_owner);
+  common::IndexMap idx_map(MPI_COMM_WORLD, size_local, ghosts,
+                           global_ghost_owner, 1);
 
   // Create some data, setting ghost values
   std::int64_t value = 15;

--- a/cpp/test/unit/common/index_map.cpp
+++ b/cpp/test/unit/common/index_map.cpp
@@ -31,7 +31,8 @@ void test_scatter_fwd()
     ghosts[i] = (mpi_rank + 1) % mpi_size * size_local + i;
 
   // Create an IndexMap
-  common::IndexMap idx_map(MPI_COMM_WORLD, size_local, ghosts, 1);
+  common::IndexMap idx_map(MPI_COMM_WORLD, size_local, ghosts, 1,
+                           std::vector<int>());
 
   // Create some data to scatter
   const std::int64_t val = 11;
@@ -62,7 +63,8 @@ void test_scatter_rev()
     ghosts[i] = (mpi_rank + 1) % mpi_size * size_local + i;
 
   // Create an IndexMap
-  common::IndexMap idx_map(MPI_COMM_WORLD, size_local, ghosts, 1);
+  common::IndexMap idx_map(MPI_COMM_WORLD, size_local, ghosts, 1,
+                           std::vector<int>());
 
   // Create some data, setting ghost values
   std::int64_t value = 15;

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -50,9 +50,9 @@ void common(py::module& m)
           [](const MPICommWrapper comm, std::int32_t local_size,
              const Eigen::Ref<
                  const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>& ghosts,
-             int block_size, std::vector<int> ghost_owners) {
+             std::vector<int> ghost_owners, int block_size) {
             return std::make_shared<dolfinx::common::IndexMap>(
-                comm.get(), local_size, ghosts, block_size, ghost_owners);
+                comm.get(), local_size, ghosts, ghost_owners, block_size);
           }))
       .def_property_readonly("size_local",
                              &dolfinx::common::IndexMap::size_local)

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -50,9 +50,9 @@ void common(py::module& m)
           [](const MPICommWrapper comm, std::int32_t local_size,
              const Eigen::Ref<
                  const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>& ghosts,
-             int block_size) {
+             int block_size, std::vector<int> ghost_owners) {
             return std::make_shared<dolfinx::common::IndexMap>(
-                comm.get(), local_size, ghosts, block_size);
+                comm.get(), local_size, ghosts, block_size, ghost_owners);
           }))
       .def_property_readonly("size_local",
                              &dolfinx::common::IndexMap::size_local)


### PR DESCRIPTION
- Remove `_all_ranges` completely and also some unnecessary `MPI_Allgather` calls (one per IndexMap construction). For that, I included a vector with the ghost owners to the IndexMap constructor;
- The function `get_global_ghost_owners` is only used for debugging.  I can remove it;
- Added global_size as a private member variable, can also be removed and calculated on demand. But the communication cost is hidden (nonblocking communication).

Next PR asymmetric neighborhood communication and optimization. I've split it into more parts to make it easier to review.