### PR TITLE
Use xtensor in pack_coefficients

### DIFF
--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -1,6 +1,6 @@
 // Copyright (C) 2018-2019 Garth N. Wells
 //
-// This file is part of DOLFINX (https://www.fenicsproject.org)
+// This file is part of DOLFINx (https://www.fenicsproject.org)
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -304,7 +304,7 @@ void assemble_exterior_facets(
     }
 
     // Tabulate tensor
-    auto coeff_array = xt::row(coeffs, c);
+    auto coeff_array = xt::row(coeffs, f);
     std::fill(Ae.begin(), Ae.end(), 0);
     kernel(Ae.data(), coeff_array.data(), constants.data(),
            coordinate_dofs.data(), &local_facet,

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -304,7 +304,7 @@ void assemble_exterior_facets(
     }
 
     // Tabulate tensor
-    auto coeff_array = xt::row(coeffs, f);
+    auto coeff_array = xt::row(coeffs, cells[0]);
     std::fill(Ae.begin(), Ae.end(), 0);
     kernel(Ae.data(), coeff_array.data(), constants.data(),
            coordinate_dofs.data(), &local_facet,

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -378,7 +378,7 @@ void assemble_interior_facets(
   xt::xtensor<double, 3> coordinate_dofs({2, num_dofs_g, gdim});
   std::vector<T> Ae, be;
   std::vector<T> coeff_array(2 * offsets.back());
-  assert(offsets.back() == coeffs.shape[1]);
+  assert(offsets.back() == coeffs.shape(1));
 
   // Temporaries for joint dofmaps
   std::vector<std::int32_t> dmapjoint0, dmapjoint1;

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -1,6 +1,6 @@
 // Copyright (C) 2019-2020 Garth N. Wells
 //
-// This file is part of DOLFINX (https://www.fenicsproject.org)
+// This file is part of DOLFINx (https://www.fenicsproject.org)
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -1,6 +1,6 @@
 // Copyright (C) 2018-2019 Garth N. Wells
 //
-// This file is part of DOLFINX (https://www.fenicsproject.org)
+// This file is part of DOLFINx (https://www.fenicsproject.org)
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 

--- a/cpp/dolfinx/fem/evaluate.h
+++ b/cpp/dolfinx/fem/evaluate.h
@@ -1,6 +1,6 @@
 // Copyright (C) 2020 Jack S. Hale
 //
-// This file is part of DOLFINX (https://www.fenicsproject.org)
+// This file is part of DOLFINx (https://www.fenicsproject.org)
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 //

--- a/cpp/dolfinx/fem/evaluate.h
+++ b/cpp/dolfinx/fem/evaluate.h
@@ -1,6 +1,6 @@
 // Copyright (C) 2020 Jack S. Hale
 //
-// This file is part of DOLFINx (https://www.fenicsproject.org)
+// This file is part of DOLFINX (https://www.fenicsproject.org)
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 //
@@ -33,7 +33,7 @@ void eval(array2d<T>& values, const fem::Expression<T>& e,
   assert(mesh);
 
   // Prepare coefficients
-  const array2d<T> coeffs = dolfinx::fem::pack_coefficients(e);
+  const xt::xtensor<T, 2> coeffs = dolfinx::fem::pack_coefficients(e);
 
   // Prepare constants
   const std::vector<T> constant_values = dolfinx::fem::pack_constants(e);
@@ -71,7 +71,7 @@ void eval(array2d<T>& values, const fem::Expression<T>& e,
                   std::next(coordinate_dofs.begin(), i * gdim));
     }
 
-    auto coeff_cell = coeffs.row(cell);
+    auto coeff_cell = xt::row(coeffs, cell);
     std::fill(values_e.begin(), values_e.end(), 0.0);
     fn(values_e.data(), coeff_cell.data(), constant_values.data(),
        coordinate_dofs.data());

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -1,6 +1,6 @@
 // Copyright (C) 2013-2020 Johan Hake, Jan Blechta and Garth N. Wells
 //
-// This file is part of DOLFINX (https://www.fenicsproject.org)
+// This file is part of DOLFINx (https://www.fenicsproject.org)
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -1,6 +1,6 @@
 // Copyright (C) 2013-2020 Johan Hake, Jan Blechta and Garth N. Wells
 //
-// This file is part of DOLFINx (https://www.fenicsproject.org)
+// This file is part of DOLFINX (https://www.fenicsproject.org)
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
@@ -373,7 +373,7 @@ create_functionspace(ufc_function_space* (*fptr)(const char*),
 // NOTE: This is subject to change
 /// Pack coefficients of u of generic type U ready for assembly
 template <typename U>
-array2d<typename U::scalar_type> pack_coefficients(const U& u)
+xt::xtensor<typename U::scalar_type, 2> pack_coefficients(const U& u)
 {
   using T = typename U::scalar_type;
 
@@ -401,7 +401,7 @@ array2d<typename U::scalar_type> pack_coefficients(const U& u)
         + mesh->topology().index_map(tdim)->num_ghosts();
 
   // Copy data into coefficient array
-  array2d<T> c(num_cells, offsets.back());
+  xt::xtensor<T, 2> c = xt::empty<double>({num_cells, offsets.back()});
   if (!coefficients.empty())
   {
     for (int cell = 0; cell < num_cells; ++cell)

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -67,13 +67,13 @@ void fem(py::module& m)
   m.def(
       "pack_coefficients",
       [](dolfinx::fem::Form<PetscScalar>& form) {
-        return as_pyarray2d(dolfinx::fem::pack_coefficients(form));
+        return xt_as_pyarray(dolfinx::fem::pack_coefficients(form));
       },
       "Pack coefficients for a Form.");
   m.def(
       "pack_coefficients",
       [](dolfinx::fem::Expression<PetscScalar>& expr) {
-        return as_pyarray2d(dolfinx::fem::pack_coefficients(expr));
+        return xt_as_pyarray(dolfinx::fem::pack_coefficients(expr));
       },
       "Pack coefficients for an Expression.");
   m.def(


### PR DESCRIPTION
`std::vector` can potentially initialize data with zeros (expensive), using `xt::empty` guarantees that data is allocated but not initialized.