### PR TITLE
give priority to cray pkgconfig files when searching for PETSc, SLEPc

### DIFF
--- a/cpp/cmake/modules/FindPETSc.cmake
+++ b/cpp/cmake/modules/FindPETSc.cmake
@@ -60,7 +60,7 @@ find_package(PkgConfig REQUIRED)
 
 # Find PETSc pkg-config file. Note: craypetsc_real is on Cray systems
 set(ENV{PKG_CONFIG_PATH} "$ENV{CRAY_PETSC_PREFIX_DIR}/lib/pkgconfig:$ENV{PETSC_DIR}/$ENV{PETSC_ARCH}/lib/pkgconfig:$ENV{PETSC_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
-pkg_search_module(PETSC petsc craypetsc_real PETSc)
+pkg_search_module(PETSC craypetsc_real petsc PETSc)
 
 # Extract major, minor, etc from version string
 if (PETSC_VERSION)

--- a/cpp/cmake/modules/FindSLEPc.cmake
+++ b/cpp/cmake/modules/FindSLEPc.cmake
@@ -48,7 +48,7 @@ find_package(PkgConfig REQUIRED)
 set(ENV{PKG_CONFIG_PATH} "$ENV{SLEPC_DIR}/$ENV{PETSC_ARCH}/lib/pkgconfig:$ENV{SLEPC_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
 set(ENV{PKG_CONFIG_PATH} "$ENV{PETSC_DIR}/$ENV{PETSC_ARCH}/lib/pkgconfig:$ENV{PETSC_DIR}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
 set(ENV{PKG_CONFIG_PATH} "$ENV{PETSC_DIR}/$ENV{PETSC_ARCH}:$ENV{PETSC_DIR}:$ENV{PKG_CONFIG_PATH}")
-pkg_search_module(SLEPC slepc crayslepc_real SLEPc)
+pkg_search_module(SLEPC crayslepc_real slepc SLEPc)
 
 # Extract major, minor, etc from version string
 if (SLEPC_VERSION)
@@ -98,7 +98,7 @@ if (DOLFINX_SKIP_BUILD_TESTS)
 
 elseif (SLEPC_FOUND)
 
-  # Create SLEPc test program
+  # Create SLEPc test pr pogram
   set(SLEPC_TEST_LIB_CPP
     "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/slepc_test_lib.cpp")
   file(WRITE ${SLEPC_TEST_LIB_CPP} "


### PR DESCRIPTION
Following on from PR#1195, when looking for PETSc and SLEPC in pkg_search_module, pkgconfig priority was previously given to the cray version of the pkgconfig files. This patch restores that priority, after including lowercase petsc and slepc as alternative pkg names.