### PR TITLE
Scatter la:Vector

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -657,22 +657,6 @@ std::map<std::int32_t, std::set<int>> IndexMap::compute_shared_indices() const
   return shared_indices;
 }
 //-----------------------------------------------------------------------------
-std::vector<std::int64_t>
-IndexMap::scatter_fwd(const std::vector<std::int64_t>& local_data, int n) const
-{
-  std::vector<std::int64_t> remote_data;
-  scatter_fwd(local_data, remote_data, n);
-  return remote_data;
-}
-//-----------------------------------------------------------------------------
-std::vector<std::int32_t>
-IndexMap::scatter_fwd(const std::vector<std::int32_t>& local_data, int n) const
-{
-  std::vector<std::int32_t> remote_data;
-  scatter_fwd(local_data, remote_data, n);
-  return remote_data;
-}
-//-----------------------------------------------------------------------------
 template <typename T>
 void IndexMap::scatter_fwd(const std::vector<T>& local_data,
                            std::vector<T>& remote_data, int n) const

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -658,7 +658,7 @@ std::map<std::int32_t, std::set<int>> IndexMap::compute_shared_indices() const
 }
 //-----------------------------------------------------------------------------
 template <typename T>
-void IndexMap::scatter_fwd(const tcb::span<T> local_data,
+void IndexMap::scatter_fwd(tcb::span<const T> local_data,
                            tcb::span<T> remote_data, int n) const
 {
 
@@ -723,24 +723,24 @@ void IndexMap::scatter_fwd(const tcb::span<T> local_data,
 //-----------------------------------------------------------------------------
 // \cond turn off doxygen
 template void
-IndexMap::scatter_fwd<std::int64_t>(const tcb::span<std::int64_t> local_data,
+IndexMap::scatter_fwd<std::int64_t>(tcb::span<const std::int64_t> local_data,
                                     tcb::span<std::int64_t> remote_data,
                                     int n) const;
 template void
-IndexMap::scatter_fwd<std::int32_t>(const tcb::span<std::int32_t> local_data,
+IndexMap::scatter_fwd<std::int32_t>(tcb::span<const std::int32_t> local_data,
                                     tcb::span<std::int32_t> remote_data,
                                     int n) const;
-template void IndexMap::scatter_fwd<double>(const tcb::span<double> local_data,
+template void IndexMap::scatter_fwd<double>(tcb::span<const double> local_data,
                                             tcb::span<double> remote_data,
                                             int n) const;
 template void IndexMap::scatter_fwd<std::complex<double>>(
-    const tcb::span<std::complex<double>> local_data,
+    tcb::span<const std::complex<double>> local_data,
     tcb::span<std::complex<double>> remote_data, int n) const;
 // \endcond
 //-----------------------------------------------------------------------------
 template <typename T>
 void IndexMap::scatter_rev(tcb::span<T> local_data,
-                           const tcb::span<T> remote_data, int n,
+                           tcb::span<const T> remote_data, int n,
                            IndexMap::Mode op) const
 {
   if ((int)remote_data.size() != n * num_ghosts())
@@ -820,20 +820,20 @@ void IndexMap::scatter_rev(tcb::span<T> local_data,
 // \cond turn off doxygen
 template void
 IndexMap::scatter_rev<std::int64_t>(tcb::span<std::int64_t> local_data,
-                                    const tcb::span<std::int64_t> remote_data,
+                                    tcb::span<const std::int64_t> remote_data,
                                     int n, IndexMap::Mode op) const;
 
 template void
 IndexMap::scatter_rev<std::int32_t>(tcb::span<std::int32_t> local_data,
-                                    const tcb::span<std::int32_t> remote_data,
+                                    tcb::span<const std::int32_t> remote_data,
                                     int n, IndexMap::Mode op) const;
 
 template void IndexMap::scatter_rev<double>(tcb::span<double> local_data,
-                                            const tcb::span<double> remote_data,
+                                            tcb::span<const double> remote_data,
                                             int n, IndexMap::Mode op) const;
 
 template void IndexMap::scatter_rev<std::complex<double>>(
     tcb::span<std::complex<double>> local_data,
-    const tcb::span<std::complex<double>> remote_data, int n,
+    tcb::span<const std::complex<double>> remote_data, int n,
     IndexMap::Mode op) const;
 // \endcond

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -657,23 +657,11 @@ std::map<std::int32_t, std::set<int>> IndexMap::compute_shared_indices() const
   return shared_indices;
 }
 //-----------------------------------------------------------------------------
-void IndexMap::scatter_fwd(const std::vector<std::int64_t>& local_data,
-                           std::vector<std::int64_t>& remote_data, int n) const
-{
-  scatter_fwd_impl(local_data, remote_data, n);
-}
-//-----------------------------------------------------------------------------
-void IndexMap::scatter_fwd(const std::vector<std::int32_t>& local_data,
-                           std::vector<std::int32_t>& remote_data, int n) const
-{
-  scatter_fwd_impl(local_data, remote_data, n);
-}
-//-----------------------------------------------------------------------------
 std::vector<std::int64_t>
 IndexMap::scatter_fwd(const std::vector<std::int64_t>& local_data, int n) const
 {
   std::vector<std::int64_t> remote_data;
-  scatter_fwd_impl(local_data, remote_data, n);
+  scatter_fwd(local_data, remote_data, n);
   return remote_data;
 }
 //-----------------------------------------------------------------------------
@@ -681,27 +669,13 @@ std::vector<std::int32_t>
 IndexMap::scatter_fwd(const std::vector<std::int32_t>& local_data, int n) const
 {
   std::vector<std::int32_t> remote_data;
-  scatter_fwd_impl(local_data, remote_data, n);
+  scatter_fwd(local_data, remote_data, n);
   return remote_data;
 }
 //-----------------------------------------------------------------------------
-void IndexMap::scatter_rev(std::vector<std::int64_t>& local_data,
-                           const std::vector<std::int64_t>& remote_data, int n,
-                           IndexMap::Mode op) const
-{
-  scatter_rev_impl(local_data, remote_data, n, op);
-}
-//-----------------------------------------------------------------------------
-void IndexMap::scatter_rev(std::vector<std::int32_t>& local_data,
-                           const std::vector<std::int32_t>& remote_data, int n,
-                           IndexMap::Mode op) const
-{
-  scatter_rev_impl(local_data, remote_data, n, op);
-}
-//-----------------------------------------------------------------------------
 template <typename T>
-void IndexMap::scatter_fwd_impl(const std::vector<T>& local_data,
-                                std::vector<T>& remote_data, int n) const
+void IndexMap::scatter_fwd(const std::vector<T>& local_data,
+                           std::vector<T>& remote_data, int n) const
 {
 
   // Get number of neighbors
@@ -726,7 +700,7 @@ void IndexMap::scatter_fwd_impl(const std::vector<T>& local_data,
 
   std::vector displs_send = _shared_disp;
   std::transform(displs_send.begin(), displs_send.end(), displs_send.begin(),
-                 std::bind(std::multiplies<T>(), std::placeholders::_1, n));
+                 std::bind(std::multiplies<int>(), std::placeholders::_1, n));
   std::vector<std::int32_t> sizes_send(outdegree, 0);
   std::adjacent_difference(displs_send.begin() + 1, displs_send.end(),
                            sizes_send.begin());
@@ -761,10 +735,26 @@ void IndexMap::scatter_fwd_impl(const std::vector<T>& local_data,
   }
 }
 //-----------------------------------------------------------------------------
+template void
+IndexMap::scatter_fwd<std::int64_t>(const std::vector<std::int64_t>& local_data,
+                                    std::vector<std::int64_t>& remote_data,
+                                    int n) const;
+template void
+IndexMap::scatter_fwd<std::int32_t>(const std::vector<std::int32_t>& local_data,
+                                    std::vector<std::int32_t>& remote_data,
+                                    int n) const;
+template void
+IndexMap::scatter_fwd<double>(const std::vector<double>& local_data,
+                              std::vector<double>& remote_data, int n) const;
+template void IndexMap::scatter_fwd<std::complex<double>>(
+    const std::vector<std::complex<double>>& local_data,
+    std::vector<std::complex<double>>& remote_data, int n) const;
+
+//-----------------------------------------------------------------------------
 template <typename T>
-void IndexMap::scatter_rev_impl(std::vector<T>& local_data,
-                                const std::vector<T>& remote_data, int n,
-                                IndexMap::Mode op) const
+void IndexMap::scatter_rev(std::vector<T>& local_data,
+                           const std::vector<T>& remote_data, int n,
+                           IndexMap::Mode op) const
 {
   assert((std::int32_t)remote_data.size() == n * num_ghosts());
   local_data.resize(n * size_local(), 0);
@@ -837,3 +827,22 @@ void IndexMap::scatter_rev_impl(std::vector<T>& local_data,
   }
 }
 //-----------------------------------------------------------------------------
+template void IndexMap::scatter_rev<std::int64_t>(
+    std::vector<std::int64_t>& local_data,
+    const std::vector<std::int64_t>& remote_data, int n,
+    IndexMap::Mode op) const;
+
+template void IndexMap::scatter_rev<std::int32_t>(
+    std::vector<std::int32_t>& local_data,
+    const std::vector<std::int32_t>& remote_data, int n,
+    IndexMap::Mode op) const;
+
+template void
+IndexMap::scatter_rev<double>(std::vector<double>& local_data,
+                              const std::vector<double>& remote_data, int n,
+                              IndexMap::Mode op) const;
+
+template void IndexMap::scatter_rev<std::complex<double>>(
+    std::vector<std::complex<double>>& local_data,
+    const std::vector<std::complex<double>>& remote_data, int n,
+    IndexMap::Mode op) const;

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -735,6 +735,7 @@ void IndexMap::scatter_fwd(const std::vector<T>& local_data,
   }
 }
 //-----------------------------------------------------------------------------
+// \cond turn off doxygen
 template void
 IndexMap::scatter_fwd<std::int64_t>(const std::vector<std::int64_t>& local_data,
                                     std::vector<std::int64_t>& remote_data,
@@ -749,7 +750,7 @@ IndexMap::scatter_fwd<double>(const std::vector<double>& local_data,
 template void IndexMap::scatter_fwd<std::complex<double>>(
     const std::vector<std::complex<double>>& local_data,
     std::vector<std::complex<double>>& remote_data, int n) const;
-
+// \endcond
 //-----------------------------------------------------------------------------
 template <typename T>
 void IndexMap::scatter_rev(std::vector<T>& local_data,
@@ -827,6 +828,7 @@ void IndexMap::scatter_rev(std::vector<T>& local_data,
   }
 }
 //-----------------------------------------------------------------------------
+// \cond turn off doxygen
 template void IndexMap::scatter_rev<std::int64_t>(
     std::vector<std::int64_t>& local_data,
     const std::vector<std::int64_t>& remote_data, int n,
@@ -846,3 +848,4 @@ template void IndexMap::scatter_rev<std::complex<double>>(
     std::vector<std::complex<double>>& local_data,
     const std::vector<std::complex<double>>& remote_data, int n,
     IndexMap::Mode op) const;
+// \endcond

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -9,6 +9,7 @@
 #include <array>
 #include <cstdint>
 #include <dolfinx/common/MPI.h>
+#include <dolfinx/common/span.hpp>
 #include <map>
 #include <tuple>
 #include <utility>
@@ -171,8 +172,8 @@ public:
   ///   from the owning process. Size will be n * num_ghosts().
   /// @param[in] n Number of data items per index
   template <typename T>
-  void scatter_fwd(const std::vector<T>& local_data,
-                   std::vector<T>& remote_data, int n) const;
+  void scatter_fwd(const tcb::span<T> local_data, tcb::span<T> remote_data,
+                   int n) const;
 
   /// Send n values for each ghost index to owning to the process
   ///
@@ -184,9 +185,8 @@ public:
   /// @param[in] n Number of data items per index
   /// @param[in] op Sum or set received values in local_data
   template <typename T>
-  void scatter_rev(std::vector<T>& local_data,
-                   const std::vector<T>& remote_data, int n,
-                   IndexMap::Mode op) const;
+  void scatter_rev(tcb::span<T> local_data, const tcb::span<T> remote_data,
+                   int n, IndexMap::Mode op) const;
 
 private:
   // Range of indices (global) owned by this process

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -174,31 +174,6 @@ public:
   void scatter_fwd(const std::vector<T>& local_data,
                    std::vector<T>& remote_data, int n) const;
 
-  /// Send n values for each index that is owned to processes that have
-  /// the index as a ghost. The size of the input array local_data must
-  /// be the same as n * size_local().
-  ///
-  /// @param[in] local_data Local data associated with each owned local
-  ///   index to be sent to process where the data is ghosted. Size must
-  ///   be n * size_local().
-  /// @param[in] n Number of data items per index
-  /// @return Ghost data on this process received from the owning
-  ///   process. Size will be n * num_ghosts().
-  std::vector<std::int64_t>
-  scatter_fwd(const std::vector<std::int64_t>& local_data, int n) const;
-
-  /// Send n values for each index that is owned to processes that have
-  /// the index as a ghost
-  ///
-  /// @param[in] local_data Local data associated with each owned local
-  ///   index to be sent to process where the data is ghosted. Size must
-  ///   be n * size_local().
-  /// @param[in] n Number of data items per index
-  /// @return Ghost data on this process received from the owning
-  ///   process. Size will be n * num_ghosts().
-  std::vector<std::int32_t>
-  scatter_fwd(const std::vector<std::int32_t>& local_data, int n) const;
-
   /// Send n values for each ghost index to owning to the process
   ///
   /// @param[in,out] local_data Local data associated with each owned

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -170,21 +170,9 @@ public:
   /// @param[in,out] remote_data Ghost data on this process received
   ///   from the owning process. Size will be n * num_ghosts().
   /// @param[in] n Number of data items per index
-  void scatter_fwd(const std::vector<std::int64_t>& local_data,
-                   std::vector<std::int64_t>& remote_data, int n) const;
-
-  /// Send n values for each index that is owned to processes that have
-  /// the index as a ghost. The size of the input array local_data must
-  /// be the same as n * size_local().
-  ///
-  /// @param[in] local_data Local data associated with each owned local
-  ///   index to be sent to process where the data is ghosted. Size must
-  ///   be n * size_local().
-  /// @param[in,out] remote_data Ghost data on this process received
-  ///   from the owning process. Size will be n * num_ghosts().
-  /// @param[in] n Number of data items per index
-  void scatter_fwd(const std::vector<std::int32_t>& local_data,
-                   std::vector<std::int32_t>& remote_data, int n) const;
+  template <typename T>
+  void scatter_fwd(const std::vector<T>& local_data,
+                   std::vector<T>& remote_data, int n) const;
 
   /// Send n values for each index that is owned to processes that have
   /// the index as a ghost. The size of the input array local_data must
@@ -220,21 +208,9 @@ public:
   ///   the owning process. Size will be n * num_ghosts().
   /// @param[in] n Number of data items per index
   /// @param[in] op Sum or set received values in local_data
-  void scatter_rev(std::vector<std::int64_t>& local_data,
-                   const std::vector<std::int64_t>& remote_data, int n,
-                   IndexMap::Mode op) const;
-
-  /// Send n values for each ghost index to owning to the process
-  ///
-  /// @param[in,out] local_data Local data associated with each owned
-  ///   local index to be sent to process where the data is ghosted.
-  ///   Size must be n * size_local().
-  /// @param[in] remote_data Ghost data on this process received from
-  ///   the owning process. Size will be n * num_ghosts().
-  /// @param[in] n Number of data items per index
-  /// @param[in] op Sum or set received values in local_data
-  void scatter_rev(std::vector<std::int32_t>& local_data,
-                   const std::vector<std::int32_t>& remote_data, int n,
+  template <typename T>
+  void scatter_rev(std::vector<T>& local_data,
+                   const std::vector<T>& remote_data, int n,
                    IndexMap::Mode op) const;
 
 private:
@@ -287,14 +263,6 @@ private:
   // starting postion in _shared_indices for data that is ghosted on
   // rank i, where i is the ith outgoing edge on _comm_owner_to_ghost.
   std::vector<std::int32_t> _shared_disp;
-
-  template <typename T>
-  void scatter_fwd_impl(const std::vector<T>& local_data,
-                        std::vector<T>& remote_data, int n) const;
-  template <typename T>
-  void scatter_rev_impl(std::vector<T>& local_data,
-                        const std::vector<T>& remote_data, int n,
-                        Mode op) const;
 };
 
 } // namespace dolfinx::common

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -172,7 +172,7 @@ public:
   ///   from the owning process. Size will be n * num_ghosts().
   /// @param[in] n Number of data items per index
   template <typename T>
-  void scatter_fwd(const tcb::span<T> local_data, tcb::span<T> remote_data,
+  void scatter_fwd(tcb::span<const T> local_data, tcb::span<T> remote_data,
                    int n) const;
 
   /// Send n values for each ghost index to owning to the process
@@ -185,7 +185,7 @@ public:
   /// @param[in] n Number of data items per index
   /// @param[in] op Sum or set received values in local_data
   template <typename T>
-  void scatter_rev(tcb::span<T> local_data, const tcb::span<T> remote_data,
+  void scatter_rev(tcb::span<T> local_data, tcb::span<const T> remote_data,
                    int n, IndexMap::Mode op) const;
 
 private:

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -97,7 +97,7 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
   std::vector<std::int64_t> global_index_remote(
       dofmap_view.index_map->num_ghosts());
   dofmap_view.index_map->scatter_fwd(
-      tcb::span<std::int64_t>(global_index),
+      tcb::span<const std::int64_t>(global_index),
       tcb::span<std::int64_t>(global_index_remote), 1);
   const std::vector ghost_owner_old = dofmap_view.index_map->ghost_owner_rank();
 

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -93,8 +93,10 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
 
   // Send new global indices for owned dofs to non-owning process, and
   // receive new global indices from owner
-  std::vector global_index_remote
-      = dofmap_view.index_map->scatter_fwd(global_index, 1);
+
+  std::vector<std::int64_t> global_index_remote(
+      dofmap_view.index_map->num_ghosts());
+  dofmap_view.index_map->scatter_fwd(global_index, global_index_remote, 1);
   const std::vector ghost_owner_old = dofmap_view.index_map->ghost_owner_rank();
 
   // Compute ghosts for collapsed dofmap

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -96,7 +96,9 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
 
   std::vector<std::int64_t> global_index_remote(
       dofmap_view.index_map->num_ghosts());
-  dofmap_view.index_map->scatter_fwd(global_index, global_index_remote, 1);
+  dofmap_view.index_map->scatter_fwd(
+      tcb::span<std::int64_t>(global_index),
+      tcb::span<std::int64_t>(global_index_remote), 1);
   const std::vector ghost_owner_old = dofmap_view.index_map->ghost_owner_rank();
 
   // Compute ghosts for collapsed dofmap

--- a/cpp/dolfinx/la/utils.h
+++ b/cpp/dolfinx/la/utils.h
@@ -20,11 +20,17 @@ enum class Norm
   frobenius
 };
 
+/// Scatter la::Vector local data to ghost values.
+/// @param[in, out] v la::Vector to update
 template <typename T>
 void scatter_fwd(Vector<T>& v);
 
+/// Scatter la::Vector ghost data to owner. This process will result in multiple
+/// incoming values, which can be summed or inserted into the local vector.
+/// @param[in, out] v la::Vector to update
+/// @param op IndexMap operation (add or insert)
 template <typename T>
-void scatter_rev(Vector<T>& v);
+void scatter_rev(Vector<T>& v, dolfinx::common::IndexMap::Mode op);
 
 } // namespace dolfinx::la
 
@@ -47,6 +53,7 @@ void dolfinx::la::scatter_rev(dolfinx::la::Vector<T>& v,
   v.map()->scatter_rev(xlocal, xremote, v.bs(), op);
 }
 
+// \cond turn off doxygen
 template void dolfinx::la::scatter_fwd<double>(dolfinx::la::Vector<double>& v);
 template void dolfinx::la::scatter_fwd<std::complex<double>>(
     dolfinx::la::Vector<std::complex<double>>& v);
@@ -57,3 +64,4 @@ dolfinx::la::scatter_rev<double>(dolfinx::la::Vector<double>& v,
 template void dolfinx::la::scatter_rev<std::complex<double>>(
     dolfinx::la::Vector<std::complex<double>>& v,
     dolfinx::common::IndexMap::Mode op);
+// \endcond

--- a/cpp/dolfinx/la/utils.h
+++ b/cpp/dolfinx/la/utils.h
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
+#include <dolfinx/common/IndexMap.h>
+#include <dolfinx/la/Vector.h>
 #pragma once
 
 namespace dolfinx::la
@@ -18,4 +20,40 @@ enum class Norm
   frobenius
 };
 
+template <typename T>
+void scatter_fwd(Vector<T>& v);
+
+template <typename T>
+void scatter_rev(Vector<T>& v);
+
 } // namespace dolfinx::la
+
+template <typename T>
+void dolfinx::la::scatter_fwd(dolfinx::la::Vector<T>& v)
+{
+  tcb::span<const T> xlocal(v.array().data(), v.map()->size_local());
+  tcb::span<T> xremote(v.mutable_array().data() + v.map()->size_local(),
+                       v.map()->num_ghosts());
+  v.map()->scatter_fwd(xlocal, xremote, v.bs());
+}
+
+template <typename T>
+void dolfinx::la::scatter_rev(dolfinx::la::Vector<T>& v,
+                              dolfinx::common::IndexMap::Mode op)
+{
+  tcb::span<T> xlocal(v.mutable_array().data(), v.map()->size_local());
+  tcb::span<const T> xremote(v.array().data() + v.map()->size_local(),
+                             v.map()->num_ghosts());
+  v.map()->scatter_rev(xlocal, xremote, v.bs(), op);
+}
+
+template void dolfinx::la::scatter_fwd<double>(dolfinx::la::Vector<double>& v);
+template void dolfinx::la::scatter_fwd<std::complex<double>>(
+    dolfinx::la::Vector<std::complex<double>>& v);
+
+template void
+dolfinx::la::scatter_rev<double>(dolfinx::la::Vector<double>& v,
+                                 dolfinx::common::IndexMap::Mode op);
+template void dolfinx::la::scatter_rev<std::complex<double>>(
+    dolfinx::la::Vector<std::complex<double>>& v,
+    dolfinx::common::IndexMap::Mode op);

--- a/cpp/test/unit/common/index_map.cpp
+++ b/cpp/test/unit/common/index_map.cpp
@@ -46,7 +46,8 @@ void test_scatter_fwd()
   std::vector<std::int64_t> data_ghost(n * num_ghosts, -1);
 
   // Scatter values to ghost and check value is correctly received
-  idx_map.scatter_fwd(data_local, data_ghost, n);
+  idx_map.scatter_fwd(tcb::span<std::int64_t>(data_local),
+                      tcb::span<std::int64_t>(data_ghost), n);
   CHECK(data_ghost.size() == n * num_ghosts);
   CHECK(std::all_of(data_ghost.begin(), data_ghost.end(), [=](auto i) {
     return i == val * ((mpi_rank + 1) % mpi_size);
@@ -82,19 +83,24 @@ void test_scatter_rev()
   std::int64_t value = 15;
   std::vector<std::int64_t> data_local(n * size_local, 0);
   std::vector<std::int64_t> data_ghost(n * num_ghosts, value);
-  idx_map.scatter_rev(data_local, data_ghost, n, common::IndexMap::Mode::add);
+  idx_map.scatter_rev(tcb::span<std::int64_t>(data_local),
+                      tcb::span<std::int64_t>(data_ghost), n,
+                      common::IndexMap::Mode::add);
 
   std::int64_t sum;
   CHECK(data_local.size() == n * size_local);
   sum = std::accumulate(data_local.begin(), data_local.end(), 0);
   CHECK(sum == n * value * num_ghosts);
 
-  idx_map.scatter_rev(data_local, data_ghost, n,
+  idx_map.scatter_rev(tcb::span<std::int64_t>(data_local),
+                      tcb::span<std::int64_t>(data_ghost), n,
                       common::IndexMap::Mode::insert);
   sum = std::accumulate(data_local.begin(), data_local.end(), 0);
   CHECK(sum == n * value * num_ghosts);
 
-  idx_map.scatter_rev(data_local, data_ghost, n, common::IndexMap::Mode::add);
+  idx_map.scatter_rev(tcb::span<std::int64_t>(data_local),
+                      tcb::span<std::int64_t>(data_ghost), n,
+                      common::IndexMap::Mode::add);
   sum = std::accumulate(data_local.begin(), data_local.end(), 0);
   CHECK(sum == 2 * n * value * num_ghosts);
 }

--- a/cpp/test/unit/common/index_map.cpp
+++ b/cpp/test/unit/common/index_map.cpp
@@ -46,7 +46,7 @@ void test_scatter_fwd()
   std::vector<std::int64_t> data_ghost(n * num_ghosts, -1);
 
   // Scatter values to ghost and check value is correctly received
-  idx_map.scatter_fwd(tcb::span<std::int64_t>(data_local),
+  idx_map.scatter_fwd(tcb::span<const std::int64_t>(data_local),
                       tcb::span<std::int64_t>(data_ghost), n);
   CHECK(data_ghost.size() == n * num_ghosts);
   CHECK(std::all_of(data_ghost.begin(), data_ghost.end(), [=](auto i) {
@@ -84,7 +84,7 @@ void test_scatter_rev()
   std::vector<std::int64_t> data_local(n * size_local, 0);
   std::vector<std::int64_t> data_ghost(n * num_ghosts, value);
   idx_map.scatter_rev(tcb::span<std::int64_t>(data_local),
-                      tcb::span<std::int64_t>(data_ghost), n,
+                      tcb::span<const std::int64_t>(data_ghost), n,
                       common::IndexMap::Mode::add);
 
   std::int64_t sum;
@@ -93,13 +93,13 @@ void test_scatter_rev()
   CHECK(sum == n * value * num_ghosts);
 
   idx_map.scatter_rev(tcb::span<std::int64_t>(data_local),
-                      tcb::span<std::int64_t>(data_ghost), n,
+                      tcb::span<const std::int64_t>(data_ghost), n,
                       common::IndexMap::Mode::insert);
   sum = std::accumulate(data_local.begin(), data_local.end(), 0);
   CHECK(sum == n * value * num_ghosts);
 
   idx_map.scatter_rev(tcb::span<std::int64_t>(data_local),
-                      tcb::span<std::int64_t>(data_ghost), n,
+                      tcb::span<const std::int64_t>(data_ghost), n,
                       common::IndexMap::Mode::add);
   sum = std::accumulate(data_local.begin(), data_local.end(), 0);
   CHECK(sum == 2 * n * value * num_ghosts);


### PR DESCRIPTION
Allows forward and reverse scatter of `la::Vector` performing ghost updates without need for external libraries