### PR TITLE
Add UI for XDMF mixed topologies

### DIFF
--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -165,9 +165,10 @@ mesh::Mesh XDMFFile::read_mesh(const fem::CoordinateElement& element,
                                const std::string xpath) const
 {
   // Read mesh data
-  const Eigen::Array<std::int64_t, Eigen::Dynamic, Eigen::Dynamic,
-                     Eigen::RowMajor>
-      cells = XDMFFile::read_topology_data(name, xpath);
+  const std::pair < dolfinx::mesh::CellType,
+      Eigen::Array<std::int64_t, Eigen::Dynamic, Eigen::Dynamic,
+                   Eigen::RowMajor>
+          cells = XDMFFile::read_topology_data(name, xpath);
   const auto x = XDMFFile::read_geometry_data(name, xpath);
 
   // Create mesh
@@ -178,7 +179,9 @@ mesh::Mesh XDMFFile::read_mesh(const fem::CoordinateElement& element,
   return mesh;
 }
 //-----------------------------------------------------------------------------
-Eigen::Array<std::int64_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+std::pair<
+    dolfinx::mesh::CellType,
+    Eigen::Array<std::int64_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>
 XDMFFile::read_topology_data(const std::string name,
                              const std::string xpath) const
 {
@@ -190,7 +193,6 @@ XDMFFile::read_topology_data(const std::string name,
       = node.select_node(("Grid[@Name='" + name + "']").c_str()).node();
   if (!grid_node)
     throw std::runtime_error("<Grid> with name '" + name + "' not found.");
-
   return xdmf_mesh::read_topology_data(_mpi_comm.comm(), _h5_id, grid_node);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -111,10 +111,15 @@ public:
   /// Read Topology data for Mesh
   /// @param[in] name Name of the mesh (Grid)
   /// @param[in] xpath XPath where Mesh Grid data is located
-  /// @return (Cell type, degree), and cells topology (global node indexing)
-  Eigen::Array<std::int64_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+  /// @param[in] tdim Topological dimension of mesh topology extracted (Default:
+  /// -1 will extract the maximum topological dimension)
+  /// @return Cell type and cells topology (global node indexing)
+  std::pair<dolfinx::mesh::CellType,
+            Eigen::Array<std::int64_t, Eigen::Dynamic, Eigen::Dynamic,
+                         Eigen::RowMajor>>
   read_topology_data(const std::string name,
-                     const std::string xpath = "/Xdmf/Domain") const;
+                     const std::string xpath = "/Xdmf/Domain",
+                     std::int32_t tdim = -1) const;
 
   /// Read Geometry data for Mesh
   /// @param[in] name Name of the mesh (Grid)

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -159,10 +159,9 @@ public:
   /// @param[in] mesh The Mesh that the data is defined on
   /// @param[in] name
   /// @param[in] xpath XPath where MeshTags Grid is stored in file
-  mesh::MeshTags<std::int32_t>
-  read_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh,
-                const std::string name,
-                const std::string xpath = "/Xdmf/Domain");
+  mesh::MeshTags<std::int32_t> read_meshtags(
+      const std::shared_ptr<const mesh::Mesh>& mesh, const std::string name,
+      const std::string xpath = "/Xdmf/Domain", std::int32_t tdim = -1);
 
   /// Write Information
   /// @param[in] name

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -159,6 +159,7 @@ public:
   /// @param[in] mesh The Mesh that the data is defined on
   /// @param[in] name
   /// @param[in] xpath XPath where MeshTags Grid is stored in file
+  /// @param[in] tdim Topological dimension of the mesh-data.
   mesh::MeshTags<std::int32_t> read_meshtags(
       const std::shared_ptr<const mesh::Mesh>& mesh, const std::string name,
       const std::string xpath = "/Xdmf/Domain", std::int32_t tdim = -1);

--- a/cpp/dolfinx/io/cells.cpp
+++ b/cpp/dolfinx/io/cells.cpp
@@ -13,78 +13,6 @@
 using namespace dolfinx;
 namespace
 {
-int cell_degree(mesh::CellType type, int num_nodes)
-{
-  switch (type)
-  {
-  case mesh::CellType::point:
-    return 1;
-  case mesh::CellType::interval:
-    return num_nodes - 1;
-  case mesh::CellType::triangle:
-    switch (num_nodes)
-    {
-    case 3:
-      return 1;
-    case 6:
-      return 2;
-    case 10:
-      return 3;
-    case 15:
-      return 4;
-    case 21:
-      return 5;
-    case 28:
-      return 6;
-    case 36:
-      return 7;
-    case 45:
-      LOG(WARNING) << "8th order mesh is untested";
-      return 8;
-    case 55:
-      LOG(WARNING) << "9th order mesh is untested";
-      return 9;
-    default:
-      throw std::runtime_error("Unknown triangle layout. Number of nodes: "
-                               + std::to_string(num_nodes));
-    }
-  case mesh::CellType::tetrahedron:
-    switch (num_nodes)
-    {
-    case 4:
-      return 1;
-    case 10:
-      return 2;
-    case 20:
-      return 3;
-    default:
-      throw std::runtime_error("Unknown tetrahedron layout.");
-    }
-  case mesh::CellType::quadrilateral:
-  {
-    const int n = std::sqrt(num_nodes);
-    if (num_nodes != n * n)
-    {
-      throw std::runtime_error("Quadrilateral of order "
-                               + std::to_string(num_nodes) + " not supported");
-    }
-    return n - 1;
-  }
-  case mesh::CellType::hexahedron:
-    switch (num_nodes)
-    {
-    case 8:
-      return 1;
-    case 27:
-      return 2;
-    default:
-      throw std::runtime_error("Unsupported hexahedron layout");
-      return 1;
-    }
-  default:
-    throw std::runtime_error("Unknown cell type.");
-  }
-}
 //-----------------------------------------------------------------------------
 std::vector<std::uint8_t> vtk_triangle(int num_nodes)
 {
@@ -93,7 +21,7 @@ std::vector<std::uint8_t> vtk_triangle(int num_nodes)
   std::iota(map.begin(), map.begin() + 3, 0);
 
   int j = 3;
-  const int degree = cell_degree(mesh::CellType::triangle, num_nodes);
+  const int degree = io::cells::cell_degree(mesh::CellType::triangle, num_nodes);
   for (int k = 1; k < degree; ++k)
     map[j++] = 3 + 2 * (degree - 1) + k - 1;
   for (int k = 1; k < degree; ++k)
@@ -275,6 +203,79 @@ std::vector<std::uint8_t> gmsh_quadrilateral(int num_nodes)
   }
 }
 } // namespace
