### PR TITLE
Expose math header

### DIFF
--- a/cpp/dolfinx/common/CMakeLists.txt
+++ b/cpp/dolfinx/common/CMakeLists.txt
@@ -13,6 +13,7 @@ set(HEADERS_common
   ${CMAKE_CURRENT_SOURCE_DIR}/TimeLogger.h
   ${CMAKE_CURRENT_SOURCE_DIR}/TimeLogManager.h
   ${CMAKE_CURRENT_SOURCE_DIR}/array2d.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/math.h
   ${CMAKE_CURRENT_SOURCE_DIR}/timing.h
   ${CMAKE_CURRENT_SOURCE_DIR}/types.h
   ${CMAKE_CURRENT_SOURCE_DIR}/UniqueIdGenerator.h


### PR DESCRIPTION
As the math header is very useful for other C++ code that uses dolfinx, I suggest exposing it.