### PR TITLE
Add Numba parallel (threaded) assembly example

### DIFF
--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -195,7 +195,7 @@ fem::transpose_dofmap(graph::AdjacencyList<std::int32_t>& dofmap)
       data[pos[dofs[i]]++] = cell_offsets[c] + i;
   }
 
-  Sort the source indices for each global index
+  // Sort the source indices for each global index
   for (int index = 0; index < max_index; ++index)
   {
     std::sort(data.begin() + index_offsets[index],

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -165,7 +165,6 @@ fem::transpose_dofmap(graph::AdjacencyList<std::int32_t>& dofmap)
   const std::int32_t max_index = dofmap.array().maxCoeff();
   std::vector<int> dofs_per_cell(dofmap.num_nodes());
   std::vector<int> num_local_contributions(max_index + 1);
-  std::cout << "Max index: " << max_index << std::endl;
   for (int c = 0; c < dofmap.num_nodes(); ++c)
   {
     auto dofs = dofmap.links(c);

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -159,13 +159,15 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
 
 //-----------------------------------------------------------------------------
 graph::AdjacencyList<std::int32_t>
-fem::transpose_dofmap(graph::AdjacencyList<std::int32_t>& dofmap)
+fem::transpose_dofmap(graph::AdjacencyList<std::int32_t>& dofmap,
+                      std::int32_t num_cells)
 {
   // Count number of cell contributions to each global index
-  const std::int32_t max_index = dofmap.array().maxCoeff();
-  std::vector<int> dofs_per_cell(dofmap.num_nodes());
+  const std::int32_t max_index
+      = dofmap.array().head(dofmap.offsets()(num_cells)).maxCoeff();
+  std::vector<int> dofs_per_cell(num_cells);
   std::vector<int> num_local_contributions(max_index + 1);
-  for (int c = 0; c < dofmap.num_nodes(); ++c)
+  for (int c = 0; c < num_cells; ++c)
   {
     auto dofs = dofmap.links(c);
     dofs_per_cell[c] = dofs.size();
@@ -187,7 +189,7 @@ fem::transpose_dofmap(graph::AdjacencyList<std::int32_t>& dofmap)
 
   std::vector<std::int32_t> data(index_offsets.back());
   std::vector<int> pos = index_offsets;
-  for (int c = 0; c < dofmap.num_nodes(); ++c)
+  for (int c = 0; c < num_cells; ++c)
   {
     auto dofs = dofmap.links(c);
     for (int i = 0; i < dofs.rows(); ++i)

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -165,14 +165,10 @@ fem::transpose_dofmap(graph::AdjacencyList<std::int32_t>& dofmap,
   // Count number of cell contributions to each global index
   const std::int32_t max_index
       = dofmap.array().head(dofmap.offsets()(num_cells)).maxCoeff();
-  std::vector<int> dofs_per_cell(num_cells);
-  std::vector<int> num_local_contributions(max_index + 1);
+  std::vector<int> num_local_contributions(max_index + 1, 0);
   for (int c = 0; c < num_cells; ++c)
   {
     auto dofs = dofmap.links(c);
-    dofs_per_cell[c] = dofs.size();
-
-    // Count cells that contribute to a global dof index
     for (int i = 0; i < dofs.rows(); ++i)
       num_local_contributions[dofs[i]]++;
   }
@@ -182,21 +178,19 @@ fem::transpose_dofmap(graph::AdjacencyList<std::int32_t>& dofmap,
   std::partial_sum(num_local_contributions.begin(),
                    num_local_contributions.end(), index_offsets.begin() + 1);
 
-  // Compute offset for each cell block
-  std::vector<int> cell_offsets(dofs_per_cell.size() + 1, 0);
-  std::partial_sum(dofs_per_cell.begin(), dofs_per_cell.end(),
-                   cell_offsets.begin() + 1);
-
   std::vector<std::int32_t> data(index_offsets.back());
   std::vector<int> pos = index_offsets;
+  int cell_offset = 0;
   for (int c = 0; c < num_cells; ++c)
   {
     auto dofs = dofmap.links(c);
     for (int i = 0; i < dofs.rows(); ++i)
-      data[pos[dofs[i]]++] = cell_offsets[c] + i;
+      data[pos[dofs[i]]++] = cell_offset++;
   }
 
   // Sort the source indices for each global index
+  // This could improve linear memory access
+  // FIXME: needs profiling
   for (int index = 0; index < max_index; ++index)
   {
     std::sort(data.begin() + index_offsets[index],

--- a/cpp/dolfinx/fem/DofMap.h
+++ b/cpp/dolfinx/fem/DofMap.h
@@ -6,37 +6,57 @@
 
 #pragma once
 
-#include "ElementDofLayout.h"
 #include <Eigen/Dense>
 #include <cstdlib>
+#include <dolfinx/common/MPI.h>
 #include <dolfinx/graph/AdjacencyList.h>
 #include <memory>
 #include <utility>
 #include <vector>
 
-namespace dolfinx
-{
-
-namespace common
+namespace dolfinx::common
 {
 class IndexMap;
 }
 
-namespace mesh
+namespace dolfinx::mesh
 {
 class Topology;
-} // namespace mesh
+}
 
-namespace fem
+namespace dolfinx::fem
 {
+class ElementDofLayout;
 
-/// Creat an adjacency list . . .
+/// Create an adjacency list that maps a global index (process-wise) to
+/// the 'unassembled' cell-wise contributions. It is built from the
+/// usual (cell, local index) -> global index dof map. An 'unassembled'
+/// vector is the stacked cell contributions, ordered by cell index.
+///
+/// If the usual dof map is:
+///
+///  Cell:                0          1          2          3
+///  Global index:  [ [0, 3, 5], [3, 2, 4], [4, 3, 2], [2, 1, 0]]
+///
+/// the 'transpose' dof map will be:
+///
+///  Global index:           0      1        2          3        4      5
+///  Unassembled index: [ [0, 11], [10], [4, 8, 9], [1, 3, 7], [5, 6], [2] ]
+///
+/// @param[in] dofmap The standard dof map that for each cell (node)
+///   gives the global (process-wise) index of each local (cell-wise)
+///   index.
+/// @param[in] num_cells The number of cells (nodes) in @p dofmap to
+///   consider. The first @p num_cells are used. This is argument is
+///   typically used to exclude ghost cell contributions.
+/// @return Map from global (process-wise) index to positions in an
+///   unaassembled array. The links for each node are sorted.
 graph::AdjacencyList<std::int32_t>
 transpose_dofmap(graph::AdjacencyList<std::int32_t>& dofmap,
                  std::int32_t num_cells);
 
 /// Degree-of-freedom map
-
+///
 /// This class handles the mapping of degrees of freedom. It builds a
 /// dof map based on an ElementDofLayout on a specific mesh topology. It
 /// will reorder the dofs when running in parallel. Sub-dofmaps, both
@@ -69,7 +89,8 @@ public:
 
   /// Local-to-global mapping of dofs on a cell
   /// @param[in] cell The cell index
-  /// @return Local-global dof map for the cell (using process-local indices)
+  /// @return Local-global dof map for the cell (using process-local
+  ///   indices)
   Eigen::Array<std::int32_t, Eigen::Dynamic, 1>::ConstSegmentReturnType
   cell_dofs(int cell) const
   {
@@ -83,7 +104,8 @@ public:
 
   /// Create a "collapsed" dofmap (collapses a sub-dofmap)
   /// @param[in] comm MPI Communicator
-  /// @param[in] topology The meshtopology that the dofmap is defined on
+  /// @param[in] topology The mesh topology that the dofmap is defined
+  ///   on
   /// @return The collapsed dofmap
   std::pair<std::unique_ptr<DofMap>, std::vector<std::int32_t>>
   collapse(MPI_Comm comm, const mesh::Topology& topology) const;
@@ -99,8 +121,7 @@ public:
   std::shared_ptr<const common::IndexMap> index_map;
 
 private:
-  // Cell-local-to-dof map (dofs for cell dofmap[i])
+  // Cell-local-to-dof map (dofs for cell dofmap[cell])
   graph::AdjacencyList<std::int32_t> _dofmap;
 };
-} // namespace fem
-} // namespace dolfinx
+} // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/DofMap.h
+++ b/cpp/dolfinx/fem/DofMap.h
@@ -32,7 +32,8 @@ namespace fem
 
 /// Creat an adjacency list . . .
 graph::AdjacencyList<std::int32_t>
-transpose_dofmap(graph::AdjacencyList<std::int32_t>& dofmap);
+transpose_dofmap(graph::AdjacencyList<std::int32_t>& dofmap,
+                 std::int32_t num_cells);
 
 /// Degree-of-freedom map
 

--- a/cpp/dolfinx/fem/DofMap.h
+++ b/cpp/dolfinx/fem/DofMap.h
@@ -30,6 +30,10 @@ class Topology;
 namespace fem
 {
 
+/// Creat an adjacency list . . .
+graph::AdjacencyList<std::int32_t>
+transpose_dofmap(graph::AdjacencyList<std::int32_t>& dofmap);
+
 /// Degree-of-freedom map
 
 /// This class handles the mapping of degrees of freedom. It builds a

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -194,15 +194,15 @@ void assemble_cells(
     // Get cell coordinates/geometry
     auto x_dofs = x_dofmap.links(c);
     for (int i = 0; i < x_dofs.rows(); ++i)
-      coordinate_dofs.row(i) = x_g.row(x_dofs[i]).head(gdim);
+      for (int j = 0; j < gdim; ++j)
+        coordinate_dofs(i, j) = x_g(x_dofs[i], j);
 
     auto dofs0 = dofmap0.links(c);
     auto dofs1 = dofmap1.links(c);
 
     // Tabulate tensor
-    auto coeff_cell = coeffs.row(c);
     Ae.setZero(dofs0.size(), dofs1.size());
-    kernel(Ae.data(), coeff_cell.data(), constants.data(),
+    kernel(Ae.data(), coeffs.row(c).data(), constants.data(),
            coordinate_dofs.data(), nullptr, nullptr, cell_info[c]);
 
     // Zero rows/columns for essential bcs
@@ -289,17 +289,17 @@ void assemble_exterior_facets(
     // Get cell vertex coordinates
     auto x_dofs = x_dofmap.links(cells[0]);
     for (int i = 0; i < num_dofs_g; ++i)
-      coordinate_dofs.row(i) = x_g.row(x_dofs[i]).head(gdim);
+      for (int j = 0; j < gdim; ++j)
+        coordinate_dofs(i, j) = x_g(x_dofs[i], j);
 
     // Get dof maps for cell
     auto dmap0 = dofmap0.cell_dofs(cells[0]);
     auto dmap1 = dofmap1.cell_dofs(cells[0]);
 
     // Tabulate tensor
-    auto coeff_cell = coeffs.row(cells[0]);
     const std::uint8_t perm = perms(local_facet, cells[0]);
     Ae.setZero(dmap0.size(), dmap1.size());
-    kernel(Ae.data(), coeff_cell.data(), constants.data(),
+    kernel(Ae.data(), coeffs.row(cells[0]).data(), constants.data(),
            coordinate_dofs.data(), &local_facet, &perm, cell_info[cells[0]]);
 
     // Zero rows/columns for essential bcs
@@ -405,8 +405,11 @@ void assemble_interior_facets(
     auto x_dofs1 = x_dofmap.links(cells[1]);
     for (int i = 0; i < num_dofs_g; ++i)
     {
-      coordinate_dofs.row(i) = x_g.row(x_dofs0[i]).head(gdim);
-      coordinate_dofs.row(i + num_dofs_g) = x_g.row(x_dofs1[i]).head(gdim);
+      for (int j = 0; j < gdim; ++j)
+      {
+        coordinate_dofs(i, j) = x_g(x_dofs0[i], j);
+        coordinate_dofs(i + num_dofs_g, j) = x_g(x_dofs1[i], j);
+      }
     }
 
     // Get dof maps for cells and pack

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -28,71 +28,64 @@ namespace dolfinx::fem::impl
 /// conditions are zeroed. Markers (bc0 and bc1) can be empty if not bcs
 /// are applied. Matrix is not finalised.
 
-template <typename ScalarType>
+template <typename T>
 void assemble_matrix(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
-                            const std::int32_t*, const ScalarType*)>&
-        mat_set_values,
-    const Form<ScalarType>& a, const std::vector<bool>& bc0,
+                            const std::int32_t*, const T*)>& mat_set_values,
+    const Form<T>& a, const std::vector<bool>& bc0,
     const std::vector<bool>& bc1);
 
 /// Execute kernel over cells and accumulate result in matrix
-template <typename ScalarType>
+template <typename T>
 void assemble_cells(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
-                            const std::int32_t*, const ScalarType*)>&
-        mat_set_values,
+                            const std::int32_t*, const T*)>& mat_set_values,
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_cells,
     const graph::AdjacencyList<std::int32_t>& dofmap0,
     const graph::AdjacencyList<std::int32_t>& dofmap1,
     const std::vector<bool>& bc0, const std::vector<bool>& bc1,
-    const std::function<void(ScalarType*, const ScalarType*, const ScalarType*,
-                             const double*, const int*, const std::uint8_t*,
-                             const std::uint32_t)>& kernel,
-    const Eigen::Array<ScalarType, Eigen::Dynamic, Eigen::Dynamic,
-                       Eigen::RowMajor>& coeffs,
-    const Eigen::Array<ScalarType, Eigen::Dynamic, 1>& constants);
+    const std::function<void(T*, const T*, const T*, const double*, const int*,
+                             const std::uint8_t*, const std::uint32_t)>& kernel,
+    const Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+        coeffs,
+    const Eigen::Array<T, Eigen::Dynamic, 1>& constants);
 
 /// Execute kernel over exterior facets and  accumulate result in Mat
-template <typename ScalarType>
+template <typename T>
 void assemble_exterior_facets(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
-                            const std::int32_t*, const ScalarType*)>&
-        mat_set_values,
+                            const std::int32_t*, const T*)>& mat_set_values,
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
-    const DofMap& dofmap0, const DofMap& dofmap1, const std::vector<bool>& bc0,
-    const std::vector<bool>& bc1,
-    const std::function<void(ScalarType*, const ScalarType*, const ScalarType*,
-                             const double*, const int*, const std::uint8_t*,
-                             const std::uint32_t)>& fn,
-    const Eigen::Array<ScalarType, Eigen::Dynamic, Eigen::Dynamic,
-                       Eigen::RowMajor>& coeffs,
-    const Eigen::Array<ScalarType, Eigen::Dynamic, 1> constants);
+    const graph::AdjacencyList<std::int32_t>& dofmap0,
+    const graph::AdjacencyList<std::int32_t>& dofmap1,
+    const std::vector<bool>& bc0, const std::vector<bool>& bc1,
+    const std::function<void(T*, const T*, const T*, const double*, const int*,
+                             const std::uint8_t*, const std::uint32_t)>& fn,
+    const Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+        coeffs,
+    const Eigen::Array<T, Eigen::Dynamic, 1> constants);
 
 /// Execute kernel over interior facets and  accumulate result in Mat
-template <typename ScalarType>
+template <typename T>
 void assemble_interior_facets(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
-                            const std::int32_t*, const ScalarType*)>&
-        mat_set_values,
+                            const std::int32_t*, const T*)>& mat_set_values,
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
     const DofMap& dofmap0, const DofMap& dofmap1, const std::vector<bool>& bc0,
     const std::vector<bool>& bc1,
-    const std::function<void(ScalarType*, const ScalarType*, const ScalarType*,
-                             const double*, const int*, const std::uint8_t*,
-                             const std::uint32_t)>& kernel,
-    const Eigen::Array<ScalarType, Eigen::Dynamic, Eigen::Dynamic,
-                       Eigen::RowMajor>& coeffs,
+    const std::function<void(T*, const T*, const T*, const double*, const int*,
+                             const std::uint8_t*, const std::uint32_t)>& kernel,
+    const Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+        coeffs,
     const std::vector<int>& offsets,
-    const Eigen::Array<ScalarType, Eigen::Dynamic, 1>& constants);
+    const Eigen::Array<T, Eigen::Dynamic, 1>& constants);
 
 //-----------------------------------------------------------------------------
-template <typename ScalarType>
+template <typename T>
 void assemble_matrix(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
-                            const std::int32_t*, const ScalarType*)>&
-        mat_set_values,
-    const Form<ScalarType>& a, const std::vector<bool>& bc0,
+                            const std::int32_t*, const T*)>& mat_set_values,
+    const Form<T>& a, const std::vector<bool>& bc0,
     const std::vector<bool>& bc1)
 {
   std::shared_ptr<const mesh::Mesh> mesh = a.mesh();
@@ -109,23 +102,20 @@ void assemble_matrix(
   // Prepare constants
   if (!a.all_constants_set())
     throw std::runtime_error("Unset constant in Form");
-  const Eigen::Array<ScalarType, Eigen::Dynamic, 1> constants
-      = pack_constants(a);
+  const Eigen::Array<T, Eigen::Dynamic, 1> constants = pack_constants(a);
 
   // Prepare coefficients
-  const Eigen::Array<ScalarType, Eigen::Dynamic, Eigen::Dynamic,
-                     Eigen::RowMajor>
-      coeffs = pack_coefficients(a);
+  const Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> coeffs
+      = pack_coefficients(a);
 
-  const FormIntegrals<ScalarType>& integrals = a.integrals();
+  const FormIntegrals<T>& integrals = a.integrals();
   for (int i = 0; i < integrals.num_integrals(IntegralType::cell); ++i)
   {
     const auto& fn = integrals.get_tabulate_tensor(IntegralType::cell, i);
     const std::vector<std::int32_t>& active_cells
         = integrals.integral_domains(IntegralType::cell, i);
-    fem::impl::assemble_cells<ScalarType>(mat_set_values, *mesh, active_cells,
-                                          dofs0, dofs1, bc0, bc1, fn, coeffs,
-                                          constants);
+    fem::impl::assemble_cells<T>(mat_set_values, *mesh, active_cells, dofs0,
+                                 dofs1, bc0, bc1, fn, coeffs, constants);
   }
 
   for (int i = 0; i < integrals.num_integrals(IntegralType::exterior_facet);
@@ -135,9 +125,9 @@ void assemble_matrix(
         = integrals.get_tabulate_tensor(IntegralType::exterior_facet, i);
     const std::vector<std::int32_t>& active_facets
         = integrals.integral_domains(IntegralType::exterior_facet, i);
-    fem::impl::assemble_exterior_facets<ScalarType>(
-        mat_set_values, *mesh, active_facets, *dofmap0, *dofmap1, bc0, bc1, fn,
-        coeffs, constants);
+    fem::impl::assemble_exterior_facets<T>(mat_set_values, *mesh, active_facets,
+                                           dofs0, dofs1, bc0, bc1, fn, coeffs,
+                                           constants);
   }
 
   const std::vector<int> c_offsets = a.coefficients().offsets();
@@ -148,26 +138,25 @@ void assemble_matrix(
         = integrals.get_tabulate_tensor(IntegralType::interior_facet, i);
     const std::vector<std::int32_t>& active_facets
         = integrals.integral_domains(IntegralType::interior_facet, i);
-    fem::impl::assemble_interior_facets<ScalarType>(
-        mat_set_values, *mesh, active_facets, *dofmap0, *dofmap1, bc0, bc1, fn,
-        coeffs, c_offsets, constants);
+    fem::impl::assemble_interior_facets<T>(mat_set_values, *mesh, active_facets,
+                                           *dofmap0, *dofmap1, bc0, bc1, fn,
+                                           coeffs, c_offsets, constants);
   }
 }
 //-----------------------------------------------------------------------------
-template <typename ScalarType>
+template <typename T>
 void assemble_cells(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
-                            const std::int32_t*, const ScalarType*)>& mat_set,
+                            const std::int32_t*, const T*)>& mat_set,
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_cells,
     const graph::AdjacencyList<std::int32_t>& dofmap0,
     const graph::AdjacencyList<std::int32_t>& dofmap1,
     const std::vector<bool>& bc0, const std::vector<bool>& bc1,
-    const std::function<void(ScalarType*, const ScalarType*, const ScalarType*,
-                             const double*, const int*, const std::uint8_t*,
-                             const std::uint32_t)>& kernel,
-    const Eigen::Array<ScalarType, Eigen::Dynamic, Eigen::Dynamic,
-                       Eigen::RowMajor>& coeffs,
-    const Eigen::Array<ScalarType, Eigen::Dynamic, 1>& constants)
+    const std::function<void(T*, const T*, const T*, const double*, const int*,
+                             const std::uint8_t*, const std::uint32_t)>& kernel,
+    const Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+        coeffs,
+    const Eigen::Array<T, Eigen::Dynamic, 1>& constants)
 {
   const int gdim = mesh.geometry().dim();
   mesh.topology_mutable().create_entity_permutations();
@@ -183,7 +172,10 @@ void assemble_cells(
   // Data structures used in assembly
   Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
       coordinate_dofs(num_dofs_g, gdim);
-  Eigen::Matrix<ScalarType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Ae;
+  const int num_dofs0 = dofmap0.links(0).size();
+  const int num_dofs1 = dofmap1.links(0).size();
+  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Ae(
+      num_dofs0, num_dofs1);
 
   const Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>& cell_info
       = mesh.topology().get_cell_permutation_info();
@@ -197,21 +189,19 @@ void assemble_cells(
       for (int j = 0; j < gdim; ++j)
         coordinate_dofs(i, j) = x_g(x_dofs[i], j);
 
-    auto dofs0 = dofmap0.links(c);
-    auto dofs1 = dofmap1.links(c);
-
     // Tabulate tensor
-    Ae.setZero(dofs0.size(), dofs1.size());
+    std::fill(Ae.data(), Ae.data() + num_dofs0 * num_dofs1, 0);
     kernel(Ae.data(), coeffs.row(c).data(), constants.data(),
            coordinate_dofs.data(), nullptr, nullptr, cell_info[c]);
 
     // Zero rows/columns for essential bcs
+    auto dofs0 = dofmap0.links(c);
+    auto dofs1 = dofmap1.links(c);
     if (!bc0.empty())
     {
       for (Eigen::Index i = 0; i < Ae.rows(); ++i)
       {
-        const std::int32_t dof = dofs0[i];
-        if (bc0[dof])
+        if (bc0[dofs0[i]])
           Ae.row(i).setZero();
       }
     }
@@ -219,8 +209,7 @@ void assemble_cells(
     {
       for (Eigen::Index j = 0; j < Ae.cols(); ++j)
       {
-        const std::int32_t dof = dofs1[j];
-        if (bc1[dof])
+        if (bc1[dofs1[j]])
           Ae.col(j).setZero();
       }
     }
@@ -229,20 +218,19 @@ void assemble_cells(
   }
 }
 //-----------------------------------------------------------------------------
-template <typename ScalarType>
+template <typename T>
 void assemble_exterior_facets(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
-                            const std::int32_t*, const ScalarType*)>&
-        mat_set_values,
+                            const std::int32_t*, const T*)>& mat_set_values,
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
-    const DofMap& dofmap0, const DofMap& dofmap1, const std::vector<bool>& bc0,
-    const std::vector<bool>& bc1,
-    const std::function<void(ScalarType*, const ScalarType*, const ScalarType*,
-                             const double*, const int*, const std::uint8_t*,
-                             const std::uint32_t)>& kernel,
-    const Eigen::Array<ScalarType, Eigen::Dynamic, Eigen::Dynamic,
-                       Eigen::RowMajor>& coeffs,
-    const Eigen::Array<ScalarType, Eigen::Dynamic, 1> constants)
+    const graph::AdjacencyList<std::int32_t>& dofmap0,
+    const graph::AdjacencyList<std::int32_t>& dofmap1,
+    const std::vector<bool>& bc0, const std::vector<bool>& bc1,
+    const std::function<void(T*, const T*, const T*, const double*, const int*,
+                             const std::uint8_t*, const std::uint32_t)>& kernel,
+    const Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+        coeffs,
+    const Eigen::Array<T, Eigen::Dynamic, 1> constants)
 {
   const int gdim = mesh.geometry().dim();
   const int tdim = mesh.topology().dim();
@@ -263,7 +251,10 @@ void assemble_exterior_facets(
   // Data structures used in assembly
   Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
       coordinate_dofs(num_dofs_g, gdim);
-  Eigen::Matrix<ScalarType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Ae;
+  const int num_dofs0 = dofmap0.links(0).size();
+  const int num_dofs1 = dofmap1.links(0).size();
+  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Ae(
+      num_dofs0, num_dofs1);
 
   const Eigen::Array<std::uint8_t, Eigen::Dynamic, Eigen::Dynamic>& perms
       = mesh.topology().get_facet_permutations();
@@ -292,17 +283,15 @@ void assemble_exterior_facets(
       for (int j = 0; j < gdim; ++j)
         coordinate_dofs(i, j) = x_g(x_dofs[i], j);
 
-    // Get dof maps for cell
-    auto dmap0 = dofmap0.cell_dofs(cells[0]);
-    auto dmap1 = dofmap1.cell_dofs(cells[0]);
-
     // Tabulate tensor
     const std::uint8_t perm = perms(local_facet, cells[0]);
-    Ae.setZero(dmap0.size(), dmap1.size());
+    std::fill(Ae.data(), Ae.data() + num_dofs0 * num_dofs1, 0);
     kernel(Ae.data(), coeffs.row(cells[0]).data(), constants.data(),
            coordinate_dofs.data(), &local_facet, &perm, cell_info[cells[0]]);
 
     // Zero rows/columns for essential bcs
+    auto dmap0 = dofmap0.links(cells[0]);
+    auto dmap1 = dofmap1.links(cells[0]);
     if (!bc0.empty())
     {
       for (Eigen::Index i = 0; i < Ae.rows(); ++i)
@@ -325,21 +314,19 @@ void assemble_exterior_facets(
   }
 }
 //-----------------------------------------------------------------------------
-template <typename ScalarType>
+template <typename T>
 void assemble_interior_facets(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
-                            const std::int32_t*, const ScalarType*)>&
-        mat_set_values,
+                            const std::int32_t*, const T*)>& mat_set_values,
     const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
     const DofMap& dofmap0, const DofMap& dofmap1, const std::vector<bool>& bc0,
     const std::vector<bool>& bc1,
-    const std::function<void(ScalarType*, const ScalarType*, const ScalarType*,
-                             const double*, const int*, const std::uint8_t*,
-                             const std::uint32_t)>& fn,
-    const Eigen::Array<ScalarType, Eigen::Dynamic, Eigen::Dynamic,
-                       Eigen::RowMajor>& coeffs,
+    const std::function<void(T*, const T*, const T*, const double*, const int*,
+                             const std::uint8_t*, const std::uint32_t)>& fn,
+    const Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
+        coeffs,
     const std::vector<int>& offsets,
-    const Eigen::Array<ScalarType, Eigen::Dynamic, 1>& constants)
+    const Eigen::Array<T, Eigen::Dynamic, 1>& constants)
 {
   const int gdim = mesh.geometry().dim();
   const int tdim = mesh.topology().dim();
@@ -361,8 +348,8 @@ void assemble_interior_facets(
   // Data structures used in assembly
   Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
       coordinate_dofs(2 * num_dofs_g, gdim);
-  Eigen::Matrix<ScalarType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Ae;
-  Eigen::Array<ScalarType, Eigen::Dynamic, 1> coeff_array(2 * offsets.back());
+  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Ae;
+  Eigen::Array<T, Eigen::Dynamic, 1> coeff_array(2 * offsets.back());
   assert(offsets.back() == coeffs.cols());
 
   // Temporaries for joint dofmaps

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -154,7 +154,8 @@ T assemble_cells(
     // Get cell coordinates/geometry
     auto x_dofs = x_dofmap.links(c);
     for (int i = 0; i < num_dofs_g; ++i)
-      coordinate_dofs.row(i) = x_g.row(x_dofs[i]).head(gdim);
+      for (int j = 0; j < gdim; ++j)
+        coordinate_dofs(i, j) = x_g(x_dofs[i], j);
 
     auto coeff_cell = coeffs.row(c);
     fn(&value, coeff_cell.data(), constant_values.data(),
@@ -220,7 +221,8 @@ T assemble_exterior_facets(
 
     auto x_dofs = x_dofmap.links(cell);
     for (int i = 0; i < num_dofs_g; ++i)
-      coordinate_dofs.row(i) = x_g.row(x_dofs[i]).head(gdim);
+      for (int j = 0; j < gdim; ++j)
+        coordinate_dofs(i, j) = x_g(x_dofs[i], j);
 
     auto coeff_cell = coeffs.row(cell);
     const std::uint8_t perm = perms(local_facet, cell);
@@ -299,8 +301,11 @@ T assemble_interior_facets(
     auto x_dofs1 = x_dofmap.links(cells[1]);
     for (int i = 0; i < num_dofs_g; ++i)
     {
-      coordinate_dofs.row(i) = x_g.row(x_dofs0[i]).head(gdim);
-      coordinate_dofs.row(i + num_dofs_g) = x_g.row(x_dofs1[i]).head(gdim);
+      for (int j = 0; j < gdim; ++j)
+      {
+        coordinate_dofs(i, j) = x_g(x_dofs0[i], j);
+        coordinate_dofs(i + num_dofs_g, j) = x_g(x_dofs1[i], j);
+      }
     }
 
     // Layout for the restricted coefficients is flattened

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -510,7 +510,7 @@ void assemble_cells(
     kernel(be.data(), coeffs.row(c).data(), constant_values.data(),
            coordinate_dofs.data(), nullptr, nullptr, cell_info[c]);
 
-    // // Scatter cell vector to 'global' vector array
+    // Scatter cell vector to 'global' vector array
     auto dofs = dofmap.links(c);
     for (Eigen::Index i = 0; i < num_dofs; ++i)
       b[dofs[i]] += be[i];

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -475,8 +475,6 @@ void assemble_cells(
         coeffs,
     const Eigen::Array<T, Eigen::Dynamic, 1>& constant_values)
 {
-  boost::timer::auto_cpu_timer t;
-
   const int gdim = mesh.geometry().dim();
   mesh.topology_mutable().create_entity_permutations();
 

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -498,11 +498,6 @@ void assemble_cells(
   const Eigen::Array<std::uint32_t, Eigen::Dynamic, 1>& cell_info
       = mesh.topology().get_cell_permutation_info();
 
-  const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& dof_array
-      = dofmap.array();
-  const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& dof_offsets
-      = dofmap.offsets();
-
   // Iterate over active cells
   for (std::int32_t c : active_cells)
   {

--- a/cpp/dolfinx/graph/BoostGraphOrdering.cpp
+++ b/cpp/dolfinx/graph/BoostGraphOrdering.cpp
@@ -32,7 +32,7 @@ T build_csr_directed_graph(const graph::AdjacencyList<X>& graph)
   {
     auto links = graph.links(v);
     for (int e = 0; e < links.rows(); ++e)
-      edges.push_back({v, links[e]});
+      edges.emplace_back(v, links[e]);
   }
 
   // Number of vertices

--- a/python/demo/elasticity/demo_elasticity.py
+++ b/python/demo/elasticity/demo_elasticity.py
@@ -38,11 +38,11 @@ def build_nullspace(V):
 
         # Build translational null space basis
         for i in range(3):
-            basis[i][V.sub(i).dofmap.list.array()] = 1.0
+            basis[i][V.sub(i).dofmap.list.array] = 1.0
 
         # Build rotational null space basis
         x = V.tabulate_dof_coordinates()
-        dofs = [V.sub(i).dofmap.list.array() for i in range(3)]
+        dofs = [V.sub(i).dofmap.list.array for i in range(3)]
         basis[3][dofs[0]] = -x[dofs[0], 1]
         basis[3][dofs[1]] = x[dofs[1], 0]
         basis[4][dofs[0]] = x[dofs[0], 2]

--- a/python/dolfinx/plotting.py
+++ b/python/dolfinx/plotting.py
@@ -30,7 +30,7 @@ def _has_matplotlib():
 def mesh2triang(mesh):
     import matplotlib.tri as tri
     xy = mesh.geometry.x
-    cells = mesh.geometry.dofmap.array().reshape((-1, mesh.topology.dim + 1))
+    cells = mesh.geometry.dofmap.array.reshape((-1, mesh.topology.dim + 1))
     return tri.Triangulation(xy[:, 0], xy[:, 1], cells)
 
 
@@ -45,7 +45,7 @@ def mplot_mesh(ax, mesh, **kwargs):
         mplot_mesh(ax, bmesh, **kwargs)
     elif gdim == 3 and tdim == 2:
         xy = mesh.geometry.x
-        cells = mesh.geometry.dofmap.array().reshape((-1, mesh.topology.dim + 1))
+        cells = mesh.geometry.dofmap.array.reshape((-1, mesh.topology.dim + 1))
         return ax.plot_trisurf(
             *[xy[:, i] for i in range(gdim)], triangles=cells, **kwargs)
     elif tdim == 1:
@@ -231,7 +231,7 @@ def mplot_function(ax, f, **kwargs):
             import matplotlib.tri as tri
             if gdim == 2 and tdim == 2:
                 # FIXME: Not tested
-                cells = mesh.geometry.dofmap.array().reshape((-1, mesh.topology.dim + 1))
+                cells = mesh.geometry.dofmap.array.reshape((-1, mesh.topology.dim + 1))
                 triang = tri.Triangulation(Xdef[0], Xdef[1], cells)
                 shading = kwargs.pop("shading", "flat")
                 return ax.tripcolor(triang, C, shading=shading, **kwargs)

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -187,6 +187,9 @@ void fem(py::module& m)
             std::move(dofmap));
       },
       "Build and dofmap on a mesh.");
+  m.def("transpose_dofmap", &dolfinx::fem::transpose_dofmap,
+        "Build the index to (cell, local index) map from a "
+        "dofmap ((cell, local index ) -> index).");
 
   // dolfinx::fem::FiniteElement
   py::class_<dolfinx::fem::FiniteElement,

--- a/python/dolfinx/wrappers/graph.cpp
+++ b/python/dolfinx/wrappers/graph.cpp
@@ -51,6 +51,9 @@ void declare_adjacency_list(py::module& m, std::string type)
 void graph(py::module& m)
 {
 
+  declare_adjacency_list<std::int32_t>(m, "int32");
+  declare_adjacency_list<std::int64_t>(m, "int64");
+
   m.def("create_local_adjacency_list",
         &dolfinx::graph::Partitioning::create_local_adjacency_list);
   m.def(
@@ -80,8 +83,5 @@ void graph(py::module& m)
         &dolfinx::graph::Partitioning::compute_local_to_global_links);
   m.def("compute_local_to_local",
         &dolfinx::graph::Partitioning::compute_local_to_local);
-
-  declare_adjacency_list<std::int32_t>(m, "int32");
-  declare_adjacency_list<std::int64_t>(m, "int64");
 }
 } // namespace dolfinx_wrappers

--- a/python/dolfinx/wrappers/graph.cpp
+++ b/python/dolfinx/wrappers/graph.cpp
@@ -35,11 +35,12 @@ void declare_adjacency_list(py::module& m, std::string type)
           },
           "Links (edges) of a node",
           py::return_value_policy::reference_internal)
-      .def("array", &dolfinx::graph::AdjacencyList<T>::array,
-           py::return_value_policy::reference_internal)
-      .def("offsets", &dolfinx::graph::AdjacencyList<T>::offsets,
-           "Index to each node in the links array",
-           py::return_value_policy::reference_internal)
+      .def_property_readonly("array", &dolfinx::graph::AdjacencyList<T>::array,
+                             py::return_value_policy::reference_internal)
+      .def_property_readonly("offsets",
+                             &dolfinx::graph::AdjacencyList<T>::offsets,
+                             "Index to each node in the links array",
+                             py::return_value_policy::reference_internal)
       .def_property_readonly("num_nodes",
                              &dolfinx::graph::AdjacencyList<T>::num_nodes)
       .def("__eq__", &dolfinx::graph::AdjacencyList<T>::operator==,

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -365,7 +365,7 @@ def test_custom_mesh_loop_ctypes_rank2():
     num_cells = num_owned_cells + mesh.topology.index_map(mesh.topology.dim).num_ghosts
     x_dofs = mesh.geometry.dofmap.array().reshape(num_cells, 3)
     x = mesh.geometry.x
-    dofmap = V.dofmap.list.array().reshape(num_cells, 3).astype(np.dtype(PETSc.IntType))
+    dofmap = V.dofmap.list.array.reshape(num_cells, 3).astype(np.dtype(PETSc.IntType))
 
     # Generated case with general assembler
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
@@ -420,7 +420,7 @@ def test_custom_mesh_loop_cffi_rank2(set_vals):
     num_cells = num_owned_cells + mesh.topology.index_map(mesh.topology.dim).num_ghosts
     x_dofs = mesh.geometry.dofmap.array().reshape(num_cells, 3)
     x = mesh.geometry.x
-    dofmap = V.dofmap.list.array().reshape(num_cells, 3).astype(np.dtype(PETSc.IntType))
+    dofmap = V.dofmap.list.array.reshape(num_cells, 3).astype(np.dtype(PETSc.IntType))
 
     A1 = A0.copy()
     for i in range(2):

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -327,13 +327,14 @@ def test_custom_mesh_loop_rank1():
     start = time.time()
     b1 = dolfinx.fem.assemble_vector(L)
     end = time.time()
-    print("Time (C++, pass 1):", end - start)
+    print("Time (C++, pass 0):", end - start)
+
     with b1.localForm() as b_local:
         b_local.set(0.0)
     start = time.time()
     dolfinx.fem.assemble_vector(b1, L)
     end = time.time()
-    print("Time (C++, pass 2):", end - start)
+    print("Time (C++, pass 1):", end - start)
     b1.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
     assert((b1 - b0.vector).norm() == pytest.approx(0.0))
 

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -183,7 +183,7 @@ def assemble_vector_parallel(b, v, x, dofmap_t_data, dofmap_t_offsets, num_cells
     """Assemble simple linear form over a mesh into the array b"""
     q0 = 1 / 3.0
     q1 = 1 / 3.0
-    b_unassembled = np.zeros((num_cells, 3), dtype=np.double)
+    b_unassembled = np.zeros((num_cells, 3), dtype=b.dtype)
     for cell in numba.prange(num_cells):
         # FIXME: This assumes a particular geometry dof layout
         A = area(x[v[cell, 0]], x[v[cell, 1]], x[v[cell, 2]])
@@ -283,7 +283,7 @@ def assemble_matrix_ctypes(A, mesh, dofmap, num_cells, set_vals, mode):
 def test_custom_mesh_loop_rank1():
 
     # Create mesh and function space
-    mesh = dolfinx.generation.UnitSquareMesh(MPI.COMM_WORLD, 1024, 1024)
+    mesh = dolfinx.generation.UnitSquareMesh(MPI.COMM_WORLD, 64, 64)
     V = dolfinx.FunctionSpace(mesh, ("Lagrange", 1))
 
     # Unpack mesh and dofmap data

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -283,7 +283,7 @@ def assemble_matrix_ctypes(A, mesh, dofmap, num_cells, set_vals, mode):
 def test_custom_mesh_loop_rank1():
 
     # Create mesh and function space
-    mesh = dolfinx.generation.UnitSquareMesh(MPI.COMM_WORLD, 64, 64)
+    mesh = dolfinx.generation.UnitSquareMesh(MPI.COMM_WORLD, 1024, 512)
     V = dolfinx.FunctionSpace(mesh, ("Lagrange", 1))
 
     # Unpack mesh and dofmap data
@@ -304,7 +304,7 @@ def test_custom_mesh_loop_rank1():
             end = time.time()
             print("Time (numba, pass {}): {}".format(i, end - start))
     b0.vector.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
-    assert(b0.vector.sum() == pytest.approx(1.0))
+    # assert(b0.vector.sum() == pytest.approx(1.0))
 
     # Assemble with pure Numba function using parallel loop (two passes,
     # first will include JIT overhead)
@@ -335,7 +335,7 @@ def test_custom_mesh_loop_rank1():
     end = time.time()
     print("Time (C++, pass 2):", end - start)
     b1.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
-    assert((b1 - b0.vector).norm() == pytest.approx(0.0))
+    # assert((b1 - b0.vector).norm() == pytest.approx(0.0))
 
     # Assemble using generated tabulate_tensor kernel and Numba assembler
     b3 = dolfinx.Function(V)
@@ -350,7 +350,7 @@ def test_custom_mesh_loop_rank1():
             print("Time (numba/cffi, pass {}): {}".format(i, end - start))
 
     b3.vector.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
-    assert((b3.vector - b0.vector).norm() == pytest.approx(0.0))
+    # assert((b3.vector - b0.vector).norm() == pytest.approx(0.0))
 
 
 def test_custom_mesh_loop_ctypes_rank2():
@@ -363,7 +363,7 @@ def test_custom_mesh_loop_ctypes_rank2():
     # Extract mesh and dofmap data
     num_owned_cells = mesh.topology.index_map(mesh.topology.dim).size_local
     num_cells = num_owned_cells + mesh.topology.index_map(mesh.topology.dim).num_ghosts
-    x_dofs = mesh.geometry.dofmap.array().reshape(num_cells, 3)
+    x_dofs = mesh.geometry.dofmap.array.reshape(num_cells, 3)
     x = mesh.geometry.x
     dofmap = V.dofmap.list.array.reshape(num_cells, 3).astype(np.dtype(PETSc.IntType))
 
@@ -418,7 +418,7 @@ def test_custom_mesh_loop_cffi_rank2(set_vals):
     # Unpack mesh and dofmap data
     num_owned_cells = mesh.topology.index_map(mesh.topology.dim).size_local
     num_cells = num_owned_cells + mesh.topology.index_map(mesh.topology.dim).num_ghosts
-    x_dofs = mesh.geometry.dofmap.array().reshape(num_cells, 3)
+    x_dofs = mesh.geometry.dofmap.array.reshape(num_cells, 3)
     x = mesh.geometry.x
     dofmap = V.dofmap.list.array.reshape(num_cells, 3).astype(np.dtype(PETSc.IntType))
 

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -199,7 +199,7 @@ def assemble_vector_parallel(b, v, x, dofmap_t_data, dofmap_t_offsets, num_cells
             b[index] += value
 
 
-@ numba.njit
+@numba.njit
 def assemble_vector_ufc(b, kernel, mesh, dofmap, num_cells):
     """Assemble provided FFCX/UFC kernel over a mesh into the array b"""
     v, x = mesh
@@ -223,7 +223,7 @@ def assemble_vector_ufc(b, kernel, mesh, dofmap, num_cells):
             b[dofmap[cell, j]] += b_local[j]
 
 
-@ numba.njit(fastmath=True)
+@numba.njit(fastmath=True)
 def assemble_matrix_cffi(A, mesh, dofmap, num_cells, set_vals, mode):
     """Assemble P1 mass matrix over a mesh into the PETSc matrix A"""
 
@@ -254,7 +254,7 @@ def assemble_matrix_cffi(A, mesh, dofmap, num_cells, set_vals, mode):
     sink(A_local, dofmap)
 
 
-@ numba.njit
+@numba.njit
 def assemble_matrix_ctypes(A, mesh, dofmap, num_cells, set_vals, mode):
     """Assemble P1 mass matrix over a mesh into the PETSc matrix A"""
     v, x = mesh
@@ -395,7 +395,7 @@ def test_custom_mesh_loop_ctypes_rank2():
     assert (A0 - A1).norm() == pytest.approx(0.0, abs=1.0e-9)
 
 
-@ pytest.mark.parametrize("set_vals", [MatSetValues_abi, MatSetValues_api])
+@pytest.mark.parametrize("set_vals", [MatSetValues_abi, MatSetValues_api])
 def test_custom_mesh_loop_cffi_rank2(set_vals):
     """Test numba assembler for bilinear form"""
 

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -183,7 +183,7 @@ def assemble_vector_parallel(b, v, x, dofmap_t_data, dofmap_t_offsets, num_cells
     """Assemble simple linear form over a mesh into the array b"""
     q0 = 1 / 3.0
     q1 = 1 / 3.0
-    b_unassembled = np.zeros((num_cells, 3), dtype=b.dtype)
+    b_unassembled = np.empty((num_cells, 3), dtype=b.dtype)
     for cell in numba.prange(num_cells):
         # FIXME: This assumes a particular geometry dof layout
         A = area(x[v[cell, 0]], x[v[cell, 1]], x[v[cell, 2]])

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -282,7 +282,7 @@ def assemble_matrix_ctypes(A, mesh, dofmap, num_cells, set_vals, mode):
 def test_custom_mesh_loop_rank1():
 
     # Create mesh and function space
-    mesh = dolfinx.generation.UnitSquareMesh(MPI.COMM_WORLD, 2048, 1024)
+    mesh = dolfinx.generation.UnitSquareMesh(MPI.COMM_WORLD, 64, 64)
     V = dolfinx.FunctionSpace(mesh, ("Lagrange", 1))
 
     # Unpack mesh and dofmap data

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -179,8 +179,7 @@ def assemble_vector(b, mesh, dofmap, num_cells):
 
 @numba.njit(parallel=True, fastmath=True)
 def assemble_vector_parallel(b, v, x, dofmap_t_data, dofmap_t_offsets, num_cells):
-    # def assemble_vector_parallel(b, mesh, num_cells):
-    """Assemble simple linear form over a mesh into the array b"""
+    """Assemble simple linear form over a mesh into the array b using a parallel loop"""
     q0 = 1 / 3.0
     q1 = 1 / 3.0
     b_unassembled = np.empty((num_cells, 3), dtype=b.dtype)

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -386,4 +386,4 @@ def test_higher_order_tetra_coordinate_map(order):
 def test_transpose_dofmap():
     dofmap = dolfinx.cpp.graph.AdjacencyList_int32(np.array([[0, 2, 1], [3, 2, 1], [4, 3, 1]]))
     transpose = dolfinx.cpp.fem.transpose_dofmap(dofmap)
-    assert np.array_equal(transpose.array(), [0, 2, 5, 8, 1, 4, 3, 7, 6])
+    assert np.array_equal(transpose.array, [0, 2, 5, 8, 1, 4, 3, 7, 6])

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 from mpi4py import MPI
 
+import dolfinx
 from dolfinx import (FunctionSpace, Mesh, UnitCubeMesh, UnitIntervalMesh,
                      UnitSquareMesh, VectorFunctionSpace, fem)
 from dolfinx.cpp.mesh import CellType
@@ -379,3 +380,10 @@ def test_higher_order_tetra_coordinate_map(order):
     assert(np.allclose(x[:, 0], X[:, 0]))
     assert(np.allclose(x[:, 1], 2 * X[:, 1]))
     assert(np.allclose(x[:, 2], 3 * X[:, 2]))
+
+
+@skip_in_parallel
+def test_transpose_dofmap():
+    dofmap = dolfinx.cpp.graph.AdjacencyList_int32(np.array([[0, 2, 1], [3, 2, 1], [4, 3, 1]]))
+    transpose = dolfinx.cpp.fem.transpose_dofmap(dofmap)
+    assert np.array_equal(transpose.array(), [0, 2, 5, 8, 1, 4, 3, 7, 6])

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -385,5 +385,5 @@ def test_higher_order_tetra_coordinate_map(order):
 @skip_in_parallel
 def test_transpose_dofmap():
     dofmap = dolfinx.cpp.graph.AdjacencyList_int32(np.array([[0, 2, 1], [3, 2, 1], [4, 3, 1]]))
-    transpose = dolfinx.cpp.fem.transpose_dofmap(dofmap)
+    transpose = dolfinx.cpp.fem.transpose_dofmap(dofmap, 3)
     assert np.array_equal(transpose.array, [0, 2, 5, 8, 1, 4, 3, 7, 6])

--- a/python/test/unit/fem/test_expression_evaluation.py
+++ b/python/test/unit/fem/test_expression_evaluation.py
@@ -74,8 +74,8 @@ def test_rank0():
                 b[dofmap[i * 6 + j]] = b_local[j]
 
     # Prepare mesh and dofmap data
-    pos = mesh.geometry.dofmap.offsets()
-    x_dofs = mesh.geometry.dofmap.array()
+    pos = mesh.geometry.dofmap.offsets
+    x_dofs = mesh.geometry.dofmap.array
     x = mesh.geometry.x
     coeff_dofmap = P2.dofmap.list.array
     dofmap = vP1.dofmap.list.array

--- a/python/test/unit/fem/test_expression_evaluation.py
+++ b/python/test/unit/fem/test_expression_evaluation.py
@@ -77,8 +77,8 @@ def test_rank0():
     pos = mesh.geometry.dofmap.offsets()
     x_dofs = mesh.geometry.dofmap.array()
     x = mesh.geometry.x
-    coeff_dofmap = P2.dofmap.list.array()
-    dofmap = vP1.dofmap.list.array()
+    coeff_dofmap = P2.dofmap.list.array
+    dofmap = vP1.dofmap.list.array
 
     # Data structure for the result
     b = dolfinx.Function(vP1)

--- a/python/test/unit/la/test_krylov_solver.py
+++ b/python/test/unit/la/test_krylov_solver.py
@@ -67,7 +67,7 @@ def test_krylov_samg_solver_elasticity():
             basis = [np.asarray(x) for x in vec_local]
 
             # Build null space basis
-            dofs = [V.sub(i).dofmap.list.array() for i in range(2)]
+            dofs = [V.sub(i).dofmap.list.array for i in range(2)]
             for i in range(2):
                 basis[i][dofs[i]] = 1.0
             x = V.tabulate_dof_coordinates()

--- a/python/test/unit/la/test_nullspace.py
+++ b/python/test/unit/la/test_nullspace.py
@@ -38,7 +38,7 @@ def build_elastic_nullspace(V):
         basis = [np.asarray(x) for x in vec_local]
 
         x = V.tabulate_dof_coordinates()
-        dofs = [V.sub(i).dofmap.list.array() for i in range(gdim)]
+        dofs = [V.sub(i).dofmap.list.array for i in range(gdim)]
 
         # Build translational null space basis
         for i in range(gdim):
@@ -70,7 +70,7 @@ def build_broken_elastic_nullspace(V):
         basis = [np.asarray(x) for x in vec_local]
 
         x = V.tabulate_dof_coordinates()
-        dofs = [V.sub(i).dofmap.list.array() for i in range(2)]
+        dofs = [V.sub(i).dofmap.list.array for i in range(2)]
         basis[0][dofs[0]] = 1.0
         basis[1][dofs[1]] = 1.0
 

--- a/python/test/unit/mesh/test_meshtags.py
+++ b/python/test/unit/mesh/test_meshtags.py
@@ -18,7 +18,7 @@ def test_create(cell_type):
     mesh.topology.create_connectivity_all()
 
     marked_lines = locate_entities(mesh, 1, lambda x: numpy.isclose(x[1], 0.5))
-    f_v = mesh.topology.connectivity(1, 0).array().reshape(-1, 2)
+    f_v = mesh.topology.connectivity(1, 0).array.reshape(-1, 2)
 
     entities = cpp.graph.AdjacencyList_int32(f_v[marked_lines])
     values = numpy.full(marked_lines.shape[0], 2, dtype=numpy.int32)


### PR DESCRIPTION
- Add 'transpose' dofmap (maps global index to local cell contributions). Used the assemble/accumulate unassembled vectors in a thread-safe fashion.
- Add test that uses `numba.prange` to parallelise an assembly loop
- Some performance optimisations in the assemblers