### PR TITLE
Higher order meshes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,6 @@ set-jit-defaults: &set-jit-defaults
 unit-tests-python: &unit-tests-python
   name: Run unit tests (Python, serial)
   command: |
-    pip3 install sympy
     mkdir -p ~/junit
     cd python/test/unit
     python3 -m pytest -n=4 --durations=50 --junitxml=~/junit/test-results.xml .

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -91,8 +91,6 @@ jobs:
       - name: Run demos (Python, MPI (np=2))
         run: python3 -m pytest -v -m mpi --num-proc=2 python/demo/test.py
 
-      - name: Install sympy
-        run: python3 -m pip install sympy
       - name: Run Python unit tests (serial)
         run: python3 -m pytest -v -n=auto --durations=50 python/test/unit/
       - name: Run Python unit tests (MPI, np=2)

--- a/cpp/dolfinx/generation/BoxMesh.cpp
+++ b/cpp/dolfinx/generation/BoxMesh.cpp
@@ -179,7 +179,7 @@ mesh::Mesh build_hex(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
     const std::int64_t v5 = v1 + (nx + 1) * (ny + 1);
     const std::int64_t v6 = v2 + (nx + 1) * (ny + 1);
     const std::int64_t v7 = v3 + (nx + 1) * (ny + 1);
-    topo.row(cell) << v0, v4, v2, v6, v1, v5, v3, v7;
+    topo.row(cell) << v0, v1, v3, v4, v5, v6, v7;
     ++cell;
   }
 

--- a/cpp/dolfinx/generation/BoxMesh.cpp
+++ b/cpp/dolfinx/generation/BoxMesh.cpp
@@ -179,7 +179,7 @@ mesh::Mesh build_hex(MPI_Comm comm, const std::array<Eigen::Vector3d, 2>& p,
     const std::int64_t v5 = v1 + (nx + 1) * (ny + 1);
     const std::int64_t v6 = v2 + (nx + 1) * (ny + 1);
     const std::int64_t v7 = v3 + (nx + 1) * (ny + 1);
-    topo.row(cell) << v0, v1, v3, v4, v5, v6, v7;
+    topo.row(cell) << v0, v1, v2, v3, v4, v5, v6, v7;
     ++cell;
   }
 

--- a/cpp/dolfinx/io/cells.cpp
+++ b/cpp/dolfinx/io/cells.cpp
@@ -207,7 +207,7 @@ std::vector<std::uint8_t> vtk_hexahedron(int num_nodes)
     return {0, 1, 3, 2, 4, 5, 7, 6};
   case 27:
     // This is the documented VTK ordering
-    return {0,  1,  3,  2,  4,  5,  7,  6,  8,  11, 13, 9,  10, 18,
+    return {0,  1,  3,  2,  4,  5,  7,  6,  8,  11, 13, 9,  16, 18,
             19, 17, 10, 12, 15, 14, 22, 23, 21, 24, 20, 25, 26};
   default:
     throw std::runtime_error("Higher order hexahedron not supported.");

--- a/cpp/dolfinx/mesh/Geometry.cpp
+++ b/cpp/dolfinx/mesh/Geometry.cpp
@@ -77,7 +77,7 @@ mesh::Geometry mesh::create_geometry(
         = topology.get_cell_permutation_info();
 
     for (std::int32_t cell = 0; cell < num_cells; ++cell)
-      coordinate_element.permute_dofs(dofmap.links(cell).data(),
+      coordinate_element.unpermute_dofs(dofmap.links(cell).data(),
                                       cell_info[cell]);
   }
 
@@ -124,7 +124,7 @@ mesh::Geometry mesh::create_geometry(
         = topology.get_cell_permutation_info();
 
     for (std::int32_t cell = 0; cell < num_cells; ++cell)
-      coordinate_element.unpermute_dofs(dofmap.links(cell).data(),
+      coordinate_element.permute_dofs(dofmap.links(cell).data(),
                                         cell_info[cell]);
   }
 

--- a/cpp/dolfinx/mesh/cell_types.cpp
+++ b/cpp/dolfinx/mesh/cell_types.cpp
@@ -130,8 +130,8 @@ mesh::get_sub_entities(CellType type, int dim0, int dim1)
          5, 2, 4, 5)
             .finished();
   const static Eigen::Array<int, 6, 4, Eigen::RowMajor> hexahedron
-      = (Eigen::Array<int, 6, 4, Eigen::RowMajor>() << 0, 3, 5, 1, 0, 4, 8, 2,
-         1, 6, 9, 2, 3, 7, 10, 4, 5, 7, 11, 6, 8, 10, 11, 9)
+      = (Eigen::Array<int, 6, 4, Eigen::RowMajor>() << 0, 1, 3, 5, 0, 2, 4, 8,
+         1, 2, 6, 9, 3, 4, 7, 10, 5, 6, 7, 11, 8, 9, 10, 11)
             .finished();
 
   switch (type)

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -577,7 +577,13 @@ void fem(py::module& m)
       .def_property_readonly("id", &dolfinx::fem::FunctionSpace::id)
       .def("__hash__", &dolfinx::fem::FunctionSpace::id)
       .def("__eq__", &dolfinx::fem::FunctionSpace::operator==)
-      .def("collapse", &dolfinx::fem::FunctionSpace::collapse)
+      .def("collapse",
+           [](dolfinx::fem::FunctionSpace& self) {
+             std::pair<std::shared_ptr<dolfinx::fem::FunctionSpace>,
+                       std::vector<std::int32_t>>
+                 c = self.collapse();
+             return std::make_pair(c.first, as_pyarray(std::move(c.second)));
+           })
       .def("component", &dolfinx::fem::FunctionSpace::component)
       .def("contains", &dolfinx::fem::FunctionSpace::contains)
       .def_property_readonly("element", &dolfinx::fem::FunctionSpace::element)

--- a/python/test/unit/fem/test_fem_pipeline.py
+++ b/python/test/unit/fem/test_fem_pipeline.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 import ufl
 from dolfinx import (DirichletBC, Function, FunctionSpace,
-                     VectorFunctionSpace, cpp, fem)
+                     VectorFunctionSpace, cpp, fem, UnitCubeMesh, UnitSquareMesh)
 from dolfinx.cpp.mesh import CellType
 from dolfinx.fem import (apply_lifting, assemble_matrix, assemble_scalar,
                          assemble_vector, locate_dofs_topological, set_bc)
@@ -230,6 +230,18 @@ def test_P_simplex(family, degree, cell_type, datadir):
 @parametrize_cell_types_simplex
 @pytest.mark.parametrize("family", ["Lagrange"])
 @pytest.mark.parametrize("degree", [2, 3, 4])
+def test_P_simplex_built_in(family, degree, cell_type, datadir):
+    if cell_type == CellType.tetrahedron:
+        mesh = UnitCubeMesh(MPI.COMM_WORLD, 5, 5, 5)
+    elif cell_type == CellType.triangle:
+        mesh = UnitSquareMesh(MPI.COMM_WORLD, 5, 5)
+    V = FunctionSpace(mesh, (family, degree))
+    run_scalar_test(mesh, V, degree)
+
+
+@parametrize_cell_types_simplex
+@pytest.mark.parametrize("family", ["Lagrange"])
+@pytest.mark.parametrize("degree", [2, 3, 4])
 def test_vector_P_simplex(family, degree, cell_type, datadir):
     if cell_type == CellType.tetrahedron and degree == 4:
         pytest.skip("Skip expensive test on tetrahedron")
@@ -284,6 +296,19 @@ def test_BDM_N2curl_simplex_highest_order(family, degree, cell_type, datadir):
 @pytest.mark.parametrize("family", ["Q"])
 @pytest.mark.parametrize("degree", [2, 3, 4])
 def test_P_tp(family, degree, cell_type, datadir):
+    mesh = get_mesh(cell_type, datadir)
+    V = FunctionSpace(mesh, (family, degree))
+    run_scalar_test(mesh, V, degree)
+
+
+@parametrize_cell_types_tp
+@pytest.mark.parametrize("family", ["Q"])
+@pytest.mark.parametrize("degree", [2, 3, 4])
+def test_P_tp_built_in_mesh(family, degree, cell_type, datadir):
+    if cell_type == CellType.hexahedron:
+        mesh = UnitCubeMesh(MPI.COMM_WORLD, 5, 5, 5, cell_type)
+    elif cell_type == CellType.quadrilateral:
+        mesh = UnitSquareMesh(MPI.COMM_WORLD, 5, 5, cell_type)
     mesh = get_mesh(cell_type, datadir)
     V = FunctionSpace(mesh, (family, degree))
     run_scalar_test(mesh, V, degree)

--- a/python/test/unit/io/test_xdmf_mesh.py
+++ b/python/test/unit/io/test_xdmf_mesh.py
@@ -96,7 +96,10 @@ def test_save_and_load_3d_mesh(tempdir, encoding, cell_type):
 
 @pytest.mark.parametrize("encoding", encodings)
 def test_read_write_p2_mesh(tempdir, encoding):
-    gmsh = pytest.importorskip("gmsh")
+    try:
+        import gmsh
+    except ImportError:
+        pytest.skip()
     if MPI.COMM_WORLD.rank == 0:
         gmsh.initialize()
         gmsh.model.occ.addSphere(0, 0, 0, 1, tag=1)

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -254,7 +254,7 @@ def test_triangle_mesh_vtk(order):
     def coord_to_vertex(x, y):
         return y * (2 * order + 3 - y) // 2 + x
 
-    # Make the cell, following https://blog.kitware.com/modeling-arbitrary-order-lagrange-finite-elements-in-the-visualization-toolkit/
+    # Make the cell, following https://blog.kitware.com/modeling-arbitrary-order-lagrange-finite-elements-in-the-visualization-toolkit/  # noqa: E501
     cell = [coord_to_vertex(i, j) for i, j in [(0, 0), (order, 0), (0, order)]]
     if order > 1:
         for i in range(1, order):
@@ -300,7 +300,7 @@ def test_tetrahedron_mesh_vtk(order):
             3 * order ** 2 - 3 * order * z + 12 * order + z ** 2 - 6 * z + 11
         ) // 6 + y * (2 * (order - z) + 3 - y) // 2 + x
 
