### PR TITLE
Fix returntypes for dolfinx::array2d

### DIFF
--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -66,29 +66,25 @@ void fem(py::module& m)
   m.def(
       "pack_coefficients",
       [](dolfinx::fem::Form<PetscScalar>& form) {
-        return as_pyarray2d<PetscScalar>(dolfinx::fem::pack_coefficients(form));
+        return as_pyarray2d(dolfinx::fem::pack_coefficients(form));
       },
       "Pack coefficients for a Form.");
   m.def(
       "pack_coefficients",
       [](dolfinx::fem::Expression<PetscScalar>& expr) {
-        return as_pyarray2d<PetscScalar>(dolfinx::fem::pack_coefficients(expr));
+        return as_pyarray2d(dolfinx::fem::pack_coefficients(expr));
       },
       "Pack coefficients for an Expression.");
   m.def(
       "pack_constants",
       [](const dolfinx::fem::Form<PetscScalar>& form) {
-        return as_pyarray(
-            dolfinx::fem::pack_constants<dolfinx::fem::Form<PetscScalar>>(
-                form));
+        return as_pyarray(dolfinx::fem::pack_constants(form));
       },
       "Pack constants for a Form.");
   m.def(
       "pack_constants",
       [](const dolfinx::fem::Expression<PetscScalar>& expression) {
-        return as_pyarray(
-            dolfinx::fem::pack_constants<dolfinx::fem::Expression<PetscScalar>>(
-                expression));
+        return as_pyarray(dolfinx::fem::pack_constants(expression));
       },
       "Pack constants for an Expression.");
   m.def("create_matrix", dolfinx::fem::create_matrix,

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -63,12 +63,24 @@ void fem(py::module& m)
   m.def("create_sparsity_pattern",
         &dolfinx::fem::create_sparsity_pattern<PetscScalar>,
         "Create a sparsity pattern for bilinear form.");
-  m.def("pack_coefficients",
-        &dolfinx::fem::pack_coefficients<dolfinx::fem::Form<PetscScalar>>,
-        "Pack coefficients for a Form.");
-  m.def("pack_coefficients",
-        &dolfinx::fem::pack_coefficients<dolfinx::fem::Expression<PetscScalar>>,
-        "Pack coefficients for an Expression.");
+  m.def(
+      "pack_coefficients",
+      [](dolfinx::fem::Form<PetscScalar>& form) {
+        dolfinx::common::array2d<PetscScalar> coeffs
+            = dolfinx::fem::pack_coefficients(form);
+        return py::array_t<PetscScalar>(coeffs.shape, coeffs.strides(),
+                                        coeffs.data());
+      },
+      "Pack coefficients for a Form.");
+  m.def(
+      "pack_coefficients",
+      [](dolfinx::fem::Expression<PetscScalar>& expr) {
+        dolfinx::common::array2d<PetscScalar> coeffs
+            = dolfinx::fem::pack_coefficients(expr);
+        return py::array_t<PetscScalar>(coeffs.shape, coeffs.strides(),
+                                        coeffs.data());
+      },
+      "Pack coefficients for an Expression.");
   m.def(
       "pack_constants",
       [](const dolfinx::fem::Form<PetscScalar>& form) {

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -66,19 +66,13 @@ void fem(py::module& m)
   m.def(
       "pack_coefficients",
       [](dolfinx::fem::Form<PetscScalar>& form) {
-        dolfinx::common::array2d<PetscScalar> coeffs
-            = dolfinx::fem::pack_coefficients(form);
-        return py::array_t<PetscScalar>(coeffs.shape, coeffs.strides(),
-                                        coeffs.data());
+        return as_pyarray2d<PetscScalar>(dolfinx::fem::pack_coefficients(form));
       },
       "Pack coefficients for a Form.");
   m.def(
       "pack_coefficients",
       [](dolfinx::fem::Expression<PetscScalar>& expr) {
-        dolfinx::common::array2d<PetscScalar> coeffs
-            = dolfinx::fem::pack_coefficients(expr);
-        return py::array_t<PetscScalar>(coeffs.shape, coeffs.strides(),
-                                        coeffs.data());
+        return as_pyarray2d<PetscScalar>(dolfinx::fem::pack_coefficients(expr));
       },
       "Pack coefficients for an Expression.");
   m.def(
@@ -247,9 +241,9 @@ void fem(py::module& m)
   // dolfinx::fem::DirichletBC
   py::class_<dolfinx::fem::DirichletBC<PetscScalar>,
              std::shared_ptr<dolfinx::fem::DirichletBC<PetscScalar>>>
-      dirichletbc(
-          m, "DirichletBC",
-          "Object for representing Dirichlet (essential) boundary conditions");
+      dirichletbc(m, "DirichletBC",
+                  "Object for representing Dirichlet (essential) boundary "
+                  "conditions");
 
   dirichletbc
       .def(py::init(
@@ -590,10 +584,12 @@ void fem(py::module& m)
                     *self.function_space()->mesh(), cells);
             dolfinx::fem::interpolate_c<PetscScalar>(self, _f, x, cells);
           },
-          "Interpolate using a pointer to an expression with a C signature")
-      .def_property_readonly(
-          "vector", &dolfinx::fem::Function<PetscScalar>::vector,
-          "Return the PETSc vector associated with the finite element Function")
+          "Interpolate using a pointer to an expression with a C "
+          "signature")
+      .def_property_readonly("vector",
+                             &dolfinx::fem::Function<PetscScalar>::vector,
+                             "Return the PETSc vector associated with "
+                             "the finite element Function")
       .def_property_readonly(
           "x", py::overload_cast<>(&dolfinx::fem::Function<PetscScalar>::x),
           "Return the vector associated with the finite element Function")

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -188,10 +188,10 @@ void mesh(py::module& m)
                              "Geometric dimension")
       .def_property_readonly("dofmap", &dolfinx::mesh::Geometry::dofmap)
       .def("index_map", &dolfinx::mesh::Geometry::index_map)
-      .def(
+      .def_property_readonly(
           "x",
-          [](dolfinx::mesh::Geometry& self) {
-            dolfinx::common::array2d<double>& x = self.x();
+          [](const dolfinx::mesh::Geometry& self) {
+            const dolfinx::common::array2d<double>& x = self.x();
             return py::array_t<double>(x.shape, x.strides(), x.data(),
                                        py::cast(self));
           },

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -188,10 +188,10 @@ void mesh(py::module& m)
                              "Geometric dimension")
       .def_property_readonly("dofmap", &dolfinx::mesh::Geometry::dofmap)
       .def("index_map", &dolfinx::mesh::Geometry::index_map)
-      .def_property_readonly(
+      .def(
           "x",
-          [](const dolfinx::mesh::Geometry& self) {
-            const dolfinx::common::array2d<double>& x = self.x();
+          [](dolfinx::mesh::Geometry& self) {
+            dolfinx::common::array2d<double>& x = self.x();
             return py::array_t<double>(x.shape, x.strides(), x.data(),
                                        py::cast(self));
           },


### PR DESCRIPTION
To be able to use dolfinx::array2d in python the need to be wrapped up as py:array_t.
