### PR TITLE
Revert "Remove DOLFINX_EIGEN_MAX_ALIGN_BYTES (#1213)"

### DIFF
--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -60,32 +60,31 @@ target_compile_definitions(dolfinx PUBLIC DOLFINX_VERSION="${DOLFINX_VERSION}")
 # UFC
 target_include_directories(dolfinx SYSTEM PUBLIC ${UFC_INCLUDE_DIRS})
 
-# Have left these well written comments about Eigen alignment 
-# here with the intention that this should be moved to build documentation.
-
-# DOLFINX uses Eigen data structures for dense linear algebra operations. Eigen
+# DOLFIN uses Eigen data structures for dense linear algebra operations. Eigen
 # performs 'ideal' memory alignment based around the -march flag passed to the
 # compiler.  However, because Python DOLFIN JIT compiles code at runtime, it is
 # possible for the user to build shared objects with incompatible alignment
 # (ABI) if they use a different -march flag than that used to originally build
-# DOLFINX. EIGEN_MAX_ALIGN_BYTES can be used to force alignment.
+# DOLFIN. DOLFINX_EIGEN_MAX_ALIGN_BYTES can be used to force alignment.
 # See: https://eigen.tuxfamily.org/dox/TopicPreprocessorDirectives.html
 # See: https://github.com/FEniCS/dolfinx/pull/143
-
-# Advice: Minimum alignment in bytes used for Eigen data structures. Set to 32 for
-# compatibility with AVX user-compiled code and 64 for AVX-512 user-compiled
-# code. Set to 0 for ideal alignment according to -march. Note that if an architecture
-# flag (e.g. "-march=skylake-avx512") is set for DOLFIN, Eigen will use the
-# appropriate ideal alignment instead if it is stricter. Otherwise, the value
-# of this variable will be used by Eigen for the alignment of all data structures.
 
 # Note: The name EIGEN_MAX_ALIGN_BYTES is confusing. In practice, Eigen
 # computes the ideal alignment based around -march.  If the ideal alignment is
 # greater than EIGEN_MAX_ALIGN_BYTES, the ideal alignment is used. If the ideal
 # alignment is less, then EIGEN_MAX_ALIGN_BYTES is used for alignment.
+set(DOLFINX_EIGEN_MAX_ALIGN_BYTES "32" CACHE STRING "\
+Minimum alignment in bytes used for Eigen data structures. Set to 32 for \
+compatibility with AVX user-compiled code and 64 for AVX-512 user-compiled \
+code. Set to 0 for ideal alignment according to -march. Note that if an architecture \
+flag (e.g. \"-march=skylake-avx512\") is set for DOLFIN, Eigen will use the \
+appropriate ideal alignment instead if it is stricter. Otherwise, the value \
+of this variable will be used by Eigen for the alignment of all data structures.\\
+")
 
 # Eigen3
 target_include_directories(dolfinx SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIR})
+target_compile_definitions(dolfinx PUBLIC "EIGEN_MAX_ALIGN_BYTES=${DOLFINX_EIGEN_MAX_ALIGN_BYTES}")
 
 # Boost
 target_link_libraries(dolfinx PUBLIC Boost::headers)


### PR DESCRIPTION
This patch exposed a number of alignment issues that we are currently investigating. Forcing the alignment of Eigen allocated memory in DOLFINX to 32 seems to 'fix' the issue.