### PR TITLE
Fix block-size for cell-centered data in XDMF IO

### DIFF
--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -56,6 +56,7 @@ bool has_cell_centred_data(const fem::Function<Scalar>& u)
   assert(u.function_space()->dofmap());
   assert(u.function_space()->dofmap()->element_dof_layout);
   return (u.function_space()->dofmap()->element_dof_layout->num_dofs()
+              * u.function_space()->dofmap()->bs()
           == cell_based_dim);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -103,14 +103,18 @@ std::vector<Scalar> _get_cell_data_values(const fem::Function<Scalar>& u)
   const auto dofmap = u.function_space()->dofmap();
   assert(dofmap->element_dof_layout);
   const int ndofs = dofmap->element_dof_layout->num_dofs();
+  const int bs = dofmap->bs();
+  assert(ndofs * bs == value_size);
 
   for (int cell = 0; cell < num_local_cells; ++cell)
   {
     // Tabulate dofs
     auto dofs = dofmap->cell_dofs(cell);
-    assert(ndofs == value_size);
     for (int i = 0; i < ndofs; ++i)
-      dof_set.push_back(dofs[i]);
+    {
+      for (int j = 0; j < bs; ++j)
+        dof_set.push_back(bs * dofs[i] + j);
+    }
   }
 
   // Get values


### PR DESCRIPTION
Fixes a bug which forced any function with block size > 1 be evaluated into "point values" (i.e. interpolated into CG1) even if the underlying element was DG0.