-    # Make the cell, following https://blog.kitware.com/modeling-arbitrary-order-lagrange-finite-elements-in-the-visualization-toolkit/
+    # Make the cell, following https://blog.kitware.com/modeling-arbitrary-order-lagrange-finite-elements-in-the-visualization-toolkit/  # noqa: E501
     cell = [coord_to_vertex(x, y, z) for x, y, z in [
         (0, 0, 0), (order, 0, 0), (0, order, 0), (0, 0, order)]]
 
@@ -319,13 +319,15 @@ def test_tetrahedron_mesh_vtk(order):
             cell.append(coord_to_vertex(0, order - i, i))
 
         if order == 3:
-            # The ordering of faces does not match documentation. See https://gitlab.kitware.com/vtk/vtk/uploads/a0dc0173a41d3cf6b03a9266c0e23688/image.png
+            # The ordering of faces does not match documentation.
+            # See https://gitlab.kitware.com/vtk/vtk/uploads/a0dc0173a41d3cf6b03a9266c0e23688/image.png
             cell.append(coord_to_vertex(1, 0, 1))
             cell.append(coord_to_vertex(1, 1, 1))
             cell.append(coord_to_vertex(0, 1, 1))
             cell.append(coord_to_vertex(1, 1, 0))
         elif order == 4:
-            # The ordering of faces does not match documentation. See https://gitlab.kitware.com/vtk/vtk/uploads/a0dc0173a41d3cf6b03a9266c0e23688/image.png
+            # The ordering of faces does not match documentation.
+            # See https://gitlab.kitware.com/vtk/vtk/uploads/a0dc0173a41d3cf6b03a9266c0e23688/image.png
             cell.append(coord_to_vertex(1, 0, 1))
             cell.append(coord_to_vertex(2, 0, 1))
             cell.append(coord_to_vertex(1, 0, 2))
@@ -387,7 +389,7 @@ def test_quadrilateral_mesh_vtk(order):
     def coord_to_vertex(x, y):
         return (order + 1) * y + x
 
-    # Make the cell, following https://blog.kitware.com/modeling-arbitrary-order-lagrange-finite-elements-in-the-visualization-toolkit/
+    # Make the cell, following https://blog.kitware.com/modeling-arbitrary-order-lagrange-finite-elements-in-the-visualization-toolkit/  # noqa: E501
     cell = [coord_to_vertex(i, j)
             for i, j in [(0, 0), (order, 0), (order, order), (0, order)]]
     if order > 1:
@@ -431,7 +433,7 @@ def test_hexahedron_mesh_vtk(order):
     def coord_to_vertex(x, y, z):
         return (order + 1) ** 2 * z + (order + 1) * y + x
 
-    # Make the cell, following https://blog.kitware.com/modeling-arbitrary-order-lagrange-finite-elements-in-the-visualization-toolkit/
+    # Make the cell, following https://blog.kitware.com/modeling-arbitrary-order-lagrange-finite-elements-in-the-visualization-toolkit/  # noqa: E501
     cell = [coord_to_vertex(x, y, z) for x, y, z in [
         (0, 0, 0), (order, 0, 0), (order, order, 0), (0, order, 0),
         (0, 0, order), (order, 0, order), (order, order, order), (0, order, order)]]
@@ -462,7 +464,8 @@ def test_hexahedron_mesh_vtk(order):
         for i in range(1, order):
             cell.append(coord_to_vertex(0, order, i))
 
-        # The ordering of faces does not match documentation. See https://gitlab.kitware.com/vtk/vtk/uploads/a0dc0173a41d3cf6b03a9266c0e23688/image.png
+        # The ordering of faces does not match documentation.
+        # See https://gitlab.kitware.com/vtk/vtk/uploads/a0dc0173a41d3cf6b03a9266c0e23688/image.png
         # The edge flip in this like however has been fixed in VTK so we follow the main documentation link for edges
         for j in range(1, order):
             for i in range(1, order):

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -10,10 +10,8 @@ import random
 
 import numpy as np
 import pytest
-import scipy.integrate
-import sympy as sp
 import ufl
-from dolfinx import Function, FunctionSpace, cpp
+from dolfinx import cpp
 from dolfinx.cpp.io import perm_gmsh, perm_vtk
 from dolfinx.cpp.mesh import CellType
 from dolfinx.fem import assemble_scalar
@@ -21,8 +19,122 @@ from dolfinx.io import XDMFFile, ufl_mesh_from_gmsh
 from dolfinx.mesh import create_mesh
 from dolfinx_utils.test.skips import skip_in_parallel
 from mpi4py import MPI
-from sympy.vector import CoordSys3D, matrix_to_vector
 from ufl import dx
