### PR TITLE
add adjacency nested list to python for mesh partitioning

### DIFF
--- a/python/dolfinx/wrappers/graph.cpp
+++ b/python/dolfinx/wrappers/graph.cpp
@@ -32,6 +32,9 @@ void declare_adjacency_list(py::module& m, std::string type)
         std::vector<T> data(adj.data(), adj.data() + adj.size());
         return dolfinx::graph::build_adjacency_list<T>(std::move(data), dim);
       }))
+      .def(py::init([](const std::vector<std::vector<T>> adj) {
+        return dolfinx::graph::AdjacencyList<T>(adj);
+      }))
       .def(
           "links",
           [](const dolfinx::graph::AdjacencyList<T>& self, int i) {

--- a/python/dolfinx/wrappers/graph.cpp
+++ b/python/dolfinx/wrappers/graph.cpp
@@ -32,9 +32,14 @@ void declare_adjacency_list(py::module& m, std::string type)
         std::vector<T> data(adj.data(), adj.data() + adj.size());
         return dolfinx::graph::build_adjacency_list<T>(std::move(data), dim);
       }))
-      .def(py::init([](const std::vector<std::vector<T>> adj) {
-        return dolfinx::graph::AdjacencyList<T>(adj);
-      }))
+      .def(py::init(
+          [](const py::array_t<T, py::array::c_style>& array,
+             const py::array_t<std::int32_t, py::array::c_style>& displ) {
+            std::vector<T> data(array.data(), array.data() + array.size());
+            std::vector<std::int32_t> offsets(displ.data(),
+                                              displ.data() + displ.size());
+            return dolfinx::graph::AdjacencyList<T>(data, offsets);
+          }))
       .def(
           "links",
           [](const dolfinx::graph::AdjacencyList<T>& self, int i) {

--- a/python/dolfinx/wrappers/graph.cpp
+++ b/python/dolfinx/wrappers/graph.cpp
@@ -38,7 +38,8 @@ void declare_adjacency_list(py::module& m, std::string type)
             std::vector<T> data(array.data(), array.data() + array.size());
             std::vector<std::int32_t> offsets(displ.data(),
                                               displ.data() + displ.size());
-            return dolfinx::graph::AdjacencyList<T>(data, offsets);
+            return dolfinx::graph::AdjacencyList<T>(std::move(data),
+                                                    std::move(offsets));
           }))
       .def(
           "links",


### PR DESCRIPTION
Needed to specify ghost cells in shared facet mode with custom partitioner