### PR TITLE
Add mapping for gmsh cell types line, line3, line4 and vertex

### DIFF
--- a/python/dolfinx/io.py
+++ b/python/dolfinx/io.py
@@ -68,7 +68,7 @@ _gmsh_cells = dict(tetra=("tetrahedron", 1), tetra10=("tetrahedron", 2), tetra20
                    triangle=("triangle", 1), triangle6=("triangle", 2), triangle10=("triangle", 3),
                    quad=("quadrilateral", 1), quad9=("quadrilateral", 2), quad16=("quadrilateral", 3),
                    line=("interval", 1), line3=("interval", 2), line4=("interval", 3),
-                   vertex=("point", 0))
+                   vertex=("point", 1))
 
 
 def ufl_mesh_from_gmsh(gmsh_cell, gdim):

--- a/python/dolfinx/io.py
+++ b/python/dolfinx/io.py
@@ -66,7 +66,9 @@ class XDMFFile(cpp.io.XDMFFile):
 _gmsh_cells = dict(tetra=("tetrahedron", 1), tetra10=("tetrahedron", 2), tetra20=("tetrahedron", 3),
                    hexahedron=("hexahedron", 1), hexahedron27=("hexahedron", 2),
                    triangle=("triangle", 1), triangle6=("triangle", 2), triangle10=("triangle", 3),
-                   quad=("quadrilateral", 1), quad9=("quadrilateral", 2), quad16=("quadrilateral", 3))
+                   quad=("quadrilateral", 1), quad9=("quadrilateral", 2), quad16=("quadrilateral", 3),
+                   line=("interval", 1), line3=("interval", 2), line4=("interval", 3),
+                   vertex=("point", 0))
 
 
 def ufl_mesh_from_gmsh(gmsh_cell, gdim):


### PR DESCRIPTION
This adds missing cell type mapping for `line`, `line3` and `line4` as well as `vertex` to dictionary `_gmsh_cells`.