### PR TITLE
GMSH eigen aligment + version update

### DIFF
--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -72,7 +72,7 @@ target_include_directories(dolfinx SYSTEM PUBLIC ${UFC_INCLUDE_DIRS})
 # computes the ideal alignment based around -march.  If the ideal alignment is
 # greater than EIGEN_MAX_ALIGN_BYTES, the ideal alignment is used. If the ideal
 # alignment is less, then EIGEN_MAX_ALIGN_BYTES is used for alignment.
-set(DOLFINX_EIGEN_MAX_ALIGN_BYTES "32" CACHE STRING "\
+set(DOLFINX_EIGEN_MAX_ALIGN_BYTES "0" CACHE STRING "\
 Minimum alignment in bytes used for Eigen data structures. Set to 32 for \
 compatibility with AVX user-compiled code and 64 for AVX-512 user-compiled \
 code. Set to 0 for ideal alignment according to -march. Note that if an architecture \

--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -66,19 +66,14 @@ target_include_directories(dolfinx SYSTEM PUBLIC ${UFC_INCLUDE_DIRS})
 # (ABI) if they use a different -march flag than that used to originally build
 # DOLFIN. DOLFINX_EIGEN_MAX_ALIGN_BYTES can be used to force alignment.
 # See: https://eigen.tuxfamily.org/dox/TopicPreprocessorDirectives.html
-# See: https://github.com/FEniCS/dolfinx/pull/143
 
-# Note: The name EIGEN_MAX_ALIGN_BYTES is confusing. In practice, Eigen
-# computes the ideal alignment based around -march.  If the ideal alignment is
-# greater than EIGEN_MAX_ALIGN_BYTES, the ideal alignment is used. If the ideal
-# alignment is less, then EIGEN_MAX_ALIGN_BYTES is used for alignment.
 set(DOLFINX_EIGEN_MAX_ALIGN_BYTES "0" CACHE STRING "\
-Minimum alignment in bytes used for Eigen data structures. Set to 32 for \
-compatibility with AVX user-compiled code and 64 for AVX-512 user-compiled \
-code. Set to 0 for ideal alignment according to -march. Note that if an architecture \
-flag (e.g. \"-march=skylake-avx512\") is set for DOLFIN, Eigen will use the \
-appropriate ideal alignment instead if it is stricter. Otherwise, the value \
-of this variable will be used by Eigen for the alignment of all data structures.\\
+Set to 0 to disable alignment completely, for compatibility with other libraries. 
+Otherwise, minimum alignment in bytes used for Eigen data structures. 
+Set to 32 for compatibility with AVX user-compiled code and 64 for AVX-512 
+user-compiled code. Note that if an architecture flag (e.g. \"-march=skylake-avx512\") 
+is set for DOLFIN, Eigen will use the appropriate ideal alignment instead if it is stricter. 
+Otherwise, the value of this variable will be used by Eigen for the alignment of all data structures.\\
 ")
 
 # Eigen3

--- a/python/demo/gmsh/demo_gmsh.py
+++ b/python/demo/gmsh/demo_gmsh.py
@@ -61,7 +61,7 @@ if MPI.COMM_WORLD.rank == 0:
     model.occ.synchronize()
 
     # Add physical tag 1 for exterior surfaces
-    boundary = model.getBoundary((3, model_dim_tags[0][0][1]))
+    boundary = model.getBoundary(model_dim_tags[0])
     boundary_ids = [b[1] for b in boundary]
     model.addPhysicalGroup(2, boundary_ids, tag=1)
     model.setPhysicalName(2, 1, "Sphere surface")


### PR DESCRIPTION
Setting default eigen alignment to zero removes the conflict between dolfin-x and gmsh eigen installations. 
One minor update due to version bump.
Adresses  #1277 