### PR TITLE
Change squared_distance to handle arbitrary order geometries

### DIFF
--- a/cpp/dolfinx/geometry/BoundingBoxTree.h
+++ b/cpp/dolfinx/geometry/BoundingBoxTree.h
@@ -18,7 +18,6 @@ namespace dolfinx
 namespace mesh
 {
 class Mesh;
-class MeshEntity;
 } // namespace mesh
 
 namespace geometry

--- a/cpp/dolfinx/geometry/utils.cpp
+++ b/cpp/dolfinx/geometry/utils.cpp
@@ -348,8 +348,6 @@ double geometry::squared_distance(const mesh::Mesh& mesh, int dim,
   const mesh::Geometry& geometry = mesh.geometry();
   const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
 
-  // Find all geometrical nodes for the entity!=vertices for higher
-  // order elements
   if (dim == tdim)
   {
     auto dofs = x_dofmap.links(index);
@@ -369,7 +367,7 @@ double geometry::squared_distance(const mesh::Mesh& mesh, int dim,
     assert(e_to_c->num_links(index) > 0);
     const std::int32_t c = e_to_c->links(index)[0];
 
-    // Find local number of entity wrt. cell
+    // Find local number of entity wrt cell
     mesh.topology_mutable().create_connectivity(tdim, dim);
     auto c_to_e = mesh.topology_mutable().connectivity(tdim, dim);
     assert(c_to_e);

--- a/cpp/dolfinx/geometry/utils.cpp
+++ b/cpp/dolfinx/geometry/utils.cpp
@@ -300,22 +300,18 @@ std::pair<int, double> geometry::compute_closest_entity(
   }
 
   // Search point cloud to get a good starting guess
-  std::pair<int, double> guess = compute_closest_point(tree_midpoint, p);
-  const double r = guess.second;
+  const auto [index0, distance0] = compute_closest_point(tree_midpoint, p);
 
   // Return if we have found the point
-  if (r == 0.0)
-    return guess;
+  if (distance0 == 0.0)
+    return {index0, distance0};
 
   // Call recursive find function
-  std::pair<int, double> e = _compute_closest_entity(
-      tree, p, tree.num_bboxes() - 1, mesh, guess.first, r * r);
+  const auto [index1, distance1] = _compute_closest_entity(
+      tree, p, tree.num_bboxes() - 1, mesh, index0, distance0 * distance0);
+  assert(index1 >= 0);
 
-  // Sanity check
-  assert(e.first >= 0);
-
-  e.second = sqrt(e.second);
-  return e;
+  return {index1, std::sqrt(distance1)};
 }
 //-----------------------------------------------------------------------------
 std::pair<int, double>

--- a/cpp/dolfinx/geometry/utils.cpp
+++ b/cpp/dolfinx/geometry/utils.cpp
@@ -12,7 +12,6 @@
 #include <dolfinx/common/log.h>
 #include <dolfinx/mesh/Geometry.h>
 #include <dolfinx/mesh/Mesh.h>
-#include <dolfinx/mesh/MeshEntity.h>
 #include <dolfinx/mesh/utils.h>
 
 using namespace dolfinx;
@@ -69,7 +68,6 @@ _compute_closest_entity(const geometry::BoundingBoxTree& tree,
     // Get entity (child_1 denotes entity index for leaves)
     assert(tree.tdim() == mesh.topology().dim());
     const int entity_index = bbox[1];
-    mesh::MeshEntity cell(mesh, mesh.topology().dim(), entity_index);
 
     // If entity is closer than best result so far, then return it
     const double r2 = geometry::squared_distance(mesh, mesh.topology().dim(),
@@ -354,8 +352,8 @@ double geometry::squared_distance(const mesh::Mesh& mesh, int dim,
   const mesh::Geometry& geometry = mesh.geometry();
   const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
 
-  // Find all geometrical nodes for the entity!=vertices for higher order
-  // elements (Currently convex hull approximation of linearized geometry)
+  // Find all geometrical nodes for the entity!=vertices for higher
+  // order elements
   if (dim == tdim)
   {
     auto dofs = x_dofmap.links(index);
@@ -386,9 +384,8 @@ double geometry::squared_distance(const mesh::Mesh& mesh, int dim,
     assert(it0 != (cell_entities.data() + cell_entities.rows()));
     const int local_cell_entity = std::distance(cell_entities.data(), it0);
 
-    auto dofs = x_dofmap.links(c);
-
     // Tabulate geometry dofs for the entity
+    auto dofs = x_dofmap.links(c);
     const Eigen::Array<int, Eigen::Dynamic, 1> entity_dofs
         = geometry.cmap().dof_layout().entity_closure_dofs(dim,
                                                            local_cell_entity);

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include "BoundingBoxTree.h"
 #include <Eigen/Dense>
 #include <utility>
 #include <vector>
@@ -16,11 +15,12 @@ namespace dolfinx
 namespace mesh
 {
 class Mesh;
-class MeshEntity;
 } // namespace mesh
 
 namespace geometry
 {
+class BoundingBoxTree;
+
 /// Create a boundary box tree for cell midpoints
 /// @param[in] mesh The mesh build tree of cell midpoints from
 /// @return Bounding box tree for mesh cell midpoints
@@ -54,7 +54,7 @@ compute_closest_entity(const BoundingBoxTree& tree,
 
 /// Compute closest point and distance to a given point
 /// @param[in] tree The bounding box tree. It must have been initialised
-///                  with topological dimension 0.
+///   with topological dimension 0.
 /// @param[in] p The point to compute the distance from
 /// @return (point index, distance)
 std::pair<int, double> compute_closest_point(const BoundingBoxTree& tree,
@@ -70,6 +70,8 @@ double compute_squared_distance_bbox(
 /// a cell (only first order convex cells are supported at this stage)
 /// Uses the GJK algorithm, see geometry::compute_distance_gjk for
 /// details.
+///
+/// @note Currently a convex hull approximation of linearized geometry.
 ///
 /// @param[in] mesh Mesh containing the mesh entity
 /// @param[in] dim The topological dimension of the mesh entity

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -68,11 +68,16 @@ double compute_squared_distance_bbox(
 
 /// Compute squared distance from a given point to the nearest point on
 /// a cell (only first order convex cells are supported at this stage)
-/// Uses the GJK algorithm, see geometry::compute_distance_gjk for details.
-/// @param[in] entity MeshEntity
-/// @param[in] p Point
+/// Uses the GJK algorithm, see geometry::compute_distance_gjk for
+/// details.
+///
+/// @param[in] mesh Mesh containing the mesh entity
+/// @param[in] dim The topological dimension of the mesh entity
+/// @param[in] index The index of the mesh entity
+/// @param[in] p The point from which to compouted the shortest distance
+///    to the mesh to compute the Point
 /// @return shortest squared distance from p to entity
-double squared_distance(const mesh::MeshEntity& entity,
+double squared_distance(const mesh::Mesh& mesh, int dim, std::int32_t index,
                         const Eigen::Vector3d& p);
 
 /// From the given Mesh, select up to n cells from the list which actually

--- a/python/dolfinx/geometry.py
+++ b/python/dolfinx/geometry.py
@@ -36,7 +36,7 @@ def compute_collisions_point(tree: BoundingBoxTree, x):
 def compute_colliding_cells(tree: BoundingBoxTree, mesh, x, n=1):
     """Return cells which the point x lies within"""
     candidate_cells = cpp.geometry.compute_collisions_point(tree._cpp_object, x)
-    return cpp.geometry.select_cells_from_candidates(mesh, candidate_cells, x, n)
+    return cpp.geometry.select_colliding_cells(mesh, candidate_cells, x, n)
 
 
 def compute_collisions(tree0: BoundingBoxTree, tree1: BoundingBoxTree):

--- a/python/test/unit/geometry/test_gjk.py
+++ b/python/test/unit/geometry/test_gjk.py
@@ -7,7 +7,7 @@
 import numpy as np
 import pytest
 from mpi4py import MPI
-from scipy.spatial.transform import Rotation as R
+from scipy.spatial.transform import Rotation
 
 import ufl
 from dolfinx import cpp, geometry
@@ -17,16 +17,12 @@ from dolfinx_utils.test.skips import skip_in_parallel
 
 
 def distance_point_to_line_3D(P1, P2, point):
-    """
-    distance from point to line
-    """
+    """Distance from point to line"""
     return np.linalg.norm(np.cross(P2 - P1, P1 - point)) / np.linalg.norm(P2 - P1)
 
 
 def distance_point_to_plane_3D(P1, P2, P3, point):
-    """
-    Distance from point to plane
-    """
+    """Distance from point to plane"""
     return np.abs(np.dot(np.cross(P2 - P1, P3 - P1)
                          / np.linalg.norm(np.cross(P2 - P1, P3 - P1)), point - P2))
 
@@ -38,9 +34,7 @@ def test_line_point_distance(delta):
     normal = np.cross(line[0], line[1])
     point = point_on_line + delta * normal
     distance = np.linalg.norm(compute_distance_gjk(line, point))
-    actual_distance = distance_point_to_line_3D(
-        line[0], line[1], point)
-    print(distance, actual_distance)
+    actual_distance = distance_point_to_line_3D(line[0], line[1], point)
     assert(np.isclose(distance, actual_distance, atol=1e-15))
 
 
@@ -52,73 +46,53 @@ def test_line_line_distance(delta):
     point = point_on_line + delta * normal
     line_2 = np.array([point, [2, 5, 6]], dtype=np.float64)
     distance = np.linalg.norm(compute_distance_gjk(line, line_2))
-    actual_distance = distance_point_to_line_3D(
-        line[0], line[1], line_2[0])
-    print(distance, actual_distance)
+    actual_distance = distance_point_to_line_3D(line[0], line[1], line_2[0])
     assert(np.isclose(distance, actual_distance, atol=1e-15))
 
 
 @pytest.mark.parametrize("delta", [0.1**(3 * i) for i in range(6)])
 def test_tri_distance(delta):
     tri_1 = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float64)
-    tri_2 = np.array([[1, delta, 0], [3, 1.2, 0], [
-        1, 1, 0]], dtype=np.float64)
+    tri_2 = np.array([[1, delta, 0], [3, 1.2, 0], [1, 1, 0]], dtype=np.float64)
     P1 = tri_1[2]
     P2 = tri_1[1]
     point = tri_2[0]
     actual_distance = distance_point_to_line_3D(P1, P2, point)
     distance = np.linalg.norm(compute_distance_gjk(tri_1, tri_2))
-    print("Computed distance ", distance, "Actual distance ", actual_distance)
-
     assert(np.isclose(distance, actual_distance, atol=1e-15))
 
 
 @pytest.mark.parametrize("delta", [0.1 * 0.1**(3 * i) for i in range(6)])
 def test_quad_distance2d(delta):
-    quad_1 = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0],
-                       [1, 1, 0]], dtype=np.float64)
-    quad_2 = np.array([[0, 1 + delta, 0], [2, 2, 0],
-                       [2, 4, 0], [4, 4, 0]], dtype=np.float64)
+    quad_1 = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]], dtype=np.float64)
+    quad_2 = np.array([[0, 1 + delta, 0], [2, 2, 0], [2, 4, 0], [4, 4, 0]], dtype=np.float64)
     P1 = quad_1[2]
     P2 = quad_1[3]
     point = quad_2[0]
     actual_distance = distance_point_to_line_3D(P1, P2, point)
     distance = np.linalg.norm(compute_distance_gjk(quad_1, quad_2))
-    print("Computed distance ", distance, "Actual distance ", actual_distance)
-
     assert(np.isclose(distance, actual_distance, atol=1e-15))
 
 
 @pytest.mark.parametrize("delta", [1 * 0.5**(3 * i) for i in range(7)])
 def test_tetra_distance_3d(delta):
-    tetra_1 = np.array([[0, 0, 0.2], [1, 0, 0.1], [0, 1, 0.3],
-                        [0, 0, 1]], dtype=np.float64)
-    tetra_2 = np.array([[0, 0, -3], [1, 0, -3], [0, 1, -3],
-                        [0.5, 0.3, -delta]], dtype=np.float64)
-    actual_distance = distance_point_to_plane_3D(tetra_1[0], tetra_1[1],
-                                                 tetra_1[2], tetra_2[3])
+    tetra_1 = np.array([[0, 0, 0.2], [1, 0, 0.1], [0, 1, 0.3], [0, 0, 1]], dtype=np.float64)
+    tetra_2 = np.array([[0, 0, -3], [1, 0, -3], [0, 1, -3], [0.5, 0.3, -delta]], dtype=np.float64)
+    actual_distance = distance_point_to_plane_3D(tetra_1[0], tetra_1[1], tetra_1[2], tetra_2[3])
     distance = np.linalg.norm(compute_distance_gjk(tetra_1, tetra_2))
-    print("Computed distance ", distance, "Actual distance ", actual_distance)
-
     assert(np.isclose(distance, actual_distance, atol=1e-15))
 
 
 @pytest.mark.parametrize("delta", [(-1)**i * np.sqrt(2) * 0.1**(3 * i)
                                    for i in range(6)])
 def test_tetra_collision_3d(delta):
-    tetra_1 = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0],
-                        [0, 0, 1]], dtype=np.float64)
-    tetra_2 = np.array([[0, 0, -3], [1, 0, -3], [0, 1, -3],
-                        [0.5, 0.3, -delta]], dtype=np.float64)
-    actual_distance = distance_point_to_plane_3D(tetra_1[0], tetra_1[1],
-                                                 tetra_1[2], tetra_2[3])
+    tetra_1 = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=np.float64)
+    tetra_2 = np.array([[0, 0, -3], [1, 0, -3], [0, 1, -3], [0.5, 0.3, -delta]], dtype=np.float64)
+    actual_distance = distance_point_to_plane_3D(tetra_1[0], tetra_1[1], tetra_1[2], tetra_2[3])
     distance = np.linalg.norm(compute_distance_gjk(tetra_1, tetra_2))
-
     if delta < 0:
         assert(np.isclose(distance, 0, atol=1e-15))
     else:
-        print("Computed distance ", distance,
-              "Actual distance ", actual_distance)
         assert(np.isclose(distance, actual_distance, atol=1e-15))
 
 
@@ -140,38 +114,37 @@ def test_hex_collision_3d(delta):
     hex_2 = np.zeros((8, 3), dtype=np.float64)
     hex_2[:4, :] = quad_1
     hex_2[4:, :] = quad_2
-    actual_distance = np.linalg.norm(
-        np.array([1, 1, P0[2]], dtype=np.float64) - hex_2[0])
+    actual_distance = np.linalg.norm(np.array([1, 1, P0[2]], dtype=np.float64) - hex_2[0])
     distance = np.linalg.norm(compute_distance_gjk(hex_1, hex_2))
-
     if P0[0] < 1:
         assert(np.isclose(distance, 0, atol=1e-15))
     else:
-        print("Computed distance ", distance,
-              "Actual distance ", actual_distance)
         assert(np.isclose(distance, actual_distance, atol=1e-15))
 
 
 @pytest.mark.parametrize("delta", [1e8, 1.0, 1e-6, 1e-12])
 @pytest.mark.parametrize("scale", [1000.0, 1.0, 1e-4])
 def test_cube_distance(delta, scale):
-
     cubes = [scale * np.array([[-1, -1, -1], [1, -1, -1], [-1, 1, -1], [1, 1, -1],
                                [-1, -1, 1], [1, -1, 1], [-1, 1, 1], [1, 1, 1]],
                               dtype=np.float64)]
 
-    # Rotate cube 45 degrees around z, so that an edge faces along x-axis (vertical)
-    r = R.from_euler('z', 45, degrees=True)
+    # Rotate cube 45 degrees around z, so that an edge faces along
+    # x-axis (vertical)
+    r = Rotation.from_euler('z', 45, degrees=True)
     cubes.append(r.apply(cubes[0]))
+
     # Rotate cube around y, so that a corner faces along the x-axis
-    r = R.from_euler('y', np.arctan2(1.0, np.sqrt(2)))
+    r = Rotation.from_euler('y', np.arctan2(1.0, np.sqrt(2)))
     cubes.append(r.apply(cubes[1]))
-    # Rotate cube 45 degrees around y, so that an edge faces along x-axis (horizontal)
-    r = R.from_euler('y', 45, degrees=True)
+
+    # Rotate cube 45 degrees around y, so that an edge faces along
+    # x-axis (horizontal)
+    r = Rotation.from_euler('y', 45, degrees=True)
     cubes.append(r.apply(cubes[0]))
 
     # Rotate scene through an arbitrary angle
-    r = R.from_euler('xyz', [22, 13, -47], degrees=True)
+    r = Rotation.from_euler('xyz', [22, 13, -47], degrees=True)
 
     for c0 in range(4):
         for c1 in range(4):
@@ -182,7 +155,6 @@ def test_cube_distance(delta, scale):
             c0rot = r.apply(cube0)
             c1rot = r.apply(cube1)
             distance = np.linalg.norm(compute_distance_gjk(c0rot, c1rot))
-            print(distance, delta)
             assert(np.isclose(distance, delta))
 
 
@@ -194,8 +166,8 @@ def test_collision_2nd_order_triangle():
     domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell, 2))
     mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
 
