### PR TITLE
Re-enable logging from command line with better argument

### DIFF
--- a/cpp/dolfinx/common/SubSystemsManager.cpp
+++ b/cpp/dolfinx/common/SubSystemsManager.cpp
@@ -45,7 +45,7 @@ void SubSystemsManager::init_mpi(int argc, char* argv[])
 void SubSystemsManager::init_logging(int argc, char* argv[])
 {
   loguru::g_stderr_verbosity = loguru::Verbosity_WARNING;
-  loguru::Options options = {"-v", "main thread", false};
+  loguru::Options options = {"-dolfinx_loglevel", "main thread", false};
   loguru::init(argc, argv, options);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/graph/Partitioning.cpp
+++ b/cpp/dolfinx/graph/Partitioning.cpp
@@ -536,8 +536,7 @@ std::vector<std::int64_t> Partitioning::compute_ghost_indices(
     MPI_Comm comm, const std::vector<std::int64_t>& global_indices,
     const std::vector<int>& ghost_owners)
 {
-  if (ghost_owners.size() == 0)
-    return std::vector<std::int64_t>();
+  LOG(INFO) << "Compute ghost indices";
 
   // Get number of local cells and global offset
   int num_local = global_indices.size() - ghost_owners.size();

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -11,6 +11,7 @@
 #include "utils.h"
 #include <algorithm>
 #include <dolfinx/common/IndexMap.h>
+#include <dolfinx/common/log.h>
 #include <dolfinx/common/utils.h>
 #include <dolfinx/fem/ElementDofLayout.h>
 #include <dolfinx/graph/AdjacencyList.h>
@@ -306,6 +307,8 @@ mesh::create_topology(MPI_Comm comm,
                       const std::vector<int>& ghost_owners,
                       const CellType& cell_type, mesh::GhostMode ghost_mode)
 {
+  LOG(INFO) << "Create topology";
+
   if (cells.num_nodes() > 0
       and cells.num_links(0) != mesh::num_cell_vertices(cell_type))
   {

--- a/python/dolfinx/__init__.py
+++ b/python/dolfinx/__init__.py
@@ -56,10 +56,7 @@ from .mesh import MeshTags
 # Initialise logging
 from dolfinx import cpp
 import sys
-# FIXME: We're not passing command link argument here because some
-# pytest arg crash loguru
-cpp.common.init_logging([""])
-# cpp.common.SubSystemsManager.init_logging(sys.argv)
+cpp.common.init_logging(sys.argv)
 del sys
 
 def get_include(user=False):

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -368,10 +368,6 @@ void fem(py::module& m)
       .value("exterior_facet", dolfinx::fem::IntegralType::exterior_facet)
       .value("interior_facet", dolfinx::fem::IntegralType::interior_facet);
 
-  //   py::class_<dolfinx::fem::FormCoefficients<PetscScalar>,
-  //              std::shared_ptr<dolfinx::fem::FormCoefficients<PetscScalar>>>(
-  //       m, "FormCoefficients", "Variational form coefficients");
-
   // dolfinx::fem::Form
   py::class_<dolfinx::fem::Form<PetscScalar>,
              std::shared_ptr<dolfinx::fem::Form<PetscScalar>>>(


### PR DESCRIPTION
* Fixes a deadlock in topology computation when certain processes have no ghost cells.
* Enables logging output with `-dolfinx_loglevel` (unambiguous) command-line option.