### PR TITLE
Fix minor problems with cmake-python

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 # Run tests to find required packages
 
 # Find Python3 and define Python3_EXECUTABLE
-find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 # Check for Boost
 set(BOOST_ROOT $ENV{BOOST_DIR} $ENV{BOOST_HOME})
@@ -258,7 +258,7 @@ install(FILES ${CMAKE_BINARY_DIR}/dolfinx.conf
 # Copy data in demo/test direcories to the build directories
 
 set(GENERATE_DEMO_TEST_DATA FALSE)
-if (PYTHONINTERP_FOUND AND (${DOLFINX_SOURCE_DIR}/demo IS_NEWER_THAN ${CMAKE_CURRENT_BINARY_DIR}/demo OR ${DOLFINX_SOURCE_DIR}/test IS_NEWER_THAN ${CMAKE_CURRENT_BINARY_DIR}/test))
+if (Python3_Interpreter_FOUND AND (${DOLFINX_SOURCE_DIR}/demo IS_NEWER_THAN ${CMAKE_CURRENT_BINARY_DIR}/demo OR ${DOLFINX_SOURCE_DIR}/test IS_NEWER_THAN ${CMAKE_CURRENT_BINARY_DIR}/test))
   file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/demo ${CMAKE_CURRENT_BINARY_DIR}/test)
   set(GENERATE_DEMO_TEST_DATA TRUE)
 endif()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 #------------------------------------------------------------------------------
 # Top level CMakeLists.txt file for DOLFIN
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 
 #------------------------------------------------------------------------------
 # Set project name and version number
@@ -10,7 +10,7 @@ project(DOLFINX VERSION 2019.2.9.99)
 #------------------------------------------------------------------------------
 # Set CMake options, see `cmake --help-policy CMP000x`
 
-cmake_policy(VERSION 3.10)
+cmake_policy(VERSION 3.12)
 if (POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()
@@ -124,6 +124,9 @@ endif()
 
 #------------------------------------------------------------------------------
 # Run tests to find required packages
+
+# Find Python3 and define Python3_EXECUTABLE
+find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 
 # Check for Boost
 set(BOOST_ROOT $ENV{BOOST_DIR} $ENV{BOOST_HOME})
@@ -265,7 +268,7 @@ if (GENERATE_DEMO_TEST_DATA)
   message(STATUS "Copying demo and test data to build directory.")
   message(STATUS "----------------------------------------------")
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} "-B" "-u" ${DOLFINX_SOURCE_DIR}/cmake/scripts/copy-test-demo-data.py ${CMAKE_CURRENT_BINARY_DIR} ${PETSC_SCALAR_COMPLEX}
+    COMMAND ${Python3_EXECUTABLE} "-B" "-u" ${DOLFINX_SOURCE_DIR}/cmake/scripts/copy-test-demo-data.py ${CMAKE_CURRENT_BINARY_DIR} ${PETSC_SCALAR_COMPLEX}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     RESULT_VARIABLE COPY_DEMO_DATA_RESULT
     OUTPUT_VARIABLE COPY_DEMO_DATA_OUTPUT
@@ -283,7 +286,7 @@ if (GENERATE_DEMO_TEST_DATA)
   message(STATUS "Generating form files in demo and test directories. May take some time...")
   message(STATUS "----------------------------------------------------------------------------------------")
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} "-B" "-u" ${DOLFINX_SOURCE_DIR}/cmake/scripts/generate-form-files.py ${PETSC_SCALAR_COMPLEX}
+    COMMAND ${Python3_EXECUTABLE} "-B" "-u" ${DOLFINX_SOURCE_DIR}/cmake/scripts/generate-form-files.py ${PETSC_SCALAR_COMPLEX}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     RESULT_VARIABLE FORM_GENERATION_RESULT
     OUTPUT_VARIABLE FORM_GENERATION_OUTPUT
