### PR TITLE
Increase vector size for OpenMPI

### DIFF
--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -398,6 +398,7 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
   {
     // Topological dimension of mesh entity that dof is associated with
     const int d = dof_entity[i].first;
+    global[d].reserve(4); // Ensure global[d] has allocation
 
     // Index of mesh entity that dof is associated with
     const int entity = dof_entity[i].second;

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -398,7 +398,6 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
   {
     // Topological dimension of mesh entity that dof is associated with
     const int d = dof_entity[i].first;
-    global[d].reserve(4); // Ensure global[d] has allocation
 
     // Index of mesh entity that dof is associated with
     const int entity = dof_entity[i].second;
@@ -428,8 +427,8 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
 
       // Number and values to send and receive
       const int num_indices = global[d].size();
-      std::vector<int> num_indices_recv(indegree);
-      num_indices_recv.reserve(4);
+      // NB add 1 for OpenMPI to ensure vector is allocated when indegree = 0
+      std::vector<int> num_indices_recv(indegree + 1);
       MPI_Neighbor_allgather(&num_indices, 1, MPI_INT, num_indices_recv.data(),
                              1, MPI_INT, comm[d]);
 
@@ -437,17 +436,13 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
       // number of received items.
       std::vector<int>& disp = recv_offsets[d];
       disp.resize(indegree + 1);
-      std::partial_sum(num_indices_recv.begin(), num_indices_recv.end(),
-                       disp.begin() + 1);
+      std::partial_sum(num_indices_recv.begin(),
+                       num_indices_recv.begin() + indegree, disp.begin() + 1);
 
       // TODO: use MPI_Ineighbor_alltoallv
       // Send global index of dofs with bcs to all neighbors
       std::vector<std::int64_t>& dofs_received = all_dofs_received[d];
       dofs_received.resize(disp.back());
-      std::cout << "global[d] = " << global[d].data()
-                << " dofs_received = " << dofs_received.data()
-                << " num_indices_recv = " << num_indices_recv.data()
-                << " disp = " << disp.data() << "\n";
       MPI_Ineighbor_allgatherv(global[d].data(), global[d].size(), MPI_INT64_T,
                                dofs_received.data(), num_indices_recv.data(),
                                disp.data(), MPI_INT64_T, comm[d],

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -429,6 +429,7 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
       // Number and values to send and receive
       const int num_indices = global[d].size();
       std::vector<int> num_indices_recv(indegree);
+      num_indices_recv.reserve(4);
       MPI_Neighbor_allgather(&num_indices, 1, MPI_INT, num_indices_recv.data(),
                              1, MPI_INT, comm[d]);
 
@@ -443,6 +444,10 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
       // Send global index of dofs with bcs to all neighbors
       std::vector<std::int64_t>& dofs_received = all_dofs_received[d];
       dofs_received.resize(disp.back());
+      std::cout << "global[d] = " << global[d].data()
+                << " dofs_received = " << dofs_received.data()
+                << " num_indices_recv = " << num_indices_recv.data()
+                << " disp = " << disp.data() << "\n";
       MPI_Ineighbor_allgatherv(global[d].data(), global[d].size(), MPI_INT64_T,
                                dofs_received.data(), num_indices_recv.data(),
                                disp.data(), MPI_INT64_T, comm[d],


### PR DESCRIPTION
Fixes Issue #1535 caused by unallocated vector of size zero.