-    # Sample points along an interior line of the domain
-    # The last point is outside the simplex made by the vertices
+    # Sample points along an interior line of the domain. The last point
+    # is outside the simplex made by the vertices.
     sample_points = np.array([[0.1, 0.3, 0], [0.2, 0.5, 0], [0.6, 0.6, 0]])
 
     # Create boundingboxtree
@@ -204,7 +176,8 @@ def test_collision_2nd_order_triangle():
         colliding_cell = geometry.compute_colliding_cells(tree, mesh, point, 1)
         assert(len(colliding_cell) == 1)
 
-    # Check if there is a point on the linear approximation of the curved facet
+    # Check if there is a point on the linear approximation of the
+    # curved facet
     def line_through_points(p0, p1):
         return lambda x: (p1[1] - p0[1]) / (p1[0] - p0[0]) * (x - p0[0]) + p0[1]
     line_func = line_through_points(points[2], points[3])
@@ -212,7 +185,5 @@ def test_collision_2nd_order_triangle():
     # Point inside 2nd order geometry, outside linear approximation
     # Usefull for debugging on a later stage
     # point = np.array([0.25, 0.89320760, 0])
-    print(point)
-    tdim = mesh.topology.dim
-    distance = cpp.geometry.squared_distance(mesh, tdim - 1, 2, point)
+    distance = cpp.geometry.squared_distance(mesh, mesh.topology.dim - 1, 2, point)
     assert np.isclose(distance, 0)