+
+
+@skip_in_parallel
+@pytest.mark.parametrize('order', range(1, 5))
+def test_triangle_mesh(order):
+    random.seed(13)
+
+    points = []
+    points += [[i / order, 0] for i in range(order + 1)]
+    for j in range(1, order):
+        points += [[i / order + 0.1, j / order] for i in range(order + 1 - j)]
+    points += [[0, 1]]
+
+    def coord_to_vertex(x, y):
+        return y * (2 * order + 3 - y) // 2 + x
+
+    cell = [coord_to_vertex(i, j) for i, j in [(0, 0), (order, 0), (0, order)]]
+    if order > 1:
+        for i in range(1, order):
+            cell.append(coord_to_vertex(order - i, i))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(0, i))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(i, 0))
+
+        for j in range(1, order):
+            for i in range(1, order - j):
+                cell.append(coord_to_vertex(i, j))
+
+    domain = ufl.Mesh(ufl.VectorElement(
+        "Lagrange", ufl.Cell("triangle", geometric_dimension=2), order))
+
+    point_order = [i for i, _ in enumerate(points)]
+    for repeat in range(5):
+        random.shuffle(point_order)
+        ordered_points = np.zeros((len(points), 2))
+        for i, j in enumerate(point_order):
+            ordered_points[j] = points[i]
+        ordered_cell = [point_order[i] for i in cell]
+
+        mesh = create_mesh(MPI.COMM_WORLD, [ordered_cell], ordered_points, domain)
+        area = assemble_scalar(1 * dx(mesh))
+
+        assert np.isclose(area, 0.5)
+
+
+@skip_in_parallel
+@pytest.mark.parametrize('order', range(1, 5))
+def test_tetrahedron_mesh(order):
+    random.seed(13)
+
+    points = []
+    points += [[i / order, j / order, 0] for j in range(order + 1)
+               for i in range(order + 1 - j)]
+    for k in range(1, order):
+        points += [[i / order, j / order + 0.1, k / order] for j in range(order + 1 - k)
+                   for i in range(order + 1 - k - j)]
+
+    points += [[0, 0, 1]]
+
+    def coord_to_vertex(x, y, z):
+        return z * (
+            3 * order ** 2 - 3 * order * z + 12 * order + z ** 2 - 6 * z + 11
+        ) // 6 + y * (2 * (order - z) + 3 - y) // 2 + x
+
+    cell = [coord_to_vertex(x, y, z) for x, y, z in [
+        (0, 0, 0), (order, 0, 0), (0, order, 0), (0, 0, order)]]
+
+    if order > 1:
+        for i in range(1, order):
+            cell.append(coord_to_vertex(0, order - i, i))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(order - i, 0, i))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(order - i, i, 0))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(0, 0, i))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(0, i, 0))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(i, 0, 0))
+
+        for j in range(1, order):
+            for i in range(1, order - j):
+                cell.append(coord_to_vertex(order - i - j, i, j))
+        for j in range(1, order):
+            for i in range(1, order - j):
+                cell.append(coord_to_vertex(0, i, j))
+        for j in range(1, order):
+            for i in range(1, order - j):
+                cell.append(coord_to_vertex(i, 0, j))
+        for j in range(1, order):
+            for i in range(1, order - j):
+                cell.append(coord_to_vertex(i, j, 0))
+
+        for k in range(1, order):
+            for j in range(1, order - k):
+                for i in range(1, order - j - k):
+                    cell.append(coord_to_vertex(i, j, k))
+
+    domain = ufl.Mesh(ufl.VectorElement(
+        "Lagrange", ufl.Cell("tetrahedron", geometric_dimension=3), order))
+
+    point_order = [i for i, _ in enumerate(points)]
+    for repeat in range(5):
+        random.shuffle(point_order)
+        ordered_points = np.zeros((len(points), 3))
+        for i, j in enumerate(point_order):
+            ordered_points[j] = points[i]
+        ordered_cell = [point_order[i] for i in cell]
+
+        mesh = create_mesh(MPI.COMM_WORLD, [ordered_cell], ordered_points, domain)
+        volume = assemble_scalar(1 * dx(mesh))
+
+        assert np.isclose(volume, 1 / 6)
 
 
 @skip_in_parallel
@@ -34,26 +146,34 @@ def test_quadrilateral_mesh(order):
     points += [[i / order, 0] for i in range(order + 1)]
     for j in range(1, order):
         points += [[i / order + 0.1, j / order] for i in range(order + 1)]
-
     points += [[j / order, 1] for j in range(order + 1)]
 
-    cell = [0, order, order * (order + 1), order * (order + 2)]
-    if order > 1:
-        cell += list(range(1, order))
-        cell += list(range(order + 1, order * (order + 1), order + 1))
-        cell += list(range(2 * order + 1, order * (order + 1), order + 1))
-        cell += list(range(order * (order + 1) + 1, order * (order + 2)))
+    def coord_to_vertex(x, y):
+        return (order + 1) * y + x
 
+    cell = [coord_to_vertex(i, j)
+            for i, j in [(0, 0), (order, 0), (0, order), (order, order)]]
+    if order > 1:
         for i in range(1, order):
-            cell += list(range(i * (order + 1) + 1, i * (order + 1) + order))
+            cell.append(coord_to_vertex(i, 0))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(0, i))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(order, i))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(i, order))
+
+        for j in range(1, order):
+            for i in range(1, order):
+                cell.append(coord_to_vertex(i, j))
 
     domain = ufl.Mesh(ufl.VectorElement(
         "Q", ufl.Cell("quadrilateral", geometric_dimension=2), order))
 
-    point_order = list(range((order + 1) ** 2))
+    point_order = [i for i, _ in enumerate(points)]
     for repeat in range(5):
         random.shuffle(point_order)
-        ordered_points = np.zeros(((order + 1) ** 2, 2))
+        ordered_points = np.zeros((len(points), 2))
         for i, j in enumerate(point_order):
             ordered_points[j] = points[i]
         ordered_cell = [point_order[i] for i in cell]
@@ -138,12 +258,10 @@ def test_hexahedron_mesh(order):
     domain = ufl.Mesh(ufl.VectorElement(
         "Q", ufl.Cell("hexahedron", geometric_dimension=3), order))
 
-    print(cell, len(cell))
-
-    point_order = list(range((order + 1) ** 3))
+    point_order = [i for i, _ in enumerate(points)]
     for repeat in range(5):
         random.shuffle(point_order)
-        ordered_points = np.zeros(((order + 1) ** 3, 3))
+        ordered_points = np.zeros((len(points), 3))
         for i, j in enumerate(point_order):
             ordered_points[j] = points[i]
         ordered_cell = [point_order[i] for i in cell]
@@ -152,50 +270,6 @@ def test_hexahedron_mesh(order):
         volume = assemble_scalar(1 * dx(mesh))
 
         assert np.isclose(volume, 1)
