### PR TITLE
Allow user to supply form constants and coefficients to assemblers

### DIFF
--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -32,7 +32,8 @@ template <typename T>
 void assemble_matrix(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                             const std::int32_t*, const T*)>& mat_set_values,
-    const Form<T>& a, const std::vector<bool>& bc0,
+    const Form<T>& a, const xtl::span<const T>& constants,
+    const array2d<T>& coeffs, const std::vector<bool>& bc0,
     const std::vector<bool>& bc1);
 
 /// Execute kernel over cells and accumulate result in matrix
@@ -41,14 +42,14 @@ void assemble_cells(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                             const std::int32_t*, const T*)>& mat_set_values,
     const mesh::Geometry& geometry,
-    const std::vector<std::int32_t>& active_cells,
+    const xtl::span<const std::int32_t>& active_cells,
     const graph::AdjacencyList<std::int32_t>& dofmap0, const int bs0,
     const graph::AdjacencyList<std::int32_t>& dofmap1, const int bs1,
     const std::vector<bool>& bc0, const std::vector<bool>& bc1,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*, const std::uint32_t)>& kernel,
-    const array2d<T>& coeffs, const std::vector<T>& constants,
-    const std::vector<std::uint32_t>& cell_info);
+    const array2d<T>& coeffs, const xtl::span<const T>& constants,
+    const xtl::span<const std::uint32_t>& cell_info);
 
 /// Execute kernel over exterior facets and  accumulate result in Mat
 template <typename T>
@@ -61,9 +62,9 @@ void assemble_exterior_facets(
     const std::vector<bool>& bc0, const std::vector<bool>& bc1,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*, const std::uint32_t)>& fn,
-    const array2d<T>& coeffs, const std::vector<T>& constants,
-    const std::vector<std::uint32_t>& cell_info,
-    const std::vector<std::uint8_t>& perms);
+    const array2d<T>& coeffs, const xtl::span<const T>& constants,
+    const xtl::span<const std::uint32_t>& cell_info,
+    const xtl::span<const std::uint8_t>& perms);
 
 /// Execute kernel over interior facets and  accumulate result in Mat
 template <typename T>
@@ -75,17 +76,18 @@ void assemble_interior_facets(
     const std::vector<bool>& bc0, const std::vector<bool>& bc1,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*, const std::uint32_t)>& kernel,
-    const array2d<T>& coeffs, const std::vector<int>& offsets,
-    const std::vector<T>& constants,
-    const std::vector<std::uint32_t>& cell_info,
-    const std::vector<std::uint8_t>& perms);
+    const array2d<T>& coeffs, const xtl::span<const int>& offsets,
+    const xtl::span<const T>& constants,
+    const xtl::span<const std::uint32_t>& cell_info,
+    const xtl::span<const std::uint8_t>& perms);
 
 //-----------------------------------------------------------------------------
 template <typename T>
 void assemble_matrix(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                             const std::int32_t*, const T*)>& mat_set_values,
-    const Form<T>& a, const std::vector<bool>& bc0,
+    const Form<T>& a, const xtl::span<const T>& constants,
+    const array2d<T>& coeffs, const std::vector<bool>& bc0,
     const std::vector<bool>& bc1)
 {
   std::shared_ptr<const mesh::Mesh> mesh = a.mesh();
@@ -105,12 +107,6 @@ void assemble_matrix(
   const int bs0 = dofmap0->bs();
   const graph::AdjacencyList<std::int32_t>& dofs1 = dofmap1->list();
   const int bs1 = dofmap1->bs();
-
-  // Prepare constants
-  const std::vector<T> constants = pack_constants(a);
-
-  // Prepare coefficients
-  const array2d<T> coeffs = pack_coefficients(a);
 
   const bool needs_permutation_data = a.needs_permutation_data();
   if (needs_permutation_data)
@@ -166,14 +162,14 @@ void assemble_cells(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                             const std::int32_t*, const T*)>& mat_set,
     const mesh::Geometry& geometry,
-    const std::vector<std::int32_t>& active_cells,
+    const xtl::span<const std::int32_t>& active_cells,
     const graph::AdjacencyList<std::int32_t>& dofmap0, const int bs0,
     const graph::AdjacencyList<std::int32_t>& dofmap1, const int bs1,
     const std::vector<bool>& bc0, const std::vector<bool>& bc1,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*, const std::uint32_t)>& kernel,
-    const array2d<T>& coeffs, const std::vector<T>& constants,
-    const std::vector<std::uint32_t>& cell_info)
+    const array2d<T>& coeffs, const xtl::span<const T>& constants,
+    const xtl::span<const std::uint32_t>& cell_info)
 {
   const std::size_t gdim = geometry.dim();
 
@@ -250,15 +246,15 @@ template <typename T>
 void assemble_exterior_facets(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                             const std::int32_t*, const T*)>& mat_set_values,
-    const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
+    const mesh::Mesh& mesh, const xtl::span<const std::int32_t>& active_facets,
     const graph::AdjacencyList<std::int32_t>& dofmap0, int bs0,
     const graph::AdjacencyList<std::int32_t>& dofmap1, int bs1,
     const std::vector<bool>& bc0, const std::vector<bool>& bc1,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*, const std::uint32_t)>& kernel,
-    const array2d<T>& coeffs, const std::vector<T>& constants,
-    const std::vector<std::uint32_t>& cell_info,
-    const std::vector<std::uint8_t>& perms)
+    const array2d<T>& coeffs, const xtl::span<const T>& constants,
+    const xtl::span<const std::uint32_t>& cell_info,
+    const xtl::span<const std::uint8_t>& perms)
 {
   const std::size_t gdim = mesh.geometry().dim();
   const int tdim = mesh.topology().dim();
@@ -352,15 +348,15 @@ template <typename T>
 void assemble_interior_facets(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                             const std::int32_t*, const T*)>& mat_set_values,
-    const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
+    const mesh::Mesh& mesh, const xtl::span<const std::int32_t>& active_facets,
     const DofMap& dofmap0, int bs0, const DofMap& dofmap1, int bs1,
     const std::vector<bool>& bc0, const std::vector<bool>& bc1,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*, const std::uint32_t)>& fn,
