### PR TITLE
Remove singleton class (SubSystemsManager)

### DIFF
--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -113,12 +113,11 @@ int main(int argc, char* argv[])
     // .. code-block:: cpp
 
     // Create mesh and define function space
-    std::array pt{Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(1, 1, 1)};
-
     auto cmap
         = fem::create_coordinate_map(create_coordinate_map_hyperelasticity);
     auto mesh = std::make_shared<mesh::Mesh>(generation::BoxMesh::create(
-        MPI_COMM_WORLD, pt, {{10, 10, 10}}, cmap, mesh::GhostMode::none));
+        MPI_COMM_WORLD, {Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(1, 1, 1)},
+        {10, 10, 10}, cmap, mesh::GhostMode::none));
 
     auto V = fem::create_functionspace(
         create_functionspace_form_hyperelasticity_F, "u", mesh);

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -115,113 +115,117 @@ int main(int argc, char* argv[])
   common::SubSystemsManager::init_logging(argc, argv);
   common::SubSystemsManager::init_petsc(argc, argv);
 
-  // Create mesh and function space
-  auto cmap = fem::create_coordinate_map(create_coordinate_map_poisson);
-  std::array pt{Eigen::Vector3d(0.0, 0.0, 0.0), Eigen::Vector3d(1.0, 1.0, 0.0)};
-  auto mesh = std::make_shared<mesh::Mesh>(generation::RectangleMesh::create(
-      MPI_COMM_WORLD, pt, {{32, 32}}, cmap, mesh::GhostMode::none));
+  {
+    // Create mesh and function space
+    auto cmap = fem::create_coordinate_map(create_coordinate_map_poisson);
+    std::array pt{Eigen::Vector3d(0.0, 0.0, 0.0),
+                  Eigen::Vector3d(1.0, 1.0, 0.0)};
+    auto mesh = std::make_shared<mesh::Mesh>(generation::RectangleMesh::create(
+        MPI_COMM_WORLD, pt, {{32, 32}}, cmap, mesh::GhostMode::none));
 
-  auto V = fem::create_functionspace(create_functionspace_form_poisson_a, "u",
-                                     mesh);
+    auto V = fem::create_functionspace(create_functionspace_form_poisson_a, "u",
+                                       mesh);
 
-  // Next, we define the variational formulation by initializing the
-  // bilinear and linear forms (:math:`a`, :math:`L`) using the previously
-  // defined :cpp:class:`FunctionSpace` ``V``.  Then we can create the
-  // source and boundary flux term (:math:`f`, :math:`g`) and attach these
-  // to the linear form.
-  //
-  // .. code-block:: cpp
+    // Next, we define the variational formulation by initializing the
+    // bilinear and linear forms (:math:`a`, :math:`L`) using the previously
+    // defined :cpp:class:`FunctionSpace` ``V``.  Then we can create the
+    // source and boundary flux term (:math:`f`, :math:`g`) and attach these
+    // to the linear form.
+    //
+    // .. code-block:: cpp
 
-  // Define variational forms
-  auto a = fem::create_form<PetscScalar>(create_form_poisson_a, {V, V});
-  auto L = fem::create_form<PetscScalar>(create_form_poisson_L, {V});
+    // Define variational forms
+    auto a = fem::create_form<PetscScalar>(create_form_poisson_a, {V, V});
+    auto L = fem::create_form<PetscScalar>(create_form_poisson_L, {V});
 
-  auto f = std::make_shared<function::Function<PetscScalar>>(V);
-  auto g = std::make_shared<function::Function<PetscScalar>>(V);
+    auto f = std::make_shared<function::Function<PetscScalar>>(V);
+    auto g = std::make_shared<function::Function<PetscScalar>>(V);
 
-  // Now, the Dirichlet boundary condition (:math:`u = 0`) can be created
-  // using the class :cpp:class:`DirichletBC`. A :cpp:class:`DirichletBC`
-  // takes two arguments: the value of the boundary condition,
-  // and the part of the boundary on which the condition applies.
-  // In our example, the value of the boundary condition (0.0) can
-  // represented using a :cpp:class:`Function`, and the Dirichlet boundary
-  // is defined by the indices of degrees of freedom to which the boundary
-  // condition applies.
-  // The definition of the Dirichlet boundary condition then looks
-  // as follows:
-  //
-  // .. code-block:: cpp
+    // Now, the Dirichlet boundary condition (:math:`u = 0`) can be created
+    // using the class :cpp:class:`DirichletBC`. A :cpp:class:`DirichletBC`
+    // takes two arguments: the value of the boundary condition,
+    // and the part of the boundary on which the condition applies.
+    // In our example, the value of the boundary condition (0.0) can
+    // represented using a :cpp:class:`Function`, and the Dirichlet boundary
+    // is defined by the indices of degrees of freedom to which the boundary
+    // condition applies.
+    // The definition of the Dirichlet boundary condition then looks
+    // as follows:
+    //
+    // .. code-block:: cpp
 
-  // FIXME: zero function and make sure ghosts are updated
-  // Define boundary condition
-  auto u0 = std::make_shared<function::Function<PetscScalar>>(V);
+    // FIXME: zero function and make sure ghosts are updated
+    // Define boundary condition
+    auto u0 = std::make_shared<function::Function<PetscScalar>>(V);
 
-  const auto bdofs = fem::locate_dofs_geometrical({*V}, [](auto& x) {
-    return (x.row(0) < DBL_EPSILON or x.row(0) > 1.0 - DBL_EPSILON);
-  });
+    const auto bdofs = fem::locate_dofs_geometrical({*V}, [](auto& x) {
+      return (x.row(0) < DBL_EPSILON or x.row(0) > 1.0 - DBL_EPSILON);
+    });
 
-  std::vector bc{
-      std::make_shared<const fem::DirichletBC<PetscScalar>>(u0, bdofs)};
+    std::vector bc{
+        std::make_shared<const fem::DirichletBC<PetscScalar>>(u0, bdofs)};
 
-  f->interpolate([](auto& x) {
-    auto dx = Eigen::square(x - 0.5);
-    return 10.0 * Eigen::exp(-(dx.row(0) + dx.row(1)) / 0.02);
-  });
+    f->interpolate([](auto& x) {
+      auto dx = Eigen::square(x - 0.5);
+      return 10.0 * Eigen::exp(-(dx.row(0) + dx.row(1)) / 0.02);
+    });
 
-  g->interpolate([](auto& x) { return Eigen::sin(5 * x.row(0)); });
-  L->set_coefficients({{"f", f}, {"g", g}});
+    g->interpolate([](auto& x) { return Eigen::sin(5 * x.row(0)); });
+    L->set_coefficients({{"f", f}, {"g", g}});
 
-  // Prepare and set Constants for the bilinear form
-  auto kappa = std::make_shared<function::Constant<PetscScalar>>(2.0);
-  a->set_constants({{"kappa", kappa}});
+    // Prepare and set Constants for the bilinear form
+    auto kappa = std::make_shared<function::Constant<PetscScalar>>(2.0);
+    a->set_constants({{"kappa", kappa}});
 
-  // Now, we have specified the variational forms and can consider the
-  // solution of the variational problem. First, we need to define a
-  // :cpp:class:`Function` ``u`` to store the solution. (Upon
-  // initialization, it is simply set to the zero function.) Next, we can
-  // call the ``solve`` function with the arguments ``a == L``, ``u`` and
-  // ``bc`` as follows:
-  //
-  // .. code-block:: cpp
+    // Now, we have specified the variational forms and can consider the
+    // solution of the variational problem. First, we need to define a
+    // :cpp:class:`Function` ``u`` to store the solution. (Upon
+    // initialization, it is simply set to the zero function.) Next, we can
+    // call the ``solve`` function with the arguments ``a == L``, ``u`` and
+    // ``bc`` as follows:
+    //
+    // .. code-block:: cpp
 
-  // Compute solution
-  function::Function<PetscScalar> u(V);
-  la::PETScMatrix A = fem::create_matrix(*a);
-  la::PETScVector b(*L->function_space(0)->dofmap()->index_map);
+    // Compute solution
+    function::Function<PetscScalar> u(V);
+    la::PETScMatrix A = fem::create_matrix(*a);
+    la::PETScVector b(*L->function_space(0)->dofmap()->index_map);
 
-  MatZeroEntries(A.mat());
-  fem::assemble_matrix(la::PETScMatrix::add_fn(A.mat()), *a, bc);
-  fem::add_diagonal(la::PETScMatrix::add_fn(A.mat()), *V, bc);
-  MatAssemblyBegin(A.mat(), MAT_FINAL_ASSEMBLY);
-  MatAssemblyEnd(A.mat(), MAT_FINAL_ASSEMBLY);
+    MatZeroEntries(A.mat());
+    fem::assemble_matrix(la::PETScMatrix::add_fn(A.mat()), *a, bc);
+    fem::add_diagonal(la::PETScMatrix::add_fn(A.mat()), *V, bc);
+    MatAssemblyBegin(A.mat(), MAT_FINAL_ASSEMBLY);
+    MatAssemblyEnd(A.mat(), MAT_FINAL_ASSEMBLY);
 
-  VecSet(b.vec(), 0.0);
-  VecGhostUpdateBegin(b.vec(), INSERT_VALUES, SCATTER_FORWARD);
-  VecGhostUpdateEnd(b.vec(), INSERT_VALUES, SCATTER_FORWARD);
-  fem::assemble_vector_petsc(b.vec(), *L);
-  fem::apply_lifting_petsc(b.vec(), {a}, {{bc}}, {}, 1.0);
-  VecGhostUpdateBegin(b.vec(), ADD_VALUES, SCATTER_REVERSE);
-  VecGhostUpdateEnd(b.vec(), ADD_VALUES, SCATTER_REVERSE);
-  fem::set_bc_petsc(b.vec(), bc, nullptr);
+    VecSet(b.vec(), 0.0);
+    VecGhostUpdateBegin(b.vec(), INSERT_VALUES, SCATTER_FORWARD);
+    VecGhostUpdateEnd(b.vec(), INSERT_VALUES, SCATTER_FORWARD);
+    fem::assemble_vector_petsc(b.vec(), *L);
+    fem::apply_lifting_petsc(b.vec(), {a}, {{bc}}, {}, 1.0);
+    VecGhostUpdateBegin(b.vec(), ADD_VALUES, SCATTER_REVERSE);
+    VecGhostUpdateEnd(b.vec(), ADD_VALUES, SCATTER_REVERSE);
+    fem::set_bc_petsc(b.vec(), bc, nullptr);
 
-  la::PETScKrylovSolver lu(MPI_COMM_WORLD);
-  la::PETScOptions::set("ksp_type", "preonly");
-  la::PETScOptions::set("pc_type", "lu");
-  lu.set_from_options();
+    la::PETScKrylovSolver lu(MPI_COMM_WORLD);
+    la::PETScOptions::set("ksp_type", "preonly");
+    la::PETScOptions::set("pc_type", "lu");
+    lu.set_from_options();
 
-  lu.set_operator(A.mat());
-  lu.solve(u.vector(), b.vec());
+    lu.set_operator(A.mat());
+    lu.solve(u.vector(), b.vec());
 
-  // The function ``u`` will be modified during the call to solve. A
-  // :cpp:class:`Function` can be saved to a file. Here, we output the
-  // solution to a ``VTK`` file (specified using the suffix ``.pvd``) for
-  // visualisation in an external program such as Paraview.
-  //
-  // .. code-block:: cpp
+    // The function ``u`` will be modified during the call to solve. A
+    // :cpp:class:`Function` can be saved to a file. Here, we output the
+    // solution to a ``VTK`` file (specified using the suffix ``.pvd``) for
+    // visualisation in an external program such as Paraview.
+    //
+    // .. code-block:: cpp
 
-  // Save solution in VTK format
-  io::VTKFile file("u.pvd");
-  file.write(u);
+    // Save solution in VTK format
+    io::VTKFile file("u.pvd");
+    file.write(u);
+  }
 
