### PR TITLE
XDMFFile.write_meshtags for owned entities

### DIFF
--- a/cpp/dolfinx/common/utils.h
+++ b/cpp/dolfinx/common/utils.h
@@ -58,32 +58,20 @@ std::pair<U, V> sort_unique(const U& indices, const V& values)
 /// Indent string block
 std::string indent(std::string block);
 
-/// Return string representation of given container of ints, floats,
-/// etc.
+/// Convert a container to string
 template <typename T>
-std::string container_to_string(const T& x, std::string delimiter,
-                                int precision, int linebreak = 0)
+std::string container_to_string(const T& x, const int precision,
+                                const int linebreak)
 {
   std::stringstream s;
   s.precision(precision);
-  if (!x.empty())
+
+  for (std::size_t i = 0; i < (std::size_t)x.size(); ++i)
   {
-    if (linebreak == 0)
-    {
-      s << *x.begin();
-      for (auto it = x.begin() + 1; it != x.end(); ++it)
-        s << delimiter << *it;
-    }
+    if ((i + 1) % linebreak == 0 && linebreak != 0)
+      s << x.data()[i] << std::endl;
     else
-    {
-      for (std::size_t i = 0; i != x.size(); ++i)
-      {
-        if ((i + 1) % linebreak == 0)
-          s << x[i] << std::endl;
-        else
-          s << x[i] << delimiter;
-      }
-    }
+      s << x.data()[i] << " ";
   }
   return s.str();
 }

