### PR TITLE
Bug fixes in CoordinateElement

### DIFF
--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -200,7 +200,7 @@ void CoordinateElement::push_forward(
     xt::xtensor<double, 2>& x, const xt::xtensor<double, 2>& cell_geometry,
     const xt::xtensor<double, 2>& phi) const
 {
-  assert(phi.shape(2) == cell_geometry.shape(0));
+  assert(phi.shape(1) == cell_geometry.shape(0));
 
   // Compute physical coordinates
   // x = phi * cell_geometry;

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -232,7 +232,7 @@ void fem(py::module& m)
                              &dolfinx::fem::CoordinateElement::dof_layout)
       .def("push_forward",
            [](const dolfinx::fem::CoordinateElement& self,
-              const py::array_t<const double, py::array::c_style>& X,
+              const py::array_t<double, py::array::c_style>& X,
               const py::array_t<double, py::array::c_style>& cell_geometry) {
              std::array<std::size_t, 2> s_x
                  = {static_cast<std::size_t>(X.shape(0)),


### PR DESCRIPTION
- `const double` is intepreted by pybind11 as longdouble.
- The assert on shape(2) (3rd dimension) makes no sense on an array of dimension 2.