+  common::SubSystemsManager::finalize_petsc();
   return 0;
 }

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -118,10 +118,10 @@ int main(int argc, char* argv[])
   {
     // Create mesh and function space
     auto cmap = fem::create_coordinate_map(create_coordinate_map_poisson);
-    std::array pt{Eigen::Vector3d(0.0, 0.0, 0.0),
-                  Eigen::Vector3d(1.0, 1.0, 0.0)};
     auto mesh = std::make_shared<mesh::Mesh>(generation::RectangleMesh::create(
-        MPI_COMM_WORLD, pt, {{32, 32}}, cmap, mesh::GhostMode::none));
+        MPI_COMM_WORLD,
+        {Eigen::Vector3d(0.0, 0.0, 0.0), Eigen::Vector3d(1.0, 1.0, 0.0)},
+        {32, 32}, cmap, mesh::GhostMode::none));
 
     auto V = fem::create_functionspace(create_functionspace_form_poisson_a, "u",
                                        mesh);

--- a/cpp/dolfinx/common/SubSystemsManager.cpp
+++ b/cpp/dolfinx/common/SubSystemsManager.cpp
@@ -24,19 +24,19 @@ using namespace dolfinx::common;
 // before use. (google "static initialization order fiasco" for full
 // explanation)
 
-SubSystemsManager& SubSystemsManager::singleton()
-{
-  static SubSystemsManager the_instance;
-  return the_instance;
-}
+// SubSystemsManager& SubSystemsManager::singleton()
+// {
+//   static SubSystemsManager the_instance;
+//   return the_instance;
+// }
 //-----------------------------------------------------------------------------