-    const array2d<T>& coeffs, const std::vector<int>& offsets,
-    const std::vector<T>& constants,
-    const std::vector<std::uint32_t>& cell_info,
-    const std::vector<std::uint8_t>& perms)
+    const array2d<T>& coeffs, const xtl::span<const int>& offsets,
+    const xtl::span<const T>& constants,
+    const xtl::span<const std::uint32_t>& cell_info,
+    const xtl::span<const std::uint8_t>& perms)
 {
   const std::size_t gdim = mesh.geometry().dim();
   const int tdim = mesh.topology().dim();
@@ -402,7 +398,7 @@ void assemble_interior_facets(
     assert(it1 != facets1.end());
     const int local_facet1 = std::distance(facets1.begin(), it1);
 
-    const std::array local_facet{local_facet0, local_facet1};
+    const std::array local_facet = {local_facet0, local_facet1};
 
     // Get cell geometry
     auto x_dofs0 = x_dofmap.links(cells[0]);

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -56,7 +56,7 @@ template <typename T>
 void assemble_exterior_facets(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                             const std::int32_t*, const T*)>& mat_set_values,
-    const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
+    const mesh::Mesh& mesh, const xtl::span<const std::int32_t>& active_facets,
     const graph::AdjacencyList<std::int32_t>& dofmap0, int bs0,
     const graph::AdjacencyList<std::int32_t>& dofmap1, int bs1,
     const std::vector<bool>& bc0, const std::vector<bool>& bc1,
@@ -71,7 +71,7 @@ template <typename T>
 void assemble_interior_facets(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                             const std::int32_t*, const T*)>& mat_set_values,
-    const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
+    const mesh::Mesh& mesh, const xtl::span<const std::int32_t>& active_facets,
     const DofMap& dofmap0, int bs0, const DofMap& dofmap1, int bs1,
     const std::vector<bool>& bc0, const std::vector<bool>& bc1,
     const std::function<void(T*, const T*, const T*, const double*, const int*,

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -81,8 +81,8 @@ T assemble_scalar(const fem::Form<T>& M, const xtl::span<const T>& constants,
     const auto& fn = M.kernel(IntegralType::cell, i);
     const std::vector<std::int32_t>& active_cells
         = M.domains(IntegralType::cell, i);
-    value += fem::impl::assemble_cells(mesh->geometry(), active_cells, fn,
-                                       constants, coeffs, cell_info);
+    value += impl::assemble_cells(mesh->geometry(), active_cells, fn, constants,
+                                  coeffs, cell_info);
   }
 
   if (M.num_integrals(IntegralType::exterior_facet) > 0
@@ -101,7 +101,7 @@ T assemble_scalar(const fem::Form<T>& M, const xtl::span<const T>& constants,
       const auto& fn = M.kernel(IntegralType::exterior_facet, i);
       const std::vector<std::int32_t>& active_facets
           = M.domains(IntegralType::exterior_facet, i);
-      value += fem::impl::assemble_exterior_facets(
+      value += impl::assemble_exterior_facets(
           *mesh, active_facets, fn, constants, coeffs, cell_info, perms);
     }
 
@@ -111,9 +111,9 @@ T assemble_scalar(const fem::Form<T>& M, const xtl::span<const T>& constants,
       const auto& fn = M.kernel(IntegralType::interior_facet, i);
       const std::vector<std::int32_t>& active_facets
           = M.domains(IntegralType::interior_facet, i);
-      value += fem::impl::assemble_interior_facets(*mesh, active_facets, fn,
-                                                   constants, coeffs, c_offsets,
-                                                   cell_info, perms);
+      value += impl::assemble_interior_facets(*mesh, active_facets, fn,
+                                              constants, coeffs, c_offsets,
+                                              cell_info, perms);
     }
   }
 

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -82,7 +82,7 @@ T assemble_scalar(const fem::Form<T>& M, const xtl::span<const T>& constants,
     const std::vector<std::int32_t>& active_cells
         = M.domains(IntegralType::cell, i);
     value += fem::impl::assemble_cells(mesh->geometry(), active_cells, fn,
-                                       coeffs, constants, cell_info);
+                                       constants, coeffs, cell_info);
   }
 
   if (M.num_integrals(IntegralType::exterior_facet) > 0
@@ -102,7 +102,7 @@ T assemble_scalar(const fem::Form<T>& M, const xtl::span<const T>& constants,
       const std::vector<std::int32_t>& active_facets
           = M.domains(IntegralType::exterior_facet, i);
       value += fem::impl::assemble_exterior_facets(
-          *mesh, active_facets, fn, coeffs, constants, cell_info, perms);
+          *mesh, active_facets, fn, constants, coeffs, cell_info, perms);
     }
 
     const std::vector<int> c_offsets = M.coefficient_offsets();
@@ -112,7 +112,7 @@ T assemble_scalar(const fem::Form<T>& M, const xtl::span<const T>& constants,
       const std::vector<std::int32_t>& active_facets
           = M.domains(IntegralType::interior_facet, i);
       value += fem::impl::assemble_interior_facets(*mesh, active_facets, fn,
-                                                   coeffs, c_offsets, constants,
+                                                   constants, coeffs, c_offsets,
                                                    cell_info, perms);
     }
   }

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -23,63 +23,50 @@ namespace dolfinx::fem::impl
 
 /// Assemble functional into an scalar
 template <typename T>
-T assemble_scalar(const fem::Form<T>& M);
+T assemble_scalar(const fem::Form<T>& M, const xtl::span<const T>& constants,
+                  const array2d<T>& coeffs);
 
 /// Assemble functional over cells
 template <typename T>
 T assemble_cells(
     const mesh::Geometry& geometry,
-    const std::vector<std::int32_t>& active_cells,
+    const xtl::span<const std::int32_t>& active_cells,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*, const std::uint32_t)>& fn,
-    const array2d<T>& coeffs, const std::vector<T>& constant_values,
-    const std::vector<std::uint32_t>& cell_info);
+    const xtl::span<const T>& constants, const array2d<T>& coeffs,
+    const xtl::span<const std::uint32_t>& cell_info);
 
 /// Execute kernel over exterior facets and accumulate result
 template <typename T>
 T assemble_exterior_facets(
-    const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_cells,
+    const mesh::Mesh& mesh, const xtl::span<const std::int32_t>& active_cells,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*, const std::uint32_t)>& fn,
-    const array2d<T>& coeffs, const std::vector<T>& constant_values,
-    const std::vector<std::uint32_t>& cell_info,
-    const std::vector<std::uint8_t>& perms);
+    const xtl::span<const T>& constants, const array2d<T>& coeffs,
+    const xtl::span<const std::uint32_t>& cell_info,
+    const xtl::span<const std::uint8_t>& perms);
 
 /// Assemble functional over interior facets
 template <typename T>
 T assemble_interior_facets(
-    const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_cells,
+    const mesh::Mesh& mesh, const xtl::span<const std::int32_t>& active_cells,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*, const std::uint32_t)>& fn,
-    const array2d<T>& coeffs, const std::vector<int>& offsets,
-    const std::vector<T>& constant_values,
-    const std::vector<std::uint32_t>& cell_info,
-    const std::vector<std::uint8_t>& perms);
+    const xtl::span<const T>& constants, const array2d<T>& coeffs,
+    const xtl::span<const int>& offsets,
+    const xtl::span<const std::uint32_t>& cell_info,
+    const xtl::span<const std::uint8_t>& perms);
 
 //-----------------------------------------------------------------------------
 template <typename T>
