### PR TITLE
Fix assembly of interior and exterior facets for vector spaces

### DIFF
--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -453,7 +453,7 @@ void assemble_interior_facets(
     }
 
     // Tabulate tensor
-    Ae.setZero(dmapjoint0.size(), dmapjoint1.size());
+    Ae.setZero(bs0 * dmapjoint0.size(), bs1 * dmapjoint1.size());
     const std::array perm{perms(local_facet[0], cells[0]),
                           perms(local_facet[1], cells[1])};
     fn(Ae.data(), coeff_array.data(), constants.data(), coordinate_dofs.data(),
@@ -464,16 +464,22 @@ void assemble_interior_facets(
     {
       for (Eigen::Index i = 0; i < dmapjoint0.size(); ++i)
       {
-        if (bc0[dmapjoint0[i]])
-          Ae.row(i).setZero();
+        for (int k = 0; k < bs0; ++k)
+        {
+          if (bc0[bs0 * dmapjoint0[i] + k])
+            Ae.row(bs0 * i + k).setZero();
+        }
       }
     }
     if (!bc1.empty())
     {
       for (Eigen::Index j = 0; j < dmapjoint1.size(); ++j)
       {
-        if (bc1[dmapjoint1[j]])
-          Ae.col(j).setZero();
+        for (int k = 0; k < bs0; ++k)
+        {
+          if (bc1[bs1 * dmapjoint0[j] + k])
+            Ae.col(bs1 * j + k).setZero();
+        }
       }
     }
 

--- a/python/test/unit/fem/test_vector_assemble.py
+++ b/python/test/unit/fem/test_vector_assemble.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2020 Jørgen S. Dokken
+#
+# This file is part of DOLFINX (https://www.fenicsproject.org)
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+"""Unit tests for assembly on vector spaces"""
+
+
+import dolfinx
+import ufl
+from mpi4py import MPI
+
+
+def test_vector_assemble_matrix_exterior():
+    mesh = dolfinx.UnitSquareMesh(MPI.COMM_WORLD, 3, 3)
+    V = dolfinx.VectorFunctionSpace(mesh, ("CG", 1))
+
+    u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
+    a = ufl.inner(u, v) * ufl.ds
+    A = dolfinx.fem.assemble_matrix(a)
+    A.assemble()
+
+
+def test_vector_assemble_matrix_interior():
+    mesh = dolfinx.UnitSquareMesh(MPI.COMM_WORLD, 3, 3)
+    V = dolfinx.VectorFunctionSpace(mesh, ("CG", 1))
+
+    u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
+    a = ufl.inner(ufl.jump(u), ufl.jump(v)) * ufl.dS
+    A = dolfinx.fem.assemble_matrix(a)
+    A.assemble()


### PR DESCRIPTION
Introduced in #1242, which only changed assembly routines for cell integrals. This PR fixes these two issues, and adds two simple tests that yielded `Loguru caught a signal: SIGABRT` without the fix
Co-authored and debugged with @chrisrichardson 