-SubSystemsManager::SubSystemsManager()
-    : petsc_err_msg(""), petsc_initialized(false), control_mpi(false)
-{
-  // Do nothing
-}
+// SubSystemsManager::SubSystemsManager()
+//     : petsc_err_msg(""), petsc_initialized(false), control_mpi(false)
+// {
+//   // Do nothing
+// }
 //-----------------------------------------------------------------------------
-SubSystemsManager::~SubSystemsManager() { finalize(); }
+// SubSystemsManager::~SubSystemsManager() { finalize(); }
 //-----------------------------------------------------------------------------
 void SubSystemsManager::init_mpi()
 {
@@ -50,7 +50,7 @@ void SubSystemsManager::init_mpi()
   std::string s("");
   char* c = const_cast<char*>(s.c_str());
   SubSystemsManager::init_mpi(0, &c, MPI_THREAD_MULTIPLE);
-  singleton().control_mpi = true;
+  // singleton().control_mpi = true;
 }
 //-----------------------------------------------------------------------------
 int SubSystemsManager::init_mpi(int argc, char* argv[],
@@ -64,7 +64,6 @@ int SubSystemsManager::init_mpi(int argc, char* argv[],
   // Initialise MPI and take responsibility
   int provided = -1;
   MPI_Init_thread(&argc, &argv, required_thread_level, &provided);
-  singleton().control_mpi = true;
 
   return provided;
 }
@@ -88,9 +87,6 @@ void SubSystemsManager::init_petsc()
 //-----------------------------------------------------------------------------
 void SubSystemsManager::init_petsc(int argc, char* argv[])
 {
-  if (singleton().petsc_initialized)
-    return;
-
   // Initialized MPI (do it here rather than letting PETSc do it to make
   // sure we MPI is initialized with any thread support
   init_mpi();
@@ -112,27 +108,27 @@ void SubSystemsManager::init_petsc(int argc, char* argv[])
 #endif
 
   // Remember that PETSc has been initialized
-  singleton().petsc_initialized = true;
+  // singleton().petsc_initialized = true;
 
   // Determine if PETSc initialised MPI (and is therefore responsible
   // for MPI finalization)
-  if (mpi_initialized() && !mpi_init_status)
-    singleton().control_mpi = false;
+  // if (mpi_initialized() && !mpi_init_status)
+  //   singleton().control_mpi = false;
 }
 //-----------------------------------------------------------------------------
-void SubSystemsManager::finalize()
-{
-  // Finalize subsystems in the correct order
-  finalize_petsc();
-  finalize_mpi();
-}
+// void SubSystemsManager::finalize()
+// {
+//   // Finalize subsystems in the correct order
+//   finalize_petsc();
+//   finalize_mpi();
+// }
 //-----------------------------------------------------------------------------
-bool SubSystemsManager::responsible_mpi() { return singleton().control_mpi; }
-//-----------------------------------------------------------------------------
-bool SubSystemsManager::responsible_petsc()
-{
-  return singleton().petsc_initialized;
-}
+// bool SubSystemsManager::responsible_mpi() { return singleton().control_mpi; }
+// //-----------------------------------------------------------------------------
+// bool SubSystemsManager::responsible_petsc()
+// {
+//   return singleton().petsc_initialized;
+// }
 //-----------------------------------------------------------------------------
 void SubSystemsManager::finalize_mpi()
 {
@@ -140,7 +136,7 @@ void SubSystemsManager::finalize_mpi()
   MPI_Initialized(&mpi_initialized);
 
   // Finalise MPI if required
-  if (mpi_initialized && singleton().control_mpi)
+  if (mpi_initialized)
   {
     // Check in MPI has already been finalised (possibly incorrectly by
     // a 3rd party library). If it hasn't, finalise as normal.
@@ -159,24 +155,24 @@ void SubSystemsManager::finalize_mpi()
                 << std::endl;
     }
 
-    singleton().control_mpi = false;
+    // singleton().control_mpi = false;
   }
 }
 //-----------------------------------------------------------------------------
 void SubSystemsManager::finalize_petsc()
 {
-  if (singleton().petsc_initialized)
-  {
-    if (!PetscFinalizeCalled)
-    {
-      PetscFinalize();
-    }
-    singleton().petsc_initialized = false;
+  // if (singleton().petsc_initialized)
+  // {
+  //   if (!PetscFinalizeCalled)
+  //   {
+  PetscFinalize();
+  // }
+  // singleton().petsc_initialized = false;
 
 #ifdef HAS_SLEPC
-    SlepcFinalize();
+  SlepcFinalize();
 #endif
-  }
+  // }
 }
 //-----------------------------------------------------------------------------
 bool SubSystemsManager::mpi_initialized()
@@ -197,29 +193,29 @@ bool SubSystemsManager::mpi_finalized()
   return mpi_finalized;
 }
 //-----------------------------------------------------------------------------
