### PR TITLE
Refactor expression interpolation

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -142,6 +142,12 @@ set_package_properties(Eigen3 PROPERTIES TYPE REQUIRED
   DESCRIPTION "Lightweight C++ template library for linear algebra"
   URL "http://eigen.tuxfamily.org")
 
+# Check for required package xtensor
+find_package(xtensor REQUIRED)
+set_package_properties(xtensor PROPERTIES TYPE REQUIRED
+  DESCRIPTION "C++ library for numerical analysis with multi-dimensional array expressions."
+  URL "https://xtensor.readthedocs.io/")
+
 find_package(PETSc 3.10)
 set_package_properties(PETSc PROPERTIES TYPE REQUIRED
   DESCRIPTION "Portable, Extensible Toolkit for Scientific Computation (PETSc)"

--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -5,6 +5,7 @@
 #include <dolfinx/fem/assembler.h>
 #include <dolfinx/fem/petsc.h>
 #include <dolfinx/la/Vector.h>
+#include <xtensor/xarray.hpp>
 
 using namespace dolfinx;
 
@@ -147,7 +148,7 @@ int main(int argc, char* argv[])
       // Large angle of rotation (60 degrees)
       const double theta = 1.04719755;
 
-      array2d<PetscScalar> values(3, x.shape[1], 0.0);
+      auto values = xt::zeros<double>({3, x.shape[1]});
       for (std::size_t i = 0; i < x.shape[1]; ++i)
       {
         // New coordinates
@@ -166,7 +167,7 @@ int main(int argc, char* argv[])
 
     auto u_clamp = std::make_shared<fem::Function<PetscScalar>>(V);
     u_clamp->interpolate([](auto& x) {
-      return array2d<PetscScalar>(3, x.shape[1], 0.0);
+      return xt::zeros<double>({3, x.shape[1]});
     });
 
     // Create Dirichlet boundary conditions

--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -139,16 +139,15 @@ int main(int argc, char* argv[])
 
     auto u_rotation = std::make_shared<fem::Function<PetscScalar>>(V);
     u_rotation->interpolate([](auto& x) {
-      const double scale = 0.005;
+      constexpr double scale = 0.005;
 
       // Center of rotation
-      const double y0 = 0.5;
-      const double z0 = 0.5;
+      constexpr double y0 = 0.5;
+      constexpr double z0 = 0.5;
 
       // Large angle of rotation (60 degrees)
-      const double theta = 1.04719755;
-      std::array<std::size_t, 2> shape = {3, x.shape(1)};
-      xt::xarray<double> values = xt::zeros<double>(shape);
+      constexpr double theta = 1.04719755;
+      xt::xarray<double> values = xt::zeros_like(x);
       for (std::size_t i = 0; i < x.shape(1); ++i)
       {
         // New coordinates
@@ -166,11 +165,8 @@ int main(int argc, char* argv[])
     });
 
     auto u_clamp = std::make_shared<fem::Function<PetscScalar>>(V);
-    u_clamp->interpolate([](auto& x) {
-      std::array<std::size_t, 2> shape = {3, x.shape(1)};
-      xt::xarray<double> out = xt::zeros<double>(shape);
-      return out;
-    });
+    u_clamp->interpolate(
+        [](auto& x) -> xt::xarray<double> { return xt::zeros_like(x); });
 
     // Create Dirichlet boundary conditions
     auto u0 = std::make_shared<fem::Function<PetscScalar>>(V);

--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -147,9 +147,9 @@ int main(int argc, char* argv[])
 
       // Large angle of rotation (60 degrees)
       const double theta = 1.04719755;
-
-      auto values = xt::zeros<double>({3, x.shape[1]});
-      for (std::size_t i = 0; i < x.shape[1]; ++i)
+      std::array<std::size_t, 2> shape = {3, x.shape(1)};
+      xt::xarray<double> values = xt::zeros<double>(shape);
+      for (std::size_t i = 0; i < x.shape(1); ++i)
       {
         // New coordinates
         double y = y0 + (x(1, i) - y0) * std::cos(theta)
@@ -167,7 +167,9 @@ int main(int argc, char* argv[])
 
     auto u_clamp = std::make_shared<fem::Function<PetscScalar>>(V);
     u_clamp->interpolate([](auto& x) {
-      return xt::zeros<double>({3, x.shape[1]});
+      std::array<std::size_t, 2> shape = {3, x.shape(1)};
+      xt::xarray<double> out = xt::zeros<double>(shape);
+      return out;
     });
 
     // Create Dirichlet boundary conditions

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -177,17 +177,17 @@ int main(int argc, char* argv[])
     std::vector bc{std::make_shared<const fem::DirichletBC<PetscScalar>>(
         u0, std::move(bdofs))};
 
-    f->interpolate([](const xt::xtensor<double, 2>& x) {
-      auto dx
-          = xt::square(xt::row(x, 0) - 0.5) + xt::square(xt::row(x, 1) - 0.5);
-      xt::xarray<PetscScalar> f = 10 * xt::exp(-(dx) / 0.02);
-      return f;
-    });
+    f->interpolate(
+        [](const xt::xtensor<double, 2>& x) -> xt::xarray<PetscScalar> {
+          auto dx = xt::square(xt::row(x, 0) - 0.5)
+                    + xt::square(xt::row(x, 1) - 0.5);
+          return 10 * xt::exp(-(dx) / 0.02);
+        });
 
-    g->interpolate([](const xt::xtensor<double, 2>& x) {
-      xt::xarray<PetscScalar> f = xt::sin(5 * xt::row(x, 0));
-      return f;
-    });
+    g->interpolate(
+        [](const xt::xtensor<double, 2>& x) -> xt::xarray<PetscScalar> {
+          return xt::sin(5 * xt::row(x, 0));
+        });
 
     // Now, we have specified the variational forms and can consider the
     // solution of the variational problem. First, we need to define a

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -92,6 +92,8 @@
 #include <dolfinx.h>
 #include <dolfinx/fem/Constant.h>
 #include <dolfinx/fem/petsc.h>
+#include <xtensor/xarray.hpp>
+#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 
@@ -161,34 +163,29 @@ int main(int argc, char* argv[])
     // Define boundary condition
     auto u0 = std::make_shared<fem::Function<PetscScalar>>(V);
 
-    const auto bdofs = fem::locate_dofs_geometrical(
-        {*V}, [](const array2d<double>& x) {
-          constexpr double eps = 10.0 * std::numeric_limits<double>::epsilon();
-          std::vector<bool> marked(x.shape[1]);
-          std::transform(
-              x.row(0).begin(), x.row(0).end(), marked.begin(),
-              [](double x0) { return x0 < eps or std::abs(x0 - 1) < eps; });
-          return marked;
-        });
+    const auto bdofs
+        = fem::locate_dofs_geometrical({*V}, [](const array2d<double>& x) {
+            constexpr double eps
+                = 10.0 * std::numeric_limits<double>::epsilon();
+            std::vector<bool> marked(x.shape[1]);
+            std::transform(
+                x.row(0).begin(), x.row(0).end(), marked.begin(),
+                [](double x0) { return x0 < eps or std::abs(x0 - 1) < eps; });
+            return marked;
+          });
 
     std::vector bc{std::make_shared<const fem::DirichletBC<PetscScalar>>(
         u0, std::move(bdofs))};
 
-    f->interpolate([](auto& x) {
-      std::vector<PetscScalar> f(x.shape[1]);
-      std::transform(x.row(0).begin(), x.row(0).end(), x.row(1).begin(),
-                     f.begin(), [](double x0, double x1) {
-                       double dx
-                           = (x0 - 0.5) * (x0 - 0.5) + (x1 - 0.5) * (x1 - 0.5);
-                       return 10.0 * std::exp(-(dx) / 0.02);
-                     });
+    f->interpolate([](const xt::xtensor<double, 2>& x) {
+      auto dx
+          = xt::square(xt::row(x, 0) - 0.5) + xt::square(xt::row(x, 1) - 0.5);
+      xt::xarray<PetscScalar> f = 10 * xt::exp(-(dx) / 0.02);
       return f;
     });
 
-    g->interpolate([](auto& x) {
-      std::vector<PetscScalar> f(x.shape[1]);
-      std::transform(x.row(0).begin(), x.row(0).end(), f.begin(),
-                     [](double x0) { return std::sin(5 * x0); });
+    g->interpolate([](const xt::xtensor<double, 2>& x) {
+      xt::xarray<PetscScalar> f = xt::sin(5 * xt::row(x, 0));
       return f;
     });
 

--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -65,6 +65,9 @@ target_link_libraries(dolfinx PUBLIC Basix::basix)
 # Eigen3
 target_include_directories(dolfinx SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
 
+# xtensor
+target_include_directories(dolfinx SYSTEM PUBLIC ${xtensor_INCLUDE_DIRS})
+
 # Boost
 target_link_libraries(dolfinx PUBLIC Boost::headers)
 target_link_libraries(dolfinx PUBLIC Boost::timer)

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -65,25 +65,19 @@ const ElementDofLayout& CoordinateElement::dof_layout() const
 }
 //-----------------------------------------------------------------------------
 void CoordinateElement::push_forward(array2d<double>& x,
-                                     const array2d<double>& X,
-                                     const array2d<double>& cell_geometry) const
+                                     const array2d<double>& cell_geometry,
+                                     const array2d<double>& phi) const
 {
-  assert(x.shape[0] == X.shape[0]);
   assert((int)x.shape[1] == this->geometric_dimension());
-  assert((int)X.shape[1] == this->topological_dimension());
-
-  // FIXME: remove dynamic memory allocation
+  assert((int)phi.shape[1] == this->geometric_dimension());
 
   // Compute physical coordinates
-  Eigen::MatrixXd phi(X.shape[0], cell_geometry.shape[0]);
-  basix::tabulate(_basix_element_handle, phi.data(), 0, X.data(), X.shape[0]);
-
   // x = phi * cell_geometry;
   std::fill(x.data(), x.data() + x.size(), 0.0);
   for (std::size_t i = 0; i < x.shape[0]; ++i)
     for (std::size_t j = 0; j < x.shape[1]; ++j)
       for (std::size_t k = 0; k < cell_geometry.shape[0]; ++k)
-        x(i, j) += phi(i, k) * cell_geometry(k, j);
+        x(i, j) += phi(k, i) * cell_geometry(k, j);
 }
 //-----------------------------------------------------------------------------
 void CoordinateElement::compute_reference_geometry(
@@ -249,3 +243,12 @@ bool CoordinateElement::needs_permutation_data() const
   return _needs_permutation_data;
 }
 //-----------------------------------------------------------------------------
+void CoordinateElement::tabulate_shape_functions(const array2d<double>& X,
+                                                 array2d<double>& phi) const
+{
+  assert(phi.shape[0] == X.shape[0]);
+  assert((int)phi.shape[1] == _gdim);
+
+  // std::vector<double> data(30);
+  basix::tabulate(_basix_element_handle, phi.data(), 0, X.data(), X.shape[0]);
+}

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -70,7 +70,7 @@ void CoordinateElement::push_forward(array2d<double>& x,
                                      const array2d<double>& phi) const
 {
   assert((int)x.shape[1] == this->geometric_dimension());
-  assert((int)phi.shape[1] == this->geometric_dimension());
+  assert(phi.shape[0] == cell_geometry.shape[0]);
 
   // Compute physical coordinates
   // x = phi * cell_geometry;
@@ -247,13 +247,7 @@ bool CoordinateElement::needs_permutation_data() const
 void CoordinateElement::tabulate_shape_functions(const array2d<double>& X,
                                                  array2d<double>& phi) const
 {
-  assert(phi.shape[0] == X.shape[0]);
-  assert((int)phi.shape[1] == _gdim);
-  assert(phi.size() == 20);
-
-  std::cout << _gdim * X.shape[0] << std::endl;
-
-  std::vector<double> phi_t(30);
-  basix::tabulate(_basix_element_handle, phi_t.data(), 0, X.data(), X.shape[0]);
-  std::copy(phi_t.begin(), phi_t.end(), phi.data());
+  // FIXME: Should probably have an assert for the number of cols in phi
+  assert(phi.shape[1] == X.shape[0]);
+  basix::tabulate(_basix_element_handle, phi.data(), 0, X.data(), X.shape[0]);
 }

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -16,7 +16,8 @@ using namespace dolfinx::fem;
 CoordinateElement::CoordinateElement(
     std::shared_ptr<basix::FiniteElement> element, int geometric_dimension,
     const std::string& signature, const ElementDofLayout& dof_layout)
-    : _gdim(geometric_dimension), _signature(signature), _dof_layout(dof_layout)
+    : _gdim(geometric_dimension), _signature(signature),
+      _dof_layout(dof_layout), _element(element)
 {
 
   int degree = _element->degree();

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -7,6 +7,7 @@
 #include "CoordinateElement.h"
 #include <Eigen/Dense>
 #include <basix.h>
+#include <iostream>
 
 using namespace dolfinx;
 using namespace dolfinx::fem;
@@ -248,7 +249,11 @@ void CoordinateElement::tabulate_shape_functions(const array2d<double>& X,
 {
   assert(phi.shape[0] == X.shape[0]);
   assert((int)phi.shape[1] == _gdim);
+  assert(phi.size() == 20);
 
-  // std::vector<double> data(30);
-  basix::tabulate(_basix_element_handle, phi.data(), 0, X.data(), X.shape[0]);
+  std::cout << _gdim * X.shape[0] << std::endl;
+
+  std::vector<double> phi_t(30);
+  basix::tabulate(_basix_element_handle, phi_t.data(), 0, X.data(), X.shape[0]);
+  std::copy(phi_t.begin(), phi_t.end(), phi.data());
 }

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -249,8 +249,7 @@ bool CoordinateElement::needs_permutation_data() const
 }
 //-----------------------------------------------------------------------------
 xt::xtensor<double, 4>
-CoordinateElement::tabulate_shape_functions(int n,
-                                            const array2d<double>& X) const
+CoordinateElement::tabulate(int n, const array2d<double>& X) const
 {
   auto _X = xt::adapt(X.data(), X.shape);
   return _element->tabulate(n, _X);

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -19,7 +19,6 @@ CoordinateElement::CoordinateElement(
     : _gdim(geometric_dimension), _signature(signature),
       _dof_layout(dof_layout), _element(element)
 {
-
   int degree = _element->degree();
   const char* cell_type
       = basix::cell::type_to_str(_element->cell_type()).c_str();
@@ -31,11 +30,7 @@ CoordinateElement::CoordinateElement(
       = basix::register_element(family_name, cell_type, degree);
 
   const mesh::CellType cell = cell_shape();
-
-  _is_affine
-      = ((cell == mesh::CellType::interval or cell == mesh::CellType::triangle
-          or cell == mesh::CellType::tetrahedron)
-         and degree == 1);
+  _is_affine = mesh : is_simplex(cell) and degree == 1;
 }
 //-----------------------------------------------------------------------------
 mesh::CellType CoordinateElement::cell_shape() const

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -291,7 +291,13 @@ void CoordinateElement::compute_jacobian_data(
   if (_is_affine)
   {
     // FIXME: This data should not be returned as transpose from basix
-    dphi = _tabulated_data.block(1, 0, tdim, d).transpose();
+    for (std::int32_t i = 0; i < tdim; ++i)
+    {
+      auto dphi_i = _tabulated_data.row(num_points * (i + 1));
+      for (std::int32_t j = 0; j < d; ++j)
+        dphi(j, i) = dphi_i[j];
+    }
+    // dphi = _tabulated_data.block(1, 0, tdim, d).transpose();
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor, 3, 3>
         J0(gdim, tdim);
     J0 = _cell_geometry.matrix().transpose() * dphi;
@@ -330,7 +336,15 @@ void CoordinateElement::compute_jacobian_data(
       Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
                                Eigen::RowMajor>>
           Kview(K.data() + ip * gdim * tdim, tdim, gdim);
-      dphi = _tabulated_data.block(ip * (tdim + 1) + 1, 0, tdim, d).transpose();
+      for (std::int32_t i = 0; i < tdim; ++i)
+      {
+        auto dphi_i = _tabulated_data.row(num_points * (i + 1) + ip);
+        for (std::int32_t j = 0; j < d; ++j)
+          dphi(j, i) = dphi_i[j];
+      }
+
+      // dphi = _tabulated_data.block(ip * (tdim + 1) + 1, 0, tdim,
+      // d).transpose();
       Jview = _cell_geometry.matrix().transpose() * dphi;
       if (gdim == tdim)
       {

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -291,7 +291,6 @@ void CoordinateElement::compute_jacobian_data(
                      cell_geometry.shape[1]);
   if (_is_affine)
   {
-    // FIXME: This data should not be returned as transpose from basix
     for (std::int32_t i = 0; i < tdim; ++i)
     {
       auto dphi_i = xt::view(tabulated_data, i + 1, 0, xt::all(), 0);
@@ -319,12 +318,12 @@ void CoordinateElement::compute_jacobian_data(
                 std::sqrt((J0.transpose() * J0).determinant()));
     }
 
-    // As J0 and K0 is constant for affine meshes, replicate per intepolation
+    // As J0 and K0 are constant for affine meshes, replicate per intepolation
     // point
-    for (int i = 0; i < num_points; i++)
+    for (int ip = 0; ip < num_points; ip++)
     {
-      std::copy_n(J0.data(), J0.size(), J.data() + i * J0.size());
-      std::copy_n(K0.data(), K0.size(), K.data() + i * K0.size());
+      std::copy_n(J0.data(), J0.size(), J.data() + ip * J0.size());
+      std::copy_n(K0.data(), K0.size(), K.data() + ip * K0.size());
     }
   }
   else

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Garth N. Wells
+// Copyright (C) 2018-2021 Garth N. Wells, Jørgen S. Dokken, Igor A. Baratta
 //
 // This file is part of DOLFINX (https://www.fenicsproject.org)
 //

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -8,6 +8,7 @@
 #include <Eigen/Dense>
 #include <basix.h>
 #include <basix/finite-element.h>
+#include <dolfinx/mesh/cell_types.h>
 
 using namespace dolfinx;
 using namespace dolfinx::fem;
@@ -30,7 +31,7 @@ CoordinateElement::CoordinateElement(
       = basix::register_element(family_name, cell_type, degree);
 
   const mesh::CellType cell = cell_shape();
-  _is_affine = mesh : is_simplex(cell) and degree == 1;
+  _is_affine = mesh::is_simplex(cell) and degree == 1;
 }
 //-----------------------------------------------------------------------------
 mesh::CellType CoordinateElement::cell_shape() const

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -57,10 +57,13 @@ public:
   /// Return the geometric dimension of the cell shape
   int geometric_dimension() const;
 
+  void tabulate_shape_functions(const array2d<double>& X,
+                                array2d<double>& phi) const;
+
   /// Return the dof layout
   const ElementDofLayout& dof_layout() const;
 
-  /// Absolute increment stopping criterium for non-affine Newton solver
+  /// Absolute increment stopping criteria for non-affine Newton solver
   double non_affine_atol = 1.0e-8;
 
   /// Maximum number of iterations for non-affine Newton solver
@@ -69,10 +72,10 @@ public:
   /// Compute physical coordinates x for points X  in the reference
   /// configuration
   /// @param[in,out] x The physical coordinates of the reference points X
-  /// @param[in] X The coordinates on the reference cells
   /// @param[in] cell_geometry The cell node coordinates (physical)
-  void push_forward(array2d<double>& x, const array2d<double>& X,
-                    const array2d<double>& cell_geometry) const;
+  /// @param[in] phi Tabulated basis functions at reference points X
+  void push_forward(array2d<double>& x, const array2d<double>& cell_geometry,
+                    const array2d<double>& phi) const;
 
   /// Compute reference coordinates X, and J, detJ and K for physical
   /// coordinates x

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -116,6 +116,8 @@ private:
   // Flag denoting affine map
   bool _is_affine;
 
+  // TODO: This should be removed now as we are transitioning to
+  // basix::FiniteElement
   // Basix element
   int _basix_element_handle;
 
@@ -128,7 +130,7 @@ private:
   // Dof permutation maker
   std::function<int(int*, const uint32_t)> _unpermute_dofs;
 
-  // Actual Element;
+  // Basix Element
   std::shared_ptr<basix::FiniteElement> _element;
 };
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -14,6 +14,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <xtensor/xtensor.hpp>
 
 namespace basix
 {
@@ -58,12 +59,13 @@ public:
 
   /// Tabulate shape functions up to n-th order derivative at points X in the
   /// reference geometry
-  void tabulate_shape_functions(const array2d<double>& X, int n,
-                                array2d<double>& phi) const;
+  /// Note: Dynamic allocation.
+  xt::xtensor<double, 4>
+  tabulate_shape_functions(int n, const array2d<double>& X) const;
 
   /// Compute J, K and detJ for a cell with given geometry, and the
   /// basis functions and first order derivatives at points X
-  void compute_jacobian_data(const array2d<double>& tabulated_data,
+  void compute_jacobian_data(const xt::xtensor<double, 4>& tabulated_data,
                              const array2d<double>& X,
                              const array2d<double>& cell_geometry,
                              std::vector<double>& J, tcb::span<double> detJ,
@@ -84,8 +86,8 @@ public:
   /// @param[in] cell_geometry The cell node coordinates (physical)
   /// @param[in] phi Tabulated basis functions at reference points X
   void push_forward(array2d<double>& x, const array2d<double>& cell_geometry,
-                    const array2d<double>& phi) const;
-                    
+                    const xt::xtensor<double, 4>& phi) const;
+
   /// Compute reference coordinates X, and J, detJ and K for physical
   /// coordinates x
   void compute_reference_geometry(array2d<double>& X, std::vector<double>& J,

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -41,6 +41,10 @@ public:
   /// Destructor
   virtual ~CoordinateElement() = default;
 
+  /// String identifying the finite element
+  /// @return The signature
+  std::string signature() const;
+
   /// Cell shape
   /// @return The cell shape
   mesh::CellType cell_shape() const;

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -86,7 +86,7 @@ public:
   /// @param[in] cell_geometry The cell node coordinates (physical)
   /// @param[in] phi Tabulated basis functions at reference points X
   void push_forward(array2d<double>& x, const array2d<double>& cell_geometry,
-                    const xt::xtensor<double, 4>& phi) const;
+                    const xt::xtensor<double, 2>& phi) const;
 
   /// Compute reference coordinates X, and J, detJ and K for physical
   /// coordinates x

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -33,6 +33,7 @@ public:
   /// Create a coordinate element
   /// @param[in] element Element from basix
   /// @param[in] geometric_dimension Geometric dimension
+  /// @param[in] signature Signature string description of coordinate map
   /// @param[in] dof_layout Layout of the geometry degrees-of-freedom
   CoordinateElement(std::shared_ptr<basix::FiniteElement> element,
                     int geometric_dimension, const std::string& signature,

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -59,8 +59,7 @@ public:
   /// Tabulate shape functions up to n-th order derivative at points X in the
   /// reference geometry
   /// Note: Dynamic allocation.
-  xt::xtensor<double, 4>
-  tabulate_shape_functions(int n, const array2d<double>& X) const;
+  xt::xtensor<double, 4> tabulate(int n, const array2d<double>& X) const;
 
   /// Compute J, K and detJ for a cell with given geometry, and the
   /// basis functions and first order derivatives at points X

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -57,8 +57,18 @@ public:
   /// Return the geometric dimension of the cell shape
   int geometric_dimension() const;
 
-  void tabulate_shape_functions(const array2d<double>& X,
+  /// Tabulate shape functions up to n-th order derivative at points X in the
+  /// reference geometry
+  void tabulate_shape_functions(const array2d<double>& X, int n,
                                 array2d<double>& phi) const;
+
+  /// Compute J, K and detJ for a cell with given geometry, and the
+  /// basis functions and first order derivatives at points X
+  void compute_jacobian_data(const array2d<double>& tabulated_data,
+                             const array2d<double>& X,
+                             const array2d<double>& cell_geometry,
+                             std::vector<double>& J, tcb::span<double> detJ,
+                             std::vector<double>& K) const;
 
   /// Return the dof layout
   const ElementDofLayout& dof_layout() const;

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -15,6 +15,11 @@
 #include <memory>
 #include <string>
 
+namespace basix
+{
+class FiniteElement;
+}
+
 namespace dolfinx::fem
 {
 
@@ -25,27 +30,21 @@ class CoordinateElement
 {
 public:
   /// Create a coordinate element
-  /// @param[in] basix_element_handle Element handle from basix
+  /// @param[in] element Element from basix
   /// @param[in] geometric_dimension Geometric dimension
-  /// @param[in] signature Signature string description of coordinate map
   /// @param[in] dof_layout Layout of the geometry degrees-of-freedom
   /// @param[in] needs_permutation_data Indicates whether or not the
   /// element needs permutation data (for higher order elements)
   /// @param[in] permute_dofs Function that permutes the DOF numbering
   /// @param[in] unpermute_dofs Function that reverses a DOF permutation
-  CoordinateElement(int basix_element_handle, int geometric_dimension,
-                    const std::string& signature,
-                    const ElementDofLayout& dof_layout,
+  CoordinateElement(std::shared_ptr<basix::FiniteElement> element,
+                    int geometric_dimension, const ElementDofLayout& dof_layout,
                     bool needs_permutation_data,
                     std::function<int(int*, const uint32_t)> permute_dofs,
                     std::function<int(int*, const uint32_t)> unpermute_dofs);
 
   /// Destructor
   virtual ~CoordinateElement() = default;
-
-  /// String identifying the finite element
-  /// @return The signature
-  std::string signature() const;
 
   /// Cell shape
   /// @return The cell shape
@@ -73,7 +72,7 @@ public:
   /// Return the dof layout
   const ElementDofLayout& dof_layout() const;
 
-  /// Absolute increment stopping criteria for non-affine Newton solver
+  /// Absolute increment stopping criterium for non-affine Newton solver
   double non_affine_atol = 1.0e-8;
 
   /// Maximum number of iterations for non-affine Newton solver
@@ -86,7 +85,7 @@ public:
   /// @param[in] phi Tabulated basis functions at reference points X
   void push_forward(array2d<double>& x, const array2d<double>& cell_geometry,
                     const array2d<double>& phi) const;
-
+                    
   /// Compute reference coordinates X, and J, detJ and K for physical
   /// coordinates x
   void compute_reference_geometry(array2d<double>& X, std::vector<double>& J,
@@ -109,9 +108,6 @@ private:
   // Geometric dimensions
   int _gdim;
 
-  // Signature, usually from UFC
-  std::string _signature;
-
   // Layout of dofs on element
   ElementDofLayout _dof_layout;
 
@@ -129,5 +125,8 @@ private:
 
   // Dof permutation maker
   std::function<int(int*, const uint32_t)> _unpermute_dofs;
+
+  // Actual Element;
+  std::shared_ptr<basix::FiniteElement> _element;
 };
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -213,6 +213,8 @@ public:
     const int num_cells = cell_map->size_local() + cell_map->num_ghosts();
     std::vector<std::int32_t> cells(num_cells, 0);
     std::iota(cells.begin(), cells.end(), 0);
+    // FIXME: Remove interpolation coords as it should be done internally in
+    // fem::interpolate
     const array2d<double> x = fem::interpolation_coords(
         *_function_space->element(), *_function_space->mesh(), cells);
     fem::interpolate(*this, f, x, cells);

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -215,7 +215,7 @@ public:
     std::iota(cells.begin(), cells.end(), 0);
     const array2d<double> x = fem::interpolation_coords(
         *_function_space->element(), *_function_space->mesh(), cells);
-    // fem::interpolate(*this, f, x, cells);
+    fem::interpolate(*this, f, x, cells);
   }
 
   /// Evaluate the Function at points

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -201,8 +201,8 @@ public:
 
   /// Interpolate an expression
   /// @param[in] f The expression to be interpolated
-  void interpolate(const std::function<std::variant<std::vector<T>, array2d<T>>(
-                       const array2d<double>&)>& f)
+  void interpolate(
+      const std::function<xt::xarray<T>(const xt::xtensor<double, 2>&)>& f)
   {
     assert(_function_space);
     assert(_function_space->element());
@@ -215,7 +215,7 @@ public:
     std::iota(cells.begin(), cells.end(), 0);
     // FIXME: Remove interpolation coords as it should be done internally in
     // fem::interpolate
-    const array2d<double> x = fem::interpolation_coords(
+    const xt::xtensor<double, 2> x = fem::interpolation_coords(
         *_function_space->element(), *_function_space->mesh(), cells);
     fem::interpolate(*this, f, x, cells);
   }

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -215,7 +215,7 @@ public:
     std::iota(cells.begin(), cells.end(), 0);
     const array2d<double> x = fem::interpolation_coords(
         *_function_space->element(), *_function_space->mesh(), cells);
-    fem::interpolate(*this, f, x, cells);
+    // fem::interpolate(*this, f, x, cells);
   }
 
   /// Evaluate the Function at points

--- a/cpp/dolfinx/fem/FunctionSpace.cpp
+++ b/cpp/dolfinx/fem/FunctionSpace.cpp
@@ -15,9 +15,8 @@
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/Topology.h>
 #include <vector>
-#include <xtensor/xview.hpp>
 #include <xtensor/xtensor.hpp>
-
+#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 using namespace dolfinx::fem;
@@ -168,9 +167,8 @@ array2d<double> FunctionSpace::tabulate_dof_coordinates(bool transpose) const
       = needs_permutation_data ? _mesh->topology().get_cell_permutation_info()
                                : std::vector<std::uint32_t>(num_cells);
 
-  auto tabulated_data = cmap.tabulate_shape_functions(0, X);
-  xt::xtensor<double, 2> phi
-      = xt::view(tabulated_data, 0, xt::all(), xt::all(), 0);
+  const xt::xtensor<double, 2> phi
+      = xt::view(cmap.tabulate(0, X), 0, xt::all(), xt::all(), 0);
 
   for (int c = 0; c < num_cells; ++c)
   {

--- a/cpp/dolfinx/fem/FunctionSpace.cpp
+++ b/cpp/dolfinx/fem/FunctionSpace.cpp
@@ -166,7 +166,7 @@ array2d<double> FunctionSpace::tabulate_dof_coordinates(bool transpose) const
                                : std::vector<std::uint32_t>(num_cells);
 
   array2d<double> phi(num_dofs_g, X.shape[0]);
-  cmap.tabulate_shape_functions(X, phi);
+  cmap.tabulate_shape_functions(X, 0, phi);
 
   for (int c = 0; c < num_cells; ++c)
   {

--- a/cpp/dolfinx/fem/FunctionSpace.cpp
+++ b/cpp/dolfinx/fem/FunctionSpace.cpp
@@ -15,6 +15,9 @@
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/Topology.h>
 #include <vector>
+#include <xtensor/xview.hpp>
+#include <xtensor/xtensor.hpp>
+
 
 using namespace dolfinx;
 using namespace dolfinx::fem;
@@ -164,8 +167,10 @@ array2d<double> FunctionSpace::tabulate_dof_coordinates(bool transpose) const
   const std::vector<std::uint32_t>& cell_info
       = needs_permutation_data ? _mesh->topology().get_cell_permutation_info()
                                : std::vector<std::uint32_t>(num_cells);
-                               
-  auto phi = cmap.tabulate_shape_functions(0, X);
+
+  auto tabulated_data = cmap.tabulate_shape_functions(0, X);
+  xt::xtensor<double, 2> phi
+      = xt::view(tabulated_data, 0, xt::all(), xt::all(), 0);
 
   for (int c = 0; c < num_cells; ++c)
   {

--- a/cpp/dolfinx/fem/FunctionSpace.cpp
+++ b/cpp/dolfinx/fem/FunctionSpace.cpp
@@ -165,7 +165,7 @@ array2d<double> FunctionSpace::tabulate_dof_coordinates(bool transpose) const
       = needs_permutation_data ? _mesh->topology().get_cell_permutation_info()
                                : std::vector<std::uint32_t>(num_cells);
 
-  array2d<double> phi(X.shape[0], gdim);
+  array2d<double> phi(num_dofs_g, X.shape[0]);
   cmap.tabulate_shape_functions(X, phi);
 
   for (int c = 0; c < num_cells; ++c)

--- a/cpp/dolfinx/fem/FunctionSpace.cpp
+++ b/cpp/dolfinx/fem/FunctionSpace.cpp
@@ -165,6 +165,9 @@ array2d<double> FunctionSpace::tabulate_dof_coordinates(bool transpose) const
       = needs_permutation_data ? _mesh->topology().get_cell_permutation_info()
                                : std::vector<std::uint32_t>(num_cells);
 
+  array2d<double> phi(X.shape[0], gdim);
+  cmap.tabulate_shape_functions(X, phi);
+
   for (int c = 0; c < num_cells; ++c)
   {
     // Extract cell geometry
@@ -174,7 +177,7 @@ array2d<double> FunctionSpace::tabulate_dof_coordinates(bool transpose) const
         coordinate_dofs(i, j) = x_g(x_dofs[i], j);
 
     // Tabulate dof coordinates on cell
-    cmap.push_forward(x, X, coordinate_dofs);
+    cmap.push_forward(x, coordinate_dofs, phi);
 
     _element->apply_dof_transformation(x.data(), cell_info[c], x.shape[1]);
 

--- a/cpp/dolfinx/fem/FunctionSpace.cpp
+++ b/cpp/dolfinx/fem/FunctionSpace.cpp
@@ -164,9 +164,8 @@ array2d<double> FunctionSpace::tabulate_dof_coordinates(bool transpose) const
   const std::vector<std::uint32_t>& cell_info
       = needs_permutation_data ? _mesh->topology().get_cell_permutation_info()
                                : std::vector<std::uint32_t>(num_cells);
-
-  array2d<double> phi(num_dofs_g, X.shape[0]);
-  cmap.tabulate_shape_functions(X, 0, phi);
+                               
+  auto phi = cmap.tabulate_shape_functions(0, X);
 
   for (int c = 0; c < num_cells; ++c)
   {

--- a/cpp/dolfinx/fem/interpolate.cpp
+++ b/cpp/dolfinx/fem/interpolate.cpp
@@ -26,8 +26,7 @@ fem::interpolation_coords(const fem::FiniteElement& element,
 
   // Get the interpolation points on the reference cells
   const array2d<double> X = element.interpolation_points();
-
-  array2d<double> phi(X.shape[0], gdim);
+  array2d<double> phi(num_dofs_g, X.shape[0]);
   cmap.tabulate_shape_functions(X, phi);
 
   // Push reference coordinates (X) forward to the physical coordinates

--- a/cpp/dolfinx/fem/interpolate.cpp
+++ b/cpp/dolfinx/fem/interpolate.cpp
@@ -22,7 +22,7 @@ fem::interpolation_coords(const fem::FiniteElement& element,
   const int gdim = mesh.geometry().dim();
   const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
   const int num_dofs_g = x_dofmap.num_links(0);
-  [[maybe_unused]] const array2d<double>& x_g = mesh.geometry().x();
+  const array2d<double>& x_g = mesh.geometry().x();
 
   const fem::CoordinateElement& cmap = mesh.geometry().cmap();
 

--- a/cpp/dolfinx/fem/interpolate.cpp
+++ b/cpp/dolfinx/fem/interpolate.cpp
@@ -26,8 +26,7 @@ fem::interpolation_coords(const fem::FiniteElement& element,
 
   // Get the interpolation points on the reference cells
   const array2d<double> X = element.interpolation_points();
-  array2d<double> phi(num_dofs_g, X.shape[0]);
-  cmap.tabulate_shape_functions(X, 0, phi);
+  auto phi = cmap.tabulate_shape_functions(0, X);
 
   // Push reference coordinates (X) forward to the physical coordinates
   // (x) for each cell

--- a/cpp/dolfinx/fem/interpolate.cpp
+++ b/cpp/dolfinx/fem/interpolate.cpp
@@ -36,7 +36,8 @@ fem::interpolation_coords(const fem::FiniteElement& element,
   // (x) for each cell
   array2d<double> x_cell(X.shape[0], gdim);
   array2d<double> coordinate_dofs(num_dofs_g, gdim);
-  xt::xtensor<double, 2> x({3, cells.size() * X.shape[0]});
+  std::array<std::size_t, 2> shape = {3, cells.size() * X.shape[0]};
+  xt::xtensor<double, 2> x = xt::zeros<double>(shape);
   for (std::size_t c = 0; c < cells.size(); ++c)
   {
     // Get geometry data for current cell

--- a/cpp/dolfinx/fem/interpolate.cpp
+++ b/cpp/dolfinx/fem/interpolate.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Garth N. Wells
+// Copyright (C) 2021 Garth N. Wells, Jørgen S. Dokken, Igor A. Baratta
 //
 // This file is part of DOLFINX (https://www.fenicsproject.org)
 //

--- a/cpp/dolfinx/fem/interpolate.cpp
+++ b/cpp/dolfinx/fem/interpolate.cpp
@@ -29,9 +29,9 @@ fem::interpolation_coords(const fem::FiniteElement& element,
   // Get the interpolation points on the reference cells
   const array2d<double> X = element.interpolation_points();
 
-  auto tabulated_data = cmap.tabulate_shape_functions(0, X);
-  xt::xtensor<double, 2> phi
-      = xt::view(tabulated_data, 0, xt::all(), xt::all(), 0);
+  const xt::xtensor<double, 2> phi
+      = xt::view(cmap.tabulate(0, X), 0, xt::all(), xt::all(), 0);
+
   // Push reference coordinates (X) forward to the physical coordinates
   // (x) for each cell
   array2d<double> x_cell(X.shape[0], gdim);

--- a/cpp/dolfinx/fem/interpolate.cpp
+++ b/cpp/dolfinx/fem/interpolate.cpp
@@ -27,7 +27,7 @@ fem::interpolation_coords(const fem::FiniteElement& element,
   // Get the interpolation points on the reference cells
   const array2d<double> X = element.interpolation_points();
   array2d<double> phi(num_dofs_g, X.shape[0]);
-  cmap.tabulate_shape_functions(X, phi);
+  cmap.tabulate_shape_functions(X, 0, phi);
 
   // Push reference coordinates (X) forward to the physical coordinates
   // (x) for each cell

--- a/cpp/dolfinx/fem/interpolate.cpp
+++ b/cpp/dolfinx/fem/interpolate.cpp
@@ -27,6 +27,9 @@ fem::interpolation_coords(const fem::FiniteElement& element,
   // Get the interpolation points on the reference cells
   const array2d<double> X = element.interpolation_points();
 
+  array2d<double> phi(X.shape[0], gdim);
+  cmap.tabulate_shape_functions(X, phi);
+
   // Push reference coordinates (X) forward to the physical coordinates
   // (x) for each cell
   array2d<double> x_cell(X.shape[0], gdim);
@@ -41,7 +44,7 @@ fem::interpolation_coords(const fem::FiniteElement& element,
         coordinate_dofs(i, j) = x_g(x_dofs[i], j);
 
     // Push forward coordinates (X -> x)
-    cmap.push_forward(x_cell, X, coordinate_dofs);
+    cmap.push_forward(x_cell, coordinate_dofs, phi);
     for (std::size_t i = 0; i < x_cell.shape[0]; ++i)
       for (std::size_t j = 0; j < x_cell.shape[1]; ++j)
         x(j, c * X.shape[0] + i) = x_cell(i, j);

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -269,6 +269,9 @@ void interpolate(Function<T>& u,
 
   array2d<T> reference_data(value_size, X.shape[0]);
 
+  array2d<double> phi(X.shape[0], gdim);
+  cmap.tabulate_shape_functions(X, phi);
+
   std::vector<T>& coeffs = u.x()->mutable_array();
   std::vector<T> _coeffs(num_scalar_dofs);
   array2d<T> _vals(value_size, X.shape[0]);
@@ -278,7 +281,8 @@ void interpolate(Function<T>& u,
     for (int i = 0; i < num_dofs_g; ++i)
       for (int j = 0; j < gdim; ++j)
         coordinate_dofs(i, j) = x_g(x_dofs[i], j);
-    cmap.push_forward(x_cell, X, coordinate_dofs);
+
+    cmap.push_forward(x_cell, coordinate_dofs, phi);
 
     cmap.compute_reference_geometry(X_ref, J, detJ, K, x_cell, coordinate_dofs);
 

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -218,7 +218,11 @@ void interpolate(
   xt::xarray<T> values = f(x);
 
   if (values.dimension() == 1)
+  {
+    if (element->value_size() != 1)
+      throw std::runtime_error("Interpolation data has the wrong shape.");
     values.reshape({element->value_size(), x.shape(1)});
+  }
 
   if (values.shape(0) != element->value_size())
     throw std::runtime_error("Interpolation data has the wrong shape.");

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -269,7 +269,7 @@ void interpolate(Function<T>& u,
 
   array2d<T> reference_data(value_size, X.shape[0]);
 
-  array2d<double> phi(X.shape[0], gdim);
+  array2d<double> phi(num_dofs_g, X.shape[0]);
   cmap.tabulate_shape_functions(X, phi);
 
   std::vector<T>& coeffs = u.x()->mutable_array();

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -240,9 +240,10 @@ void interpolate(
   // Loop over cells and compute interpolation dofs
   const int num_scalar_dofs = element->space_dimension() / element_bs;
   const int value_size = element->value_size() / element_bs;
-  std::vector<T> _coeffs(num_scalar_dofs);
 
   std::vector<T>& coeffs = u.x()->mutable_array();
+  std::vector<T> _coeffs(num_scalar_dofs);
+
   // This assumes that any element with an identity interpolation matrix is a
   // point evaluation
   if (element->interpolation_ident())
@@ -251,7 +252,6 @@ void interpolate(
     {
       tcb::span<const std::int32_t> dofs = dofmap->cell_dofs(c);
       assert(dofs.size() == num_scalar_dofs);
-
       for (int k = 0; k < element_bs; ++k)
       {
         for (int i = 0; i < num_scalar_dofs; ++i)
@@ -260,8 +260,9 @@ void interpolate(
                                                             cell_info[c], 1);
         for (int i = 0; i < num_scalar_dofs; ++i)
         {
-          const int dof = dofs[i] * element_bs + k;
-          coeffs[dof] = _coeffs[i];
+          const int dof = i * element_bs + k;
+          std::div_t pos = std::div(dof, dofmap_bs);
+          coeffs[dofmap_bs * dofs[pos.quot] + pos.rem] = _coeffs[i];
         }
       }
     }

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -292,8 +292,7 @@ void interpolate(
 
     // Tabulate 0th and 1st order derivatives of shape functions at
     // interpolation coords
-    auto tabulated_data = cmap.tabulate_shape_functions(1, X);
-
+    xt::xtensor<double, 4> tabulated_data = cmap.tabulate(1, X);
     for (std::int32_t c : cells)
     {
       auto x_dofs = x_dofmap.links(c);

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -277,8 +277,7 @@ void interpolate(Function<T>& u,
 
   // Tabulate 0th and 1st order derivatives of shape functions at interpolation
   // coords
-  array2d<double> tabulated_data(X.shape[0] * (tdim + 1), num_dofs_g);
-  cmap.tabulate_shape_functions(X, 1, tabulated_data);
+  auto tabulated_data = cmap.tabulate_shape_functions(1, X);
 
   for (std::int32_t c : cells)
   {

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -286,15 +286,10 @@ void interpolate(Function<T>& u,
       for (int j = 0; j < gdim; ++j)
         coordinate_dofs(i, j) = x_g(x_dofs[i], j);
 
-    // cmap.push_forward(x_cell, coordinate_dofs, phi);
-    cmap.compute_jacobian_data(tabulated_data, X, coordinate_dofs, J, detJ, K);
-    // cmap.compute_reference_geometry(X_ref, J, detJ, K, x_cell,
-    // coordinate_dofs);
-
     // Compute J, detJ and K
+    cmap.compute_jacobian_data(tabulated_data, X, coordinate_dofs, J, detJ, K);
 
     auto dofs = dofmap->cell_dofs(c);
-
     for (int k = 0; k < element_bs; ++k)
     {
       // Extract computed expression values for element block k

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -53,11 +53,11 @@ void interpolate(Function<T>& u, const Function<T>& v);
 /// interpolate. Should be the same as the list used when calling
 /// fem::interpolation_coords.
 template <typename T>
-void interpolate(Function<T>& u,
-                 const std::function<std::variant<std::vector<T>, array2d<T>>(
-                     const array2d<double>&)>& f,
-                 const array2d<double>& x,
-                 const tcb::span<const std::int32_t>& cells);
+void interpolate(
+    Function<T>& u,
+    const std::function<xt::xarray<T>(const xt::xtensor<double, 2>&)>& f,
+    const xt::xtensor<double, 2>& x,
+    const tcb::span<const std::int32_t>& cells);
 
 /// Interpolate an expression f(x)
 ///

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -7,6 +7,7 @@
 #include "utils.h"
 #include <array>
 #include <basix.h>
+#include <basix/finite-element.h>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/common/log.h>
@@ -223,11 +224,11 @@ fem::create_coordinate_map(const ufc_coordinate_mapping& ufc_cmap)
          {hexahedron, "hexahedron"}};
   const std::string cell_name = ufc_to_string.at(ufc_cmap.cell_shape);
 
-  int handle = basix::register_element(
-      ufc_cmap.element_family, cell_name.c_str(), ufc_cmap.element_degree);
-  return fem::CoordinateElement(handle, ufc_cmap.geometric_dimension,
-                                ufc_cmap.signature, dof_layout,
-                                ufc_cmap.needs_transformation_data,
+  auto basix_element
+      = std::make_shared<basix::FiniteElement>(basix::create_element(
+          ufc_cmap.element_family, cell_name.c_str(), ufc_cmap.element_degree));
+  return fem::CoordinateElement(basix_element, ufc_cmap.geometric_dimension,
+                                dof_layout, ufc_cmap.needs_transformation_data,
                                 ufc_cmap.permute_dofs, ufc_cmap.unpermute_dofs);
 }
 //-----------------------------------------------------------------------------

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -243,9 +243,8 @@ void fem(py::module& m)
                          _cell_geometry.data());
              dolfinx::array2d<double> x(_X.shape[0],
                                         self.geometric_dimension());
-             auto tabulated_data = self.tabulate_shape_functions(0, _X);
              xt::xtensor<double, 2> phi
-                 = xt::view(tabulated_data, 0, xt::all(), xt::all(), 0);
+                 = xt::view(self.tabulate(0, _X), 0, xt::all(), xt::all(), 0);
              self.push_forward(x, _cell_geometry, phi);
              return as_pyarray2d(std::move(x));
            })
@@ -627,7 +626,7 @@ void fem(py::module& m)
             const auto x = dolfinx::fem::interpolation_coords(
                 *self.function_space()->element(),
                 *self.function_space()->mesh(), cells);
-                
+
             dolfinx::fem::interpolate_c<PetscScalar>(self, _f, x, cells);
           },
           "Interpolate using a pointer to an expression with a C "

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -240,7 +240,8 @@ void fem(py::module& m)
                          _cell_geometry.data());
              dolfinx::array2d<double> x(_X.shape[0],
                                         self.geometric_dimension());
-             self.push_forward(x, _X, _cell_geometry);
+             auto phi = self.tabulate_shape_functions(0, _X);
+             self.push_forward(x, _cell_geometry, phi);
              return as_pyarray2d(std::move(x));
            })
       .def_readwrite("non_affine_atol",

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -43,6 +43,9 @@
 #include <pybind11/stl.h>
 #include <string>
 #include <ufc.h>
+#include <xtensor/xadapt.hpp>
+#include <xtensor/xtensor.hpp>
+#include <xtensor/xview.hpp>
 
 namespace py = pybind11;
 
@@ -240,7 +243,9 @@ void fem(py::module& m)
                          _cell_geometry.data());
              dolfinx::array2d<double> x(_X.shape[0],
                                         self.geometric_dimension());
-             auto phi = self.tabulate_shape_functions(0, _X);
+             auto tabulated_data = self.tabulate_shape_functions(0, _X);
+             xt::xtensor<double, 2> phi
+                 = xt::view(tabulated_data, 0, xt::all(), xt::all(), 0);
              self.push_forward(x, _cell_geometry, phi);
              return as_pyarray2d(std::move(x));
            })
@@ -347,21 +352,25 @@ void fem(py::module& m)
           dolfinx::fem::add_diagonal(dolfinx::la::PETScMatrix::add_fn(A), V,
                                      bcs, diagonal);
         });
-  m.def("assemble_matrix",
-        [](const std::function<int(const py::array_t<std::int32_t>&,
-                                   const py::array_t<std::int32_t>&,
-                                   const py::array_t<PetscScalar>&)>& fin,
-           const dolfinx::fem::Form<PetscScalar>& form,
-           const std::vector<std::shared_ptr<
-               const dolfinx::fem::DirichletBC<PetscScalar>>>& bcs) {
-          std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
-                            const std::int32_t*, const PetscScalar*)>
-              f = [&fin](int nr, const int* rows, int nc, const int* cols,
-                         const PetscScalar* data) {
-                return fin(py::array(nr, rows), py::array(nc, cols), py::array(nr*nc, data));
-              };
-          dolfinx::fem::assemble_matrix<PetscScalar>(f, form, bcs);
-        }, "Experimental assembly with Python insertion function. This will be slow. Testing use only.");
+  m.def(
+      "assemble_matrix",
+      [](const std::function<int(const py::array_t<std::int32_t>&,
+                                 const py::array_t<std::int32_t>&,
+                                 const py::array_t<PetscScalar>&)>& fin,
+         const dolfinx::fem::Form<PetscScalar>& form,
+         const std::vector<std::shared_ptr<
+             const dolfinx::fem::DirichletBC<PetscScalar>>>& bcs) {
+        std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
+                          const std::int32_t*, const PetscScalar*)>
+            f = [&fin](int nr, const int* rows, int nc, const int* cols,
+                       const PetscScalar* data) {
+              return fin(py::array(nr, rows), py::array(nc, cols),
+                         py::array(nr * nc, data));
+            };
+        dolfinx::fem::assemble_matrix<PetscScalar>(f, form, bcs);
+      },
+      "Experimental assembly with Python insertion function. This will be "
+      "slow. Testing use only.");
 
   // BC modifiers
   m.def(
@@ -572,19 +581,24 @@ void fem(py::module& m)
           [](dolfinx::fem::Function<PetscScalar>& self,
              const std::function<py::array_t<PetscScalar>(
                  const py::array_t<double>&)>& f) {
-            auto _f = [&f](const dolfinx::array2d<double>& x)
-                -> std::variant<std::vector<PetscScalar>,
-                                dolfinx::array2d<PetscScalar>> {
-              py::array_t _x(x.shape, x.strides(), x.data(), py::none());
+            auto _f = [&f](const xt::xtensor<double, 2>& x)
+                -> xt::xarray<PetscScalar> {
+              auto strides = x.strides();
+              for (auto& s : strides)
+                s *= sizeof(double);
+              py::array_t _x(x.shape(), strides, x.data(), py::none());
               py::array_t v = f(_x);
               if (v.ndim() > 1)
               {
-                dolfinx::array2d<PetscScalar> vals(v.shape()[0], v.shape()[1]);
-                std::copy_n(v.data(), v.size(), vals.data());
-                return vals;
+                std::vector<std::size_t> shape;
+                for (pybind11::ssize_t i = 0; i < v.ndim(); i++)
+                  shape.push_back(v.shape()[i]);
+                return xt::adapt(v.mutable_data(), shape);
               }
               else
-                return std::vector<PetscScalar>(v.data(), v.data() + v.size());
+              {
+                return xt::adapt(v.data(), {std::size_t(v.size())});
+              }
             };
 
             self.interpolate(_f);
@@ -601,9 +615,11 @@ void fem(py::module& m)
                 = reinterpret_cast<void (*)(PetscScalar*, int, int,
                                             const double*)>(addr);
 
-            auto _f = [&f](dolfinx::array2d<PetscScalar>& values,
-                           const dolfinx::array2d<double>& x) -> void {
-              f(values.data(), values.shape[1], values.shape[0], x.data());
+            [[maybe_unused]] auto _f
+                = [&f](xt::xarray<PetscScalar>& values,
+                       const xt::xtensor<double, 2>& x) -> void {
+              f(values.data(), int(values.shape(1)), int(values.shape(0)),
+                x.data());
             };
 
             assert(self.function_space());
@@ -617,10 +633,9 @@ void fem(py::module& m)
                 = cell_map->size_local() + cell_map->num_ghosts();
             std::vector<std::int32_t> cells(num_cells, 0);
             std::iota(cells.begin(), cells.end(), 0);
-            const dolfinx::array2d<double> x
-                = dolfinx::fem::interpolation_coords(
-                    *self.function_space()->element(),
-                    *self.function_space()->mesh(), cells);
+            const auto x = dolfinx::fem::interpolation_coords(
+                *self.function_space()->element(),
+                *self.function_space()->mesh(), cells);
 
             dolfinx::fem::interpolate_c<PetscScalar>(self, _f, x, cells);
           },


### PR DESCRIPTION
Co-author: @jorgensd 

- Remove tabulation from loops:
   - `CoordinateElement::push_forward` now receives the tabulated data.
   - Created a function to compute the jacobian and related data `compute_jacobian_data` given the tabulated data at the interpolation points (reference domain). In main, a newton to back engineer the interpolation point using compute reference geometry, which is not necessary because the we know the interpolation points.
 - Introduce xtensor to communicate directly with `basix::FiniteElement`
 - Use xtensor to allocate large datasets (instead of array2d or vector because they need initialization).
 - Remove Eigen::Replicate and avoid some lazy computation, which were expensive.

Further optimizations (in a future PR):
- Special treatment for Lagrange elements  (straightforward).
- Optimize `FiniteElement::map_pull_back`, which corresponds of 50-60% of the interpolation time. Currently it incurs in unnecessary copies and transposition, the idea is no interface directly with `basix::FiniteElement` using xtensor.
- Reconsider the number of interpolation points in basix (currently 5*degree for non-Lagrange elements). 
   - Maybe use the (max degree of the polynomial set)**2+ 1


Some comparisons with main:
For each function space (family +  degree + cel ltype) we increased the number of cells  
- #Tetrahedral elements: 3072, 24576, 196608
- #Hexahedral elements: 512, 4096, 32768 

**Lagrange**
![lagrange_interpolate_speedup](https://user-images.githubusercontent.com/15614155/114083713-3f117080-98a7-11eb-8fab-ae9719e607f6.png)

**Raviart–Thomas**
![rt_interpolate_speedup](https://user-images.githubusercontent.com/15614155/114083751-4c2e5f80-98a7-11eb-83e3-bbf778ebe7d2.png)

**Nédélec**
![n1curl_interpolate_speedup](https://user-images.githubusercontent.com/15614155/114083774-54869a80-98a7-11eb-9ddd-685337ede43b.png)


**Tabulate dof coordinates (byproduct)**
Due to the refactoring of push-forward we see also a boost in the performance of tabulate dof coordinates:
![lagrange_tabulate_coords_speedup](https://user-images.githubusercontent.com/15614155/114083844-66683d80-98a7-11eb-95eb-5b02df5fb6cc.png)
