### PR TITLE
Introduce accurate formulas for determinant and inverse of small matrices

### DIFF
--- a/cpp/dolfinx/common/linalg.h
+++ b/cpp/dolfinx/common/linalg.h
@@ -11,7 +11,7 @@
 namespace dolfinx::linalg
 {
 
-/// Kahan’s method to compute x = ad − bc with fused multiply-adds
+/// Kahan’s method to compute x = ad − bc with fused multiply-adds.
 /// The absolute error is bounded by 1.5 ulps, units of least precision.
 template <typename T>
 inline T difference_of_products(T a, T b, T c, T d) noexcept
@@ -22,8 +22,8 @@ inline T difference_of_products(T a, T b, T c, T d) noexcept
   return (diff + err);
 }
 
-/// Compute the determinant of a small matrix (1x1, 2x2, or 3x3)
-/// Tailored for use in computations usin the Jacobian
+/// Compute the determinant of a small matrix (1x1, 2x2, or 3x3).
+/// Tailored for use in computations using the Jacobian.
 template <typename Matrix>
 auto det(const Matrix& A)
 {
@@ -50,9 +50,9 @@ auto det(const Matrix& A)
     return w4;
   }
   default:
-    throw std::runtime_error("det is no implement for "
+    throw std::runtime_error("linalg::det is not implement for "
                              + std::to_string(A.shape(0)) + "x"
-                             + std::to_string(A.shape(0)) + " matrices");
+                             + std::to_string(A.shape(1)) + " matrices.");
   }
 }
 
@@ -101,9 +101,9 @@ void inv(const Matrix& A, Matrix& B)
     break;
   }
   default:
-    throw std::runtime_error("det is no implement for "
+    throw std::runtime_error("linalg::inv is not implement for "
                              + std::to_string(A.shape(0)) + "x"
-                             + std::to_string(A.shape(0)) + " matrices");
+                             + std::to_string(A.shape(1)) + " matrices.");
   }
 }
 

--- a/cpp/dolfinx/common/linalg.h
+++ b/cpp/dolfinx/common/linalg.h
@@ -50,7 +50,7 @@ auto det(const Matrix& A)
     return w4;
   }
   default:
-    throw std::runtime_error("linalg::det is not implement for "
+    throw std::runtime_error("linalg::det is not implemented for "
                              + std::to_string(A.shape(0)) + "x"
                              + std::to_string(A.shape(1)) + " matrices.");
   }
@@ -101,7 +101,7 @@ void inv(const Matrix& A, Matrix& B)
     break;
   }
   default:
-    throw std::runtime_error("linalg::inv is not implement for "
+    throw std::runtime_error("linalg::inv is not implemented for "
                              + std::to_string(A.shape(0)) + "x"
                              + std::to_string(A.shape(1)) + " matrices.");
   }

--- a/cpp/dolfinx/common/linalg.h
+++ b/cpp/dolfinx/common/linalg.h
@@ -45,7 +45,7 @@ auto det(const Matrix& A)
     value_type w0 = difference_of_products(A(1, 1), A(1, 2), A(2, 1), A(2, 2));
     value_type w1 = difference_of_products(A(1, 0), A(1, 2), A(2, 0), A(2, 2));
     value_type w2 = difference_of_products(A(1, 0), A(1, 1), A(2, 0), A(2, 1));
-    value_type w3 = difference_of_products(A(0, 0), A(0, 2), w1, w0);
+    value_type w3 = difference_of_products(A(0, 0), A(0, 1), w1, w0);
     value_type w4 = std::fma(A(0, 2), w2, w3);
     return w4;
   }
@@ -83,7 +83,7 @@ void inv(const Matrix& A, Matrix& B)
     value_type w0 = difference_of_products(A(1, 1), A(1, 2), A(2, 1), A(2, 2));
     value_type w1 = difference_of_products(A(1, 0), A(1, 2), A(2, 0), A(2, 2));
     value_type w2 = difference_of_products(A(1, 0), A(1, 1), A(2, 0), A(2, 1));
-    value_type w3 = difference_of_products(A(0, 0), A(0, 2), w1, w0);
+    value_type w3 = difference_of_products(A(0, 0), A(0, 1), w1, w0);
     value_type det = std::fma(A(0, 2), w2, w3);
     assert(det != 0.);
     idet = 1 / det;