+//-----------------------------------------------------------------------------
+int io::cells::cell_degree(mesh::CellType type, int num_nodes)
+{
+  switch (type)
+  {
+  case mesh::CellType::point:
+    return 1;
+  case mesh::CellType::interval:
+    return num_nodes - 1;
+  case mesh::CellType::triangle:
+    switch (num_nodes)
+    {
+    case 3:
+      return 1;
+    case 6:
+      return 2;
+    case 10:
+      return 3;
+    case 15:
+      return 4;
+    case 21:
+      return 5;
+    case 28:
+      return 6;
+    case 36:
+      return 7;
+    case 45:
+      LOG(WARNING) << "8th order mesh is untested";
+      return 8;
+    case 55:
+      LOG(WARNING) << "9th order mesh is untested";
+      return 9;
+    default:
+      throw std::runtime_error("Unknown triangle layout. Number of nodes: "
+                               + std::to_string(num_nodes));
+    }
+  case mesh::CellType::tetrahedron:
+    switch (num_nodes)
+    {
+    case 4:
+      return 1;
+    case 10:
+      return 2;
+    case 20:
+      return 3;
+    default:
+      throw std::runtime_error("Unknown tetrahedron layout.");
+    }
+  case mesh::CellType::quadrilateral:
+  {
+    const int n = std::sqrt(num_nodes);
+    if (num_nodes != n * n)
+    {
+      throw std::runtime_error("Quadrilateral of order "
+                               + std::to_string(num_nodes) + " not supported");
+    }
+    return n - 1;
+  }
+  case mesh::CellType::hexahedron:
+    switch (num_nodes)
+    {
+    case 8:
+      return 1;
+    case 27:
+      return 2;
+    default:
+      throw std::runtime_error("Unsupported hexahedron layout");
+      return 1;
+    }
+  default:
+    throw std::runtime_error("Unknown cell type.");
+  }
+}
 //-----------------------------------------------------------------------------
 std::vector<std::uint8_t> io::cells::perm_vtk(mesh::CellType type,
                                               int num_nodes)

--- a/cpp/dolfinx/io/cells.h
+++ b/cpp/dolfinx/io/cells.h
@@ -96,6 +96,12 @@ std::vector<std::uint8_t> perm_vtk(mesh::CellType type, int num_nodes);
 ///   =[a[p[0]], a[p[1]], a[p[2]], a[p[3]]] = [10, 4, 3, 7]`
 std::vector<std::uint8_t> perm_gmsh(mesh::CellType type, int num_nodes);
 
+/// Get the order of a cell given the number of nodes defining the cell
+/// @param[in] type The cell shape
+/// @param[in] num_nodes
+/// @return The cell order
+int cell_degree(mesh::CellType type, int num_nodes);
+
 /// Compute the transpose of a re-ordering map
 ///
 /// @param[in] map A re-ordering map