--- a/python/test/unit/geometry/test_gjk.py
+++ b/python/test/unit/geometry/test_gjk.py
@@ -214,6 +214,5 @@ def test_collision_2nd_order_triangle():
     # point = np.array([0.25, 0.89320760, 0])
     print(point)
     tdim = mesh.topology.dim
-    curved_facet = cpp.mesh.MeshEntity(mesh, tdim - 1, 2)
-    distance = cpp.geometry.squared_distance(curved_facet, point)
+    distance = cpp.geometry.squared_distance(mesh, tdim - 1, 2, point)
     assert np.isclose(distance, 0)

--- a/python/test/unit/mesh/test_cell.py
+++ b/python/test/unit/mesh/test_cell.py
@@ -8,37 +8,37 @@ import mpi4py
 import numpy
 import pytest
 from mpi4py import MPI
-from dolfinx_utils.test.skips import skip_in_parallel
 
-from dolfinx import (Mesh, MeshEntity, UnitCubeMesh, UnitIntervalMesh,
-                     UnitSquareMesh, cpp)
+from dolfinx import Mesh, UnitCubeMesh, UnitIntervalMesh, UnitSquareMesh, cpp
 from dolfinx.cpp.mesh import CellType
+from dolfinx_utils.test.skips import skip_in_parallel
 
 
 @skip_in_parallel
 def test_distance_interval():
     mesh = UnitIntervalMesh(MPI.COMM_SELF, 1)
