### PR TITLE
Remove block size from IndexMap

### DIFF
--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -20,11 +20,12 @@ public:
       std::shared_ptr<fem::Form<PetscScalar>> J,
       std::vector<std::shared_ptr<const fem::DirichletBC<PetscScalar>>> bcs)
       : _u(u), _l(L), _j(J), _bcs(bcs),
-        _b(L->function_spaces()[0]->dofmap()->index_map),
+        _b(L->function_spaces()[0]->dofmap()->index_map,
+           L->function_spaces()[0]->dofmap()->index_map_bs()),
         _matA(fem::create_matrix(*J))
   {
     auto map = L->function_spaces()[0]->dofmap()->index_map;
-    const int bs = map->block_size();
+    const int bs = L->function_spaces()[0]->dofmap()->index_map_bs();
     std::int32_t size_local = bs * map->size_local();
     std::int32_t num_ghosts = bs * map->num_ghosts();
     const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>& ghosts = map->ghosts();

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -116,6 +116,8 @@ int main(int argc, char* argv[])
   common::SubSystemsManager::init_petsc(argc, argv);
 
   {
+    std::cout << "Stage 0" << std::endl;
+
     // Create mesh and function space
     auto cmap = fem::create_coordinate_map(create_coordinate_map_poisson);
     auto mesh = std::make_shared<mesh::Mesh>(generation::RectangleMesh::create(
@@ -137,15 +139,19 @@ int main(int argc, char* argv[])
     // Prepare and set Constants for the bilinear form
     auto kappa = std::make_shared<function::Constant<PetscScalar>>(2.0);
 
+    std::cout << "Stage 1" << std::endl;
     auto f = std::make_shared<function::Function<PetscScalar>>(V);
+    std::cout << "Stage 1b" << std::endl;
     auto g = std::make_shared<function::Function<PetscScalar>>(V);
 
     // Define variational forms
+    std::cout << "Stage 1c" << std::endl;
     auto a = fem::create_form<PetscScalar>(create_form_poisson_a, {V, V}, {},
                                            {{"kappa", kappa}}, {});
+    std::cout << "Stage 1d" << std::endl;
     auto L = fem::create_form<PetscScalar>(create_form_poisson_L, {V},
                                            {{"f", f}, {"g", g}}, {}, {});
-
+    std::cout << "Stage 2" << std::endl;
     // Now, the Dirichlet boundary condition (:math:`u = 0`) can be created
     // using the class :cpp:class:`DirichletBC`. A :cpp:class:`DirichletBC`
     // takes two arguments: the value of the boundary condition,
@@ -189,10 +195,14 @@ int main(int argc, char* argv[])
     // .. code-block:: cpp
 
     // Compute solution
+    std::cout << "Stage 3" << std::endl;
     function::Function<PetscScalar> u(V);
+    std::cout << "Stage 4" << std::endl;
     la::PETScMatrix A = fem::create_matrix(*a);
+    std::cout << "Stage 5" << std::endl;
     la::PETScVector b(*L->function_spaces()[0]->dofmap()->index_map,
                       L->function_spaces()[0]->dofmap()->index_map_bs());
+    std::cout << "Stage 6" << std::endl;
 
     MatZeroEntries(A.mat());
     fem::assemble_matrix(la::PETScMatrix::add_fn(A.mat()), *a, bc);

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -191,7 +191,8 @@ int main(int argc, char* argv[])
     // Compute solution
     function::Function<PetscScalar> u(V);
     la::PETScMatrix A = fem::create_matrix(*a);
-    la::PETScVector b(*L->function_spaces()[0]->dofmap()->index_map);
+    la::PETScVector b(*L->function_spaces()[0]->dofmap()->index_map,
+                      L->function_spaces()[0]->dofmap()->index_map_bs());
 
     MatZeroEntries(A.mat());
     fem::assemble_matrix(la::PETScMatrix::add_fn(A.mat()), *a, bc);

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -116,14 +116,12 @@ int main(int argc, char* argv[])
   common::SubSystemsManager::init_petsc(argc, argv);
 
   {
-    std::cout << "Stage 0" << std::endl;
-
     // Create mesh and function space
     auto cmap = fem::create_coordinate_map(create_coordinate_map_poisson);
     auto mesh = std::make_shared<mesh::Mesh>(generation::RectangleMesh::create(
         MPI_COMM_WORLD,
         {Eigen::Vector3d(0.0, 0.0, 0.0), Eigen::Vector3d(1.0, 1.0, 0.0)},
-        {32, 32}, cmap, mesh::GhostMode::none));
+        {32, 32}, cmap, mesh::GhostMode::shared_facet));
 
     auto V = fem::create_functionspace(create_functionspace_form_poisson_a, "u",
                                        mesh);
@@ -138,20 +136,15 @@ int main(int argc, char* argv[])
 
     // Prepare and set Constants for the bilinear form
     auto kappa = std::make_shared<function::Constant<PetscScalar>>(2.0);
-
-    std::cout << "Stage 1" << std::endl;
     auto f = std::make_shared<function::Function<PetscScalar>>(V);
-    std::cout << "Stage 1b" << std::endl;
     auto g = std::make_shared<function::Function<PetscScalar>>(V);
 
     // Define variational forms
-    std::cout << "Stage 1c" << std::endl;
     auto a = fem::create_form<PetscScalar>(create_form_poisson_a, {V, V}, {},
                                            {{"kappa", kappa}}, {});
-    std::cout << "Stage 1d" << std::endl;
     auto L = fem::create_form<PetscScalar>(create_form_poisson_L, {V},
                                            {{"f", f}, {"g", g}}, {}, {});
-    std::cout << "Stage 2" << std::endl;
+
     // Now, the Dirichlet boundary condition (:math:`u = 0`) can be created
     // using the class :cpp:class:`DirichletBC`. A :cpp:class:`DirichletBC`
     // takes two arguments: the value of the boundary condition,
@@ -195,14 +188,10 @@ int main(int argc, char* argv[])
     // .. code-block:: cpp
 
     // Compute solution
-    std::cout << "Stage 3" << std::endl;
     function::Function<PetscScalar> u(V);
-    std::cout << "Stage 4" << std::endl;
     la::PETScMatrix A = fem::create_matrix(*a);
-    std::cout << "Stage 5" << std::endl;
     la::PETScVector b(*L->function_spaces()[0]->dofmap()->index_map,
                       L->function_spaces()[0]->dofmap()->index_map_bs());
-    std::cout << "Stage 6" << std::endl;
 
     MatZeroEntries(A.mat());
     fem::assemble_matrix(la::PETScMatrix::add_fn(A.mat()), *a, bc);

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -547,7 +547,7 @@ std::vector<std::int32_t> IndexMap::global_to_local(
     else
     {
       if (auto it = global_to_local.find(index); it != global_to_local.end())
-        local.push_back(it->second + index);
+        local.push_back(it->second);
       else
         local.push_back(-1);
     }

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -27,11 +27,11 @@ void local_to_global_impl(
     const std::div_t pos = std::div(indices[i], bs);
     const std::int32_t index_block = pos.quot;
     if (index_block < local_size)
-      global[i] = global_offset + bs * index_block + pos.rem;
+      global[i] = bs * (global_offset + index_block) + pos.rem;
     else
     {
       assert((index_block - local_size) < ghosts.size());
-      global[i] = bs * ghosts[index_block - local_size] + pos.quot;
+      global[i] = bs * ghosts[index_block - local_size] + pos.rem;
     }
   }
 }

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -518,18 +518,16 @@ std::vector<std::int64_t> IndexMap::global_indices() const
 }
 //-----------------------------------------------------------------------------
 std::vector<std::int32_t>
-IndexMap::global_to_local_block(const std::vector<std::int64_t>& indices,
-                                int bs) const
+IndexMap::global_to_local(const std::vector<std::int64_t>& indices) const
 {
   const Eigen::Map<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>
       _indices(indices.data(), indices.size());
-  return this->global_to_local_block(_indices, bs);
+  return this->global_to_local(_indices);
 }
 //-----------------------------------------------------------------------------
-std::vector<std::int32_t> IndexMap::global_to_local_block(
+std::vector<std::int32_t> IndexMap::global_to_local(
     const Eigen::Ref<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>&
-        indices,
-    int bs) const
+        indices) const
 {
   const std::int32_t local_size = _local_range[1] - _local_range[0];
 
@@ -544,16 +542,12 @@ std::vector<std::int32_t> IndexMap::global_to_local_block(
   for (Eigen::Index i = 0; i < indices.size(); ++i)
   {
     const std::int64_t index = indices[i];
-    if (index >= bs * range[0] and index < bs * range[1])
-      local.push_back(index - bs * range[0]);
+    if (index >= range[0] and index < range[1])
+      local.push_back(index - range[0]);
     else
     {
-      const std::int64_t index_block = index / bs;
-      if (auto it = global_to_local.find(index_block);
-          it != global_to_local.end())
-      {
-        local.push_back(it->second * bs + index % bs);
-      }
+      if (auto it = global_to_local.find(index); it != global_to_local.end())
+        local.push_back(it->second + index);
       else
         local.push_back(-1);
     }

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -479,7 +479,7 @@ const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>& IndexMap::ghosts() const
   return _ghosts;
 }
 //-----------------------------------------------------------------------------
-Eigen::Array<std::int64_t, Eigen::Dynamic, 1> IndexMap::local_to_global(
+Eigen::Array<std::int64_t, Eigen::Dynamic, 1> IndexMap::local_to_global_block(
     const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>&
         indices,
     int bs) const
@@ -492,8 +492,8 @@ Eigen::Array<std::int64_t, Eigen::Dynamic, 1> IndexMap::local_to_global(
 }
 //-----------------------------------------------------------------------------
 std::vector<std::int64_t>
-IndexMap::local_to_global(const std::vector<std::int32_t>& indices,
-                          int bs) const
+IndexMap::local_to_global_block(const std::vector<std::int32_t>& indices,
+                                int bs) const
 {
   const std::int64_t global_offset = _local_range[0];
   const std::int32_t local_size = _local_range[1] - _local_range[0];
@@ -522,15 +522,15 @@ std::vector<std::int64_t> IndexMap::global_indices() const
 }
 //-----------------------------------------------------------------------------
 std::vector<std::int32_t>
-IndexMap::global_to_local(const std::vector<std::int64_t>& indices,
-                          int bs) const
+IndexMap::global_to_local_block(const std::vector<std::int64_t>& indices,
+                                int bs) const
 {
   const Eigen::Map<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>
       _indices(indices.data(), indices.size());
-  return this->global_to_local(_indices, bs);
+  return this->global_to_local_block(_indices, bs);
 }
 //-----------------------------------------------------------------------------
-std::vector<std::int32_t> IndexMap::global_to_local(
+std::vector<std::int32_t> IndexMap::global_to_local_block(
     const Eigen::Ref<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>&
         indices,
     int bs) const

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -479,21 +479,19 @@ const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>& IndexMap::ghosts() const
   return _ghosts;
 }
 //-----------------------------------------------------------------------------
-Eigen::Array<std::int64_t, Eigen::Dynamic, 1> IndexMap::local_to_global_block(
+Eigen::Array<std::int64_t, Eigen::Dynamic, 1> IndexMap::local_to_global(
     const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>&
-        indices,
-    int bs) const
+        indices) const
 {
   const std::int64_t global_offset = _local_range[0];
   const std::int32_t local_size = _local_range[1] - _local_range[0];
   Eigen::Array<std::int64_t, Eigen::Dynamic, 1> global(indices.rows());
-  local_to_global_impl(global, indices, global_offset, local_size, _ghosts, bs);
+  local_to_global_impl(global, indices, global_offset, local_size, _ghosts, 1);
   return global;
 }
 //-----------------------------------------------------------------------------
 std::vector<std::int64_t>
-IndexMap::local_to_global_block(const std::vector<std::int32_t>& indices,
-                                int bs) const
+IndexMap::local_to_global(const std::vector<std::int32_t>& indices) const
 {
   const std::int64_t global_offset = _local_range[0];
   const std::int32_t local_size = _local_range[1] - _local_range[0];
@@ -504,7 +502,7 @@ IndexMap::local_to_global_block(const std::vector<std::int32_t>& indices,
   const Eigen::Map<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>
       _indices(indices.data(), indices.size());
   local_to_global_impl(_global, _indices, global_offset, local_size, _ghosts,
-                       bs);
+                       1);
   return global;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -464,16 +464,17 @@ std::array<std::int64_t, 2> IndexMap::local_range() const noexcept
   return _local_range;
 }
 //-----------------------------------------------------------------------------
-std::int32_t IndexMap::num_ghosts() const { return _ghosts.rows(); }
+std::int32_t IndexMap::num_ghosts() const noexcept { return _ghosts.rows(); }
 //-----------------------------------------------------------------------------
-std::int32_t IndexMap::size_local() const
+std::int32_t IndexMap::size_local() const noexcept
 {
   return _local_range[1] - _local_range[0];
 }
 //-----------------------------------------------------------------------------
-std::int64_t IndexMap::size_global() const { return _size_global; }
+std::int64_t IndexMap::size_global() const noexcept { return _size_global; }
 //-----------------------------------------------------------------------------
-const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>& IndexMap::ghosts() const
+const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>&
+IndexMap::ghosts() const noexcept
 {
   return _ghosts;
 }
@@ -556,7 +557,7 @@ std::vector<std::int32_t> IndexMap::global_to_local(
   return local;
 }
 //-----------------------------------------------------------------------------
-const std::vector<std::int32_t>& IndexMap::shared_indices() const
+const std::vector<std::int32_t>& IndexMap::shared_indices() const noexcept
 {
   return _shared_indices;
 }
@@ -580,15 +581,12 @@ Eigen::Array<int, Eigen::Dynamic, 1> IndexMap::ghost_owner_rank() const
 //----------------------------------------------------------------------------
 Eigen::Array<std::int64_t, Eigen::Dynamic, 1> IndexMap::indices() const
 {
-  const int bs = 1;
   const std::array local_range = this->local_range();
-  const std::int32_t size_local = this->size_local() * bs;
-  Eigen::Array<std::int64_t, Eigen::Dynamic, 1> indx(size_local
-                                                     + num_ghosts() * bs);
-  std::iota(indx.data(), indx.data() + size_local, bs * local_range[0]);
+  const std::int32_t size_local = this->size_local();
+  Eigen::Array<std::int64_t, Eigen::Dynamic, 1> indx(size_local + num_ghosts());
+  std::iota(indx.data(), indx.data() + size_local, local_range[0]);
   for (Eigen::Index i = 0; i < num_ghosts(); ++i)
-    for (Eigen::Index j = 0; j < bs; ++j)
-      indx[size_local + bs * i + j] = bs * _ghosts[i] + j;
+    indx[size_local * i] = _ghosts[i];
 
   return indx;
 }

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -33,8 +33,8 @@ std::tuple<std::int64_t, std::vector<std::int32_t>,
            std::vector<std::vector<std::int64_t>>,
            std::vector<std::vector<int>>>
 stack_index_maps(
-    const std::vector<std::reference_wrapper<const common::IndexMap>>& maps,
-    const std::vector<int>& bs);
+    const std::vector<
+        std::pair<std::reference_wrapper<const common::IndexMap>, int>>& maps);
 
 /// This class represents the distribution index arrays across
 /// processes. An index array is a contiguous collection of N+1 indices

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -192,7 +192,7 @@ public:
       int bs) const;
 
   /// Compute local indices for array of global indices
-s  /// @param[in] indices Global indices
+  /// @param[in] indices Global indices
   /// @return The local of the corresponding global index in indices.
   ///   Return -1 if the local index does not exist on this process.
   std::vector<std::int32_t> global_to_local(

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -142,12 +142,6 @@ public:
   /// @return A neighborhood communicator for the specified edge direction
   MPI_Comm comm(Direction dir = Direction::symmetric) const;
 
-  /// TODO
-  // Eigen::Array<std::int64_t, Eigen::Dynamic, 1> local_to_global_block(
-  //     const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>&
-  //         indices,
-  //     int bs) const;
-
   /// Compute global indices for array of local indices
   /// @param[in] indices Local indices
   /// @return The global index of the corresponding local index in
@@ -155,10 +149,6 @@ public:
   Eigen::Array<std::int64_t, Eigen::Dynamic, 1> local_to_global(
       const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>&
           indices) const;
-
-  /// TODO
-  // std::vector<std::int64_t>
-  // local_to_global_block(const std::vector<std::int32_t>& indices, int bs) const;
 
   /// @todo Consider removing this function in favour of the version
   /// that accepts an Eigen array.
@@ -169,9 +159,6 @@ public:
   ///   indices.
   std::vector<std::int64_t>
   local_to_global(const std::vector<std::int32_t>& indices) const;
-  // {
-  //   return local_to_global_block(indices, 1);
-  // }
 
   /// TODO
   std::vector<std::int32_t>

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -104,7 +104,7 @@ public:
           ghosts,
       const std::vector<int>& src_ranks);
 
-  /// Copy constructor
+  // Copy constructor
   IndexMap(const IndexMap& map) = delete;
 
   /// Move constructor
@@ -112,6 +112,12 @@ public:
 
   /// Destructor
   ~IndexMap() = default;
+
+  /// Move assignment
+  IndexMap& operator=(IndexMap&& map) = default;
+
+  // Copy assignment
+  IndexMap& operator=(const IndexMap& map) = delete;
 
   /// Range of indices (global) owned by this process
   std::array<std::int64_t, 2> local_range() const noexcept;
@@ -137,10 +143,10 @@ public:
   MPI_Comm comm(Direction dir = Direction::symmetric) const;
 
   /// TODO
-  Eigen::Array<std::int64_t, Eigen::Dynamic, 1> local_to_global_block(
-      const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>&
-          indices,
-      int bs) const;
+  // Eigen::Array<std::int64_t, Eigen::Dynamic, 1> local_to_global_block(
+  //     const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>&
+  //         indices,
+  //     int bs) const;
 
   /// Compute global indices for array of local indices
   /// @param[in] indices Local indices
@@ -148,14 +154,11 @@ public:
   ///   indices.
   Eigen::Array<std::int64_t, Eigen::Dynamic, 1> local_to_global(
       const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>&
-          indices) const
-  {
-    return local_to_global_block(indices, 1);
-  }
+          indices) const;
 
   /// TODO
-  std::vector<std::int64_t>
-  local_to_global_block(const std::vector<std::int32_t>& indices, int bs) const;
+  // std::vector<std::int64_t>
+  // local_to_global_block(const std::vector<std::int32_t>& indices, int bs) const;
 
   /// @todo Consider removing this function in favour of the version
   /// that accepts an Eigen array.
@@ -165,10 +168,10 @@ public:
   /// @return The global index of the corresponding local index in
   ///   indices.
   std::vector<std::int64_t>
-  local_to_global(const std::vector<std::int32_t>& indices) const
-  {
-    return local_to_global_block(indices, 1);
-  }
+  local_to_global(const std::vector<std::int32_t>& indices) const;
+  // {
+  //   return local_to_global_block(indices, 1);
+  // }
 
   /// TODO
   std::vector<std::int32_t>

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -23,8 +23,7 @@ class IndexMap;
 /// index map, i.e. 'splice' multiple maps into one. Communication is
 /// required to compute the new ghost indices.
 ///
-/// @param[in] maps List of index maps
-/// @param[in] bs Block size for each index map in maps
+/// @param[in] maps List of (index map, block size) pairs
 /// @returns The (0) global offset of a stacked map for this rank, (1)
 ///   local offset for each submap in the stacked map, and (2) new
 ///   indices for the ghosts for each submap (3) owner rank of each ghost

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -139,6 +139,7 @@ public:
 
   /// Compute global indices for array of local indices
   /// @param[in] indices Local indices
+  /// @param[in] bs
   /// @return The global index of the corresponding local index in
   ///   indices.
   Eigen::Array<std::int64_t, Eigen::Dynamic, 1> local_to_global(

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -137,6 +137,12 @@ public:
   /// @return A neighborhood communicator for the specified edge direction
   MPI_Comm comm(Direction dir = Direction::symmetric) const;
 
+  /// TODO
+  Eigen::Array<std::int64_t, Eigen::Dynamic, 1> local_to_global_block(
+      const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>&
+          indices,
+      int bs) const;
+
   /// Compute global indices for array of local indices
   /// @param[in] indices Local indices
   /// @param[in] bs
@@ -144,8 +150,14 @@ public:
   ///   indices.
   Eigen::Array<std::int64_t, Eigen::Dynamic, 1> local_to_global(
       const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>&
-          indices,
-      int bs) const;
+          indices) const
+  {
+    return local_to_global_block(indices, 1);
+  }
+
+  /// TODO
+  std::vector<std::int64_t>
+  local_to_global_block(const std::vector<std::int32_t>& indices, int bs) const;
 
   /// @todo Consider removing this function in favour of the version
   /// that accepts an Eigen array.
@@ -156,7 +168,14 @@ public:
   /// @return The global index of the corresponding local index in
   ///   indices.
   std::vector<std::int64_t>
-  local_to_global(const std::vector<std::int32_t>& indices, int bs) const;
+  local_to_global(const std::vector<std::int32_t>& indices) const
+  {
+    return local_to_global_block(indices, 1);
+  }
+
+  /// TODO
+  std::vector<std::int32_t>
+  global_to_local_block(const std::vector<std::int64_t>& indices, int bs) const;
 
   /// Compute local indices for array of global indices
   /// @param[in] indices Global indices
@@ -164,7 +183,16 @@ public:
   /// @return The local of the corresponding global index in indices.
   ///   Returns -1 if the local index does not exist on this process.
   std::vector<std::int32_t>
-  global_to_local(const std::vector<std::int64_t>& indices, int bs) const;
+  global_to_local(const std::vector<std::int64_t>& indices) const
+  {
+    return global_to_local_block(indices, 1);
+  }
+
+  /// TODO
+  std::vector<std::int32_t> global_to_local_block(
+      const Eigen::Ref<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>&
+          indices,
+      int bs) const;
 
   /// Compute local indices for array of global indices
   /// @param[in] indices Global indices
@@ -173,8 +201,10 @@ public:
   ///   Return -1 if the local index does not exist on this process.
   std::vector<std::int32_t> global_to_local(
       const Eigen::Ref<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>&
-          indices,
-      int bs) const;
+          indices) const
+  {
+    return global_to_local_block(indices, 1);
+  }
 
   /// Global indices
   /// @return The global index for all local indices (0, 1, 2, ...) on

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -123,17 +123,17 @@ public:
   std::array<std::int64_t, 2> local_range() const noexcept;
 
   /// Number of ghost indices on this process
-  std::int32_t num_ghosts() const;
+  std::int32_t num_ghosts() const noexcept;
 
   /// Number of indices owned by on this process
-  std::int32_t size_local() const;
+  std::int32_t size_local() const noexcept;
 
   /// Number indices across communicator
-  std::int64_t size_global() const;
+  std::int64_t size_global() const noexcept;
 
   /// Local-to-global map for ghosts (local indexing beyond end of local
   /// range)
-  const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>& ghosts() const;
+  const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>& ghosts() const noexcept;
 
   /// Return a MPI communicator with attached distributed graph topology
   /// information
@@ -184,7 +184,7 @@ public:
   /// Local (owned) indices shared with neighbor processes, i.e. are
   /// ghosts on other processes
   /// @return List of indices that are ghosted on other processes
-  const std::vector<std::int32_t>& shared_indices() const;
+  const std::vector<std::int32_t>& shared_indices() const noexcept;
 
   /// Owner rank (on global communicator) of each ghost entry
   Eigen::Array<int, Eigen::Dynamic, 1> ghost_owner_rank() const;

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -145,7 +145,6 @@ public:
 
   /// Compute global indices for array of local indices
   /// @param[in] indices Local indices
-  /// @param[in] bs
   /// @return The global index of the corresponding local index in
   ///   indices.
   Eigen::Array<std::int64_t, Eigen::Dynamic, 1> local_to_global(
@@ -164,7 +163,6 @@ public:
   ///
   /// Compute global indices for array of local indices
   /// @param[in] indices Local indices
-  /// @param[in] bs
   /// @return The global index of the corresponding local index in
   ///   indices.
   std::vector<std::int64_t>
@@ -179,7 +177,6 @@ public:
 
   /// Compute local indices for array of global indices
   /// @param[in] indices Global indices
-  /// @param[in] bs
   /// @return The local of the corresponding global index in indices.
   ///   Returns -1 if the local index does not exist on this process.
   std::vector<std::int32_t>
@@ -195,8 +192,7 @@ public:
       int bs) const;
 
   /// Compute local indices for array of global indices
-  /// @param[in] indices Global indices
-  /// @param[in] bs
+s  /// @param[in] indices Global indices
   /// @return The local of the corresponding global index in indices.
   ///   Return -1 if the local index does not exist on this process.
   std::vector<std::int32_t> global_to_local(

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -160,25 +160,12 @@ public:
   std::vector<std::int64_t>
   local_to_global(const std::vector<std::int32_t>& indices) const;
 
-  /// TODO
-  std::vector<std::int32_t>
-  global_to_local_block(const std::vector<std::int64_t>& indices, int bs) const;
-
   /// Compute local indices for array of global indices
   /// @param[in] indices Global indices
   /// @return The local of the corresponding global index in indices.
   ///   Returns -1 if the local index does not exist on this process.
   std::vector<std::int32_t>
-  global_to_local(const std::vector<std::int64_t>& indices) const
-  {
-    return global_to_local_block(indices, 1);
-  }
-
-  /// TODO
-  std::vector<std::int32_t> global_to_local_block(
-      const Eigen::Ref<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>&
-          indices,
-      int bs) const;
+  global_to_local(const std::vector<std::int64_t>& indices) const;
 
   /// Compute local indices for array of global indices
   /// @param[in] indices Global indices
@@ -186,10 +173,7 @@ public:
   ///   Return -1 if the local index does not exist on this process.
   std::vector<std::int32_t> global_to_local(
       const Eigen::Ref<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>&
-          indices) const
-  {
-    return global_to_local_block(indices, 1);
-  }
+          indices) const;
 
   /// Global indices
   /// @return The global index for all local indices (0, 1, 2, ...) on

--- a/cpp/dolfinx/fem/DirichletBC.cpp
+++ b/cpp/dolfinx/fem/DirichletBC.cpp
@@ -174,8 +174,10 @@ get_remote_bcs2(const common::IndexMap& map0, const common::IndexMap& map1,
   return dofs;
 }
 //-----------------------------------------------------------------------------
-Eigen::Array<std::int32_t, Eigen::Dynamic, 2> _locate_dofs_topological(
-    const std::vector<std::reference_wrapper<function::FunctionSpace>>& V,
+std::array<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>, 2>
+_locate_dofs_topological(
+    const std::array<std::reference_wrapper<const function::FunctionSpace>, 2>&
+        V,
     const int dim, const Eigen::Ref<const Eigen::ArrayXi>& entities,
     bool remote)
 {
@@ -288,7 +290,7 @@ Eigen::Array<std::int32_t, Eigen::Dynamic, 2> _locate_dofs_topological(
     dofs(i, 1) = bc_dofs[i][1];
   }
 
-  return dofs;
+  return {dofs.col(0), dofs.col(1)};
 }
 //-----------------------------------------------------------------------------
 
@@ -492,18 +494,22 @@ Eigen::Array<std::int32_t, Eigen::Dynamic, 1> _locate_dofs_geometrical(
 } // namespace
 
 //-----------------------------------------------------------------------------
-Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic>
+std::array<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>, 2>
 fem::locate_dofs_topological(
-    const std::vector<std::reference_wrapper<function::FunctionSpace>>& V,
+    const std::array<std::reference_wrapper<const function::FunctionSpace>, 2>&
+        V,
     const int dim, const Eigen::Ref<const Eigen::ArrayXi>& entities,
     bool remote)
 {
-  if (V.size() == 2)
-    return _locate_dofs_topological(V, dim, entities, remote);
-  else if (V.size() == 1)
-    return _locate_dofs_topological(V[0].get(), dim, entities, remote);
-  else
-    throw std::runtime_error("Expected only 1 or 2 function spaces.");
+  return _locate_dofs_topological(V, dim, entities, remote);
+}
+//-----------------------------------------------------------------------------
+Eigen::Array<std::int32_t, Eigen::Dynamic, 1>
+fem::locate_dofs_topological(const function::FunctionSpace& V, const int dim,
+                             const Eigen::Ref<const Eigen::ArrayXi>& entities,
+                             bool remote)
+{
+  return _locate_dofs_topological(V, dim, entities, remote);
 }
 //-----------------------------------------------------------------------------
 Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic>

--- a/cpp/dolfinx/fem/DirichletBC.cpp
+++ b/cpp/dolfinx/fem/DirichletBC.cpp
@@ -61,7 +61,7 @@ get_remote_bcs1(const common::IndexMap& map, int bs,
   // std::cout << "Case 2" << std::endl;
   std::vector<std::int32_t> dofs_local_block = dofs_local;
   // std::cout << "(A) dofs_local" << bs << std::endl;
-  int rank = dolfinx::MPI::rank(MPI_COMM_WORLD);
+  // int rank = dolfinx::MPI::rank(MPI_COMM_WORLD);
   // if (rank == 1)
   // {
   //   for (auto i : dofs_local_block)

--- a/cpp/dolfinx/fem/DirichletBC.cpp
+++ b/cpp/dolfinx/fem/DirichletBC.cpp
@@ -383,8 +383,10 @@ _locate_dofs_topological(const function::FunctionSpace& V, const int entity_dim,
   return _dofs;
 }
 //-----------------------------------------------------------------------------
-Eigen::Array<std::int32_t, Eigen::Dynamic, 2> _locate_dofs_geometrical(
-    const std::vector<std::reference_wrapper<function::FunctionSpace>>& V,
+std::array<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>, 2>
+_locate_dofs_geometrical(
+    const std::array<std::reference_wrapper<const function::FunctionSpace>, 2>&
+        V,
     const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker)
@@ -459,7 +461,7 @@ Eigen::Array<std::int32_t, Eigen::Dynamic, 2> _locate_dofs_geometrical(
     dofs(i, 1) = bc_dofs[i][1];
   }
 
-  return dofs;
+  return {dofs.col(0), dofs.col(1)};
 }
 //-----------------------------------------------------------------------------
 Eigen::Array<std::int32_t, Eigen::Dynamic, 1> _locate_dofs_geometrical(
@@ -512,18 +514,23 @@ fem::locate_dofs_topological(const function::FunctionSpace& V, const int dim,
   return _locate_dofs_topological(V, dim, entities, remote);
 }
 //-----------------------------------------------------------------------------
-Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic>
+std::array<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>, 2>
 fem::locate_dofs_geometrical(
-    const std::vector<std::reference_wrapper<function::FunctionSpace>>& V,
+    const std::array<std::reference_wrapper<const function::FunctionSpace>, 2>&
+        V,
     const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker)
 {
-  if (V.size() == 2)
-    return _locate_dofs_geometrical(V, marker);
-  else if (V.size() == 1)
-    return _locate_dofs_geometrical(V[0].get(), marker);
-  else
-    throw std::runtime_error("Expected only 1 or 2 function spaces.");
+  return _locate_dofs_geometrical(V, marker);
+}
+//-----------------------------------------------------------------------------
+Eigen::Array<std::int32_t, Eigen::Dynamic, 1> fem::locate_dofs_geometrical(
+    const function::FunctionSpace& V,
+    const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+        const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
+                                            Eigen::RowMajor>>&)>& marker)
+{
+  return _locate_dofs_geometrical(V, marker);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/DirichletBC.cpp
+++ b/cpp/dolfinx/fem/DirichletBC.cpp
@@ -57,7 +57,7 @@ get_remote_bcs1(const common::IndexMap& map, int bs,
   // NOTE: we could consider only dofs that we know are shared
   // Build array of global indices of dofs
   const std::vector<std::int64_t> dofs_global
-      = map.local_to_global(dofs_local, bs);
+      = map.local_to_global_block(dofs_local, bs);
 
   // Compute displacements for data to receive. Last entry has total
   // number of received items.
@@ -80,7 +80,7 @@ get_remote_bcs1(const common::IndexMap& map, int bs,
   // FIXME: check that dofs is sorted
   // Build vector of local dof indicies that have been marked by another
   // process
-  std::vector<std::int32_t> dofs = map.global_to_local(dofs_received, bs);
+  std::vector<std::int32_t> dofs = map.global_to_local_block(dofs_received, bs);
   dofs.erase(std::remove(dofs.begin(), dofs.end(), -1), dofs.end());
 
   return dofs;
@@ -127,8 +127,9 @@ get_remote_bcs2(const common::IndexMap& map0, const common::IndexMap& map1,
   // Build array of global indices of dofs
   Eigen::Array<std::int64_t, Eigen::Dynamic, 2, Eigen::RowMajor> dofs_global(
       dofs_local.size(), 2);
-  dofs_global.col(0) = map0.local_to_global(dofs_local0, false);
-  dofs_global.col(1) = map1.local_to_global(dofs_local1, false);
+  throw std::runtime_error("Needs updating");
+  // dofs_global.col(0) = map0.local_to_global_block(dofs_local0, false);
+  // dofs_global.col(1) = map1.local_to_global_block(dofs_local1, false);
 
   // Compute displacements for data to receive. Last entry has total
   // number of received items.
@@ -159,8 +160,9 @@ get_remote_bcs2(const common::IndexMap& map0, const common::IndexMap& map1,
     dofs_received1[i] = dofs_received(i, 1);
   }
 
-  std::vector dofs0 = map0.global_to_local(dofs_received0, false);
-  std::vector dofs1 = map1.global_to_local(dofs_received1, false);
+  throw std::runtime_error("Needs updating for bs");
+  std::vector dofs0 = map0.global_to_local_block(dofs_received0, 0);
+  std::vector dofs1 = map1.global_to_local_block(dofs_received1, 0);
 
   // FIXME: check that dofs is sorted
   dofs0.erase(std::remove(dofs0.begin(), dofs0.end(), -1), dofs0.end());

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -150,7 +150,7 @@ public:
       : _function_space(g->function_space()), _g(g), _dofs({dofs, dofs})
   {
     // Stack indices as columns, fits column-major _dofs layout
-    const int owned_size = _function_space->dofmap()->index_map->block_size()
+    const int owned_size = _function_space->dofmap()->index_map_bs()
                            * _function_space->dofmap()->index_map->size_local();
     auto* it = std::lower_bound(_dofs[0].data(),
                                 _dofs[0].data() + _dofs[0].rows(), owned_size);
@@ -172,7 +172,7 @@ public:
               std::shared_ptr<const function::FunctionSpace> V)
       : _function_space(V), _g(g), _dofs({V_g_dofs[0], V_g_dofs[1]})
   {
-    const int owned_size = _function_space->dofmap()->index_map->block_size()
+    const int owned_size = _function_space->dofmap()->index_map_bs()
                            * _function_space->dofmap()->index_map->size_local();
     auto* it = std::lower_bound(_dofs[0].data(),
                                 _dofs[0].data() + _dofs[0].rows(), owned_size);

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -95,7 +95,7 @@ locate_dofs_geometrical(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker);
 
-// TODO
+/// TODO
 Eigen::Array<std::int32_t, Eigen::Dynamic, 1> locate_dofs_geometrical(
     const function::FunctionSpace& V,
     const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -87,9 +87,17 @@ locate_dofs_topological(const function::FunctionSpace& V, const int dim,
 ///     two spaces are passed in). If two spaces are passed in, the (i,
 ///     0) entry is the DOF index in the space V[0] and (i, 1) is the
 ///     correspinding DOF entry in the space V[1].
-Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic>
+std::array<Eigen::Array<std::int32_t, Eigen::Dynamic, 1>, 2>
 locate_dofs_geometrical(
-    const std::vector<std::reference_wrapper<function::FunctionSpace>>& V,
+    const std::array<std::reference_wrapper<const function::FunctionSpace>, 2>&
+        V,
+    const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+        const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
+                                            Eigen::RowMajor>>&)>& marker);
+
+// TODO
+Eigen::Array<std::int32_t, Eigen::Dynamic, 1> locate_dofs_geometrical(
+    const function::FunctionSpace& V,
     const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker);

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -143,7 +143,6 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
                           Eigen::RowMajor>>
       _dofmap(dofmap.data(), dofmap.rows() / cell_dimension, cell_dimension);
 
-  // FIXME X
   return fem::DofMap(element_dof_layout, index_map, 1,
                      graph::AdjacencyList<std::int32_t>(_dofmap));
 }

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -40,16 +40,14 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
       dofmap_view.element_dof_layout->copy());
   assert(element_dof_layout);
 
-  if (dofmap_view.index_map->block_size() == 1
-      and element_dof_layout->block_size() > 1)
+  if (dofmap_view.index_map_bs() == 1 and element_dof_layout->block_size() > 1)
   {
     throw std::runtime_error(
         "Cannot collapse dofmap with block size greater "
         "than 1 from parent with block size of 1. Create new dofmap first.");
   }
 
-  if (dofmap_view.index_map->block_size() > 1
-      and element_dof_layout->block_size() > 1)
+  if (dofmap_view.index_map_bs() > 1 and element_dof_layout->block_size() > 1)
   {
     throw std::runtime_error(
         "Cannot (yet) collapse dofmap with block size greater "
@@ -74,7 +72,7 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
   dofs_view.erase(std::unique(dofs_view.begin(), dofs_view.end()),
                   dofs_view.end());
   // Get block sizes
-  const int bs_view = dofmap_view.index_map->block_size();
+  const int bs_view = dofmap_view.index_map_bs();
 
   // Compute sizes
   const std::int32_t num_owned_view = dofmap_view.index_map->size_local();
@@ -121,7 +119,7 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
       comm, num_owned,
       dolfinx::MPI::compute_graph_edges(
           comm, std::set<int>(ghost_owners.begin(), ghost_owners.end())),
-      ghosts, ghost_owners, 1);
+      ghosts, ghost_owners);
 
   // Create array from dofs in view to new dof indices
   std::vector<std::int32_t> old_to_new(dofs_view.back() + 1, -1);
@@ -145,7 +143,8 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
                           Eigen::RowMajor>>
       _dofmap(dofmap.data(), dofmap.rows() / cell_dimension, cell_dimension);
 
-  return fem::DofMap(element_dof_layout, index_map,
+  // FIXME X
+  return fem::DofMap(element_dof_layout, index_map, 1,
                      graph::AdjacencyList<std::int32_t>(_dofmap));
 }
 
@@ -196,9 +195,10 @@ fem::transpose_dofmap(graph::AdjacencyList<std::int32_t>& dofmap,
 //-----------------------------------------------------------------------------
 DofMap::DofMap(std::shared_ptr<const ElementDofLayout> element_dof_layout,
                std::shared_ptr<const common::IndexMap> index_map,
+               int index_map_bs,
                const graph::AdjacencyList<std::int32_t>& dofmap)
     : element_dof_layout(element_dof_layout), index_map(index_map),
-      _dofmap(dofmap)
+      _index_map_bs(index_map_bs), _dofmap(dofmap)
 {
   // Dofmap data is copied as the types for dofmap and _dofmap may
   // differ, typically 32- vs 64-bit integers
@@ -229,7 +229,7 @@ DofMap DofMap::extract_sub_dofmap(const std::vector<int>& component) const
       dofmap(c, i) = cell_dmap_parent[sub_element_map_view[i]];
   }
 
-  return DofMap(sub_element_dof_layout, this->index_map,
+  return DofMap(sub_element_dof_layout, this->index_map, this->index_map_bs(),
                 graph::AdjacencyList<std::int32_t>(dofmap));
 }
 //-----------------------------------------------------------------------------
@@ -245,8 +245,7 @@ DofMap::collapse(MPI_Comm comm, const mesh::Topology& topology) const
   // new submap to get block structure for collapsed dofmap.
   // Create new dofmap
   std::unique_ptr<DofMap> dofmap_new;
-  if (this->index_map->block_size() == 1
-      and this->element_dof_layout->block_size() > 1)
+  if (this->index_map_bs() == 1 and this->element_dof_layout->block_size() > 1)
   {
     // Create new element dof layout and reset parent
     auto collapsed_dof_layout
@@ -254,9 +253,9 @@ DofMap::collapse(MPI_Comm comm, const mesh::Topology& topology) const
 
     // Parent does not have block structure but sub-map does, so build
     // new submap to get block structure for collapsed dofmap.
-    auto [index_map, dofmap]
+    auto [index_map, bs, dofmap]
         = DofMapBuilder::build(comm, topology, *collapsed_dof_layout);
-    dofmap_new = std::make_unique<DofMap>(element_dof_layout, index_map,
+    dofmap_new = std::make_unique<DofMap>(element_dof_layout, index_map, bs,
                                           std::move(dofmap));
   }
   else
@@ -271,7 +270,7 @@ DofMap::collapse(MPI_Comm comm, const mesh::Topology& topology) const
   auto index_map_new = dofmap_new->index_map;
   const std::int32_t size
       = (index_map_new->size_local() + index_map_new->num_ghosts())
-        * index_map_new->block_size();
+        * dofmap_new->index_map_bs();
   std::vector<std::int32_t> collapsed_map(size);
 
   const int tdim = topology.dim();
@@ -291,4 +290,11 @@ DofMap::collapse(MPI_Comm comm, const mesh::Topology& topology) const
 
   return {std::move(dofmap_new), std::move(collapsed_map)};
 }
+//-----------------------------------------------------------------------------
+const graph::AdjacencyList<std::int32_t>& DofMap::list() const
+{
+  return _dofmap;
+}
+//-----------------------------------------------------------------------------
+int DofMap::index_map_bs() const { return _index_map_bs; }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/DofMap.h
+++ b/cpp/dolfinx/fem/DofMap.h
@@ -69,7 +69,7 @@ public:
   /// IndexMap defining the distribution of dofs across processes and a
   /// vector of indices
   DofMap(std::shared_ptr<const ElementDofLayout> element_dof_layout,
-         std::shared_ptr<const common::IndexMap> index_map,
+         std::shared_ptr<const common::IndexMap> index_map, int index_map_bs,
          const graph::AdjacencyList<std::int32_t>& dofmap);
 
   // Copy constructor
@@ -112,7 +112,7 @@ public:
 
   /// Get dofmap data
   /// @return The adjacency list with dof indices for each cell
-  const graph::AdjacencyList<std::int32_t>& list() const { return _dofmap; }
+  const graph::AdjacencyList<std::int32_t>& list() const;
 
   /// Layout of dofs on an element
   std::shared_ptr<const ElementDofLayout> element_dof_layout;
@@ -120,7 +120,13 @@ public:
   /// Index map that described the parallel distribution of the dofmap
   std::shared_ptr<const common::IndexMap> index_map;
 
+  /// Index map that described the parallel distribution of the dofmap
+  int index_map_bs() const;
+
 private:
+  // Cell-local-to-dof map (dofs for cell dofmap[cell])
+  int _index_map_bs = -1;
+
   // Cell-local-to-dof map (dofs for cell dofmap[cell])
   graph::AdjacencyList<std::int32_t> _dofmap;
 };

--- a/cpp/dolfinx/fem/DofMapBuilder.cpp
+++ b/cpp/dolfinx/fem/DofMapBuilder.cpp
@@ -85,7 +85,6 @@ build_basic_dofmap(const mesh::Topology& topology,
     {
       auto map = topology.index_map(d);
       assert(map);
-      // FIXME X
       global_indices[d] = map->global_indices();
     }
   }

--- a/cpp/dolfinx/fem/DofMapBuilder.h
+++ b/cpp/dolfinx/fem/DofMapBuilder.h
@@ -40,7 +40,8 @@ namespace DofMapBuilder
 /// @param[in] element_dof_layout The element dof layout for the function
 /// space
 /// @return The index map and local to global DOF data for the DOF map.
-std::pair<std::shared_ptr<common::IndexMap>, graph::AdjacencyList<std::int32_t>>
+std::tuple<std::shared_ptr<common::IndexMap>, int,
+           graph::AdjacencyList<std::int32_t>>
 build(MPI_Comm comm, const mesh::Topology& topology,
       const ElementDofLayout& element_dof_layout);
 

--- a/cpp/dolfinx/fem/SparsityPatternBuilder.cpp
+++ b/cpp/dolfinx/fem/SparsityPatternBuilder.cpp
@@ -49,7 +49,6 @@ void SparsityPatternBuilder::interior_facets(
   // Loop over owned facets
   auto map = topology.index_map(D - 1);
   assert(map);
-  assert(map->block_size() == 1);
   const std::int32_t num_facets = map->size_local();
   for (int f = 0; f < num_facets; ++f)
   {
@@ -93,7 +92,6 @@ void SparsityPatternBuilder::exterior_facets(
   // Loop over owned facets
   auto map = topology.index_map(D - 1);
   assert(map);
-  assert(map->block_size() == 1);
   const std::int32_t num_facets = map->size_local();
   for (int f = 0; f < num_facets; ++f)
   {

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -828,9 +828,9 @@ void apply_lifting(
       auto V1 = a[j]->function_spaces()[1];
       assert(V1);
       auto map1 = V1->dofmap()->index_map;
+      const int bs1 = V1->dofmap()->index_map_bs();
       assert(map1);
-      const int crange
-          = map1->block_size() * (map1->size_local() + map1->num_ghosts());
+      const int crange = bs1 * (map1->size_local() + map1->num_ghosts());
       bc_markers1.assign(crange, false);
       bc_values1 = Eigen::Matrix<T, Eigen::Dynamic, 1>::Zero(crange);
       for (const std::shared_ptr<const DirichletBC<T>>& bc : bcs1[j])

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -102,15 +102,15 @@ void assemble_matrix(
   // Index maps for dof ranges
   auto map0 = a.function_spaces().at(0)->dofmap()->index_map;
   auto map1 = a.function_spaces().at(1)->dofmap()->index_map;
+  auto bs0 = a.function_spaces().at(0)->dofmap()->index_map_bs();
+  auto bs1 = a.function_spaces().at(1)->dofmap()->index_map_bs();
 
   // Build dof markers
   std::vector<bool> dof_marker0, dof_marker1;
   assert(map0);
-  std::int32_t dim0
-      = map0->block_size() * (map0->size_local() + map0->num_ghosts());
+  std::int32_t dim0 = bs0 * (map0->size_local() + map0->num_ghosts());
   assert(map1);
-  std::int32_t dim1
-      = map1->block_size() * (map1->size_local() + map1->num_ghosts());
+  std::int32_t dim1 = bs1 * (map1->size_local() + map1->num_ghosts());
   for (std::size_t k = 0; k < bcs.size(); ++k)
   {
     assert(bcs[k]);

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -203,7 +203,7 @@ void add_diagonal(
   {
     assert(bc);
     if (V.contains(*bc->function_space()))
-      add_diagonal<T>(mat_add, bc->dofs_owned().col(0), diagonal);
+      add_diagonal<T>(mat_add, bc->dofs_owned()[0], diagonal);
   }
 }
 

--- a/cpp/dolfinx/fem/petsc.cpp
+++ b/cpp/dolfinx/fem/petsc.cpp
@@ -174,7 +174,9 @@ la::PETScMatrix fem::create_matrix_nest(
     {
       if (a(i, j))
       {
+        std::cout << "*** Create PETSc mat: " << i << ", " << j << std::endl;
         mats(i, j) = std::make_shared<la::PETScMatrix>(create_matrix(*a(i, j)));
+        std::cout << "*** End Create PETSc mat" << std::endl;
         petsc_mats(i, j) = mats(i, j)->mat();
       }
       else
@@ -189,6 +191,7 @@ la::PETScMatrix fem::create_matrix_nest(
   MatNestSetSubMats(_A, petsc_mats.rows(), nullptr, petsc_mats.cols(), nullptr,
                     petsc_mats.data());
   MatSetUp(_A);
+  std::cout << "*** End Nest Create PETSc mat" << std::endl;
 
   return la::PETScMatrix(_A);
 }

--- a/cpp/dolfinx/fem/petsc.cpp
+++ b/cpp/dolfinx/fem/petsc.cpp
@@ -34,7 +34,6 @@ la::PETScMatrix fem::create_matrix_block(
         const Eigen::Array<const fem::Form<PetscScalar>*, Eigen::Dynamic,
                            Eigen::Dynamic, Eigen::RowMajor>>& a)
 {
-  std::cout << "Create block matrix 0" << std::endl;
   // Extract and check row/column ranges
   auto V = function::common_function_spaces(extract_function_spaces(a));
 
@@ -86,8 +85,6 @@ la::PETScMatrix fem::create_matrix_block(
     }
   }
 
-  std::cout << "Create block matrix 1" << std::endl;
-
   // Compute offsets for the fields
   std::array<std::vector<std::reference_wrapper<const common::IndexMap>>, 2>
       maps;
@@ -101,16 +98,12 @@ la::PETScMatrix fem::create_matrix_block(
     }
   }
 
-  std::cout << "Create block matrix 2" << std::endl;
-
   // FIXME: This is computed again inside the SparsityPattern
   // constructor, but we also need to outside to build the PETSc
   // local-to-global map. Compute outside and pass into SparsityPattern
   // constructor.
   auto [rank_offset, local_offset, ghosts, owner]
       = common::stack_index_maps(maps[0], bs[0]);
-
-  std::cout << "Create block matrix 3" << std::endl;
 
   // Create merged sparsity pattern
   std::vector<std::vector<const la::SparsityPattern*>> p(V[0].size());
@@ -122,8 +115,6 @@ la::PETScMatrix fem::create_matrix_block(
 
   // FIXME: Add option to pass customised local-to-global map to PETSc
   // Mat constructor.
-
-  std::cout << "Create block matrix 4" << std::endl;
 
   // Initialise matrix
   la::PETScMatrix A(mesh->mpi_comm(), pattern);
@@ -145,9 +136,6 @@ la::PETScMatrix fem::create_matrix_block(
     }
   }
 
-  std::cout << "Create block matrix 5" << std::endl;
-
-
   // Create PETSc local-to-global map/index sets and attach to matrix
   ISLocalToGlobalMapping petsc_local_to_global0, petsc_local_to_global1;
   ISLocalToGlobalMappingCreate(MPI_COMM_SELF, 1, _maps[0].size(),
@@ -162,8 +150,6 @@ la::PETScMatrix fem::create_matrix_block(
   // Clean up local-to-global maps
   ISLocalToGlobalMappingDestroy(&petsc_local_to_global0);
   ISLocalToGlobalMappingDestroy(&petsc_local_to_global1);
-
-  std::cout << "Create block matrix" << std::endl;
 
   return A;
 }
@@ -188,9 +174,7 @@ la::PETScMatrix fem::create_matrix_nest(
     {
       if (a(i, j))
       {
-        std::cout << "*** Create PETSc mat: " << i << ", " << j << std::endl;
         mats(i, j) = std::make_shared<la::PETScMatrix>(create_matrix(*a(i, j)));
-        std::cout << "*** End Create PETSc mat" << std::endl;
         petsc_mats(i, j) = mats(i, j)->mat();
       }
       else
@@ -205,7 +189,6 @@ la::PETScMatrix fem::create_matrix_nest(
   MatNestSetSubMats(_A, petsc_mats.rows(), nullptr, petsc_mats.cols(), nullptr,
                     petsc_mats.data());
   MatSetUp(_A);
-  std::cout << "*** End Nest Create PETSc mat" << std::endl;
 
   return la::PETScMatrix(_A);
 }
@@ -339,7 +322,6 @@ void fem::set_bc_petsc(
     const std::vector<std::shared_ptr<const DirichletBC<PetscScalar>>>& bcs,
     const Vec x0, double scale)
 {
-  // VecGhostGetLocalForm(b, &b_local);
   PetscInt n = 0;
   VecGetLocalSize(b, &n);
   PetscScalar* array = nullptr;

--- a/cpp/dolfinx/fem/petsc.cpp
+++ b/cpp/dolfinx/fem/petsc.cpp
@@ -34,6 +34,7 @@ la::PETScMatrix fem::create_matrix_block(
         const Eigen::Array<const fem::Form<PetscScalar>*, Eigen::Dynamic,
                            Eigen::Dynamic, Eigen::RowMajor>>& a)
 {
+  std::cout << "Create block matrix 0" << std::endl;
   // Extract and check row/column ranges
   auto V = function::common_function_spaces(extract_function_spaces(a));
 
@@ -85,6 +86,8 @@ la::PETScMatrix fem::create_matrix_block(
     }
   }
 
+  std::cout << "Create block matrix 1" << std::endl;
+
   // Compute offsets for the fields
   std::array<std::vector<std::reference_wrapper<const common::IndexMap>>, 2>
       maps;
@@ -98,12 +101,16 @@ la::PETScMatrix fem::create_matrix_block(
     }
   }
 
+  std::cout << "Create block matrix 2" << std::endl;
+
   // FIXME: This is computed again inside the SparsityPattern
   // constructor, but we also need to outside to build the PETSc
   // local-to-global map. Compute outside and pass into SparsityPattern
   // constructor.
   auto [rank_offset, local_offset, ghosts, owner]
       = common::stack_index_maps(maps[0], bs[0]);
+
+  std::cout << "Create block matrix 3" << std::endl;
 
   // Create merged sparsity pattern
   std::vector<std::vector<const la::SparsityPattern*>> p(V[0].size());
@@ -115,6 +122,8 @@ la::PETScMatrix fem::create_matrix_block(
 
   // FIXME: Add option to pass customised local-to-global map to PETSc
   // Mat constructor.
+
+  std::cout << "Create block matrix 4" << std::endl;
 
   // Initialise matrix
   la::PETScMatrix A(mesh->mpi_comm(), pattern);
@@ -136,6 +145,9 @@ la::PETScMatrix fem::create_matrix_block(
     }
   }
 
+  std::cout << "Create block matrix 5" << std::endl;
+
+
   // Create PETSc local-to-global map/index sets and attach to matrix
   ISLocalToGlobalMapping petsc_local_to_global0, petsc_local_to_global1;
   ISLocalToGlobalMappingCreate(MPI_COMM_SELF, 1, _maps[0].size(),
@@ -150,6 +162,8 @@ la::PETScMatrix fem::create_matrix_block(
   // Clean up local-to-global maps
   ISLocalToGlobalMappingDestroy(&petsc_local_to_global0);
   ISLocalToGlobalMappingDestroy(&petsc_local_to_global1);
+
+  std::cout << "Create block matrix" << std::endl;
 
   return A;
 }

--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -46,13 +46,13 @@ la::PETScMatrix create_matrix_nest(
 
 /// Initialise monolithic vector. Vector is not zeroed.
 la::PETScVector create_vector_block(
-    const std::vector<std::reference_wrapper<const common::IndexMap>>& maps,
-    const std::vector<int>& bs);
+    const std::vector<
+        std::pair<std::reference_wrapper<const common::IndexMap>, int>>& maps);
 
 /// Create nested (VecNest) vector. Vector is not zeroed.
-la::PETScVector
-create_vector_nest(const std::vector<const common::IndexMap*>& maps,
-                   const std::vector<int>& bs);
+la::PETScVector create_vector_nest(
+    const std::vector<
+        std::pair<std::reference_wrapper<const common::IndexMap>, int>>& maps);
 
 // -- Vectors ----------------------------------------------------------------
 

--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -46,11 +46,13 @@ la::PETScMatrix create_matrix_nest(
 
 /// Initialise monolithic vector. Vector is not zeroed.
 la::PETScVector create_vector_block(
-    const std::vector<std::reference_wrapper<const common::IndexMap>>& maps);
+    const std::vector<std::reference_wrapper<const common::IndexMap>>& maps,
+    const std::vector<int>& bs);
 
 /// Create nested (VecNest) vector. Vector is not zeroed.
 la::PETScVector
-create_vector_nest(const std::vector<const common::IndexMap*>& maps);
+create_vector_nest(const std::vector<const common::IndexMap*>& maps,
+                   const std::vector<int>& bs);
 
 // -- Vectors ----------------------------------------------------------------
 

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -66,12 +66,13 @@ fem::create_sparsity_pattern(const mesh::Topology& topology,
   common::Timer t0("Build sparsity");
 
   // Get common::IndexMaps for each dimension
-  std::array index_maps{dofmaps[0]->index_map, dofmaps[1]->index_map};
+  const std::array index_maps{dofmaps[0]->index_map, dofmaps[1]->index_map};
+  const std::array bs = {dofmaps[0]->index_map_bs(), dofmaps[1]->index_map_bs()};
 
   // Create and build sparsity pattern
   assert(dofmaps[0]);
   assert(dofmaps[0]->index_map);
-  la::SparsityPattern pattern(dofmaps[0]->index_map->comm(), index_maps);
+  la::SparsityPattern pattern(dofmaps[0]->index_map->comm(), index_maps, bs);
   for (auto type : integrals)
   {
     if (type == fem::IntegralType::cell)
@@ -201,9 +202,9 @@ fem::DofMap fem::create_dofmap(MPI_Comm comm, const ufc_dofmap& ufc_dofmap,
     }
   }
 
-  auto [index_map, dofmap]
+  auto [index_map, bs, dofmap]
       = DofMapBuilder::build(comm, topology, *element_dof_layout);
-  return DofMap(element_dof_layout, index_map, std::move(dofmap));
+  return DofMap(element_dof_layout, index_map, bs, std::move(dofmap));
 }
 //-----------------------------------------------------------------------------
 std::vector<std::string> fem::get_coefficient_names(const ufc_form& ufc_form)

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -164,6 +164,8 @@ Form<T> create_form(
     const std::map<IntegralType, const mesh::MeshTags<int>*>& subdomains,
     const std::shared_ptr<const mesh::Mesh>& mesh = nullptr)
 {
+  std::cout << "Create form 0" << std::endl;
+
   if (ufc_form.rank != (int)spaces.size())
     throw std::runtime_error("Wrong number of argument spaces for Form.");
   if (ufc_form.num_coefficients != (int)coefficients.size())
@@ -177,7 +179,9 @@ Form<T> create_form(
         "Mismatch between number of expected and provided Form constants.");
   }
 
+  std::cout << "Create form 1" << std::endl;
   // Check argument function spaces
+
 #ifdef DEBUG
   for (std::size_t i = 0; i < spaces.size(); ++i)
   {
@@ -194,7 +198,9 @@ Form<T> create_form(
   }
 #endif
 
+  std::cout << "Create form 2" << std::endl;
   // Get list of integral IDs, and load tabulate tensor into memory for each
+
   using kern = std::function<void(PetscScalar*, const PetscScalar*,
                                   const PetscScalar*, const double*, const int*,
                                   const std::uint8_t*, const std::uint32_t)>;
@@ -203,6 +209,8 @@ Form<T> create_form(
       integral_data;
 
   bool needs_permutation_data = false;
+
+  std::cout << "Create form 3" << std::endl;
 
   // Attach cell kernels
   std::vector<int> cell_integral_ids(ufc_form.num_cell_integrals);
@@ -227,17 +235,25 @@ Form<T> create_form(
 
   // FIXME: Can facets be handled better?
 
+  std::cout << "Create form 4" << std::endl;
+
   // Create facets, if required
   if (ufc_form.num_exterior_facet_integrals > 0
       or ufc_form.num_interior_facet_integrals > 0)
   {
     if (!spaces.empty())
     {
+      std::cout << "Create form 4a" << std::endl;
       auto mesh = spaces[0]->mesh();
+      std::cout << "Create form 4b" << std::endl;
       const int tdim = mesh->topology().dim();
+      std::cout << "Create form 4c" << std::endl;
       spaces[0]->mesh()->topology_mutable().create_entities(tdim - 1);
+      std::cout << "Create form 4d" << std::endl;
     }
   }
+
+  std::cout << "Create form 5" << std::endl;
 
   // Attach exterior facet kernels
   std::vector<int> exterior_facet_integral_ids(
@@ -291,6 +307,8 @@ Form<T> create_form(
     throw std::runtime_error(
         "Vertex integrals not supported. Under development.");
   }
+
+  std::cout << "Create form 5" << std::endl;
 
   return fem::Form(spaces, integral_data, coefficients, constants,
                    needs_permutation_data, mesh);

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -164,8 +164,6 @@ Form<T> create_form(
     const std::map<IntegralType, const mesh::MeshTags<int>*>& subdomains,
     const std::shared_ptr<const mesh::Mesh>& mesh = nullptr)
 {
-  // std::cout << "Create form 0" << std::endl;
-
   if (ufc_form.rank != (int)spaces.size())
     throw std::runtime_error("Wrong number of argument spaces for Form.");
   if (ufc_form.num_coefficients != (int)coefficients.size())
@@ -179,9 +177,7 @@ Form<T> create_form(
         "Mismatch between number of expected and provided Form constants.");
   }
 
-  // std::cout << "Create form 1" << std::endl;
   // Check argument function spaces
-
 #ifdef DEBUG
   for (std::size_t i = 0; i < spaces.size(); ++i)
   {
@@ -198,9 +194,8 @@ Form<T> create_form(
   }
 #endif
 
-  // std::cout << "Create form 2" << std::endl;
-  // Get list of integral IDs, and load tabulate tensor into memory for each
-
+  // Get list of integral IDs, and load tabulate tensor into memory for
+  // each
   using kern = std::function<void(PetscScalar*, const PetscScalar*,
                                   const PetscScalar*, const double*, const int*,
                                   const std::uint8_t*, const std::uint32_t)>;
@@ -209,8 +204,6 @@ Form<T> create_form(
       integral_data;
 
   bool needs_permutation_data = false;
-
-  // std::cout << "Create form 3" << std::endl;
 
   // Attach cell kernels
   std::vector<int> cell_integral_ids(ufc_form.num_cell_integrals);
@@ -235,25 +228,17 @@ Form<T> create_form(
 
   // FIXME: Can facets be handled better?
 
-  // std::cout << "Create form 4" << std::endl;
-
   // Create facets, if required
   if (ufc_form.num_exterior_facet_integrals > 0
       or ufc_form.num_interior_facet_integrals > 0)
   {
     if (!spaces.empty())
     {
-      // std::cout << "Create form 4a" << std::endl;
       auto mesh = spaces[0]->mesh();
-      // std::cout << "Create form 4b" << std::endl;
       const int tdim = mesh->topology().dim();
-      // std::cout << "Create form 4c" << std::endl;
       spaces[0]->mesh()->topology_mutable().create_entities(tdim - 1);
-      // std::cout << "Create form 4d" << std::endl;
     }
   }
-
-  // std::cout << "Create form 5" << std::endl;
 
   // Attach exterior facet kernels
   std::vector<int> exterior_facet_integral_ids(
@@ -307,8 +292,6 @@ Form<T> create_form(
     throw std::runtime_error(
         "Vertex integrals not supported. Under development.");
   }
-
-  // std::cout << "Create form 5" << std::endl;
 
   return fem::Form(spaces, integral_data, coefficients, constants,
                    needs_permutation_data, mesh);

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -164,7 +164,7 @@ Form<T> create_form(
     const std::map<IntegralType, const mesh::MeshTags<int>*>& subdomains,
     const std::shared_ptr<const mesh::Mesh>& mesh = nullptr)
 {
-  std::cout << "Create form 0" << std::endl;
+  // std::cout << "Create form 0" << std::endl;
 
   if (ufc_form.rank != (int)spaces.size())
     throw std::runtime_error("Wrong number of argument spaces for Form.");
@@ -179,7 +179,7 @@ Form<T> create_form(
         "Mismatch between number of expected and provided Form constants.");
   }
 
-  std::cout << "Create form 1" << std::endl;
+  // std::cout << "Create form 1" << std::endl;
   // Check argument function spaces
 
 #ifdef DEBUG
@@ -198,7 +198,7 @@ Form<T> create_form(
   }
 #endif
 
-  std::cout << "Create form 2" << std::endl;
+  // std::cout << "Create form 2" << std::endl;
   // Get list of integral IDs, and load tabulate tensor into memory for each
 
   using kern = std::function<void(PetscScalar*, const PetscScalar*,
@@ -210,7 +210,7 @@ Form<T> create_form(
 
   bool needs_permutation_data = false;
 
-  std::cout << "Create form 3" << std::endl;
+  // std::cout << "Create form 3" << std::endl;
 
   // Attach cell kernels
   std::vector<int> cell_integral_ids(ufc_form.num_cell_integrals);
@@ -235,7 +235,7 @@ Form<T> create_form(
 
   // FIXME: Can facets be handled better?
 
-  std::cout << "Create form 4" << std::endl;
+  // std::cout << "Create form 4" << std::endl;
 
   // Create facets, if required
   if (ufc_form.num_exterior_facet_integrals > 0
@@ -243,17 +243,17 @@ Form<T> create_form(
   {
     if (!spaces.empty())
     {
-      std::cout << "Create form 4a" << std::endl;
+      // std::cout << "Create form 4a" << std::endl;
       auto mesh = spaces[0]->mesh();
-      std::cout << "Create form 4b" << std::endl;
+      // std::cout << "Create form 4b" << std::endl;
       const int tdim = mesh->topology().dim();
-      std::cout << "Create form 4c" << std::endl;
+      // std::cout << "Create form 4c" << std::endl;
       spaces[0]->mesh()->topology_mutable().create_entities(tdim - 1);
-      std::cout << "Create form 4d" << std::endl;
+      // std::cout << "Create form 4d" << std::endl;
     }
   }
 
-  std::cout << "Create form 5" << std::endl;
+  // std::cout << "Create form 5" << std::endl;
 
   // Attach exterior facet kernels
   std::vector<int> exterior_facet_integral_ids(
@@ -308,7 +308,7 @@ Form<T> create_form(
         "Vertex integrals not supported. Under development.");
   }
 
-  std::cout << "Create form 5" << std::endl;
+  // std::cout << "Create form 5" << std::endl;
 
   return fem::Form(spaces, integral_data, coefficients, constants,
                    needs_permutation_data, mesh);

--- a/cpp/dolfinx/function/FunctionSpace.cpp
+++ b/cpp/dolfinx/function/FunctionSpace.cpp
@@ -44,7 +44,7 @@ internal_tabulate_dof_coordinates(
   std::shared_ptr<const common::IndexMap> index_map = dofmap->index_map;
   assert(index_map);
 
-  int bs = index_map->block_size();
+  int bs = dofmap->index_map_bs();
   int element_block_size = element->block_size();
 
   std::int32_t local_size
@@ -147,7 +147,7 @@ std::int64_t FunctionSpace::dim() const
   }
 
   assert(_dofmap->index_map);
-  return _dofmap->index_map->size_global() * _dofmap->index_map->block_size();
+  return _dofmap->index_map->size_global() * _dofmap->index_map_bs();
 }
 //-----------------------------------------------------------------------------
 std::shared_ptr<FunctionSpace>

--- a/cpp/dolfinx/graph/Partitioning.cpp
+++ b/cpp/dolfinx/graph/Partitioning.cpp
@@ -412,7 +412,7 @@ Partitioning::create_distributed_adjacency_list(
                            dolfinx::MPI::compute_graph_edges(
                                comm, std::set<int>(ghost_owners.begin(),
                                                    ghost_owners.end())),
-                           ghosts, ghost_owners, 1)};
+                           ghosts, ghost_owners)};
 }
 //-----------------------------------------------------------------------------
 std::tuple<graph::AdjacencyList<std::int64_t>, std::vector<int>,

--- a/cpp/dolfinx/la/PETScMatrix.cpp
+++ b/cpp/dolfinx/la/PETScMatrix.cpp
@@ -35,7 +35,7 @@ Mat la::create_petsc_matrix(
                         sparsity_pattern.index_map(1)};
   const int bs0 = sparsity_pattern.block_size(0);
   const int bs1 = sparsity_pattern.block_size(1);
-  std::cout << "Block sizes: " << bs0 << ", " << bs1 << std::endl;
+  // std::cout << "Block sizes: " << bs0 << ", " << bs1 << std::endl;
 
   // Get global and local dimensions
   const std::int64_t M = bs0 * index_maps[0]->size_global();
@@ -43,7 +43,7 @@ Mat la::create_petsc_matrix(
   const std::int32_t m = bs0 * index_maps[0]->size_local();
   const std::int32_t n = bs1 * index_maps[1]->size_local();
 
-  std::cout << "Matrix sizes: " << M << ", " << N << std::endl;
+  // std::cout << "Matrix sizes: " << M << ", " << N << std::endl;
 
   // Find common block size across rows/columns
   const int bs = (bs0 == bs1 ? bs0 : 1);
@@ -74,13 +74,13 @@ Mat la::create_petsc_matrix(
   for (std::size_t i = 0; i < _nnz_offdiag.size(); ++i)
     _nnz_offdiag[i] = off_diagonal_pattern.links(bs * i).rows() / bs;
 
-  std::cout << "Non zeros per row (D): " << bs << std::endl;
-  for (auto i : _nnz_diag)
-    std::cout << i << std::endl;
-  std::cout << "Non zeros per row (O): " << bs << std::endl;
-  for (auto i : _nnz_offdiag)
-    std::cout << i << std::endl;
-  std::cout << "----------------" << std::endl;
+  // std::cout << "Non zeros per row (D): " << bs << std::endl;
+  // for (auto i : _nnz_diag)
+  //   std::cout << i << std::endl;
+  // std::cout << "Non zeros per row (O): " << bs << std::endl;
+  // for (auto i : _nnz_offdiag)
+  //   std::cout << i << std::endl;
+  // std::cout << "----------------" << std::endl;
 
   // Allocate space for matrix
   ierr = MatXAIJSetPreallocation(A, bs, _nnz_diag.data(), _nnz_offdiag.data(),
@@ -100,12 +100,12 @@ Mat la::create_petsc_matrix(
   const std::vector<PetscInt> map0(_map0.begin(), _map0.end());
   const std::vector<PetscInt> map1(_map1.begin(), _map1.end());
 
-  std::cout << "l2g0: " << bs0 << std::endl;
-  for (auto i : map0)
-    std::cout << i << std::endl;
-  std::cout << "l2g1: " << bs1 << std::endl;
-  for (auto i : map1)
-    std::cout << i << std::endl;
+  // std::cout << "l2g0: " << bs0 << std::endl;
+  // for (auto i : map0)
+  //   std::cout << i << std::endl;
+  // std::cout << "l2g1: " << bs1 << std::endl;
+  // for (auto i : map1)
+  //   std::cout << i << std::endl;
 
   ISLocalToGlobalMapping petsc_local_to_global0, petsc_local_to_global1;
   ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs0, map0.size(),

--- a/cpp/dolfinx/la/PETScMatrix.cpp
+++ b/cpp/dolfinx/la/PETScMatrix.cpp
@@ -35,12 +35,15 @@ Mat la::create_petsc_matrix(
                         sparsity_pattern.index_map(1)};
   const int bs0 = sparsity_pattern.block_size(0);
   const int bs1 = sparsity_pattern.block_size(1);
+  std::cout << "Block sizes: " << bs0 << ", " << bs1 << std::endl;
 
   // Get global and local dimensions
   const std::int64_t M = bs0 * index_maps[0]->size_global();
   const std::int64_t N = bs1 * index_maps[1]->size_global();
   const std::int32_t m = bs0 * index_maps[0]->size_local();
   const std::int32_t n = bs1 * index_maps[1]->size_local();
+
+  std::cout << "Matrix sizes: " << M << ", " << N << std::endl;
 
   // Find common block size across rows/columns
   const int bs = (bs0 == bs1 ? bs0 : 1);
@@ -71,11 +74,21 @@ Mat la::create_petsc_matrix(
   for (std::size_t i = 0; i < _nnz_offdiag.size(); ++i)
     _nnz_offdiag[i] = off_diagonal_pattern.links(bs * i).rows() / bs;
 
+  std::cout << "Non zeros per row (D): " << bs << std::endl;
+  for (auto i : _nnz_diag)
+    std::cout << i << std::endl;
+  std::cout << "Non zeros per row (O): " << bs << std::endl;
+  for (auto i : _nnz_offdiag)
+    std::cout << i << std::endl;
+  std::cout << "----------------" << std::endl;
+
   // Allocate space for matrix
   ierr = MatXAIJSetPreallocation(A, bs, _nnz_diag.data(), _nnz_offdiag.data(),
                                  nullptr, nullptr);
   if (ierr != 0)
     petsc_error(ierr, __FILE__, "MatXIJSetPreallocation");
+
+  MatSetBlockSizes(A, bs0, bs1);
 
   // FIXME: In many cases the rows and columns could shared a common
   // local-to-global map
@@ -86,6 +99,13 @@ Mat la::create_petsc_matrix(
   const std::vector _map1 = index_maps[1]->global_indices();
   const std::vector<PetscInt> map0(_map0.begin(), _map0.end());
   const std::vector<PetscInt> map1(_map1.begin(), _map1.end());
+
+  std::cout << "l2g0: " << bs0 << std::endl;
+  for (auto i : map0)
+    std::cout << i << std::endl;
+  std::cout << "l2g1: " << bs1 << std::endl;
+  for (auto i : map1)
+    std::cout << i << std::endl;
 
   ISLocalToGlobalMapping petsc_local_to_global0, petsc_local_to_global1;
   ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs0, map0.size(),
@@ -107,9 +127,9 @@ Mat la::create_petsc_matrix(
 
   // Note: This should be called after having set the local-to-global
   // map for MATIS (this is a dummy call if A is not of type MATIS)
-  ierr = MatISSetPreallocation(A, 0, _nnz_diag.data(), 0, _nnz_offdiag.data());
-  if (ierr != 0)
-    petsc_error(ierr, __FILE__, "MatISSetPreallocation");
+  // ierr = MatISSetPreallocation(A, 0, _nnz_diag.data(), 0,
+  // _nnz_offdiag.data()); if (ierr != 0)
+  //   petsc_error(ierr, __FILE__, "MatISSetPreallocation");
 
   // Clean up local-to-global maps
   ierr = ISLocalToGlobalMappingDestroy(&petsc_local_to_global0);

--- a/cpp/dolfinx/la/PETScMatrix.cpp
+++ b/cpp/dolfinx/la/PETScMatrix.cpp
@@ -120,6 +120,14 @@ Mat la::create_petsc_matrix(
     ierr = MatSetLocalToGlobalMapping(A, local_to_global0, local_to_global1);
     if (ierr != 0)
       petsc_error(ierr, __FILE__, "MatSetLocalToGlobalMapping");
+
+    // Clean up local-to-global maps
+    ierr = ISLocalToGlobalMappingDestroy(&local_to_global0);
+    if (ierr != 0)
+      petsc_error(ierr, __FILE__, "ISLocalToGlobalMappingDestroy");
+    ierr = ISLocalToGlobalMappingDestroy(&local_to_global1);
+    if (ierr != 0)
+      petsc_error(ierr, __FILE__, "ISLocalToGlobalMappingDestroy");
   }
 
   // Note: This should be called after having set the local-to-global

--- a/cpp/dolfinx/la/PETScMatrix.cpp
+++ b/cpp/dolfinx/la/PETScMatrix.cpp
@@ -33,8 +33,8 @@ Mat la::create_petsc_matrix(
   // Get IndexMaps from sparsity patterm, and block size
   std::array index_maps{sparsity_pattern.index_map(0),
                         sparsity_pattern.index_map(1)};
-  const int bs0 = index_maps[0]->block_size();
-  const int bs1 = index_maps[1]->block_size();
+  const int bs0 = sparsity_pattern.block_size(0);
+  const int bs1 = sparsity_pattern.block_size(1);
 
   // Get global and local dimensions
   const std::int64_t M = bs0 * index_maps[0]->size_global();
@@ -81,19 +81,19 @@ Mat la::create_petsc_matrix(
   // local-to-global map
 
   // Create PETSc local-to-global map/index set
-  const bool blocked = (bs0 == bs1 ? true : false);
-  const std::vector _map0 = index_maps[0]->global_indices(blocked);
-  const std::vector _map1 = index_maps[1]->global_indices(blocked);
+  // const bool blocked = (bs0 == bs1 ? true : false);
+  const std::vector _map0 = index_maps[0]->global_indices();
+  const std::vector _map1 = index_maps[1]->global_indices();
   const std::vector<PetscInt> map0(_map0.begin(), _map0.end());
   const std::vector<PetscInt> map1(_map1.begin(), _map1.end());
 
   ISLocalToGlobalMapping petsc_local_to_global0, petsc_local_to_global1;
-  ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs, map0.size(),
+  ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs0, map0.size(),
                                       map0.data(), PETSC_COPY_VALUES,
                                       &petsc_local_to_global0);
   if (ierr != 0)
     petsc_error(ierr, __FILE__, "ISLocalToGlobalMappingCreate");
-  ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs, map1.size(),
+  ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs1, map1.size(),
                                       map1.data(), PETSC_COPY_VALUES,
                                       &petsc_local_to_global1);
   if (ierr != 0)

--- a/cpp/dolfinx/la/PETScMatrix.cpp
+++ b/cpp/dolfinx/la/PETScMatrix.cpp
@@ -31,16 +31,15 @@ Mat la::create_petsc_matrix(
     petsc_error(ierr, __FILE__, "MatCreate");
 
   // Get IndexMaps from sparsity patterm, and block size
-  std::array index_maps{sparsity_pattern.index_map(0),
-                        sparsity_pattern.index_map(1)};
-  const int bs0 = sparsity_pattern.block_size(0);
-  const int bs1 = sparsity_pattern.block_size(1);
+  std::array maps{sparsity_pattern.index_map(0), sparsity_pattern.index_map(1)};
+  const std::array bs
+      = {sparsity_pattern.block_size(0), sparsity_pattern.block_size(1)};
 
   // Get global and local dimensions
-  const std::int64_t M = bs0 * index_maps[0]->size_global();
-  const std::int64_t N = bs1 * index_maps[1]->size_global();
-  const std::int32_t m = bs0 * index_maps[0]->size_local();
-  const std::int32_t n = bs1 * index_maps[1]->size_local();
+  const std::int64_t M = bs[0] * maps[0]->size_global();
+  const std::int64_t N = bs[1] * maps[1]->size_global();
+  const std::int32_t m = bs[0] * maps[0]->size_local();
+  const std::int32_t n = bs[1] * maps[1]->size_local();
 
   // Set matrix size
   ierr = MatSetSizes(A, m, n, M, N);
@@ -60,65 +59,74 @@ Mat la::create_petsc_matrix(
     petsc_error(ierr, __FILE__, "MatSetFromOptions");
 
   // Find a common block size across rows/columns
-  const int bs = (bs0 == bs1 ? bs0 : 1);
+  const int _bs = (bs[0] == bs[1] ? bs[0] : 1);
 
   // Build data to initialise sparsity pattern (modify for block size)
-  std::vector<PetscInt> _nnz_diag(index_maps[0]->size_local() * bs0 / bs),
-      _nnz_offdiag(index_maps[0]->size_local() * bs0 / bs);
-
+  std::vector<PetscInt> _nnz_diag(maps[0]->size_local() * bs[0] / _bs),
+      _nnz_offdiag(maps[0]->size_local() * bs[0] / _bs);
   for (std::size_t i = 0; i < _nnz_diag.size(); ++i)
-    _nnz_diag[i] = diagonal_pattern.links(bs * i).rows() / bs;
+    _nnz_diag[i] = diagonal_pattern.links(_bs * i).rows() / _bs;
   for (std::size_t i = 0; i < _nnz_offdiag.size(); ++i)
-    _nnz_offdiag[i] = off_diagonal_pattern.links(bs * i).rows() / bs;
+    _nnz_offdiag[i] = off_diagonal_pattern.links(_bs * i).rows() / _bs;
 
   // Allocate space for matrix
-  ierr = MatXAIJSetPreallocation(A, bs, _nnz_diag.data(), _nnz_offdiag.data(),
+  ierr = MatXAIJSetPreallocation(A, _bs, _nnz_diag.data(), _nnz_offdiag.data(),
                                  nullptr, nullptr);
   if (ierr != 0)
     petsc_error(ierr, __FILE__, "MatXIJSetPreallocation");
 
-  MatSetBlockSizes(A, bs0, bs1);
+  // Set block sizes
+  ierr = MatSetBlockSizes(A, bs[0], bs[1]);
+  if (ierr != 0)
+    petsc_error(ierr, __FILE__, "MatSetBlockSizes");
 
-  // FIXME: In many cases the rows and columns could shared a common
-  // local-to-global map
+  // Find a common block size across rows/columns
+  const bool common_is = (maps[0] == maps[1] and bs[0] == bs[1] ? true : false);
 
-  // Create PETSc local-to-global map/index set
-  const std::vector _map0 = index_maps[0]->global_indices();
-  const std::vector _map1 = index_maps[1]->global_indices();
+  // Create PETSc local-to-global map/index sets
+  ISLocalToGlobalMapping local_to_global0;
+  const std::vector _map0 = maps[0]->global_indices();
   const std::vector<PetscInt> map0(_map0.begin(), _map0.end());
-  const std::vector<PetscInt> map1(_map1.begin(), _map1.end());
-
-  ISLocalToGlobalMapping petsc_local_to_global0, petsc_local_to_global1;
-  ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs0, map0.size(),
+  ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs[0], map0.size(),
                                       map0.data(), PETSC_COPY_VALUES,
-                                      &petsc_local_to_global0);
-  if (ierr != 0)
-    petsc_error(ierr, __FILE__, "ISLocalToGlobalMappingCreate");
-  ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs1, map1.size(),
-                                      map1.data(), PETSC_COPY_VALUES,
-                                      &petsc_local_to_global1);
+                                      &local_to_global0);
   if (ierr != 0)
     petsc_error(ierr, __FILE__, "ISLocalToGlobalMappingCreate");
 
-  // Set matrix local-to-global maps
-  ierr = MatSetLocalToGlobalMapping(A, petsc_local_to_global0,
-                                    petsc_local_to_global1);
-  if (ierr != 0)
-    petsc_error(ierr, __FILE__, "MatSetLocalToGlobalMappingXXX");
+  if (common_is)
+  {
+    // Set matrix local-to-global maps
+    ierr = MatSetLocalToGlobalMapping(A, local_to_global0, local_to_global0);
+    if (ierr != 0)
+      petsc_error(ierr, __FILE__, "MatSetLocalToGlobalMapping");
+
+    // Clean up local-to-global maps
+    ierr = ISLocalToGlobalMappingDestroy(&local_to_global0);
+    if (ierr != 0)
+      petsc_error(ierr, __FILE__, "ISLocalToGlobalMappingDestroy");
+  }
+  else
+  {
+    ISLocalToGlobalMapping local_to_global1;
+    const std::vector _map1 = maps[1]->global_indices();
+    const std::vector<PetscInt> map1(_map1.begin(), _map1.end());
+    ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs[1], map1.size(),
+                                        map1.data(), PETSC_COPY_VALUES,
+                                        &local_to_global1);
+    if (ierr != 0)
+      petsc_error(ierr, __FILE__, "ISLocalToGlobalMappingCreate");
+
+    // Set matrix local-to-global maps
+    ierr = MatSetLocalToGlobalMapping(A, local_to_global0, local_to_global1);
+    if (ierr != 0)
+      petsc_error(ierr, __FILE__, "MatSetLocalToGlobalMapping");
+  }
 
   // Note: This should be called after having set the local-to-global
   // map for MATIS (this is a dummy call if A is not of type MATIS)
   // ierr = MatISSetPreallocation(A, 0, _nnz_diag.data(), 0,
   // _nnz_offdiag.data()); if (ierr != 0)
   //   petsc_error(ierr, __FILE__, "MatISSetPreallocation");
-
-  // Clean up local-to-global maps
-  ierr = ISLocalToGlobalMappingDestroy(&petsc_local_to_global0);
-  if (ierr != 0)
-    petsc_error(ierr, __FILE__, "ISLocalToGlobalMappingDestroy");
-  ierr = ISLocalToGlobalMappingDestroy(&petsc_local_to_global1);
-  if (ierr != 0)
-    petsc_error(ierr, __FILE__, "ISLocalToGlobalMappingDestroy");
 
   // Set some options on Mat object
   ierr = MatSetOption(A, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);

--- a/cpp/dolfinx/la/PETScVector.h
+++ b/cpp/dolfinx/la/PETScVector.h
@@ -25,11 +25,12 @@ namespace la
 /// Create a PETSc Vec that wraps the data in x
 /// @param[in] map The index map that described the parallel layout of
 ///   the distributed vector
+/// @param[in] bs Block size
 /// @param[in] x The local part of the vector, including ghost entries
 /// @return A PETSc Vec object that share the x data. The caller is
 ///   responsible for destroying the Vec.
 Vec create_ghosted_vector(
-    const common::IndexMap& map,
+    const common::IndexMap& map, int bs,
     const Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>& x);
 
 /// Print error message for PETSc calls that return an error
@@ -44,13 +45,15 @@ void petsc_error(int error_code, std::string filename,
 /// responsible for destruction of each IS.
 ///
 /// @param[in] maps Vector of IndexMaps
+/// @param[in] bs Block sizes
 /// @returns Vector of PETSc Index Sets, created on PETSc_COMM_SELF
 std::vector<IS>
-create_petsc_index_sets(const std::vector<const common::IndexMap*>& maps);
+create_petsc_index_sets(const std::vector<const common::IndexMap*>& maps,
+                        const std::vector<int>& bs);
 
 /// Create a ghosted PETSc Vec. Caller is responsible for destroying the
 /// returned object.
-Vec create_petsc_vector(const common::IndexMap& map);
+Vec create_petsc_vector(const common::IndexMap& map, int bs);
 
 /// Create a ghosted PETSc Vec. Caller is responsible for destroying the
 /// returned object.
@@ -62,14 +65,15 @@ Vec create_petsc_vector(
 
 /// Copy blocks from Vec into Eigen vectors
 std::vector<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>>
-get_local_vectors(const Vec x,
-                  const std::vector<const common::IndexMap*>& maps);
+get_local_vectors(const Vec x, const std::vector<const common::IndexMap*>& maps,
+                  const std::vector<int>& bs);
 
 /// Scatter local Eigen vectors to Vec
 void scatter_local_vectors(
     Vec x,
     const std::vector<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>>& x_b,
-    const std::vector<const common::IndexMap*>& maps);
+    const std::vector<const common::IndexMap*>& maps,
+    const std::vector<int>& bs);
 
 /// It is a simple wrapper for a PETSc vector pointer (Vec). Its main
 /// purpose is to assist memory management of PETSc Vec objects.
@@ -81,7 +85,7 @@ class PETScVector
 {
 public:
   /// Create vector
-  PETScVector(const common::IndexMap& map);
+  PETScVector(const common::IndexMap& map, int bs);
 
   /// Create vector
   PETScVector(

--- a/cpp/dolfinx/la/PETScVector.h
+++ b/cpp/dolfinx/la/PETScVector.h
@@ -44,12 +44,11 @@ void petsc_error(int error_code, std::string filename,
 /// IS[0] = {0, 1, 2, 3, 4, 5, 6} and IS[1] = {7, 8, 9, 10}. Caller is
 /// responsible for destruction of each IS.
 ///
-/// @param[in] maps Vector of IndexMaps
-/// @param[in] bs Block sizes
+/// @param[in] maps Vector of IndexMaps and corresponding block size
 /// @returns Vector of PETSc Index Sets, created on PETSc_COMM_SELF
-std::vector<IS>
-create_petsc_index_sets(const std::vector<const common::IndexMap*>& maps,
-                        const std::vector<int>& bs);
+std::vector<IS> create_petsc_index_sets(
+    const std::vector<
+        std::pair<std::reference_wrapper<const common::IndexMap>, int>>& maps);
 
 /// Create a ghosted PETSc Vec. Caller is responsible for destroying the
 /// returned object.
@@ -61,19 +60,20 @@ Vec create_petsc_vector(
     MPI_Comm comm, std::array<std::int64_t, 2> range,
     const Eigen::Ref<const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>&
         ghost_indices,
-    int block_size);
+    int bs);
 
 /// Copy blocks from Vec into Eigen vectors
-std::vector<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>>
-get_local_vectors(const Vec x, const std::vector<const common::IndexMap*>& maps,
-                  const std::vector<int>& bs);
+std::vector<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>> get_local_vectors(
+    const Vec x,
+    const std::vector<
+        std::pair<std::reference_wrapper<const common::IndexMap>, int>>& maps);
 
 /// Scatter local Eigen vectors to Vec
 void scatter_local_vectors(
     Vec x,
     const std::vector<Eigen::Matrix<PetscScalar, Eigen::Dynamic, 1>>& x_b,
-    const std::vector<const common::IndexMap*>& maps,
-    const std::vector<int>& bs);
+    const std::vector<
+        std::pair<std::reference_wrapper<const common::IndexMap>, int>>& maps);
 
 /// It is a simple wrapper for a PETSc vector pointer (Vec). Its main
 /// purpose is to assist memory management of PETSc Vec objects.
@@ -91,7 +91,7 @@ public:
   PETScVector(
       MPI_Comm comm, std::array<std::int64_t, 2> range,
       const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>& ghost_indices,
-      int block_size);
+      int bs);
 
   // Delete copy constructor to avoid accidental copying of 'heavy' data
   PETScVector(const PETScVector& x) = delete;

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -18,12 +18,13 @@ using namespace dolfinx::la;
 //-----------------------------------------------------------------------------
 SparsityPattern::SparsityPattern(
     MPI_Comm comm,
-    const std::array<std::shared_ptr<const common::IndexMap>, 2>& index_maps,
+    const std::array<std::shared_ptr<const common::IndexMap>, 2>& maps,
     const std::array<int, 2>& bs)
-    : _mpi_comm(comm), _index_maps(index_maps), _bs(bs)
+    : _mpi_comm(comm), _index_maps(maps), _bs(bs)
 {
+  assert(maps[0]);
   const std::int32_t local_size0
-      = bs[0] * (index_maps[0]->size_local() + index_maps[0]->num_ghosts());
+      = bs[0] * (maps[0]->size_local() + maps[0]->num_ghosts());
   _diagonal_cache.resize(local_size0);
   _off_diagonal_cache.resize(local_size0);
 }

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -18,12 +18,12 @@ using namespace dolfinx::la;
 //-----------------------------------------------------------------------------
 SparsityPattern::SparsityPattern(
     MPI_Comm comm,
-    const std::array<std::shared_ptr<const common::IndexMap>, 2>& index_maps)
-    : _mpi_comm(comm), _index_maps(index_maps)
+    const std::array<std::shared_ptr<const common::IndexMap>, 2>& index_maps,
+    const std::array<int, 2>& bs)
+    : _mpi_comm(comm), _index_maps(index_maps), _bs(bs)
 {
   const std::int32_t local_size0
-      = index_maps[0]->block_size()
-        * (index_maps[0]->size_local() + index_maps[0]->num_ghosts());
+      = bs[0] * (index_maps[0]->size_local() + index_maps[0]->num_ghosts());
   _diagonal_cache.resize(local_size0);
   _off_diagonal_cache.resize(local_size0);
 }
@@ -32,16 +32,17 @@ SparsityPattern::SparsityPattern(
     MPI_Comm comm,
     const std::vector<std::vector<const SparsityPattern*>>& patterns,
     const std::array<
-        std::vector<std::reference_wrapper<const common::IndexMap>>, 2>& maps)
-    : _mpi_comm(comm)
+        std::vector<std::reference_wrapper<const common::IndexMap>>, 2>& maps,
+    const std::array<std::vector<int>, 2>& bs)
+    : _mpi_comm(comm), _bs({1, 1})
 {
   // FIXME: - Add range/bound checks for each block
   //        - Check for compatible block sizes for each block
 
   const auto [rank_offset0, local_offset0, ghosts_new0, owners0]
-      = common::stack_index_maps(maps[0]);
+      = common::stack_index_maps(maps[0], bs[0]);
   const auto [rank_offset1, local_offset1, ghosts_new1, owners1]
-      = common::stack_index_maps(maps[1]);
+      = common::stack_index_maps(maps[1], bs[1]);
 
   std::vector<std::int64_t> ghosts0, ghosts1;
   std::vector<std::int32_t> ghost_offsets0(1, 0);
@@ -64,12 +65,12 @@ SparsityPattern::SparsityPattern(
       comm, local_offset0.back(),
       dolfinx::MPI::compute_graph_edges(
           comm, std::set<int>(ghost_owners0.begin(), ghost_owners0.end())),
-      ghosts0, ghost_owners0, 1);
+      ghosts0, ghost_owners0);
   _index_maps[1] = std::make_shared<common::IndexMap>(
       comm, local_offset1.back(),
       dolfinx::MPI::compute_graph_edges(
           comm, std::set<int>(ghost_owners1.begin(), ghost_owners1.end())),
-      ghosts1, ghost_owners1, 1);
+      ghosts1, ghost_owners1);
 
   // Size cache arrays
   const std::int32_t size_row = local_offset0.back() + ghosts0.size();
@@ -84,16 +85,18 @@ SparsityPattern::SparsityPattern(
   for (std::size_t col = 0; col < maps[1].size(); ++col)
   {
     auto map = maps[1][col];
-    const int bs = map.get().block_size();
+    // const int bs = map.get().block_size();
+    const int bs_col = bs[1][col];
     const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>& ghosts_old
         = map.get().ghosts();
-    assert(ghosts_new1[col].size() == (std::size_t)(bs * ghosts_old.rows()));
+    assert(ghosts_new1[col].size()
+           == (std::size_t)(bs_col * ghosts_old.rows()));
     for (int i = 0; i < ghosts_old.rows(); ++i)
     {
-      for (int j = 0; j < bs; ++j)
+      for (int j = 0; j < bs_col; ++j)
       {
         col_old_to_new[col].insert(
-            {bs * ghosts_old[i] + j, ghosts_new1[col][i * bs + j]});
+            {bs_col * ghosts_old[i] + j, ghosts_new1[col][i * bs_col + j]});
       }
     }
   }
@@ -102,10 +105,9 @@ SparsityPattern::SparsityPattern(
   for (std::size_t row = 0; row < patterns.size(); ++row)
   {
     const common::IndexMap& map_row = maps[0][row].get();
-    const std::int32_t num_rows_local
-        = map_row.size_local() * map_row.block_size();
-    const std::int32_t num_rows_ghost
-        = map_row.num_ghosts() * map_row.block_size();
+    const int bs_row = bs[0][row];
+    const std::int32_t num_rows_local = map_row.size_local() * bs_row;
+    const std::int32_t num_rows_ghost = map_row.num_ghosts() * bs_row;
 
     // Iterate over block columns of current row (block)
     for (std::size_t col = 0; col < patterns[row].size(); ++col)
@@ -171,9 +173,8 @@ SparsityPattern::SparsityPattern(
 //-----------------------------------------------------------------------------
 std::array<std::int64_t, 2> SparsityPattern::local_range(int dim) const
 {
-  const int bs = _index_maps.at(dim)->block_size();
   const std::array lrange = _index_maps[dim]->local_range();
-  return {bs * lrange[0], bs * lrange[1]};
+  return {_bs[dim] * lrange[0], _bs[dim] * lrange[1]};
 }
 //-----------------------------------------------------------------------------
 std::shared_ptr<const common::IndexMap>
@@ -182,6 +183,9 @@ SparsityPattern::index_map(int dim) const
   return _index_maps.at(dim);
 }
 //-----------------------------------------------------------------------------
+int SparsityPattern::block_size(int dim) const { return _bs[0]; }
+//-----------------------------------------------------------------------------
+
 void SparsityPattern::insert(
     const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>& rows,
     const Eigen::Ref<const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>>& cols)
@@ -193,12 +197,10 @@ void SparsityPattern::insert(
   }
 
   assert(_index_maps[0]);
-  const int bs0 = _index_maps[0]->block_size();
   const std::int32_t size0
-      = bs0 * (_index_maps[0]->size_local() + _index_maps[0]->num_ghosts());
+      = _bs[0] * (_index_maps[0]->size_local() + _index_maps[0]->num_ghosts());
 
   assert(_index_maps[1]);
-  const int bs1 = _index_maps[1]->block_size();
   const std::int32_t local_size1 = _index_maps[1]->size_local();
   const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>& ghosts1
       = _index_maps[1]->ghosts();
@@ -209,13 +211,14 @@ void SparsityPattern::insert(
     {
       for (Eigen::Index j = 0; j < cols.rows(); ++j)
       {
-        if (cols[j] < bs1 * local_size1)
+        if (cols[j] < _bs[1] * local_size1)
           _diagonal_cache[rows[i]].push_back(cols[j]);
         else
         {
-          const std::div_t div = std::div(cols[j], bs1);
+          const std::div_t div = std::div(cols[j], _bs[1]);
           const std::int64_t block_global = ghosts1[div.quot - local_size1];
-          _off_diagonal_cache[rows[i]].push_back(bs1 * block_global + div.rem);
+          _off_diagonal_cache[rows[i]].push_back(_bs[1] * block_global
+                                                 + div.rem);
         }
       }
     }
@@ -237,9 +240,8 @@ void SparsityPattern::insert_diagonal(
   }
 
   assert(_index_maps[0]);
-  const int bs0 = _index_maps[0]->block_size();
   const std::int32_t local_size0
-      = bs0 * (_index_maps[0]->size_local() + _index_maps[0]->num_ghosts());
+      = _bs[0] * (_index_maps[0]->size_local() + _index_maps[0]->num_ghosts());
   for (Eigen::Index i = 0; i < rows.rows(); ++i)
   {
     if (rows[i] < local_size0)
@@ -259,7 +261,6 @@ void SparsityPattern::assemble()
   assert(!_off_diagonal);
 
   assert(_index_maps[0]);
-  const int bs0 = _index_maps[0]->block_size();
   const std::int32_t local_size0 = _index_maps[0]->size_local();
   const std::int32_t num_ghosts0 = _index_maps[0]->num_ghosts();
   const std::array local_range0 = _index_maps[0]->local_range();
@@ -267,7 +268,6 @@ void SparsityPattern::assemble()
       = _index_maps[0]->ghosts();
 
   assert(_index_maps[1]);
-  const int bs1 = _index_maps[1]->block_size();
   const std::int32_t local_size1 = _index_maps[1]->size_local();
   const std::array local_range1 = _index_maps[1]->local_range();
   const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>& ghosts1
@@ -280,10 +280,10 @@ void SparsityPattern::assemble()
   {
     const std::int64_t row_node_global = ghosts0[i];
     const std::int32_t row_node_local = local_size0 + i;
-    for (int j = 0; j < bs0; ++j)
+    for (int j = 0; j < _bs[0]; ++j)
     {
-      const std::int64_t row_global = bs0 * row_node_global + j;
-      const std::int32_t row_local = bs0 * row_node_local + j;
+      const std::int64_t row_global = _bs[0] * row_node_global + j;
+      const std::int32_t row_local = _bs[0] * row_node_local + j;
       assert((std::size_t)row_local < _diagonal_cache.size());
       const std::vector<std::int32_t>& cols = _diagonal_cache[row_local];
       for (std::size_t c = 0; c < cols.size(); ++c)
@@ -291,13 +291,13 @@ void SparsityPattern::assemble()
         ghost_data.push_back(row_global);
 
         // Convert to global column index
-        if (cols[c] < bs1 * local_size1)
-          ghost_data.push_back(cols[c] + bs1 * local_range1[0]);
+        if (cols[c] < _bs[1] * local_size1)
+          ghost_data.push_back(cols[c] + _bs[1] * local_range1[0]);
         else
         {
-          const std::div_t div = std::div(cols[c], bs1);
+          const std::div_t div = std::div(cols[c], _bs[1]);
           const std::int64_t block_global = ghosts1[div.quot - local_size1];
-          ghost_data.push_back(bs1 * block_global + div.rem);
+          ghost_data.push_back(_bs[1] * block_global + div.rem);
         }
       }
 
@@ -343,14 +343,14 @@ void SparsityPattern::assemble()
   for (std::size_t i = 0; i < ghost_data_received.size(); i += 2)
   {
     const std::int64_t row = ghost_data_received[i];
-    if (row >= bs0 * local_range0[0] and row < bs0 * local_range0[1])
+    if (row >= _bs[0] * local_range0[0] and row < _bs[0] * local_range0[1])
     {
-      const std::int32_t row_local = row - bs0 * local_range0[0];
+      const std::int32_t row_local = row - _bs[0] * local_range0[0];
       const std::int64_t col = ghost_data_received[i + 1];
-      if (col >= bs1 * local_range1[0] and col < bs1 * local_range1[1])
+      if (col >= _bs[1] * local_range1[0] and col < _bs[1] * local_range1[1])
       {
         // Convert to local column index
-        const std::int32_t J = col - bs1 * local_range1[0];
+        const std::int32_t J = col - _bs[1] * local_range1[0];
         _diagonal_cache[row_local].push_back(J);
       }
       else
@@ -361,7 +361,7 @@ void SparsityPattern::assemble()
     }
   }
 
-  _diagonal_cache.resize(bs0 * local_size0);
+  _diagonal_cache.resize(_bs[0] * local_size0);
   for (std::vector<std::int32_t>& row : _diagonal_cache)
   {
     std::sort(row.begin(), row.end());
@@ -371,7 +371,7 @@ void SparsityPattern::assemble()
       = std::make_shared<graph::AdjacencyList<std::int32_t>>(_diagonal_cache);
   std::vector<std::vector<std::int32_t>>().swap(_diagonal_cache);
 
-  _off_diagonal_cache.resize(bs0 * local_size0);
+  _off_diagonal_cache.resize(_bs[0] * local_size0);
   for (std::vector<std::int64_t>& row : _off_diagonal_cache)
   {
     std::sort(row.begin(), row.end());

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -183,7 +183,7 @@ SparsityPattern::index_map(int dim) const
   return _index_maps.at(dim);
 }
 //-----------------------------------------------------------------------------
-int SparsityPattern::block_size(int dim) const { return _bs[0]; }
+int SparsityPattern::block_size(int dim) const { return _bs[dim]; }
 //-----------------------------------------------------------------------------
 
 void SparsityPattern::insert(

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -50,9 +50,8 @@ public:
   /// @param[in] comm The MPI communicator
   /// @param[in] patterns Rectangular array of sparsity pattern. The
   ///   patterns must not be finalised. Null block are permited
-  /// @param[in] maps Index maps for each row block (maps[0]) and column
-  ///   blocks (maps[1])
-  /// @param[in] bs
+  /// @param[in] maps Pairs of (index map, block size) for each row
+  ///   block (maps[0]) and column blocks (maps[1])
   SparsityPattern(
       MPI_Comm comm,
       const std::vector<std::vector<const SparsityPattern*>>& patterns,

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -40,7 +40,8 @@ public:
   /// Create an empty sparsity pattern with specified dimensions
   SparsityPattern(
       MPI_Comm comm,
-      const std::array<std::shared_ptr<const common::IndexMap>, 2>& index_maps);
+      const std::array<std::shared_ptr<const common::IndexMap>, 2>& index_maps,
+      const std::array<int, 2>& bs);
 
   /// Create a new sparsity pattern by concatenating sub-patterns, e.g.
   /// pattern =[ pattern00 ][ pattern 01]
@@ -55,8 +56,8 @@ public:
       MPI_Comm comm,
       const std::vector<std::vector<const SparsityPattern*>>& patterns,
       const std::array<
-          std::vector<std::reference_wrapper<const common::IndexMap>>, 2>&
-          maps);
+          std::vector<std::reference_wrapper<const common::IndexMap>>, 2>& maps,
+      const std::array<std::vector<int>, 2>& bs);
 
   SparsityPattern(const SparsityPattern& pattern) = delete;
 
@@ -74,6 +75,9 @@ public:
 
   /// Return index map for dimension dim
   std::shared_ptr<const common::IndexMap> index_map(int dim) const;
+
+  /// Return index map block size for dimension dim
+  int block_size(int dim) const;
 
   /// Insert non-zero locations using local (process-wise) indices
   void
@@ -112,6 +116,7 @@ private:
 
   // common::IndexMaps for each dimension
   std::array<std::shared_ptr<const common::IndexMap>, 2> _index_maps;
+  std::array<int, 2> _bs;
 
   // Caches for diagonal and off-diagonal blocks
   std::vector<std::vector<std::int32_t>> _diagonal_cache;

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -52,6 +52,7 @@ public:
   ///   patterns must not be finalised. Null block are permited
   /// @param[in] maps Index maps for each row block (maps[0]) and column
   ///   blocks (maps[1])
+  /// @param[in] bs
   SparsityPattern(
       MPI_Comm comm,
       const std::vector<std::vector<const SparsityPattern*>>& patterns,

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -57,8 +57,9 @@ public:
       MPI_Comm comm,
       const std::vector<std::vector<const SparsityPattern*>>& patterns,
       const std::array<
-          std::vector<std::reference_wrapper<const common::IndexMap>>, 2>& maps,
-      const std::array<std::vector<int>, 2>& bs);
+          std::vector<
+              std::pair<std::reference_wrapper<const common::IndexMap>, int>>,
+          2>& maps);
 
   SparsityPattern(const SparsityPattern& pattern) = delete;
 

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -40,7 +40,7 @@ public:
   /// Create an empty sparsity pattern with specified dimensions
   SparsityPattern(
       MPI_Comm comm,
-      const std::array<std::shared_ptr<const common::IndexMap>, 2>& index_maps,
+      const std::array<std::shared_ptr<const common::IndexMap>, 2>& maps,
       const std::array<int, 2>& bs);
 
   /// Create a new sparsity pattern by concatenating sub-patterns, e.g.

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -20,11 +20,12 @@ class Vector
 {
 public:
   /// Create vector
-  Vector(const std::shared_ptr<const common::IndexMap>& map) : _map(map)
+  Vector(const std::shared_ptr<const common::IndexMap>& map, int bs)
+      : _map(map), _bs(bs)
   {
     assert(map);
     const std::int32_t local_size
-        = map->block_size() * (map->size_local() + map->num_ghosts());
+        = bs * (map->size_local() + map->num_ghosts());
     _x.resize(local_size);
   }
 
@@ -46,6 +47,9 @@ public:
   /// Get local part of the vector (const version)
   std::shared_ptr<const common::IndexMap> map() const { return _map; }
 
+  /// Get block size
+  int bs() const { return _bs; }
+
   /// Get local part of the vector (const version)
   const Eigen::Matrix<T, Eigen::Dynamic, 1>& array() const { return _x; }
 
@@ -55,6 +59,9 @@ public:
 private:
   // Map describing the data layout
   std::shared_ptr<const common::IndexMap> _map;
+
+  // Block size
+  int _bs;
 
   // Data
   Eigen::Matrix<T, Eigen::Dynamic, 1> _x;

--- a/cpp/dolfinx/mesh/Geometry.cpp
+++ b/cpp/dolfinx/mesh/Geometry.cpp
@@ -75,7 +75,7 @@ mesh::Geometry mesh::create_geometry(
   // fem::DofMapBuilder::build to take connectivities
 
   //  Build 'geometry' dofmap on the topology
-  auto [dof_index_map, dofmap] = fem::DofMapBuilder::build(
+  auto [dof_index_map, bs, dofmap] = fem::DofMapBuilder::build(
       comm, topology, coordinate_element.dof_layout());
 
   // Build list of unique (global) node indices from adjacency list

--- a/cpp/dolfinx/mesh/PermutationComputation.cpp
+++ b/cpp/dolfinx/mesh/PermutationComputation.cpp
@@ -30,13 +30,13 @@ compute_face_permutations_simplex(
 
   for (int c = 0; c < num_cells; ++c)
   {
-    auto cell_vertices = im->local_to_global(c_to_v.links(c), 1);
+    auto cell_vertices = im->local_to_global(c_to_v.links(c));
     auto cell_faces = c_to_f.links(c);
     for (int i = 0; i < faces_per_cell; ++i)
     {
       // Get the face
       const int face = cell_faces[i];
-      const auto vertices = im->local_to_global(f_to_v.links(face), 1);
+      const auto vertices = im->local_to_global(f_to_v.links(face));
 
       // Orient that triangle so the the lowest numbered vertex is the
       // origin, and the next vertex anticlockwise from the lowest has a
@@ -110,13 +110,13 @@ compute_face_permutations_tp(const graph::AdjacencyList<std::int32_t>& c_to_v,
 
   for (int c = 0; c < num_cells; ++c)
   {
-    auto cell_vertices = im->local_to_global(c_to_v.links(c), 1);
+    auto cell_vertices = im->local_to_global(c_to_v.links(c));
     auto cell_faces = c_to_f.links(c);
     for (int i = 0; i < faces_per_cell; ++i)
     {
       // Get the face
       const int face = cell_faces[i];
-      auto vertices = im->local_to_global(f_to_v.links(face), 1);
+      auto vertices = im->local_to_global(f_to_v.links(face));
 
       // Orient that triangle so the the lowest numbered vertex is the
       // origin, and the next vertex anticlockwise from the lowest has a
@@ -243,11 +243,11 @@ compute_edge_reflections(const mesh::Topology& topology)
       edges_per_cell, c_to_v->num_nodes());
   for (int c = 0; c < c_to_v->num_nodes(); ++c)
   {
-    auto cell_vertices = im->local_to_global(c_to_v->links(c), 1);
+    auto cell_vertices = im->local_to_global(c_to_v->links(c));
     auto cell_edges = c_to_e->links(c);
     for (int i = 0; i < edges_per_cell; ++i)
     {
-      auto vertices = im->local_to_global(e_to_v->links(cell_edges[i]), 1);
+      auto vertices = im->local_to_global(e_to_v->links(cell_edges[i]));
 
       // If the entity is an interval, it should be oriented pointing
       // from the lowest numbered vertex to the highest numbered vertex.

--- a/cpp/dolfinx/mesh/PermutationComputation.cpp
+++ b/cpp/dolfinx/mesh/PermutationComputation.cpp
@@ -30,13 +30,13 @@ compute_face_permutations_simplex(
 
   for (int c = 0; c < num_cells; ++c)
   {
-    auto cell_vertices = im->local_to_global(c_to_v.links(c));
+    auto cell_vertices = im->local_to_global(c_to_v.links(c), 1);
     auto cell_faces = c_to_f.links(c);
     for (int i = 0; i < faces_per_cell; ++i)
     {
       // Get the face
       const int face = cell_faces[i];
-      const auto vertices = im->local_to_global(f_to_v.links(face));
+      const auto vertices = im->local_to_global(f_to_v.links(face), 1);
 
       // Orient that triangle so the the lowest numbered vertex is the
       // origin, and the next vertex anticlockwise from the lowest has a
@@ -110,13 +110,13 @@ compute_face_permutations_tp(const graph::AdjacencyList<std::int32_t>& c_to_v,
 
   for (int c = 0; c < num_cells; ++c)
   {
-    auto cell_vertices = im->local_to_global(c_to_v.links(c));
+    auto cell_vertices = im->local_to_global(c_to_v.links(c), 1);
     auto cell_faces = c_to_f.links(c);
     for (int i = 0; i < faces_per_cell; ++i)
     {
       // Get the face
       const int face = cell_faces[i];
-      auto vertices = im->local_to_global(f_to_v.links(face));
+      auto vertices = im->local_to_global(f_to_v.links(face), 1);
 
       // Orient that triangle so the the lowest numbered vertex is the
       // origin, and the next vertex anticlockwise from the lowest has a
@@ -243,11 +243,11 @@ compute_edge_reflections(const mesh::Topology& topology)
       edges_per_cell, c_to_v->num_nodes());
   for (int c = 0; c < c_to_v->num_nodes(); ++c)
   {
-    auto cell_vertices = im->local_to_global(c_to_v->links(c));
+    auto cell_vertices = im->local_to_global(c_to_v->links(c), 1);
     auto cell_edges = c_to_e->links(c);
     for (int i = 0; i < edges_per_cell; ++i)
     {
-      auto vertices = im->local_to_global(e_to_v->links(cell_edges[i]));
+      auto vertices = im->local_to_global(e_to_v->links(cell_edges[i]), 1);
 
       // If the entity is an interval, it should be oriented pointing
       // from the lowest numbered vertex to the highest numbered vertex.

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -322,7 +322,7 @@ mesh::create_topology(MPI_Comm comm,
   const int num_local_cells = cells.num_nodes() - ghost_owners.size();
   std::shared_ptr<common::IndexMap> index_map_c;
   if (ghost_mode == mesh::GhostMode::none)
-    index_map_c = std::make_shared<common::IndexMap>(comm, num_local_cells, 1);
+    index_map_c = std::make_shared<common::IndexMap>(comm, num_local_cells);
   else
   {
     // Get global indices of ghost cells
@@ -333,7 +333,7 @@ mesh::create_topology(MPI_Comm comm,
         comm, num_local_cells,
         dolfinx::MPI::compute_graph_edges(
             comm, std::set<int>(ghost_owners.begin(), ghost_owners.end())),
-        cell_ghost_indices, ghost_owners, 1);
+        cell_ghost_indices, ghost_owners);
   }
 
   // Create map from existing global vertex index to local index,
@@ -612,7 +612,7 @@ mesh::create_topology(MPI_Comm comm,
       dolfinx::MPI::compute_graph_edges(
           comm, std::set<int>(ghost_vertices_owners.begin(),
                               ghost_vertices_owners.end())),
-      ghost_vertices, ghost_vertices_owners, 1);
+      ghost_vertices, ghost_vertices_owners);
   topology.set_index_map(0, index_map_v);
   auto c0 = std::make_shared<graph::AdjacencyList<std::int32_t>>(
       index_map_v->size_local() + index_map_v->num_ghosts());

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -175,23 +175,18 @@ std::int32_t Topology::create_entities(int dim)
     return -1;
 
   // Create local entities
-  std::cout << "Create entities: " << dim << std::endl;
   const auto [cell_entity, entity_vertex, index_map]
       = TopologyComputation::compute_entities(_mpi_comm.comm(), *this, dim);
 
-  std::cout << "Create entities 0" << std::endl;
   if (cell_entity)
     set_connectivity(cell_entity, this->dim(), dim);
 
   // TODO: is this check necessary? Seems redundant after to the "skip check"
-  std::cout << "Create entities 1" << std::endl;
   if (entity_vertex)
     set_connectivity(entity_vertex, dim, 0);
 
-  std::cout << "Create entities 2" << std::endl;
   assert(index_map);
-  set_index_map(dim, index_map);
-  std::cout << "Create entities 3" << std::endl;
+  this->set_index_map(dim, index_map);
 
   return index_map->size_local();
 }

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -190,7 +190,7 @@ std::int32_t Topology::create_entities(int dim)
 
   std::cout << "Create entities 2" << std::endl;
   assert(index_map);
-  this->set_index_map(dim, index_map);
+  set_index_map(dim, index_map);
   std::cout << "Create entities 3" << std::endl;
 
   return index_map->size_local();

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -175,18 +175,23 @@ std::int32_t Topology::create_entities(int dim)
     return -1;
 
   // Create local entities
+  std::cout << "Create entities: " << dim << std::endl;
   const auto [cell_entity, entity_vertex, index_map]
       = TopologyComputation::compute_entities(_mpi_comm.comm(), *this, dim);
 
+  std::cout << "Create entities 0" << std::endl;
   if (cell_entity)
     set_connectivity(cell_entity, this->dim(), dim);
 
   // TODO: is this check necessary? Seems redundant after to the "skip check"
+  std::cout << "Create entities 1" << std::endl;
   if (entity_vertex)
     set_connectivity(entity_vertex, dim, 0);
 
+  std::cout << "Create entities 2" << std::endl;
   assert(index_map);
-  set_index_map(dim, index_map);
+  this->set_index_map(dim, index_map);
+  std::cout << "Create entities 3" << std::endl;
 
   return index_map->size_local();
 }

--- a/cpp/dolfinx/mesh/TopologyComputation.cpp
+++ b/cpp/dolfinx/mesh/TopologyComputation.cpp
@@ -394,7 +394,7 @@ get_local_indexing(
       comm, num_local,
       dolfinx::MPI::compute_graph_edges(
           comm, std::set<int>(ghost_owners.begin(), ghost_owners.end())),
-      ghost_indices, ghost_owners, 1);
+      ghost_indices, ghost_owners);
 
   // Map from initial numbering to new local indices
   std::vector<std::int32_t> new_entity_index(entity_index.size());

--- a/cpp/dolfinx/mesh/TopologyComputation.cpp
+++ b/cpp/dolfinx/mesh/TopologyComputation.cpp
@@ -208,7 +208,7 @@ get_local_indexing(
 
         vlocal.assign(entity_list.row(i).data(),
                       entity_list.row(i).data() + num_vertices);
-        vglobal = vertex_indexmap->local_to_global(vlocal, false);
+        vglobal = vertex_indexmap->local_to_global(vlocal, 1);
         std::sort(vglobal.begin(), vglobal.end());
 
         global_entity_to_entity_index.insert({vglobal, entity_index[i]});
@@ -429,6 +429,8 @@ compute_entities_by_key_matching(
         "Cannot create vertices for topology. Should already exist.");
   }
 
+  std::cout << "Compute by matching (0)" << std::endl;
+
   // Start timer
   common::Timer timer("Compute entities of dim = " + std::to_string(dim));
 
@@ -438,12 +440,14 @@ compute_entities_by_key_matching(
   const int num_vertices_per_entity
       = mesh::num_cell_vertices(mesh::cell_entity_type(cell_type, dim));
 
+  std::cout << "Compute by matching (1)" << std::endl;
   // Create map from cell vertices to entity vertices
   Eigen::Array<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> e_vertices
       = mesh::get_entity_vertices(cell_type, dim);
 
   const int num_cells = cells.num_nodes();
 
+  std::cout << "Compute by matching (2)" << std::endl;
   // List of vertices for each entity in each cell
   Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
       entity_list(num_cells * num_entities_per_cell, num_vertices_per_entity);
@@ -468,6 +472,8 @@ compute_entities_by_key_matching(
   std::vector<std::int32_t> entity_index(entity_list.rows());
   std::int32_t entity_count = 0;
 
+  std::cout << "Compute by matching (3)" << std::endl;
+
   // Copy list and sort vertices of each entity into order
   Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
       entity_list_sorted = entity_list;
@@ -476,6 +482,8 @@ compute_entities_by_key_matching(
     std::sort(entity_list_sorted.row(i).data(),
               entity_list_sorted.row(i).data() + num_vertices_per_entity);
   }
+
+  std::cout << "Compute by matching (4)" << std::endl;
 
   // Sort the list and label uniquely
   const std::vector sort_order = sort_by_perm<std::int32_t>(entity_list_sorted);
@@ -491,16 +499,20 @@ compute_entities_by_key_matching(
   }
   ++entity_count;
 
+  std::cout << "Compute by matching (5)" << std::endl;
+
   // Communicate with other processes to find out which entities are
   // ghosted and shared. Remap the numbering so that ghosts are at the
   // end.
   const auto [local_index, index_map] = get_local_indexing(
       comm, cell_index_map, vertex_index_map, entity_list, entity_index);
 
+  std::cout << "Compute by matching (6)" << std::endl;
   Eigen::Array<std::int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
       connectivity_ce(num_cells, num_entities_per_cell);
   std::copy(local_index.begin(), local_index.end(), connectivity_ce.data());
 
+  std::cout << "Compute by matching (7)" << std::endl;
   // Cell-entity connectivity
   auto ce
       = std::make_shared<graph::AdjacencyList<std::int32_t>>(connectivity_ce);
@@ -511,6 +523,7 @@ compute_entities_by_key_matching(
   for (int i = 0; i < entity_list.rows(); ++i)
     connectivity_ev.row(local_index[i]) = entity_list.row(i);
 
+  std::cout << "Compute by matching (8)" << std::endl;
   auto ev
       = std::make_shared<graph::AdjacencyList<std::int32_t>>(connectivity_ev);
 
@@ -643,6 +656,8 @@ TopologyComputation::compute_entities(MPI_Comm comm, const Topology& topology,
   if (dim == 0)
     return {nullptr, nullptr, nullptr};
 
+  std::cout << "Compute ents:  " << dim << std::endl;
+
   if (topology.connectivity(dim, 0))
   {
     // Make sure we really have the connectivity
@@ -657,19 +672,24 @@ TopologyComputation::compute_entities(MPI_Comm comm, const Topology& topology,
     return {nullptr, nullptr, nullptr};
   }
 
+  std::cout << "Compute ents (A)" << std::endl;
+
   auto cells = topology.connectivity(tdim, 0);
   if (!cells)
     throw std::runtime_error("Cell connectivity missing.");
 
+  std::cout << "Compute ents (B)" << std::endl;
   auto vertex_map = topology.index_map(0);
   assert(vertex_map);
   auto cell_map = topology.index_map(tdim);
   assert(cell_map);
+  std::cout << "Compute ents (C)" << std::endl;
   std::tuple<std::shared_ptr<graph::AdjacencyList<std::int32_t>>,
              std::shared_ptr<graph::AdjacencyList<std::int32_t>>,
              std::shared_ptr<common::IndexMap>>
       data = compute_entities_by_key_matching(
           comm, *cells, vertex_map, cell_map, topology.cell_type(), dim);
+  std::cout << "Compute ents (D)" << std::endl;
 
   return data;
 }

--- a/cpp/dolfinx/mesh/TopologyComputation.cpp
+++ b/cpp/dolfinx/mesh/TopologyComputation.cpp
@@ -208,7 +208,7 @@ get_local_indexing(
 
         vlocal.assign(entity_list.row(i).data(),
                       entity_list.row(i).data() + num_vertices);
-        vglobal = vertex_indexmap->local_to_global(vlocal, 1);
+        vglobal = vertex_indexmap->local_to_global(vlocal);
         std::sort(vglobal.begin(), vglobal.end());
 
         global_entity_to_entity_index.insert({vglobal, entity_index[i]});

--- a/cpp/dolfinx/refinement/PlazaRefinementND.cpp
+++ b/cpp/dolfinx/refinement/PlazaRefinementND.cpp
@@ -341,7 +341,7 @@ face_long_edge(const mesh::Mesh& mesh)
   auto f_to_e = mesh.topology().connectivity(2, 1);
   assert(f_to_e);
   const std::vector global_indices
-      = mesh.topology().index_map(0)->global_indices(true);
+      = mesh.topology().index_map(0)->global_indices();
   for (int f = 0; f < f_to_v->num_nodes(); ++f)
   {
     auto face_edges = f_to_e->links(f);

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -215,7 +215,8 @@ void refinement::update_logical_edgefunction(
             .array();
 
   // Flatten received values and set marked_edges at each index received
-  std::vector<std::int32_t> local_indices = map_e.global_to_local(data_to_recv);
+  std::vector<std::int32_t> local_indices
+      = map_e.global_to_local(data_to_recv, 1);
   for (std::int32_t local_index : local_indices)
     marked_edges[local_index] = true;
 }
@@ -305,7 +306,7 @@ refinement::create_new_vertices(
   for (int i = 0; i < received_values.size() / 2; ++i)
     recv_global_edge.push_back(received_values[i * 2]);
   std::vector<std::int32_t> recv_local_edge
-      = mesh.topology().index_map(1)->global_to_local(recv_global_edge);
+      = mesh.topology().index_map(1)->global_to_local(recv_global_edge, 1);
   for (int i = 0; i < received_values.size() / 2; ++i)
   {
     auto it = local_edge_to_new_vertex.insert(
@@ -332,7 +333,7 @@ std::vector<std::int64_t> refinement::adjust_indices(
   for (std::int32_t r : recvn)
     global_offsets.push_back(global_offsets.back() + r);
 
-  std::vector global_indices = index_map->global_indices(true);
+  std::vector global_indices = index_map->global_indices();
 
   Eigen::Array<int, Eigen::Dynamic, 1> ghost_owners
       = index_map->ghost_owner_rank();
@@ -438,7 +439,7 @@ mesh::Mesh refinement::partition(
     const int tdim = topology_local.dim();
     auto map = std::make_shared<common::IndexMap>(
         comm, cells_local.num_nodes(), std::vector<int>(),
-        std::vector<std::int64_t>(), std::vector<int>(), 1);
+        std::vector<std::int64_t>(), std::vector<int>());
     topology_local.set_index_map(tdim, map);
     auto _cells_local
         = std::make_shared<graph::AdjacencyList<std::int32_t>>(cells_local);
@@ -447,7 +448,7 @@ mesh::Mesh refinement::partition(
     const int n = local_to_global_vertices.size();
     map = std::make_shared<common::IndexMap>(comm, n, std::vector<int>(),
                                              std::vector<std::int64_t>(),
-                                             std::vector<int>(), 1);
+                                             std::vector<int>());
     topology_local.set_index_map(0, map);
     auto _vertices_local
         = std::make_shared<graph::AdjacencyList<std::int32_t>>(n);
@@ -491,7 +492,7 @@ mesh::Mesh refinement::partition(
     // Set cell IndexMap and cell-vertex connectivity
     auto index_map_c = std::make_shared<common::IndexMap>(
         comm, cells_d.num_nodes(), std::vector<int>(),
-        std::vector<std::int64_t>(), std::vector<int>(), 1);
+        std::vector<std::int64_t>(), std::vector<int>());
     topology.set_index_map(tdim, index_map_c);
     auto _cells_d
         = std::make_shared<graph::AdjacencyList<std::int32_t>>(cells_d);

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -215,8 +215,7 @@ void refinement::update_logical_edgefunction(
             .array();
 
   // Flatten received values and set marked_edges at each index received
-  std::vector<std::int32_t> local_indices
-      = map_e.global_to_local(data_to_recv, 1);
+  std::vector<std::int32_t> local_indices = map_e.global_to_local(data_to_recv);
   for (std::int32_t local_index : local_indices)
     marked_edges[local_index] = true;
 }
@@ -306,7 +305,7 @@ refinement::create_new_vertices(
   for (int i = 0; i < received_values.size() / 2; ++i)
     recv_global_edge.push_back(received_values[i * 2]);
   std::vector<std::int32_t> recv_local_edge
-      = mesh.topology().index_map(1)->global_to_local(recv_global_edge, 1);
+      = mesh.topology().index_map(1)->global_to_local(recv_global_edge);
   for (int i = 0; i < received_values.size() / 2; ++i)
   {
     auto it = local_edge_to_new_vertex.insert(

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -217,7 +217,10 @@ void refinement::update_logical_edgefunction(
   // Flatten received values and set marked_edges at each index received
   std::vector<std::int32_t> local_indices = map_e.global_to_local(data_to_recv);
   for (std::int32_t local_index : local_indices)
+  {
+    assert(local_index != -1);
     marked_edges[local_index] = true;
+  }
 }
 //-----------------------------------------------------------------------------
 std::pair<std::map<std::int32_t, std::int64_t>,
@@ -308,6 +311,7 @@ refinement::create_new_vertices(
       = mesh.topology().index_map(1)->global_to_local(recv_global_edge);
   for (int i = 0; i < received_values.size() / 2; ++i)
   {
+    assert(recv_local_edge[i] != -1);
     auto it = local_edge_to_new_vertex.insert(
         {recv_local_edge[i], received_values[i * 2 + 1]});
     assert(it.second);

--- a/cpp/test/unit/common/index_map.cpp
+++ b/cpp/test/unit/common/index_map.cpp
@@ -38,7 +38,7 @@ void test_scatter_fwd()
       dolfinx::MPI::compute_graph_edges(
           MPI_COMM_WORLD,
           std::set<int>(global_ghost_owner.begin(), global_ghost_owner.end())),
-      ghosts, global_ghost_owner, 1);
+      ghosts, global_ghost_owner);
 
   // Create some data to scatter
   const std::int64_t val = 11;
@@ -76,7 +76,7 @@ void test_scatter_rev()
       dolfinx::MPI::compute_graph_edges(
           MPI_COMM_WORLD,
           std::set<int>(global_ghost_owner.begin(), global_ghost_owner.end())),
-      ghosts, global_ghost_owner, 1);
+      ghosts, global_ghost_owner);
 
   // Create some data, setting ghost values
   std::int64_t value = 15;

--- a/python/demo/elasticity/demo_elasticity.py
+++ b/python/demo/elasticity/demo_elasticity.py
@@ -41,7 +41,7 @@ def build_nullspace(V):
 
     # Create list of vectors for null space
     index_map = V.dofmap.index_map
-    nullspace_basis = [cpp.la.create_vector(index_map) for i in range(6)]
+    nullspace_basis = [cpp.la.create_vector(index_map, V.dofmap.index_map_bs) for i in range(6)]
 
     with ExitStack() as stack:
         vec_local = [stack.enter_context(x.localForm()) for x in nullspace_basis]

--- a/python/demo/helmholtz2D/demo_helmholtz_2d.py
+++ b/python/demo/helmholtz2D/demo_helmholtz_2d.py
@@ -42,7 +42,6 @@ else:
 
 # Test and trial function space
 V = FunctionSpace(mesh, ("Lagrange", deg))
-exit(0)
 
 # Define variational problem
 u = TrialFunction(V)

--- a/python/demo/helmholtz2D/demo_helmholtz_2d.py
+++ b/python/demo/helmholtz2D/demo_helmholtz_2d.py
@@ -42,6 +42,7 @@ else:
 
 # Test and trial function space
 V = FunctionSpace(mesh, ("Lagrange", deg))
+exit(0)
 
 # Define variational problem
 u = TrialFunction(V)

--- a/python/demo/stokes-taylor-hood/demo_stokes-taylor-hood.py
+++ b/python/demo/stokes-taylor-hood/demo_stokes-taylor-hood.py
@@ -289,7 +289,7 @@ b = dolfinx.fem.assemble.assemble_vector_block(L, a, bcs)
 
 # Set near null space for pressure
 null_vec = A.createVecLeft()
-offset = V.dofmap.index_map.size_local * V.dofmap.index_map.block_size
+offset = V.dofmap.index_map.size_local * V.dofmap.index_map_bs
 null_vec.array[offset:] = 1.0
 null_vec.normalize()
 nsp = PETSc.NullSpace().create(vectors=[null_vec])
@@ -299,9 +299,9 @@ A.setNullSpace(nsp)
 # Build IndexSets for each field (global dof indices for each field)
 V_map = V.dofmap.index_map
 Q_map = Q.dofmap.index_map
-offset_u = V_map.local_range[0] * V_map.block_size + Q_map.local_range[0]
-offset_p = offset_u + V_map.size_local * V_map.block_size
-is_u = PETSc.IS().createStride(V_map.size_local * V_map.block_size, offset_u, 1, comm=PETSc.COMM_SELF)
+offset_u = V_map.local_range[0] * V.dofmap.index_map_bs + Q_map.local_range[0]
+offset_p = offset_u + V_map.size_local * V.dofmap.index_map_bs
+is_u = PETSc.IS().createStride(V_map.size_local * V.dofmap.index_map_bs, offset_u, 1, comm=PETSc.COMM_SELF)
 is_p = PETSc.IS().createStride(Q_map.size_local, offset_p, 1, comm=PETSc.COMM_SELF)
 
 # Create Krylov solver
@@ -338,7 +338,7 @@ ksp.solve(b, x)
 
 # Create Functions and scatter x solution
 u, p = Function(V), Function(Q)
-offset = V_map.size_local * V_map.block_size
+offset = V_map.size_local * V.dofmap.index_map_bs
 u.vector.array[:] = x.array_r[:offset]
 p.vector.array[:] = x.array_r[offset:]
 
@@ -373,7 +373,7 @@ ksp.solve(b, x)
 
 # Create Functions and scatter x solution
 u, p = Function(V), Function(Q)
-offset = V_map.size_local * V_map.block_size
+offset = V_map.size_local * V.dofmap.index_map_bs
 u.vector.array[:] = x.array_r[:offset]
 p.vector.array[:] = x.array_r[offset:]
 

--- a/python/doc/source/installation.rst
+++ b/python/doc/source/installation.rst
@@ -72,7 +72,7 @@ e.g. ``mkdir -p build/`` and in the build run directory::
 
 To set the installation prefix::
 
-    cmake -DCMAKE_INSTALL_PATH=<my-install-path> ../
+    cmake -DCMAKE_INSTALL_PREFIX=<my-install-path> ../
     make install
 
 

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -154,7 +154,7 @@ def assemble_vector_block(L: typing.List[typing.Union[Form, cpp.fem.Form]],
     return assemble_vector_block(b, L, a, bcs, x0, scale)
 
 
-@ assemble_vector_block.register(PETSc.Vec)
+@assemble_vector_block.register(PETSc.Vec)
 def _(b: PETSc.Vec,
       L: typing.List[typing.Union[Form, cpp.fem.Form]],
       a,
@@ -198,7 +198,7 @@ def _(b: PETSc.Vec,
 # -- Matrix assembly ---------------------------------------------------------
 
 
-@ functools.singledispatch
+@functools.singledispatch
 def assemble_matrix(a: typing.Union[Form, cpp.fem.Form],
                     bcs: typing.List[DirichletBC] = [],
                     diagonal: float = 1.0) -> PETSc.Mat:
@@ -210,7 +210,7 @@ def assemble_matrix(a: typing.Union[Form, cpp.fem.Form],
     return assemble_matrix(A, a, bcs, diagonal)
 
 
-@ assemble_matrix.register(PETSc.Mat)
+@assemble_matrix.register(PETSc.Mat)
 def _(A: PETSc.Mat,
       a: typing.Union[Form, cpp.fem.Form],
       bcs: typing.List[DirichletBC] = [],
@@ -227,7 +227,7 @@ def _(A: PETSc.Mat,
 
 
 # FIXME: Revise this interface
-@ functools.singledispatch
+@functools.singledispatch
 def assemble_matrix_nest(a: typing.List[typing.List[typing.Union[Form, cpp.fem.Form]]],
                          bcs: typing.List[DirichletBC] = [],
                          diagonal: float = 1.0) -> PETSc.Mat:
@@ -237,7 +237,7 @@ def assemble_matrix_nest(a: typing.List[typing.List[typing.Union[Form, cpp.fem.F
     return A
 
 
-@ assemble_matrix_nest.register(PETSc.Mat)
+@assemble_matrix_nest.register(PETSc.Mat)
 def _(A: PETSc.Mat,
       a: typing.List[typing.List[typing.Union[Form, cpp.fem.Form]]],
       bcs: typing.List[DirichletBC] = [],
@@ -253,7 +253,7 @@ def _(A: PETSc.Mat,
 
 
 # FIXME: Revise this interface
-@ functools.singledispatch
+@functools.singledispatch
 def assemble_matrix_block(a: typing.List[typing.List[typing.Union[Form, cpp.fem.Form]]],
                           bcs: typing.List[DirichletBC] = [],
                           diagonal: float = 1.0) -> PETSc.Mat:
@@ -292,7 +292,7 @@ def _extract_function_spaces(a: typing.List[typing.List[typing.Union[Form, cpp.f
     return rows, cols
 
 
-@ assemble_matrix_block.register(PETSc.Mat)
+@assemble_matrix_block.register(PETSc.Mat)
 def _(A: PETSc.Mat,
       a: typing.List[typing.List[typing.Union[Form, cpp.fem.Form]]],
       bcs: typing.List[DirichletBC] = [],

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -248,11 +248,11 @@ def _(A: PETSc.Mat,
         for j, a_block in enumerate(a_row):
             if a_block is not None:
                 Asub = A.getNestSubMatrix(i, j)
-                print("I, J", i, j)
-                Asub.getLGMap()[0].view()
-                print("bs mat0:", Asub.getLGMap()[0].getBlockSize())
-                Asub.getLGMap()[1].view()
-                print("bs mat1:", Asub.getLGMap()[1].getBlockSize())
+                # print("I, J", i, j)
+                # Asub.getLGMap()[0].view()
+                # print("bs mat0:", Asub.getLGMap()[0].getBlockSize())
+                # Asub.getLGMap()[1].view()
+                # print("bs mat1:", Asub.getLGMap()[1].getBlockSize())
                 assemble_matrix(Asub, a_block, bcs)
     return A
 
@@ -263,7 +263,9 @@ def assemble_matrix_block(a: typing.List[typing.List[typing.Union[Form, cpp.fem.
                           bcs: typing.List[DirichletBC] = [],
                           diagonal: float = 1.0) -> PETSc.Mat:
     """Assemble bilinear forms into matrix"""
+    print("A: ********")
     A = cpp.fem.create_matrix_block(_create_cpp_form(a))
+    print("B: ********")
     return assemble_matrix_block(A, a, bcs, diagonal)
 
 
@@ -303,12 +305,16 @@ def _(A: PETSc.Mat,
       bcs: typing.List[DirichletBC] = [],
       diagonal: float = 1.0) -> PETSc.Mat:
     """Assemble bilinear forms into matrix"""
+    print("Main 0")
     _a = _create_cpp_form(a)
+    print("Main 1")
     V = _extract_function_spaces(_a)
+    print("Main 2")
     is_rows = cpp.la.create_petsc_index_sets([Vsub.dofmap.index_map for Vsub in V[0]],
                                              [Vsub.dofmap.index_map_bs for Vsub in V[0]])
     is_cols = cpp.la.create_petsc_index_sets([Vsub.dofmap.index_map for Vsub in V[1]],
                                              [Vsub.dofmap.index_map_bs for Vsub in V[1]])
+    print("Main 3")
     for i, a_row in enumerate(_a):
         for j, a_sub in enumerate(a_row):
             if a_sub is not None:

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -248,11 +248,6 @@ def _(A: PETSc.Mat,
         for j, a_block in enumerate(a_row):
             if a_block is not None:
                 Asub = A.getNestSubMatrix(i, j)
-                # print("I, J", i, j)
-                # Asub.getLGMap()[0].view()
-                # print("bs mat0:", Asub.getLGMap()[0].getBlockSize())
-                # Asub.getLGMap()[1].view()
-                # print("bs mat1:", Asub.getLGMap()[1].getBlockSize())
                 assemble_matrix(Asub, a_block, bcs)
     return A
 
@@ -263,9 +258,7 @@ def assemble_matrix_block(a: typing.List[typing.List[typing.Union[Form, cpp.fem.
                           bcs: typing.List[DirichletBC] = [],
                           diagonal: float = 1.0) -> PETSc.Mat:
     """Assemble bilinear forms into matrix"""
-    print("A: ********")
     A = cpp.fem.create_matrix_block(_create_cpp_form(a))
-    print("B: ********")
     return assemble_matrix_block(A, a, bcs, diagonal)
 
 
@@ -305,16 +298,12 @@ def _(A: PETSc.Mat,
       bcs: typing.List[DirichletBC] = [],
       diagonal: float = 1.0) -> PETSc.Mat:
     """Assemble bilinear forms into matrix"""
-    print("Main 0")
     _a = _create_cpp_form(a)
-    print("Main 1")
     V = _extract_function_spaces(_a)
-    print("Main 2")
     is_rows = cpp.la.create_petsc_index_sets([Vsub.dofmap.index_map for Vsub in V[0]],
                                              [Vsub.dofmap.index_map_bs for Vsub in V[0]])
     is_cols = cpp.la.create_petsc_index_sets([Vsub.dofmap.index_map for Vsub in V[1]],
                                              [Vsub.dofmap.index_map_bs for Vsub in V[1]])
-    print("Main 3")
     for i, a_row in enumerate(_a):
         for j, a_sub in enumerate(a_row):
             if a_sub is not None:

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -205,7 +205,6 @@ def assemble_matrix(a: typing.Union[Form, cpp.fem.Form],
 
     """
     A = cpp.fem.create_matrix(_create_cpp_form(a))
-    A.zeroEntries()
     return assemble_matrix(A, a, bcs, diagonal)
 
 
@@ -232,7 +231,6 @@ def assemble_matrix_nest(a: typing.List[typing.List[typing.Union[Form, cpp.fem.F
                          diagonal: float = 1.0) -> PETSc.Mat:
     """Assemble bilinear forms into matrix"""
     A = cpp.fem.create_matrix_nest(_create_cpp_form(a))
-    A.zeroEntries()
     assemble_matrix_nest(A, a, bcs, diagonal)
     return A
 
@@ -248,6 +246,11 @@ def _(A: PETSc.Mat,
         for j, a_block in enumerate(a_row):
             if a_block is not None:
                 Asub = A.getNestSubMatrix(i, j)
+                print("I, J", i, j)
+                Asub.getLGMap()[0].view()
+                print("bs mat0:", Asub.getLGMap()[0].getBlockSize())
+                Asub.getLGMap()[1].view()
+                print("bs mat1:", Asub.getLGMap()[1].getBlockSize())
                 assemble_matrix(Asub, a_block, bcs)
     return A
 
@@ -259,7 +262,6 @@ def assemble_matrix_block(a: typing.List[typing.List[typing.Union[Form, cpp.fem.
                           diagonal: float = 1.0) -> PETSc.Mat:
     """Assemble bilinear forms into matrix"""
     A = cpp.fem.create_matrix_block(_create_cpp_form(a))
-    A.zeroEntries()
     return assemble_matrix_block(A, a, bcs, diagonal)
 
 

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -40,12 +40,14 @@ def create_vector(L: typing.Union[Form, cpp.fem.Form]) -> PETSc.Vec:
 
 def create_vector_block(L: typing.List[typing.Union[Form, cpp.fem.Form]]) -> PETSc.Vec:
     maps = [form.function_spaces[0].dofmap.index_map for form in _create_cpp_form(L)]
-    return cpp.fem.create_vector_block(maps)
+    bs = [form.function_spaces[0].dofmap.index_map_bs for form in _create_cpp_form(L)]
+    return cpp.fem.create_vector_block(maps, bs)
 
 
 def create_vector_nest(L: typing.List[typing.Union[Form, cpp.fem.Form]]) -> PETSc.Vec:
     maps = [form.function_spaces[0].dofmap.index_map for form in _create_cpp_form(L)]
-    return cpp.fem.create_vector_nest(maps)
+    bs = [form.function_spaces[0].dofmap.index_map_bs for form in _create_cpp_form(L)]
+    return cpp.fem.create_vector_nest(maps, bs)
 
 
 # -- Matrix instantiation ----------------------------------------------------

--- a/python/dolfinx/fem/dirichletbc.py
+++ b/python/dolfinx/fem/dirichletbc.py
@@ -101,13 +101,13 @@ def locate_dofs_topological(V: typing.Iterable[typing.Union[cpp.function.Functio
                 _V.append(space._cpp_object)
             except AttributeError:
                 _V.append(space)
+        return cpp.fem.locate_dofs_topological(_V, entity_dim, entities, remote)
     else:
         try:
-            _V = [V._cpp_object]
+            _V = V._cpp_object
         except AttributeError:
-            _V = [V]
-
-    return cpp.fem.locate_dofs_topological(_V, entity_dim, entities, remote)
+            _V = V
+        return cpp.fem.locate_dofs_topological(_V, entity_dim, entities, remote)
 
 
 class DirichletBC(cpp.fem.DirichletBC):

--- a/python/dolfinx/fem/dirichletbc.py
+++ b/python/dolfinx/fem/dirichletbc.py
@@ -54,13 +54,13 @@ def locate_dofs_geometrical(V: typing.Iterable[typing.Union[cpp.function.Functio
                 _V.append(space._cpp_object)
             except AttributeError:
                 _V.append(space)
+        return cpp.fem.locate_dofs_geometrical(_V, marker)
     else:
         try:
-            _V = [V._cpp_object]
+            _V = V._cpp_object
         except AttributeError:
-            _V = [V]
-
-    return cpp.fem.locate_dofs_geometrical(_V, marker)
+            _V = V
+        return cpp.fem.locate_dofs_geometrical(_V, marker)
 
 
 def locate_dofs_topological(V: typing.Iterable[typing.Union[cpp.function.FunctionSpace, function.FunctionSpace]],

--- a/python/dolfinx/fem/dofmap.py
+++ b/python/dolfinx/fem/dofmap.py
@@ -30,5 +30,9 @@ class DofMap:
         return self._cpp_object.index_map
 
     @property
+    def index_map_bs(self):
+        return self._cpp_object.index_map_bs
+
+    @property
     def list(self):
         return self._cpp_object.list()

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -50,10 +50,9 @@ void common(py::module& m)
              const std::vector<int>& dest_ranks,
              const Eigen::Ref<
                  const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>>& ghosts,
-             const std::vector<int>& ghost_owners, int block_size) {
+             const std::vector<int>& ghost_owners) {
             return std::make_shared<dolfinx::common::IndexMap>(
-                comm.get(), local_size, dest_ranks, ghosts, ghost_owners,
-                block_size);
+                comm.get(), local_size, dest_ranks, ghosts, ghost_owners);
           }))
       .def_property_readonly("size_local",
                              &dolfinx::common::IndexMap::size_local)
@@ -61,9 +60,6 @@ void common(py::module& m)
                              &dolfinx::common::IndexMap::size_global)
       .def_property_readonly("num_ghosts",
                              &dolfinx::common::IndexMap::num_ghosts)
-      .def_property_readonly("block_size",
-                             &dolfinx::common::IndexMap::block_size,
-                             "Return block size")
       .def_property_readonly("local_range",
                              &dolfinx::common::IndexMap::local_range,
                              "Range of indices owned by this map")

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -457,6 +457,25 @@ void fem(py::module& m)
         py::arg("V"), py::arg("dim"), py::arg("entities"),
         py::arg("remote") = true);
 
-  m.def("locate_dofs_geometrical", &dolfinx::fem::locate_dofs_geometrical);
+  m.def(
+      "locate_dofs_geometrical",
+      [](const std::vector<
+             std::reference_wrapper<const dolfinx::function::FunctionSpace>>& V,
+         const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+             const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
+                                                 Eigen::RowMajor>>&)>& marker) {
+        if (V.size() != 2)
+          throw std::runtime_error("Expected two function spaces.");
+        return dolfinx::fem::locate_dofs_geometrical({V[0], V[1]}, marker);
+      },
+      py::arg("V"), py::arg("marker"));
+  m.def("locate_dofs_geometrical",
+        py::overload_cast<
+            const dolfinx::function::FunctionSpace&,
+            const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+                const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
+                                                    Eigen::RowMajor>>&)>&>(
+            &dolfinx::fem::locate_dofs_geometrical),
+        py::arg("V"), py::arg("marker"));
 }
 } // namespace dolfinx_wrappers

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -79,11 +79,10 @@ void fem(py::module& m)
   // utils
   m.def(
       "create_vector_block",
-      [](const std::vector<
-             std::reference_wrapper<const dolfinx::common::IndexMap>>& maps,
-         const std::vector<int>& bs) {
-        dolfinx::la::PETScVector x
-            = dolfinx::fem::create_vector_block(maps, bs);
+      [](const std::vector<std::pair<
+             std::reference_wrapper<const dolfinx::common::IndexMap>, int>>&
+             maps) {
+        dolfinx::la::PETScVector x = dolfinx::fem::create_vector_block(maps);
         Vec _x = x.vec();
         PetscObjectReference((PetscObject)_x);
         return _x;
@@ -92,9 +91,10 @@ void fem(py::module& m)
       "Create a monolithic vector for multiple (stacked) linear forms.");
   m.def(
       "create_vector_nest",
-      [](const std::vector<const dolfinx::common::IndexMap*>& maps,
-         const std::vector<int>& bs) {
-        auto x = dolfinx::fem::create_vector_nest(maps, bs);
+      [](const std::vector<std::pair<
+             std::reference_wrapper<const dolfinx::common::IndexMap>, int>>&
+             maps) {
+        auto x = dolfinx::fem::create_vector_nest(maps);
         Vec _x = x.vec();
         PetscObjectReference((PetscObject)_x);
         return _x;

--- a/python/dolfinx/wrappers/function.cpp
+++ b/python/dolfinx/wrappers/function.cpp
@@ -136,7 +136,7 @@ void function(py::module& m)
       .def(py::init([](
                const std::vector<std::shared_ptr<const dolfinx::function::Function<PetscScalar>>>& coefficients,
 	       const std::vector<std::shared_ptr<const dolfinx::function::Constant<PetscScalar>>>& constants,
-	       const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh, 
+	       const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh,
                const Eigen::Ref<const Eigen::Array<
                    double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>& x,
 	       py::object addr,

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -36,9 +36,9 @@ void la(py::module& m)
       .def(py::init(
           [](const MPICommWrapper comm,
              const std::array<std::shared_ptr<const dolfinx::common::IndexMap>,
-                              2>& index_maps,
+                              2>& maps,
              const std::array<int, 2>& bs) {
-            return dolfinx::la::SparsityPattern(comm.get(), index_maps, bs);
+            return dolfinx::la::SparsityPattern(comm.get(), maps, bs);
           }))
       .def(py::init(
           [](const MPICommWrapper comm,

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -35,9 +35,10 @@ void la(py::module& m)
                                                             "SparsityPattern")
       .def(py::init(
           [](const MPICommWrapper comm,
-             std::array<std::shared_ptr<const dolfinx::common::IndexMap>, 2>
-                 index_maps) {
-            return dolfinx::la::SparsityPattern(comm.get(), index_maps);
+             const std::array<std::shared_ptr<const dolfinx::common::IndexMap>,
+                              2>& index_maps,
+             const std::array<int, 2>& bs) {
+            return dolfinx::la::SparsityPattern(comm.get(), index_maps, bs);
           }))
       .def(py::init(
           [](const MPICommWrapper comm,
@@ -45,9 +46,10 @@ void la(py::module& m)
                  patterns,
              const std::array<std::vector<std::reference_wrapper<
                                   const dolfinx::common::IndexMap>>,
-                              2>& maps) {
+                              2>& maps,
+             const std::array<std::vector<int>, 2>& bs) {
             return std::make_unique<dolfinx::la::SparsityPattern>(
-                comm.get(), patterns, maps);
+                comm.get(), patterns, maps, bs);
           }))
       .def("local_range", &dolfinx::la::SparsityPattern::local_range)
       .def("index_map", &dolfinx::la::SparsityPattern::index_map)
@@ -98,7 +100,7 @@ void la(py::module& m)
 
   // utils
   m.def("create_vector",
-        py::overload_cast<const dolfinx::common::IndexMap&>(
+        py::overload_cast<const dolfinx::common::IndexMap&, int>(
             &dolfinx::la::create_petsc_vector),
         py::return_value_policy::take_ownership,
         "Create a ghosted PETSc Vec for index map.");
@@ -106,9 +108,9 @@ void la(py::module& m)
       "create_vector",
       [](const MPICommWrapper comm, std::array<std::int64_t, 2> range,
          const Eigen::Array<std::int64_t, Eigen::Dynamic, 1>& ghost_indices,
-         int block_size) {
+         int bs) {
         return dolfinx::la::create_petsc_vector(comm.get(), range,
-                                                ghost_indices, block_size);
+                                                ghost_indices, bs);
       },
       py::return_value_policy::take_ownership, "Create a PETSc Vec.");
   m.def(

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -44,12 +44,13 @@ void la(py::module& m)
           [](const MPICommWrapper comm,
              const std::vector<std::vector<const dolfinx::la::SparsityPattern*>>
                  patterns,
-             const std::array<std::vector<std::reference_wrapper<
-                                  const dolfinx::common::IndexMap>>,
-                              2>& maps,
-             const std::array<std::vector<int>, 2>& bs) {
+             const std::array<
+                 std::vector<std::pair<
+                     std::reference_wrapper<const dolfinx::common::IndexMap>,
+                     int>>,
+                 2>& maps) {
             return std::make_unique<dolfinx::la::SparsityPattern>(
-                comm.get(), patterns, maps, bs);
+                comm.get(), patterns, maps);
           }))
       .def("local_range", &dolfinx::la::SparsityPattern::local_range)
       .def("index_map", &dolfinx::la::SparsityPattern::index_map)
@@ -120,6 +121,7 @@ void la(py::module& m)
       },
       py::return_value_policy::take_ownership,
       "Create a PETSc Mat from sparsity pattern.");
+  // TODO: check reference counting for index sets
   m.def("create_petsc_index_sets", &dolfinx::la::create_petsc_index_sets,
         py::return_value_policy::take_ownership);
   m.def("scatter_local_vectors", &dolfinx::la::scatter_local_vectors,

--- a/python/test/unit/fem/test_assemble_cppimport.py
+++ b/python/test/unit/fem/test_assemble_cppimport.py
@@ -94,7 +94,7 @@ m.def("assemble_matrix", &assemble_csr<PetscScalar>);
         if _a.function_spaces[0].id == _a.function_spaces[1].id:
             for bc in bcs:
                 if _a.function_spaces[0].contains(bc.function_space):
-                    bc_dofs = bc.dof_indices[:, 0]
+                    bc_dofs = bc.dof_indices[0]
                     A[bc_dofs, bc_dofs] = 1.0
         return A
 

--- a/python/test/unit/fem/test_assemble_cppimport.py
+++ b/python/test/unit/fem/test_assemble_cppimport.py
@@ -66,10 +66,12 @@ const auto mat_add
 dolfinx::fem::assemble_matrix<T>(mat_add, a, bcs);
 
 auto map0 = a.function_spaces().at(0)->dofmap()->index_map;
+int bs0 = a.function_spaces().at(0)->dofmap()->index_map_bs();
 auto map1 = a.function_spaces().at(1)->dofmap()->index_map;
+int bs1 = a.function_spaces().at(1)->dofmap()->index_map_bs();
 Eigen::SparseMatrix<T, Eigen::RowMajor> mat(
-    map0->block_size() * (map0->size_local() + map0->num_ghosts()),
-    map1->block_size() * (map1->size_local() + map1->num_ghosts()));
+    bs0 * (map0->size_local() + map0->num_ghosts()),
+    bs1 * (map1->size_local() + map1->num_ghosts()));
 mat.setFromTriplets(triplets.begin(), triplets.end());
 return mat;
 }

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -316,7 +316,6 @@ def test_assembly_solve_block(mode):
     V0 = dolfinx.function.FunctionSpace(mesh, P)
     V1 = V0.clone()
 
-
     def boundary(x):
         return numpy.logical_or(x[0] < 1.0e-6, x[0] > 1.0 - 1.0e-6)
 

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -456,9 +456,9 @@ def test_assembly_solve_block(mode):
 
 @pytest.mark.parametrize("mesh", [
     UnitSquareMesh(MPI.COMM_WORLD, 12, 11, ghost_mode=dolfinx.cpp.mesh.GhostMode.none),
-    # UnitSquareMesh(MPI.COMM_WORLD, 12, 11, ghost_mode=dolfinx.cpp.mesh.GhostMode.shared_facet),
-    # UnitCubeMesh(MPI.COMM_WORLD, 3, 7, 3, ghost_mode=dolfinx.cpp.mesh.GhostMode.none),
-    # UnitCubeMesh(MPI.COMM_WORLD, 3, 7, 3, ghost_mode=dolfinx.cpp.mesh.GhostMode.shared_facet)
+    UnitSquareMesh(MPI.COMM_WORLD, 12, 11, ghost_mode=dolfinx.cpp.mesh.GhostMode.shared_facet),
+    UnitCubeMesh(MPI.COMM_WORLD, 3, 7, 3, ghost_mode=dolfinx.cpp.mesh.GhostMode.none),
+    UnitCubeMesh(MPI.COMM_WORLD, 3, 7, 3, ghost_mode=dolfinx.cpp.mesh.GhostMode.shared_facet)
 ])
 def test_assembly_solve_taylor_hood(mesh):
     """Assemble Stokes problem with Taylor-Hood elements and solve."""

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -479,6 +479,7 @@ def test_assembly_solve_taylor_hood(mesh):
     u0 = dolfinx.Function(P2)
     u0.vector.set(1.0)
     u0.vector.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+
     bc0 = dolfinx.DirichletBC(u0, bdofs0)
     bc1 = dolfinx.DirichletBC(u0, bdofs1)
 

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -303,20 +303,19 @@ def test_matrix_assembly_block(mode):
     assert b2.norm() == pytest.approx(bnorm0, 1.0e-9)
 
 
-# @pytest.mark.parametrize("mode", [dolfinx.cpp.mesh.GhostMode.none, dolfinx.cpp.mesh.GhostMode.shared_facet])
 @pytest.mark.parametrize("mode", [
     dolfinx.cpp.mesh.GhostMode.none,
-    # dolfinx.cpp.mesh.GhostMode.shared_facet,
+    dolfinx.cpp.mesh.GhostMode.shared_facet,
 ])
 def test_assembly_solve_block(mode):
     """Solve a two-field mass-matrix like problem with block matrix approaches
     and test that solution is the same.
     """
-    # mesh = UnitSquareMesh(MPI.COMM_WORLD, 32, 31, ghost_mode=mode)
-    mesh = UnitSquareMesh(MPI.COMM_WORLD, 1, 1, ghost_mode=mode)
+    mesh = UnitSquareMesh(MPI.COMM_WORLD, 32, 31, ghost_mode=mode)
     P = ufl.FiniteElement("Lagrange", mesh.ufl_cell(), 1)
     V0 = dolfinx.function.FunctionSpace(mesh, P)
     V1 = V0.clone()
+
 
     def boundary(x):
         return numpy.logical_or(x[0] < 1.0e-6, x[0] > 1.0 - 1.0e-6)

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -456,9 +456,9 @@ def test_assembly_solve_block(mode):
 
 @pytest.mark.parametrize("mesh", [
     UnitSquareMesh(MPI.COMM_WORLD, 12, 11, ghost_mode=dolfinx.cpp.mesh.GhostMode.none),
-    UnitSquareMesh(MPI.COMM_WORLD, 12, 11, ghost_mode=dolfinx.cpp.mesh.GhostMode.shared_facet),
-    UnitCubeMesh(MPI.COMM_WORLD, 3, 7, 3, ghost_mode=dolfinx.cpp.mesh.GhostMode.none),
-    UnitCubeMesh(MPI.COMM_WORLD, 3, 7, 3, ghost_mode=dolfinx.cpp.mesh.GhostMode.shared_facet)
+    # UnitSquareMesh(MPI.COMM_WORLD, 12, 11, ghost_mode=dolfinx.cpp.mesh.GhostMode.shared_facet),
+    # UnitCubeMesh(MPI.COMM_WORLD, 3, 7, 3, ghost_mode=dolfinx.cpp.mesh.GhostMode.none),
+    # UnitCubeMesh(MPI.COMM_WORLD, 3, 7, 3, ghost_mode=dolfinx.cpp.mesh.GhostMode.shared_facet)
 ])
 def test_assembly_solve_taylor_hood(mesh):
     """Assemble Stokes problem with Taylor-Hood elements and solve."""

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -303,12 +303,17 @@ def test_matrix_assembly_block(mode):
     assert b2.norm() == pytest.approx(bnorm0, 1.0e-9)
 
 
-@pytest.mark.parametrize("mode", [dolfinx.cpp.mesh.GhostMode.none, dolfinx.cpp.mesh.GhostMode.shared_facet])
+# @pytest.mark.parametrize("mode", [dolfinx.cpp.mesh.GhostMode.none, dolfinx.cpp.mesh.GhostMode.shared_facet])
+@pytest.mark.parametrize("mode", [
+    dolfinx.cpp.mesh.GhostMode.none,
+    # dolfinx.cpp.mesh.GhostMode.shared_facet,
+])
 def test_assembly_solve_block(mode):
     """Solve a two-field mass-matrix like problem with block matrix approaches
     and test that solution is the same.
     """
-    mesh = UnitSquareMesh(MPI.COMM_WORLD, 32, 31, ghost_mode=mode)
+    # mesh = UnitSquareMesh(MPI.COMM_WORLD, 32, 31, ghost_mode=mode)
+    mesh = UnitSquareMesh(MPI.COMM_WORLD, 1, 1, ghost_mode=mode)
     P = ufl.FiniteElement("Lagrange", mesh.ufl_cell(), 1)
     V0 = dolfinx.function.FunctionSpace(mesh, P)
     V1 = V0.clone()

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -25,12 +25,13 @@ def test_locate_dofs_geometrical():
     dofs = dolfinx.fem.locate_dofs_geometrical(
         (W.sub(0), V), lambda x: np.isclose(x.T, [0, 0, 0]).all(axis=1))
 
-    # Collect dofs from all processes (does not matter that the numbering
-    # is local to each process for this test)
+    # Collect dofs from all processes (does not matter that the
+    # numbering is local to each process for this test)
     all_dofs = np.vstack(MPI.COMM_WORLD.allgather(dofs))
 
     # Check only one dof pair is returned
-    assert len(all_dofs) == 1
+    assert len(all_dofs[0]) == 1
+    assert len(all_dofs[1]) == 1
 
     # On process with the dof pair
     if len(dofs) == 1:

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -87,8 +87,8 @@ def test_matrix_assembly_block():
     x0 = dolfinx.fem.create_vector_block(L_block)
     dolfinx.cpp.la.scatter_local_vectors(
         x0, [u.vector.array_r, p.vector.array_r],
-        [u.function_space.dofmap.index_map, p.function_space.dofmap.index_map],
-        [u.function_space.dofmap.index_map_bs, p.function_space.dofmap.index_map_bs])
+        [(u.function_space.dofmap.index_map, u.function_space.dofmap.index_map_bs),
+         (p.function_space.dofmap.index_map, p.function_space.dofmap.index_map_bs)])
     x0.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
     # Ghosts are updated inside assemble_vector_block
@@ -187,7 +187,7 @@ class NonlinearPDE_SNESProblem():
         x_array = x.getArray(readonly=True)
         for var in self.soln_vars:
             size_local = var.vector.getLocalSize()
-            var.vector.array[:] = x_array[offset:offset + size_local]
+            var.vector.array[:] = x_array[offset: offset + size_local]
             var.vector.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
             offset += size_local
 
@@ -314,8 +314,8 @@ def test_assembly_solve_block():
     x0 = dolfinx.fem.create_vector_block(F)
     dolfinx.cpp.la.scatter_local_vectors(
         x0, [u.vector.array_r, p.vector.array_r],
-        [u.function_space.dofmap.index_map, p.function_space.dofmap.index_map],
-        [u.function_space.dofmap.index_map_bs, p.function_space.dofmap.index_map_bs])
+        [(u.function_space.dofmap.index_map, u.function_space.dofmap.index_map_bs),
+         (p.function_space.dofmap.index_map, p.function_space.dofmap.index_map_bs)])
     x0.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
     snes.solve(None, x0)
@@ -517,8 +517,8 @@ def test_assembly_solve_taylor_hood(mesh):
     with u.vector.localForm() as _u, p.vector.localForm() as _p:
         dolfinx.cpp.la.scatter_local_vectors(
             x0, [_u.array_r, _p.array_r],
-            [u.function_space.dofmap.index_map, p.function_space.dofmap.index_map],
-            [u.function_space.dofmap.index_map_bs, p.function_space.dofmap.index_map_bs])
+            [(u.function_space.dofmap.index_map, u.function_space.dofmap.index_map_bs),
+             (p.function_space.dofmap.index_map, p.function_space.dofmap.index_map_bs)])
     x0.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
     snes.solve(None, x0)

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -87,7 +87,8 @@ def test_matrix_assembly_block():
     x0 = dolfinx.fem.create_vector_block(L_block)
     dolfinx.cpp.la.scatter_local_vectors(
         x0, [u.vector.array_r, p.vector.array_r],
-        [u.function_space.dofmap.index_map, p.function_space.dofmap.index_map])
+        [u.function_space.dofmap.index_map, p.function_space.dofmap.index_map],
+        [u.function_space.dofmap.index_map_bs, p.function_space.dofmap.index_map_bs])
     x0.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
     # Ghosts are updated inside assemble_vector_block
@@ -313,7 +314,8 @@ def test_assembly_solve_block():
     x0 = dolfinx.fem.create_vector_block(F)
     dolfinx.cpp.la.scatter_local_vectors(
         x0, [u.vector.array_r, p.vector.array_r],
-        [u.function_space.dofmap.index_map, p.function_space.dofmap.index_map])
+        [u.function_space.dofmap.index_map, p.function_space.dofmap.index_map],
+        [u.function_space.dofmap.index_map_bs, p.function_space.dofmap.index_map_bs])
     x0.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
     snes.solve(None, x0)
@@ -515,7 +517,8 @@ def test_assembly_solve_taylor_hood(mesh):
     with u.vector.localForm() as _u, p.vector.localForm() as _p:
         dolfinx.cpp.la.scatter_local_vectors(
             x0, [_u.array_r, _p.array_r],
-            [u.function_space.dofmap.index_map, p.function_space.dofmap.index_map])
+            [u.function_space.dofmap.index_map, p.function_space.dofmap.index_map],
+            [u.function_space.dofmap.index_map_bs, p.function_space.dofmap.index_map_bs])
     x0.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
     snes.solve(None, x0)

--- a/python/test/unit/la/test_nullspace.py
+++ b/python/test/unit/la/test_nullspace.py
@@ -30,7 +30,7 @@ def build_elastic_nullspace(V):
     dim = 3 if gdim == 2 else 6
 
     # Create list of vectors for null space
-    nullspace_basis = [cpp.la.create_vector(V.dofmap.index_map) for i in range(dim)]
+    nullspace_basis = [cpp.la.create_vector(V.dofmap.index_map, V.dofmap.index_map_bs) for i in range(dim)]
 
     with ExitStack() as stack:
         vec_local = [stack.enter_context(x.localForm()) for x in nullspace_basis]
@@ -62,7 +62,7 @@ def build_broken_elastic_nullspace(V):
     """Function to build incorrect null space for 2D elasticity"""
 
     # Create list of vectors for null space
-    nullspace_basis = [cpp.la.create_vector(V.dofmap.index_map) for i in range(4)]
+    nullspace_basis = [cpp.la.create_vector(V.dofmap.index_map, V.dofmap.index_map_bs) for i in range(4)]
 
     with ExitStack() as stack:
         vec_local = [stack.enter_context(x.localForm()) for x in nullspace_basis]

--- a/python/test/unit/mesh/test_surface_mesh.py
+++ b/python/test/unit/mesh/test_surface_mesh.py
@@ -31,8 +31,7 @@ def test_b_mesh_mapping(celltype):
     b_mesh.topology.create_connectivity(
         b_mesh.topology.dim, b_mesh.topology.dim)
     b_imap = b_mesh.topology.index_map(b_mesh.topology.dim)
-    tdim_entities = np.arange(b_imap.size_local * b_imap.block_size,
-                              dtype=np.int32)
+    tdim_entities = np.arange(b_imap.size_local, dtype=np.int32)
     boundary_geometry = cmesh.entities_to_geometry(
         b_mesh, b_mesh.topology.dim, tdim_entities, False)
 

--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -185,7 +185,7 @@ def test_nonlinear_pde_snes():
     u.vector.set(0.9)
     u.vector.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
-    b = dolfinx.cpp.la.create_vector(V.dofmap.index_map)
+    b = dolfinx.cpp.la.create_vector(V.dofmap.index_map, V.dofmap.index_map_bs)
     J = dolfinx.cpp.fem.create_matrix(problem.a_comp._cpp_object)
 
     # Create Newton solver and solve


### PR DESCRIPTION
This is a major step towards supporting blocked degree-of-freedom maps and block CSR matrices. The confusing 'block size' in IndexMap has been removed and the block size is now stored in the relatively places where it's required.

Another change is that PETSc matrices now share a local-to-global map for rows and columns where this is possible.