--- a/cpp/dolfinx/io/xdmf_mesh.h
+++ b/cpp/dolfinx/io/xdmf_mesh.h
@@ -69,8 +69,9 @@ read_geometry_data(MPI_Comm comm, const hid_t h5_id,
                    const pugi::xml_node& node);
 
 /// Read Topology data
-/// @returns ((cell type, degree), topology)
-Eigen::Array<std::int64_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+/// @returns cell_type, ((cell_type, degree), topology)
+std::map<dolfinx::mesh::CellType, Eigen::Array<std::int64_t, Eigen::Dynamic,
+                                               Eigen::Dynamic, Eigen::RowMajor>>
 read_topology_data(MPI_Comm comm, const hid_t h5_id,
                    const pugi::xml_node& node);
 

--- a/cpp/dolfinx/io/xdmf_mesh.h
+++ b/cpp/dolfinx/io/xdmf_mesh.h
@@ -70,10 +70,11 @@ read_geometry_data(MPI_Comm comm, const hid_t h5_id,
 
 /// Read Topology data
 /// @returns cell_type, ((cell_type, degree), topology)
-std::map<dolfinx::mesh::CellType, Eigen::Array<std::int64_t, Eigen::Dynamic,
-                                               Eigen::Dynamic, Eigen::RowMajor>>
-read_topology_data(MPI_Comm comm, const hid_t h5_id,
-                   const pugi::xml_node& node);
+std::pair<
+    dolfinx::mesh::CellType,
+    Eigen::Array<std::int64_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>
+read_topology_data(MPI_Comm comm, const hid_t h5_id, const pugi::xml_node& node,
+                   std::int32_t tdim = -1);
 
 } // namespace io::xdmf_mesh
 } // namespace dolfinx

--- a/cpp/dolfinx/io/xdmf_read.h
+++ b/cpp/dolfinx/io/xdmf_read.h
@@ -24,7 +24,7 @@ namespace dolfinx::io::xdmf_read
 template <typename T>
 std::vector<T> get_dataset(MPI_Comm comm, const pugi::xml_node& dataset_node,
                            const hid_t h5_id,
-                           std::array<std::int64_t, 2> range = {{0, 0}})
+                           std::array<std::int64_t, 2> range = {{-1, -1}})
 {
   // FIXME: Need to sort out datasset dimensions - can't depend on HDF5
   // shape, and a Topology data item is not required to have a
@@ -90,7 +90,7 @@ std::vector<T> get_dataset(MPI_Comm comm, const pugi::xml_node& dataset_node,
 
     // If range = {0, 0} then no range is supplied and we must determine
     // the range
-    if (range[0] == 0 and range[1] == 0)
+    if (range[0] == -1 and range[1] == -1)
     {
       if (shape_xml == shape_hdf5)
       {

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -65,7 +65,8 @@ xdmf_utils::get_cell_type(const pugi::xml_node& topology_node)
          {"quadrilateral", {"quadrilateral", 1}},
          {"quadrilateral_9", {"quadrilateral", 2}},
          {"quadrilateral_16", {"quadrilateral", 3}},
-         {"hexahedron", {"hexahedron", 1}}};
+         {"hexahedron", {"hexahedron", 1}},
+         {"mixed", {"mixed", 0}}};
 
   // Convert XDMF cell type string to DOLFINX cell type string
   std::string cell_type = type_attr.as_string();

--- a/cpp/dolfinx/io/xdmf_utils.h
+++ b/cpp/dolfinx/io/xdmf_utils.h
@@ -159,5 +159,11 @@ void add_data_item(pugi::xml_node& xml_node, const hid_t h5_id,
   }
 }
 
+/// Extract cell values from a mixed topology
+std::vector<std::int32_t>
+extract_mixed_topology_values(MPI_Comm comm, const hid_t h5_id,
+                              const pugi::xml_node& node,
+                              mesh::CellType cell_type);
+
 } // namespace io::xdmf_utils
 } // namespace dolfinx

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -146,6 +146,7 @@ create_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh, const int dim,
     throw std::runtime_error("Number of entities and values must match");
 
   // Tagged entity topological dimension
+  mesh->topology_mutable().create_connectivity(mesh->topology().dim(), dim);
   const auto map_e = mesh->topology().index_map(dim);
   assert(map_e);
 

--- a/cpp/dolfinx/mesh/cell_types.cpp
+++ b/cpp/dolfinx/mesh/cell_types.cpp
@@ -218,6 +218,8 @@ std::string mesh::to_string(mesh::CellType type)
     return "quadrilateral";
   case mesh::CellType::hexahedron:
     return "hexahedron";
+  case mesh::CellType::mixed:
+    return "mixed";
   default:
     throw std::runtime_error("Unknown cell type.");
     return std::string();
