### PR TITLE
Remove IndexMap.indices()

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -559,18 +559,6 @@ Eigen::Array<int, Eigen::Dynamic, 1> IndexMap::ghost_owner_rank() const
   return owners;
 }
 //----------------------------------------------------------------------------
-Eigen::Array<std::int64_t, Eigen::Dynamic, 1> IndexMap::indices() const
-{
-  const std::array local_range = this->local_range();
-  const std::int32_t size_local = this->size_local();
-  Eigen::Array<std::int64_t, Eigen::Dynamic, 1> indx(size_local + num_ghosts());
-  std::iota(indx.data(), indx.data() + size_local, local_range[0]);
-  for (Eigen::Index i = 0; i < num_ghosts(); ++i)
-    indx[size_local * i] = _ghosts[i];
-
-  return indx;
-}
-//----------------------------------------------------------------------------
 MPI_Comm IndexMap::comm(Direction dir) const
 {
   switch (dir)

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -186,10 +186,6 @@ public:
   /// Owner rank (on global communicator) of each ghost entry
   Eigen::Array<int, Eigen::Dynamic, 1> ghost_owner_rank() const;
 
-  /// Return array of global indices for all indices on this process,
-  /// including ghosts
-  Eigen::Array<std::int64_t, Eigen::Dynamic, 1> indices() const;
-
   /// @todo Aim to remove this function? If it's kept, should it work
   /// with neighborhood ranks?
   ///

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -10,10 +10,10 @@
 #include <Eigen/Dense>
 #include <complex>
 #include <dolfinx/common/IndexMap.h>
-#include <dolfinx/common/subsystem.h>
 #include <dolfinx/common/Table.h>
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/common/defines.h>
+#include <dolfinx/common/subsystem.h>
 #include <dolfinx/common/timing.h>
 #include <memory>
 #include <pybind11/eigen.h>
@@ -68,9 +68,7 @@ void common(py::module& m)
       .def_property_readonly("ghosts", &dolfinx::common::IndexMap::ghosts,
                              py::return_value_policy::reference_internal,
                              "Return list of ghost indices")
-      .def("global_indices", &dolfinx::common::IndexMap::global_indices)
-      .def("indices", &dolfinx::common::IndexMap::indices,
-           "Return array of global indices for all indices on this process");
+      .def("global_indices", &dolfinx::common::IndexMap::global_indices);
 
   // dolfinx::common::Timer
   py::class_<dolfinx::common::Timer, std::shared_ptr<dolfinx::common::Timer>>(


### PR DESCRIPTION
This function is a duplicate of `IndexMap::global_indices()` and is not used anywhere in the code base. It also has a type (IndexMap.cpp, Line 569) causing crashes if ever used in parallel.