### PR TITLE
Fix local writing of meshtags

### DIFF
--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -60,31 +60,32 @@ target_compile_definitions(dolfinx PUBLIC DOLFINX_VERSION="${DOLFINX_VERSION}")
 # UFC
 target_include_directories(dolfinx SYSTEM PUBLIC ${UFC_INCLUDE_DIRS})
 
-# DOLFIN uses Eigen data structures for dense linear algebra operations. Eigen
+# Have left these well written comments about Eigen alignment 
+# here with the intention that this should be moved to build documentation.
+
+# DOLFINX uses Eigen data structures for dense linear algebra operations. Eigen
 # performs 'ideal' memory alignment based around the -march flag passed to the
 # compiler.  However, because Python DOLFIN JIT compiles code at runtime, it is
 # possible for the user to build shared objects with incompatible alignment
 # (ABI) if they use a different -march flag than that used to originally build
-# DOLFIN. DOLFINX_EIGEN_MAX_ALIGN_BYTES can be used to force alignment.
+# DOLFINX. EIGEN_MAX_ALIGN_BYTES can be used to force alignment.
 # See: https://eigen.tuxfamily.org/dox/TopicPreprocessorDirectives.html
 # See: https://github.com/FEniCS/dolfinx/pull/143
+
+# Advice: Minimum alignment in bytes used for Eigen data structures. Set to 32 for
+# compatibility with AVX user-compiled code and 64 for AVX-512 user-compiled
+# code. Set to 0 for ideal alignment according to -march. Note that if an architecture
+# flag (e.g. "-march=skylake-avx512") is set for DOLFIN, Eigen will use the
+# appropriate ideal alignment instead if it is stricter. Otherwise, the value
+# of this variable will be used by Eigen for the alignment of all data structures.
 
 # Note: The name EIGEN_MAX_ALIGN_BYTES is confusing. In practice, Eigen
 # computes the ideal alignment based around -march.  If the ideal alignment is
 # greater than EIGEN_MAX_ALIGN_BYTES, the ideal alignment is used. If the ideal
 # alignment is less, then EIGEN_MAX_ALIGN_BYTES is used for alignment.
-set(DOLFINX_EIGEN_MAX_ALIGN_BYTES "32" CACHE STRING "\
-Minimum alignment in bytes used for Eigen data structures. Set to 32 for \
-compatibility with AVX user-compiled code and 64 for AVX-512 user-compiled \
-code. Set to 0 for ideal alignment according to -march. Note that if an architecture \
-flag (e.g. \"-march=skylake-avx512\") is set for DOLFIN, Eigen will use the \
-appropriate ideal alignment instead if it is stricter. Otherwise, the value \
-of this variable will be used by Eigen for the alignment of all data structures.\\
-")
 
 # Eigen3
 target_include_directories(dolfinx SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIR})
-target_compile_definitions(dolfinx PUBLIC "EIGEN_MAX_ALIGN_BYTES=${DOLFINX_EIGEN_MAX_ALIGN_BYTES}")
 
 # Boost
 target_link_libraries(dolfinx PUBLIC Boost::headers)

