### PR TITLE
pass PYTHON_EXECUTABLE as well as Python3_EXECUTALBE from setup.py to make

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -49,6 +49,7 @@ class CMakeBuild(build_ext):
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+                      '-DPYTHON_EXECUTABLE=' + sys.executable,
                       '-DPython3_EXECUTABLE=' + sys.executable]
 
         cfg = 'Debug' if self.debug else 'Release'

--- a/python/setup.py
+++ b/python/setup.py
@@ -49,8 +49,8 @@ class CMakeBuild(build_ext):
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-                      '-DPYTHON_EXECUTABLE=' + sys.executable,
-                      '-DPython3_EXECUTABLE=' + sys.executable]
+                      '-DPYTHON_EXECUTABLE=' + sys.executable, #for pybind11
+                      '-DPython3_EXECUTABLE=' + sys.executable] #for PETSc4py & MPI4py
 
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]


### PR DESCRIPTION
The pybind11 CMake module reads PYTHON_EXECUTABLE and the PETSc4py CMake module reads Python3_EXECUTABLE. We should specify both to avoid potential problems of having two different pythons in the same build. 