-
-
-def sympy_scipy(points, nodes, L, H):
-    """Approximated integration of z + x*y over a surface where the z-coordinate
-    is only dependent of the y-component of the box. x in [0,L], y in
-    [0,H]
-
-    Input: points: All points of defining the geometry nodes:  Points on
-      one of the outer boundaries varying in the y-direction
-    """
-    degree = len(nodes) - 1
-
-    x, y, z = sp.symbols("x y z")
-    a = [sp.Symbol("a{0:d}".format(i)) for i in range(degree + 1)]
-
-    # Find polynomial for variation in z-direction
-    poly = 0
-    for deg in range(degree + 1):
-        poly += a[deg] * y**deg
-    eqs = []
-    for node in nodes:
-        eqs.append(poly.subs(y, points[node][-2]) - points[node][-1])
-    coeffs = sp.solve(eqs, a)
-    transform = poly
-    for i in range(len(a)):
-        transform = transform.subs(a[i], coeffs[a[i]])
-
-    # Compute integral
-    C = CoordSys3D("C")
-    para = sp.Matrix([x, y, transform])
-    vec = matrix_to_vector(para, C)
-    cross = (vec.diff(x) ^ vec.diff(y)).magnitude()
-
-    expr = (transform + x * y) * cross
-    approx = sp.lambdify((x, y), expr)
-
-    ref = scipy.integrate.nquad(approx, [[0, L], [0, H]])[0]
-
-    # Slow and only works for simple integrals
-    # integral = sp.integrate(expr, (y, 0, H))
-    # integral = sp.integrate(integral, (x, 0, L))
-    # ex = integral.evalf()
-
-    return ref
 
 
 @skip_in_parallel
@@ -212,300 +286,6 @@ def test_map_vtk_to_dolfin(vtk, dolfin, cell_type):
     p = np.argsort(perm_vtk(cell_type, len(vtk)))
     cell_p = np.array(dolfin)[p]
     assert (cell_p == vtk).all()
