### PR TITLE
Surface facet calculation

### DIFF
--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -833,11 +833,12 @@ mesh::entities_to_geometry(
       // Compute vector triple product of two edges and vector to midpoint
       Eigen::Vector3d p0 = mesh.geometry().node(entity_geometry(i, 0));
       Eigen::Matrix3d a;
-      a.row(0) = p0 - midpoint;
+      a.row(0) = midpoint - p0;
       a.row(1) = mesh.geometry().node(entity_geometry(i, 1)) - p0;
       a.row(2) = mesh.geometry().node(entity_geometry(i, 2)) - p0;
-      // Switch order if sign is negative
-      if (a.determinant() < 0.0)
+      // Midpoint direction should be opposite to normal, hence this should be
+      // negative. Switch points if not.
+      if (a.determinant() > 0.0)
         std::swap(entity_geometry(i, 1), entity_geometry(i, 2));
     }
   }

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -797,7 +797,8 @@ mesh::entities_to_geometry(
   Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
       entity_geometry(entity_list.size(), num_entity_vertices);
 
-  if (orient and cell_type != dolfinx::mesh::CellType::tetrahedron)
+  if (orient
+      and (cell_type != dolfinx::mesh::CellType::tetrahedron or dim != 2))
     throw std::runtime_error("Can only orient facets of a tetrahedral mesh");
 
   const auto xdofs = mesh.geometry().dofmap();
@@ -817,7 +818,8 @@ mesh::entities_to_geometry(
     const auto xc = xdofs.links(cell);
     for (int j = 0; j < num_entity_vertices; ++j)
     {
-      int k = std::find(cv.data(), cv.data() + cv.size(), ev[j]) - cv.data();
+      int k = std::distance(cv.data(),
+                            std::find(cv.data(), cv.data() + cv.size(), ev[j]));
       assert(k < cv.size());
       entity_geometry(i, j) = xc[k];
     }

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -791,15 +791,14 @@ mesh::entities_to_geometry(
     const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& entity_list,
     bool orient)
 {
-
-  // FIXME - add more checks for cell types
-  if (orient and (mesh.topology().dim() != 3 or dim != 2))
-    throw std::runtime_error("Can only orient facets of 3D mesh");
   dolfinx::mesh::CellType cell_type = mesh.topology().cell_type();
   const int num_entity_vertices
       = mesh::num_cell_vertices(mesh::cell_entity_type(cell_type, dim));
   Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
       entity_geometry(entity_list.size(), num_entity_vertices);
+
+  if (orient and cell_type != dolfinx::mesh::CellType::tetrahedron)
+    throw std::runtime_error("Can only orient facets of a tetrahedral mesh");
 
   const auto xdofs = mesh.geometry().dofmap();
   const auto e_to_c = mesh.topology().connectivity(dim, mesh.topology().dim());

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -791,7 +791,7 @@ mesh::entities_to_geometry(
     const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& entity_list)
 {
   // FIXME - this is only true for simplices
-  const int num_entity_vertices = dim;
+  const int num_entity_vertices = dim + 1;
 
   Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
       entity_geometry(entity_list.size(), num_entity_vertices);

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -833,7 +833,7 @@ mesh::entities_to_geometry(
       // Compute vector triple product of two edges and vector to midpoint
       Eigen::Vector3d p0 = mesh.geometry().node(entity_geometry(i, 0));
       Eigen::Matrix3d a;
-      a.row(0) = midpoint - p0;
+      a.row(0) = p0 - midpoint;
       a.row(1) = mesh.geometry().node(entity_geometry(i, 1)) - p0;
       a.row(2) = mesh.geometry().node(entity_geometry(i, 2)) - p0;
       // Switch order if sign is negative

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -108,11 +108,21 @@ Eigen::Array<std::int32_t, Eigen::Dynamic, 1> locate_entities_boundary(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker);
 
-/// Compute the geometry of given entities from the mesh geometry
+/// Compute the geometry indices of given entities from the mesh geometry
+/// @param[in] mesh Mesh
+/// @param[in] dim Topological dimension of the entities of interest
+/// @param[in] entity_list List of entities to obtain vertex geometry
+/// @return Vertex indices in the geometry dofmap of the mesh for each entity
 Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
 entities_to_geometry(
     const mesh::Mesh& mesh, const int dim,
     const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& entity_list);
+
+/// Compute exterior facet indices only
+/// @param[in] mesh Mesh
+/// @return List of facet indices of exterior facets of the mesh
+Eigen::Array<std::int32_t, Eigen::Dynamic, 1>
+exterior_facet_indices(const Mesh& mesh);
 
 } // namespace mesh
 } // namespace dolfinx

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -112,11 +112,14 @@ Eigen::Array<std::int32_t, Eigen::Dynamic, 1> locate_entities_boundary(
 /// @param[in] mesh Mesh
 /// @param[in] dim Topological dimension of the entities of interest
 /// @param[in] entity_list List of entities to obtain vertex geometry
+/// @param[in] orient If true, in 3D, reorients facets to have consistent normal
+/// direction
 /// @return Vertex indices in the geometry dofmap of the mesh for each entity
 Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
 entities_to_geometry(
     const mesh::Mesh& mesh, const int dim,
-    const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& entity_list);
+    const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& entity_list,
+    bool orient);
 
 /// Compute exterior facet indices only
 /// @param[in] mesh Mesh

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -108,20 +108,25 @@ Eigen::Array<std::int32_t, Eigen::Dynamic, 1> locate_entities_boundary(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker);
 
-/// Compute the geometry indices of given entities from the mesh geometry
+/// Compute the geometry indices of vertices of the given entities from the mesh
+/// geometry
 /// @param[in] mesh Mesh
 /// @param[in] dim Topological dimension of the entities of interest
-/// @param[in] entity_list List of entities to obtain vertex geometry
+/// @param[in] entity_list List of entity indices (local)
 /// @param[in] orient If true, in 3D, reorients facets to have consistent normal
 /// direction
-/// @return Vertex indices in the geometry dofmap of the mesh for each entity
+/// @return Indices in the geometry array for the mesh entity vertices, i.e.
+/// indices(i, j) is the position in the geometry array of the j-th vertex of
+/// the entity entity_list[i].
 Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
 entities_to_geometry(
     const mesh::Mesh& mesh, const int dim,
     const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& entity_list,
     bool orient);
 
-/// Compute exterior facet indices only
+/// Compute the indices (local) of all exterior facets. An exterior facet
+/// (co-dimension 1) is one that is connected globally to only one cell of
+/// co-dimension 0).
 /// @param[in] mesh Mesh
 /// @return List of facet indices of exterior facets of the mesh
 Eigen::Array<std::int32_t, Eigen::Dynamic, 1>

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -108,5 +108,11 @@ Eigen::Array<std::int32_t, Eigen::Dynamic, 1> locate_entities_boundary(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker);
 
+/// Compute the geometry of given entities from the mesh geometry
+Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+entities_to_geometry(
+    const mesh::Mesh& mesh, const int dim,
+    const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& entity_list);
+
 } // namespace mesh
 } // namespace dolfinx

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -251,5 +251,8 @@ void mesh(py::module& m)
   m.def("locate_entities", &dolfinx::mesh::locate_entities);
   m.def("locate_entities_boundary", &dolfinx::mesh::locate_entities_boundary);
 
+  m.def("entities_to_geometry", &dolfinx::mesh::entities_to_geometry);
+  m.def("exterior_facet_indices", &dolfinx::mesh::exterior_facet_indices);
+
 } // namespace dolfinx_wrappers
 } // namespace dolfinx_wrappers

