### PR TITLE
Use package dir

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -86,4 +86,5 @@ setup(name='fenics-dolfinx',
       ext_modules=[CMakeExtension('dolfinx.cpp')],
       cmdclass=dict(build_ext=CMakeBuild),
       install_requires=REQUIREMENTS,
+      package_dir={"dolfinx": "dolfinx"},
       zip_safe=False)


### PR DESCRIPTION
* Add package_dir to setup.py for dolfinx (similar to setup for ffcx)

This seems to help when installing to non-system paths (i.e. not to /usr/lib/python3.7/site-packages but another user location).
Otherwise, if setup.py generates an easy-install.pth file, it just gets ignored.

Perhaps this is not an issue when using `pip install`  - but with `setup.py` on our spack build it seems to be a problem.

