### PR TITLE
Remove Eigen::Array<bool, Eigen::Dynamic, 1>  from interface

### DIFF
--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -177,11 +177,15 @@ int main(int argc, char* argv[])
 
     const auto bdofs_left = fem::locate_dofs_geometrical({*V}, [](auto& x) {
       static const double epsilon = std::numeric_limits<double>::epsilon();
-      return x.row(0).abs() < 10.0 * epsilon;
+      Eigen::Array<bool, Eigen::Dynamic, 1> out
+          = x.row(0).abs() < 10.0 * epsilon;
+      return std::vector<bool>(out.data(), out.data() + out.size());
     });
     const auto bdofs_right = fem::locate_dofs_geometrical({*V}, [](auto& x) {
       static const double epsilon = std::numeric_limits<double>::epsilon();
-      return (x.row(0) - 1.0).abs() < 10.0 * epsilon;
+      Eigen::Array<bool, Eigen::Dynamic, 1> out
+          = (x.row(0) - 1.0).abs() < 10.0 * epsilon;
+      return std::vector<bool>(out.data(), out.data() + out.size());
     });
 
     auto bcs

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -164,8 +164,11 @@ int main(int argc, char* argv[])
 
     const auto bdofs = fem::locate_dofs_geometrical({*V}, [](auto& x) {
       static const double epsilon = std::numeric_limits<double>::epsilon();
-      return (x.row(0).abs() < 10.0 * epsilon
-              or (x.row(0) - 1.0).abs() < 10.0 * epsilon);
+      std::vector<bool> out(x.cols());
+      for (int j = 0; j < x.cols(); j++)
+        out[j] = std::abs(x(0, j)) < 10.0 * epsilon
+                 or std::abs(x(0, j) - 1.0) < 10.0 * epsilon;
+      return out;
     });
 
     std::vector bc{std::make_shared<const fem::DirichletBC<PetscScalar>>(

--- a/cpp/dolfinx/fem/DirichletBC.cpp
+++ b/cpp/dolfinx/fem/DirichletBC.cpp
@@ -451,7 +451,7 @@ fem::locate_dofs_topological(const fem::FunctionSpace& V, const int dim,
 //-----------------------------------------------------------------------------
 std::array<std::vector<std::int32_t>, 2> fem::locate_dofs_geometrical(
     const std::array<std::reference_wrapper<const fem::FunctionSpace>, 2>& V,
-    const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+    const std::function<std::vector<bool>(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker_fn)
 {
@@ -481,8 +481,7 @@ std::array<std::vector<std::int32_t>, 2> fem::locate_dofs_geometrical(
       = V1.tabulate_dof_coordinates().transpose();
 
   // Evaluate marker for each dof coordinate
-  const Eigen::Array<bool, Eigen::Dynamic, 1> marked_dofs
-      = marker_fn(dof_coordinates);
+  const std::vector<bool> marked_dofs = marker_fn(dof_coordinates);
 
   // Get dofmaps
   std::shared_ptr<const fem::DofMap> dofmap0 = V0.dofmap();
@@ -544,7 +543,7 @@ std::array<std::vector<std::int32_t>, 2> fem::locate_dofs_geometrical(
 //-----------------------------------------------------------------------------
 std::vector<std::int32_t> fem::locate_dofs_geometrical(
     const fem::FunctionSpace& V,
-    const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+    const std::function<std::vector<bool>(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker_fn)
 {
@@ -557,12 +556,12 @@ std::vector<std::int32_t> fem::locate_dofs_geometrical(
       = V.tabulate_dof_coordinates().transpose();
 
   // Compute marker for each dof coordinate
-  const Eigen::Array<bool, Eigen::Dynamic, 1> marked_dofs
-      = marker_fn(dof_coordinates);
+  const std::vector<bool> marked_dofs = marker_fn(dof_coordinates);
 
   std::vector<std::int32_t> dofs;
-  dofs.reserve(marked_dofs.count());
-  for (Eigen::Index i = 0; i < marked_dofs.rows(); ++i)
+  std::int32_t count = std::count(marked_dofs.begin(), marked_dofs.end(), true);
+  dofs.reserve(count);
+  for (std::size_t i = 0; i < marked_dofs.size(); ++i)
   {
     if (marked_dofs[i])
       dofs.push_back(i);

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -96,7 +96,7 @@ locate_dofs_topological(const fem::FunctionSpace& V, const int dim,
 /// V[1]. The returned dofs are 'unrolled', i.e. block size = 1.
 std::array<std::vector<std::int32_t>, 2> locate_dofs_geometrical(
     const std::array<std::reference_wrapper<const fem::FunctionSpace>, 2>& V,
-    const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+    const std::function<std::vector<bool>(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker_fn);
 
@@ -113,7 +113,7 @@ std::array<std::vector<std::int32_t>, 2> locate_dofs_geometrical(
 /// with V.
 std::vector<std::int32_t> locate_dofs_geometrical(
     const fem::FunctionSpace& V,
-    const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+    const std::function<std::vector<bool>(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker_fn);
 

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -196,7 +196,7 @@ mesh::midpoints(const mesh::Mesh& mesh, int dim,
 //-----------------------------------------------------------------------------
 std::vector<std::int32_t> mesh::locate_entities(
     const mesh::Mesh& mesh, int dim,
-    const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+    const std::function<std::vector<bool>(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker)
 {
@@ -233,8 +233,8 @@ std::vector<std::int32_t> mesh::locate_entities(
     x_vertices.col(i) = x_nodes.row(vertex_to_node[i]);
 
   // Run marker function on vertex coordinates
-  const Eigen::Array<bool, Eigen::Dynamic, 1> marked = marker(x_vertices);
-  if (marked.rows() != x_vertices.cols())
+  const std::vector<bool> marked = marker(x_vertices);
+  if ((int)marked.size() != x_vertices.cols())
     throw std::runtime_error("Length of array of markers is wrong.");
 
   // Iterate over entities to build vector of marked entities
@@ -263,7 +263,7 @@ std::vector<std::int32_t> mesh::locate_entities(
 //-----------------------------------------------------------------------------
 std::vector<std::int32_t> mesh::locate_entities_boundary(
     const mesh::Mesh& mesh, int dim,
-    const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+    const std::function<std::vector<bool>(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker)
 {
@@ -341,8 +341,8 @@ std::vector<std::int32_t> mesh::locate_entities_boundary(
   }
 
   // Run marker function on the vertex coordinates
-  const Eigen::Array<bool, Eigen::Dynamic, 1> marked = marker(x_vertices);
-  if (marked.size() != x_vertices.cols())
+  const std::vector<bool> marked = marker(x_vertices);
+  if ((int)marked.size() != x_vertices.cols())
     throw std::runtime_error("Length of array of markers is wrong.");
 
   // Loop over entities and check vertex markers

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -65,7 +65,7 @@ midpoints(const mesh::Mesh& mesh, int dim,
 ///   (indices local to the process)
 std::vector<std::int32_t> locate_entities(
     const mesh::Mesh& mesh, int dim,
-    const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+    const std::function<std::vector<bool>(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker);
 
@@ -91,7 +91,7 @@ std::vector<std::int32_t> locate_entities(
 /// process)
 std::vector<std::int32_t> locate_entities_boundary(
     const mesh::Mesh& mesh, int dim,
-    const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+    const std::function<std::vector<bool>(
         const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                             Eigen::RowMajor>>&)>& marker);
 

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -474,7 +474,7 @@ void fem(py::module& m)
       "locate_dofs_geometrical",
       [](const std::vector<
              std::reference_wrapper<const dolfinx::fem::FunctionSpace>>& V,
-         const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+         const std::function<std::vector<bool>(
              const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                                  Eigen::RowMajor>>&)>& marker)
           -> std::array<py::array, 2> {
@@ -488,7 +488,7 @@ void fem(py::module& m)
   m.def(
       "locate_dofs_geometrical",
       [](const dolfinx::fem::FunctionSpace& V,
-         const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+         const std::function<std::vector<bool>(
              const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                                  Eigen::RowMajor>>&)>& marker) {
         return as_pyarray(dolfinx::fem::locate_dofs_geometrical(V, marker));

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -268,7 +268,7 @@ void mesh(py::module& m)
   m.def(
       "locate_entities",
       [](const dolfinx::mesh::Mesh& mesh, int dim,
-         const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+         const std::function<std::vector<bool>(
              const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                                  Eigen::RowMajor>>&)>& marker) {
         return as_pyarray(dolfinx::mesh::locate_entities(mesh, dim, marker));
@@ -276,7 +276,7 @@ void mesh(py::module& m)
   m.def(
       "locate_entities_boundary",
       [](const dolfinx::mesh::Mesh& mesh, int dim,
-         const std::function<Eigen::Array<bool, Eigen::Dynamic, 1>(
+         const std::function<std::vector<bool>(
              const Eigen::Ref<const Eigen::Array<double, 3, Eigen::Dynamic,
                                                  Eigen::RowMajor>>&)>& marker) {
         return as_pyarray(


### PR DESCRIPTION
`std::vector<bool>` is already used extensively for markers.