--- a/cpp/dolfinx/io/xdmf_mesh.h
+++ b/cpp/dolfinx/io/xdmf_mesh.h
@@ -51,11 +51,11 @@ void add_mesh(MPI_Comm comm, pugi::xml_node& xml_node, const hid_t h5_id,
 /// @param[in] active_entities Local-to-process indices of mesh entities
 ///   whose topology will be saved. This is used to save subsets of
 ///   Mesh.
-void add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
-                       const hid_t h5_id, const std::string path_prefix,
-                       const mesh::Topology& topology,
-                       const mesh::Geometry& geometry, const int cell_dim,
-                       const std::vector<std::int32_t>& active_entities);
+void add_topology_data(
+    MPI_Comm comm, pugi::xml_node& xml_node, const hid_t h5_id,
+    const std::string path_prefix, const mesh::Topology& topology,
+    const mesh::Geometry& geometry, const int cell_dim,
+    const Eigen::Array<std::int32_t, Eigen::Dynamic, 1>& active_entities);
 
 /// Add Geometry xml node
 void add_geometry_data(MPI_Comm comm, pugi::xml_node& xml_node,

--- a/cpp/dolfinx/io/xdmf_meshtags.h
+++ b/cpp/dolfinx/io/xdmf_meshtags.h
@@ -34,8 +34,7 @@ void add_meshtags(MPI_Comm comm, const mesh::MeshTags<T>& meshtags,
   const int dim = meshtags.dim();
 
   const std::int32_t num_local_entities
-      = mesh->topology().index_map(dim)->size_local()
-        * mesh->topology().index_map(dim)->block_size();
+      = mesh->topology().index_map(dim)->size_local();
 
   // Find number of tagged entities in local range
   const int num_active_entities

--- a/cpp/dolfinx/io/xdmf_utils.h
+++ b/cpp/dolfinx/io/xdmf_utils.h
@@ -118,7 +118,7 @@ void add_data_item(pugi::xml_node& xml_node, const hid_t h5_id,
     data_item_node.append_attribute("Format") = "XML";
     assert(shape.size() == 2);
     data_item_node.append_child(pugi::node_pcdata)
-        .set_value(common::container_to_string(x, " ", 16, shape[1]).c_str());
+        .set_value(common::container_to_string(x, 16, shape[1]).c_str());
   }
   else
   {

--- a/python/test/unit/io/test_xdmf_meshdata.py
+++ b/python/test/unit/io/test_xdmf_meshdata.py
@@ -1,15 +1,13 @@
-# Copyright (C) 2012-2020 Garth N. Wells, Jørgen S. Dokken
+# Copyright (C) 2012-2019 Garth N. Wells
 #
 # This file is part of DOLFINX (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import os
-from xml.etree import ElementTree
 
-import numpy as np
 import pytest
-from dolfinx import MeshTags, UnitCubeMesh, UnitIntervalMesh, UnitSquareMesh
+from dolfinx import UnitCubeMesh, UnitIntervalMesh, UnitSquareMesh
 from dolfinx.cpp.mesh import CellType
 from dolfinx.io import XDMFFile
 from dolfinx_utils.test.fixtures import tempdir
@@ -64,44 +62,3 @@ def test_read_mesh_data(tempdir, tdim, n):
     assert cell_type[1] == 1
     assert mesh.topology.index_map(tdim).size_global == mesh.mpi_comm().allreduce(cells.shape[0], op=MPI.SUM)
     assert mesh.geometry.index_map().size_global == mesh.mpi_comm().allreduce(x.shape[0], op=MPI.SUM)
-
-
-def test_write_mesh_data(tempdir):
-    comm_world = MPI.COMM_WORLD
-    comm_self = MPI.COMM_SELF
-    filename_serial = os.path.join(tempdir, "mesh_serial.xdmf")
-    filename_parallel = os.path.join(tempdir, "mesh_parallel.xdmf")
-
-    if comm_world.rank == 0:
-        mesh = UnitCubeMesh(comm_self, 2, 2, 2)
-        mesh.name = "mesh"
-        num_cells = mesh.topology.index_map(mesh.topology.dim).size_local
-        indices = np.arange(num_cells, dtype=np.int32)
-        values = np.ones(num_cells, dtype=np.int32)
-        mt = MeshTags(mesh, mesh.topology.dim, indices, values)
-        mt.name = "cells"
-        with XDMFFile(comm_self, filename_serial, "w") as xdmf:
-            xdmf.write_mesh(mesh)
-            xdmf.write_meshtags(mt)
-    comm_world.barrier()
-
-    with XDMFFile(comm_world, filename_serial, "r") as xdmf:
-        mesh2 = xdmf.read_mesh(name="mesh")
-        mt2 = xdmf.read_meshtags(mesh2, name="cells")
-
-    with XDMFFile(comm_world, filename_parallel, "w") as xdmf:
-        xdmf.write_mesh(mesh2)
-        xdmf.write_meshtags(mt2)
-
-    parser = ElementTree.XMLParser()
-    tree = ElementTree.parse(filename_parallel, parser)
-    root = tree.getroot()
-    domain = list(root)[0]
-    meshes = list(domain)
-    num_cells = []
-    for mesh in meshes:
-        elements = list(mesh)
-        for element in elements:
-            if element.tag == "Topology":
-                num_cells.append(element.get("NumberOfElements"))
-    assert(num_cells[0] == num_cells[1])

--- a/python/test/unit/io/test_xdmf_meshdata.py
+++ b/python/test/unit/io/test_xdmf_meshdata.py
@@ -1,13 +1,15 @@
-# Copyright (C) 2012-2019 Garth N. Wells
+# Copyright (C) 2012-2020 Garth N. Wells, Jørgen S. Dokken
 #
 # This file is part of DOLFINX (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import os
+from xml.etree import ElementTree
 
+import numpy as np
 import pytest
-from dolfinx import UnitCubeMesh, UnitIntervalMesh, UnitSquareMesh
+from dolfinx import MeshTags, UnitCubeMesh, UnitIntervalMesh, UnitSquareMesh
 from dolfinx.cpp.mesh import CellType
 from dolfinx.io import XDMFFile
 from dolfinx_utils.test.fixtures import tempdir
@@ -62,3 +64,44 @@ def test_read_mesh_data(tempdir, tdim, n):
     assert cell_type[1] == 1
     assert mesh.topology.index_map(tdim).size_global == mesh.mpi_comm().allreduce(cells.shape[0], op=MPI.SUM)
     assert mesh.geometry.index_map().size_global == mesh.mpi_comm().allreduce(x.shape[0], op=MPI.SUM)
+
+
+def test_write_mesh_data(tempdir):
+    comm_world = MPI.COMM_WORLD
+    comm_self = MPI.COMM_SELF
+    filename_serial = os.path.join(tempdir, "mesh_serial.xdmf")
+    filename_parallel = os.path.join(tempdir, "mesh_parallel.xdmf")
+
+    if comm_world.rank == 0:
+        mesh = UnitCubeMesh(comm_self, 2, 2, 2)
+        mesh.name = "mesh"
+        num_cells = mesh.topology.index_map(mesh.topology.dim).size_local
+        indices = np.arange(num_cells, dtype=np.int32)
+        values = np.ones(num_cells, dtype=np.int32)
+        mt = MeshTags(mesh, mesh.topology.dim, indices, values)
+        mt.name = "cells"
+        with XDMFFile(comm_self, filename_serial, "w") as xdmf:
+            xdmf.write_mesh(mesh)
+            xdmf.write_meshtags(mt)
+    comm_world.barrier()
+
+    with XDMFFile(comm_world, filename_serial, "r") as xdmf:
+        mesh2 = xdmf.read_mesh(name="mesh")
+        mt2 = xdmf.read_meshtags(mesh2, name="cells")
+
+    with XDMFFile(comm_world, filename_parallel, "w") as xdmf:
+        xdmf.write_mesh(mesh2)
+        xdmf.write_meshtags(mt2)
+
+    parser = ElementTree.XMLParser()
+    tree = ElementTree.parse(filename_parallel, parser)
+    root = tree.getroot()
+    domain = list(root)[0]
+    meshes = list(domain)
+    num_cells = []
+    for mesh in meshes:
+        elements = list(mesh)
+        for element in elements:
+            if element.tag == "Topology":
+                num_cells.append(element.get("NumberOfElements"))
+    assert(num_cells[0] == num_cells[1])

--- a/python/test/unit/io/test_xdmf_meshtags.py
+++ b/python/test/unit/io/test_xdmf_meshtags.py
@@ -1,10 +1,11 @@
-# Copyright (C) 2020 Michal Habera
+# Copyright (C) 2020 Michal Habera, Jørgen S. Dokken
 #
 # This file is part of DOLFINX (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import os
+from xml.etree import ElementTree
 
 import numpy as np
 import pytest
@@ -78,4 +79,28 @@ def test_3d(tempdir, cell_type, encoding):
     lines_local_in = comm.allreduce(
         (mt_lines_in.indices < mesh_in.topology.index_map(1).size_local).sum(), op=MPI.SUM)
 
+    imap = mesh.topology.index_map(mesh_in.topology.dim)
+    num_cells = imap.size_local + imap.num_ghosts
+    indices = np.arange(num_cells, dtype=np.int32)
+    values = np.ones(num_cells + imap.num_ghosts, dtype=np.int32)
+    mt = MeshTags(mesh_in, mesh_in.topology.dim, indices, values)
+    mt.name = "cells"
+    with XDMFFile(comm, os.path.join(tempdir, "meshtags_3d_2_out.xdmf"), "w", encoding=encoding) as file:
+        file.write_mesh(mesh_in)
+        file.write_meshtags(mt)
+
     assert lines_local == lines_local_in
+
+    MPI.COMM_WORLD.barrier()
+    parser = ElementTree.XMLParser()
+    tree = ElementTree.parse(os.path.join(tempdir, "meshtags_3d_2_out.xdmf"), parser)
+    root = tree.getroot()
+    domain = list(root)[0]
+    meshes = list(domain)
+    num_cells = []
+    for mesh in meshes:
+        elements = list(mesh)
+        for element in elements:
+            if element.tag == "Topology":
+                num_cells.append(element.get("NumberOfElements"))
+    assert(num_cells[0] == num_cells[1])


### PR DESCRIPTION
Improved version of #1223, writing only owned entities of mesh tags to file to avoid duplication in parallel.