-
-
-@skip_in_parallel
-def test_second_order_tri():
-    # Test second order mesh by computing volume of two cells
-    #  *-----*-----*   3----6-----2
-    #  | \         |   | \        |
-    #  |   \       |   |   \      |
-    #  *     *     *   7     8    5
-    #  |       \   |   |      \   |
-    #  |         \ |   |        \ |
-    #  *-----*-----*   0----4-----1
-    for H in (1.0, 2.0):
-        for Z in (0.0, 0.5):
-            L = 1
-            points = np.array([[0, 0, 0], [L, 0, 0], [L, H, Z], [0, H, Z],
-                               [L / 2, 0, 0], [L, H / 2, 0], [L / 2, H, Z],
-                               [0, H / 2, 0], [L / 2, H / 2, 0]])
-
-            cells = np.array([[0, 1, 3, 4, 8, 7],
-                              [1, 2, 3, 5, 6, 8]])
-            cells = cells[:, perm_vtk(CellType.triangle, cells.shape[1])]
-
-            cell = ufl.Cell("triangle", geometric_dimension=points.shape[1])
-            domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell, 2))
-            mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
-
-            def e2(x):
-                return x[2] + x[0] * x[1]
-            # Interpolate function
-            V = FunctionSpace(mesh, ("CG", 2))
-            u = Function(V)
-            u.interpolate(e2)
-
-            intu = assemble_scalar(u * dx(mesh, metadata={"quadrature_degree": 20}))
-            intu = mesh.mpi_comm().allreduce(intu, op=MPI.SUM)
-
-            nodes = [0, 3, 7]
-            ref = sympy_scipy(points, nodes, L, H)
-            assert ref == pytest.approx(intu, rel=1e-6)
-
-
-@skip_in_parallel
-def test_third_order_tri():
-    #  *---*---*---*   3--11--10--2
-    #  | \         |   | \        |
-    #  *   *   *   *   8   7  15  13
-    #  |     \     |   |    \     |
-    #  *  *    *   *   9  14  6   12
-    #  |         \ |   |        \ |
-    #  *---*---*---*   0--4---5---1
-    for H in (1.0, 2.0):
-        for Z in (0.0, 0.5):
-            L = 1
-            points = np.array([[0, 0, 0], [L, 0, 0], [L, H, Z], [0, H, Z],  # 0, 1, 2, 3
-                               [L / 3, 0, 0], [2 * L / 3, 0, 0],            # 4, 5
-                               [2 * L / 3, H / 3, 0], [L / 3, 2 * H / 3, 0],  # 6, 7
-                               [0, 2 * H / 3, 0], [0, H / 3, 0],        # 8, 9
-                               [2 * L / 3, H, Z], [L / 3, H, Z],              # 10, 11
-                               [L, H / 3, 0], [L, 2 * H / 3, 0],  # 12, 13
-                               [L / 3, H / 3, 0],                         # 14
-                               [2 * L / 3, 2 * H / 3, 0]])            # 15
-            cells = np.array([[0, 1, 3, 4, 5, 6, 7, 8, 9, 14],
-                              [1, 2, 3, 12, 13, 10, 11, 7, 6, 15]])
-            cells = cells[:, perm_vtk(CellType.triangle, cells.shape[1])]
-
-            cell = ufl.Cell("triangle", geometric_dimension=points.shape[1])
-            domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell, 3))
-            mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
-
-            def e2(x):
-                return x[2] + x[0] * x[1]
-            # Interpolate function
-            V = FunctionSpace(mesh, ("Lagrange", 3))
-            u = Function(V)
-            u.interpolate(e2)
-
-            intu = assemble_scalar(u * dx(metadata={"quadrature_degree": 40}))
-            intu = mesh.mpi_comm().allreduce(intu, op=MPI.SUM)
-
-            nodes = [0, 9, 8, 3]
-            ref = sympy_scipy(points, nodes, L, H)
-            assert ref == pytest.approx(intu, rel=1e-6)
-
-
-@skip_in_parallel
-def test_fourth_order_tri():
-    L = 1
-    #  *--*--*--*--*   3-21-20-19--2
-    #  | \         |   | \         |
-    #  *   *  * *  *   10 9 24 23  18
-    #  |     \     |   |    \      |
-    #  *  *   *  * *   11 15  8 22 17
-    #  |       \   |   |       \   |
-    #  *  * *   *  *   12 13 14 7  16
-    #  |         \ |   |         \ |
-    #  *--*--*--*--*   0--4--5--6--1
-    for H in (1.0, 2.0):
-        for Z in (0.0, 0.5):
-            points = np.array(
-                [[0, 0, 0], [L, 0, 0], [L, H, Z], [0, H, Z],   # 0, 1, 2, 3
-                 [L / 4, 0, 0], [L / 2, 0, 0], [3 * L / 4, 0, 0],  # 4, 5, 6
-                 [3 / 4 * L, H / 4, Z / 2], [L / 2, H / 2, 0],         # 7, 8
-                 [L / 4, 3 * H / 4, 0], [0, 3 * H / 4, 0],         # 9, 10
-                 [0, H / 2, 0], [0, H / 4, Z / 2],                     # 11, 12
-                 [L / 4, H / 4, Z / 2], [L / 2, H / 4, Z / 2], [L / 4, H / 2, 0],  # 13, 14, 15
-                 [L, H / 4, Z / 2], [L, H / 2, 0], [L, 3 * H / 4, 0],          # 16, 17, 18
-                 [3 * L / 4, H, Z], [L / 2, H, Z], [L / 4, H, Z],          # 19, 20, 21
-                 [3 * L / 4, H / 2, 0], [3 * L / 4, 3 * H / 4, 0],         # 22, 23
-                 [L / 2, 3 * H / 4, 0]]                                    # 24
-            )
-
-            cells = np.array([[0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
-                              [1, 2, 3, 16, 17, 18, 19, 20, 21, 9, 8, 7, 22, 23, 24]])
-            cells = cells[:, perm_vtk(CellType.triangle, cells.shape[1])]
-            cell = ufl.Cell("triangle", geometric_dimension=points.shape[1])
-            domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell, 4))
-            mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
-
-            def e2(x):
-                return x[2] + x[0] * x[1]
-
-            # Interpolate function
-            V = FunctionSpace(mesh, ("Lagrange", 4))
-            u = Function(V)
-            u.interpolate(e2)
-
-            intu = assemble_scalar(u * dx(metadata={"quadrature_degree": 50}))
-            intu = mesh.mpi_comm().allreduce(intu, op=MPI.SUM)
-            nodes = [0, 3, 10, 11, 12]
-            ref = sympy_scipy(points, nodes, L, H)
-            assert ref == pytest.approx(intu, rel=1e-4)
-
-
-def scipy_one_cell(points, nodes):
-    degree = len(nodes) - 1
-
-    x, y, z = sp.symbols("x y z")
-    a = [sp.Symbol("a{0:d}".format(i)) for i in range(degree + 1)]
-
-    # Find polynomial for variation in z-direction
-    poly = 0
-    for deg in range(degree + 1):
-        poly += a[deg] * y**deg
-    eqs = []
-    for node in nodes:
-        eqs.append(poly.subs(y, points[node][-2]) - points[node][-1])
-    coeffs = sp.solve(eqs, a)
-    transform = poly
-
-    for i in range(len(a)):
-        transform = transform.subs(a[i], coeffs[a[i]])
-    # Compute integral
-    C = CoordSys3D("C")
-    para = sp.Matrix([x, y, transform])
-    vec = matrix_to_vector(para, C)
-    cross = (vec.diff(x) ^ vec.diff(y)).magnitude()
-
-    expr = (transform + x * y) * cross
-
-    approx = sp.lambdify((x, y), expr)
-    ref = scipy.integrate.dblquad(approx, 0, 1, lambda x: 0, lambda x: 1 - x)[0]
-    return ref
-
-
-# FIXME: Higher order tests are too slow, need to find a better test
-@skip_in_parallel
-@pytest.mark.parametrize("order", range(1, 6))
-def test_nth_order_triangle(order):
-    num_nodes = (order + 1) * (order + 2) / 2
-    cells = np.array([range(int(num_nodes))])
-    cells = cells[:, perm_vtk(CellType.triangle, cells.shape[1])]
-
-    if order == 1:
-        points = np.array([[0.00000, 0.00000, 0.00000], [1.00000, 0.00000, 0.00000],
-                           [0.00000, 1.00000, 0.00000]])
-    elif order == 2:
-        points = np.array([[0.00000, 0.00000, 0.00000], [1.00000, 0.00000, 0.00000],
-                           [0.00000, 1.00000, 0.00000], [0.50000, 0.00000, 0.00000],
-                           [0.50000, 0.50000, -0.25000], [0.00000, 0.50000, -0.25000]])
-
-    elif order == 3:
-        points = np.array([[0.00000, 0.00000, 0.00000], [1.00000, 0.00000, 0.00000],
-                           [0.00000, 1.00000, 0.00000], [0.33333, 0.00000, 0.00000],
-                           [0.66667, 0.00000, 0.00000], [0.66667, 0.33333, -0.11111],
-                           [0.33333, 0.66667, 0.11111], [0.00000, 0.66667, 0.11111],
-                           [0.00000, 0.33333, -0.11111], [0.33333, 0.33333, -0.11111]])
-    elif order == 4:
-        points = np.array([[0.00000, 0.00000, 0.00000], [1.00000, 0.00000, 0.00000],
-                           [0.00000, 1.00000, 0.00000], [0.25000, 0.00000, 0.00000],
-                           [0.50000, 0.00000, 0.00000], [0.75000, 0.00000, 0.00000],
-                           [0.75000, 0.25000, -0.06250], [0.50000, 0.50000, 0.06250],
-                           [0.25000, 0.75000, -0.06250], [0.00000, 0.75000, -0.06250],
-                           [0.00000, 0.50000, 0.06250], [0.00000, 0.25000, -0.06250],
-                           [0.25000, 0.25000, -0.06250], [0.50000, 0.25000, -0.06250],
-                           [0.25000, 0.50000, 0.06250]])
-
-    elif order == 5:
-        points = np.array([[0.00000, 0.00000, 0.00000], [1.00000, 0.00000, 0.00000],
-                           [0.00000, 1.00000, 0.00000], [0.20000, 0.00000, 0.00000],
-                           [0.40000, 0.00000, 0.00000], [0.60000, 0.00000, 0.00000],
-                           [0.80000, 0.00000, 0.00000], [0.80000, 0.20000, -0.04000],
-                           [0.60000, 0.40000, 0.04000], [0.40000, 0.60000, -0.04000],
-                           [0.20000, 0.80000, 0.04000], [0.00000, 0.80000, 0.04000],
-                           [0.00000, 0.60000, -0.04000], [0.00000, 0.40000, 0.04000],
-                           [0.00000, 0.20000, -0.04000], [0.20000, 0.20000, -0.04000],
-                           [0.60000, 0.20000, -0.04000], [0.20000, 0.60000, -0.04000],
-                           [0.40000, 0.20000, -0.04000], [0.40000, 0.40000, 0.04000],
-                           [0.20000, 0.40000, 0.04000]])
-
-    elif order == 6:
-        points = np.array([[0.00000, 0.00000, 0.00000], [1.00000, 0.00000, 0.00000],
-                           [0.00000, 1.00000, 0.00000], [0.16667, 0.00000, 0.00000],
-                           [0.33333, 0.00000, 0.00000], [0.50000, 0.00000, 0.00000],
-                           [0.66667, 0.00000, 0.00000], [0.83333, 0.00000, 0.00000],
-                           [0.83333, 0.16667, -0.00463], [0.66667, 0.33333, 0.00463],
-                           [0.50000, 0.50000, -0.00463], [0.33333, 0.66667, 0.00463],
-                           [0.16667, 0.83333, -0.00463], [0.00000, 0.83333, -0.00463],
-                           [0.00000, 0.66667, 0.00463], [0.00000, 0.50000, -0.00463],
-                           [0.00000, 0.33333, 0.00463], [0.00000, 0.16667, -0.00463],
-                           [0.16667, 0.16667, -0.00463], [0.66667, 0.16667, -0.00463],
-                           [0.16667, 0.66667, 0.00463], [0.33333, 0.16667, -0.00463],
-                           [0.50000, 0.16667, -0.00463], [0.50000, 0.33333, 0.00463],
-                           [0.33333, 0.50000, -0.00463], [0.16667, 0.50000, -0.00463],
-                           [0.16667, 0.33333, 0.00463], [0.33333, 0.33333, 0.00463]])
-    elif order == 7:
-        points = np.array([[0.00000, 0.00000, 0.00000], [1.00000, 0.00000, 0.00000],
-                           [0.00000, 1.00000, 0.00000], [0.14286, 0.00000, 0.00000],
-                           [0.28571, 0.00000, 0.00000], [0.42857, 0.00000, 0.00000],
-                           [0.57143, 0.00000, 0.00000], [0.71429, 0.00000, 0.00000],
-                           [0.85714, 0.00000, 0.00000], [0.85714, 0.14286, -0.02041],
-                           [0.71429, 0.28571, 0.02041], [0.57143, 0.42857, -0.02041],
-                           [0.42857, 0.57143, 0.02041], [0.28571, 0.71429, -0.02041],
-                           [0.14286, 0.85714, 0.02041], [0.00000, 0.85714, 0.02041],
-                           [0.00000, 0.71429, -0.02041], [0.00000, 0.57143, 0.02041],
-                           [0.00000, 0.42857, -0.02041], [0.00000, 0.28571, 0.02041],
-                           [0.00000, 0.14286, -0.02041], [0.14286, 0.14286, -0.02041],
-                           [0.71429, 0.14286, -0.02041], [0.14286, 0.71429, -0.02041],
-                           [0.28571, 0.14286, -0.02041], [0.42857, 0.14286, -0.02041],
-                           [0.57143, 0.14286, -0.02041], [0.57143, 0.28571, 0.02041],
-                           [0.42857, 0.42857, -0.02041], [0.28571, 0.57143, 0.02041],
-                           [0.14286, 0.57143, 0.02041], [0.14286, 0.42857, -0.02041],
-                           [0.14286, 0.28571, 0.02041], [0.28571, 0.28571, 0.02041],
-                           [0.42857, 0.28571, 0.02041], [0.28571, 0.42857, -0.02041]])
-    # Higher order tests are too slow
-    elif order == 8:
-        points = np.array([[0.00000, 0.00000, 0.00000], [1.00000, 0.00000, 0.00000],
-                           [0.00000, 1.00000, 0.00000], [0.12500, 0.00000, 0.00000],
-                           [0.25000, 0.00000, 0.00000], [0.37500, 0.00000, 0.00000],
-                           [0.50000, 0.00000, 0.00000], [0.62500, 0.00000, 0.00000],
-                           [0.75000, 0.00000, 0.00000], [0.87500, 0.00000, 0.00000],
-                           [0.87500, 0.12500, -0.00195], [0.75000, 0.25000, 0.00195],
-                           [0.62500, 0.37500, -0.00195], [0.50000, 0.50000, 0.00195],
-                           [0.37500, 0.62500, -0.00195], [0.25000, 0.75000, 0.00195],
-                           [0.12500, 0.87500, -0.00195], [0.00000, 0.87500, -0.00195],
-                           [0.00000, 0.75000, 0.00195], [0.00000, 0.62500, -0.00195],
-                           [0.00000, 0.50000, 0.00195], [0.00000, 0.37500, -0.00195],
-                           [0.00000, 0.25000, 0.00195], [0.00000, 0.12500, -0.00195],
-                           [0.12500, 0.12500, -0.00195], [0.75000, 0.12500, -0.00195],
-                           [0.12500, 0.75000, 0.00195], [0.25000, 0.12500, -0.00195],
-                           [0.37500, 0.12500, -0.00195], [0.50000, 0.12500, -0.00195],
-                           [0.62500, 0.12500, -0.00195], [0.62500, 0.25000, 0.00195],
-                           [0.50000, 0.37500, -0.00195], [0.37500, 0.50000, 0.00195],
-                           [0.25000, 0.62500, -0.00195], [0.12500, 0.62500, -0.00195],
-                           [0.12500, 0.50000, 0.00195], [0.12500, 0.37500, -0.00195],
-                           [0.12500, 0.25000, 0.00195], [0.25000, 0.25000, 0.00195],
-                           [0.50000, 0.25000, 0.00195], [0.25000, 0.50000, 0.00195],
-                           [0.37500, 0.25000, 0.00195], [0.37500, 0.37500, -0.00195],
-                           [0.25000, 0.37500, -0.00195]])
-
-    cell = ufl.Cell("triangle", geometric_dimension=points.shape[1])
-    domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell, order))
-    mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
-
-    # Find nodes corresponding to y axis
-    nodes = []
-    for j in range(points.shape[0]):
-        if np.isclose(points[j][0], 0):
-            nodes.append(j)
-
-    def e2(x):
-        return x[2] + x[0] * x[1]
-
-    # For solution to be in functionspace
-    V = FunctionSpace(mesh, ("CG", max(2, order)))
-    u = Function(V)
-    u.interpolate(e2)
-
-    quad_order = 30
-    intu = assemble_scalar(u * dx(metadata={"quadrature_degree": quad_order}))
-    intu = mesh.mpi_comm().allreduce(intu, op=MPI.SUM)
-
-    ref = scipy_one_cell(points, nodes)
-    assert ref == pytest.approx(intu, rel=3e-3)
 
 
 @skip_in_parallel

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Jørgen Schartum Dokken and Matthew Scroggs
+# Copyright (C) 2019-2021 Jørgen Schartum Dokken and Matthew Scroggs
 #
 # This file is part of DOLFINX (https://www.fenicsproject.org)
 #