-PetscErrorCode SubSystemsManager::PetscDolfinErrorHandler(
-    MPI_Comm, int line, const char* fun, const char* file, PetscErrorCode n,
-    PetscErrorType, const char* mess, void*)
-{
-  // Store message for printing later (by PETScObject::petsc_error) only
-  // if it's not empty message (passed by PETSc when repeating error)
-  std::string _mess = mess;
-  boost::algorithm::trim(_mess);
-  if (_mess != "")
-    singleton().petsc_err_msg = _mess;
+// PetscErrorCode SubSystemsManager::PetscDolfinErrorHandler(
+//     MPI_Comm, int line, const char* fun, const char* file, PetscErrorCode n,
+//     PetscErrorType, const char* mess, void*)
+// {
+//   // Store message for printing later (by PETScObject::petsc_error) only
+//   // if it's not empty message (passed by PETSc when repeating error)
+//   std::string _mess = mess;
+//   boost::algorithm::trim(_mess);
+//   if (_mess != "")
+//     singleton().petsc_err_msg = _mess;
 
-  // Fetch PETSc error description
-  const char* desc;
-  PetscErrorMessage(n, &desc, nullptr);
+//   // Fetch PETSc error description
+//   const char* desc;
+//   PetscErrorMessage(n, &desc, nullptr);
 
-  // Log detailed error info
-  LOG(ERROR)
-      << "PetscDolfinErrorHandler: line '{}', function '{}', file '{}',\n"
-         "                       : error code '{}' ({}), message follows:"
-      << line << fun << file << n << desc;
-  LOG(ERROR) << (_mess);
+//   // Log detailed error info
+//   LOG(ERROR)
+//       << "PetscDolfinErrorHandler: line '{}', function '{}', file '{}',\n"
+//          "                       : error code '{}' ({}), message follows:"
+//       << line << fun << file << n << desc;
+//   LOG(ERROR) << (_mess);
 
-  // Continue with error handling
-  PetscFunctionReturn(n);
-}
+//   // Continue with error handling
+//   PetscFunctionReturn(n);
+// }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/SubSystemsManager.cpp
+++ b/cpp/dolfinx/common/SubSystemsManager.cpp
@@ -25,24 +25,21 @@ void SubSystemsManager::init_mpi()
   if (mpi_initialized)
     return;
 
-  // Init MPI with highest level of thread support
+  // Init MPI
   std::string s("");
   char* c = const_cast<char*>(s.c_str());
-  SubSystemsManager::init_mpi(0, &c, MPI_THREAD_MULTIPLE);
+  SubSystemsManager::init_mpi(0, &c);
 }
 //-----------------------------------------------------------------------------
-int SubSystemsManager::init_mpi(int argc, char* argv[],
-                                int required_thread_level)
+void SubSystemsManager::init_mpi(int argc, char* argv[])
 {
   int mpi_initialized;
   MPI_Initialized(&mpi_initialized);
   if (mpi_initialized)
-    return -100;
+    return;
 
-  // Initialise MPI and take responsibility
-  int provided = -1;
-  MPI_Init_thread(&argc, &argv, required_thread_level, &provided);
-  return provided;
+  // Initialise MPI
+  MPI_Init(&argc, &argv);
 }
 //-----------------------------------------------------------------------------
 void SubSystemsManager::init_logging(int argc, char* argv[])

--- a/cpp/dolfinx/common/SubSystemsManager.cpp
+++ b/cpp/dolfinx/common/SubSystemsManager.cpp
@@ -4,14 +4,12 @@
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
-#define MPICH_IGNORE_CXX_SEEK 1
-
 #include "SubSystemsManager.h"
-#include <boost/algorithm/string/trim.hpp>
 #include <dolfinx/common/log.h>
 #include <iostream>
 #include <mpi.h>
 #include <petscsys.h>
+#include <string>
 
 #ifdef HAS_SLEPC
 #include <slepcsys.h>
@@ -129,30 +127,4 @@ bool SubSystemsManager::mpi_finalized()
   MPI_Finalized(&mpi_finalized);
   return mpi_finalized;
 }
-//-----------------------------------------------------------------------------
-// PetscErrorCode SubSystemsManager::PetscDolfinErrorHandler(
-//     MPI_Comm, int line, const char* fun, const char* file, PetscErrorCode n,
-//     PetscErrorType, const char* mess, void*)
-// {
-//   // Store message for printing later (by PETScObject::petsc_error) only
-//   // if it's not empty message (passed by PETSc when repeating error)
-//   std::string _mess = mess;
-//   boost::algorithm::trim(_mess);
-//   if (_mess != "")
-//     singleton().petsc_err_msg = _mess;
-
-//   // Fetch PETSc error description
-//   const char* desc;
-//   PetscErrorMessage(n, &desc, nullptr);
-
-//   // Log detailed error info
-//   LOG(ERROR)
-//       << "PetscDolfinErrorHandler: line '{}', function '{}', file '{}',\n"
-//          "                       : error code '{}' ({}), message follows:"
-//       << line << fun << file << n << desc;
-//   LOG(ERROR) << (_mess);
-
-//   // Continue with error handling
-//   PetscFunctionReturn(n);
-// }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/SubSystemsManager.cpp
+++ b/cpp/dolfinx/common/SubSystemsManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2008-2017 Garth N. Wells, Anders Logg, Jan Blechta
+// Copyright (C) 2008-2020 Garth N. Wells, Anders Logg, Jan Blechta
 //
 // This file is part of DOLFINX (https://www.fenicsproject.org)
 //
@@ -11,7 +11,6 @@
 #include <dolfinx/common/log.h>
 #include <iostream>
 #include <mpi.h>
-// #include <petsc.h>
 #include <petscsys.h>
 
 #ifdef HAS_SLEPC
@@ -20,24 +19,6 @@
 
 using namespace dolfinx::common;
 
