### PR TITLE
Bump GMSH to 4.8.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,7 @@
 #    docker build --target dev-env --file dolfinx/docker/Dockerfile --build-arg PETSC_SLEPC_OPTFLAGS="-O2 -march=native" .
 #
 
-ARG GMSH_VERSION=4.6.0
+ARG GMSH_VERSION=4.8.0
 ARG PYBIND11_VERSION=2.6.2
 ARG PETSC_VERSION=3.14.3
 ARG SLEPC_VERSION=3.14.1

--- a/python/demo/gmsh/demo_gmsh.py
+++ b/python/demo/gmsh/demo_gmsh.py
@@ -59,7 +59,7 @@ if MPI.COMM_WORLD.rank == 0:
     model.occ.synchronize()
 
     # Add physical tag 1 for exterior surfaces
-    boundary = model.getBoundary((3, model_dim_tags[0][0][1]))
+    boundary = model.getBoundary(model_dim_tags[0])
     boundary_ids = [b[1] for b in boundary]
     model.addPhysicalGroup(2, boundary_ids, tag=1)
     model.setPhysicalName(2, 1, "Sphere surface")


### PR DESCRIPTION
As Eigen is out of basix, we can bump gmsh without getting alignment segfaults.

Fix one interface change from 4.6.0 -> 4.8.0