### PR TITLE
Mesh naming consistecy fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
 install-python-components: &install-python-components
   name: Install FEniCS Python components
   command: |
-    pip3 install git+https://github.com/firedrakeproject/fiat.git@toriesz --upgrade
+    pip3 install git+https://github.com/FEniCS/fiat.git --upgrade
     pip3 install git+https://github.com/FEniCS/ufl.git --upgrade
     pip3 install git+https://github.com/FEniCS/ffcx.git --upgrade
     rm -rf /usr/local/include/dolfin /usr/local/include/dolfin.h

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
 install-python-components: &install-python-components
   name: Install FEniCS Python components
   command: |
-    pip3 install git+https://github.com/FEniCS/fiat.git --upgrade
+    pip3 install git+https://github.com/firedrakeproject/fiat.git@toriesz --upgrade
     pip3 install git+https://github.com/FEniCS/ufl.git --upgrade
     pip3 install git+https://github.com/FEniCS/ffcx.git --upgrade
     rm -rf /usr/local/include/dolfin /usr/local/include/dolfin.h

--- a/cpp/dolfinx/generation/BoxMesh.cpp
+++ b/cpp/dolfinx/generation/BoxMesh.cpp
@@ -138,8 +138,8 @@ mesh::Mesh build_tet(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
     ++cell;
   }
 
-  return mesh::create(comm, graph::AdjacencyList<std::int64_t>(topo), element,
-                      geom, ghost_mode);
+  return mesh::create_mesh(comm, graph::AdjacencyList<std::int64_t>(topo),
+                           element, geom, ghost_mode);
 }
 //-----------------------------------------------------------------------------
 mesh::Mesh build_hex(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
@@ -180,8 +180,8 @@ mesh::Mesh build_hex(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
     ++cell;
   }
 
-  return mesh::create(comm, graph::AdjacencyList<std::int64_t>(topo), element,
-                      geom, ghost_mode);
+  return mesh::create_mesh(comm, graph::AdjacencyList<std::int64_t>(topo),
+                           element, geom, ghost_mode);
 }
 //-----------------------------------------------------------------------------
 

--- a/cpp/dolfinx/generation/IntervalMesh.cpp
+++ b/cpp/dolfinx/generation/IntervalMesh.cpp
@@ -26,8 +26,8 @@ mesh::Mesh build(MPI_Comm comm, std::size_t nx, std::array<double, 2> x,
   {
     Eigen::Array<double, 0, 1> geom(0, 1);
     Eigen::Array<std::int64_t, 0, 2, Eigen::RowMajor> topo(0, 2);
-    return mesh::create(comm, graph::AdjacencyList<std::int64_t>(topo), element,
-                        geom, ghost_mode);
+    return mesh::create_mesh(comm, graph::AdjacencyList<std::int64_t>(topo),
+                             element, geom, ghost_mode);
   }
 
   const double a = x[0];
@@ -59,8 +59,8 @@ mesh::Mesh build(MPI_Comm comm, std::size_t nx, std::array<double, 2> x,
   for (std::size_t ix = 0; ix < nx; ix++)
     topo.row(ix) << ix, ix + 1;
 
-  return mesh::create(comm, graph::AdjacencyList<std::int64_t>(topo), element,
-                      geom, ghost_mode);
+  return mesh::create_mesh(comm, graph::AdjacencyList<std::int64_t>(topo),
+                           element, geom, ghost_mode);
 }
 } // namespace
 

--- a/cpp/dolfinx/generation/RectangleMesh.cpp
+++ b/cpp/dolfinx/generation/RectangleMesh.cpp
@@ -28,8 +28,8 @@ mesh::Mesh build_tri(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
   {
     Eigen::Array<double, 0, 2, Eigen::RowMajor> geom(0, 2);
     Eigen::Array<std::int64_t, 0, 3, Eigen::RowMajor> topo(0, 3);
-    return mesh::create(comm, graph::AdjacencyList<std::int64_t>(topo), element,
-                        geom, ghost_mode);
+    return mesh::create_mesh(comm, graph::AdjacencyList<std::int64_t>(topo),
+                             element, geom, ghost_mode);
   }
 
   // Check options
@@ -192,8 +192,8 @@ mesh::Mesh build_tri(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
     }
   }
 
-  return mesh::create(comm, graph::AdjacencyList<std::int64_t>(topo), element,
-                      geom, ghost_mode);
+  return mesh::create_mesh(comm, graph::AdjacencyList<std::int64_t>(topo),
+                           element, geom, ghost_mode);
 }
 
 } // namespace