-// Return singleton instance. Do NOT make the singleton a global static
-// object; the method here ensures that the singleton is initialised
-// before use. (google "static initialization order fiasco" for full
-// explanation)
-
-// SubSystemsManager& SubSystemsManager::singleton()
-// {
-//   static SubSystemsManager the_instance;
-//   return the_instance;
-// }
-//-----------------------------------------------------------------------------
-// SubSystemsManager::SubSystemsManager()
-//     : petsc_err_msg(""), petsc_initialized(false), control_mpi(false)
-// {
-//   // Do nothing
-// }
-//-----------------------------------------------------------------------------
-// SubSystemsManager::~SubSystemsManager() { finalize(); }
 //-----------------------------------------------------------------------------
 void SubSystemsManager::init_mpi()
 {

--- a/cpp/dolfinx/common/SubSystemsManager.cpp
+++ b/cpp/dolfinx/common/SubSystemsManager.cpp
@@ -54,7 +54,6 @@ void SubSystemsManager::init_logging(int argc, char* argv[])
 //-----------------------------------------------------------------------------
 void SubSystemsManager::init_petsc()
 {
-  // Initialize PETSc
   int argc = 0;
   char** argv = nullptr;
   init_petsc(argc, argv);
@@ -62,7 +61,6 @@ void SubSystemsManager::init_petsc()
 //-----------------------------------------------------------------------------
 void SubSystemsManager::init_petsc(int argc, char* argv[])
 {
-  // Print message if PETSc is initialised with command line arguments
   if (argc > 1)
     LOG(INFO) << "Initializing PETSc with given command-line arguments.";
 
@@ -80,11 +78,9 @@ void SubSystemsManager::finalize_mpi()
 {
   int mpi_initialized;
   MPI_Initialized(&mpi_initialized);
-
-  // Finalise MPI if required
   if (mpi_initialized)
   {
-    // Check in MPI has already been finalised (possibly incorrectly by
+    // Check if MPI has already been finalised (possibly incorrectly by
     // a 3rd party library). If it hasn't, finalise as normal.
     int mpi_finalized;
     MPI_Finalized(&mpi_finalized);
@@ -93,11 +89,8 @@ void SubSystemsManager::finalize_mpi()
     else
     {
       // Use std::cout since log system may fail because MPI has been shut down.
-      std::cout << "DOLFINX is responsible for MPI, but it has been finalized "
-                   "elsewhere prematurely."
-                << std::endl;
-      std::cout << "This is usually due to a bug in a 3rd party library, and "
-                   "can lead to unpredictable behaviour."
+      std::cout << "MPI has already been finalised, possibly prematurely by "
+                   "another library."
                 << std::endl;
     }
   }

--- a/cpp/dolfinx/common/SubSystemsManager.h
+++ b/cpp/dolfinx/common/SubSystemsManager.h
@@ -25,12 +25,12 @@ int init_mpi(int argc, char* argv[], int required_thread_level);
 /// Initialise loguru
 void init_logging(int argc, char* argv[]);
 
-/// Initialize PETSc without command-line arguments
+/// Initialize PETSc (and SLEPc, if configured) without command-line
+/// arguments
 void init_petsc();
 
-/// Initialize PETSc with command-line arguments. Note that PETSc
-/// command-line arguments may also be filtered and sent to PETSc by
-/// parameters.parse(argc, argv).
+/// Initialize PETSc (and SLEPc, if configured) with command-line
+/// arguments
 void init_petsc(int argc, char* argv[]);
 
 /// Check if MPI has been initialised (returns true if MPI has been

--- a/cpp/dolfinx/common/SubSystemsManager.h
+++ b/cpp/dolfinx/common/SubSystemsManager.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <petscsys.h>
 #include <string>
 
 namespace dolfinx::common

--- a/cpp/dolfinx/common/SubSystemsManager.h
+++ b/cpp/dolfinx/common/SubSystemsManager.h
@@ -19,8 +19,8 @@ namespace SubSystemsManager
 /// Initialise MPI
 void init_mpi();
 
-/// Initialise MPI with required level of thread support
-int init_mpi(int argc, char* argv[], int required_thread_level);
+/// Initialise MPI
+void init_mpi(int argc, char* argv[]);
 
 /// Initialise loguru
 void init_logging(int argc, char* argv[]);

--- a/cpp/dolfinx/common/SubSystemsManager.h
+++ b/cpp/dolfinx/common/SubSystemsManager.h
@@ -15,80 +15,80 @@ namespace dolfinx::common
 /// This is a singleton class which manages the initialisation and
 /// finalisation of various sub systems, such as MPI and PETSc.
 
-class SubSystemsManager
+namespace SubSystemsManager
 {
-public:
-  /// Singleton instance. Calling this ensures singleton instance of
-  /// SubSystemsManager is initialized according to the "Construct on
-  /// First Use" idiom.
-  static SubSystemsManager& singleton();
+// public:
+/// Singleton instance. Calling this ensures singleton instance of
+/// SubSystemsManager is initialized according to the "Construct on
+/// First Use" idiom.
+// static SubSystemsManager& singleton();
 
-  // Copy constructor
-  SubSystemsManager(const SubSystemsManager&) = delete;
+// Copy constructor
+// SubSystemsManager(const SubSystemsManager&) = delete;
 
-  /// Initialise MPI
-  static void init_mpi();
+/// Initialise MPI
+void init_mpi();
 
-  /// Initialise MPI with required level of thread support
-  static int init_mpi(int argc, char* argv[], int required_thread_level);
+/// Initialise MPI with required level of thread support
+int init_mpi(int argc, char* argv[], int required_thread_level);
 
-  /// Initialise loguru
-  static void init_logging(int argc, char* argv[]);
+/// Initialise loguru
+void init_logging(int argc, char* argv[]);
 
-  /// Initialize PETSc without command-line arguments
-  static void init_petsc();
+/// Initialize PETSc without command-line arguments
+void init_petsc();
 
-  /// Initialize PETSc with command-line arguments. Note that PETSc
-  /// command-line arguments may also be filtered and sent to PETSc by
-  /// parameters.parse(argc, argv).
-  static void init_petsc(int argc, char* argv[]);
+/// Initialize PETSc with command-line arguments. Note that PETSc
+/// command-line arguments may also be filtered and sent to PETSc by
+/// parameters.parse(argc, argv).
+void init_petsc(int argc, char* argv[]);
 
-  /// Finalize subsystems. This will be called by the destructor, but in
-  /// special cases it may be necessary to call finalize() explicitly.
-  static void finalize();
+/// Finalize subsystems. This will be called by the destructor, but in
+/// special cases it may be necessary to call finalize() explicitly.
+// static void finalize();
 
-  /// Return true if DOLFINX initialised MPI (and is therefore
-  /// responsible for finalization)
-  static bool responsible_mpi();
+/// Return true if DOLFINX initialised MPI (and is therefore
+/// responsible for finalization)
+// static bool responsible_mpi();
 
-  /// Return true if DOLFINX initialised PETSc (and is therefore
-  /// responsible for finalization)
-  static bool responsible_petsc();
+/// Return true if DOLFINX initialised PETSc (and is therefore
+/// responsible for finalization)
+// static bool responsible_petsc();
 
-  /// Check if MPI has been initialised (returns true if MPI has been
-  /// initialised, even if it is later finalised)
-  static bool mpi_initialized();
+/// Check if MPI has been initialised (returns true if MPI has been
+/// initialised, even if it is later finalised)
+bool mpi_initialized();
 
-  /// Check if MPI has been finalized (returns true if MPI has been
-  /// finalised)
-  static bool mpi_finalized();
+/// Check if MPI has been finalized (returns true if MPI has been
+/// finalised)
+bool mpi_finalized();
 
-  /// PETSc error handler. Logs everything known to DOLFINX logging
-  /// system (with level TRACE) and stores the error message into
-  /// pests_err_msg member.
-  static PetscErrorCode
-  PetscDolfinErrorHandler(MPI_Comm comm, int line, const char* fun,
-                          const char* file, PetscErrorCode n, PetscErrorType p,
-                          const char* mess, void* ctx);
+/// PETSc error handler. Logs everything known to DOLFINX logging
+/// system (with level TRACE) and stores the error message into
+/// pests_err_msg member.
+// static PetscErrorCode
+// PetscDolfinErrorHandler(MPI_Comm comm, int line, const char* fun,
+//                         const char* file, PetscErrorCode n, PetscErrorType p,
+//                         const char* mess, void* ctx);
 
-  /// Last recorded PETSc error message
-  std::string petsc_err_msg;
+/// Last recorded PETSc error message
+// std::string petsc_err_msg;
 
-private:
-  // Constructor (private)
-  SubSystemsManager();
+// private:
+//   // Constructor (private)
+//   SubSystemsManager();
 
-  // Destructor
-  ~SubSystemsManager();
+//   // Destructor
+//   ~SubSystemsManager();
 
-  // Finalize MPI
-  static void finalize_mpi();
+/// Finalize MPI
+void finalize_mpi();
 
-  // Finalize PETSc
-  static void finalize_petsc();
+/// Finalize PETSc
+void finalize_petsc();
 
-  // State variables
-  bool petsc_initialized;
-  bool control_mpi;
-};
+// State variables
+// bool petsc_initialized;
+// bool control_mpi;
+}; // namespace SubSystemsManager
 } // namespace dolfinx::common

--- a/cpp/dolfinx/common/SubSystemsManager.h
+++ b/cpp/dolfinx/common/SubSystemsManager.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <string>
-
 namespace dolfinx::common
 {
 
@@ -42,17 +40,6 @@ bool mpi_initialized();
 /// Check if MPI has been finalized (returns true if MPI has been
 /// finalised)
 bool mpi_finalized();
-
-/// PETSc error handler. Logs everything known to DOLFINX logging
-/// system (with level TRACE) and stores the error message into
-/// pests_err_msg member.
-// static PetscErrorCode
-// PetscDolfinErrorHandler(MPI_Comm comm, int line, const char* fun,
-//                         const char* file, PetscErrorCode n, PetscErrorType p,
-//                         const char* mess, void* ctx);
-
-/// Last recorded PETSc error message
-// std::string petsc_err_msg;
 
 /// Finalize MPI
 void finalize_mpi();

--- a/cpp/dolfinx/common/SubSystemsManager.h
+++ b/cpp/dolfinx/common/SubSystemsManager.h
@@ -47,5 +47,5 @@ void finalize_mpi();
 /// Finalize PETSc
 void finalize_petsc();
 
-}; // namespace SubSystemsManager
+} // namespace SubSystemsManager
 } // namespace dolfinx::common

