### PR TITLE
Graphbuilder checks

### DIFF
--- a/cpp/dolfinx/common/SubSystemsManager.cpp
+++ b/cpp/dolfinx/common/SubSystemsManager.cpp
@@ -46,7 +46,7 @@ void SubSystemsManager::init_mpi(int argc, char* argv[])
 void SubSystemsManager::init_logging(int argc, char* argv[])
 {
   loguru::g_stderr_verbosity = loguru::Verbosity_WARNING;
-  // loguru::Options options = {"-dolfinx_loglevel", "main thread", false};
+  loguru::Options options = {"-dolfinx_loglevel", "main thread", false};
 
   // Make a copy of argv, as loguru may modify it.
   std::vector<char*> argv_copy;
@@ -54,7 +54,7 @@ void SubSystemsManager::init_logging(int argc, char* argv[])
     argv_copy.push_back(argv[i]);
   argv_copy.push_back(nullptr);
 
-  // loguru::init(argc, argv_copy.data(), options);
+  loguru::init(argc, argv_copy.data(), options);
 }
 //-----------------------------------------------------------------------------
 void SubSystemsManager::init_petsc()

--- a/cpp/dolfinx/common/SubSystemsManager.cpp
+++ b/cpp/dolfinx/common/SubSystemsManager.cpp
@@ -46,7 +46,7 @@ void SubSystemsManager::init_mpi(int argc, char* argv[])
 void SubSystemsManager::init_logging(int argc, char* argv[])
 {
   loguru::g_stderr_verbosity = loguru::Verbosity_WARNING;
-  loguru::Options options = {"-dolfinx_loglevel", "main thread", false};
+  // loguru::Options options = {"-dolfinx_loglevel", "main thread", false};
 
   // Make a copy of argv, as loguru may modify it.
   std::vector<char*> argv_copy;
@@ -54,7 +54,7 @@ void SubSystemsManager::init_logging(int argc, char* argv[])
     argv_copy.push_back(argv[i]);
   argv_copy.push_back(nullptr);
 
-  loguru::init(argc, argv_copy.data(), options);
+  // loguru::init(argc, argv_copy.data(), options);
 }
 //-----------------------------------------------------------------------------
 void SubSystemsManager::init_petsc()

--- a/cpp/dolfinx/mesh/GraphBuilder.cpp
+++ b/cpp/dolfinx/mesh/GraphBuilder.cpp
@@ -350,6 +350,8 @@ compute_nonlocal_dual_graph(
       edges.push_back(cell_list[i + 1]);
       ++num_nonlocal_edges;
     }
+    else
+      LOG(ERROR) << "Received an edge I already had";
     ghost_nodes.insert(cell_list[i + 1]);
   }
 

--- a/cpp/dolfinx/mesh/GraphBuilder.h
+++ b/cpp/dolfinx/mesh/GraphBuilder.h
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/types.h>
+#include <dolfinx/graph/AdjacencyList.h>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -27,14 +28,14 @@ namespace GraphBuilder
 /// Build distributed dual graph (cell-cell connections) from minimal
 /// mesh data, and return (graph, ghost_vertices, [num local edges,
 /// num non-local edges])
-std::pair<std::vector<std::vector<std::int64_t>>, std::array<std::int32_t, 3>>
+std::pair<graph::AdjacencyList<std::int64_t>, std::array<std::int32_t, 3>>
 compute_dual_graph(const MPI_Comm mpi_comm,
                    const graph::AdjacencyList<std::int64_t>& cell_vertices,
                    const mesh::CellType& cell_type);
 
 /// Compute local part of the dual graph, and return (local_graph,
 /// facet_cell_map, number of local edges in the graph (undirected)
-std::tuple<std::vector<std::vector<std::int32_t>>,
+std::tuple<graph::AdjacencyList<std::int32_t>,
            std::vector<std::pair<std::vector<std::int64_t>, std::int32_t>>,
            std::int32_t>
 compute_local_dual_graph(

--- a/cpp/dolfinx/mesh/Partitioning.cpp
+++ b/cpp/dolfinx/mesh/Partitioning.cpp
@@ -46,8 +46,6 @@ graph::AdjacencyList<std::int32_t> Partitioning::partition_cells(
   const auto [num_ghost_nodes, num_local_edges, num_nonlocal_edges]
       = graph_info;
 
-  // graph::AdjacencyList<std::int64_t> adj_graph(dual_graph);
-
   // Just flag any kind of ghosting for now
   bool ghosting = (ghost_mode != mesh::GhostMode::none);
 

--- a/cpp/dolfinx/mesh/Partitioning.cpp
+++ b/cpp/dolfinx/mesh/Partitioning.cpp
@@ -46,14 +46,14 @@ graph::AdjacencyList<std::int32_t> Partitioning::partition_cells(
   const auto [num_ghost_nodes, num_local_edges, num_nonlocal_edges]
       = graph_info;
 
-  graph::AdjacencyList<std::int64_t> adj_graph(dual_graph);
+  // graph::AdjacencyList<std::int64_t> adj_graph(dual_graph);
 
   // Just flag any kind of ghosting for now
   bool ghosting = (ghost_mode != mesh::GhostMode::none);
 
   // Call partitioner
   graph::AdjacencyList<std::int32_t> partition = graph::SCOTCH::partition(
-      comm, n, adj_graph, num_ghost_nodes, ghosting);
+      comm, n, dual_graph, num_ghost_nodes, ghosting);
 
   return partition;
 }


### PR DESCRIPTION
This PR updates the dual graph builder, which processes raw mesh topology before partitioning.
* Check for error conditions (e.g. >2 cells sharing a facet)
* Use AdjacencyList more
* Provide better load balancing of the global match phase (speeds up overall computation)