@@ -308,7 +311,7 @@ if (GENERATE_DEMO_TEST_DATA)
   message(STATUS "-------------------------------------------------------------------")
   # Generate CMakeLists.txt files in build directory
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} ${DOLFINX_SOURCE_DIR}/cmake/scripts/generate-cmakefiles.py
+    COMMAND ${Python3_EXECUTABLE} ${DOLFINX_SOURCE_DIR}/cmake/scripts/generate-cmakefiles.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     RESULT_VARIABLE CMAKE_GENERATION_RESULT
     OUTPUT_VARIABLE CMAKE_GENERATION_OUTPUT
@@ -322,7 +325,7 @@ if (GENERATE_DEMO_TEST_DATA)
     # Generate CMakeLists.txt files in source directory as well, as developers might find it
     # easier to run in-place demo builds while preparing new demos or modifying existing ones
     execute_process(
-      COMMAND ${PYTHON_EXECUTABLE} ${DOLFINX_SOURCE_DIR}/cmake/scripts/generate-cmakefiles.py
+      COMMAND ${Python3_EXECUTABLE} ${DOLFINX_SOURCE_DIR}/cmake/scripts/generate-cmakefiles.py
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       RESULT_VARIABLE CMAKE_GENERATION_RESULT
       OUTPUT_VARIABLE CMAKE_GENERATION_OUTPUT

--- a/cpp/cmake/modules/FindUFC.cmake
+++ b/cpp/cmake/modules/FindUFC.cmake
@@ -57,7 +57,6 @@ if (DEFINED ENV{UFC_INCLUDE_DIR})
    endif()
 else()
   MESSAGE(STATUS "Asking Python module FFCX for location of UFC...")
-  find_package(Python3 COMPONENTS Interpreter REQUIRED)
   execute_process(
     COMMAND ${Python3_EXECUTABLE} -c "import ffcx.codegeneration, sys; sys.stdout.write(ffcx.codegeneration.get_include_path())"
     OUTPUT_VARIABLE UFC_INCLUDE_DIR

--- a/cpp/cmake/modules/FindUFC.cmake
+++ b/cpp/cmake/modules/FindUFC.cmake
@@ -41,13 +41,13 @@
 # Two paths: Set UFC_INCLUDE_DIR manually, or ask Python/FFCX for location
 # of UFC headers.
 
-if (DEFINED UFC_INCLUDE_DIR)
-  MESSAGE(STATUS "Looking for UFC in ${UFC_INCLUDE_DIR}...")
+if (DEFINED ENV{UFC_INCLUDE_DIR})
+  MESSAGE(STATUS "Looking for UFC in $ENV{UFC_INCLUDE_DIR}...")
 
-  if (EXISTS "${UFC_INCLUDE_DIR}/ufc.h" AND EXISTS "${UFC_INCLUDE_DIR}/ufc_geometry.h")
-    set(UFC_INCLUDE_DIRS ${UFC_INCLUDE_DIR} CACHE STRING "Where to find ufc.h and ufc_geometry.h")
+  if (EXISTS "$ENV{UFC_INCLUDE_DIR}/ufc.h" AND EXISTS "$ENV{UFC_INCLUDE_DIR}/ufc_geometry.h")
+    set(UFC_INCLUDE_DIRS $ENV{UFC_INCLUDE_DIR} CACHE STRING "Where to find ufc.h and ufc_geometry.h")
     execute_process(
-      COMMAND /bin/bash -c "cat ${UFC_INCLUDE_DIR}/ufc.h ${UFC_INCLUDE_DIR}/ufc_geometry.h | sha1sum | cut -c 1-40"
+      COMMAND /bin/bash -c "cat $ENV{UFC_INCLUDE_DIR}/ufc.h $ENV{UFC_INCLUDE_DIR}/ufc_geometry.h | sha1sum | cut -c 1-40"
       OUTPUT_VARIABLE UFC_SIGNATURE OUTPUT_STRIP_TRAILING_WHITESPACE)
     # Assume user knows what they are doing.
     set(UFC_VERSION ${UFC_FIND_VERSION})
@@ -57,9 +57,9 @@ if (DEFINED UFC_INCLUDE_DIR)
    endif()
 else()
   MESSAGE(STATUS "Asking Python module FFCX for location of UFC...")
-  find_package(PythonInterp 3 REQUIRED)
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import ffcx.codegeneration, sys; sys.stdout.write(ffcx.codegeneration.get_include_path())"
+    COMMAND ${Python3_EXECUTABLE} -c "import ffcx.codegeneration, sys; sys.stdout.write(ffcx.codegeneration.get_include_path())"
     OUTPUT_VARIABLE UFC_INCLUDE_DIR
     )
 
@@ -67,7 +67,7 @@ else()
     set(UFC_INCLUDE_DIRS ${UFC_INCLUDE_DIR} CACHE STRING "Where to find ufc.h and ufc_geometry.h")
 
     execute_process(
-      COMMAND ${PYTHON_EXECUTABLE} -c "import ffcx, sys; sys.stdout.write(ffcx.__version__)"
+      COMMAND ${Python3_EXECUTABLE} -c "import ffcx, sys; sys.stdout.write(ffcx.__version__)"
       OUTPUT_VARIABLE UFC_VERSION
       )
 
@@ -83,7 +83,7 @@ else()
   endif()
 
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import ffcx.codegeneration, sys; sys.stdout.write(ffcx.codegeneration.get_signature())"
+    COMMAND ${Python3_EXECUTABLE} -c "import ffcx.codegeneration, sys; sys.stdout.write(ffcx.codegeneration.get_signature())"
     OUTPUT_VARIABLE UFC_SIGNATURE
   )
 endif()