-    cell = MeshEntity(mesh, mesh.topology.dim, 0)
-    assert cpp.geometry.squared_distance(cell, numpy.array([-1.0, 0, 0])) == pytest.approx(1.0)
-    assert cpp.geometry.squared_distance(cell, numpy.array([0.5, 0, 0])) == pytest.approx(0.0)
+    assert cpp.geometry.squared_distance(mesh, mesh.topology.dim, 0, numpy.array([-1.0, 0, 0])) == pytest.approx(1.0)
+    assert cpp.geometry.squared_distance(mesh, mesh.topology.dim, 0, numpy.array([0.5, 0, 0])) == pytest.approx(0.0)
 
 
 @skip_in_parallel
 def test_distance_triangle():
     mesh = UnitSquareMesh(MPI.COMM_SELF, 1, 1)
-    cell = MeshEntity(mesh, mesh.topology.dim, 1)
-    assert cpp.geometry.squared_distance(cell, numpy.array([-1.0, -1.0, 0.0])) == pytest.approx(2.0)
-    assert cpp.geometry.squared_distance(cell, numpy.array([-1.0, 0.5, 0.0])) == pytest.approx(1.0)
-    assert cpp.geometry.squared_distance(cell, numpy.array([0.5, 0.5, 0.0])) == pytest.approx(0.0)
+    assert cpp.geometry.squared_distance(mesh, mesh.topology.dim, 1,
+                                         numpy.array([-1.0, -1.0, 0.0])) == pytest.approx(2.0)
+    assert cpp.geometry.squared_distance(mesh, mesh.topology.dim, 1,
+                                         numpy.array([-1.0, 0.5, 0.0])) == pytest.approx(1.0)
+    assert cpp.geometry.squared_distance(mesh, mesh.topology.dim, 1, numpy.array([0.5, 0.5, 0.0])) == pytest.approx(0.0)
 
 
 @skip_in_parallel
 def test_distance_tetrahedron():
     mesh = UnitCubeMesh(MPI.COMM_SELF, 1, 1, 1)
-    cell = MeshEntity(mesh, mesh.topology.dim, 5)
-    assert cpp.geometry.squared_distance(cell, numpy.array([-1.0, -1.0, -1.0])) == pytest.approx(3.0)
-    assert cpp.geometry.squared_distance(cell, numpy.array([-1.0, 0.5, 0.5])) == pytest.approx(1.0)
-    assert cpp.geometry.squared_distance(cell, numpy.array([0.5, 0.5, 0.5])) == pytest.approx(0.0)
+    assert cpp.geometry.squared_distance(mesh, mesh.topology.dim, 5,
+                                         numpy.array([-1.0, -1.0, -1.0])) == pytest.approx(3.0)
+    assert cpp.geometry.squared_distance(mesh, mesh.topology.dim, 5,
+                                         numpy.array([-1.0, 0.5, 0.5])) == pytest.approx(1.0)
+    assert cpp.geometry.squared_distance(mesh, mesh.topology.dim, 5, numpy.array([0.5, 0.5, 0.5])) == pytest.approx(0.0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Works for all mesh entities.

Makes a linear approximation of the curved geometry.
This is the first step in better support of collision detection for higher order meshes.