### PR TITLE
Move permute_dofs and unpermute_dofs functions from FFCx to Basix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,14 @@ version: 2.1
 install-python-components: &install-python-components
   name: Install FEniCS Python components
   command: |
-    git clone https://github.com/FEniCS/basix.git --branch mscroggs/dof-permutations --single-branch
+    git clone https://github.com/FEniCS/basix.git --branch main --single-branch
     cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -B build-dir -S ./basix
     cmake --build build-dir --parallel 3
     cmake --install build-dir
     pip3 install ./basix/python
     # pip3 install git+https://github.com/FEniCS/basix.git
     pip3 install git+https://github.com/FEniCS/ufl.git
-    pip3 install git+https://github.com/FEniCS/ffcx.git@mscroggs/dof-permutations
+    pip3 install git+https://github.com/FEniCS/ffcx.git
 
 flake8-python-code: &flake8-python-code
   name: Flake8 checks on Python code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,14 @@ version: 2.1
 install-python-components: &install-python-components
   name: Install FEniCS Python components
   command: |
-    git clone https://github.com/FEniCS/basix.git --branch main --single-branch
+    git clone https://github.com/FEniCS/basix.git --branch mscroggs/dof-permutations --single-branch
     cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -B build-dir -S ./basix
     cmake --build build-dir --parallel 3
     cmake --install build-dir
     pip3 install ./basix/python
     # pip3 install git+https://github.com/FEniCS/basix.git
     pip3 install git+https://github.com/FEniCS/ufl.git
-    pip3 install git+https://github.com/FEniCS/ffcx.git
+    pip3 install git+https://github.com/FEniCS/ffcx.git@mscroggs/dof-permutations
 
 flake8-python-code: &flake8-python-code
   name: Flake8 checks on Python code

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           path: ./basix
           repository: FEniCS/basix
-          ref: mscroggs/dof-permutations
+          ref: main
 
       - name: Install FEniCS Python components
         run: |
@@ -49,8 +49,7 @@ jobs:
           cmake --install build-dir
           python3 -m pip install ./basix/python
           python3 -m pip install git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install git+https://github.com/FEniCS/ffcx.git@mscroggs/dof-permutations
-
+          python3 -m pip install git+https://github.com/FEniCS/ffcx.git
       - name: Flake8 checks
         run: |
           cd python/

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           path: ./basix
           repository: FEniCS/basix
-          ref: main
+          ref: mscroggs/dof-permutations
 
       - name: Install FEniCS Python components
         run: |
@@ -49,7 +49,7 @@ jobs:
           cmake --install build-dir
           python3 -m pip install ./basix/python
           python3 -m pip install git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install git+https://github.com/FEniCS/ffcx.git
+          python3 -m pip install git+https://github.com/FEniCS/ffcx.git@mscroggs/dof-permutations
 
       - name: Flake8 checks
         run: |

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -229,12 +229,13 @@ void CoordinateElement::compute_reference_geometry(
   }
 }
 //-----------------------------------------------------------------------------
-void CoordinateElement::permute_dofs(int* dofs, const uint32_t cell_perm) const
+void CoordinateElement::permute_dofs(std::int32_t* dofs,
+                                     const uint32_t cell_perm) const
 {
   basix::permute_dofs(_basix_element_handle, dofs, cell_perm);
 }
 //-----------------------------------------------------------------------------
