### PR TITLE
Skip github action related to documentation push on fenicsproject.org when running on forks

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -89,19 +89,20 @@ jobs:
         run: mpirun -np 2 python3 -m pytest python/test/unit/
 
       - name: Install SSH key for fenicsproject.org documentation push
+        if: github.repository == 'FEniCS/dolfinx' && github.ref == 'master'
         uses: shimataro/ssh-key-action@v2.0.3
         with:
           key: ${{ secrets.SSH_DOCS_PRIVATE_KEY }}
           known_hosts: ${{ secrets.SSH_DOCS_KNOWN_HOSTS }}
 
       - name: Push C++ documentation
-        if: github.ref == 'master'
+        if: github.repository == 'FEniCS/dolfinx' && github.ref == 'master'
         run: |
           cd cpp/doc
           scp -r * docs@fenicsproject.org:/var/www/vhosts/fenicsproject.org/docs/dolfinx/dev/cpp/
 
       - name: Push Python documentation
-        if: github.ref == 'master'
+        if: github.repository == 'FEniCS/dolfinx' && github.ref == 'master'
         run: |
           cd python/doc
           scp -r * docs@fenicsproject.org:/var/www/vhosts/fenicsproject.org/docs/dolfinx/dev/python/


### PR DESCRIPTION
See e.g.
https://github.com/francesco-ballarin/dolfinx/actions/runs/197560010
for a failing run before this commit, and
https://github.com/francesco-ballarin/dolfinx/actions/runs/197642963
for a successful run with this commit