### PR TITLE
Fix neighbor spelling

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -88,7 +88,7 @@ std::vector<int> get_ghost_ranks(
 
 /// Compute (owned) global indices shared with neighbor processes
 ///
-/// @param[in] comm MPI communicator where the neighbourhood sources are
+/// @param[in] comm MPI communicator where the neighborhood sources are
 ///   the owning ranks of the callers ghosts (comm_ghost_to_owner)
 /// @param[in] ghosts Global index of ghosts indices on the caller
 /// @param[in] ghost_src_ranks The src rank on @p comm for each ghost on
@@ -155,11 +155,11 @@ compute_owned_shared(
 
   // Return global indices received from each rank that ghost my owned
   // indices, and return how many global indices are received from each
-  // neighbourhood rank
+  // neighborhood rank
   return {recv_indices, recv_disp};
 }
 //-----------------------------------------------------------------------------
-/// Create neighbourhood communicators
+/// Create neighborhood communicators
 /// @param[in] comm Communicator create communicators with neighborhood
 ///   topology from
 /// @param[in] halo_src_ranks Ranks that own indices in the halo (ghost
@@ -316,7 +316,7 @@ common::stack_index_maps(
   /// Build arrays from old ghost index to composite ghost index for
   /// each field
   std::vector<std::vector<std::int64_t>> ghosts_new(maps.size());
-  std::vector<std::vector<int>> ghost_onwers_new(maps.size());
+  std::vector<std::vector<int>> ghost_owners_new(maps.size());
   for (std::size_t f = 0; f < maps.size(); ++f)
   {
     const int bs = maps[f].get().block_size();
@@ -331,13 +331,13 @@ common::stack_index_maps(
         auto it = ghost_maps[f].find(bs * ghosts[i] + j);
         assert(it != ghost_maps[f].end());
         ghosts_new[f].push_back(it->second);
-        ghost_onwers_new[f].push_back(ghost_owners[i]);
+        ghost_owners_new[f].push_back(ghost_owners[i]);
       }
     }
   }
 
   return {process_offset, std::move(local_offset), std::move(ghosts_new),
-          std::move(ghost_onwers_new)};
+          std::move(ghost_owners_new)};
 }
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
@@ -363,7 +363,7 @@ IndexMap::IndexMap(MPI_Comm comm, std::int32_t local_size, int block_size)
   // Wait for the MPI_Iallreduce to complete
   MPI_Wait(&request, MPI_STATUS_IGNORE);
 
-  // FIXME: Remove need to do thos
+  // FIXME: Remove need to do this
   // Create communicators with empty neighborhoods
   MPI_Comm comm0, comm1, comm2;
   std::vector<int> ranks(0);