-void CoordinateElement::unpermute_dofs(int* dofs,
+void CoordinateElement::unpermute_dofs(std::int32_t* dofs,
                                        const uint32_t cell_perm) const
 {
   basix::unpermute_dofs(_basix_element_handle, dofs, cell_perm);

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -12,16 +12,12 @@ using namespace dolfinx;
 using namespace dolfinx::fem;
 
 //-----------------------------------------------------------------------------
-CoordinateElement::CoordinateElement(
-    int basix_element_handle, int geometric_dimension,
-    const std::string& signature, const ElementDofLayout& dof_layout,
-    bool needs_permutation_data,
-    std::function<int(int*, const uint32_t)> permute_dofs,
-    std::function<int(int*, const uint32_t)> unpermute_dofs)
+CoordinateElement::CoordinateElement(int basix_element_handle,
+                                     int geometric_dimension,
+                                     const std::string& signature,
+                                     const ElementDofLayout& dof_layout)
     : _gdim(geometric_dimension), _signature(signature),
-      _dof_layout(dof_layout), _basix_element_handle(basix_element_handle),
-      _needs_permutation_data(needs_permutation_data),
-      _permute_dofs(permute_dofs), _unpermute_dofs(unpermute_dofs)
+      _dof_layout(dof_layout), _basix_element_handle(basix_element_handle)
 {
   const mesh::CellType cell = cell_shape();
   int degree = basix::degree(basix_element_handle);
@@ -235,17 +231,17 @@ void CoordinateElement::compute_reference_geometry(
 //-----------------------------------------------------------------------------
 void CoordinateElement::permute_dofs(int* dofs, const uint32_t cell_perm) const
 {
-  _permute_dofs(dofs, cell_perm);
+  basix::permute_dofs(_basix_element_handle, dofs, cell_perm);
 }
 //-----------------------------------------------------------------------------
 void CoordinateElement::unpermute_dofs(int* dofs,
                                        const uint32_t cell_perm) const
 {
-  _unpermute_dofs(dofs, cell_perm);
+  basix::unpermute_dofs(_basix_element_handle, dofs, cell_perm);
 }
 //-----------------------------------------------------------------------------
 bool CoordinateElement::needs_permutation_data() const
 {
-  return _needs_permutation_data;
+  return !basix::dof_transformations_are_identity(_basix_element_handle);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -29,10 +29,6 @@ public:
   /// @param[in] geometric_dimension Geometric dimension
   /// @param[in] signature Signature string description of coordinate map
   /// @param[in] dof_layout Layout of the geometry degrees-of-freedom
-  /// @param[in] needs_permutation_data Indicates whether or not the
-  /// element needs permutation data (for higher order elements)
-  /// @param[in] permute_dofs Function that permutes the DOF numbering
-  /// @param[in] unpermute_dofs Function that reverses a DOF permutation
   CoordinateElement(int basix_element_handle, int geometric_dimension,
                     const std::string& signature,
                     const ElementDofLayout& dof_layout);

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -76,10 +76,10 @@ public:
                                   const array2d<double>& cell_geometry) const;
 
   /// Permutes a list of DOF numbers on a cell
-  void permute_dofs(int* dofs, const uint32_t cell_perm) const;
+  void permute_dofs(std::int32_t* dofs, const uint32_t cell_perm) const;
 
   /// Reverses a DOF permutation
-  void unpermute_dofs(int* dofs, const uint32_t cell_perm) const;
+  void unpermute_dofs(std::int32_t* dofs, const uint32_t cell_perm) const;
 
   /// Indicates whether the coordinate map needs permutation data
   /// passing in (for higher order geometries)

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -35,10 +35,7 @@ public:
   /// @param[in] unpermute_dofs Function that reverses a DOF permutation
   CoordinateElement(int basix_element_handle, int geometric_dimension,
                     const std::string& signature,
-                    const ElementDofLayout& dof_layout,
-                    bool needs_permutation_data,
-                    std::function<int(int*, const uint32_t)> permute_dofs,
-                    std::function<int(int*, const uint32_t)> unpermute_dofs);
+                    const ElementDofLayout& dof_layout);
 
   /// Destructor
   virtual ~CoordinateElement() = default;
@@ -110,11 +107,5 @@ private:
 
   // Does the element need permutation data
   bool _needs_permutation_data;
-
-  // Dof permutation maker
-  std::function<int(int*, const uint32_t)> _permute_dofs;
-
-  // Dof permutation maker
-  std::function<int(int*, const uint32_t)> _unpermute_dofs;
 };
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -100,8 +100,5 @@ private:
 
   // Basix element
   int _basix_element_handle;
-
-  // Does the element need permutation data
-  bool _needs_permutation_data;
 };
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -226,9 +226,7 @@ fem::create_coordinate_map(const ufc_coordinate_mapping& ufc_cmap)
   int handle = basix::register_element(
       ufc_cmap.element_family, cell_name.c_str(), ufc_cmap.element_degree);
   return fem::CoordinateElement(handle, ufc_cmap.geometric_dimension,
-                                ufc_cmap.signature, dof_layout,
-                                ufc_cmap.needs_transformation_data,
-                                ufc_cmap.permute_dofs, ufc_cmap.unpermute_dofs);
+                                ufc_cmap.signature, dof_layout);
 }
 //-----------------------------------------------------------------------------
 fem::CoordinateElement


### PR DESCRIPTION
Added permute_dofs and unpermute_dofs functions to Basix, so these can be removed from the generated code.

This PR is coupled with FEniCS/basix#187 and FEniCS/ffcx#325.