### PR TITLE
Compile pybind11 wrappers in debug mode, expose symbols

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ build-python-interface: &build-python-interface
   name: Build Python/pybind11 interface
   command: |
     cd python
-    pip3 -v install . --user
+    pip3 -v install --global-option build --global-option --debug . --user
 
 build-documentation-python: &build-documentation-python
   name: Build documentation (Python)

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -72,7 +72,7 @@ jobs:
           ctest -R demo -R mpi_2
 
       - name: Build Python interface
-        run: python3 -m pip -v install python/
+        run: python3 -m pip -v install --global-option build --global-option --debug python/
       - name: Build Python interface documentation
         run: |
           cd python/demo && python3 ./generate-demo-files.py

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -34,6 +34,12 @@ if (HAVE_PEDANTIC)
   target_compile_options(cpp PRIVATE -Wall;-Werror;-pedantic)
 endif()
 
+# In Debug mode override pybind11 symbols visibility
+# Symbols must be visible to backtrace_symbols() to produce nice logs
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  target_compile_options(cpp PRIVATE "-fvisibility=default")
+endif()
+
 # Add DOLFINX libraries and other config
 target_link_libraries(cpp PRIVATE pybind11::module dolfinx)
 


### PR DESCRIPTION
Improves stack trace caught by loguru.
Pybind11 always adds `-fvisibility=hidden` for some internal reasons (and performance), which hides symbols and makes backtraces which dynamically load `/usr/local/lib/python3.8/dist-packages/dolfinx/cpp.cpython-38-x86_64-linux-gnu.so` not very informative.

With this PR any segfault during assembler (dolfinx header code) is nicely caught (only in debug mode) as 
```
...
8       0x7fb2e8ed8b83 void dolfinx::fem::assemble_matrix<double>(std::function<int (int, int const*, int, int const*, double const*)> const&, dolfinx::fem::Form<double> const&, std::vector<std::shared_ptr<dolfinx::fem::DirichletBC<double> const>, std::allocator<std::shared_ptr<dolfinx::fem::DirichletBC<double> const> > > const&) + 1379
7       0x7fb2e8ee8b2f void dolfinx::fem::impl::assemble_matrix<double>(std::function<int (int, int const*, int, int const*, double const*)> const&, dolfinx::fem::Form<double> const&, std::vector<bool> const&, std::vector<bool> const&) + 2242
6       0x7fb2e8f053f2 void dolfinx::fem::impl::assemble_interior_facets<double>(std::function<int (int, int const*, int, int const*, double const*)> const&, dolfinx::mesh::Mesh const&, std::vector<int> const&, dolfinx::fem::DofMap const&, int, dolfinx::fem::DofMap const&, int, std::vector<bool> const&, std::vector<bool> const&, std::function<void (double*, double const*, double const*, double const*, int const*, unsigned char const*, unsigned int)> const&, Eigen::Array<double, -1, -1, 1, -1, -1> const&, std::vector<int> const&, std::vector<double> const&, std::vector<unsigned int > const&, Eigen::Array<unsigned char, -1, -1, 0, -1, -1> const&) + 3903
5       0x7fb2e8f20d3f std::vector<bool>::operator[](unsigned long) const + 93
4       0x7fb2e8e605b8 std::_Bit_const_iterator::operator*() const + 82
3       0x7fb2e8e6003f std::_Bit_reference::operator bool() const + 19
2       0x7fb2e9f74210 /lib/x86_64-linux-gnu/libc.so.6(+0x46210) [0x7fb2e9f74210]
1       0x7fb2e9f7418b gsignal + 203
0       0x7fb2e9f74210 /lib/x86_64-linux-gnu/libc.so.6(+0x46210) [0x7fb2e9f74210]
2021-01-07 09:57:09.570 (   0.821s) [main            ]                       :0     FATL| Signal: SIGSEGV
```