@@ -114,7 +114,7 @@ void dot(const Matrix& A, const Matrix& B, Matrix& C)
   using value_type = typename Matrix::value_type;
   for (std::size_t i = 0; i < N; i++)
   {
-    for (std::size_t j = 0; j < B.shape(0); j++)
+    for (std::size_t j = 0; j < B.shape(1); j++)
     {
       value_type result = 0;
       for (std::size_t k = 0; k < M; k++)

--- a/cpp/dolfinx/common/linalg.h
+++ b/cpp/dolfinx/common/linalg.h
@@ -107,22 +107,4 @@ void inv(const Matrix& A, Matrix& B)
   }
 }
 
-/// Compute the dot product of two matrices, where the dimensions of the first
-/// matrix are know at compile time.
-template <std::size_t N, std::size_t M, typename Matrix>
-void dot(const Matrix& A, const Matrix& B, Matrix& C)
-{
-  using value_type = typename Matrix::value_type;
-  for (std::size_t i = 0; i < N; i++)
-  {
-    for (std::size_t j = 0; j < B.shape(1); j++)
-    {
-      value_type result = 0;
-      for (std::size_t k = 0; k < M; k++)
-        result += A(i, k) * B(k, j);
-      C(i, j) = result;
-    }
-  }
-}
-
 } // namespace dolfinx::linalg

--- a/cpp/dolfinx/common/linalg.h
+++ b/cpp/dolfinx/common/linalg.h
@@ -1,0 +1,123 @@
+// Copyright (C) 2021 Igor Baratta
+//
+// This file is part of DOLFINX (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+
+#pragma once
+
+#include <cmath>
+
+namespace dolfinx::linalg
+{
+
+/// Kahan’s method to compute x = ad − bc with fused multiply-adds
+/// The absolute error is bounded by 1.5 ulps, units of least precision.
+template <typename T>
+inline T difference_of_products(T a, T b, T c, T d) noexcept
+{
+  double w = b * c;
+  double err = std::fma(-b, c, w);
+  double diff = std::fma(a, d, -w);
+  return (diff + err);
+}
+
+/// Compute the determinant of a small matrix (1x1, 2x2, or 3x3)
+/// Tailored for use in computations usin the Jacobian
+template <typename Matrix>
+auto det(const Matrix& A)
+{
+  using value_type = typename Matrix::value_type;
+  assert(A.shape(0) == A.shape(1));
+  assert(A.dimension() == 2);
+
+  const int nrows = A.shape(0);
+  switch (nrows)
+  {
+  case 1:
+    return A(0, 0);
+  case 2:
+    return difference_of_products(A(0, 0), A(0, 1), A(1, 0), A(1, 1));
+  case 3:
+  {
+    // Leibniz formula combined with Kahan’s method for accurate
+    // computation of 3 x 3 determinants
+    value_type w0 = difference_of_products(A(1, 1), A(1, 2), A(2, 1), A(2, 2));
+    value_type w1 = difference_of_products(A(1, 0), A(1, 2), A(2, 0), A(2, 2));
+    value_type w2 = difference_of_products(A(1, 0), A(1, 1), A(2, 0), A(2, 1));
+    value_type w3 = difference_of_products(A(0, 0), A(0, 2), w1, w0);
+    value_type w4 = std::fma(A(0, 2), w2, w3);
+    return w4;
+  }
+  default:
+    throw std::runtime_error("det is no implement for "
+                             + std::to_string(A.shape(0)) + "x"
+                             + std::to_string(A.shape(0)) + " matrices");
+  }
+}
+
+/// Compute the inverse of a square matrix A and assign the result to a
+/// preallocated matrix B.
+/// @warning This function does not check if A is invertible!
+template <typename Matrix>
+void inv(const Matrix& A, Matrix& B)
+{
+  using value_type = typename Matrix::value_type;
+  value_type idet = 0;
+  const int nrows = A.shape(0);
+  switch (nrows)
+  {
+  case 1:
+    B(0, 0) = 1 / A(0, 0);
+  case 2:
+    idet = 1. / compute_determinant(A);
+    B(0, 0) = idet * A(1, 1);
+    B(0, 1) = -idet * A(0, 1);
+    B(1, 0) = -idet * A(1, 0);
+    B(1, 1) = idet * A(0, 0);
+    break;
+  case 3:
+    value_type w0 = difference_of_products(A(1, 1), A(1, 2), A(2, 1), A(2, 2));
+    value_type w1 = difference_of_products(A(1, 0), A(1, 2), A(2, 0), A(2, 2));
+    value_type w2 = difference_of_products(A(1, 0), A(1, 1), A(2, 0), A(2, 1));
+    value_type w3 = difference_of_products(A(0, 0), A(0, 2), w1, w0);
+    value_type det = std::fma(A(0, 2), w2, w3);
+    assert(det != 0.);
+    idet = 1 / det;
+
+    B(0, 0) = w0 * idet;
+    B(1, 0) = -w1 * idet;
+    B(2, 0) = w2 * idet;
+    B(0, 1) = difference_of_products(A(0, 2), A(0, 1), A(2, 2), A(2, 1)) * idet;
+    B(0, 2) = difference_of_products(A(0, 1), A(0, 2), A(1, 1), A(1, 2)) * idet;
+    B(1, 1) = difference_of_products(A(0, 0), A(0, 2), A(2, 0), A(2, 2)) * idet;
+    B(1, 2) = difference_of_products(A(1, 0), A(0, 0), A(1, 2), A(0, 2)) * idet;
+    B(2, 1) = difference_of_products(A(2, 0), A(0, 0), A(2, 1), A(0, 1)) * idet;
+    B(2, 2) = difference_of_products(A(0, 0), A(1, 0), A(0, 1), A(1, 1)) * idet;
+    break;
+  default:
+    throw std::runtime_error("det is no implement for "
+                             + std::to_string(A.shape(0)) + "x"
+                             + std::to_string(A.shape(0)) + " matrices");
+  }
+}
+
+/// Compute the dot product of two matrices, where the dimensions of the first
+/// matrix are know at compile time.
+template <std::size_t N, std::size_t M, typename Matrix>
+void dot(const Matrix& A, const Matrix& B, Matrix& C)
+{
+  using value_type = typename Matrix::value_type;
+  for (std::size_t i = 0; i < N; i++)
+  {
+    for (std::size_t j = 0; j < B.shape(0); j++)
+    {
+      value_type result = 0;
+      for (std::size_t k = 0; k < M; k++)
+        result += A(i, k) * B(k, j);
+      C(i, j) = result;
+    }
+  }
+}
+
+} // namespace dolfinx::linalg

