### PR TITLE
Minor changes to asemble csr matrix

### DIFF
--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -7,6 +7,7 @@
 
 import functools
 import typing
+import scipy.sparse
 
 from petsc4py import PETSc
 
@@ -189,7 +190,7 @@ def _(b: PETSc.Vec,
 
 def assemble_csr_matrix(a: typing.Union[Form, cpp.fem.Form],
                         bcs: typing.List[DirichletBC] = [],
-                        diagonal: float = 1.0) -> PETSc.Mat:
+                        diagonal: float = 1.0) -> scipy.sparse.csr_matrix:
     """Assemble bilinear form into an Scipy CSR matrix, in serial.
     """
     _a = _create_cpp_form(a)
@@ -199,8 +200,7 @@ def assemble_csr_matrix(a: typing.Union[Form, cpp.fem.Form],
         for bc in bcs:
             if _a.function_space(0).contains(bc.function_space):
                 bc_dofs = bc.dof_indices[:, 0]
-                for i in bc_dofs:
-                    A[i, i] = 1.0
+                A[bc_dofs, bc_dofs] = diagonal
     return A
 
 

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -112,8 +112,8 @@ def test_eigen_assembly(mode):
     A1 = dolfinx.fem.assemble_matrix(a, [bc])
     A1.assemble()
 
-    cpp_form = dolfinx.Form(a)._cpp_object
-    A2 = dolfinx.fem.assemble_csr_matrix(cpp_form, [bc])
+    A2 = dolfinx.fem.assemble_csr_matrix(a, [bc])
+
     assert numpy.isclose(A1.norm(), scipy.sparse.linalg.norm(A2))
 
 

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -113,7 +113,6 @@ def test_eigen_assembly(mode):
     A1.assemble()
 
     A2 = dolfinx.fem.assemble_csr_matrix(a, [bc])
-
     assert numpy.isclose(A1.norm(), scipy.sparse.linalg.norm(A2))
 
 


### PR DESCRIPTION
- Fix return type (hint) and diagonal value
- remove python 'for loop'