@@ -530,7 +530,10 @@ def test_xdmf_input_tri(datadir):
 @pytest.mark.parametrize('order', range(1, 4))
 @pytest.mark.parametrize('cell_type', [CellType.triangle, CellType.quadrilateral])
 def test_gmsh_input_2d(order, cell_type):
-    gmsh = pytest.importorskip("gmsh")
+    try:
+        import gmsh
+    except ImportError:
+        pytest.skip()
     res = 0.2
     gmsh.initialize()
     gmsh.option.setNumber("Mesh.CharacteristicLengthMin", res)
@@ -590,9 +593,12 @@ def test_gmsh_input_2d(order, cell_type):
 @pytest.mark.parametrize('order', range(1, 4))
 @pytest.mark.parametrize('cell_type', [CellType.tetrahedron, CellType.hexahedron])
 def test_gmsh_input_3d(order, cell_type):
+    try:
+        import gmsh
+    except ImportError:
+        pytest.skip()
     if cell_type == CellType.hexahedron and order > 2:
         pytest.xfail("GMSH permutation for order > 2 hexahedra not implemented in DOLFINX.")
-    gmsh = pytest.importorskip("gmsh")
 
     res = 0.2
 

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -6,6 +6,7 @@
 """ Unit-tests for higher order meshes """
 
 import os
+import random
 
 import numpy as np
 import pytest
@@ -22,6 +23,135 @@ from dolfinx_utils.test.skips import skip_in_parallel
 from mpi4py import MPI
 from sympy.vector import CoordSys3D, matrix_to_vector
 from ufl import dx