@@ -238,6 +240,8 @@ mesh::CellType mesh::to_type(const std::string& cell)
     return mesh::CellType::quadrilateral;
   else if (cell == "hexahedron")
     return mesh::CellType::hexahedron;
+  else if (cell == "mixed")
+    return mesh::CellType::mixed;
   else
     throw std::runtime_error("Unknown cell type (" + cell + ")");
 }

--- a/cpp/dolfinx/mesh/cell_types.h
+++ b/cpp/dolfinx/mesh/cell_types.h
@@ -20,6 +20,7 @@ namespace dolfinx::mesh
 enum class CellType : int
 {
   // NOTE: Simplex cells have index > 0, see mesh::is_simplex
+  mixed = -11,
   point = 1,
   interval = 2,
   triangle = 3,

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -35,6 +35,9 @@ void io(py::module& m)
   m.def("perm_vtk", &dolfinx::io::cells::perm_vtk);
   m.def("perm_gmsh", &dolfinx::io::cells::perm_gmsh);
 
+  // Cell degree identification
+  m.def("cell_degree", &dolfinx::io::cells::cell_degree);
+
   // TODO: Template for different values dtypes
   m.def("extract_local_entities",
         [](const dolfinx::mesh::Mesh& mesh, const int entity_dim,
@@ -78,7 +81,8 @@ void io(py::module& m)
            py::arg("geometry"), py::arg("name") = "geometry",
            py::arg("xpath") = "/Xdmf/Domain")
       .def("read_topology_data", &dolfinx::io::XDMFFile::read_topology_data,
-           py::arg("name") = "mesh", py::arg("xpath") = "/Xdmf/Domain")
+           py::arg("name") = "mesh", py::arg("xpath") = "/Xdmf/Domain",
+           py::arg("tdim") = -1)
       .def("read_geometry_data", &dolfinx::io::XDMFFile::read_geometry_data,
            py::arg("name") = "mesh", py::arg("xpath") = "/Xdmf/Domain")
       .def("read_cell_type", &dolfinx::io::XDMFFile::read_cell_type,

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -94,7 +94,8 @@ void io(py::module& m)
            py::arg("geometry_xpath") = "/Xdmf/Domain/Grid/Geometry",
            py::arg("xpath") = "/Xdmf/Domain")
       .def("read_meshtags", &dolfinx::io::XDMFFile::read_meshtags,
-           py::arg("mesh"), py::arg("name"), py::arg("xpath") = "/Xdmf/Domain")
+           py::arg("mesh"), py::arg("name"), py::arg("xpath") = "/Xdmf/Domain",
+           py::arg("tdim") = -1)
       .def("write_information", &dolfinx::io::XDMFFile::write_information,
            py::arg("name"), py::arg("value"), py::arg("xpath") = "/Xdmf/Domain")
       .def("read_information", &dolfinx::io::XDMFFile::read_information,

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -86,7 +86,8 @@ void mesh(py::module& m)
       .value("triangle", dolfinx::mesh::CellType::triangle)
       .value("quadrilateral", dolfinx::mesh::CellType::quadrilateral)
       .value("tetrahedron", dolfinx::mesh::CellType::tetrahedron)
-      .value("hexahedron", dolfinx::mesh::CellType::hexahedron);
+      .value("hexahedron", dolfinx::mesh::CellType::hexahedron)
+      .value("mixed", dolfinx::mesh::CellType::mixed);
 
   m.def("to_string", &dolfinx::mesh::to_string);
   m.def("to_type", &dolfinx::mesh::to_type);

--- a/python/test/unit/io/test_xdmf_meshdata.py
+++ b/python/test/unit/io/test_xdmf_meshdata.py
@@ -55,9 +55,10 @@ def test_read_mesh_data(tempdir, tdim, n):
 
     with XDMFFile(MPI.COMM_WORLD, filename, "r") as file:
         cell_type = file.read_cell_type()
-        cells = file.read_topology_data()
+        ct, cells = file.read_topology_data()
         x = file.read_geometry_data()
 
+    assert ct == cell_type[0]
     assert cell_type[0] == mesh.topology.cell_type
     assert cell_type[1] == 1
     assert mesh.topology.index_map(tdim).size_global == mesh.mpi_comm().allreduce(cells.shape[0], op=MPI.SUM)


### PR DESCRIPTION
See details about the input data in #1156 

This PR adds the possibility of selecting with topological dimension of a XDMFTopology of typed "mixed" one should extract. Default behavior will be to extract the topology with highest topological dimension.

Similar features added for reading in meshtags.

Note that all data is read on the first processor, then distributed later on, as there is no reasonable way of partitioning the cell_topology or cell_values a priori.