--- a/python/cmake/FindMPI4PY.cmake
+++ b/python/cmake/FindMPI4PY.cmake
@@ -10,7 +10,7 @@
 
 if(NOT MPI4PY_INCLUDE_DIR)
     execute_process(COMMAND
-      "${PYTHON_EXECUTABLE}" "-c" "import mpi4py; print(mpi4py.get_include())"
+      "${Python3_EXECUTABLE}" "-c" "import mpi4py; print(mpi4py.get_include())"
       OUTPUT_VARIABLE MPI4PY_INCLUDE_DIR
       RESULT_VARIABLE MPI4PY_COMMAND_RESULT
       OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/python/cmake/FindPETSc4py.cmake
+++ b/python/cmake/FindPETSc4py.cmake
@@ -46,7 +46,7 @@ if(PETSC4PY_INCLUDE_DIRS)
 endif(PETSC4PY_INCLUDE_DIRS)
 
 execute_process(
-  COMMAND ${PYTHON_EXECUTABLE} -c "import petsc4py; print(petsc4py.get_include())"
+  COMMAND ${Python3_EXECUTABLE} -c "import petsc4py; print(petsc4py.get_include())"
   OUTPUT_VARIABLE PETSC4PY_INCLUDE_DIRS
   RESULT_VARIABLE PETSC4PY_NOT_FOUND
   ERROR_QUIET
@@ -62,7 +62,7 @@ endif(PETSC4PY_INCLUDE_DIRS)
 
 if(PETSC4PY_FOUND)
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import petsc4py; print(petsc4py.__version__)"
+    COMMAND ${Python3_EXECUTABLE} -c "import petsc4py; print(petsc4py.__version__)"
     OUTPUT_VARIABLE PETSC4PY_VERSION
     RESULT_VARIABLE PETSC4PY_NOT_FOUND
     OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/python/setup.py
+++ b/python/setup.py
@@ -49,7 +49,7 @@ class CMakeBuild(build_ext):
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-                      '-DPYTHON_EXECUTABLE=' + sys.executable]
+                      '-DPython3_EXECUTABLE=' + sys.executable]
 
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]


### PR DESCRIPTION
 -  Move `find_package(Python3)` to the top level CMakeList
 - Use `FindPython3` module, `FindPythonInterp` is deprecated since CMake 3.12.  The new module allows to find active virtualenv python (good for hpc systems !).
 - Read `UFC_INCLUDE_DIR` environment variable. (It was not being used)

- Bump CMake version (?)