### PR TITLE
Remove timings binding

### DIFF
--- a/python/dolfinx/__init__.py
+++ b/python/dolfinx/__init__.py
@@ -33,7 +33,7 @@ from .cpp import __version__
 
 from dolfinx.common import (has_debug, has_petsc_complex, has_kahip,
                            has_parmetis, git_commit_hash, TimingType, timing,
-                           timings, list_timings)
+                           list_timings)
 
 import dolfinx.log
 

--- a/python/dolfinx/__init__.py
+++ b/python/dolfinx/__init__.py
@@ -8,6 +8,21 @@
 # flake8: noqa
 
 # Store dl open flags to restore them after import
+from dolfinx import cpp
+from .mesh import MeshTags
+from .function import (FunctionSpace, VectorFunctionSpace,
+                       TensorFunctionSpace, Constant, Expression, Function)
+from .fem.solving import solve
+from .fem.dirichletbc import DirichletBC
+from .fem.form import Form
+from .cpp.nls import (NonlinearProblem, NewtonSolver)
+from .cpp.mesh import Topology, Geometry
+from dolfinx.generation import (IntervalMesh, BoxMesh, RectangleMesh,
+                                UnitIntervalMesh, UnitSquareMesh, UnitCubeMesh)
+import dolfinx.log
+from dolfinx.common import (has_debug, has_petsc_complex, has_kahip,
+                            has_parmetis, git_commit_hash, TimingType, timing, list_timings)
+from .cpp import __version__
 import sys
 stored_dlopen_flags = sys.getdlopenflags()
 
@@ -28,36 +43,12 @@ del sys
 # del sys
 
 # Import cpp modules
-from .cpp import __version__
 
-
-from dolfinx.common import (has_debug, has_petsc_complex, has_kahip,
-                           has_parmetis, git_commit_hash, TimingType, timing,
-                           timings, list_timings)
-
-import dolfinx.log
-
-from dolfinx.generation import (IntervalMesh, BoxMesh, RectangleMesh,
-                               UnitIntervalMesh, UnitSquareMesh, UnitCubeMesh)
-
-from .cpp.mesh import Topology, Geometry
-
-from .cpp.nls import (NonlinearProblem, NewtonSolver)
-
-from .fem.form import Form
-from .fem.dirichletbc import DirichletBC
-from .fem.solving import solve
-
-from .function import (FunctionSpace, VectorFunctionSpace,
-                       TensorFunctionSpace, Constant, Expression, Function)
-
-from .mesh import MeshTags
 
 # Initialise logging
-from dolfinx import cpp
-import sys
 cpp.common.init_logging(sys.argv)
 del sys
+
 
 def get_include(user=False):
     import os

--- a/python/dolfinx/__init__.py
+++ b/python/dolfinx/__init__.py
@@ -8,21 +8,6 @@
 # flake8: noqa
 
 # Store dl open flags to restore them after import
-from dolfinx import cpp
-from .mesh import MeshTags
-from .function import (FunctionSpace, VectorFunctionSpace,
-                       TensorFunctionSpace, Constant, Expression, Function)
-from .fem.solving import solve
-from .fem.dirichletbc import DirichletBC
-from .fem.form import Form
-from .cpp.nls import (NonlinearProblem, NewtonSolver)
-from .cpp.mesh import Topology, Geometry
-from dolfinx.generation import (IntervalMesh, BoxMesh, RectangleMesh,
-                                UnitIntervalMesh, UnitSquareMesh, UnitCubeMesh)
-import dolfinx.log
-from dolfinx.common import (has_debug, has_petsc_complex, has_kahip,
-                            has_parmetis, git_commit_hash, TimingType, timing, list_timings)
-from .cpp import __version__
 import sys
 stored_dlopen_flags = sys.getdlopenflags()
 
@@ -43,12 +28,36 @@ del sys
 # del sys
 
 # Import cpp modules
+from .cpp import __version__
 
+
+from dolfinx.common import (has_debug, has_petsc_complex, has_kahip,
+                           has_parmetis, git_commit_hash, TimingType, timing,
+                           timings, list_timings)
+
+import dolfinx.log
+
+from dolfinx.generation import (IntervalMesh, BoxMesh, RectangleMesh,
+                               UnitIntervalMesh, UnitSquareMesh, UnitCubeMesh)
+
+from .cpp.mesh import Topology, Geometry
+
+from .cpp.nls import (NonlinearProblem, NewtonSolver)
+
+from .fem.form import Form
+from .fem.dirichletbc import DirichletBC
+from .fem.solving import solve
+
+from .function import (FunctionSpace, VectorFunctionSpace,
+                       TensorFunctionSpace, Constant, Expression, Function)
+
+from .mesh import MeshTags
 
 # Initialise logging
+from dolfinx import cpp
+import sys
 cpp.common.init_logging(sys.argv)
 del sys
-
 
 def get_include(user=False):
     import os

--- a/python/dolfinx/common.py
+++ b/python/dolfinx/common.py
@@ -17,10 +17,6 @@ def timing(task: str):
     return cpp.common.timing(task)
 
 
-def timings(timing_types: list):
-    return cpp.common.timings(timing_types)
-
-
 def list_timings(mpi_comm, timing_types: list):
     return cpp.common.list_timings(mpi_comm, timing_types)
 

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -90,10 +90,7 @@ void common(py::module& m)
 
   // dolfin/common free functions
   m.def("timing", &dolfinx::timing);
-  m.def("timings", [](std::vector<dolfinx::TimingType> type) {
-    std::set<dolfinx::TimingType> _type(type.begin(), type.end());
-    return dolfinx::timings(_type);
-  });
+
   m.def("list_timings",
         [](const MPICommWrapper comm, std::vector<dolfinx::TimingType> type) {
           std::set<dolfinx::TimingType> _type(type.begin(), type.end());


### PR DESCRIPTION
As `dolfinx::Table` is not wrapped to Python, this binding would only cause an error, see: #1217. This PR removes it.