### PR TITLE
Optimization of `interpolation_coords`

### DIFF
--- a/cpp/dolfinx/fem/interpolate.cpp
+++ b/cpp/dolfinx/fem/interpolate.cpp
@@ -55,7 +55,7 @@ fem::interpolation_coords(const fem::FiniteElement& element,
         double acc = 0;
         for (std::size_t k = 0; k < coordinate_dofs.shape(0); ++k)
           acc += phi(i, k) * coordinate_dofs(k, j);
-        x(j, c * X.shape(0) + i) += acc;
+        x(j, c * X.shape(0) + i) = acc;
       }
     }
   }

--- a/cpp/dolfinx/fem/interpolate.cpp
+++ b/cpp/dolfinx/fem/interpolate.cpp
@@ -48,10 +48,16 @@ fem::interpolation_coords(const fem::FiniteElement& element,
         coordinate_dofs(i, j) = x_g(x_dofs[i], j);
 
     // Push forward coordinates (X -> x)
-    cmap.push_forward(x_cell, coordinate_dofs, phi);
     for (std::size_t i = 0; i < x_cell.shape(0); ++i)
+    {
       for (std::size_t j = 0; j < x_cell.shape(1); ++j)
-        x(j, c * X.shape(0) + i) = x_cell(i, j);
+      {
+        double acc = 0;
+        for (std::size_t k = 0; k < coordinate_dofs.shape(0); ++k)
+          acc += phi(i, k) * coordinate_dofs(k, j);
+        x(j, c * X.shape(0) + i) += acc;
+      }
+    }
   }
 
   return x;

--- a/cpp/dolfinx/fem/interpolate.cpp
+++ b/cpp/dolfinx/fem/interpolate.cpp
@@ -34,7 +34,6 @@ fem::interpolation_coords(const fem::FiniteElement& element,
 
   // Push reference coordinates (X) forward to the physical coordinates
   // (x) for each cell
-  xt::xtensor<double, 2> x_cell = xt::zeros<double>({X.shape(0), gdim});
   xt::xtensor<double, 2> coordinate_dofs
       = xt::zeros<double>({num_dofs_g, gdim});
   std::array<std::size_t, 2> shape = {3, cells.size() * X.shape(0)};
@@ -48,12 +47,12 @@ fem::interpolation_coords(const fem::FiniteElement& element,
         coordinate_dofs(i, j) = x_g(x_dofs[i], j);
 
     // Push forward coordinates (X -> x)
-    for (std::size_t i = 0; i < x_cell.shape(0); ++i)
+    for (std::size_t i = 0; i < X.shape(0); ++i)
     {
-      for (std::size_t j = 0; j < x_cell.shape(1); ++j)
+      for (std::size_t j = 0; j < gdim; ++j)
       {
         double acc = 0;
-        for (std::size_t k = 0; k < coordinate_dofs.shape(0); ++k)
+        for (std::size_t k = 0; k < num_dofs_g; ++k)
           acc += phi(i, k) * coordinate_dofs(k, j);
         x(j, c * X.shape(0) + i) = acc;
       }


### PR DESCRIPTION
Instead of calling push forward with a repeated `ij`-loop and zeroing of data, merge the loops with direct assignment of an accumulator.
Speed-ups compared to main for Nedelec and Lagrange showed below.
![nedelec_speedup_push](https://user-images.githubusercontent.com/8554300/115570434-02d20d00-a2b6-11eb-8a18-29fd093fa569.png)
![lagrange_speedup_push](https://user-images.githubusercontent.com/8554300/115570436-036aa380-a2b6-11eb-8edb-468fe8995868.png)