@@ -208,8 +208,8 @@ mesh::Mesh build_quad(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
   {
     Eigen::Array<double, 0, 2, Eigen::RowMajor> geom(0, 2);
     Eigen::Array<std::int64_t, Eigen::Dynamic, 4, Eigen::RowMajor> topo(0, 4);
-    return mesh::create(comm, graph::AdjacencyList<std::int64_t>(topo), element,
-                        geom, ghost_mode);
+    return mesh::create_mesh(comm, graph::AdjacencyList<std::int64_t>(topo),
+                             element, geom, ghost_mode);
   }
 
   const std::size_t nx = n[0];
@@ -253,8 +253,8 @@ mesh::Mesh build_quad(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
       ++cell;
     }
 
-  return mesh::create(comm, graph::AdjacencyList<std::int64_t>(topo), element,
-                      geom, ghost_mode);
+  return mesh::create_mesh(comm, graph::AdjacencyList<std::int64_t>(topo),
+                           element, geom, ghost_mode);
 }
 //-----------------------------------------------------------------------------
 mesh::Mesh RectangleMesh::create(MPI_Comm comm,

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -173,7 +173,8 @@ mesh::Mesh XDMFFile::read_mesh(const fem::CoordinateElement& element,
 
   // Create mesh
   graph::AdjacencyList<std::int64_t> cells_adj(cells);
-  mesh::Mesh mesh = mesh::create(_mpi_comm.comm(), cells_adj, element, x, mode);
+  mesh::Mesh mesh
+      = mesh::create_mesh(_mpi_comm.comm(), cells_adj, element, x, mode);
   mesh.name = name;
   return mesh;
 }
@@ -372,7 +373,7 @@ void XDMFFile::write_information(const std::string name,
 }
 //-----------------------------------------------------------------------------
 std::string XDMFFile::read_information(const std::string name,
-                                        const std::string xpath)
+                                       const std::string xpath)
 {
   pugi::xml_node node = _xml_doc->select_node(xpath.c_str()).node();
   if (!node)
@@ -380,7 +381,8 @@ std::string XDMFFile::read_information(const std::string name,
   pugi::xml_node info_node
       = node.select_node(("Information[@Name='" + name + "']").c_str()).node();
   if (!info_node)
-    throw std::runtime_error("<Information> with name '" + name + "' not found.");
+    throw std::runtime_error("<Information> with name '" + name
+                             + "' not found.");
 
   // Read data and trim any leading/trailing whitespace
   pugi::xml_node data_node = info_node.first_child();

--- a/cpp/dolfinx/io/cells.cpp
+++ b/cpp/dolfinx/io/cells.cpp
@@ -215,46 +215,66 @@ std::vector<std::uint8_t> vtk_hexahedron(int num_nodes)
   }
 }
 //-----------------------------------------------------------------------------