+
+
+@skip_in_parallel
+@pytest.mark.parametrize('order', [1, 2, 3, 4])
+def test_quadrilateral_mesh(order):
+    random.seed(13)
+
+    points = []
+    points += [[i / order, 0] for i in range(order + 1)]
+    for j in range(1, order):
+        points += [[i / order + 0.1, j / order] for i in range(order + 1)]
+
+    points += [[j / order, 1] for j in range(order + 1)]
+
+    cell = [0, order, order * (order + 1), order * (order + 2)]
+    if order > 1:
+        cell += list(range(1, order))
+        cell += list(range(order + 1, order * (order + 1), order + 1))
+        cell += list(range(2 * order + 1, order * (order + 1), order + 1))
+        cell += list(range(order * (order + 1) + 1, order * (order + 2)))
+
+        for i in range(1, order):
+            cell += list(range(i * (order + 1) + 1, i * (order + 1) + order))
+
+    domain = ufl.Mesh(ufl.VectorElement(
+        "Q", ufl.Cell("quadrilateral", geometric_dimension=2), order))
+
+    point_order = list(range((order + 1) ** 2))
+    for repeat in range(5):
+        random.shuffle(point_order)
+        ordered_points = np.zeros(((order + 1) ** 2, 2))
+        for i, j in enumerate(point_order):
+            ordered_points[j] = points[i]
+        ordered_cell = [point_order[i] for i in cell]
+
+        mesh = create_mesh(MPI.COMM_WORLD, [ordered_cell], ordered_points, domain)
+        area = assemble_scalar(1 * dx(mesh))
+
+        assert np.isclose(area, 1)
+
+
+@skip_in_parallel
+@pytest.mark.parametrize('order', [1, 2, 3, 4])
+def test_hexahedron_mesh(order):
+    random.seed(13)
+
+    points = []
+    points += [[i / order, j / order, 0] for j in range(order + 1)
+               for i in range(order + 1)]
+    for k in range(1, order):
+        points += [[i / order, j / order + 0.1, k / order] for j in range(order + 1)
+                   for i in range(order + 1)]
+
+    points += [[i / order, j / order, 1] for j in range(order + 1) for i in range(order + 1)]
+
+    def coord_to_vertex(x, y, z):
+        return (order + 1) ** 2 * z + (order + 1) * y + x
+
+    cell = [coord_to_vertex(x, y, z) for x, y, z in [
+        (0, 0, 0), (order, 0, 0), (0, order, 0), (order, order, 0),
+        (0, 0, order), (order, 0, order), (0, order, order), (order, order, order)]]
+
+    if order > 1:
+        for i in range(1, order):
+            cell.append(coord_to_vertex(i, 0, 0))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(0, i, 0))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(0, 0, i))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(order, i, 0))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(order, 0, i))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(i, order, 0))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(0, order, i))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(order, order, i))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(i, 0, order))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(0, i, order))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(order, i, order))
+        for i in range(1, order):
+            cell.append(coord_to_vertex(i, order, order))
+
+        for j in range(1, order):
+            for i in range(1, order):
+                cell.append(coord_to_vertex(i, j, 0))
+        for j in range(1, order):
+            for i in range(1, order):
+                cell.append(coord_to_vertex(i, 0, j))
+        for j in range(1, order):
+            for i in range(1, order):
+                cell.append(coord_to_vertex(0, i, j))
+        for j in range(1, order):
+            for i in range(1, order):
+                cell.append(coord_to_vertex(order, i, j))
+        for j in range(1, order):
+            for i in range(1, order):
+                cell.append(coord_to_vertex(i, order, j))
+        for j in range(1, order):
+            for i in range(1, order):
+                cell.append(coord_to_vertex(i, j, order))
+
+        for k in range(1, order):
+            for j in range(1, order):
+                for i in range(1, order):
+                    cell.append(coord_to_vertex(i, j, k))
+
+    domain = ufl.Mesh(ufl.VectorElement(
+        "Q", ufl.Cell("hexahedron", geometric_dimension=3), order))
+
+    print(cell, len(cell))
+
+    point_order = list(range((order + 1) ** 3))
+    for repeat in range(5):
+        random.shuffle(point_order)
+        ordered_points = np.zeros(((order + 1) ** 3, 3))
+        for i, j in enumerate(point_order):
+            ordered_points[j] = points[i]
+        ordered_cell = [point_order[i] for i in cell]
+
+        mesh = create_mesh(MPI.COMM_WORLD, [ordered_cell], ordered_points, domain)
+        volume = assemble_scalar(1 * dx(mesh))
+
+        assert np.isclose(volume, 1)
 
 
 def sympy_scipy(points, nodes, L, H):
@@ -384,168 +514,6 @@ def test_xdmf_input_tri(datadir):
         mesh = xdmf.read_mesh(name="Grid")
     surface = assemble_scalar(1 * dx(mesh))
     assert mesh.mpi_comm().allreduce(surface, op=MPI.SUM) == pytest.approx(4 * np.pi, rel=1e-4)