-T assemble_scalar(const fem::Form<T>& M)
+T assemble_scalar(const fem::Form<T>& M, const xtl::span<const T>& constants,
+                  const array2d<T>& coeffs)
 {
   std::shared_ptr<const mesh::Mesh> mesh = M.mesh();
   assert(mesh);
   const int tdim = mesh->topology().dim();
   const std::int32_t num_cells
       = mesh->topology().connectivity(tdim, 0)->num_nodes();
-
-  // Prepare constants
-  const std::vector<std::shared_ptr<const fem::Constant<T>>>& constants
-      = M.constants();
-
-  std::vector<T> constant_values;
-  for (auto const& constant : constants)
-  {
-    // Get underlying data array of this Constant
-    const std::vector<T>& array = constant->value;
-    constant_values.insert(constant_values.end(), array.begin(), array.end());
-  }
-
-  // Prepare coefficients
-  const array2d<T> coeffs = pack_coefficients(M);
 
   const bool needs_permutation_data = M.needs_permutation_data();
   if (needs_permutation_data)
@@ -95,7 +82,7 @@ T assemble_scalar(const fem::Form<T>& M)
     const std::vector<std::int32_t>& active_cells
         = M.domains(IntegralType::cell, i);
     value += fem::impl::assemble_cells(mesh->geometry(), active_cells, fn,
-                                       coeffs, constant_values, cell_info);
+                                       coeffs, constants, cell_info);
   }
 
   if (M.num_integrals(IntegralType::exterior_facet) > 0
@@ -115,7 +102,7 @@ T assemble_scalar(const fem::Form<T>& M)
       const std::vector<std::int32_t>& active_facets
           = M.domains(IntegralType::exterior_facet, i);
       value += fem::impl::assemble_exterior_facets(
-          *mesh, active_facets, fn, coeffs, constant_values, cell_info, perms);
+          *mesh, active_facets, fn, coeffs, constants, cell_info, perms);
     }
 
     const std::vector<int> c_offsets = M.coefficient_offsets();
@@ -124,9 +111,9 @@ T assemble_scalar(const fem::Form<T>& M)
       const auto& fn = M.kernel(IntegralType::interior_facet, i);
       const std::vector<std::int32_t>& active_facets
           = M.domains(IntegralType::interior_facet, i);
-      value += fem::impl::assemble_interior_facets(
-          *mesh, active_facets, fn, coeffs, c_offsets, constant_values,
-          cell_info, perms);
+      value += fem::impl::assemble_interior_facets(*mesh, active_facets, fn,
+                                                   coeffs, c_offsets, constants,
+                                                   cell_info, perms);
     }
   }
 
@@ -136,11 +123,11 @@ T assemble_scalar(const fem::Form<T>& M)
 template <typename T>
 T assemble_cells(
     const mesh::Geometry& geometry,
-    const std::vector<std::int32_t>& active_cells,
+    const xtl::span<const std::int32_t>& active_cells,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*, const std::uint32_t)>& fn,
-    const array2d<T>& coeffs, const std::vector<T>& constant_values,
-    const std::vector<std::uint32_t>& cell_info)
+    const xtl::span<const T>& constants, const array2d<T>& coeffs,
+    const xtl::span<const std::uint32_t>& cell_info)
 {
   const std::size_t gdim = geometry.dim();
 
@@ -167,8 +154,8 @@ T assemble_cells(
     }
 
     auto coeff_cell = coeffs.row(c);
-    fn(&value, coeff_cell.data(), constant_values.data(),
-       coordinate_dofs.data(), nullptr, nullptr, cell_info[c]);
+    fn(&value, coeff_cell.data(), constants.data(), coordinate_dofs.data(),
+       nullptr, nullptr, cell_info[c]);
   }
 
   return value;
@@ -176,12 +163,12 @@ T assemble_cells(
 //-----------------------------------------------------------------------------
 template <typename T>
 T assemble_exterior_facets(
-    const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
+    const mesh::Mesh& mesh, const xtl::span<const std::int32_t>& active_facets,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*, const std::uint32_t)>& fn,
-    const array2d<T>& coeffs, const std::vector<T>& constant_values,
-    const std::vector<std::uint32_t>& cell_info,
-    const std::vector<std::uint8_t>& perms)
+    const xtl::span<const T>& constants, const array2d<T>& coeffs,
+    const xtl::span<const std::uint32_t>& cell_info,
+    const xtl::span<const std::uint8_t>& perms)
 {
   const std::size_t gdim = mesh.geometry().dim();
   const int tdim = mesh.topology().dim();
@@ -224,9 +211,9 @@ T assemble_exterior_facets(
     }
 
     auto coeff_cell = coeffs.row(cell);
-    fn(&value, coeff_cell.data(), constant_values.data(),
-       coordinate_dofs.data(), &local_facet,
-       &perms[cell * facets.size() + local_facet], cell_info[cell]);
+    fn(&value, coeff_cell.data(), constants.data(), coordinate_dofs.data(),
+       &local_facet, &perms[cell * facets.size() + local_facet],
+       cell_info[cell]);
   }
 
   return value;
