### PR TITLE
Update and simplify Boost detection

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -125,17 +125,13 @@ endif()
 #------------------------------------------------------------------------------
 # Run tests to find required packages
 
-# Check for Boost
-set(BOOST_ROOT $ENV{BOOST_DIR} $ENV{BOOST_HOME})
-if (BOOST_ROOT)
+# Note: When updating Boost version, also update DOLFINXCongif.cmake.in
+if(DEFINED ENV{BOOST_ROOT} OR DEFINED BOOST_ROOT)
   set(Boost_NO_SYSTEM_PATHS on)
 endif()
 set(Boost_USE_MULTITHREADED $ENV{BOOST_USE_MULTITHREADED})
-
-
-# Note: When updating Boost version, also update DOLFINXCongif.cmake.in
 set(Boost_VERBOSE TRUE)
-find_package(Boost 1.70 PATHS ${BOOST_ROOT} REQUIRED timer filesystem program_options)
+find_package(Boost 1.70 REQUIRED timer filesystem program_options)
 set_package_properties(Boost PROPERTIES TYPE REQUIRED
   DESCRIPTION "Boost C++ libraries"
   URL "http://www.boost.org")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -130,31 +130,12 @@ set(BOOST_ROOT $ENV{BOOST_DIR} $ENV{BOOST_HOME})
 if (BOOST_ROOT)
   set(Boost_NO_SYSTEM_PATHS on)
 endif()
-
-# Prevent FindBoost.cmake from looking for system Boost{foo}.cmake
-# files
-set(Boost_NO_BOOST_CMAKE true)
-
 set(Boost_USE_MULTITHREADED $ENV{BOOST_USE_MULTITHREADED})
-# Note: When updating Boost version, also update FindDOLFIN.cmake.
-find_package(Boost 1.56 QUIET REQUIRED)
 
-# Boost public/private libraries to link to.
-# Note: These should all be private as they do not appear in the
-# DOLFIN public interface , but there is a linking issues with older
-# Boost or CMake. Ubuntu 16.04 requires linking DOLFIN programs with
-# filesystem, whereas Ubuntu 16.10 and macOS (Homebrew) do not.
-if (Boost_VERSION VERSION_LESS 106100)
-  set(DOLFINX_BOOST_COMPONENTS_PUBLIC filesystem timer)
-  set(DOLFINX_BOOST_COMPONENTS_PRIVATE program_options)
-else()
-  set(DOLFINX_BOOST_COMPONENTS_PUBLIC timer)
-  set(DOLFINX_BOOST_COMPONENTS_PRIVATE filesystem program_options)
-endif()
 
-# Find required Boost libraries
-find_package(Boost COMPONENTS
-  ${DOLFINX_BOOST_COMPONENTS_PUBLIC} ${DOLFINX_BOOST_COMPONENTS_PRIVATE} REQUIRED)
+# Note: When updating Boost version, also update DOLFINXCongif.cmake.in
+set(Boost_VERBOSE TRUE)
+find_package(Boost 1.70 PATHS ${BOOST_ROOT} REQUIRED timer filesystem program_options)
 set_package_properties(Boost PROPERTIES TYPE REQUIRED
   DESCRIPTION "Boost C++ libraries"
   URL "http://www.boost.org")

--- a/cpp/cmake/templates/DOLFINXConfig.cmake.in
+++ b/cpp/cmake/templates/DOLFINXConfig.cmake.in
@@ -14,16 +14,14 @@ include(CMakeFindDependencyMacro)
 find_dependency(MPI REQUIRED)
 
 # Check for Boost
-set(BOOST_ROOT $ENV{BOOST_DIR} $ENV{BOOST_HOME})
+set(BOOST_ROOT $ENV{BOOST_DIR} ${BOOST_ROOT})
 if (BOOST_ROOT)
   set(Boost_NO_SYSTEM_PATHS on)
 endif()
-
-# Prevent FindBoost.cmake from looking for system Boost{foo}.cmake files
-set(Boost_NO_BOOST_CMAKE true)
-
 set(Boost_USE_MULTITHREADED $ENV{BOOST_USE_MULTITHREADED})
-find_dependency(Boost 1.56 QUIET REQUIRED COMPONENTS @DOLFINX_BOOST_COMPONENTS_PUBLIC@;@DOLFINX_BOOST_COMPONENTS_PRIVATE@)
+
+set(Boost_VERBOSE TRUE)
+find_package(Boost 1.70 PATHS ${BOOST_ROOT} REQUIRED COMPONENTS timer filesystem program_options)
 
 if (NOT TARGET PETSC::petsc)
   set(DOLFINX_SKIP_BUILD_TESTS TRUE)

--- a/cpp/cmake/templates/DOLFINXConfig.cmake.in
+++ b/cpp/cmake/templates/DOLFINXConfig.cmake.in
@@ -14,14 +14,12 @@ include(CMakeFindDependencyMacro)
 find_dependency(MPI REQUIRED)
 
 # Check for Boost