--- a/cpp/dolfinx/common/linalg.h
+++ b/cpp/dolfinx/common/linalg.h
@@ -69,9 +69,10 @@ void inv(const Matrix& A, Matrix& B)
   {
   case 1:
     B(0, 0) = 1 / A(0, 0);
+    break;
   case 2:
   {
-    idet = 1. / compute_determinant(A);
+    idet = 1. / det(A);
     B(0, 0) = idet * A(1, 1);
     B(0, 1) = -idet * A(0, 1);
     B(1, 0) = -idet * A(1, 0);

--- a/cpp/dolfinx/common/linalg.h
+++ b/cpp/dolfinx/common/linalg.h
@@ -70,13 +70,16 @@ void inv(const Matrix& A, Matrix& B)
   case 1:
     B(0, 0) = 1 / A(0, 0);
   case 2:
+  {
     idet = 1. / compute_determinant(A);
     B(0, 0) = idet * A(1, 1);
     B(0, 1) = -idet * A(0, 1);
     B(1, 0) = -idet * A(1, 0);
     B(1, 1) = idet * A(0, 0);
     break;
+  }
   case 3:
+  {
     value_type w0 = difference_of_products(A(1, 1), A(1, 2), A(2, 1), A(2, 2));
     value_type w1 = difference_of_products(A(1, 0), A(1, 2), A(2, 0), A(2, 2));
     value_type w2 = difference_of_products(A(1, 0), A(1, 1), A(2, 0), A(2, 1));
@@ -95,6 +98,7 @@ void inv(const Matrix& A, Matrix& B)
     B(2, 1) = difference_of_products(A(2, 0), A(0, 0), A(2, 1), A(0, 1)) * idet;
     B(2, 2) = difference_of_products(A(0, 0), A(1, 0), A(0, 1), A(1, 1)) * idet;
     break;
+  }
   default:
     throw std::runtime_error("det is no implement for "
                              + std::to_string(A.shape(0)) + "x"

--- a/cpp/dolfinx/common/math.h
+++ b/cpp/dolfinx/common/math.h
@@ -16,9 +16,9 @@ namespace dolfinx::math
 template <typename T>
 inline T difference_of_products(T a, T b, T c, T d) noexcept
 {
-  double w = b * c;
-  double err = std::fma(-b, c, w);
-  double diff = std::fma(a, d, -w);
+  T w = b * c;
+  T err = std::fma(-b, c, w);
+  T diff = std::fma(a, d, -w);
   return (diff + err);
 }
 
@@ -50,7 +50,7 @@ auto det(const Matrix& A)
     return w4;
   }
   default:
-    throw std::runtime_error("linalg::det is not implemented for "
+    throw std::runtime_error("math::det is not implemented for "
                              + std::to_string(A.shape(0)) + "x"
                              + std::to_string(A.shape(1)) + " matrices.");
   }
@@ -59,11 +59,10 @@ auto det(const Matrix& A)
 /// Compute the inverse of a square matrix A and assign the result to a
 /// preallocated matrix B.
 /// @warning This function does not check if A is invertible!
-template <typename Matrix>
-void inv(const Matrix& A, Matrix& B)
+template <typename U, typename V>
+void inv(const U& A, V& B)
 {
-  using value_type = typename Matrix::value_type;
-  value_type idet = 0;
+  using value_type = typename U::value_type;
   const int nrows = A.shape(0);
   switch (nrows)
   {
@@ -72,7 +71,7 @@ void inv(const Matrix& A, Matrix& B)
     break;
   case 2:
   {
-    idet = 1. / det(A);
+    value_type idet = 1. / det(A);
     B(0, 0) = idet * A(1, 1);
     B(0, 1) = -idet * A(0, 1);
     B(1, 0) = -idet * A(1, 0);
@@ -87,7 +86,7 @@ void inv(const Matrix& A, Matrix& B)
     value_type w3 = difference_of_products(A(0, 0), A(0, 1), w1, w0);
     value_type det = std::fma(A(0, 2), w2, w3);
     assert(det != 0.);
-    idet = 1 / det;
+    value_type idet = 1 / det;
 
     B(0, 0) = w0 * idet;
     B(1, 0) = -w1 * idet;
@@ -101,7 +100,7 @@ void inv(const Matrix& A, Matrix& B)
     break;
   }
   default:
-    throw std::runtime_error("linalg::inv is not implemented for "
+    throw std::runtime_error("math::inv is not implemented for "
                              + std::to_string(A.shape(0)) + "x"
                              + std::to_string(A.shape(1)) + " matrices.");
   }

--- a/cpp/dolfinx/common/math.h
+++ b/cpp/dolfinx/common/math.h
@@ -8,7 +8,7 @@
 
 #include <cmath>
 
-namespace dolfinx::linalg
+namespace dolfinx::math
 {
 
 /// Kahan’s method to compute x = ad − bc with fused multiply-adds.
@@ -107,4 +107,4 @@ void inv(const Matrix& A, Matrix& B)
   }
 }
 
-} // namespace dolfinx::linalg
+} // namespace dolfinx::math

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -7,6 +7,7 @@
 #include "CoordinateElement.h"
 #include <basix.h>
 #include <basix/finite-element.h>
+#include <dolfinx/common/linalg.h>
 #include <dolfinx/mesh/cell_types.h>
 #include <xtensor-blas/xlinalg.hpp>
 #include <xtensor/xview.hpp>
@@ -21,11 +22,11 @@ namespace
 double compute_determinant(xt::xtensor<double, 2>& A)
 {
   if (A.shape(0) == A.shape(1))
-    return xt::linalg::det(A);
+    return linalg::det(A);
   else
   {
     auto ATA = xt::linalg::dot(xt::transpose(A), A);
-    return std::sqrt(xt::linalg::det(ATA));
+    return std::sqrt(linalg::det(ATA));
   }
 }
 } // namespace

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -7,7 +7,7 @@
 #include "CoordinateElement.h"
 #include <basix.h>
 #include <basix/finite-element.h>