--- a/cpp/dolfinx/common/SubSystemsManager.h
+++ b/cpp/dolfinx/common/SubSystemsManager.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2008-2017 Garth N. Wells
+// Copyright (C) 2008-2020 Garth N. Wells
 //
 // This file is part of DOLFINX (https://www.fenicsproject.org)
 //
@@ -11,19 +11,12 @@
 namespace dolfinx::common
 {
 
-/// This is a singleton class which manages the initialisation and
-/// finalisation of various sub systems, such as MPI and PETSc.
+/// Function in this namesspace are convenience functtions for the
+/// initialisation and finalisation of various sub systems, such as MPI
+/// and PETSc.
 
 namespace SubSystemsManager
 {
-// public:
-/// Singleton instance. Calling this ensures singleton instance of
-/// SubSystemsManager is initialized according to the "Construct on
-/// First Use" idiom.
-// static SubSystemsManager& singleton();
-
-// Copy constructor
-// SubSystemsManager(const SubSystemsManager&) = delete;
 
 /// Initialise MPI
 void init_mpi();
@@ -41,18 +34,6 @@ void init_petsc();
 /// command-line arguments may also be filtered and sent to PETSc by
 /// parameters.parse(argc, argv).
 void init_petsc(int argc, char* argv[]);
-
-/// Finalize subsystems. This will be called by the destructor, but in
-/// special cases it may be necessary to call finalize() explicitly.
-// static void finalize();
-
-/// Return true if DOLFINX initialised MPI (and is therefore
-/// responsible for finalization)
-// static bool responsible_mpi();
-
-/// Return true if DOLFINX initialised PETSc (and is therefore
-/// responsible for finalization)
-// static bool responsible_petsc();
 
 /// Check if MPI has been initialised (returns true if MPI has been
 /// initialised, even if it is later finalised)
@@ -73,21 +54,11 @@ bool mpi_finalized();
 /// Last recorded PETSc error message
 // std::string petsc_err_msg;
 
-// private:
-//   // Constructor (private)
-//   SubSystemsManager();
-
-//   // Destructor
-//   ~SubSystemsManager();
-
 /// Finalize MPI
 void finalize_mpi();
 
 /// Finalize PETSc
 void finalize_petsc();
 
-// State variables
-// bool petsc_initialized;
-// bool control_mpi;
 }; // namespace SubSystemsManager
 } // namespace dolfinx::common