-std::vector<std::uint8_t> gmsh(std::string type)
+std::vector<std::uint8_t> gmsh_triangle(int num_nodes)
 {
-  if (type == "tetra")
-    return {0, 1, 2, 3};
-  else if (type == "tetra10")
+  switch (num_nodes)
   {
+  case 3:
+    return {0, 1, 2};
+  case 6:
+    return {0, 1, 2, 5, 3, 4};
+  default:
+    throw std::runtime_error("Higher order GMSH triangle not supported");
+  }
+}
+//-----------------------------------------------------------------------------
+std::vector<std::uint8_t> gmsh_tetrahedron(int num_nodes)
+{
+  switch (num_nodes)
+  {
+  case 4:
+    return {0, 1, 2, 3};
+  case 10:
     // NOTE: GMSH DOCUMENTATION IS WRONG, it would have the following
     // permutation:
     // return std::vector<std::uint8_t>{0, 1, 2, 3, 9, 6, 8, 7, 4, 5};
     // This is the one returned by pygmsh
     return {0, 1, 2, 3, 9, 6, 8, 7, 5, 4};
-  }
-  else if (type == "tetra20")
-  {
+  case 20:
     return {0,  1,  2, 3, 14, 15, 8,  9,  13, 12,
             11, 10, 5, 4, 7,  6,  19, 18, 17, 16};
+  default:
+    throw std::runtime_error("Higher order GMSH tetrahedron not supported");
   }
-  else if (type == "hexahedron")
-    return {0, 4, 6, 2, 1, 5, 7, 3};
-  else if (type == "hexahedron27")
+}
+//-----------------------------------------------------------------------------
+std::vector<std::uint8_t> gmsh_hexahedron(int num_nodes)
+{
+  switch (num_nodes)
   {
+  case 8:
+    return {0, 4, 6, 2, 1, 5, 7, 3};
+  case 27:
     return {0,  9, 12, 3, 1,  10, 13, 4,  18, 6,  2,  15, 11, 21,
             14, 5, 19, 7, 16, 22, 24, 20, 8,  17, 23, 25, 26};
+  default:
+    throw std::runtime_error("Higher order GMSH hexahedron not supported");
   }
-  else if (type == "triangle")
-    return {0, 1, 2};
-  else if (type == "triangle6")
-    return {0, 1, 2, 5, 3, 4};
-  else if (type == "triangle10")
-    return {0, 1, 2, 7, 8, 3, 4, 6, 5, 9};
-  else if (type == "quad")
-    return {0, 2, 3, 1};
-  else if (type == "quad9")
-    return {0, 3, 4, 1, 6, 5, 7, 2, 8};
-  else if (type == "quad16")
+}
+//-----------------------------------------------------------------------------
+std::vector<std::uint8_t> gmsh_quadrilateral(int num_nodes)
+{
+  switch (num_nodes)
   {
+  case 4:
+    return {0, 2, 3, 1};
+  case 9:
+    return {0, 3, 4, 1, 6, 5, 7, 2, 8};
+  case 16:
     return {0, 4, 5, 1, 8, 12, 6, 7, 13, 9, 3, 2, 10, 14, 15, 11};
+  default:
+    throw std::runtime_error("Higher order GMSH quadrilateral not supported");
   }
-  else
-    throw std::runtime_error("Gmsh cell type not recognized");
 }
 } // namespace
 //-----------------------------------------------------------------------------
@@ -290,9 +310,36 @@ std::vector<std::uint8_t> io::cells::perm_vtk(mesh::CellType type,
   return io::cells::transpose(map);
 }
 //-----------------------------------------------------------------------------
-std::vector<std::uint8_t> io::cells::perm_gmsh(std::string type)
+std::vector<std::uint8_t> io::cells::perm_gmsh(const mesh::CellType type,
+                                               const int num_nodes)
 {
-  return io::cells::transpose(gmsh(type));
+  std::vector<std::uint8_t> map;
+  switch (type)
+  {
+  case mesh::CellType::point:
+    map = {0};
+    break;
+  case mesh::CellType::interval:
+    map.resize(num_nodes);
+    std::iota(map.begin(), map.end(), 0);
+    break;
+  case mesh::CellType::triangle:
+    map = gmsh_triangle(num_nodes);
+    break;
+  case mesh::CellType::tetrahedron:
+    map = gmsh_tetrahedron(num_nodes);
+    break;
+  case mesh::CellType::quadrilateral:
+    map = gmsh_quadrilateral(num_nodes);
+    break;
+  case mesh::CellType::hexahedron:
+    map = gmsh_hexahedron(num_nodes);
+    break;
+  default:
+    throw std::runtime_error("Unknown cell type.");
+  }
+
+  return io::cells::transpose(map);
 }
 //-----------------------------------------------------------------------------
 std::vector<std::uint8_t>

--- a/cpp/dolfinx/io/cells.h
+++ b/cpp/dolfinx/io/cells.h
@@ -88,12 +88,13 @@ std::vector<std::uint8_t> perm_vtk(mesh::CellType type, int num_nodes);
 
 /// Permutation array to map from Gmsh to DOLFINX node ordering
 ///
-/// @param[in] type The gmsh cell type
+/// @param[in] type The cell shape
+/// @param[in] num_nodes
 /// @return Permutation array @p for permuting from Gmsh ordering to
 ///   DOLFIN ordering, i.e. `a_dolfin[i] = a_gmsh[p[i]]
 /// @details If `p = [0, 2, 1, 3]` and `a = [10, 3, 4, 7]`, then `a_p
 ///   =[a[p[0]], a[p[1]], a[p[2]], a[p[3]]] = [10, 4, 3, 7]`