-#include <dolfinx/common/linalg.h>
+#include <dolfinx/common/math.h>
 #include <dolfinx/mesh/cell_types.h>
 #include <xtensor-blas/xlinalg.hpp>
 #include <xtensor/xview.hpp>
@@ -22,11 +22,11 @@ namespace
 double compute_determinant(xt::xtensor<double, 2>& A)
 {
   if (A.shape(0) == A.shape(1))
-    return linalg::det(A);
+    return math::det(A);
   else
   {
     auto ATA = xt::linalg::dot(xt::transpose(A), A);
-    return std::sqrt(linalg::det(ATA));
+    return std::sqrt(math::det(ATA));
   }
 }
 } // namespace
@@ -137,7 +137,7 @@ void CoordinateElement::compute_jacobian_inverse(
   {
     J0 = xt::view(J, 0, xt::all(), xt::all());
     if (gdim == tdim)
-      linalg::inv(J0, K0);
+      math::inv(J0, K0);
     else
       K0 = xt::linalg::pinv(J0);
     K = xt::broadcast(K0, K.shape());
@@ -148,7 +148,7 @@ void CoordinateElement::compute_jacobian_inverse(
     {
       J0 = xt::view(J, ip, xt::all(), xt::all());
       if (gdim == tdim)
-        linalg::inv(J0, K0);
+        math::inv(J0, K0);
       else
         K0 = xt::linalg::pinv(J0);
       auto K_ip = xt::view(K, ip, xt::all(), xt::all());

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -18,7 +18,7 @@ using namespace dolfinx::fem;
 namespace
 {
 // Computes the determinant of rectangular matrices
-// det(AT * A) = det(A) * det(A)
+// det(A^T * A) = det(A) * det(A)
 double compute_determinant(xt::xtensor<double, 2>& A)
 {
   if (A.shape(0) == A.shape(1))
@@ -137,9 +137,7 @@ void CoordinateElement::compute_jacobian_inverse(
   {
     J0 = xt::view(J, 0, xt::all(), xt::all());
     if (gdim == tdim)
-    {
-      K0 = xt::linalg::inv(J0);
-    }
+      linalg::inv(J0, K0);
     else
       K0 = xt::linalg::pinv(J0);
     K = xt::broadcast(K0, K.shape());
@@ -150,7 +148,7 @@ void CoordinateElement::compute_jacobian_inverse(
     {
       J0 = xt::view(J, ip, xt::all(), xt::all());
       if (gdim == tdim)
-        K0 = xt::linalg::inv(J0);
+        linalg::inv(J0, K0);
       else
         K0 = xt::linalg::pinv(J0);
       auto K_ip = xt::view(K, ip, xt::all(), xt::all());


### PR DESCRIPTION
xtensor and numpy compute the determinant using LU decomposition.
This PR introduces formulas that are more accurate and faster for matrices up to 3x3.

Impact on performance:
```python3
mesh = dolfinx.UnitCubeMesh(comm, 100, 100, 100, CellType.tetrahedron)
V = dolfinx.FunctionSpace(mesh, ("N1curl", 1))
```

| | Main | This branch |
| :---         |     :---:      |          :---: |
| `compute_point_values`   | 21.30 s    | 17.13 s   |
| `interpolate`    | 47.74 s     | 32.91 s    |

```python3
mesh = dolfinx.UnitCubeMesh(comm, 100, 100, 100, CellType.hexahedron)
V = dolfinx.FunctionSpace(mesh, ("NCE", 1))
```
| | Main | This branch |
| :---         |     :---:      |          :---: |
| `compute_point_values`   | 19.59 s| 15.64 s  |
| `interpolate`    |  58.31 s      | 16.42 s  |


```python3
mesh = dolfinx.UnitCubeMesh(comm, 100, 100, 100, CellType.Tetrahedron)
V = dolfinx.FunctionSpace(mesh, ("Lagrange", 1))
```
| | Main | This branch |
| :---         |     :---:      |          :---: |
| `compute_point_values`   |  25.09  s   | 13.03 s  |
| `interpolate`    |  10.69  s    | 10.70 s |