### PR TITLE
Fix broken code for cell_normals and make it more efficient by using entitiy lists

### DIFF
--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -467,8 +467,13 @@ Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> mesh::cell_normals(
       = mesh::cell_entity_type(mesh.topology().cell_type(), dim);
   // Find geometry nodes for topology entities
   const mesh::Geometry& geometry = mesh.geometry();
+  // Orient cells if they are tetrahedron
+  bool orient = false;
+  if (mesh.topology().cell_type() == mesh::CellType::tetrahedron)
+    orient = true;
   Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
-      geometry_entities = entities_to_geometry(mesh, dim, entity_indices, true);
+      geometry_entities
+      = entities_to_geometry(mesh, dim, entity_indices, orient);
 
   const std::int32_t num_entities = entity_indices.size();
   Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> n(num_entities, 3);

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -468,8 +468,7 @@ Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> mesh::cell_normals(
   // Find geometry nodes for topology entities
   const mesh::Geometry& geometry = mesh.geometry();
   Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
-      geometry_entities
-      = entities_to_geometry(mesh, dim, entity_indices, false);
+      geometry_entities = entities_to_geometry(mesh, dim, entity_indices, true);
 
   const std::int32_t num_entities = entity_indices.size();
   Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> n(num_entities, 3);

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -57,8 +57,9 @@ Eigen::ArrayXd radius_ratio(const Mesh& mesh,
                             const Eigen::Ref<const Eigen::ArrayXi>& entities);
 
 /// Compute normal to given cell (viewed as embedded in 3D)
-Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor>
-cell_normals(const Mesh& mesh, int dim);
+Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> cell_normals(
+    const Mesh& mesh, int dim,
+    const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& entity_indices);
 
 /// Compute midpoints or mesh entities of a given dimension
 Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> midpoints(

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -96,6 +96,7 @@ void mesh(py::module& m)
   m.def("cell_dim", &dolfinx::mesh::cell_dim);
   m.def("cell_num_entities", &dolfinx::mesh::cell_num_entities);
   m.def("cell_num_vertices", &dolfinx::mesh::num_cell_vertices);
+  m.def("cell_normals", &dolfinx::mesh::cell_normals);
   m.def("get_entity_vertices", &dolfinx::mesh::get_entity_vertices);
 
   m.def("extract_topology", &dolfinx::mesh::extract_topology);

--- a/python/test/unit/mesh/test_face.py
+++ b/python/test/unit/mesh/test_face.py
@@ -42,15 +42,15 @@ def test_area(cube, square):
 
 
 def test_normals(cube, square):
-    """ Test that cell normals of a set of facets """
+    """ Test cell normals for a subset of facets """
     def left_side(x):
         return numpy.isclose(x[0], 0)
     fdim = cube.topology.dim - 1
     facets = locate_entities_boundary(cube, fdim, left_side)
     normals = cell_normals(cube, fdim, facets)
-    assert(numpy.isclose(normals, [-1, 0, 0]).all(axis=1).all())
+    assert(numpy.allclose(normals, [-1, 0, 0]))
 
     fdim = square.topology.dim - 1
     facets = locate_entities_boundary(square, fdim, left_side)
     normals = cell_normals(square, fdim, facets)
-    assert(numpy.isclose(normals, [-1, 0, 0]).all(axis=1).all())
+    assert(numpy.allclose(normals, [-1, 0, 0]))


### PR DESCRIPTION
Current master is broken, as the following test:
```

def test_normals(cube, square):
    """ Test that cell normals of a set of facets """
    def left_side(x):
        return numpy.isclose(x[0], 0)
    fdim = cube.topology.dim - 1
    facets = locate_entities_boundary(cube, fdim, left_side)
    normals = cell_normals(cube, fdim)
    assert(numpy.isclose(normals[facets], [-1, 0, 0]).all(axis=1).all())

    fdim = square.topology.dim - 1
    facets = locate_entities_boundary(square, fdim, left_side)
    normals = cell_normals(square, fdim)
    assert(numpy.isclose(normals[facets], [-1, 0, 0]).all(axis=1).all())
```
would return gibberish if we exposed `cell_normals` to the python layer. This is because it is missing the topology->geometry mapping, which was created way back when we separated mesh topology and geometry.

This pull request adds in this mapping, and exploits the fact that in most cases one is only interested in a subset of facets.