### PR TITLE
libbasix.so was not being copied from intermediate to final image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -331,7 +331,7 @@ ONBUILD ARG DOLFINX_CMAKE_CXX_FLAGS
 
 # The dolfinx-onbuild container expects to have folders basix/ ufl/ ffcx/ and
 # dolfinx/ mounted/shared at /src.
-ONBUILD RUN cd basix && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -B build-dir -S . && \
+ONBUILD RUN cd basix && cmake -G Ninja -DCMAKE_BUILD_TYPE=${DOLFINX_CMAKE_BUILD_TYPE} -DCMAKE_CXX_FLAGS=${DOLFINX_CMAKE_CXX_FLAGS} -B build-dir -S . && \
     cmake --build build-dir && \
     cmake --install build-dir && \
     python3 -m pip install ./python && \
@@ -377,11 +377,7 @@ LABEL description="DOLFIN-X in 32-bit real and complex modes"
 # Docker that you cannot cleanup after an ADD operation. This reduces the
 # container size by around 80MB as the /src folder no longer exists in the final
 # image.
-
-COPY --from=intermediate /usr/local/dolfinx-real /usr/local/dolfinx-real
-COPY --from=intermediate /usr/local/dolfinx-complex /usr/local/dolfinx-complex
-COPY --from=intermediate /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
-COPY --from=intermediate /usr/local/bin /usr/local/bin
+COPY --from=intermediate /usr/local /usr/local
 COPY --from=intermediate /root/.config /root/.config
 
 # Real by default.

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -42,7 +42,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 # Add DOLFINX libraries and other config
-target_link_libraries(cpp PRIVATE pybind11::module dolfinx basix)
+target_link_libraries(cpp PRIVATE pybind11::module dolfinx)
 
 # Add to CMake search path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
Will have to see if this increases size of final image or whether Docker can work out that many COPYed files are the same between intermediate and dev-env images. At least it should now work.