### PR TITLE
Wait for os.mkdir

### DIFF
--- a/python/dolfinx_utils/test/fixtures.py
+++ b/python/dolfinx_utils/test/fixtures.py
@@ -77,10 +77,10 @@ def _create_tempdir(request):
         # Wait until the above created the directory
         waited = 0
         while not os.path.exists(path):
-            time.sleep(1)
-            waited += 1
+            time.sleep(0.1)
+            waited += 0.1
 
-            if waited > 10:
+            if waited > 1:
                 raise RuntimeError(f"Unable to create test directory {path}")
 
     comm.Barrier()

--- a/python/dolfinx_utils/test/fixtures.py
+++ b/python/dolfinx_utils/test/fixtures.py
@@ -6,6 +6,7 @@
 """Shared fixtures for unit tests."""
 
 import os
+import time
 import shutil
 from collections import defaultdict
 from mpi4py import MPI
@@ -72,7 +73,7 @@ def _create_tempdir(request):
         # e.g. test_foo_tempdir/test_something__3
         if not os.path.exists(path):
             os.mkdir(path)
-        
+
         # Wait until the above created the directory
         waited = 0
         while not os.path.exists(path):

--- a/python/dolfinx_utils/test/fixtures.py
+++ b/python/dolfinx_utils/test/fixtures.py
@@ -72,6 +72,16 @@ def _create_tempdir(request):
         # e.g. test_foo_tempdir/test_something__3
         if not os.path.exists(path):
             os.mkdir(path)
+        
+        # Wait until the above created the directory
+        waited = 0
+        while not os.path.exists(file_path):
+            time.sleep(1)
+            waited += 1
+
+            if waited > 10:
+                raise RuntimeError(f"Unable to create test directory {file_path}")
+
     comm.Barrier()
 
     return path

--- a/python/dolfinx_utils/test/fixtures.py
+++ b/python/dolfinx_utils/test/fixtures.py
@@ -75,12 +75,12 @@ def _create_tempdir(request):
         
         # Wait until the above created the directory
         waited = 0
-        while not os.path.exists(file_path):
+        while not os.path.exists(path):
             time.sleep(1)
             waited += 1
 
             if waited > 10:
-                raise RuntimeError(f"Unable to create test directory {file_path}")
+                raise RuntimeError(f"Unable to create test directory {path}")
 
     comm.Barrier()
 


### PR DESCRIPTION
Hotfix for failing IO tests. Adds a 1s waiting loop to assure os.mkdir did touch the filesystem.