### PR TITLE
Keep the geometrical dimension of parent mesh when refining

### DIFF
--- a/cpp/dolfinx/refinement/ParallelRefinement.cpp
+++ b/cpp/dolfinx/refinement/ParallelRefinement.cpp
@@ -144,7 +144,8 @@ create_new_geometry(
       = mesh::midpoints(mesh, 1, edges);
   new_vertex_coordinates.bottomRows(num_new_vertices) = midpoints;
 
-  return new_vertex_coordinates;
+  const int gdim = mesh.geometry().dim();
+  return new_vertex_coordinates.leftCols(gdim);
 }
 } // namespace
 

--- a/cpp/dolfinx/refinement/ParallelRefinement.cpp
+++ b/cpp/dolfinx/refinement/ParallelRefinement.cpp
@@ -408,7 +408,7 @@ mesh::Mesh ParallelRefinement::build_local(
   mesh::Mesh mesh = mesh::create_mesh(
       _mesh.mpi_comm(), graph::AdjacencyList<std::int64_t>(cells),
       _mesh.geometry().cmap(), _new_vertex_coordinates, mesh::GhostMode::none);
-
+  assert(mesh.geometry().dim() == _mesh.geometry().dim());
   return mesh;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/refinement/ParallelRefinement.h
+++ b/cpp/dolfinx/refinement/ParallelRefinement.h
@@ -110,7 +110,7 @@ private:
   const mesh::Mesh& _mesh;
 
   // New storage for all coordinates when creating new vertices
-  Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>
+  Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
       _new_vertex_coordinates;
 
   // Management of marked edges


### PR DESCRIPTION
Bug reported at [discourse](https://fenicsproject.discourse.group/t/dolfinx-dim-change-in-mesh-refinement-and-parent-children-relationship/3492)
MWE:
```
import dolfinx
import ufl
import numpy as np
points = np.array([[0, 0],  [1.2, 0],  [1.5, 1],  [0.2, 1]])
cells = np.array([[0, 1, 2],  [0, 2, 3]])
cell = ufl.Cell("triangle", geometric_dimension=2)
domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell, 1))
mesh = dolfinx.mesh.create_mesh(MPI.COMM_WORLD, cells, points, domain)
print(mesh.topology.dim, mesh.geometry.dim)  # 2   2

mesh2=refine(mesh)
print(mesh2.topology.dim, mesh2.geometry.dim)  # 2 3

```
This is the least intrusive way of slicing the new_vertex_coordinates, as the returned midpoints are 3D.