--- a/cpp/dolfinx/io/xdmf_meshtags.h
+++ b/cpp/dolfinx/io/xdmf_meshtags.h
@@ -38,21 +38,16 @@ void add_meshtags(MPI_Comm comm, const mesh::MeshTags<T>& meshtags,
   const std::vector<std::int32_t>& active_entities = meshtags.indices();
   const std::vector<T>& values = meshtags.values();
 
-  // Remove ghost indices (note that indices are sorted)
-  std::int32_t num_entities = 0;
-  const std::int32_t num_active_entities = active_entities.size();
-  for (std::int32_t i = 0; i < num_active_entities; ++i)
-  {
-    if (active_entities[i] < num_local_entities)
-      ++num_entities;
-    else
-      break;
-  }
+  // Find number of tagged entities in local range
+  const int num_active_entities
+      = std::lower_bound(active_entities.begin(), active_entities.end(),
+                         num_local_entities)
+        - active_entities.begin();
 
   const std::vector<std::int32_t> local_entities(
-      active_entities.begin(), active_entities.begin() + num_entities);
+      active_entities.begin(), active_entities.begin() + num_active_entities);
   const std::vector<T> local_values(values.begin(),
-                                    values.begin() + num_entities);
+                                    values.begin() + num_active_entities);
   const std::string path_prefix = "/MeshTags/" + name;
   xdmf_mesh::add_topology_data(comm, xml_node, h5_id, path_prefix,
                                mesh->topology(), mesh->geometry(), dim,

--- a/cpp/dolfinx/io/xdmf_meshtags.h
+++ b/cpp/dolfinx/io/xdmf_meshtags.h
@@ -32,23 +32,27 @@ void add_meshtags(MPI_Comm comm, const mesh::MeshTags<T>& meshtags,
   assert(meshtags.mesh());
   std::shared_ptr<const mesh::Mesh> mesh = meshtags.mesh();
   const int dim = meshtags.dim();
-  const int local_range = mesh->topology().index_map(dim)->size_local();
+  const std::int32_t num_local_entities
+      = mesh->topology().index_map(dim)->size_local()
+        * mesh->topology().index_map(dim)->block_size();
   const std::vector<std::int32_t>& active_entities = meshtags.indices();
-  const std::vector<std::int32_t>& values = meshtags.values();
+  const std::vector<T>& values = meshtags.values();
 
   // Remove ghost indices (note that indices are sorted)
-  int num_local_entities = 0;
-  for (std::uint32_t i = 0; i < active_entities.size(); ++i)
+  std::int32_t num_entities = 0;
+  const std::int32_t num_active_entities = active_entities.size();
+  for (std::int32_t i = 0; i < num_active_entities; ++i)
   {
-    if (active_entities[i] < local_range)
-      ++num_local_entities;
+    if (active_entities[i] < num_local_entities)
+      ++num_entities;
     else
       break;
   }
+
   const std::vector<std::int32_t> local_entities(
-      active_entities.begin(), active_entities.begin() + num_local_entities);
+      active_entities.begin(), active_entities.begin() + num_entities);
   const std::vector<T> local_values(values.begin(),
-                                    values.begin() + num_local_entities);
+                                    values.begin() + num_entities);
   const std::string path_prefix = "/MeshTags/" + name;
   xdmf_mesh::add_topology_data(comm, xml_node, h5_id, path_prefix,
                                mesh->topology(), mesh->geometry(), dim,


### PR DESCRIPTION
Currently `XDMFFile.write_meshtags` writes ghost entities, which results in major duplication + visualization issues.
This PR changes `write_meshtags` such that it only writes owned entities (instead of owned + ghosted entities).

MWE:
```
from dolfinx import UnitCubeMesh, MeshTags
from dolfinx.io import XDMFFile
from mpi4py import MPI
import numpy as np

comm_world = MPI.COMM_WORLD
comm_self = MPI.COMM_SELF

if comm_world.rank == 0:
    mesh = UnitCubeMesh(comm_self, 10, 10, 10)
    mesh.name = "mesh"
    num_cells = mesh.topology.index_map(mesh.topology.dim).size_local
    indices = np.arange(num_cells, dtype=np.int32)
    values = np.ones(num_cells, dtype=np.int32)
    mt = MeshTags(mesh, mesh.topology.dim, indices, values)
    mt.name = "cells"
    with XDMFFile(comm_self, "mesh_serial.xdmf", "w") as xdmf:
        xdmf.write_mesh(mesh)
        xdmf.write_meshtags(mt)
    print("Serial indices:", len(mt.indices))
comm_world.barrier()


with XDMFFile(comm_world, "mesh_serial.xdmf", "r") as xdmf:
    mesh2 = xdmf.read_mesh(name="mesh")
    mt2 = xdmf.read_meshtags(mesh2, name="cells")
    print("Parallel indices:", len(mt2.indices))

with XDMFFile(comm_world, "mesh_parallel.xdmf", "w") as xdmf:
    xdmf.write_mesh(mesh2)
    xdmf.write_meshtags(mt2)
```