### PR TITLE
Test intel compilers

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -2,9 +2,9 @@ name: C++ testing with Intel compilers
 
 on:
   # Uncomment the below 'push' to trigger on push
-  # push:
-  #  branches:
-  #    - "**"
+  push:
+   branches:
+     - "**"
   schedule:
     # '*' is a special character in YAML, so string must be quoted
     - cron: "0 2 * * TUE"
@@ -19,16 +19,21 @@ jobs:
         shell: bash
 
     env:
-      CC: icc
-      CXX: icpc
-      PETSC_ARCH: linux-gnu-${{ matrix.petsc_arch }}-${{ matrix.petsc_int_type }}
+      CC:  ${{ matrix.c_compiler }}
+      CXX: ${{ matrix.cxx_compiler }}
+      PETSC_ARCH: linux-gnu-real-32
 
     strategy:
       matrix:
-        petsc_arch: [real]
-        petsc_int_type: [32]
-
-    steps:
+        include:
+#           - compiler: "Classic"
+#             c_compiler: icc
+#             cxx_compiler: icpc
+          - compiler: "LLVM-based"
+            c_compiler: icx
+            cxx_compiler: icpx
+      
+    steps:  
       - uses: actions/checkout@v2
 
       - name: Install Intel compilers
@@ -38,12 +43,12 @@ jobs:
           echo "deb https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list
           apt update
           # apt install -y intel-hpckit
-          apt install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          apt install -y intel-oneapi-common-vars intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic 
 
       - name: Install FEniCS Python components
         run: |
           . /opt/intel/oneapi/setvars.sh
-          python3 -m pip install git+https://github.com/FEniCS/fiat.git git+https://github.com/FEniCS/ufl.git git+https://github.com/FEniCS/ffcx.git
+          python3 -m pip install git+https://github.com/FEniCS/basix.git git+https://github.com/FEniCS/ufl.git git+https://github.com/FEniCS/ffcx.git
 
       - name: Configure C++
         run: |
@@ -73,25 +78,34 @@ jobs:
           cd build/demo
           ctest -R demo -R serial
           ctest -R demo -R mpi_2
-      #
-      # The Python interface does not build with Intel compiler due to
-      # bugs in the compiler that cause failures with pybind11.
-      #
-      # - name: Build Python interface
-      #   run: |
-      #     . /opt/intel/oneapi/setvars.sh
-      #     export CC=icc
-      #     export CXX=icpc
-      #     python3 -m pip -v install python/
-      # - name: Set default DOLFINX JIT parameters
-      #   run: |
-      #     mkdir -p ~/.config/dolfinx
-      #     echo '{ "cffi_extra_compile_args": ["-g0", "-O0" ] }' > ~/.config/dolfinx/dolfinx_jit_parameters.json
-      # - name: Run demos (Python, serial)
-      #   run: python3 -m pytest -v -n=2 -m serial --durations=10 python/demo/test.py
-      # - name: Run demos (Python, MPI (np=2))
-      #   run: python3 -m pytest -v -m mpi --num-proc=2 python/demo/test.py
-      # - name: Run Python unit tests (serial)
-      #   run: python3 -m pytest -n=auto --durations=50 python/test/unit/
-      # - name: Run Python unit tests (MPI, np=2)
-      #   run: mpirun -np 2 python3 -m pytest python/test/unit/
+
+      - name: Build Python interface
+        if: contains(matrix.compiler, 'LLVM')
+        run: |
+          . /opt/intel/oneapi/setvars.sh
+          python3 -m pip -v install python/
+      - name: Set default DOLFINX JIT parameters
+        run: |
+          mkdir -p ~/.config/dolfinx
+          echo '{ "cffi_extra_compile_args": ["-g0", "-O0" ] }' > ~/.config/dolfinx/dolfinx_jit_parameters.json
+      - name: Run demos (Python, serial)
+        if: contains(matrix.compiler, 'LLVM')
+        run: |
+          . /opt/intel/oneapi/setvars.sh
+          python3 -m pytest -v -n=2 -m serial --durations=10 python/demo/test.py
+      - name: Run demos (Python, MPI (np=2))
+        if: contains(matrix.compiler, 'LLVM')
+        run: |
+          . /opt/intel/oneapi/setvars.sh
+          python3 -m pytest -v -m mpi --num-proc=2 python/demo/test.py
+      - name: Run Python unit tests (serial)
+        if: contains(matrix.compiler, 'LLVM')
+        run: |
+          . /opt/intel/oneapi/setvars.sh
+          pip3 install sympy
+          python3 -m pytest -n=auto --durations=50 python/test/unit/
+      - name: Run Python unit tests (MPI, np=2)
+        if: contains(matrix.compiler, 'LLVM')
+        run: |
+          . /opt/intel/oneapi/setvars.sh
+          mpirun -np 2 python3 -m pytest python/test/unit/

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -1,4 +1,4 @@
-name: C++ testing with Intel compilers
+name: Intel compilers
 
 on:
   # Uncomment the below 'push' to trigger on push
@@ -80,7 +80,6 @@ jobs:
           ctest -R demo -R mpi_2
 
       - name: Build Python interface
-        if: contains(matrix.compiler, 'LLVM')
         run: |
           . /opt/intel/oneapi/setvars.sh
           python3 -m pip -v install python/
@@ -89,23 +88,19 @@ jobs:
           mkdir -p ~/.config/dolfinx
           echo '{ "cffi_extra_compile_args": ["-g0", "-O0" ] }' > ~/.config/dolfinx/dolfinx_jit_parameters.json
       - name: Run demos (Python, serial)
-        if: contains(matrix.compiler, 'LLVM')
         run: |
           . /opt/intel/oneapi/setvars.sh
           python3 -m pytest -v -n=2 -m serial --durations=10 python/demo/test.py
       - name: Run demos (Python, MPI (np=2))
-        if: contains(matrix.compiler, 'LLVM')
         run: |
           . /opt/intel/oneapi/setvars.sh
           python3 -m pytest -v -m mpi --num-proc=2 python/demo/test.py
       - name: Run Python unit tests (serial)
-        if: contains(matrix.compiler, 'LLVM')
         run: |
           . /opt/intel/oneapi/setvars.sh
           pip3 install sympy
           python3 -m pytest -n=auto --durations=50 python/test/unit/
       - name: Run Python unit tests (MPI, np=2)
-        if: contains(matrix.compiler, 'LLVM')
         run: |
           . /opt/intel/oneapi/setvars.sh
           mpirun -np 2 python3 -m pytest python/test/unit/


### PR DESCRIPTION
Tests with classic Intel compilers are disabled due to an issue with pybind.
Once that is solved I can re-enable the tests.

Fix expected to pybind version 2.6.2:
https://github.com/pybind/pybind11/issues/2771