--- a/cpp/dolfinx/la/PETScVector.cpp
+++ b/cpp/dolfinx/la/PETScVector.cpp
@@ -25,15 +25,15 @@ using namespace dolfinx::la;
   } while (0)
 
 //-----------------------------------------------------------------------------
-void la::petsc_error(int error_code, std::string filename,
-                     std::string petsc_function)
+void la::petsc_error(int error_code, std::string, std::string petsc_function)
 {
   // Fetch PETSc error description
   const char* desc;
   PetscErrorMessage(error_code, &desc, nullptr);
 
   // // Fetch and clear PETSc error message
-  // const std::string msg = common::SubSystemsManager::singleton().petsc_err_msg;
+  // const std::string msg =
+  // common::SubSystemsManager::singleton().petsc_err_msg;
   // common::SubSystemsManager::singleton().petsc_err_msg = "";
 
   // // // Log detailed error info

--- a/cpp/dolfinx/la/PETScVector.cpp
+++ b/cpp/dolfinx/la/PETScVector.cpp
@@ -10,7 +10,6 @@
 #include <cstddef>
 #include <cstring>
 #include <dolfinx/common/IndexMap.h>
-#include <dolfinx/common/SubSystemsManager.h>
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/common/log.h>
 
@@ -25,30 +24,18 @@ using namespace dolfinx::la;
   } while (0)
 
 //-----------------------------------------------------------------------------
-void la::petsc_error(int error_code, std::string, std::string petsc_function)
+void la::petsc_error(int error_code, std::string filename,
+                     std::string petsc_function)
 {
   // Fetch PETSc error description
   const char* desc;
   PetscErrorMessage(error_code, &desc, nullptr);
 
-  // // Fetch and clear PETSc error message
-  // const std::string msg =
-  // common::SubSystemsManager::singleton().petsc_err_msg;
-  // common::SubSystemsManager::singleton().petsc_err_msg = "";
+  // Log detailed error info
+  DLOG(INFO) << "PETSc error in '" << filename.c_str() << "', '"
+             << petsc_function.c_str() << "'";
+  DLOG(INFO) << "PETSc error code '" << error_code << "' (" << desc << ".";
 
-  // // // Log detailed error info
-  // DLOG(INFO) << "PETSc error in '" << filename.c_str() << "', '"
-  //            << petsc_function.c_str() << "'";
-
-  // DLOG(INFO) << "PETSc error code '" << error_code << "' (" << desc
-  //            << "), message follows:";
-
-  // // NOTE: don't put msg as variadic argument; it might get trimmed
-  // DLOG(INFO) << std::string(78, '-');
-  // DLOG(INFO) << msg;
-  // DLOG(INFO) << std::string(78, '-');
-
-  // Raise exception with standard error message
   throw std::runtime_error("Failed to successfully call PETSc function '"
                            + petsc_function + "'. PETSc error code is: "
                            + std ::to_string(error_code) + ", "

--- a/cpp/dolfinx/la/PETScVector.cpp
+++ b/cpp/dolfinx/la/PETScVector.cpp
@@ -32,21 +32,21 @@ void la::petsc_error(int error_code, std::string filename,
   const char* desc;
   PetscErrorMessage(error_code, &desc, nullptr);
 
-  // Fetch and clear PETSc error message
-  const std::string msg = common::SubSystemsManager::singleton().petsc_err_msg;
-  common::SubSystemsManager::singleton().petsc_err_msg = "";
+  // // Fetch and clear PETSc error message
+  // const std::string msg = common::SubSystemsManager::singleton().petsc_err_msg;
+  // common::SubSystemsManager::singleton().petsc_err_msg = "";
 
-  // // Log detailed error info
-  DLOG(INFO) << "PETSc error in '" << filename.c_str() << "', '"
-             << petsc_function.c_str() << "'";
+  // // // Log detailed error info
+  // DLOG(INFO) << "PETSc error in '" << filename.c_str() << "', '"
+  //            << petsc_function.c_str() << "'";
 
-  DLOG(INFO) << "PETSc error code '" << error_code << "' (" << desc
-             << "), message follows:";
+  // DLOG(INFO) << "PETSc error code '" << error_code << "' (" << desc
+  //            << "), message follows:";
 
-  // NOTE: don't put msg as variadic argument; it might get trimmed
-  DLOG(INFO) << std::string(78, '-');
-  DLOG(INFO) << msg;
-  DLOG(INFO) << std::string(78, '-');
+  // // NOTE: don't put msg as variadic argument; it might get trimmed
+  // DLOG(INFO) << std::string(78, '-');
+  // DLOG(INFO) << msg;
+  // DLOG(INFO) << std::string(78, '-');
 
   // Raise exception with standard error message
   throw std::runtime_error("Failed to successfully call PETSc function '"

--- a/python/dolfinx/__init__.py
+++ b/python/dolfinx/__init__.py
@@ -53,15 +53,14 @@ from .function import (FunctionSpace, VectorFunctionSpace,
 
 from .mesh import MeshTags
 
-# Initialise PETSc and logging
+# Initialise logging
 from dolfinx import cpp
 import sys
 # FIXME: We're not passing command link argument here because some
 # pytest arg crash loguru
-cpp.common.SubSystemsManager.init_logging([""])
+cpp.common.init_logging([""])
 # cpp.common.SubSystemsManager.init_logging(sys.argv)
 del sys
-cpp.common.SubSystemsManager.init_petsc()
 
 def get_include(user=False):
     import os

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -10,8 +10,7 @@
 #include <Eigen/Dense>
 #include <complex>
 #include <dolfinx/common/IndexMap.h>
-#include <dolfinx/common/MPI.h>
-#include <dolfinx/common/SubSystemsManager.h>
+// #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/Table.h>
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/common/defines.h>
@@ -106,35 +105,35 @@ void common(py::module& m)
         });
 
   // dolfinx::SubSystemsManager
-  py::class_<dolfinx::common::SubSystemsManager,
-             std::unique_ptr<dolfinx::common::SubSystemsManager, py::nodelete>>(
-      m, "SubSystemsManager")
-      .def_static("init_petsc",
-                  (void (*)()) & dolfinx::common::SubSystemsManager::init_petsc)
-      .def_static("init_petsc",
-                  [](std::vector<std::string> args) {
-                    std::vector<char*> argv(args.size());
-                    for (std::size_t i = 0; i < args.size(); ++i)
-                      argv[i] = const_cast<char*>(args[i].data());
-                    dolfinx::common::SubSystemsManager::init_petsc(args.size(),
-                                                                   argv.data());
-                  })
-      .def_static("init_logging",
-                  [](std::vector<std::string> args) {
-                    std::vector<char*> argv(args.size() + 1, nullptr);
-                    for (std::size_t i = 0; i < args.size(); ++i)
-                      argv[i] = const_cast<char*>(args[i].data());
-                    dolfinx::common::SubSystemsManager::init_logging(
-                        args.size(), argv.data());
-                  })
-      .def_static("finalize", &dolfinx::common::SubSystemsManager::finalize)
-      .def_static("responsible_mpi",
-                  &dolfinx::common::SubSystemsManager::responsible_mpi)
-      .def_static("responsible_petsc",
-                  &dolfinx::common::SubSystemsManager::responsible_petsc)
-      .def_static("mpi_initialized",
-                  &dolfinx::common::SubSystemsManager::mpi_initialized)
-      .def_static("mpi_finalized",
-                  &dolfinx::common::SubSystemsManager::mpi_finalized);
+  // py::class_<dolfinx::common::SubSystemsManager,
+  //            std::unique_ptr<dolfinx::common::SubSystemsManager, py::nodelete>>(
+  //     m, "SubSystemsManager")
+  //     .def_static("init_petsc",
+  //                 (void (*)()) & dolfinx::common::SubSystemsManager::init_petsc)
+  //     .def_static("init_petsc",
+  //                 [](std::vector<std::string> args) {
+  //                   std::vector<char*> argv(args.size());
+  //                   for (std::size_t i = 0; i < args.size(); ++i)
+  //                     argv[i] = const_cast<char*>(args[i].data());
+  //                   dolfinx::common::SubSystemsManager::init_petsc(args.size(),
+  //                                                                  argv.data());
+  //                 })
+  //     .def_static("init_logging",
+  //                 [](std::vector<std::string> args) {
+  //                   std::vector<char*> argv(args.size() + 1, nullptr);
+  //                   for (std::size_t i = 0; i < args.size(); ++i)
+  //                     argv[i] = const_cast<char*>(args[i].data());
+  //                   dolfinx::common::SubSystemsManager::init_logging(
+  //                       args.size(), argv.data());
+  //                 })
+  //     .def_static("finalize", &dolfinx::common::SubSystemsManager::finalize)
+  //     .def_static("responsible_mpi",
+  //                 &dolfinx::common::SubSystemsManager::responsible_mpi)
+  //     .def_static("responsible_petsc",
+  //                 &dolfinx::common::SubSystemsManager::responsible_petsc)
+  //     .def_static("mpi_initialized",
+  //                 &dolfinx::common::SubSystemsManager::mpi_initialized)
+  //     .def_static("mpi_finalized",
+  //                 &dolfinx::common::SubSystemsManager::mpi_finalized);
 }
 } // namespace dolfinx_wrappers

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -10,7 +10,7 @@
 #include <Eigen/Dense>
 #include <complex>
 #include <dolfinx/common/IndexMap.h>
-// #include <dolfinx/common/MPI.h>
+#include <dolfinx/common/SubSystemsManager.h>
 #include <dolfinx/common/Table.h>
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/common/defines.h>
@@ -104,36 +104,11 @@ void common(py::module& m)
           dolfinx::list_timings(comm.get(), _type);
         });
 