@@ -234,13 +221,13 @@ T assemble_exterior_facets(
 //-----------------------------------------------------------------------------
 template <typename T>
 T assemble_interior_facets(
-    const mesh::Mesh& mesh, const std::vector<std::int32_t>& active_facets,
+    const mesh::Mesh& mesh, const xtl::span<const std::int32_t>& active_facets,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*, const std::uint32_t)>& fn,
-    const array2d<T>& coeffs, const std::vector<int>& offsets,
-    const std::vector<T>& constant_values,
-    const std::vector<std::uint32_t>& cell_info,
-    const std::vector<std::uint8_t>& perms)
+    const xtl::span<const T>& constants, const array2d<T>& coeffs,
+    const xtl::span<const int>& offsets,
+    const xtl::span<const std::uint32_t>& cell_info,
+    const xtl::span<const std::uint8_t>& perms)
 {
   const std::size_t gdim = mesh.geometry().dim();
   const int tdim = mesh.topology().dim();
@@ -314,9 +301,8 @@ T assemble_interior_facets(
 
     const std::array perm{perms[cells[0] * facets_per_cell + local_facet[0]],
                           perms[cells[1] * facets_per_cell + local_facet[1]]};
-    fn(&value, coeff_array.data(), constant_values.data(),
-       coordinate_dofs.data(), local_facet.data(), perm.data(),
-       cell_info[cells[0]]);
+    fn(&value, coeff_array.data(), constants.data(), coordinate_dofs.data(),
+       local_facet.data(), perm.data(), cell_info[cells[0]]);
   }
 
   return value;

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -88,8 +88,8 @@ void assemble_interior_facets(
 /// @param[in,out] b The vector to be modified
 /// @param[in] a The bilinear forms, where a[j] is the form that
 /// generates A_j
-/// @param[in] coeffs Coefficients that appear in `a`
 /// @param[in] constants Constants that appear in `a`
+/// @param[in] coeffs Coefficients that appear in `a`
 /// @param[in] bcs1 List of boundary conditions for each block, i.e.
 /// bcs1[2] are the boundary conditions applied to the columns of a[2] /
 /// x0[2] block

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -567,8 +567,8 @@ void assemble_vector(xtl::span<T> b, const Form<T>& L,
     const auto& fn = L.kernel(IntegralType::cell, i);
     const std::vector<std::int32_t>& active_cells
         = L.domains(IntegralType::cell, i);
-    fem::impl::assemble_cells(b, mesh->geometry(), active_cells, dofs, bs, fn,
-                              constants, coeffs, cell_info);
+    impl::assemble_cells(b, mesh->geometry(), active_cells, dofs, bs, fn,
+                         constants, coeffs, cell_info);
   }
 
   if (L.num_integrals(IntegralType::exterior_facet) > 0
@@ -586,8 +586,8 @@ void assemble_vector(xtl::span<T> b, const Form<T>& L,
       const auto& fn = L.kernel(IntegralType::exterior_facet, i);
       const std::vector<std::int32_t>& active_facets
           = L.domains(IntegralType::exterior_facet, i);
-      fem::impl::assemble_exterior_facets(b, *mesh, active_facets, dofs, bs, fn,
-                                          constants, coeffs, cell_info, perms);
+      impl::assemble_exterior_facets(b, *mesh, active_facets, dofs, bs, fn,
+                                     constants, coeffs, cell_info, perms);
     }
 
     const std::vector<int> c_offsets = L.coefficient_offsets();
@@ -596,9 +596,9 @@ void assemble_vector(xtl::span<T> b, const Form<T>& L,
       const auto& fn = L.kernel(IntegralType::interior_facet, i);
       const std::vector<std::int32_t>& active_facets
           = L.domains(IntegralType::interior_facet, i);
-      fem::impl::assemble_interior_facets(b, *mesh, active_facets, *dofmap, fn,
-                                          constants, coeffs, c_offsets,
-                                          cell_info, perms);
+      impl::assemble_interior_facets(b, *mesh, active_facets, *dofmap, fn,
+                                     constants, coeffs, c_offsets, cell_info,
+                                     perms);
     }
   }
 }

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -156,7 +156,6 @@ void apply_lifting(
 
 // -- Matrices ---------------------------------------------------------------
 
-// Experimental
 /// Assemble bilinear form into a matrix
 /// @param[in] mat_add The function for adding values into the matrix
 /// @param[in] a The bilinear from to assemble
@@ -206,7 +205,6 @@ void assemble_matrix(
                         dof_marker1);
 }
 
-// Experimental
 /// Assemble bilinear form into a matrix
 /// @param[in] mat_add The function for adding values into the matrix
 /// @param[in] a The bilinear from to assemble

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -37,7 +37,7 @@ template <typename T>
 T assemble_scalar(const Form<T>& M, const xtl::span<const T>& constants,
                   const array2d<T>& coeffs)
 {
-  return fem::impl::assemble_scalar(M, constants, coeffs);
+  return impl::assemble_scalar(M, constants, coeffs);
 }
 
 /// Assemble functional into scalar
@@ -68,7 +68,7 @@ void assemble_vector(xtl::span<T> b, const Form<T>& L,
                      const xtl::span<const T>& constants,
                      const array2d<T>& coeffs)
 {
-  fem::impl::assemble_vector(b, L, constants, coeffs);
+  impl::assemble_vector(b, L, constants, coeffs);
 }
 
 /// Assemble linear form into a vector
@@ -109,7 +109,7 @@ void apply_lifting(
     const std::vector<std::vector<std::shared_ptr<const DirichletBC<T>>>>& bcs1,
     const std::vector<xtl::span<const T>>& x0, double scale)
 {
-  fem::impl::apply_lifting(b, a, constants, coeffs, bcs1, x0, scale);
+  impl::apply_lifting(b, a, constants, coeffs, bcs1, x0, scale);
 }
 
 /// Modify b such that:

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -145,8 +145,13 @@ void assemble_matrix(
     }
   }
 
