### PR TITLE
Removed Eigen::Tensor

### DIFF
--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -6,7 +6,6 @@
 
 #include "CoordinateElement.h"
 #include <basix.h>
-#include <unsupported/Eigen/CXX11/Tensor>
 
 using namespace dolfinx;
 using namespace dolfinx::fem;
@@ -84,8 +83,7 @@ void CoordinateElement::push_forward(
 //-----------------------------------------------------------------------------
 void CoordinateElement::compute_reference_geometry(
     Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& X,
-    Eigen::Tensor<double, 3, Eigen::RowMajor>& J, tcb::span<double> detJ,
-    Eigen::Tensor<double, 3, Eigen::RowMajor>& K,
+    std::vector<double>& J, tcb::span<double> detJ, std::vector<double>& K,
     const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
                                         Eigen::RowMajor>>& x,
     const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
@@ -105,13 +103,9 @@ void CoordinateElement::compute_reference_geometry(
   // In/out size checks
   assert(X.rows() == num_points);
   assert(X.cols() == tdim);
-  assert(J.dimension(0) == num_points);
-  assert(J.dimension(1) == gdim);
-  assert(J.dimension(2) == tdim);
+  assert((int)J.size() == num_points * gdim * tdim);
   assert((int)detJ.size() == num_points);
-  assert(K.dimension(0) == num_points);
-  assert(K.dimension(1) == tdim);
-  assert(K.dimension(2) == gdim);
+  assert((int)K.size() == num_points * gdim * tdim);
 
   // FIXME: Array and matrix rows/cols transpose etc all very tortuous
   // FIXME: tidy up and sort out

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -14,7 +14,6 @@
 #include <functional>
 #include <memory>
 #include <string>
-#include <unsupported/Eigen/CXX11/Tensor>
 
 namespace dolfinx::fem
 {
@@ -86,8 +85,7 @@ public:
   /// coordinates x
   void compute_reference_geometry(
       Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& X,
-      Eigen::Tensor<double, 3, Eigen::RowMajor>& J, tcb::span<double> detJ,
-      Eigen::Tensor<double, 3, Eigen::RowMajor>& K,
+      std::vector<double>& J, tcb::span<double> detJ, std::vector<double>& K,
       const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,
                                           Eigen::Dynamic, Eigen::RowMajor>>& x,
       const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -128,7 +128,7 @@ int FiniteElement::value_dimension(int i) const
 std::string FiniteElement::family() const noexcept { return _family; }
 //-----------------------------------------------------------------------------
 void FiniteElement::evaluate_reference_basis(
-    Eigen::Tensor<double, 3, Eigen::RowMajor>& reference_values,
+    std::vector<double>& reference_values,
     const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
                                         Eigen::RowMajor>>& X) const
 {
@@ -140,20 +140,21 @@ void FiniteElement::evaluate_reference_basis(
   assert(basix_data.cols() % scalar_reference_value_size == 0);
   const int scalar_dofs = basix_data.cols() / scalar_reference_value_size;
 
-  assert(reference_values.dimension(0) == X.rows());
-  assert(reference_values.dimension(1) == scalar_dofs);
-  assert(reference_values.dimension(2) == scalar_reference_value_size);
+  assert((int)reference_values.size()
+         == X.rows() * scalar_dofs * scalar_reference_value_size);
 
   assert(basix_data.rows() == X.rows());
 
   for (int p = 0; p < X.rows(); ++p)
     for (int d = 0; d < scalar_dofs; ++d)
       for (int v = 0; v < scalar_reference_value_size; ++v)
-        reference_values(p, d, v) = basix_data(p, d + scalar_dofs * v);
+        reference_values[(p * scalar_dofs + d) * scalar_reference_value_size
+                         + v]
+            = basix_data(p, d + scalar_dofs * v);
 }
 //-----------------------------------------------------------------------------
 void FiniteElement::evaluate_reference_basis_derivatives(
-    Eigen::Tensor<double, 4, Eigen::RowMajor>& values, int order,
+    std::vector<double>& values, int order,
     const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
                                         Eigen::RowMajor>>& X) const
 {
@@ -171,18 +172,18 @@ void FiniteElement::evaluate_reference_basis_derivatives(
     for (int d = 0; d < basix_data[0].cols() / _reference_value_size; ++d)
       for (int v = 0; v < _reference_value_size; ++v)
         for (std::size_t deriv = 0; deriv < basix_data.size() - 1; ++deriv)
-          values(p, d, v, deriv)
+          values[(p * basix_data[0].cols() + d * _reference_value_size + v)
+                     * (basix_data.size() - 1)
+                 + deriv]
               = basix_data[deriv](p, d * _reference_value_size + v);
 }
 //-----------------------------------------------------------------------------
 void FiniteElement::transform_reference_basis(
-    Eigen::Tensor<double, 3, Eigen::RowMajor>& values,
-    const Eigen::Tensor<double, 3, Eigen::RowMajor>& reference_values,
+    std::vector<double>& values, const std::vector<double>& reference_values,
     const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
                                         Eigen::RowMajor>>& X,
-    const Eigen::Tensor<double, 3, Eigen::RowMajor>& J,
-    const tcb::span<const double>& detJ,
-    const Eigen::Tensor<double, 3, Eigen::RowMajor>& K) const
+    const std::vector<double>& J, const tcb::span<const double>& detJ,
+    const std::vector<double>& K) const
 {
   assert(_transform_reference_basis_derivatives);
   const int num_points = X.rows();
@@ -198,13 +199,12 @@ void FiniteElement::transform_reference_basis(
 }
 //-----------------------------------------------------------------------------
 void FiniteElement::transform_reference_basis_derivatives(
-    Eigen::Tensor<double, 4, Eigen::RowMajor>& values, std::size_t order,
-    const Eigen::Tensor<double, 4, Eigen::RowMajor>& reference_values,
+    std::vector<double>& values, std::size_t order,
+    const std::vector<double>& reference_values,
     const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic,
                                         Eigen::RowMajor>>& X,
-    const Eigen::Tensor<double, 3, Eigen::RowMajor>& J,
-    const tcb::span<const double>& detJ,
-    const Eigen::Tensor<double, 3, Eigen::RowMajor>& K) const
+    const std::vector<double>& J, const tcb::span<const double>& detJ,
+    const std::vector<double>& K) const
 {
   assert(_transform_reference_basis_derivatives);
   const int num_points = X.rows();

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -11,7 +11,6 @@
 #include <dolfinx/mesh/cell_types.h>
 #include <functional>
 #include <memory>
-#include <unsupported/Eigen/CXX11/Tensor>
 #include <vector>
 
 struct ufc_coordinate_mapping;
@@ -84,7 +83,7 @@ public:
   /// Evaluate all basis functions at given points in reference cell
   // reference_values[num_points][num_dofs][reference_value_size]
   void evaluate_reference_basis(
-      Eigen::Tensor<double, 3, Eigen::RowMajor>& values,
+      std::vector<double>& values,
       const Eigen::Ref<const Eigen::Array<
           double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>& X) const;
 
@@ -92,29 +91,26 @@ public:
   /// reference cell
   // reference_value_derivatives[num_points][num_dofs][reference_value_size][num_derivatives]
   void evaluate_reference_basis_derivatives(
-      Eigen::Tensor<double, 4, Eigen::RowMajor>& reference_values, int order,
+      std::vector<double>& reference_values, int order,
       const Eigen::Ref<const Eigen::Array<
           double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>& X) const;
 
   /// Push basis functions forward to physical element
   void transform_reference_basis(
-      Eigen::Tensor<double, 3, Eigen::RowMajor>& values,
-      const Eigen::Tensor<double, 3, Eigen::RowMajor>& reference_values,
+      std::vector<double>& values, const std::vector<double>& reference_values,
       const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,
                                           Eigen::Dynamic, Eigen::RowMajor>>& X,
-      const Eigen::Tensor<double, 3, Eigen::RowMajor>& J,
-      const tcb::span<const double>& detJ,
-      const Eigen::Tensor<double, 3, Eigen::RowMajor>& K) const;
+      const std::vector<double>& J, const tcb::span<const double>& detJ,
+      const std::vector<double>& K) const;
 
   /// Push basis function (derivatives) forward to physical element
   void transform_reference_basis_derivatives(
-      Eigen::Tensor<double, 4, Eigen::RowMajor>& values, std::size_t order,
-      const Eigen::Tensor<double, 4, Eigen::RowMajor>& reference_values,
+      std::vector<double>& values, std::size_t order,
+      const std::vector<double>& reference_values,
       const Eigen::Ref<const Eigen::Array<double, Eigen::Dynamic,
                                           Eigen::Dynamic, Eigen::RowMajor>>& X,
-      const Eigen::Tensor<double, 3, Eigen::RowMajor>& J,
-      const tcb::span<const double>& detJ,
-      const Eigen::Tensor<double, 3, Eigen::RowMajor>& K) const;
+      const std::vector<double>& J, const tcb::span<const double>& detJ,
+      const std::vector<double>& K) const;
 
   /// Get the number of sub elements (for a mixed element)
   /// @return the Number of sub elements

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -282,17 +282,16 @@ public:
     }
 
     // Prepare geometry data structures
-    Eigen::Tensor<double, 3, Eigen::RowMajor> J(1, gdim, tdim);
+    std::vector<double> J(gdim * tdim);
     std::array<double, 1> detJ;
-    Eigen::Tensor<double, 3, Eigen::RowMajor> K(1, tdim, gdim);
+    std::vector<double> K(tdim * gdim);
     Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> X(
         1, tdim);
 
     // Prepare basis function data structures
-    Eigen::Tensor<double, 3, Eigen::RowMajor> basis_reference_values(
-        1, space_dimension, reference_value_size);
-    Eigen::Tensor<double, 3, Eigen::RowMajor> basis_values(1, space_dimension,
-                                                           value_size);
+    std::vector<double> basis_reference_values(space_dimension
+                                               * reference_value_size);
+    std::vector<double> basis_values(space_dimension * value_size);
 
     // Create work vector for expansion coefficients
     Eigen::Matrix<T, 1, Eigen::Dynamic> coefficients(space_dimension
@@ -356,8 +355,8 @@ public:
           for (int j = 0; j < value_size; ++j)
           {
             // TODO: Find an Eigen shortcut for this operation?
-            u_row[j * bs_element + k]
-                += coefficients[bs_element * i + k] * basis_values(0, i, j);
+            u_row[j * bs_element + k] += coefficients[bs_element * i + k]
+                                         * basis_values[i * value_size + j];
           }
         }
       }

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -9,6 +9,7 @@
 #include "topologycomputation.h"
 #include "utils.h"
 #include <algorithm>
+#include <bits/stdc++.h>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/log.h>
 #include <dolfinx/common/utils.h>


### PR DESCRIPTION
Eigen Tensors can't be sliced (only single items can be accessed), and are a huge pain to wrap with pybind. Until a new version of Eigen comes out with proper Tensor support std::vector might be better?