-  // dolfinx::SubSystemsManager
-  // py::class_<dolfinx::common::SubSystemsManager,
-  //            std::unique_ptr<dolfinx::common::SubSystemsManager, py::nodelete>>(
-  //     m, "SubSystemsManager")
-  //     .def_static("init_petsc",
-  //                 (void (*)()) & dolfinx::common::SubSystemsManager::init_petsc)
-  //     .def_static("init_petsc",
-  //                 [](std::vector<std::string> args) {
-  //                   std::vector<char*> argv(args.size());
-  //                   for (std::size_t i = 0; i < args.size(); ++i)
-  //                     argv[i] = const_cast<char*>(args[i].data());
-  //                   dolfinx::common::SubSystemsManager::init_petsc(args.size(),
-  //                                                                  argv.data());
-  //                 })
-  //     .def_static("init_logging",
-  //                 [](std::vector<std::string> args) {
-  //                   std::vector<char*> argv(args.size() + 1, nullptr);
-  //                   for (std::size_t i = 0; i < args.size(); ++i)
-  //                     argv[i] = const_cast<char*>(args[i].data());
-  //                   dolfinx::common::SubSystemsManager::init_logging(
-  //                       args.size(), argv.data());
-  //                 })
-  //     .def_static("finalize", &dolfinx::common::SubSystemsManager::finalize)
-  //     .def_static("responsible_mpi",
-  //                 &dolfinx::common::SubSystemsManager::responsible_mpi)
-  //     .def_static("responsible_petsc",
-  //                 &dolfinx::common::SubSystemsManager::responsible_petsc)
-  //     .def_static("mpi_initialized",
-  //                 &dolfinx::common::SubSystemsManager::mpi_initialized)
-  //     .def_static("mpi_finalized",
-  //                 &dolfinx::common::SubSystemsManager::mpi_finalized);
+  m.def("init_logging", [](std::vector<std::string> args) {
+    std::vector<char*> argv(args.size() + 1, nullptr);
+    for (std::size_t i = 0; i < args.size(); ++i)
+      argv[i] = const_cast<char*>(args[i].data());
+    dolfinx::common::SubSystemsManager::init_logging(args.size(), argv.data());
+  });
 }
 } // namespace dolfinx_wrappers


### PR DESCRIPTION
This removes the rather ugly singleton for initialising and finalising MPI, PETSc, etc from C++. It makes the actions explicit and removes one of the problem areas for multi-threaded applications.

This change is consistent with the C++ interface being explicit. It does not affect the Python interface.