+  // Prepare constants and coefficients
+  const std::vector<T> constants = pack_constants(a);
+  const array2d<T> coeffs = pack_coefficients(a);
+
   // Assemble
-  impl::assemble_matrix(mat_add, a, dof_marker0, dof_marker1);
+  impl::assemble_matrix(mat_add, a, tcb::make_span(constants), coeffs,
+                        dof_marker0, dof_marker1);
 }
 
 /// Assemble bilinear form into a matrix. Matrix must already be
@@ -167,7 +172,13 @@ void assemble_matrix(
     const std::vector<bool>& dof_marker1)
 
 {
-  impl::assemble_matrix(mat_add, a, dof_marker0, dof_marker1);
+  // Prepare constants and coefficients
+  const std::vector<T> constants = pack_constants(a);
+  const array2d<T> coeffs = pack_coefficients(a);
+
+  // Assemble
+  impl::assemble_matrix(mat_add, a, tcb::make_span(constants), coeffs,
+                        dof_marker0, dof_marker1);
 }
 
 /// Sets a value to the diagonal of a matrix for specified rows. It is

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -32,7 +32,9 @@ class FunctionSpace;
 template <typename T>
 T assemble_scalar(const Form<T>& M)
 {
-  return fem::impl::assemble_scalar(M);
+  const std::vector<T> constants = pack_constants(M);
+  const array2d<T> coeffs = pack_coefficients(M);
+  return fem::impl::assemble_scalar(M, tcb::make_span(constants), coeffs);
 }
 
 // -- Vectors ----------------------------------------------------------------

--- a/cpp/dolfinx/fem/evaluate.h
+++ b/cpp/dolfinx/fem/evaluate.h
@@ -19,7 +19,7 @@ namespace dolfinx::fem
 template <typename T>
 class Expression;
 
-/// Evaluate a UFC expression.
+/// Evaluate a UFC expression
 /// @param[out] values An array to evaluate the expression into
 /// @param[in] e The expression to evaluate
 /// @param[in] active_cells The cells on which to evaluate the
