### PR TITLE
Fix python lambda assembler

### DIFF
--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -239,7 +239,7 @@ void fem(py::module& m)
              std::copy_n(cell_geometry.data(), cell_geometry.size(),
                          _cell_geometry.data());
              dolfinx::array2d<double> x(_X.shape[0],
-                                                self.geometric_dimension());
+                                        self.geometric_dimension());
              self.push_forward(x, _X, _cell_geometry);
              return as_pyarray2d(std::move(x));
            })
@@ -347,13 +347,20 @@ void fem(py::module& m)
                                      bcs, diagonal);
         });
   m.def("assemble_matrix",
-        py::overload_cast<const std::function<int(
-                              std::int32_t, const std::int32_t*, std::int32_t,
-                              const std::int32_t*, const PetscScalar*)>&,
-                          const dolfinx::fem::Form<PetscScalar>&,
-                          const std::vector<std::shared_ptr<
-                              const dolfinx::fem::DirichletBC<PetscScalar>>>&>(
-            &dolfinx::fem::assemble_matrix<PetscScalar>));
+        [](const std::function<int(const py::array_t<std::int32_t>&,
+                                   const py::array_t<std::int32_t>&,
+                                   const py::array_t<PetscScalar>&)>& fin,
+           const dolfinx::fem::Form<PetscScalar>& form,
+           const std::vector<std::shared_ptr<
+               const dolfinx::fem::DirichletBC<PetscScalar>>>& bcs) {
+          std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
+                            const std::int32_t*, const PetscScalar*)>
+              f = [&fin](int nr, const int* rows, int nc, const int* cols,
+                         const PetscScalar* data) {
+                return fin(py::array(nr, rows), py::array(nc, cols), py::array(nr*nc, data));
+              };
+          dolfinx::fem::assemble_matrix<PetscScalar>(f, form, bcs);
+        });
 
   // BC modifiers
   m.def(
@@ -571,8 +578,7 @@ void fem(py::module& m)
               py::array_t v = f(_x);
               if (v.ndim() > 1)
               {
-                dolfinx::array2d<PetscScalar> vals(v.shape()[0],
-                                                           v.shape()[1]);
+                dolfinx::array2d<PetscScalar> vals(v.shape()[0], v.shape()[1]);
                 std::copy_n(v.data(), v.size(), vals.data());
                 return vals;
               }
@@ -635,8 +641,7 @@ void fem(py::module& m)
             // TODO: handle 1d case
             dolfinx::array2d<double> _x(x.shape()[0], x.shape()[1]);
             std::copy_n(x.data(), x.size(), _x.data());
-            dolfinx::array2d<PetscScalar> _u(u.shape()[0],
-                                                     u.shape()[1]);
+            dolfinx::array2d<PetscScalar> _u(u.shape()[0], u.shape()[1]);
             self.eval(_x, tcb::span(cells.data(), cells.size()), _u);
             std::copy_n(_u.data(), _u.size(), u.mutable_data());
           },
@@ -701,8 +706,7 @@ void fem(py::module& m)
                  auto tabulate_expression_ptr = (void (*)(
                      PetscScalar*, const PetscScalar*, const PetscScalar*,
                      const double*))addr.cast<std::uintptr_t>();
-                 dolfinx::array2d<double> _X(X.shape()[0],
-                                                     X.shape()[1]);
+                 dolfinx::array2d<double> _X(X.shape()[0], X.shape()[1]);
                  std::copy_n(X.data(), X.size(), _X.data());
                  return dolfinx::fem::Expression<PetscScalar>(
                      coefficients, constants, mesh, _X, tabulate_expression_ptr,
@@ -714,9 +718,9 @@ void fem(py::module& m)
            [](const dolfinx::fem::Expression<PetscScalar>& self,
               const py::array_t<std::int32_t, py::array::c_style>& active_cells,
               py::array_t<PetscScalar> values) {
-             dolfinx::array2d<PetscScalar> _values(
-                 active_cells.shape()[0],
-                 self.num_points() * self.value_size());
+             dolfinx::array2d<PetscScalar> _values(active_cells.shape()[0],
+                                                   self.num_points()
+                                                       * self.value_size());
              self.eval(tcb::span(active_cells.data(), active_cells.size()),
                        _values);
              assert(values.ndim() == 2);

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -360,7 +360,7 @@ void fem(py::module& m)
                 return fin(py::array(nr, rows), py::array(nc, cols), py::array(nr*nc, data));
               };
           dolfinx::fem::assemble_matrix<PetscScalar>(f, form, bcs);
-        });
+        }, "Experimental assembly with Python insertion function. This will be slow. Testing use only.");
 
   // BC modifiers
   m.def(

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -9,6 +9,7 @@ import math
 
 import dolfinx
 import numpy
+import scipy.sparse
 import pytest
 import ufl
 from dolfinx import fem
@@ -17,7 +18,7 @@ from dolfinx.mesh import create_mesh
 from dolfinx_utils.test.skips import skip_in_parallel
 from mpi4py import MPI
 from petsc4py import PETSc
-from ufl import derivative, ds, dx, inner
+from ufl import derivative, ds, dx, inner, grad
 
 
 def nest_matrix_norm(A):
@@ -698,3 +699,32 @@ def test_basic_assembly_constant(mode):
 
     assert (A1 * 3.0 - A2 * 5.0).norm() == pytest.approx(0.0)
     assert (b1 * 3.0 - b2 * 5.0).norm() == pytest.approx(0.0)
+
+
+def test_lambda_assembler():
+    """Tests assembly with a lambda function
+
+    """
+    mesh = UnitSquareMesh(MPI.COMM_WORLD, 5, 5)
+    V = fem.FunctionSpace(mesh, ("Lagrange", 1))
+    u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
+
+    a = inner(grad(u), grad(v))*dx
+
+    # Initial assembly
+    a_form = fem.Form(a)
+
+    rdata = []
+    cdata = []
+    vdata = []
+    def mat_insert(rows, cols, vals):
+        vdata.append(vals)
+        rdata.append(numpy.repeat(rows, len(cols)))
+        cdata.append(numpy.tile(cols, len(rows)))
+        return 0
+
+    dolfinx.cpp.fem.assemble_matrix(mat_insert, a_form._cpp_object, [])
+    vdata = numpy.array(vdata).flatten()
+    cdata = numpy.array(cdata).flatten()
+    rdata = numpy.array(rdata).flatten()
+    mat = scipy.sparse.coo_matrix((vdata, (rdata, cdata)))


### PR DESCRIPTION
Fixes current broken pybind, which translates `int*` as `int` for python.