### PR TITLE
Simplify Docker image hierarchy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,27 +233,11 @@ jobs:
           name: Login to Dockerhub
           command: echo ${DH_TOKEN} | sudo docker login -u ${DH_USERNAME} --password-stdin
       - build-and-push-target:
-          docker-target: "base"
+          docker-target: "dev-env"
       - build-and-push-target:
-          docker-target: "dev-env-real"
-      - build-and-push-target:
-          docker-target: "dev-env-complex"
-      - build-and-push-target:
-          docker-target: "real-onbuild"
-      - build-and-push-target:
-          docker-target: "complex-onbuild"
-      - build-and-push-target:
-          docker-target: "real"
-      - build-and-push-target:
-          docker-target: "complex"
-      - build-and-push-target:
-          docker-target: "notebook"
-      - build-and-push-target:
-          docker-target: "notebook-complex"
+          docker-target: "dolfinx"
       - build-and-push-target:
           docker-target: "lab"
-      - build-and-push-target:
-          docker-target: "lab-complex"
 
 workflows:
   build-and-pushdoc:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,26 @@ For detailed instructions, see the file INSTALL.
 
 ## Docker
 
-Nightly Docker images are available at https://hub.docker.com/u/dolfinx.
+A Docker image with DOLFINX built nightly:
+
+```
+docker run -ti dolfinx/dolfinx
+```
+
+A Jupyter Lab environment with DOLFINX built nightly:
+
+```
+docker run -ti -p 8888:8888 dolfinx/lab # Access at http://localhost:8888
+```
+
+A development image with all of the dependencies required
+to build DOLFINX:
+
+```
+docker run -ti dolfinx/dev-env
+```
+
+For more information, see https://hub.docker.com/u/dolfinx
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ A Docker image with DOLFINX built nightly:
 docker run -ti dolfinx/dolfinx
 ```
 
+To switch between real and complex builds of DOLFINX.
+```
+source /usr/local/bin/dolfinx-complex-mode
+source /usr/local/bin/dolfinx-real-mode
+```
+
 A Jupyter Lab environment with DOLFINX built nightly:
 
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -150,21 +150,22 @@ ENV PATH=/usr/local/gmsh-${GMSH_VERSION}-Linux64-sdk/bin:$PATH
 # Add gmsh python API
 ENV PYTHONPATH=/usr/local/gmsh-${GMSH_VERSION}-Linux64-sdk/lib:$PYTHONPATH
 
-WORKDIR /
-
 # Install PETSc with real and complex types
+ENV PETSC_DIR=/usr/local/petsc SLEPC_DIR=/usr/local/slepc
+WORKDIR /tmp
 RUN apt-get -qq update && \
     apt-get -y install bison flex && \
     wget -nc --quiet http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-${PETSC_VERSION}.tar.gz -O petsc-${PETSC_VERSION}.tar.gz && \
-    mkdir -p petsc && tar -xf petsc-${PETSC_VERSION}.tar.gz -C petsc --strip-components 1 && \
-    cd petsc && \
+    mkdir -p ${PETSC_DIR} && tar -xf petsc-${PETSC_VERSION}.tar.gz -C ${PETSC_DIR} --strip-components 1 && \
+    cd ${PETSC_DIR} && \
     python3 ./configure \
-    --PETSC_ARCH=linux-gnu-real-32 \
+    PETSC_ARCH=linux-gnu-real-32 \
     --COPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
     --CXXOPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
     --FOPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
     --with-debugging=${PETSC_SLEPC_DEBUGGING} \
     --with-fortran-bindings=no \
+    --with-shared-libraries \
     --download-blacs \
     --download-hypre \
     --download-metis \
@@ -175,15 +176,16 @@ RUN apt-get -qq update && \
     --download-suitesparse \
     --download-superlu \
     --download-superlu_dist \
-    --with-scalar-type=real \
-    make ${MAKEFLAGS} && \
+    --with-scalar-type=real && \
+    make PETSC_DIR=/usr/local/petsc PETSC_ARCH=linux-gnu-real-32 ${MAKEFLAGS} all && \
     python3 ./configure \
-    --PETSC_ARCH=linux-gnu-complex-32 \
+    PETSC_ARCH=linux-gnu-complex-32 \
     --COPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
     --CXXOPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
     --FOPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
     --with-debugging=${PETSC_SLEPC_DEBUGGING} \
     --with-fortran-bindings=no \
+    --with-shared-libraries \
     --download-blacs \
     --download-metis \
     --download-mumps \
@@ -192,12 +194,12 @@ RUN apt-get -qq update && \
     --download-suitesparse \
     --download-superlu \
     --download-superlu_dist \
-    --with-scalar-type=complex \
-    make ${MAKEFLAGS} && \
-    apt-get -y purge bison flex python && \
+    --with-scalar-type=complex && \
+    make PETSC_DIR=/usr/local/petsc PETSC_ARCH=linux-gnu-complex-32 ${MAKEFLAGS} all && \
+    apt-get -y purge bison flex && \
     apt-get -y autoremove && \
     apt-get clean && \
-    PETSC_DIR=/usr/local/petsc rm -rf \
+    rm -rf \
     ${PETSC_DIR}/**/tests/ \
     ${PETSC_DIR}/**/obj/ \
     ${PETSC_DIR}/**/externalpackages/  \
@@ -210,11 +212,11 @@ RUN apt-get -qq update && \
     ${PETSC_DIR}/systems/ \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN cd /tmp && \
-    wget -nc --quiet https://slepc.upv.es/download/distrib/slepc-${SLEPC_VERSION}.tar.gz -O slepc-${SLEPC_VERSION}.tar.gz && \
-    mkdir -p slepc && tar -xf slepc-${SLEPC_VERSION}.tar.gz -C slepc --strip-components 1 && \
-    cd slepc && \
-    export PETSC_DIR=/usr/local/petsc && \
+# Install SLEPc
+WORKDIR /tmp
+RUN wget -nc --quiet https://slepc.upv.es/download/distrib/slepc-${SLEPC_VERSION}.tar.gz -O slepc-${SLEPC_VERSION}.tar.gz && \
+    mkdir -p ${SLEPC_DIR} && tar -xf slepc-${SLEPC_VERSION}.tar.gz -C ${SLEPC_DIR} --strip-components 1 && \
+    cd ${SLEPC_DIR} && \
     export PETSC_ARCH=linux-gnu-real-32 && \
     python3 ./configure && \
     make && \
@@ -223,8 +225,6 @@ RUN cd /tmp && \
     make && \
     rm -rf ${SLEPC_DIR}/CTAGS ${SLEPC_DIR}/TAGS ${SLEPC_DIR}/docs ${SLEPC_DIR}/src/ ${SLEPC_DIR}/**/obj/ ${SLEPC_DIR}/**/test/ && \
     rm -rf /tmp/*
-
-ENV PETSC_DIR=/usr/local/petsc SLEPC_DIR=/usr/local/slepc
 
 # Install petsc4py and slepc4py with real and complex types
 RUN PETSC_ARCH=linux-gnu-real-32:linux-gnu-complex-32 pip3 install --no-cache-dir petsc4py==${PETSC4PY_VERSION} slepc4py==${SLEPC4PY_VERSION}
@@ -251,11 +251,11 @@ ONBUILD RUN pip3 install --no-cache-dir ipython && \
     pip3 install --no-cache-dir git+https://github.com/FEniCS/ufl.git && \
     pip3 install --no-cache-dir git+https://github.com/FEniCS/ffcx.git
 
-ONBUILD RUN git clone https://github.com/fenics/dolfinx.git && \
+ONBUILD RUN git clone --depth 1 https://github.com/fenics/dolfinx.git && \
     cd dolfinx && \
     mkdir build && \
     cd build && \
-    PETSC_ARCH=linux-gnu-real-32 -G Ninja ../cpp && \
+    PETSC_ARCH=linux-gnu-real-32 cmake -G Ninja ../cpp && \
     ninja ${MAKEFLAGS} install && \
     cd ../python && \
     PETSC_ARCH=linux-gnu-real-32 pip3 install . && \
@@ -287,5 +287,6 @@ ARG TINI_VERSION
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini && \
     pip3 install --no-cache-dir jupyter jupyterlab
+EXPOSE 8888/tcp
 
 ENTRYPOINT ["/tini", "--", "jupyter", "lab", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -255,10 +255,10 @@ ONBUILD RUN git clone --depth 1 https://github.com/fenics/dolfinx.git && \
     cd dolfinx && \
     mkdir build && \
     cd build && \
-    PETSC_ARCH=linux-gnu-real-32 cmake -G Ninja ../cpp && \
+    PETSC_ARCH=linux-gnu-real-32 cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-real ../cpp && \
     ninja ${MAKEFLAGS} install && \
     cd ../python && \
-    PETSC_ARCH=linux-gnu-real-32 pip3 install . && \
+    PETSC_ARCH=linux-gnu-real-32 pip3 install --target /usr/local/dolfinx-real/lib/python3.8/dist-packages --no-dependencies --ignore-installed . && \
     cd ../ && \
     git clean -fdx && \
     mkdir build && \
@@ -269,6 +269,13 @@ ONBUILD RUN git clone --depth 1 https://github.com/fenics/dolfinx.git && \
     cd ../python && \
     PETSC_ARCH=linux-gnu-complex-32 pip3 install --target /usr/local/dolfinx-complex/lib/python3.8/dist-packages --no-dependencies --ignore-installed . && \
     rm -rf /tmp/*
+
+# Real by default.
+ONBUILD ENV LD_LIBRARY_PATH=/usr/local/dolfinx-real/lib:$LD_LIBRARY_PATH \
+        PATH=/usr/local/dolfinx-real/bin:$PATH \
+        PKG_CONFIG_PATH=/usr/local/dolfinx-real/lib/pkgconfig:$PKG_CONFIG_PATH \
+        PETSC_ARCH=linux-gnu-real-32 \
+        PYTHONPATH=/usr/local/dolfinx-real/lib/python3.8/dist-packages:$PYTHONPATH
 
 ONBUILD WORKDIR /root
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,21 +9,15 @@
 #
 # To run a nightly build:
 #
-#    docker run -ti dolfinx/real
-#    docker run -ti dolfinx/complex
+#    docker run -ti dolfinx/dolfinx
 #
-# To build a new FEniCS-X image from master (real or complex version):
+# To run a Jupyter lab session:
 #
-#    docker build --target real-onbuild .
-#    docker build --target complex-onbuild .
-#
-# To run a notebook:
-#
-#    docker run -p 8888:8888 dolfinx/notebook
+#    docker run -p 8888:8888 dolfinx/lab
 #
 # To run and share the current host directory with the container:
 #
-#    docker run -p 8888:8888 -v "$(pwd)":/tmp dolfinx/notebook
+#    docker run -p 8888:8888 -v "$(pwd)":/root/shared dolfinx/lab
 #
 
 ARG TINI_VERSION=v0.18.0
@@ -40,12 +34,25 @@ ARG MAKEFLAGS
 ARG PETSC_SLEPC_OPTFLAGS="-02 -g"
 ARG PETSC_SLEPC_DEBUGGING="yes"
 
+
+WORKDIR /root
+
+########################################
+
 FROM ubuntu:20.04 as base
 LABEL maintainer="fenics-project <fenics-support@googlegroups.org>"
-LABEL description="Base image for real and complex FEniCS test environments"
+LABEL description="FEniCS development environment with PETSc real and complex modes"
 
 ARG GMSH_VERSION
 ARG PYBIND11_VERSION
+ARG PETSC_VERSION
+ARG PETSC4PY_VERSION
+ARG SLEPC_VERSION
+ARG SLEPC4PY_VERSION
+
+ARG MAKEFLAGS
+ARG PETSC_SLEPC_OPTFLAGS
+ARG PETSC_SLEPC_DEBUGGING
 
 WORKDIR /tmp
 
@@ -145,24 +152,6 @@ ENV PATH=/usr/local/gmsh-${GMSH_VERSION}-Linux64-sdk/bin:$PATH
 
 # Add gmsh python API
 ENV PYTHONPATH=/usr/local/gmsh-${GMSH_VERSION}-Linux64-sdk/lib:$PYTHONPATH
-
-WORKDIR /root
-
-########################################
-
-FROM base as dev-env-real
-LABEL maintainer="fenics-project <fenics-support@googlegroups.org>"
-LABEL description="FEniCS development environment with PETSc real mode"
-
-ARG PETSC_VERSION
-ARG PETSC4PY_VERSION
-ARG SLEPC_VERSION
-ARG SLEPC4PY_VERSION
-
-ARG MAKEFLAGS
-ARG PETSC_SLEPC_OPTFLAGS
-ARG PETSC_SLEPC_DEBUGGING
-
 WORKDIR /tmp
 
 # Install PETSc and SLEPc with real types
@@ -188,15 +177,15 @@ RUN apt-get -qq update && \
     --download-superlu \
     --download-superlu_dist \
     --with-scalar-type=real \
-    --prefix=/usr/local/petsc && \
+    --prefix=/usr/local/petsc-real && \
     make ${MAKEFLAGS} && \
     make install && \
-    export PETSC_DIR=/usr/local/petsc && \
+    export PETSC_DIR=/usr/local/petsc-real && \
     cd /tmp && \
     wget -nc --quiet https://slepc.upv.es/download/distrib/slepc-${SLEPC_VERSION}.tar.gz -O slepc-${SLEPC_VERSION}.tar.gz && \
     mkdir -p slepc-src && tar -xf slepc-${SLEPC_VERSION}.tar.gz -C slepc-src --strip-components 1 && \
     cd slepc-src && \
-    python3 ./configure --prefix=/usr/local/slepc && \
+    python3 ./configure --prefix=/usr/local/slepc-real && \
     make ${MAKEFLAGS} && \
     make install && \
     apt-get -y purge bison flex python && \
@@ -205,29 +194,9 @@ RUN apt-get -qq update && \
     rm -rf /tmp/* && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV PETSC_DIR=/usr/local/petsc SLEPC_DIR=/usr/local/slepc
-
-# Install petsc4py and slepc4py
-RUN pip3 install --no-cache-dir petsc4py==${PETSC4PY_VERSION} && \
-    pip3 install --no-cache-dir slepc4py==${SLEPC4PY_VERSION}
-
-WORKDIR /root
-
-########################################
-
-FROM base as dev-env-complex
-LABEL description="FEniCS development environment with PETSc complex mode"
-
-ARG PETSC_VERSION
-ARG PETSC4PY_VERSION
-ARG SLEPC_VERSION
-ARG SLEPC4PY_VERSION
-
-ARG MAKEFLAGS
-ARG PETSC_SLEPC_OPTFLAGS
-ARG PETSC_SLEPC_DEBUGGING
-
-WORKDIR /tmp
+# Install petsc4py and slepc4py with real types
+RUN PETSC_DIR=/usr/local/petsc-real pip3 install --no-cache-dir petsc4py==${PETSC4PY_VERSION} && \
+    PETSC_DIR=/usr/local/petsc-real SLEPC_DIR=/usr/local/slepc-real pip3 install --no-cache-dir slepc4py==${SLEPC4PY_VERSION}
 
 # Install PETSc and SLEPc with complex scalar types
 RUN apt-get -qq update && \
@@ -250,15 +219,15 @@ RUN apt-get -qq update && \
     --download-superlu \
     --download-superlu_dist \
     --with-scalar-type=complex \
-    --prefix=/usr/local/petsc && \
+    --prefix=/usr/local/petsc-complex && \
     make ${MAKEFLAGS} && \
     make install && \
-    export PETSC_DIR=/usr/local/petsc && \
+    export PETSC_DIR=/usr/local/petsc-complex && \
     cd /tmp && \
     wget -nc --quiet https://slepc.upv.es/download/distrib/slepc-${SLEPC_VERSION}.tar.gz -O slepc-${SLEPC_VERSION}.tar.gz && \
     mkdir -p slepc-src && tar -xf slepc-${SLEPC_VERSION}.tar.gz -C slepc-src --strip-components 1 && \
     cd slepc-src && \
-    python3  ./configure --prefix=/usr/local/slepc && \
+    python3  ./configure --prefix=/usr/local/slepc-complex && \
     make ${MAKEFLAGS} && \
     make install && \
     apt-get -y purge bison flex python && \
@@ -267,18 +236,21 @@ RUN apt-get -qq update && \
     rm -rf /tmp/* && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV PETSC_DIR=/usr/local/petsc SLEPC_DIR=/usr/local/slepc
+# Install petsc4py and slepc4py with complex types
+RUN PETSC_DIR=/usr/local/petsc-complex pip3 install --no-cache-dir petsc4py==${PETSC4PY_VERSION} && \
+    PETSC_DIR=/usr/local/petsc-complex SLEPC_DIR=/usr/local/slepc-real pip3 install --no-cache-dir slepc4py==${SLEPC4PY_VERSION}
 
-# Install complex petsc4py and slepc4py
-RUN pip3 install --no-cache-dir petsc4py==${PETSC4PY_VERSION} && \
-    pip3 install --no-cache-dir slepc4py==${SLEPC4PY_VERSION}
+# Default is to use real version of PETSc
+# petsc4py and slepc4py build against real PETSc are found automatically in the default sitepackages path
+# User must set PYTHONPATH to use complex version of petsc4py and slepc4py
+ENV PETSC_DIR=/usr/local/petsc-real SLEPC_DIR=/usr/local/slepc-real
 
 WORKDIR /root
 
 ########################################
 
-FROM dev-env-real as real-onbuild
-LABEL description="DOLFIN-X in real mode (ONBUILD)"
+FROM dev-env as dolfinx-onbuild
+LABEL description="DOLFIN-X user environment in real and complex modes"
 
 ONBUILD ARG MAKEFLAGS
 
@@ -291,7 +263,7 @@ ONBUILD RUN pip3 install --no-cache-dir ipython && \
     pip3 install --no-cache-dir git+https://github.com/FEniCS/ufl.git && \
     pip3 install --no-cache-dir git+https://github.com/FEniCS/ffcx.git
 
-# Install dolfinx
+# Install dolfinx real mode
 ONBUILD RUN git clone https://github.com/fenics/dolfinx.git && \
     cd dolfinx && \
     mkdir build && \
@@ -306,46 +278,12 @@ ONBUILD WORKDIR /root
 
 ########################################
 
-FROM real-onbuild as real
+FROM dolfinx-onbuild as dolfinx
 LABEL description="DOLFIN-X in real mode"
 
 ########################################
 
-FROM dev-env-complex as complex-onbuild
-LABEL description="DOLFIN-X in complex mode (ONBUILD)"
-
-ONBUILD ARG MAKEFLAGS
-
-ONBUILD WORKDIR /tmp
-
-# Install ipython (optional), FIAT, UFL and FFCX (development versions,
-# master branch)
-ONBUILD RUN pip3 install --no-cache-dir ipython && \
-    pip3 install --no-cache-dir git+https://github.com/FEniCS/fiat.git && \
-    pip3 install --no-cache-dir git+https://github.com/FEniCS/ufl.git && \
-    pip3 install --no-cache-dir git+https://github.com/FEniCS/ffcx.git
-
-# Install dolfinx
-ONBUILD RUN git clone https://github.com/fenics/dolfinx.git && \
-    cd dolfinx && \
-    mkdir build && \
-    cd build && \
-    cmake -G Ninja ../cpp && \
-    ninja ${MAKEFLAGS} install && \
-    cd ../python && \
-    pip3 install . && \
-    rm -rf /tmp/*
-
-ONBUILD WORKDIR /root
-
-########################################
-
-FROM complex-onbuild as complex
-LABEL description="DOLFIN-X in real mode"
-
-########################################
-
-FROM real as notebook
+FROM dolfinx as lab
 LABEL description="DOLFIN-X Jupyter Notebook"
 WORKDIR /root
 
@@ -354,33 +292,4 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini && \
     pip3 install --no-cache-dir jupyter jupyterlab
 
-ENTRYPOINT ["/tini", "--", "jupyter", "notebook", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]
-
-########################################
-
-FROM complex as notebook-complex
-LABEL description="DOLFIN-X (complex mode) Jupyter Notebook"
-
-ARG TINI_VERSION
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini && \
-    pip3 install --no-cache-dir jupyter jupyterlab
-
-WORKDIR /root
-ENTRYPOINT ["/tini", "--", "jupyter", "notebook", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]
-
-########################################
-
-FROM notebook as lab
-LABEL description="DOLFIN-X Jupyter Lab"
-
-WORKDIR /root
-ENTRYPOINT ["/tini", "--", "jupyter", "lab", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]
-
-########################################
-
-FROM notebook-complex as lab-complex
-LABEL description="DOLFIN-X (complex mode) Jupyter Lab"
-
-WORKDIR /root
 ENTRYPOINT ["/tini", "--", "jupyter", "lab", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,13 +20,13 @@
 #    docker run -p 8888:8888 -v "$(pwd)":/root/shared dolfinx/lab
 #
 
-ARG TINI_VERSION=v0.18.0
-ARG GMSH_VERSION=4.5.5
-ARG PYBIND11_VERSION=2.4.3
-ARG PETSC_VERSION=3.12.4
-ARG SLEPC_VERSION=3.12.2
-ARG PETSC4PY_VERSION=3.12.0
-ARG SLEPC4PY_VERSION=3.12.0
+ARG TINI_VERSION=v0.19.0
+ARG GMSH_VERSION=4.5.6
+ARG PYBIND11_VERSION=2.5.0
+ARG PETSC_VERSION=3.13.2
+ARG SLEPC_VERSION=3.13.2
+ARG PETSC4PY_VERSION=3.13.0
+ARG SLEPC4PY_VERSION=3.13.0
 # Should be updated upon a new KaHIP release
 ARG KAHIP_VERSION=14be06c
 
@@ -150,15 +150,16 @@ ENV PATH=/usr/local/gmsh-${GMSH_VERSION}-Linux64-sdk/bin:$PATH
 # Add gmsh python API
 ENV PYTHONPATH=/usr/local/gmsh-${GMSH_VERSION}-Linux64-sdk/lib:$PYTHONPATH
 
-WORKDIR /tmp
+WORKDIR /
 
-# Install PETSc and SLEPc with real types
+# Install PETSc with real and complex types
 RUN apt-get -qq update && \
     apt-get -y install bison flex && \
     wget -nc --quiet http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-${PETSC_VERSION}.tar.gz -O petsc-${PETSC_VERSION}.tar.gz && \
-    mkdir -p petsc-src && tar -xf petsc-${PETSC_VERSION}.tar.gz -C petsc-src --strip-components 1 && \
-    cd petsc-src && \
+    mkdir -p petsc && tar -xf petsc-${PETSC_VERSION}.tar.gz -C petsc --strip-components 1 && \
+    cd petsc && \
     python3 ./configure \
+    --PETSC_ARCH=linux-gnu-real-32 \
     --COPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
     --CXXOPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
     --FOPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
@@ -175,33 +176,9 @@ RUN apt-get -qq update && \
     --download-superlu \
     --download-superlu_dist \
     --with-scalar-type=real \
-    --prefix=/usr/local/petsc-real && \
     make ${MAKEFLAGS} && \
-    make install && \
-    export PETSC_DIR=/usr/local/petsc-real && \
-    cd /tmp && \
-    wget -nc --quiet https://slepc.upv.es/download/distrib/slepc-${SLEPC_VERSION}.tar.gz -O slepc-${SLEPC_VERSION}.tar.gz && \
-    mkdir -p slepc-src && tar -xf slepc-${SLEPC_VERSION}.tar.gz -C slepc-src --strip-components 1 && \
-    cd slepc-src && \
-    python3 ./configure --prefix=/usr/local/slepc-real && \
-    make ${MAKEFLAGS} && \
-    make install && \
-    apt-get -y purge bison flex python && \
-    apt-get -y autoremove && \
-    apt-get clean && \
-    rm -rf /tmp/* && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Install petsc4py and slepc4py with real types
-RUN PETSC_DIR=/usr/local/petsc-real SLEPC_DIR=/usr/local/slepc-real pip3 install --no-cache-dir petsc4py==${PETSC4PY_VERSION} slepc4py==${SLEPC4PY_VERSION}
-
-# Install PETSc and SLEPc with complex scalar types
-RUN apt-get -qq update && \
-    apt-get -y install bison flex && \
-    wget -nc --quiet http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-${PETSC_VERSION}.tar.gz -O petsc-${PETSC_VERSION}.tar.gz && \
-    mkdir -p petsc-src && tar -xf petsc-${PETSC_VERSION}.tar.gz -C petsc-src --strip-components 1 && \
-    cd petsc-src && \
     python3 ./configure \
+    --PETSC_ARCH=linux-gnu-complex-32 \
     --COPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
     --CXXOPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
     --FOPTFLAGS=${PETSC_SLEPC_OPTFLAGS} \
@@ -216,31 +193,41 @@ RUN apt-get -qq update && \
     --download-superlu \
     --download-superlu_dist \
     --with-scalar-type=complex \
-    --prefix=/usr/local/petsc-complex && \
     make ${MAKEFLAGS} && \
-    make install && \
-    export PETSC_DIR=/usr/local/petsc-complex && \
-    cd /tmp && \
-    wget -nc --quiet https://slepc.upv.es/download/distrib/slepc-${SLEPC_VERSION}.tar.gz -O slepc-${SLEPC_VERSION}.tar.gz && \
-    mkdir -p slepc-src && tar -xf slepc-${SLEPC_VERSION}.tar.gz -C slepc-src --strip-components 1 && \
-    cd slepc-src && \
-    python3  ./configure --prefix=/usr/local/slepc-complex && \
-    make ${MAKEFLAGS} && \
-    make install && \
     apt-get -y purge bison flex python && \
     apt-get -y autoremove && \
     apt-get clean && \
-    rm -rf /tmp/* && \
+    PETSC_DIR=/usr/local/petsc rm -rf \
+    ${PETSC_DIR}/**/tests/ \
+    ${PETSC_DIR}/**/obj/ \
+    ${PETSC_DIR}/**/externalpackages/  \
+    ${PETSC_DIR}/CTAGS \
+    ${PETSC_DIR}/RDict.log \
+    ${PETSC_DIR}/TAGS \
+    ${PETSC_DIR}/docs/ \
+    ${PETSC_DIR}/share/ \
+    ${PETSC_DIR}/src/ \
+    ${PETSC_DIR}/systems/ \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Install petsc4py and slepc4py with complex types
-RUN mkdir -p /usr/local/lib/python3.8/dist-packages-complex && \
-    PETSC_DIR=/usr/local/petsc-complex SLEPC_DIR=/usr/local/slepc-real pip3 install --no-cache-dir --no-dependencies --ignore-installed --target /usr/local/lib/python3.8/dist-packages-complex petsc4py==${PETSC4PY_VERSION} slepc4py==${SLEPC4PY_VERSION}
+RUN cd /tmp && \
+    wget -nc --quiet https://slepc.upv.es/download/distrib/slepc-${SLEPC_VERSION}.tar.gz -O slepc-${SLEPC_VERSION}.tar.gz && \
+    mkdir -p slepc && tar -xf slepc-${SLEPC_VERSION}.tar.gz -C slepc --strip-components 1 && \
+    cd slepc && \
+    export PETSC_DIR=/usr/local/petsc && \
+    export PETSC_ARCH=linux-gnu-real-32 && \
+    python3 ./configure && \
+    make && \
+    export PETSC_ARCH=linux-gnu-complex-32 && \
+    python3 ./configure && \
+    make && \
+    rm -rf ${SLEPC_DIR}/CTAGS ${SLEPC_DIR}/TAGS ${SLEPC_DIR}/docs ${SLEPC_DIR}/src/ ${SLEPC_DIR}/**/obj/ ${SLEPC_DIR}/**/test/ && \
+    rm -rf /tmp/*
 
-# Default is to use real version of PETSc
-# petsc4py and slepc4py build against real PETSc are found automatically in the default PYTHONPATH
-# User must set PYTHONPATH to use complex version of petsc4py and slepc4py
-ENV PETSC_DIR=/usr/local/petsc-real SLEPC_DIR=/usr/local/slepc-real
+ENV PETSC_DIR=/usr/local/petsc SLEPC_DIR=/usr/local/slepc
+
+# Install petsc4py and slepc4py with real and complex types
+RUN PETSC_ARCH=linux-gnu-real-32:linux-gnu-complex-32 pip3 install --no-cache-dir petsc4py==${PETSC4PY_VERSION} slepc4py==${SLEPC4PY_VERSION}
 
 WORKDIR /root
 
@@ -268,21 +255,19 @@ ONBUILD RUN git clone https://github.com/fenics/dolfinx.git && \
     cd dolfinx && \
     mkdir build && \
     cd build && \
-    cmake -G Ninja ../cpp && \
+    PETSC_ARCH=linux-gnu-real-32 -G Ninja ../cpp && \
     ninja ${MAKEFLAGS} install && \
     cd ../python && \
-    pip3 install . && \
-    rm -rf /tmp/*
-
-ONBUILD RUN git clone https://github.com/fenics/dolfinx.git && \
-    cd dolfinx && \
+    PETSC_ARCH=linux-gnu-real-32 pip3 install . && \
+    cd ../ && \
+    git clean -fdx && \
     mkdir build && \
     cd build && \
-    PYTHONPATH=/usr/local/lib/python3.8/dist-packages-complex PETSC_DIR=/usr/local/petsc-complex SLEPC_DIR=/usr/local/slepc-complex cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-complex ../cpp && \
+    PETSC_ARCH=linux-gnu-complex-32 cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-complex ../cpp && \
     ninja ${MAKEFLAGS} install && \
     . /usr/local/dolfinx-complex/share/dolfinx/dolfinx.conf && \
     cd ../python && \
-    PETSC_DIR=/usr/local/petsc-complex pip3 install --target /usr/local/lib/python3.8/dist-packages-complex --no-dependencies --ignore-installed . && \
+    PETSC_ARCH=linux-gnu-complex-32 pip3 install --target /usr/local/dolfinx-complex/lib/python3.8/dist-packages --no-dependencies --ignore-installed . && \
     rm -rf /tmp/*
 
 ONBUILD WORKDIR /root

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,12 +34,9 @@ ARG MAKEFLAGS
 ARG PETSC_SLEPC_OPTFLAGS="-02 -g"
 ARG PETSC_SLEPC_DEBUGGING="yes"
 
-
-WORKDIR /root
-
 ########################################
 
-FROM ubuntu:20.04 as base
+FROM ubuntu:20.04 as dev-env
 LABEL maintainer="fenics-project <fenics-support@googlegroups.org>"
 LABEL description="FEniCS development environment with PETSc real and complex modes"
 
@@ -152,6 +149,7 @@ ENV PATH=/usr/local/gmsh-${GMSH_VERSION}-Linux64-sdk/bin:$PATH
 
 # Add gmsh python API
 ENV PYTHONPATH=/usr/local/gmsh-${GMSH_VERSION}-Linux64-sdk/lib:$PYTHONPATH
+
 WORKDIR /tmp
 
 # Install PETSc and SLEPc with real types
@@ -195,8 +193,7 @@ RUN apt-get -qq update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install petsc4py and slepc4py with real types
-RUN PETSC_DIR=/usr/local/petsc-real pip3 install --no-cache-dir petsc4py==${PETSC4PY_VERSION} && \
-    PETSC_DIR=/usr/local/petsc-real SLEPC_DIR=/usr/local/slepc-real pip3 install --no-cache-dir slepc4py==${SLEPC4PY_VERSION}
+RUN PETSC_DIR=/usr/local/petsc-real SLEPC_DIR=/usr/local/slepc-real pip3 install --no-cache-dir petsc4py==${PETSC4PY_VERSION} slepc4py==${SLEPC4PY_VERSION}
 
 # Install PETSc and SLEPc with complex scalar types
 RUN apt-get -qq update && \
@@ -237,11 +234,11 @@ RUN apt-get -qq update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install petsc4py and slepc4py with complex types
-RUN PETSC_DIR=/usr/local/petsc-complex pip3 install --no-cache-dir petsc4py==${PETSC4PY_VERSION} && \
-    PETSC_DIR=/usr/local/petsc-complex SLEPC_DIR=/usr/local/slepc-real pip3 install --no-cache-dir slepc4py==${SLEPC4PY_VERSION}
+RUN mkdir -p /usr/local/lib/python3.8/dist-packages-complex && \
+    PETSC_DIR=/usr/local/petsc-complex SLEPC_DIR=/usr/local/slepc-real pip3 install --no-cache-dir --no-dependencies --ignore-installed --target /usr/local/lib/python3.8/dist-packages-complex petsc4py==${PETSC4PY_VERSION} slepc4py==${SLEPC4PY_VERSION}
 
 # Default is to use real version of PETSc
-# petsc4py and slepc4py build against real PETSc are found automatically in the default sitepackages path
+# petsc4py and slepc4py build against real PETSc are found automatically in the default PYTHONPATH
 # User must set PYTHONPATH to use complex version of petsc4py and slepc4py
 ENV PETSC_DIR=/usr/local/petsc-real SLEPC_DIR=/usr/local/slepc-real
 
@@ -250,7 +247,7 @@ WORKDIR /root
 ########################################
 
 FROM dev-env as dolfinx-onbuild
-LABEL description="DOLFIN-X user environment in real and complex modes"
+LABEL description="DOLFIN-X in real and complex modes (onbuild)"
 
 ONBUILD ARG MAKEFLAGS
 
@@ -263,7 +260,7 @@ ONBUILD RUN pip3 install --no-cache-dir ipython && \
     pip3 install --no-cache-dir git+https://github.com/FEniCS/ufl.git && \
     pip3 install --no-cache-dir git+https://github.com/FEniCS/ffcx.git
 
-# Install dolfinx real mode
+
 ONBUILD RUN git clone https://github.com/fenics/dolfinx.git && \
     cd dolfinx && \
     mkdir build && \
@@ -274,17 +271,28 @@ ONBUILD RUN git clone https://github.com/fenics/dolfinx.git && \
     pip3 install . && \
     rm -rf /tmp/*
 
+ONBUILD RUN git clone https://github.com/fenics/dolfinx.git && \
+    cd dolfinx && \
+    mkdir build && \
+    cd build && \
+    PYTHONPATH=/usr/local/lib/python3.8/dist-packages-complex PETSC_DIR=/usr/local/petsc-complex SLEPC_DIR=/usr/local/slepc-complex cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfin-complex ../cpp && \
+    ninja ${MAKEFLAGS} install && \
+    . /usr/local/dolfin-complex/share/dolfinx/dolfinx.conf && \
+    cd ../python && \
+    PETSC_DIR=/usr/local/petsc-complex pip3 install --target /usr/local/lib/python3.8/dist-packages-complex --no-dependencies --ignore-installed . && \
+    rm -rf /tmp/*
+
 ONBUILD WORKDIR /root
 
 ########################################
 
 FROM dolfinx-onbuild as dolfinx
-LABEL description="DOLFIN-X in real mode"
+LABEL description="DOLFIN-X in real and complex modes"
 
 ########################################
 
 FROM dolfinx as lab
-LABEL description="DOLFIN-X Jupyter Notebook"
+LABEL description="DOLFIN-X Jupyter Lab"
 WORKDIR /root
 
 ARG TINI_VERSION

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -249,6 +249,10 @@ WORKDIR /root
 FROM dev-env as dolfinx-onbuild
 LABEL description="DOLFIN-X in real and complex modes (onbuild)"
 
+ADD dolfinx-real-mode /usr/local/bin/dolfinx-real-mode
+ADD dolfinx-complex-mode /usr/local/bin/dolfinx-complex-mode
+RUN chmod +x /usr/local/bin/dolfinx-*-mode
+
 ONBUILD ARG MAKEFLAGS
 
 ONBUILD WORKDIR /tmp
@@ -259,7 +263,6 @@ ONBUILD RUN pip3 install --no-cache-dir ipython && \
     pip3 install --no-cache-dir git+https://github.com/FEniCS/fiat.git && \
     pip3 install --no-cache-dir git+https://github.com/FEniCS/ufl.git && \
     pip3 install --no-cache-dir git+https://github.com/FEniCS/ffcx.git
-
 
 ONBUILD RUN git clone https://github.com/fenics/dolfinx.git && \
     cd dolfinx && \
@@ -275,9 +278,9 @@ ONBUILD RUN git clone https://github.com/fenics/dolfinx.git && \
     cd dolfinx && \
     mkdir build && \
     cd build && \
-    PYTHONPATH=/usr/local/lib/python3.8/dist-packages-complex PETSC_DIR=/usr/local/petsc-complex SLEPC_DIR=/usr/local/slepc-complex cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfin-complex ../cpp && \
+    PYTHONPATH=/usr/local/lib/python3.8/dist-packages-complex PETSC_DIR=/usr/local/petsc-complex SLEPC_DIR=/usr/local/slepc-complex cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-complex ../cpp && \
     ninja ${MAKEFLAGS} install && \
-    . /usr/local/dolfin-complex/share/dolfinx/dolfinx.conf && \
+    . /usr/local/dolfinx-complex/share/dolfinx/dolfinx.conf && \
     cd ../python && \
     PETSC_DIR=/usr/local/petsc-complex pip3 install --target /usr/local/lib/python3.8/dist-packages-complex --no-dependencies --ignore-installed . && \
     rm -rf /tmp/*

--- a/docker/dolfinx-complex-mode
+++ b/docker/dolfinx-complex-mode
@@ -1,0 +1,5 @@
+#!/bin/bash
+source /usr/local/dolfinx-complex/share/dolfinx/dolfinx.conf
+export PYTHONPATH=/usr/local/lib/python3.8/dist-packages-complex:$PYTHONPATH
+export PETSC_DIR=/usr/local/petsc-complex
+export SLEPC_DIR=/usr/local/slepc-complex

--- a/docker/dolfinx-complex-mode
+++ b/docker/dolfinx-complex-mode
@@ -1,4 +1,6 @@
 #!/bin/bash
-source /usr/local/dolfinx-complex/share/dolfinx/dolfinx.conf
+export LD_LIBRARY_PATH=/usr/local/dolfinx-complex/lib:$LD_LIBRARY_PATH
+export PATH=/usr/local/dolfinx-complex/bin:$PATH
+export PKG_CONFIG_PATH=/usr/local/dolfinx-complex/lib/pkgconfig:$PKG_CONFIG_PATH
 export PETSC_ARCH=linux-gnu-complex-32
 export PYTHONPATH=/usr/local/dolfinx-complex/lib/python3.8/dist-packages:$PYTHONPATH

--- a/docker/dolfinx-complex-mode
+++ b/docker/dolfinx-complex-mode
@@ -1,4 +1,4 @@
 #!/bin/bash
 source /usr/local/dolfinx-complex/share/dolfinx/dolfinx.conf
 export PETSC_ARCH=linux-gnu-complex-32
-export PYTHONPATH=/usr/local/lib/dolfinx-complex/lib/python3.8/dist-packages:$PYTHONPATH
+export PYTHONPATH=/usr/local/dolfinx-complex/lib/python3.8/dist-packages:$PYTHONPATH

--- a/docker/dolfinx-complex-mode
+++ b/docker/dolfinx-complex-mode
@@ -1,5 +1,4 @@
 #!/bin/bash
 source /usr/local/dolfinx-complex/share/dolfinx/dolfinx.conf
-export PYTHONPATH=/usr/local/lib/python3.8/dist-packages-complex:$PYTHONPATH
-export PETSC_DIR=/usr/local/petsc-complex
-export SLEPC_DIR=/usr/local/slepc-complex
+export PETSC_ARCH=linux-gnu-complex-32
+export PYTHONPATH=/usr/local/lib/dolfinx-complex/lib/python3.8/dist-packages:$PYTHONPATH

--- a/docker/dolfinx-real-mode
+++ b/docker/dolfinx-real-mode
@@ -1,4 +1,6 @@
 #!/bin/bash
-source /usr/local/share/dolfinx/dolfinx.conf
+export LD_LIBRARY_PATH=/usr/local/dolfinx-real/lib:$LD_LIBRARY_PATH
+export PATH=/usr/local/dolfinx-real/bin:$PATH
+export PKG_CONFIG_PATH=/usr/local/dolfinx-real/lib/pkgconfig:$PKG_CONFIG_PATH
 export PETSC_ARCH=linux-gnu-real-32
-export PYTHONPATH=/usr/local/lib/python3.8/dist-packages:$PYTHONPATH
+export PYTHONPATH=/usr/local/dolfinx-real/lib/python3.8/dist-packages:$PYTHONPATH

--- a/docker/dolfinx-real-mode
+++ b/docker/dolfinx-real-mode
@@ -1,0 +1,5 @@
+#!/bin/bash
+source /usr/local/share/dolfinx/dolfinx.conf
+export PYTHONPATH=/usr/local/lib/python3.8/dist-packages:$PYTHONPATH
+export PETSC_DIR=/usr/local/petsc-real
+export SLEPC_DIR=/usr/local/slepc-real

--- a/docker/dolfinx-real-mode
+++ b/docker/dolfinx-real-mode
@@ -1,5 +1,4 @@
 #!/bin/bash
 source /usr/local/share/dolfinx/dolfinx.conf
+export PETSC_ARCH=linux-gnu-real-32
 export PYTHONPATH=/usr/local/lib/python3.8/dist-packages:$PYTHONPATH
-export PETSC_DIR=/usr/local/petsc-real
-export SLEPC_DIR=/usr/local/slepc-real


### PR DESCRIPTION
I propose three concrete images in this new `Dockerfile`: `dolfinx/dev-env`, `dolfinx/dolfinx` and `dolfinx/lab`.

Still TODO:
1. Shell script to switch between dolfinx in real and complex modes.
2. Update CircleCI (and/or GH actions) nightly builds.

