### PR TITLE
Change int32 to intc in test that calls UFC interface.

### DIFF
--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -186,7 +186,7 @@ def assemble_vector(b, mesh, dofmap):
 def assemble_vector_ufc(b, kernel, mesh, dofmap):
     """Assemble provided FFCX/UFC kernel over a mesh into the array b"""
     pos, x_dofmap, x = mesh
-    entity_local_index = np.array([0], dtype=np.int32)
+    entity_local_index = np.array([0], dtype=np.intc)
     perm = np.array([0], dtype=np.uint8)
     geometry = np.zeros((3, 2))
     coeffs = np.zeros(1, dtype=PETSc.ScalarType)


### PR DESCRIPTION
C type `int` is not guaranteed to be an `np.int32`, better to use `np.intc`.

Reflects change made in FFCX unit tests (https://github.com/FEniCS/ffcx/pull/271).