### PR TITLE
Change dof finder return type for blocked degrees of freedom support

### DIFF
--- a/cpp/dolfinx/fem/DirichletBC.cpp
+++ b/cpp/dolfinx/fem/DirichletBC.cpp
@@ -174,8 +174,10 @@ get_remote_bcs2(const common::IndexMap& map0, const common::IndexMap& map1,
   return dofs;
 }
 //-----------------------------------------------------------------------------
-Eigen::Array<std::int32_t, Eigen::Dynamic, 2> _locate_dofs_topological(
-    const std::vector<std::reference_wrapper<function::FunctionSpace>>& V,
+std::array<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>, 2>
+_locate_dofs_topological(
+    const std::array<std::reference_wrapper<const function::FunctionSpace>, 2>&
+        V,
     const int dim, const Eigen::Ref<const Eigen::ArrayXi>& entities,
     bool remote)
 {
@@ -288,7 +290,7 @@ Eigen::Array<std::int32_t, Eigen::Dynamic, 2> _locate_dofs_topological(
     dofs(i, 1) = bc_dofs[i][1];
   }
 
-  return dofs;
+  return {dofs.col(0), dofs.col(1)};
 }
 //-----------------------------------------------------------------------------
 
@@ -492,18 +494,22 @@ Eigen::Array<std::int32_t, Eigen::Dynamic, 1> _locate_dofs_geometrical(
 } // namespace
 
 //-----------------------------------------------------------------------------
-Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic>
+std::array<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>, 2>
 fem::locate_dofs_topological(
-    const std::vector<std::reference_wrapper<function::FunctionSpace>>& V,
+    const std::array<std::reference_wrapper<const function::FunctionSpace>, 2>&
+        V,
     const int dim, const Eigen::Ref<const Eigen::ArrayXi>& entities,
     bool remote)
 {
-  if (V.size() == 2)
-    return _locate_dofs_topological(V, dim, entities, remote);
-  else if (V.size() == 1)
-    return _locate_dofs_topological(V[0].get(), dim, entities, remote);
-  else
-    throw std::runtime_error("Expected only 1 or 2 function spaces.");
+  return _locate_dofs_topological(V, dim, entities, remote);
+}
+//-----------------------------------------------------------------------------
+Eigen::Array<std::int32_t, Eigen::Dynamic, 1>
+fem::locate_dofs_topological(const function::FunctionSpace& V, const int dim,
+                             const Eigen::Ref<const Eigen::ArrayXi>& entities,
+                             bool remote)
+{
+  return _locate_dofs_topological(V, dim, entities, remote);
 }
 //-----------------------------------------------------------------------------
 Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic>

--- a/cpp/dolfinx/fem/DirichletBC.cpp
+++ b/cpp/dolfinx/fem/DirichletBC.cpp
@@ -383,8 +383,10 @@ _locate_dofs_topological(const function::FunctionSpace& V, const int entity_dim,
   return _dofs;
 }
 //-----------------------------------------------------------------------------
-Eigen::Array<std::int32_t, Eigen::Dynamic, 2> _locate_dofs_geometrical(
-    const std::vector<std::reference_wrapper<function::FunctionSpace>>& V,
+std::array<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>, 2>
+_locate_dofs_geometrical(
+    const std::array<std::reference_wrapper<const function::FunctionSpace>, 2>&
+        V,
     const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker)
@@ -459,7 +461,7 @@ Eigen::Array<std::int32_t, Eigen::Dynamic, 2> _locate_dofs_geometrical(
     dofs(i, 1) = bc_dofs[i][1];
   }
 
-  return dofs;
+  return {dofs.col(0), dofs.col(1)};
 }
 //-----------------------------------------------------------------------------
 Eigen::Array<std::int32_t, Eigen::Dynamic, 1> _locate_dofs_geometrical(
@@ -512,18 +514,23 @@ fem::locate_dofs_topological(const function::FunctionSpace& V, const int dim,
   return _locate_dofs_topological(V, dim, entities, remote);
 }
 //-----------------------------------------------------------------------------
-Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic>
+std::array<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>, 2>
 fem::locate_dofs_geometrical(
-    const std::vector<std::reference_wrapper<function::FunctionSpace>>& V,
+    const std::array<std::reference_wrapper<const function::FunctionSpace>, 2>&
+        V,
     const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker)
 {
-  if (V.size() == 2)
-    return _locate_dofs_geometrical(V, marker);
-  else if (V.size() == 1)
-    return _locate_dofs_geometrical(V[0].get(), marker);
-  else
-    throw std::runtime_error("Expected only 1 or 2 function spaces.");
+  return _locate_dofs_geometrical(V, marker);
+}
+//-----------------------------------------------------------------------------
+Eigen::Array<std::int32_t, Eigen::Dynamic, 1> fem::locate_dofs_geometrical(
+    const function::FunctionSpace& V,
+    const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+        const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
+                                            Eigen::RowMajor>>&)>& marker)
+{
+  return _locate_dofs_geometrical(V, marker);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -95,7 +95,7 @@ locate_dofs_geometrical(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker);
 
-// TODO
+/// TODO
 Eigen::Array<std::int32_t, Eigen::Dynamic, 1> locate_dofs_geometrical(
     const function::FunctionSpace& V,
     const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -87,9 +87,17 @@ locate_dofs_topological(const function::FunctionSpace& V, const int dim,
 ///     two spaces are passed in). If two spaces are passed in, the (i,
 ///     0) entry is the DOF index in the space V[0] and (i, 1) is the
 ///     correspinding DOF entry in the space V[1].
-Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic>
+std::array<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>, 2>
 locate_dofs_geometrical(
-    const std::vector<std::reference_wrapper<function::FunctionSpace>>& V,
+    const std::array<std::reference_wrapper<const function::FunctionSpace>, 2>&
+        V,
+    const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+        const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
+                                            Eigen::RowMajor>>&)>& marker);
+
+// TODO
+Eigen::Array<std::int32_t, Eigen::Dynamic, 1> locate_dofs_geometrical(
+    const function::FunctionSpace& V,
     const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker);

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -203,7 +203,7 @@ void add_diagonal(
   {
     assert(bc);
     if (V.contains(*bc->function_space()))
-      add_diagonal<T>(mat_add, bc->dofs_owned().col(0), diagonal);
+      add_diagonal<T>(mat_add, bc->dofs_owned()[0], diagonal);
   }
 }
 

--- a/python/dolfinx/fem/dirichletbc.py
+++ b/python/dolfinx/fem/dirichletbc.py
@@ -101,13 +101,13 @@ def locate_dofs_topological(V: typing.Iterable[typing.Union[cpp.function.Functio
                 _V.append(space._cpp_object)
             except AttributeError:
                 _V.append(space)
+        return cpp.fem.locate_dofs_topological(_V, entity_dim, entities, remote)
     else:
         try:
-            _V = [V._cpp_object]
+            _V = V._cpp_object
         except AttributeError:
-            _V = [V]
-
-    return cpp.fem.locate_dofs_topological(_V, entity_dim, entities, remote)
+            _V = V
+        return cpp.fem.locate_dofs_topological(_V, entity_dim, entities, remote)
 
 
 class DirichletBC(cpp.fem.DirichletBC):

--- a/python/dolfinx/fem/dirichletbc.py
+++ b/python/dolfinx/fem/dirichletbc.py
@@ -54,13 +54,13 @@ def locate_dofs_geometrical(V: typing.Iterable[typing.Union[cpp.function.Functio
                 _V.append(space._cpp_object)
             except AttributeError:
                 _V.append(space)
+        return cpp.fem.locate_dofs_geometrical(_V, marker)
     else:
         try:
-            _V = [V._cpp_object]
+            _V = V._cpp_object
         except AttributeError:
-            _V = [V]
-
-    return cpp.fem.locate_dofs_geometrical(_V, marker)
+            _V = V
+        return cpp.fem.locate_dofs_geometrical(_V, marker)
 
 
 def locate_dofs_topological(V: typing.Iterable[typing.Union[cpp.function.FunctionSpace, function.FunctionSpace]],

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -457,6 +457,25 @@ void fem(py::module& m)
         py::arg("V"), py::arg("dim"), py::arg("entities"),
         py::arg("remote") = true);
 
-  m.def("locate_dofs_geometrical", &dolfinx::fem::locate_dofs_geometrical);
+  m.def(
+      "locate_dofs_geometrical",
+      [](const std::vector<
+             std::reference_wrapper<const dolfinx::function::FunctionSpace>>& V,
+         const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+             const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
+                                                 Eigen::RowMajor>>&)>& marker) {
+        if (V.size() != 2)
+          throw std::runtime_error("Expected two function spaces.");
+        return dolfinx::fem::locate_dofs_geometrical({V[0], V[1]}, marker);
+      },
+      py::arg("V"), py::arg("marker"));
+  m.def("locate_dofs_geometrical",
+        py::overload_cast<
+            const dolfinx::function::FunctionSpace&,
+            const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+                const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
+                                                    Eigen::RowMajor>>&)>&>(
+            &dolfinx::fem::locate_dofs_geometrical),
+        py::arg("V"), py::arg("marker"));
 }
 } // namespace dolfinx_wrappers

--- a/python/test/unit/fem/test_assemble_cppimport.py
+++ b/python/test/unit/fem/test_assemble_cppimport.py
@@ -94,7 +94,7 @@ m.def("assemble_matrix", &assemble_csr<PetscScalar>);
         if _a.function_spaces[0].id == _a.function_spaces[1].id:
             for bc in bcs:
                 if _a.function_spaces[0].contains(bc.function_space):
-                    bc_dofs = bc.dof_indices[:, 0]
+                    bc_dofs = bc.dof_indices[0]
                     A[bc_dofs, bc_dofs] = 1.0
         return A
 

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -479,6 +479,7 @@ def test_assembly_solve_taylor_hood(mesh):
     u0 = dolfinx.Function(P2)
     u0.vector.set(1.0)
     u0.vector.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+
     bc0 = dolfinx.DirichletBC(u0, bdofs0)
     bc1 = dolfinx.DirichletBC(u0, bdofs1)
 

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -25,12 +25,13 @@ def test_locate_dofs_geometrical():
     dofs = dolfinx.fem.locate_dofs_geometrical(
         (W.sub(0), V), lambda x: np.isclose(x.T, [0, 0, 0]).all(axis=1))
 
-    # Collect dofs from all processes (does not matter that the numbering
-    # is local to each process for this test)
+    # Collect dofs from all processes (does not matter that the
+    # numbering is local to each process for this test)
     all_dofs = np.vstack(MPI.COMM_WORLD.allgather(dofs))
 
     # Check only one dof pair is returned
-    assert len(all_dofs) == 1
+    assert len(all_dofs[0]) == 1
+    assert len(all_dofs[1]) == 1
 
     # On process with the dof pair
     if len(dofs) == 1:

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -27,11 +27,12 @@ def test_locate_dofs_geometrical():
 
     # Collect dofs from all processes (does not matter that the
     # numbering is local to each process for this test)
-    all_dofs = np.vstack(MPI.COMM_WORLD.allgather(dofs))
+    all_dofs0 = np.concatenate(MPI.COMM_WORLD.allgather(dofs[0]))
+    all_dofs1 = np.concatenate(MPI.COMM_WORLD.allgather(dofs[1]))
 
     # Check only one dof pair is returned
-    assert len(all_dofs[0]) == 1
-    assert len(all_dofs[1]) == 1
+    assert len(all_dofs0) == 1
+    assert len(all_dofs1) == 1
 
     # On process with the dof pair
     if len(dofs) == 1:


### PR DESCRIPTION
This small change is for `locate_dofs_topological` and `locate_dofs_geometrical` to return two 1D arrays rather than one 2D array. This is preparatory work for supporting blocked degree-of-freedom maps, in which case the two returns arrays can possibly have different lengths.