@@ -32,11 +32,9 @@ void eval(array2d<T>& values, const fem::Expression<T>& e,
   auto mesh = e.mesh();
   assert(mesh);
 
-  // Prepare coefficients
-  const array2d<T> coeffs = dolfinx::fem::pack_coefficients(e);
-
-  // Prepare constants
-  const std::vector<T> constant_values = dolfinx::fem::pack_constants(e);
+  // Prepare coefficients and constants
+  const array2d<T> coeffs = pack_coefficients(e);
+  const std::vector<T> constant_values = pack_constants(e);
 
   const auto& fn = e.get_tabulate_expression();
 

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -66,27 +66,23 @@ void fem(py::module& m)
         "Create a sparsity pattern for bilinear form.");
   m.def(
       "pack_coefficients",
-      [](dolfinx::fem::Form<PetscScalar>& form) {
-        return as_pyarray2d(dolfinx::fem::pack_coefficients(form));
-      },
+      [](dolfinx::fem::Form<PetscScalar>& form)
+      { return as_pyarray2d(dolfinx::fem::pack_coefficients(form)); },
       "Pack coefficients for a Form.");
   m.def(
       "pack_coefficients",
-      [](dolfinx::fem::Expression<PetscScalar>& expr) {
-        return as_pyarray2d(dolfinx::fem::pack_coefficients(expr));
-      },
+      [](dolfinx::fem::Expression<PetscScalar>& expr)
+      { return as_pyarray2d(dolfinx::fem::pack_coefficients(expr)); },
       "Pack coefficients for an Expression.");
   m.def(
       "pack_constants",
-      [](const dolfinx::fem::Form<PetscScalar>& form) {
-        return as_pyarray(dolfinx::fem::pack_constants(form));
-      },
+      [](const dolfinx::fem::Form<PetscScalar>& form)
+      { return as_pyarray(dolfinx::fem::pack_constants(form)); },
       "Pack constants for a Form.");
   m.def(
       "pack_constants",
-      [](const dolfinx::fem::Expression<PetscScalar>& expression) {
-        return as_pyarray(dolfinx::fem::pack_constants(expression));
-      },
+      [](const dolfinx::fem::Expression<PetscScalar>& expression)
+      { return as_pyarray(dolfinx::fem::pack_constants(expression)); },
       "Pack constants for an Expression.");
   m.def("create_matrix", dolfinx::fem::create_matrix,
         py::return_value_policy::take_ownership, py::arg("a"),
@@ -103,7 +99,8 @@ void fem(py::module& m)
   m.def(
       "create_element_dof_layout",
       [](const std::uintptr_t dofmap, const dolfinx::mesh::CellType cell_type,
-         const std::vector<int>& parent_map) {
+         const std::vector<int>& parent_map)
+      {
         const ufc_dofmap* p = reinterpret_cast<const ufc_dofmap*>(dofmap);
         return dolfinx::fem::create_element_dof_layout(*p, cell_type,
                                                        parent_map);
@@ -112,7 +109,8 @@ void fem(py::module& m)
   m.def(
       "create_dofmap",
       [](const MPICommWrapper comm, const std::uintptr_t dofmap,
-         dolfinx::mesh::Topology& topology) {
+         dolfinx::mesh::Topology& topology)
+      {
         const ufc_dofmap* p = reinterpret_cast<const ufc_dofmap*>(dofmap);
         return dolfinx::fem::create_dofmap(comm.get(), *p, topology);
       },
@@ -128,7 +126,8 @@ void fem(py::module& m)
              const dolfinx::fem::Constant<PetscScalar>>>& constants,
          const std::map<dolfinx::fem::IntegralType,
                         const dolfinx::mesh::MeshTags<int>*>& subdomains,
-         const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh) {
+         const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh)
+      {
         const ufc_form* p = reinterpret_cast<const ufc_form*>(form);
         return dolfinx::fem::create_form<PetscScalar>(
             *p, spaces, coefficients, constants, subdomains, mesh);
@@ -137,7 +136,8 @@ void fem(py::module& m)
   m.def(
       "build_dofmap",
       [](const MPICommWrapper comm, const dolfinx::mesh::Topology& topology,
-         const dolfinx::fem::ElementDofLayout& element_dof_layout) {
+         const dolfinx::fem::ElementDofLayout& element_dof_layout)
+      {
         auto [map, bs, dofmap] = dolfinx::fem::build_dofmap_data(
             comm.get(), topology, element_dof_layout);
         return std::tuple(map, bs, std::move(dofmap));
@@ -151,14 +151,17 @@ void fem(py::module& m)
   py::class_<dolfinx::fem::FiniteElement,
              std::shared_ptr<dolfinx::fem::FiniteElement>>(
       m, "FiniteElement", "Finite element object")
-      .def(py::init([](const std::uintptr_t ufc_element) {
-        const ufc_finite_element* p
-            = reinterpret_cast<const ufc_finite_element*>(ufc_element);
-        return dolfinx::fem::FiniteElement(*p);
-      }))
+      .def(py::init(
+          [](const std::uintptr_t ufc_element)
+          {
+            const ufc_finite_element* p
+                = reinterpret_cast<const ufc_finite_element*>(ufc_element);
+            return dolfinx::fem::FiniteElement(*p);
+          }))
       .def("num_sub_elements", &dolfinx::fem::FiniteElement::num_sub_elements)
       .def("interpolation_points",
-           [](const dolfinx::fem::FiniteElement& self) {
+           [](const dolfinx::fem::FiniteElement& self)
+           {
              const xt::xtensor<double, 2>& x = self.interpolation_points();
 
              // FIXME: Set read-only flag and return wrapper
@@ -175,7 +178,8 @@ void fem(py::module& m)
       .def("apply_dof_transformation",
            [](const dolfinx::fem::FiniteElement& self,
               py::array_t<double, py::array::c_style>& x,
-              std::uint32_t cell_permutation, int dim) {
+              std::uint32_t cell_permutation, int dim)
+           {
              self.apply_dof_transformation(
                  xtl::span(x.mutable_data(), x.size()), cell_permutation, dim);
            })
@@ -213,7 +217,8 @@ void fem(py::module& m)
                              &dolfinx::fem::DofMap::index_map_bs)
       .def_readonly("dof_layout", &dolfinx::fem::DofMap::element_dof_layout)
       .def("cell_dofs",
-           [](const dolfinx::fem::DofMap& self, int cell) {
+           [](const dolfinx::fem::DofMap& self, int cell)
+           {
              xtl::span<const std::int32_t> dofs = self.cell_dofs(cell);
              return py::array_t<std::int32_t>(dofs.size(), dofs.data(),
                                               py::cast(self));
@@ -233,7 +238,8 @@ void fem(py::module& m)
       .def("push_forward",
            [](const dolfinx::fem::CoordinateElement& self,
               const py::array_t<double, py::array::c_style>& X,
-              const py::array_t<double, py::array::c_style>& cell_geometry) {
+              const py::array_t<double, py::array::c_style>& cell_geometry)
+           {
              std::array<std::size_t, 2> s_x
                  = {static_cast<std::size_t>(X.shape(0)),
                     static_cast<std::size_t>(X.shape(1))};
@@ -268,7 +274,8 @@ void fem(py::module& m)
       .def(py::init(
           [](const std::shared_ptr<const dolfinx::fem::Function<PetscScalar>>&
                  g,
-             const py::array_t<std::int32_t, py::array::c_style>& dofs) {
+             const py::array_t<std::int32_t, py::array::c_style>& dofs)
+          {
             return dolfinx::fem::DirichletBC<PetscScalar>(
                 g, std::vector<std::int32_t>(dofs.data(),
                                              dofs.data() + dofs.size()));
@@ -278,7 +285,8 @@ void fem(py::module& m)
                  g,
              const std::array<py::array_t<std::int32_t, py::array::c_style>, 2>&
                  V_g_dofs,
-             const std::shared_ptr<const dolfinx::fem::FunctionSpace>& V) {
+             const std::shared_ptr<const dolfinx::fem::FunctionSpace>& V)
+          {
             std::array dofs = {std::vector<std::int32_t>(
                                    V_g_dofs[0].data(),
                                    V_g_dofs[0].data() + V_g_dofs[0].size()),
@@ -288,7 +296,8 @@ void fem(py::module& m)
             return dolfinx::fem::DirichletBC(g, std::move(dofs), V);
           }))
       .def("dof_indices",
-           [](const dolfinx::fem::DirichletBC<PetscScalar>& self) {
+           [](const dolfinx::fem::DirichletBC<PetscScalar>& self)
+           {
              auto [dofs, owned] = self.dof_indices();
              return std::pair(py::array_t<std::int32_t>(
                                   dofs.size(), dofs.data(), py::cast(self)),
@@ -301,14 +310,18 @@ void fem(py::module& m)
                              &dolfinx::fem::DirichletBC<PetscScalar>::value);
 
   // dolfinx::fem::assemble
+
   // Functional
-  m.def("assemble_scalar", &dolfinx::fem::assemble_scalar<PetscScalar>,
+  m.def("assemble_scalar",
+        py::overload_cast<const dolfinx::fem::Form<PetscScalar>&>(
+            &dolfinx::fem::assemble_scalar<PetscScalar>),
         "Assemble functional over mesh");
   // Vector
   m.def(
       "assemble_vector",
       [](py::array_t<PetscScalar, py::array::c_style> b,
-         const dolfinx::fem::Form<PetscScalar>& L) {
+         const dolfinx::fem::Form<PetscScalar>& L)
+      {
         dolfinx::fem::assemble_vector<PetscScalar>(
             xtl::span(b.mutable_data(), b.size()), L);
       },
@@ -318,13 +331,15 @@ void fem(py::module& m)
   m.def("assemble_matrix_petsc",
         [](Mat A, const dolfinx::fem::Form<PetscScalar>& a,
            const std::vector<std::shared_ptr<
-               const dolfinx::fem::DirichletBC<PetscScalar>>>& bcs) {
+               const dolfinx::fem::DirichletBC<PetscScalar>>>& bcs)
+        {
           dolfinx::fem::assemble_matrix(
               dolfinx::la::PETScMatrix::set_block_fn(A, ADD_VALUES), a, bcs);
         });
   m.def("assemble_matrix_petsc",
         [](Mat A, const dolfinx::fem::Form<PetscScalar>& a,
-           const std::vector<bool>& rows0, const std::vector<bool>& rows1) {
+           const std::vector<bool>& rows0, const std::vector<bool>& rows1)
+        {
           dolfinx::fem::assemble_matrix(
               dolfinx::la::PETScMatrix::set_block_fn(A, ADD_VALUES), a, rows0,
               rows1);
@@ -332,7 +347,8 @@ void fem(py::module& m)
   m.def("assemble_matrix_petsc_unrolled",
         [](Mat A, const dolfinx::fem::Form<PetscScalar>& a,
            const std::vector<std::shared_ptr<
-               const dolfinx::fem::DirichletBC<PetscScalar>>>& bcs) {
+               const dolfinx::fem::DirichletBC<PetscScalar>>>& bcs)
+        {
           dolfinx::fem::assemble_matrix(
               dolfinx::la::PETScMatrix::set_block_expand_fn(
                   A, a.function_spaces()[0]->dofmap()->bs(),
@@ -341,7 +357,8 @@ void fem(py::module& m)
         });
   m.def("assemble_matrix_petsc_unrolled",
         [](Mat A, const dolfinx::fem::Form<PetscScalar>& a,
-           const std::vector<bool>& rows0, const std::vector<bool>& rows1) {
+           const std::vector<bool>& rows0, const std::vector<bool>& rows1)
+        {
           dolfinx::fem::assemble_matrix(
               dolfinx::la::PETScMatrix::set_block_expand_fn(
                   A, a.function_spaces()[0]->dofmap()->bs(),
@@ -352,7 +369,8 @@ void fem(py::module& m)
         [](Mat A, const dolfinx::fem::FunctionSpace& V,
            const std::vector<std::shared_ptr<
                const dolfinx::fem::DirichletBC<PetscScalar>>>& bcs,
-           PetscScalar diagonal) {
+           PetscScalar diagonal)
+        {
           dolfinx::fem::set_diagonal(
               dolfinx::la::PETScMatrix::set_fn(A, INSERT_VALUES), V, bcs,
               diagonal);
@@ -364,14 +382,16 @@ void fem(py::module& m)
                                  const py::array_t<PetscScalar>&)>& fin,
          const dolfinx::fem::Form<PetscScalar>& form,
          const std::vector<std::shared_ptr<
-             const dolfinx::fem::DirichletBC<PetscScalar>>>& bcs) {
+             const dolfinx::fem::DirichletBC<PetscScalar>>>& bcs)
+      {
         std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                           const std::int32_t*, const PetscScalar*)>
             f = [&fin](int nr, const int* rows, int nc, const int* cols,
-                       const PetscScalar* data) {
-              return fin(py::array(nr, rows), py::array(nc, cols),
-                         py::array(nr * nc, data));
-            };
+                       const PetscScalar* data)
+        {
+          return fin(py::array(nr, rows), py::array(nc, cols),
+                     py::array(nr * nc, data));
+        };
         dolfinx::fem::assemble_matrix<PetscScalar>(f, form, bcs);
       },
       "Experimental assembly with Python insertion function. This will be "
@@ -386,7 +406,8 @@ void fem(py::module& m)
          const std::vector<std::vector<std::shared_ptr<
              const dolfinx::fem::DirichletBC<PetscScalar>>>>& bcs1,
          const std::vector<py::array_t<PetscScalar, py::array::c_style>>& x0,
-         double scale) {
+         double scale)
+      {
         std::vector<xtl::span<const PetscScalar>> _x0;
         for (const auto& x : x0)
           _x0.emplace_back(x.data(), x.size());
@@ -399,7 +420,8 @@ void fem(py::module& m)
       [](py::array_t<PetscScalar, py::array::c_style> b,
          const std::vector<std::shared_ptr<
              const dolfinx::fem::DirichletBC<PetscScalar>>>& bcs,
-         const py::array_t<PetscScalar, py::array::c_style>& x0, double scale) {
+         const py::array_t<PetscScalar, py::array::c_style>& x0, double scale)
+      {
         if (x0.ndim() == 0)
         {
           dolfinx::fem::set_bc<PetscScalar>(
@@ -423,7 +445,8 @@ void fem(py::module& m)
   m.def(
       "create_discrete_gradient",
       [](const dolfinx::fem::FunctionSpace& V0,
-         const dolfinx::fem::FunctionSpace& V1) {
+         const dolfinx::fem::FunctionSpace& V1)
+      {
         dolfinx::la::SparsityPattern sp
             = dolfinx::fem::create_sparsity_discrete_gradient(V0, V1);
         Mat A = dolfinx::la::create_petsc_matrix(MPI_COMM_WORLD, sp);
@@ -513,7 +536,8 @@ void fem(py::module& m)
              std::reference_wrapper<const dolfinx::fem::FunctionSpace>>& V,
          const int dim,
          const py::array_t<std::int32_t, py::array::c_style>& entities,
-         bool remote) -> std::array<py::array, 2> {
+         bool remote) -> std::array<py::array, 2>
+      {
         if (V.size() != 2)
           throw std::runtime_error("Expected two function spaces.");
         std::array<std::vector<std::int32_t>, 2> dofs
@@ -528,7 +552,8 @@ void fem(py::module& m)
       "locate_dofs_topological",
       [](const dolfinx::fem::FunctionSpace& V, const int dim,
          const py::array_t<std::int32_t, py::array::c_style>& entities,
-         bool remote) {
+         bool remote)
+      {
         return as_pyarray(dolfinx::fem::locate_dofs_topological(
             V, dim, xtl::span(entities.data(), entities.size()), remote));
       },
@@ -539,12 +564,14 @@ void fem(py::module& m)
       [](const std::vector<
              std::reference_wrapper<const dolfinx::fem::FunctionSpace>>& V,
          const std::function<py::array_t<bool>(const py::array_t<double>&)>&
-             marker) -> std::array<py::array, 2> {
+             marker) -> std::array<py::array, 2>
+      {
         if (V.size() != 2)
           throw std::runtime_error("Expected two function spaces.");
 
-        auto _marker =
-            [&marker](const xt::xtensor<double, 2>& x) -> xt::xtensor<bool, 1> {
+        auto _marker
+            = [&marker](const xt::xtensor<double, 2>& x) -> xt::xtensor<bool, 1>
+        {
           auto strides = x.strides();
           std::transform(strides.begin(), strides.end(), strides.begin(),
                          [](auto s) { return s * sizeof(double); });
@@ -563,9 +590,11 @@ void fem(py::module& m)
       "locate_dofs_geometrical",
       [](const dolfinx::fem::FunctionSpace& V,
          const std::function<py::array_t<bool>(const py::array_t<double>&)>&
-             marker) {
-        auto _marker =
-            [&marker](const xt::xtensor<double, 2>& x) -> xt::xtensor<bool, 1> {
+             marker)
+      {
+        auto _marker
+            = [&marker](const xt::xtensor<double, 2>& x) -> xt::xtensor<bool, 1>
+        {
           auto strides = x.strides();
           std::transform(strides.begin(), strides.end(), strides.begin(),
                          [](auto s) { return s * sizeof(double); });
@@ -596,9 +625,11 @@ void fem(py::module& m)
           "interpolate",
           [](dolfinx::fem::Function<PetscScalar>& self,
              const std::function<py::array_t<PetscScalar>(
-                 const py::array_t<double>&)>& f) {
-            auto _f = [&f](const xt::xtensor<double, 2>& x)
-                -> xt::xarray<PetscScalar> {
+                 const py::array_t<double>&)>& f)
+          {
+            auto _f =
+                [&f](const xt::xtensor<double, 2>& x) -> xt::xarray<PetscScalar>
+            {
               auto strides = x.strides();
               std::transform(strides.begin(), strides.end(), strides.begin(),
                              [](auto s) { return s * sizeof(double); });
@@ -618,7 +649,8 @@ void fem(py::module& m)
            py::arg("u"), "Interpolate a finite element function")
       .def(
           "interpolate_ptr",
-          [](dolfinx::fem::Function<PetscScalar>& self, std::uintptr_t addr) {
+          [](dolfinx::fem::Function<PetscScalar>& self, std::uintptr_t addr)
+          {
             const std::function<void(PetscScalar*, int, int, const double*)> f
                 = reinterpret_cast<void (*)(PetscScalar*, int, int,
                                             const double*)>(addr);
@@ -660,7 +692,8 @@ void fem(py::module& m)
           [](const dolfinx::fem::Function<PetscScalar>& self,
              const py::array_t<double, py::array::c_style>& x,
              const py::array_t<std::int32_t, py::array::c_style>& cells,
-             py::array_t<PetscScalar, py::array::c_style>& u) {
+             py::array_t<PetscScalar, py::array::c_style>& u)
+          {
             // TODO: handle 1d case
 
             std::array<std::size_t, 2> shape_x
@@ -681,9 +714,8 @@ void fem(py::module& m)
           "Evaluate Function")
       .def(
           "compute_point_values",
-          [](const dolfinx::fem::Function<PetscScalar>& self) {
-            return xt_as_pyarray(self.compute_point_values());
-          },
+          [](const dolfinx::fem::Function<PetscScalar>& self)
+          { return xt_as_pyarray(self.compute_point_values()); },
           "Compute values at all mesh points")
       .def_property_readonly(
           "function_space",
@@ -706,9 +738,8 @@ void fem(py::module& m)
       .def_property_readonly("dofmap", &dolfinx::fem::FunctionSpace::dofmap)
       .def("sub", &dolfinx::fem::FunctionSpace::sub)
       .def("tabulate_dof_coordinates",
-           [](const dolfinx::fem::FunctionSpace& self) {
-             return xt_as_pyarray(self.tabulate_dof_coordinates(false));
-           });
+           [](const dolfinx::fem::FunctionSpace& self)
+           { return xt_as_pyarray(self.tabulate_dof_coordinates(false)); });
 
   // dolfinx::fem::Constant
   py::class_<dolfinx::fem::Constant<PetscScalar>,
@@ -718,9 +749,8 @@ void fem(py::module& m)
            "Create a constant from a scalar value array")
       .def(
           "value",
-          [](dolfinx::fem::Constant<PetscScalar>& self) {
-            return py::array(self.shape, self.value.data(), py::none());
-          },
+          [](dolfinx::fem::Constant<PetscScalar>& self)
+          { return py::array(self.shape, self.value.data(), py::none()); },
           py::return_value_policy::reference_internal);
 
   // dolfinx::fem::Expression
@@ -734,7 +764,8 @@ void fem(py::module& m)
                       const dolfinx::fem::Constant<PetscScalar>>>& constants,
                   const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh,
                   const py::array_t<double, py::array::c_style>& X,
-                  py::object addr, const std::size_t value_size) {
+                  py::object addr, const std::size_t value_size)
+               {
                  auto tabulate_expression_ptr = (void (*)(
                      PetscScalar*, const PetscScalar*, const PetscScalar*,
                      const double*))addr.cast<std::uintptr_t>();
@@ -749,7 +780,8 @@ void fem(py::module& m)
       .def("eval",
            [](const dolfinx::fem::Expression<PetscScalar>& self,
               const py::array_t<std::int32_t, py::array::c_style>& active_cells,
-              py::array_t<PetscScalar> values) {
+              py::array_t<PetscScalar> values)
+           {
              dolfinx::array2d<PetscScalar> _values(active_cells.shape()[0],
                                                    self.num_points()
                                                        * self.value_size());


### PR DESCRIPTION
This change allows form constants and coefficients to be re-used, avoiding unnecessary re-computation in cases.