-
-
-@skip_in_parallel
-@pytest.mark.parametrize('L', [1, 2])
-@pytest.mark.parametrize('H', [1])
-@pytest.mark.parametrize('Z', [0, 0.3])
-def test_second_order_quad(L, H, Z):
-    """ Test by comparing integration of z+x*y against sympy/scipy
-    integration of a quad element. Z>0 implies curved element.
-
-      *-----*   3--6--2
-      |     |   |     |
-      |     |   7  8  5
-      |     |   |     |
-      *-----*   0--4--1
-
-    """
-    points = np.array([[0, 0, 0], [L, 0, 0], [L, H, Z], [0, H, Z],
-                       [L / 2, 0, 0], [L, H / 2, 0],
-                       [L / 2, H, Z], [0, H / 2, 0],
-                       [L / 2, H / 2, 0],
-                       [2 * L, 0, 0], [2 * L, H, Z]])
-    cells = np.array([[0, 1, 2, 3, 4, 5, 6, 7, 8]])
-    cells = cells[:, perm_vtk(CellType.quadrilateral, cells.shape[1])]
-    cell = ufl.Cell("quadrilateral", geometric_dimension=points.shape[1])
-    domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell, 2))
-    mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
-
-    def e2(x):
-        return x[2] + x[0] * x[1]
-
-    # Interpolate function
-    V = FunctionSpace(mesh, ("CG", 2))
-    u = Function(V)
-    u.interpolate(e2)
-
-    intu = assemble_scalar(u * dx(mesh))
-    intu = mesh.mpi_comm().allreduce(intu, op=MPI.SUM)
-
-    nodes = [0, 3, 7]
-    ref = sympy_scipy(points, nodes, L, H)
-    assert ref == pytest.approx(intu, rel=1e-6)
-
-
-@skip_in_parallel
-@pytest.mark.parametrize('L', [1, 2])
-@pytest.mark.parametrize('H', [1])
-@pytest.mark.parametrize('Z', [0, 0.3])
-def test_third_order_quad(L, H, Z):
-    """Test by comparing integration of z+x*y against sympy/scipy integration
-    of a quad element. Z>0 implies curved element.
-
-      *---------*   3--8--9--2-22-23-17
-      |         |   |        |       |
-      |         |   11 14 15 7 26 27 21
-      |         |   |        |       |
-      |         |   10 12 13 6 24 25 20
-      |         |   |        |       |
-      *---------*   0--4--5--1-18-19-16
-
-    """
-    points = np.array([[0, 0, 0], [L, 0, 0], [L, H, Z], [0, H, Z],        # 0  1 2 3
-                       [L / 3, 0, 0], [2 * L / 3, 0, 0],                  # 4  5
-                       [L, H / 3, 0], [L, 2 * H / 3, 0],                  # 6  7
-                       [L / 3, H, Z], [2 * L / 3, H, Z],                  # 8  9
-                       [0, H / 3, 0], [0, 2 * H / 3, 0],                  # 10 11
-                       [L / 3, H / 3, 0], [2 * L / 3, H / 3, 0],          # 12 13
-                       [L / 3, 2 * H / 3, 0], [2 * L / 3, 2 * H / 3, 0],  # 14 15
-                       [2 * L, 0, 0], [2 * L, H, Z],                      # 16 17
-                       [4 * L / 3, 0, 0], [5 * L / 3, 0, 0],              # 18 19
-                       [2 * L, H / 3, 0], [2 * L, 2 * H / 3, 0],          # 20 21
-                       [4 * L / 3, H, Z], [5 * L / 3, H, Z],              # 22 23
-                       [4 * L / 3, H / 3, 0], [5 * L / 3, H / 3, 0],           # 24 25
-                       [4 * L / 3, 2 * H / 3, 0], [5 * L / 3, 2 * H / 3, 0]])  # 26 27
-
-    # Change to multiple cells when matthews dof-maps work for quads
-    cells = np.array([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
-                      [1, 16, 17, 2, 18, 19, 20, 21, 22, 23, 6, 7, 24, 25, 26, 27]])
-    cells = cells[:, perm_vtk(CellType.quadrilateral, cells.shape[1])]
-    cell = ufl.Cell("quadrilateral", geometric_dimension=points.shape[1])
-    domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell, 3))
-    mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
-
-    def e2(x):
-        return x[2] + x[0] * x[1]
-
-    # Interpolate function
-    V = FunctionSpace(mesh, ("CG", 3))
-    u = Function(V)
-    u.interpolate(e2)
-
-    intu = assemble_scalar(u * dx(mesh))
-    intu = mesh.mpi_comm().allreduce(intu, op=MPI.SUM)
-
-    nodes = [0, 3, 10, 11]
-    ref = sympy_scipy(points, nodes, 2 * L, H)
-    assert ref == pytest.approx(intu, rel=1e-6)
-
-
-@skip_in_parallel
-@pytest.mark.parametrize('L', [1, 2])
-@pytest.mark.parametrize('H', [1])
-@pytest.mark.parametrize('Z', [0, 0.3])
-def test_fourth_order_quad(L, H, Z):
-    """Test by comparing integration of z+x*y against sympy/scipy integration
-    of a quad element. Z>0 implies curved element.
-
-      *---------*   20-21-22-23-24-41--42--43--44
-      |         |   |           |              |
-      |         |   15 16 17 18 19 37  38  39  40
-      |         |   |           |              |
-      |         |   10 11 12 13 14 33  34  35  36
-      |         |   |           |              |
-      |         |   5  6  7  8  9  29  30  31  32
-      |         |   |           |              |
-      *---------*   0--1--2--3--4--25--26--27--28
-
-    """
-    points = np.array([[0, 0, 0], [L / 4, 0, 0], [L / 2, 0, 0],               # 0 1 2
-                       [3 * L / 4, 0, 0], [L, 0, 0],                          # 3 4
-                       [0, H / 4, -Z / 3], [L / 4, H / 4, -Z / 3], [L / 2, H / 4, -Z / 3],   # 5 6 7
-                       [3 * L / 4, H / 4, -Z / 3], [L, H / 4, -Z / 3],                  # 8 9
-                       [0, H / 2, 0], [L / 4, H / 2, 0], [L / 2, H / 2, 0],   # 10 11 12
-                       [3 * L / 4, H / 2, 0], [L, H / 2, 0],                  # 13 14
-                       [0, (3 / 4) * H, 0], [L / 4, (3 / 4) * H, 0],          # 15 16
-                       [L / 2, (3 / 4) * H, 0], [3 * L / 4, (3 / 4) * H, 0],  # 17 18
-                       [L, (3 / 4) * H, 0], [0, H, Z], [L / 4, H, Z],         # 19 20 21
-                       [L / 2, H, Z], [3 * L / 4, H, Z], [L, H, Z],           # 22 23 24
-                       [(5 / 4) * L, 0, 0], [(6 / 4) * L, 0, 0],              # 25 26
-                       [(7 / 4) * L, 0, 0], [2 * L, 0, 0],                    # 27 28
-                       [(5 / 4) * L, H / 4, -Z / 3], [(6 / 4) * L, H / 4, -Z / 3],      # 29 30
-                       [(7 / 4) * L, H / 4, -Z / 3], [2 * L, H / 4, -Z / 3],            # 31 32
-                       [(5 / 4) * L, H / 2, 0], [(6 / 4) * L, H / 2, 0],      # 33 34
-                       [(7 / 4) * L, H / 2, 0], [2 * L, H / 2, 0],            # 35 36
-                       [(5 / 4) * L, 3 / 4 * H, 0],                           # 37
-                       [(6 / 4) * L, 3 / 4 * H, 0],                           # 38
-                       [(7 / 4) * L, 3 / 4 * H, 0], [2 * L, 3 / 4 * H, 0],    # 39 40
-                       [(5 / 4) * L, H, Z], [(6 / 4) * L, H, Z],              # 41 42
-                       [(7 / 4) * L, H, Z], [2 * L, H, Z]])                   # 43 44
-
-    # VTK ordering
-    cells = np.array([[0, 4, 24, 20, 1, 2, 3, 9, 14, 19, 21, 22, 23, 5, 10, 15, 6, 7, 8, 11, 12, 13, 16, 17, 18],
-                      [4, 28, 44, 24, 25, 26, 27, 32, 36, 40, 41, 42, 43, 9, 14, 19,
-                       29, 30, 31, 33, 34, 35, 37, 38, 39]])
-    cells = cells[:, perm_vtk(CellType.quadrilateral, cells.shape[1])]
-    cell = ufl.Cell("quadrilateral", geometric_dimension=points.shape[1])
-    domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell, 4))
-    mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
-
-    def e2(x):
-        return x[2] + x[0] * x[1]
-
-    V = FunctionSpace(mesh, ("CG", 4))
-    u = Function(V)
-    u.interpolate(e2)
-
-    intu = assemble_scalar(u * dx(mesh))
-    intu = mesh.mpi_comm().allreduce(intu, op=MPI.SUM)
-
-    nodes = [0, 5, 10, 15, 20]
-    ref = sympy_scipy(points, nodes, 2 * L, H)
-    assert ref == pytest.approx(intu, rel=1e-5)
 
 
 @skip_in_parallel

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -26,6 +26,7 @@ def check_cell_volume(points, cell, domain, volume):
 
     point_order = [i for i, _ in enumerate(points)]
     for repeat in range(5):
+        # Shuffle the cell to check that permutations of CoordinateElement are correct
         random.shuffle(point_order)
         ordered_points = np.zeros((len(points), len(points[0])))
         for i, j in enumerate(point_order):
@@ -50,6 +51,7 @@ def test_triangle_mesh(order):
     def coord_to_vertex(x, y):
         return y * (2 * order + 3 - y) // 2 + x
 
+    # Define a cell using dolfin ordering
     cell = [coord_to_vertex(i, j) for i, j in [(0, 0), (order, 0), (0, order)]]
     if order > 1:
         for i in range(1, order):
@@ -86,6 +88,7 @@ def test_tetrahedron_mesh(order):
             3 * order ** 2 - 3 * order * z + 12 * order + z ** 2 - 6 * z + 11
         ) // 6 + y * (2 * (order - z) + 3 - y) // 2 + x
 
+    # Define a cell using dolfin ordering
     cell = [coord_to_vertex(x, y, z) for x, y, z in [
         (0, 0, 0), (order, 0, 0), (0, order, 0), (0, 0, order)]]
 
@@ -141,6 +144,7 @@ def test_quadrilateral_mesh(order):
     def coord_to_vertex(x, y):
         return (order + 1) * y + x
 
+    # Define a cell using dolfin ordering
     cell = [coord_to_vertex(i, j)
             for i, j in [(0, 0), (order, 0), (0, order), (order, order)]]
     if order > 1:
@@ -180,6 +184,7 @@ def test_hexahedron_mesh(order):
     def coord_to_vertex(x, y, z):
         return (order + 1) ** 2 * z + (order + 1) * y + x
 
+    # Define a cell using dolfin ordering
     cell = [coord_to_vertex(x, y, z) for x, y, z in [
         (0, 0, 0), (order, 0, 0), (0, order, 0), (order, order, 0),
         (0, 0, order), (order, 0, order), (0, order, order), (order, order, order)]]

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -11,7 +11,6 @@ import random
 import numpy as np
 import pytest
 import ufl
-from dolfinx import cpp
 from dolfinx.cpp.io import perm_gmsh, perm_vtk
 from dolfinx.cpp.mesh import CellType
 from dolfinx.fem import assemble_scalar


### PR DESCRIPTION
Correct a few bugs in how higher order meshes are handled.

Added scalar pipeline tests using Unit meshes to be sure there are not broken.

Simplified higher order mesh tests and added 3D tests.

Close #54 