### PR TITLE
Change getboundary to modern syntax

### DIFF
--- a/python/demo/gmsh/demo_gmsh.py
+++ b/python/demo/gmsh/demo_gmsh.py
@@ -59,7 +59,7 @@ if MPI.COMM_WORLD.rank == 0:
     model.occ.synchronize()
 
     # Add physical tag 1 for exterior surfaces
-    boundary = model.getBoundary((3, model_dim_tags[0][0][1]))
+    boundary = model.getBoundary(model_dim_tags[0])
     boundary_ids = [b[1] for b in boundary]
     model.addPhysicalGroup(2, boundary_ids, tag=1)
     model.setPhysicalName(2, 1, "Sphere surface")


### PR DESCRIPTION
Part of the step by step approach of bumping gmsh. 
We start with updating syntax that is deprecated in future releases.