### PR TITLE
Test branch to fix KaHIP on containers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -150,7 +150,7 @@ RUN wget -nc --quiet https://github.com/pybind/pybind11/archive/v${PYBIND11_VERS
 ENV KAHIP_DIR=/usr/local/KaHIP/deploy
 RUN cd /usr/local && \
     # git clone https://github.com/schulzchristian/KaHIP.git && \
-    git clone git@github.com:IgorBaratta/KaHIP.git && \
+    git clone https://github.com/IgorBaratta/KaHIP.git && \
     cd KaHIP/ && \
     # git checkout ${KAHIP_VERSION} && \
     mkdir build && cd build && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -149,9 +149,10 @@ RUN wget -nc --quiet https://github.com/pybind/pybind11/archive/v${PYBIND11_VERS
 # Install KaHIP
 ENV KAHIP_DIR=/usr/local/KaHIP/deploy
 RUN cd /usr/local && \
-    git clone https://github.com/schulzchristian/KaHIP.git && \
+    # git clone https://github.com/schulzchristian/KaHIP.git && \
+    git clone git@github.com:IgorBaratta/KaHIP.git && \
     cd KaHIP/ && \
-    git checkout ${KAHIP_VERSION} && \
+    # git checkout ${KAHIP_VERSION} && \
     mkdir build && cd build && \
     cmake -G Ninja -DCMAKE_INSTALL_PREFIX=${KAHIP_DIR} .. && \
     ninja install


### PR DESCRIPTION
Removed aggressive compiler flags from KaHIP `CMakeList` that "apparently" break portability 
(KaHIP is crashing with illegal hardware instruction errors on some docker images).

An issue has been filed in the KaHIP repository.

