### PR TITLE
add missing python dependencies scipy and pybind11

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -17,6 +17,7 @@ RESTRICT_REQUIREMENTS = ">=2019.2.0.dev0,<2019.3"
 
 REQUIREMENTS = [
     "numpy",
+    "scipy",
     "mpi4py",
     "petsc4py",
     "fenics-ffcx",

--- a/python/setup.py
+++ b/python/setup.py
@@ -18,6 +18,7 @@ RESTRICT_REQUIREMENTS = ">=2019.2.0.dev0,<2019.3"
 REQUIREMENTS = [
     "numpy",
     "scipy",
+    "pybind11"
     "mpi4py",
     "petsc4py",
     "fenics-ffcx",

--- a/python/setup.py
+++ b/python/setup.py
@@ -18,7 +18,7 @@ RESTRICT_REQUIREMENTS = ">=2019.2.0.dev0,<2019.3"
 REQUIREMENTS = [
     "numpy",
     "scipy",
-    "pybind11"
+    "pybind11",
     "mpi4py",
     "petsc4py",
     "fenics-ffcx",


### PR DESCRIPTION
scipy is used in `python/dolfinx/fem/assemble.py` and pybind11 is used in lots of places to build the python interface. 

Inspired by the comment here https://github.com/spack/spack/pull/17743#discussion_r462688105