### PR TITLE
Fix interpolation speed regression

### DIFF
--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -78,6 +78,7 @@ FiniteElement::FiniteElement(const ufc_finite_element& ufc_element)
   {
     _basix_element_handle = basix::register_element(
         family.c_str(), cell_shape.c_str(), ufc_element.degree);
+    _interpolation_matrix = basix::interpolation_matrix(_basix_element_handle);
   }
 
   // Fill value dimension
@@ -91,7 +92,6 @@ FiniteElement::FiniteElement(const ufc_finite_element& ufc_element)
     _sub_elements.push_back(std::make_shared<FiniteElement>(*ufc_sub_element));
     std::free(ufc_sub_element);
   }
-  _interpolation_matrix = basix::interpolation_matrix(_basix_element_handle);
 }
 //-----------------------------------------------------------------------------
 std::string FiniteElement::signature() const noexcept { return _signature; }

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -227,9 +227,13 @@ private:
   // _interpolate_into_cell is not required
   bool _interpolation_is_ident;
 
+  // True if element needs dof permutation
   bool _needs_permutation_data;
 
   // The basix element identifier
   int _basix_element_handle;
+
+  // The interpolation matrix
+  Eigen::MatrixXd _interpolation_matrix;
 };
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -392,28 +392,21 @@ public:
 
     // Interpolate point values on each cell (using last computed value if
     // not continuous, e.g. discontinuous Galerkin methods)
-    Eigen::Array<double, Eigen::Dynamic, 3, Eigen::RowMajor> x(num_dofs_g, 3);
-    Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> values(
-        num_dofs_g, value_size_loc);
     auto map = mesh->topology().index_map(tdim);
     assert(map);
     const std::int32_t num_cells = map->size_local() + map->num_ghosts();
+
+    Eigen::Array<int, Eigen::Dynamic, 1> cells(x_g.rows());
+
     for (std::int32_t c = 0; c < num_cells; ++c)
     {
       // Get coordinates for all points in cell
       auto dofs = x_dofmap.links(c);
       for (int i = 0; i < num_dofs_g; ++i)
-        x.row(i) = x_g.row(dofs[i]);
-
-      // Call evaluate function
-      Eigen::Array<int, Eigen::Dynamic, 1> cells(x.rows());
-      cells = c;
-      eval(x, cells, values);
-
-      // Copy values to array of point values
-      for (int i = 0; i < values.rows(); ++i)
-        point_values.row(dofs[i]) = values.row(i);
+        cells[dofs[i]] = c;
     }
+
+    eval(x_g, cells, point_values);
 
     return point_values;
   }

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -405,7 +405,7 @@ public:
         cells[dofs[i]] = c;
     }
 
-    eval(x_g, tcb::span(cells.data(), cells.size()), point_values);
+    eval(x_g, cells, point_values);
 
     return point_values;
   }

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -249,7 +249,6 @@ public:
     const int gdim = mesh->geometry().dim();
     const int tdim = mesh->topology().dim();
     auto map = mesh->topology().index_map(tdim);
-    const int num_cells = map->size_local() + map->num_ghosts();
 
     // Get geometry data
     const graph::AdjacencyList<std::int32_t>& x_dofmap
@@ -304,13 +303,9 @@ public:
     assert(dofmap);
     const int bs_dof = dofmap->bs();
 
-    const bool needs_permutation_data = element->needs_permutation_data();
-    if (needs_permutation_data)
-      mesh->topology_mutable().create_entity_permutations();
+    mesh->topology_mutable().create_entity_permutations();
     const std::vector<std::uint32_t>& cell_info
-        = needs_permutation_data ? mesh->topology().get_cell_permutation_info()
-                                 : std::vector<std::uint32_t>(num_cells);
-
+        = mesh->topology().get_cell_permutation_info();
     Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
         coordinate_dofs(num_dofs_g, gdim);
 

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -396,17 +396,16 @@ public:
     assert(map);
     const std::int32_t num_cells = map->size_local() + map->num_ghosts();
 
-    Eigen::Array<int, Eigen::Dynamic, 1> cells(x_g.rows());
-
+    std::vector<std::int32_t> cells(x_g.rows());
     for (std::int32_t c = 0; c < num_cells; ++c)
     {
       // Get coordinates for all points in cell
-      auto dofs = x_dofmap.links(c);
+      tcb::span<const std::int32_t> dofs = x_dofmap.links(c);
       for (int i = 0; i < num_dofs_g; ++i)
         cells[dofs[i]] = c;
     }
 
-    eval(x_g, cells, point_values);
+    eval(x_g, tcb::span(cells.data(), cells.size()), point_values);
 
     return point_values;
   }

--- a/cpp/dolfinx/fem/evaluate.h
+++ b/cpp/dolfinx/fem/evaluate.h
@@ -46,15 +46,9 @@ void eval(
   const fem::CoordinateElement& cmap = mesh->geometry().cmap();
 
   // Prepate cell permutation info
-  const std::int32_t num_cells
-      = mesh->topology().connectivity(mesh->topology().dim(), 0)->num_nodes();
-
-  const bool needs_permutation_data = cmap.needs_permutation_data();
-  if (needs_permutation_data)
-    mesh->topology_mutable().create_entity_permutations();
+  mesh->topology_mutable().create_entity_permutations();
   const std::vector<std::uint32_t>& cell_info
-      = needs_permutation_data ? mesh->topology().get_cell_permutation_info()
-                               : std::vector<std::uint32_t>(num_cells);
+      = mesh->topology().get_cell_permutation_info();
 
   // FIXME: Add proper interface for num coordinate dofs
   const int num_dofs_g = x_dofmap.num_links(0);

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -252,6 +252,12 @@ void interpolate(
   // Loop over cells and compute interpolation dofs
   const int num_scalar_dofs = element->space_dimension() / element_bs;
   const int value_size = element->value_size() / element_bs;
+
+  // Check that return type from f is the correct shape
+  if ((values.rows() != value_size * element_bs)
+      || (values.cols() != num_cells * X.rows()))
+    throw std::runtime_error("Interpolation data has the wrong shape.");
+
   std::vector<T>& coeffs = u.x()->mutable_array();
   std::vector<T> _coeffs(num_scalar_dofs);
   Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> _vals;
@@ -261,7 +267,7 @@ void interpolate(
     for (int k = 0; k < element_bs; ++k)
     {
       // Extract computed expression values for element block k
-      _vals = values.block(k, c * X.rows(), value_size, X.rows());
+      _vals = values.block(k * value_size, c * X.rows(), value_size, X.rows());
 
       // Get element degrees of freedom for block
       element->interpolate(_vals, cell_info[c], _coeffs);

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -194,12 +194,9 @@ void interpolate(
   const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& X
       = element->interpolation_points();
 
-  const bool needs_permutation_data = element->needs_permutation_data();
-  if (needs_permutation_data)
-    mesh->topology_mutable().create_entity_permutations();
+  mesh->topology_mutable().create_entity_permutations();
   const std::vector<std::uint32_t>& cell_info
-      = needs_permutation_data ? mesh->topology().get_cell_permutation_info()
-                               : std::vector<std::uint32_t>(num_cells);
+      = mesh->topology().get_cell_permutation_info();
 
   // Push reference coordinates (X) forward to the physical coordinates
   // (x) for each cell


### PR DESCRIPTION
Fixes #1358 and another potential issue in FiniteElement only getting the interpolation matrix from basix once
Some additional bug-fixes in interpolation, and proper error handling for mixed elements or invalid lambda functions.