### PR TITLE
Add eps argument for Newton solver in CoordinateElement

### DIFF
--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -66,7 +66,8 @@ void CoordinateElement::compute_reference_geometry(
     const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
                                         Eigen::RowMajor>>& x,
     const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
-                                        Eigen::RowMajor>>& cell_geometry) const
+                                        Eigen::RowMajor>>& cell_geometry,
+    double eps) const
 {
   // Number of points
   int num_points = x.rows();
@@ -173,7 +174,7 @@ void CoordinateElement::compute_reference_geometry(
         // Increment to new point in reference
         Eigen::Matrix<double, Eigen::Dynamic, 1, Eigen::ColMajor, 3, 1> dX
             = Kview * (x.row(ip).matrix().transpose() - xk);
-        if (dX.squaredNorm() < 1e-16)
+        if (dX.squaredNorm() < eps)
           break;
         Xk += dX;
       }

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -83,7 +83,8 @@ public:
                                           Eigen::Dynamic, Eigen::RowMajor>>& x,
       const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,
                                           Eigen::Dynamic, Eigen::RowMajor>>&
-          cell_geometry) const;
+          cell_geometry,
+      double eps = 1.0e-16) const;
 
 private:
   // Topological and geometric dimensions


### PR DESCRIPTION
Allows caller to control the tolerance.