### PR TITLE
Python related includes are installed into `wrappers/`

### DIFF
--- a/python/dolfinx/__init__.py
+++ b/python/dolfinx/__init__.py
@@ -60,9 +60,9 @@ del sys
 def get_include(user=False):
     import os
     d = os.path.dirname(__file__)
-    if os.path.exists(os.path.join(d, "include")):
+    if os.path.exists(os.path.join(d, "wrappers")):
         # Package is installed
-        return os.path.join(d, "include")
+        return os.path.join(d, "wrappers")
     else:
         # Package is from a source directory
         return os.path.join(os.path.dirname(d), "src")


### PR DESCRIPTION
Something changed about install location since you wrote this code last year @garth-wells.