@@ -438,7 +438,7 @@ IndexMap::IndexMap(
     const auto it
         = std::find(halo_src_ranks.begin(), halo_src_ranks.end(), src_ranks[j]);
     assert(it != halo_src_ranks.end());
-    const int p_neighbour = std::distance(halo_src_ranks.begin(), it);
+    const int p_neighbor = std::distance(halo_src_ranks.begin(), it);
     if (src_ranks[j] == myrank)
     {
       throw std::runtime_error("IndexMap Error: Ghost in local range. Rank = "
@@ -447,7 +447,7 @@ IndexMap::IndexMap(
     }
 
     // Store owner neighborhood rank for each ghost
-    _ghost_owners[j] = p_neighbour;
+    _ghost_owners[j] = p_neighbor;
   }
 
   // Create communicators with directional edges:
@@ -459,7 +459,7 @@ IndexMap::IndexMap(
   _comm_symmetric = dolfinx::MPI::Comm(comm_array[2], false);
 
   // Compute owned indices which are ghosted by other ranks, and how
-  // many of my indices each neighbour ghosts
+  // many of my indices each neighbor ghosts
   const auto [shared_ind, shared_disp] = compute_owned_shared(
       _comm_ghost_to_owner.comm(), _ghosts, _ghost_owners);
   _shared_disp = std::move(shared_disp);
@@ -650,7 +650,7 @@ MPI_Comm IndexMap::comm(Direction dir) const
 //----------------------------------------------------------------------------
 std::map<std::int32_t, std::set<int>> IndexMap::compute_shared_indices() const
 {
-  // Get number of neighbours and neighbor ranks
+  // Get number of neighbors and neighbor ranks
   int indegree(-1), outdegree(-2), weighted(-1);
   MPI_Dist_graph_neighbors_count(_comm_owner_to_ghost.comm(), &indegree,
                                  &outdegree, &weighted);
@@ -811,7 +811,7 @@ void IndexMap::scatter_fwd_impl(const std::vector<T>& local_data,
                                 std::vector<T>& remote_data, int n) const
 {
 
-  // Get number of neighbours
+  // Get number of neighbors
   int indegree(-1), outdegree(-2), weighted(-1);
   MPI_Dist_graph_neighbors_count(_comm_owner_to_ghost.comm(), &indegree,
                                  &outdegree, &weighted);
@@ -876,7 +876,7 @@ void IndexMap::scatter_rev_impl(std::vector<T>& local_data,
   assert((std::int32_t)remote_data.size() == n * num_ghosts());
   local_data.resize(n * size_local(), 0);
 
-  // Get number of neighbours
+  // Get number of neighbors
   int indegree(-1), outdegree(-2), weighted(-1);
   MPI_Dist_graph_neighbors_count(_comm_ghost_to_owner.comm(), &indegree,
                                  &outdegree, &weighted);

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -300,7 +300,7 @@ private:
   // Number indices across communicator
   std::int64_t _size_global;
 
-  // MPI neighbourhood communicators
+  // MPI neighborhood communicators
 
   // Communicator where the source ranks own the indices in the callers
   // halo, and the destination ranks 'ghost' indices owned by the

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -164,7 +164,7 @@ dolfinx::MPI::neighbors(MPI_Comm neighbor_comm)
   MPI_Topo_test(neighbor_comm, &status);
   assert(status != MPI_UNDEFINED);
 
-  // Get list of neighbours
+  // Get list of neighbors
   int indegree(-1), outdegree(-2), weighted(-1);
   MPI_Dist_graph_neighbors_count(neighbor_comm, &indegree, &outdegree,
                                  &weighted);

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -89,9 +89,9 @@ public:
   static std::vector<int> compute_graph_edges(MPI_Comm comm,
                                               const std::set<int>& edges);
 
-  /// Neighbourhood all-to-all. Send data to neighbours using offsets
+  /// neighborhood all-to-all. Send data to neighbors using offsets
   /// into contiguous data array. Offset array should contain
-  /// (num_neighbours + 1) entries, starting from zero.
+  /// (num_neighbors + 1) entries, starting from zero.
   template <typename T>
   static graph::AdjacencyList<T>
   neighbor_all_to_all(MPI_Comm neighbor_comm,
@@ -100,7 +100,7 @@ public:
 
   /// @todo Clarify directions
   ///
-  /// Return list of neighbours for a neighbourhood communicator
+  /// Return list of neighbors for a neighborhood communicator
   /// @param[in] neighbor_comm Neighborhood communicator
   /// @return source ranks, destination ranks
   static std::tuple<std::vector<int>, std::vector<int>>
@@ -242,7 +242,7 @@ dolfinx::MPI::neighbor_all_to_all(MPI_Comm neighbor_comm,
                                   const std::vector<int>& send_offsets,
                                   const std::vector<T>& send_data)
 {
-  // Get neighbour processes
+  // Get neighbor processes
   int indegree(-1), outdegree(-2), weighted(-1);
   MPI_Dist_graph_neighbors_count(neighbor_comm, &indegree, &outdegree,
                                  &weighted);

--- a/cpp/dolfinx/fem/DofMapBuilder.cpp
+++ b/cpp/dolfinx/fem/DofMapBuilder.cpp
@@ -334,7 +334,7 @@ std::pair<std::vector<std::int32_t>, std::int32_t> compute_reordering_map(
 /// @param [in] dof_entity The ith entry gives (topological dim, local
 ///   index) of the mesh entity to which node i (old local index) is
 ///   associated
-/// @returns The (0) global indices for unowned dofs, (1) onwer rank of each
+/// @returns The (0) global indices for unowned dofs, (1) owner rank of each
 ///   unowned dof
 std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
     const mesh::Topology& topology, const std::int32_t num_owned,
@@ -394,7 +394,7 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
     {
       comm[d] = map->comm(common::IndexMap::Direction::symmetric);
 
-      // Get number of neighbours
+      // Get number of neighbors
       int indegree(-1), outdegree(-2), weighted(-1);
       MPI_Dist_graph_neighbors_count(comm[d], &indegree, &outdegree, &weighted);
 

--- a/cpp/dolfinx/graph/Partitioning.h
+++ b/cpp/dolfinx/graph/Partitioning.h
@@ -25,7 +25,7 @@ namespace dolfinx::graph
 class Partitioning
 {
 public:
-  /// @todo Return the list of neighbour processes which is computed
+  /// @todo Return the list of neighbor processes which is computed
   /// internally
   ///
   /// Compute new, contiguous global indices from a collection of

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -161,11 +161,11 @@ std::int64_t xdmf_utils::get_num_cells(const pugi::xml_node& topology_node)
   assert(topology_node);
 
   // Get number of cells from topology
-  std::int64_t num_cells_topolgy = -1;
+  std::int64_t num_cells_topology = -1;
   pugi::xml_attribute num_cells_attr
       = topology_node.attribute("NumberOfElements");
   if (num_cells_attr)
-    num_cells_topolgy = num_cells_attr.as_llong();
+    num_cells_topology = num_cells_attr.as_llong();
 
   // Get number of cells from topology dataset
   pugi::xml_node topology_dataset_node = topology_node.child("DataItem");
@@ -173,18 +173,18 @@ std::int64_t xdmf_utils::get_num_cells(const pugi::xml_node& topology_node)
   const std::vector tdims = get_dataset_shape(topology_dataset_node);
 
   // Check that number of cells can be determined
-  if (tdims.size() != 2 and num_cells_topolgy == -1)
-    throw std::runtime_error("Cannot determine number of cells in XMDF mesh");
+  if (tdims.size() != 2 and num_cells_topology == -1)
+    throw std::runtime_error("Cannot determine number of cells in XDMF mesh");
 
   // Check for consistency if number of cells appears in both the topology
   // and DataItem nodes
-  if (num_cells_topolgy != -1 and tdims.size() == 2)
+  if (num_cells_topology != -1 and tdims.size() == 2)
   {
-    if (num_cells_topolgy != tdims[0])
-      throw std::runtime_error("Cannot determine number of cells in XMDF mesh");
+    if (num_cells_topology != tdims[0])
+      throw std::runtime_error("Cannot determine number of cells in XDMF mesh");
   }
 
-  return std::max(num_cells_topolgy, tdims[0]);
+  return std::max(num_cells_topology, tdims[0]);
 }
 //----------------------------------------------------------------------------
 std::vector<PetscScalar>
@@ -458,7 +458,7 @@ xdmf_utils::extract_local_entities(
 
   // NOTE: Could: (i) use a std::unordered_multimap, or (ii) only send
   // owned nodes to the postmaster and use map, unordered_map or
-  // std::vector<pair>>, followed by a neighbourhood all_to_all at the
+  // std::vector<pair>>, followed by a neighborhood all_to_all at the
   // end.
   //
   // Build map from global node index to ranks that have the node

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -404,25 +404,24 @@ mesh::create_topology(MPI_Comm comm,
   // Get global offset for local indices
   std::int64_t global_offset = dolfinx::MPI::global_offset(comm, nlocal, true);
 
-  // Find all vertex-sharing neighbours, and process-to-neighbour map
-  std::set<int> vertex_neighbours;
+  // Find all vertex-sharing neighbors, and process-to-neighbor map
+  std::set<int> vertex_neighbors;
   for (auto q : global_to_procs)
-    vertex_neighbours.insert(q.second.begin(), q.second.end());
-  vertex_neighbours.erase(mpi_rank);
-  std::vector<int> neighbours(vertex_neighbours.begin(),
-                              vertex_neighbours.end());
-  std::unordered_map<int, int> proc_to_neighbours;
-  for (std::size_t i = 0; i < neighbours.size(); ++i)
-    proc_to_neighbours.insert({neighbours[i], i});
+    vertex_neighbors.insert(q.second.begin(), q.second.end());
+  vertex_neighbors.erase(mpi_rank);
+  std::vector<int> neighbors(vertex_neighbors.begin(), vertex_neighbors.end());
+  std::unordered_map<int, int> proc_to_neighbors;
+  for (std::size_t i = 0; i < neighbors.size(); ++i)
+    proc_to_neighbors.insert({neighbors[i], i});
 
-  // Communicate new global index to neighbours
-  MPI_Comm neighbour_comm;
-  MPI_Dist_graph_create_adjacent(comm, neighbours.size(), neighbours.data(),
-                                 MPI_UNWEIGHTED, neighbours.size(),
-                                 neighbours.data(), MPI_UNWEIGHTED,
-                                 MPI_INFO_NULL, false, &neighbour_comm);
+  // Communicate new global index to neighbors
+  MPI_Comm neighbor_comm;
+  MPI_Dist_graph_create_adjacent(comm, neighbors.size(), neighbors.data(),
+                                 MPI_UNWEIGHTED, neighbors.size(),
+                                 neighbors.data(), MPI_UNWEIGHTED,
+                                 MPI_INFO_NULL, false, &neighbor_comm);
 
-  std::vector<std::vector<std::int64_t>> send_pairs(neighbours.size());
+  std::vector<std::vector<std::int64_t>> send_pairs(neighbors.size());
   for (const auto& q : global_to_procs)
   {
     const std::vector<int>& procs = q.second;
@@ -436,7 +435,7 @@ mesh::create_topology(MPI_Comm comm,
       // NB starting from 1. 0 is self.
       for (std::size_t j = 1; j < procs.size(); ++j)
       {
-        int np = proc_to_neighbours[procs[j]];
+        int np = proc_to_neighbors[procs[j]];
         send_pairs[np].push_back(it->first);
         send_pairs[np].push_back(it->second + global_offset);
       }
@@ -452,7 +451,7 @@ mesh::create_topology(MPI_Comm comm,
   }
 
   Eigen::Array<std::int64_t, Eigen::Dynamic, 1> recv_pairs
-      = dolfinx::MPI::neighbor_all_to_all(neighbour_comm, qsend_offsets,
+      = dolfinx::MPI::neighbor_all_to_all(neighbor_comm, qsend_offsets,
                                           qsend_data)
             .array();
 
@@ -495,13 +494,13 @@ mesh::create_topology(MPI_Comm comm,
     }
 
     // Precompute sizes and offsets
-    std::vector<int> send_sizes(neighbours.size());
-    std::vector<int> send_offsets(neighbours.size() + 1);
+    std::vector<int> send_sizes(neighbors.size());
+    std::vector<int> send_offsets(neighbors.size() + 1);
     for (const auto& q : fwd_shared_vertices)
     {
       for (int p : q.second)
       {
-        const int np = proc_to_neighbours[p];
+        const int np = proc_to_neighbors[p];
         send_sizes[np] += 2;
       }
     }
@@ -509,7 +508,7 @@ mesh::create_topology(MPI_Comm comm,
                      send_offsets.begin() + 1);
     std::vector<int> tmp_offsets(send_offsets.begin(), send_offsets.end());
 
-    // Fill data for neighbour alltoall
+    // Fill data for neighbor alltoall
     std::vector<std::int64_t> send_pair_data(send_offsets.back());
     for (const auto& q : fwd_shared_vertices)
     {
@@ -525,14 +524,14 @@ mesh::create_topology(MPI_Comm comm,
 
       for (int p : q.second)
       {
-        const int np = proc_to_neighbours[p];
+        const int np = proc_to_neighbors[p];
         send_pair_data[tmp_offsets[np]++] = q.first;
         send_pair_data[tmp_offsets[np]++] = gi;
       }
     }
 
     Eigen::Array<std::int64_t, Eigen::Dynamic, 1> recv_pairs
-        = dolfinx::MPI::neighbor_all_to_all(neighbour_comm, send_offsets,
+        = dolfinx::MPI::neighbor_all_to_all(neighbor_comm, send_offsets,
                                             send_pair_data)
               .array();
 
@@ -550,14 +549,14 @@ mesh::create_topology(MPI_Comm comm,
     }
   }
 
-  // Get global onwers of ghost vertices
+  // Get global owners of ghost vertices
   // TODO: Get vertice owner from cell owner? Can use neighborhood
   // communication?
   int mpi_size = -1;
-  MPI_Comm_size(neighbour_comm, &mpi_size);
+  MPI_Comm_size(neighbor_comm, &mpi_size);
   std::vector<std::int32_t> local_sizes(mpi_size);
   MPI_Allgather(&nlocal, 1, MPI_INT32_T, local_sizes.data(), 1, MPI_INT32_T,
-                neighbour_comm);
+                neighbor_comm);
 
   std::vector<std::int64_t> all_ranges(mpi_size + 1, 0);
   std::partial_sum(local_sizes.begin(), local_sizes.end(),
@@ -573,7 +572,7 @@ mesh::create_topology(MPI_Comm comm,
     ghost_vertices_owners[i] = p;
   }
 
-  MPI_Comm_free(&neighbour_comm);
+  MPI_Comm_free(&neighbor_comm);
 
   const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>& cells_array
       = cells.array();

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -191,7 +191,7 @@ private:
 ///   global indices for the vertices. It contains cells that have been
 ///   distributed to this rank, e.g. via a graph partitioner. It must
 ///   also contain all ghost cells via facet, i.e. cells which are on a
-///   neighbouring process and share a facet with a local cell.
+///   neighboring process and share a facet with a local cell.
 /// @param[in] original_cell_index The original global index associated
 ///   with each cell.
 /// @param[in] ghost_owners The ownership of the ghost cells (ghost

--- a/cpp/dolfinx/refinement/ParallelRefinement.cpp
+++ b/cpp/dolfinx/refinement/ParallelRefinement.cpp
@@ -164,36 +164,35 @@ ParallelRefinement::ParallelRefinement(const mesh::Mesh& mesh) : _mesh(mesh)
   std::map<std::int32_t, std::set<int>> shared_edges
       = _mesh.topology().index_map(1)->compute_shared_indices();
 
-  // Compute a slightly wider neighbourhood for direct communication of shared
+  // Compute a slightly wider neighborhood for direct communication of shared
   // edges
-  std::set<int> all_neighbour_set;
+  std::set<int> all_neighbor_set;
   for (const auto& q : shared_edges)
-    all_neighbour_set.insert(q.second.begin(), q.second.end());
-  std::vector<int> neighbours(all_neighbour_set.begin(),
-                              all_neighbour_set.end());
+    all_neighbor_set.insert(q.second.begin(), q.second.end());
+  std::vector<int> neighbors(all_neighbor_set.begin(), all_neighbor_set.end());
 
   MPI_Dist_graph_create_adjacent(
-      mesh.mpi_comm(), neighbours.size(), neighbours.data(), MPI_UNWEIGHTED,
-      neighbours.size(), neighbours.data(), MPI_UNWEIGHTED, MPI_INFO_NULL,
-      false, &_neighbour_comm);
+      mesh.mpi_comm(), neighbors.size(), neighbors.data(), MPI_UNWEIGHTED,
+      neighbors.size(), neighbors.data(), MPI_UNWEIGHTED, MPI_INFO_NULL, false,
+      &_neighbor_comm);
 
-  // Create a "shared_edge to neighbour map"
-  std::map<int, int> proc_to_neighbour;
-  for (std::size_t i = 0; i < neighbours.size(); ++i)
-    proc_to_neighbour.insert({neighbours[i], i});
+  // Create a "shared_edge to neighbor map"
+  std::map<int, int> proc_to_neighbor;
+  for (std::size_t i = 0; i < neighbors.size(); ++i)
+    proc_to_neighbor.insert({neighbors[i], i});
 
   for (auto& q : shared_edges)
   {
-    std::set<int> neighbour_set;
+    std::set<int> neighbor_set;
     for (int r : q.second)
-      neighbour_set.insert(proc_to_neighbour[r]);
-    _shared_edges.insert({q.first, neighbour_set});
+      neighbor_set.insert(proc_to_neighbor[r]);
+    _shared_edges.insert({q.first, neighbor_set});
   }
 
-  _marked_for_update.resize(neighbours.size());
+  _marked_for_update.resize(neighbors.size());
 }
 //-----------------------------------------------------------------------------
-ParallelRefinement::~ParallelRefinement() { MPI_Comm_free(&_neighbour_comm); }
+ParallelRefinement::~ParallelRefinement() { MPI_Comm_free(&_neighbor_comm); }
 //-----------------------------------------------------------------------------
 const std::vector<bool>& ParallelRefinement::marked_edges() const
 {
@@ -212,7 +211,7 @@ bool ParallelRefinement::mark(std::int32_t edge_index)
 
   _marked_edges[edge_index] = true;
 
-  // If it is a shared edge, add all sharing neighbours to update set
+  // If it is a shared edge, add all sharing neighbors to update set
   if (auto map_it = _shared_edges.find(edge_index);
       map_it != _shared_edges.end())
   {
@@ -258,8 +257,8 @@ void ParallelRefinement::update_logical_edgefunction()
 {
   std::vector<std::int32_t> send_offsets = {0};
   std::vector<std::int64_t> data_to_send;
-  int num_neighbours = _marked_for_update.size();
-  for (int i = 0; i < num_neighbours; ++i)
+  int num_neighbors = _marked_for_update.size();
+  for (int i = 0; i < num_neighbors; ++i)
   {
     data_to_send.insert(data_to_send.end(), _marked_for_update[i].begin(),
                         _marked_for_update[i].end());
@@ -270,7 +269,7 @@ void ParallelRefinement::update_logical_edgefunction()
   // Send all shared edges marked for update and receive from other
   // processes
   const Eigen::Array<std::int64_t, Eigen::Dynamic, 1> data_to_recv
-      = MPI::neighbor_all_to_all(_neighbour_comm, send_offsets, data_to_send)
+      = MPI::neighbor_all_to_all(_neighbor_comm, send_offsets, data_to_send)
             .array();
 
   // Flatten received values and set _marked_edges at each index received
@@ -313,8 +312,8 @@ std::map<std::int32_t, std::int64_t> ParallelRefinement::create_new_vertices()
   // If they are shared, then the new global vertex index needs to be
   // sent off-process.
 
-  int num_neighbours = _marked_for_update.size();
-  std::vector<std::vector<std::int64_t>> values_to_send(num_neighbours);
+  int num_neighbors = _marked_for_update.size();
+  std::vector<std::vector<std::int64_t>> values_to_send(num_neighbors);
   for (auto& local_edge : local_edge_to_new_vertex)
   {
     const std::size_t local_i = local_edge.first;
@@ -333,10 +332,10 @@ std::map<std::int32_t, std::int64_t> ParallelRefinement::create_new_vertices()
     }
   }
 
-  // Send new vertex indices to edge neighbours and receive
+  // Send new vertex indices to edge neighbors and receive
   std::vector<std::int64_t> send_values;
   std::vector<int> send_offsets = {0};
-  for (int i = 0; i < num_neighbours; ++i)
+  for (int i = 0; i < num_neighbors; ++i)
   {
     send_values.insert(send_values.end(), values_to_send[i].begin(),
                        values_to_send[i].end());
@@ -344,7 +343,7 @@ std::map<std::int32_t, std::int64_t> ParallelRefinement::create_new_vertices()
   }
 
   const Eigen::Array<std::int64_t, Eigen::Dynamic, 1> received_values
-      = MPI::neighbor_all_to_all(_neighbour_comm, send_offsets, send_values)
+      = MPI::neighbor_all_to_all(_neighbor_comm, send_offsets, send_values)
             .array();
 
   // Add received remote global vertex indices to map

--- a/cpp/dolfinx/refinement/ParallelRefinement.h
+++ b/cpp/dolfinx/refinement/ParallelRefinement.h
@@ -123,7 +123,7 @@ private:
   // Shared edges between processes
   std::map<std::int32_t, std::set<std::int32_t>> _shared_edges;
 
-  // neighborhood communicator
+  // Neighborhood communicator
   MPI_Comm _neighbor_comm;
 };
 } // namespace refinement

--- a/cpp/dolfinx/refinement/ParallelRefinement.h
+++ b/cpp/dolfinx/refinement/ParallelRefinement.h
@@ -123,8 +123,8 @@ private:
   // Shared edges between processes
   std::map<std::int32_t, std::set<std::int32_t>> _shared_edges;
 
-  // Neighbourhood communicator
-  MPI_Comm _neighbour_comm;
+  // neighborhood communicator
+  MPI_Comm _neighbor_comm;
 };
 } // namespace refinement
 } // namespace dolfinx


### PR DESCRIPTION
Two different spellings of _neighbor_ are used. 
The idea of this PR is to set one, to make it easier to search for variables or functions... 