-set(BOOST_ROOT $ENV{BOOST_DIR} ${BOOST_ROOT})
-if (BOOST_ROOT)
+if(DEFINED ENV{BOOST_ROOT} OR DEFINED BOOST_ROOT)
   set(Boost_NO_SYSTEM_PATHS on)
 endif()
 set(Boost_USE_MULTITHREADED $ENV{BOOST_USE_MULTITHREADED})
-
 set(Boost_VERBOSE TRUE)
-find_package(Boost 1.70 PATHS ${BOOST_ROOT} REQUIRED COMPONENTS timer filesystem program_options)
+find_package(Boost 1.70 REQUIRED COMPONENTS timer filesystem program_options)
 
 if (NOT TARGET PETSC::petsc)
   set(DOLFINX_SKIP_BUILD_TESTS TRUE)

--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -87,13 +87,9 @@ target_include_directories(dolfinx SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIR})
 target_compile_definitions(dolfinx PUBLIC "EIGEN_MAX_ALIGN_BYTES=${DOLFINX_EIGEN_MAX_ALIGN_BYTES}")
 
 # Boost
-target_link_libraries(dolfinx PUBLIC Boost::boost)
-foreach (BOOST_PACKAGE ${DOLFINX_BOOST_COMPONENTS_PUBLIC})
-  target_link_libraries(dolfinx PUBLIC "Boost::${BOOST_PACKAGE}")
-endforeach()
-foreach (BOOST_PACKAGE ${DOLFINX_BOOST_COMPONENTS_PRIVATE})
-  target_link_libraries(dolfinx PRIVATE "Boost::${BOOST_PACKAGE}")
-endforeach()
+target_link_libraries(dolfinx PUBLIC Boost::headers)
+target_link_libraries(dolfinx PUBLIC Boost::timer)
+target_link_libraries(dolfinx PRIVATE Boost::filesystem Boost::program_options)
 
 # MPI
 target_link_libraries(dolfinx PUBLIC MPI::MPI_CXX)
@@ -211,7 +207,7 @@ foreach(_target ${PKGCONFIG_DOLFINX_TARGET_LINK_LIBRARIES})
     endif()
 
     # Special handling for compiled Boost imported targets
-    if (("${_target}" MATCHES "^.*Boost::.*$") AND NOT "${_target}" STREQUAL "Boost::boost")
+    if (("${_target}" MATCHES "^.*Boost::.*$") AND NOT "${_target}" STREQUAL "Boost::headers")
       get_target_property(_libs ${_target} IMPORTED_LOCATION_RELEASE)
       if (_libs)
         list(APPEND PKGCONFIG_DOLFINX_LIBS ${_libs})
@@ -248,14 +244,13 @@ foreach(_lib ${PKGCONFIG_DOLFINX_LIBS})
   if ("${_lib}" MATCHES "-Wl,[^ ]*")
     set(PKG_LINKFLAGS "${_lib} ${PKG_LINKFLAGS}")
   else()
-    string(REGEX REPLACE "(.?:?/[^ ]*)/lib([^ ]*)\\.(a|so|dylib|dll)" "-L\\1 -l\\2"
-      _linkflags
-      "${_lib}"
-      )
+    get_filename_component(_path ${_lib} DIRECTORY)
+    get_filename_component(_name ${_lib} NAME_WE)
+    string(REPLACE "lib" "" _name "${_name}")
 
     # Add libraries that matches the form -L<libdir> -l<lib>
-    if ("${_linkflags}" MATCHES "-L.+ -l.+")
-      set(PKG_LINKFLAGS "${_linkflags} ${PKG_LINKFLAGS}")
+    if (NOT "${_path}" STREQUAL "")
+      set(PKG_LINKFLAGS "-L${_path} -l${_name} ${PKG_LINKFLAGS}")
     endif()
   endif()
 endforeach()
@@ -271,7 +266,7 @@ foreach(_linkflag ${DOLFINX_LINK_FLAGS})
 endforeach()
 
 # Boost include dir (used as pkg-config variable)
-get_target_property(BOOST_INCLUDE_DIR Boost::boost INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(BOOST_INCLUDE_DIR Boost::headers INTERFACE_INCLUDE_DIRECTORIES)
 
 # Configure and install pkg-config file
 configure_file(${DOLFINX_SOURCE_DIR}/cmake/templates/dolfinx.pc.in ${CMAKE_BINARY_DIR}/dolfinx.pc @ONLY)


### PR DESCRIPTION
The PR use just one way to detect Boost (using the Boost provided CMake file). This avoids the issue when CMake provided the Boost detection, but the Boost release post-dates the CMake release (the CMake Boost needs updating every time there is a Boost release).

This change requires Boost >= 1.70, which was the first version to include CMake files.

The CMake output for finding Boost had been made more verbose to make it easier to check which Boost installation is being picked up.

The PR also supports Spack installs (further updates on this to follow).