### PR TITLE
Allow control of non-affine NR iterations

### DIFF
--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -66,8 +66,7 @@ void CoordinateElement::compute_reference_geometry(
     const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
                                         Eigen::RowMajor>>& x,
     const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
-                                        Eigen::RowMajor>>& cell_geometry,
-    double eps) const
+                                        Eigen::RowMajor>>& cell_geometry) const
 {
   // Number of points
   int num_points = x.rows();
@@ -154,9 +153,8 @@ void CoordinateElement::compute_reference_geometry(
           Kview(K.data() + ip * _gdim * _tdim, _tdim, _gdim);
       // TODO: Xk - use cell midpoint instead?
       Xk.setZero();
-      const int max_its = 10;
       int k;
-      for (k = 0; k < max_its; ++k)
+      for (k = 0; k < non_affine_max_its; ++k)
       {
         // Compute physical coordinates
         _evaluate_basis_derivatives(phi.data(), 0, 1, Xk.data());
@@ -174,11 +172,11 @@ void CoordinateElement::compute_reference_geometry(
         // Increment to new point in reference
         Eigen::Matrix<double, Eigen::Dynamic, 1, Eigen::ColMajor, 3, 1> dX
             = Kview * (x.row(ip).matrix().transpose() - xk);
-        if (dX.squaredNorm() < eps)
+        if (dX.norm() < non_affine_atol)
           break;
         Xk += dX;
       }
-      if (k == max_its)
+      if (k == non_affine_max_its)
       {
         throw std::runtime_error(
             "Newton method failed to converge for non-affine geometry");

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -57,6 +57,12 @@ public:
   /// Return the dof layout
   const ElementDofLayout& dof_layout() const;
 
+  /// Absolute increment stopping criterium for non-affine Newton solver
+  double non_affine_atol = 1.0e-8;
+
+  /// Maximum number of iterations for non-affine Newton solver
+  int non_affine_max_its = 10;
+
   /// Compute physical coordinates x for points X  in the reference
   /// configuration
   /// @param[in,out] x The physical coordinates of the reference points X
@@ -83,8 +89,7 @@ public:
                                           Eigen::Dynamic, Eigen::RowMajor>>& x,
       const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,
                                           Eigen::Dynamic, Eigen::RowMajor>>&
-          cell_geometry,
-      double eps = 1.0e-16) const;
+          cell_geometry) const;
 
 private:
   // Topological and geometric dimensions

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -267,7 +267,9 @@ void fem(py::module& m)
       m, "CoordinateElement", "Coordinate map element")
       .def_property_readonly("dof_layout",
                              &dolfinx::fem::CoordinateElement::dof_layout)
-      .def("push_forward", &dolfinx::fem::CoordinateElement::push_forward);
+      .def("push_forward", &dolfinx::fem::CoordinateElement::push_forward)
+      .def_readwrite("non_affine_atol", &dolfinx::fem::CoordinateElement::non_affine_atol)
+      .def_readwrite("non_affine_max_its", &dolfinx::fem::CoordinateElement::non_affine_max_its);
 
   // dolfinx::fem::DirichletBC
   py::class_<dolfinx::fem::DirichletBC<PetscScalar>,


### PR DESCRIPTION
Some practitioner's meshes fail to do any IO, since it is calling eval() which needs physical-to-reference map. This small change allows users to do
```python
mesh.geometry.cmap.non_affine_atol = 1.0e-8
mesh.geometry.cmap.non_affine_max_its = 20
```
(or whatever works) before the respective NR calls.