-std::vector<std::uint8_t> perm_gmsh(std::string type);
+std::vector<std::uint8_t> perm_gmsh(mesh::CellType type, int num_nodes);
 
 /// Compute the transpose of a re-ordering map
 ///

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -61,12 +61,12 @@ Eigen::ArrayXd cell_r(const mesh::Mesh& mesh)
 } // namespace
 
 //-----------------------------------------------------------------------------
-Mesh mesh::create(MPI_Comm comm,
-                  const graph::AdjacencyList<std::int64_t>& cells,
-                  const fem::CoordinateElement& element,
-                  const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
-                                     Eigen::RowMajor>& x,
-                  mesh::GhostMode ghost_mode)
+Mesh mesh::create_mesh(MPI_Comm comm,
+                       const graph::AdjacencyList<std::int64_t>& cells,
+                       const fem::CoordinateElement& element,
+                       const Eigen::Array<double, Eigen::Dynamic,
+                                          Eigen::Dynamic, Eigen::RowMajor>& x,
+                       mesh::GhostMode ghost_mode)
 {
   if (ghost_mode == mesh::GhostMode::shared_vertex)
     throw std::runtime_error("Ghost mode via vertex currently disabled.");

--- a/cpp/dolfinx/mesh/Mesh.h
+++ b/cpp/dolfinx/mesh/Mesh.h
@@ -155,11 +155,11 @@ private:
 };
 
 /// Create a mesh
-Mesh create(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
-            const fem::CoordinateElement& element,
-            const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
-                               Eigen::RowMajor>& x,
-            GhostMode ghost_mode);
+Mesh create_mesh(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
+                 const fem::CoordinateElement& element,
+                 const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
+                                    Eigen::RowMajor>& x,
+                 GhostMode ghost_mode);
 
 } // namespace mesh
 } // namespace dolfinx