--- a/python/test/unit/mesh/test_surface_mesh.py
+++ b/python/test/unit/mesh/test_surface_mesh.py
@@ -15,7 +15,7 @@ import ufl
 from mpi4py import MPI
 
 
-def create_boundary_mesh(mesh, comm, orient=True):
+def create_boundary_mesh(mesh, comm, orient=False):
     """
     Create a mesh consisting of all exterior facets of a mesh
     Input:
@@ -78,8 +78,7 @@ def test_b_mesh_mapping(celltype):
 
 
 @pytest.mark.parametrize("celltype",
-                         [cmesh.CellType.tetrahedron,
-                          cmesh.CellType.hexahedron])
+                         [cmesh.CellType.tetrahedron])
 def test_b_mesh_orientation(celltype):
     """
     Test orientation of boundary facets on 3D meshes
@@ -107,17 +106,11 @@ def test_b_mesh_orientation(celltype):
         for j in range(num_cell_vertices):
             entity_geometry[i, j] = xc[j]
 
-    # Compute dot((p0-midpoint), cross(p1-p0, p2-p0)) for every facet
+    # Compute dot(p0, cross(p1-p0, p2-p0)) for every facet
     # to check that the orientation is correct
+    # p0 is vector from centre of mesh
     for i in range(num_cells):
-        midpoint = np.zeros(3, dtype=np.float64)
-        for j in range(num_cell_vertices):
-            midpoint += b_mesh.geometry.x[entity_geometry[i, j]]
-        midpoint /= num_cell_vertices
-        a = np.zeros((3, 3), dtype=np.float64)
-        a[0] = b_mesh.geometry.x[entity_geometry[i, 0]] - midpoint
-        a[1] = b_mesh.geometry.x[entity_geometry[i, 1]]
-        - b_mesh.geometry.x[entity_geometry[i, 0]]
-        a[2] = b_mesh.geometry.x[entity_geometry[i, 2]]
-        - b_mesh.geometry.x[entity_geometry[i, 0]]
+        a = b_mesh.geometry.x[entity_geometry[i, :]]
+        a[1] -= a[0]
+        a[2] -= a[0]
         assert(np.linalg.det(a) > 0)