--- a/cpp/dolfinx/refinement/ParallelRefinement.cpp
+++ b/cpp/dolfinx/refinement/ParallelRefinement.cpp
@@ -403,7 +403,7 @@ mesh::Mesh ParallelRefinement::build_local(
                                 Eigen::RowMajor>>
       cells(cell_topology.data(), num_cells, num_cell_vertices);
 
-  mesh::Mesh mesh = mesh::create(
+  mesh::Mesh mesh = mesh::create_mesh(
       _mesh.mpi_comm(), graph::AdjacencyList<std::int64_t>(cells),
       _mesh.geometry().cmap(), _new_vertex_coordinates, mesh::GhostMode::none);
 
@@ -432,10 +432,10 @@ ParallelRefinement::partition(const std::vector<std::int64_t>& cell_topology,
   // Build mesh
   if (redistribute)
   {
-    return mesh::create(_mesh.mpi_comm(),
-                        graph::AdjacencyList<std::int64_t>(cells),
-                        _mesh.geometry().cmap(), _new_vertex_coordinates,
-                        mesh::GhostMode::none);
+    return mesh::create_mesh(_mesh.mpi_comm(),
+                             graph::AdjacencyList<std::int64_t>(cells),
+                             _mesh.geometry().cmap(), _new_vertex_coordinates,
+                             mesh::GhostMode::none);
   }
 
   MPI_Comm comm = _mesh.mpi_comm();

--- a/python/demo/gmsh/demo_gmsh.py
+++ b/python/demo/gmsh/demo_gmsh.py
@@ -13,10 +13,9 @@ import pygmsh
 from mpi4py import MPI
 
 from dolfinx import cpp
-from dolfinx.cpp.io import cell_perm_gmsh, extract_local_entities
+from dolfinx.cpp.io import perm_gmsh, extract_local_entities
 from dolfinx.io import XDMFFile, ufl_mesh_from_gmsh
-from dolfinx.mesh import create as create_mesh
-from dolfinx.cpp.mesh import create_meshtags
+from dolfinx.mesh import create_mesh, create_meshtags
 
 # Generating a mesh on each process rank
 # ======================================
@@ -113,14 +112,14 @@ else:
 
 # Permute the topology from GMSH to DOLFIN-X ordering
 domain = ufl_mesh_from_gmsh("tetra10", 3)
-gmsh_tetra10 = cell_perm_gmsh("tetra10")
+gmsh_tetra10 = perm_gmsh(cpp.mesh.CellType.tetrahedron, 10)
 cells = cells[:, gmsh_tetra10]
 
 mesh = create_mesh(MPI.COMM_WORLD, cells, x, domain)
 mesh.name = "ball_d2"
 
 # Permute also entities which are tagged
-gmsh_triangle6 = cell_perm_gmsh("triangle6")
+gmsh_triangle6 = perm_gmsh(cpp.mesh.CellType.triangle, 6)
 marked_entities = marked_entities[:, gmsh_triangle6]
 
 local_entities, local_values = extract_local_entities(mesh, 2, marked_entities, values)
@@ -169,14 +168,14 @@ else:
 
 # Permute the mesh topology from GMSH ordering to DOLFIN-X ordering
 domain = ufl_mesh_from_gmsh("hexahedron27", 3)
-gmsh_hex27 = cell_perm_gmsh("hexahedron27")
+gmsh_hex27 = perm_gmsh(cpp.mesh.CellType.hexahedron, 27)
 cells = cells[:, gmsh_hex27]
 
 mesh = create_mesh(MPI.COMM_WORLD, cells, x, domain)
 mesh.name = "hex_d2"
 
 # Permute also entities which are tagged
-gmsh_quad9 = cell_perm_gmsh("quad9")
+gmsh_quad9 = perm_gmsh(cpp.mesh.CellType.quadrilateral, 9)
 marked_entities = marked_entities[:, gmsh_quad9]
 
 local_entities, local_values = extract_local_entities(mesh, 2, marked_entities, values)

--- a/python/dolfinx/io.py
+++ b/python/dolfinx/io.py
@@ -54,7 +54,7 @@ class XDMFFile(cpp.io.XDMFFile):
         cmap = fem.create_coordinate_map(domain)
 
         # Build the mesh
-        mesh = cpp.mesh.create(self.comm(), cpp.graph.AdjacencyList_int64(cells), cmap, x, ghost_mode)
+        mesh = cpp.mesh.create_mesh(self.comm(), cpp.graph.AdjacencyList_int64(cells), cmap, x, ghost_mode)
         mesh.name = name
         domain._ufl_cargo = mesh
         mesh._ufl_domain = domain

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -9,7 +9,7 @@ import types
 import numpy
 import ufl
 from dolfinx import cpp, fem
-from cpp.mesh import create_meshtags
+from dolfinx.cpp.mesh import create_meshtags
 
 __all__ = [
     "locate_entities", "locate_entities_boundary", "refine", "create_mesh", "create_meshtags"

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -33,8 +33,8 @@ void io(py::module& m)
 {
 
   // dolfinx::io::cell permutation functions
-  m.def("cell_perm_vtk", &dolfinx::io::cells::perm_vtk);
-  m.def("cell_perm_gmsh", &dolfinx::io::cells::perm_gmsh);
+  m.def("perm_vtk", &dolfinx::io::cells::perm_vtk);
+  m.def("perm_gmsh", &dolfinx::io::cells::perm_gmsh);
 
   // TODO: Template for different values dtypes
   m.def("extract_local_entities",

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -68,14 +68,15 @@ void mesh(py::module& m)
   m.def("compute_boundary_facets", &dolfinx::mesh::compute_boundary_facets);
 
   m.def(
-      "create",
+      "create_mesh",
       [](const MPICommWrapper comm,
          const dolfinx::graph::AdjacencyList<std::int64_t>& cells,
          const dolfinx::fem::CoordinateElement& element,
          const Eigen::Ref<const Eigen::Array<
              double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>& x,
          dolfinx::mesh::GhostMode ghost_mode) {
-        return dolfinx::mesh::create(comm.get(), cells, element, x, ghost_mode);
+        return dolfinx::mesh::create_mesh(comm.get(), cells, element, x,
+                                          ghost_mode);
       },
       "Helper function for creating meshes.");
 

--- a/python/test/unit/fem/test_dof_permuting.py
+++ b/python/test/unit/fem/test_dof_permuting.py
@@ -13,7 +13,7 @@ from mpi4py import MPI
 
 import ufl
 from dolfinx import FunctionSpace, fem
-from dolfinx.mesh import create as create_mesh
+from dolfinx.mesh import create_mesh
 
 xfail = pytest.mark.xfail(strict=True)
 

--- a/python/test/unit/io/test_xdmf_mesh.py
+++ b/python/test/unit/io/test_xdmf_mesh.py
@@ -14,7 +14,7 @@ from dolfinx import UnitCubeMesh, UnitIntervalMesh, UnitSquareMesh, cpp
 from dolfinx.cpp.io import perm_vtk
 from dolfinx.cpp.mesh import CellType
 from dolfinx.io import XDMFFile, ufl_mesh_from_gmsh
-from dolfinx.mesh import create as create_mesh
+from dolfinx.mesh import create_mesh
 from dolfinx_utils.test.fixtures import tempdir
 
 assert (tempdir)

--- a/python/test/unit/io/test_xdmf_mesh.py
+++ b/python/test/unit/io/test_xdmf_mesh.py
@@ -11,7 +11,7 @@ import pytest
 from mpi4py import MPI
 
 from dolfinx import UnitCubeMesh, UnitIntervalMesh, UnitSquareMesh, cpp
-from dolfinx.cpp.io import cell_perm_vtk
+from dolfinx.cpp.io import perm_vtk
 from dolfinx.cpp.mesh import CellType
 from dolfinx.io import XDMFFile, ufl_mesh_from_gmsh
 from dolfinx.mesh import create as create_mesh
@@ -115,7 +115,7 @@ def test_read_write_p2_mesh(tempdir, encoding):
 
     domain = ufl_mesh_from_gmsh(cell_type, gdim)
     cell_type = cpp.mesh.to_type(str(domain.ufl_cell()))
-    cells = cells[:, cell_perm_vtk(cell_type, cells.shape[1])]
+    cells = cells[:, perm_vtk(cell_type, cells.shape[1])]
     mesh = create_mesh(MPI.COMM_WORLD, cells, x, domain)
 
     filename = os.path.join(tempdir, "tet10_mesh.xdmf")

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -15,7 +15,7 @@ from mpi4py import MPI
 from sympy.vector import CoordSys3D, matrix_to_vector
 
 from dolfinx import Function, FunctionSpace
-from dolfinx.cpp.io import cell_perm_vtk
+from dolfinx.cpp.io import perm_vtk
 from dolfinx.cpp.mesh import CellType, GhostMode
 from dolfinx.fem import assemble_scalar
 from dolfinx.io import XDMFFile
@@ -75,11 +75,11 @@ def sympy_scipy(points, nodes, L, H):
     ([0, 1, 2, 3, 4, 5, 6, 7], [0, 4, 3, 7, 1, 5, 2, 6], CellType.hexahedron)
 ])
 def test_map_vtk_to_dolfin(vtk, dolfin, cell_type):
-    p = cell_perm_vtk(cell_type, len(vtk))
+    p = perm_vtk(cell_type, len(vtk))
     cell_p = np.array(vtk)[p]
     assert (cell_p == dolfin).all()
 
-    p = np.argsort(cell_perm_vtk(cell_type, len(vtk)))
+    p = np.argsort(perm_vtk(cell_type, len(vtk)))
     cell_p = np.array(dolfin)[p]
     assert (cell_p == vtk).all()
 
@@ -103,7 +103,7 @@ def test_second_order_tri():
 
             cells = np.array([[0, 1, 3, 4, 8, 7],
                               [1, 2, 3, 5, 6, 8]])
-            cells = cells[:, cell_perm_vtk(CellType.triangle, cells.shape[1])]
+            cells = cells[:, perm_vtk(CellType.triangle, cells.shape[1])]
             mesh = Mesh(MPI.COMM_WORLD, CellType.triangle, points, cells, [], degree=2)
 
             def e2(x):
@@ -143,7 +143,7 @@ def xtest_third_order_tri():
                                [2 * L / 3, 2 * H / 3, 0]])            # 15
             cells = np.array([[0, 1, 3, 4, 5, 6, 7, 8, 9, 14],
                               [1, 2, 3, 12, 13, 10, 11, 7, 6, 15]])
-            cells = cells[:, cell_perm_vtk(CellType.triangle, cells.shape[1])]
+            cells = cells[:, perm_vtk(CellType.triangle, cells.shape[1])]
             mesh = Mesh(MPI.COMM_WORLD, CellType.triangle, points, cells, [], degree=3)
 
             def e2(x):
@@ -191,7 +191,7 @@ def xtest_fourth_order_tri():
 
             cells = np.array([[0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
                               [1, 2, 3, 16, 17, 18, 19, 20, 21, 9, 8, 7, 22, 23, 24]])
-            cells = cells[:, cell_perm_vtk(CellType.triangle, cells.shape[1])]
+            cells = cells[:, perm_vtk(CellType.triangle, cells.shape[1])]
             mesh = Mesh(MPI.COMM_WORLD, CellType.triangle, points, cells, [], degree=4)
 
             def e2(x):
@@ -247,7 +247,7 @@ def scipy_one_cell(points, nodes):
 def test_nth_order_triangle(order):
     num_nodes = (order + 1) * (order + 2) / 2
     cells = np.array([range(int(num_nodes))])
-    cells = cells[:, cell_perm_vtk(CellType.triangle, cells.shape[1])]
+    cells = cells[:, perm_vtk(CellType.triangle, cells.shape[1])]
 
     if order == 1:
         points = np.array([[0.00000, 0.00000, 0.00000], [1.00000, 0.00000, 0.00000],
@@ -401,7 +401,7 @@ def test_second_order_quad(L, H, Z):
                        [L / 2, H / 2, 0],
                        [2 * L, 0, 0], [2 * L, H, Z]])
     cells = np.array([[0, 1, 2, 3, 4, 5, 6, 7, 8]])
-    cells = cells[:, cell_perm_vtk(CellType.quadrilateral, cells.shape[1])]
+    cells = cells[:, perm_vtk(CellType.quadrilateral, cells.shape[1])]
     mesh = Mesh(MPI.COMM_WORLD, CellType.quadrilateral, points, cells, [], degree=2)
 
     def e2(x):
@@ -454,7 +454,7 @@ def xtest_third_order_quad(L, H, Z):
     # Change to multiple cells when matthews dof-maps work for quads
     cells = np.array([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
                       [1, 16, 17, 2, 18, 19, 20, 21, 22, 23, 6, 7, 24, 25, 26, 27]])
-    cells = cells[:, cell_perm_vtk(CellType.quadrilateral, cells.shape[1])]
+    cells = cells[:, perm_vtk(CellType.quadrilateral, cells.shape[1])]
     mesh = Mesh(MPI.COMM_WORLD, CellType.quadrilateral, points, cells, [])
 
     def e2(x):
@@ -518,7 +518,7 @@ def xtest_fourth_order_quad(L, H, Z):
     cells = np.array([[0, 4, 24, 20, 1, 2, 3, 9, 14, 19, 21, 22, 23, 5, 10, 15, 6, 7, 8, 11, 12, 13, 16, 17, 18],
                       [4, 28, 44, 24, 25, 26, 27, 32, 36, 40, 41, 42, 43, 9, 14, 19,
                        29, 30, 31, 33, 34, 35, 37, 38, 39]])
-    cells = cells[:, cell_perm_vtk(CellType.quadrilateral, cells.shape[1])]
+    cells = cells[:, perm_vtk(CellType.quadrilateral, cells.shape[1])]
     mesh = Mesh(MPI.COMM_WORLD, CellType.quadrilateral, points, cells, [], GhostMode.none)
 
     def e2(x):
@@ -564,7 +564,7 @@ def test_gmsh_input_quad(order):
                 cells[i, j] = msh.cells_dict[element][i, msh_to_dolfin[j]]
     else:
         # XDMF does not support higher order quads
-        cells = msh.cells_dict[element][:, cell_perm_vtk(CellType.quadrilateral, msh.cells_dict[element].shape[1])]
+        cells = msh.cells_dict[element][:, perm_vtk(CellType.quadrilateral, msh.cells_dict[element].shape[1])]
 
     mesh = Mesh(MPI.COMM_WORLD, CellType.quadrilateral, msh.points, cells,
                 [], degree=order)

--- a/python/test/unit/mesh/test_meshtags.py
+++ b/python/test/unit/mesh/test_meshtags.py
@@ -1,5 +1,5 @@
 from dolfinx.generation import UnitCubeMesh
-from dolfinx.mesh import locate_entities
+from dolfinx.mesh import locate_entities, create_meshtags
 from dolfinx.cpp.mesh import CellType
 from dolfinx import cpp
 import pytest
@@ -23,5 +23,5 @@ def test_create(cell_type):
     entities = cpp.graph.AdjacencyList_int32(f_v[marked_lines])
     values = numpy.full(marked_lines.shape[0], 2, dtype=numpy.int32)
 
-    mt = cpp.mesh.create_meshtags(mesh, 1, entities, values)
+    mt = create_meshtags(mesh, 1, entities, values)
     assert mt.indices.shape == marked_lines.shape


### PR DESCRIPTION
`mesh::create` --> `mesh::create_mesh` to be analogous to `mesh::create_meshtags`,
`cell_perm_vtk` --> `perm_vtk` to have the same name as in c++,
`perm_gmsh()` now takes the same arguments as `perm_vtk()`.