--- a/python/test/unit/mesh/test_surface_mesh.py
+++ b/python/test/unit/mesh/test_surface_mesh.py
@@ -1,0 +1,60 @@
+import dolfinx
+import dolfinx.cpp.mesh as cmesh
+import dolfinx.fem
+import dolfinx.io
+import dolfinx.mesh
+import numpy as np
+import ufl
+from mpi4py import MPI
+
+
+def create_boundary_mesh(mesh, comm):
+    """
+    Create a mesh consisting of all exterior facets of a mesh
+    Input:
+      mesh - The mesh
+    Output:
+      bmesh - The boundary mesh
+      bmesh_to_geometry - Map from cells of the boundary mesh
+                          to the geometry of the original mesh
+    """
+    ext_facets = cmesh.exterior_facet_indices(mesh)
+    boundary_geometry = cmesh.entities_to_geometry(
+        mesh, mesh.topology.dim - 1, ext_facets, True)
+    facet_type = dolfinx.cpp.mesh.to_string(cmesh.cell_entity_type(
+        mesh.topology.cell_type, mesh.topology.dim - 1))
+    facet_cell = ufl.Cell(facet_type,
+                          geometric_dimension=mesh.geometry.dim)
+    degree = mesh.ufl_domain().ufl_coordinate_element().degree()
+    ufl_domain = ufl.Mesh(ufl.VectorElement("Lagrange", facet_cell, degree))
+    bmesh = dolfinx.mesh.create_mesh(
+        comm, boundary_geometry, mesh.geometry.x, ufl_domain)
+    return bmesh, boundary_geometry
+
+
+def test_b_mesh_mapping():
+    mesh = dolfinx.UnitCubeMesh(MPI.COMM_WORLD, 2, 2, 2)
+
+    b_mesh, bndry_to_mesh = create_boundary_mesh(mesh, MPI.COMM_SELF)
+
+    # Compute map from boundary mesh topology to boundary mesh geometry
+    b_mesh.topology.create_connectivity(
+        b_mesh.topology.dim, b_mesh.topology.dim)
+    b_imap = b_mesh.topology.index_map(b_mesh.topology.dim)
+    tdim_entities = np.arange(b_imap.size_local * b_imap.block_size,
+                              dtype=np.int32)
+    boundary_geometry = cmesh.entities_to_geometry(
+        b_mesh, b_mesh.topology.dim, tdim_entities, False)
+
+    # Compare geometry maps
+    for i in range(boundary_geometry.shape[0]):
+        assert(
+            np.allclose(b_mesh.geometry.x[boundary_geometry[i]],
+                        mesh.geometry.x[bndry_to_mesh[i]]))
+
+    # Check that boundary mesh integrated has the correct area
+    b_volume = mesh.mpi_comm().allreduce(dolfinx.fem.assemble_scalar(
+        dolfinx.Constant(b_mesh, 1) * ufl.dx), op=MPI.SUM)
+    mesh_surface = mesh.mpi_comm().allreduce(dolfinx.fem.assemble_scalar(
+        dolfinx.Constant(mesh, 1) * ufl.ds), op=MPI.SUM)
+    assert(np.isclose(b_volume, mesh_surface))

--- a/python/test/unit/mesh/test_surface_mesh.py
+++ b/python/test/unit/mesh/test_surface_mesh.py
@@ -110,7 +110,7 @@ def test_b_mesh_orientation(celltype):
     # to check that the orientation is correct
     # p0 is vector from centre of mesh
     for i in range(num_cells):
-        a = b_mesh.geometry.x[entity_geometry[i, :]]
-        a[1] -= a[0]
-        a[2] -= a[0]
-        assert(np.linalg.det(a) > 0)
+        p = b_mesh.geometry.x[entity_geometry[i, :]]
+        p[1] -= p[0]
+        p[2] -= p[0]
+        assert(np.linalg.det(p) > 0)


### PR DESCRIPTION
Add two utility functions to `mesh::` 
* `entities_to_geometry` - computes the indices in `mesh::Geometry` of the vertices of the given entities
 - this is needed in several places in the library, and will be useful for future refactoring
* `exterior_facet_indices` - computes the facet indices of facets which lie on the external surface.
 - the logic is similar to that in `FormIntegrals`. It does not return exterior facets of ghost cells.

By using `facet_indices = exterior_facet_indices(mesh);` we can obtain a list of topology indices for surface facets (unoriented),
Further by using `geom_indices = entities_to_geometry(mesh, tdim -1, facet_indices, true);` we get the oriented geometry.