### PR TITLE
Expose underlying basix element in coordinate element.

### DIFF
--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -316,3 +316,10 @@ bool CoordinateElement::needs_permutation_data() const
   return !_element->dof_transformations_are_identity();
 }
 //-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+std::shared_ptr<basix::FiniteElement> CoordinateElement::element() const
+{
+  assert(_element);
+  return _element;
+}

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -123,6 +123,9 @@ public:
   /// passing in (for higher order geometries)
   bool needs_permutation_data() const;
 
+  /// Return shared pointer to Basix
+  std::shared_ptr<basix::FiniteElement> element() const;
+
   /// Absolute increment stopping criterium for non-affine Newton solver
   double non_affine_atol = 1.0e-8;
 

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -121,7 +121,6 @@ FiniteElement::FiniteElement(const ufc_finite_element& ufc_element)
     ufc_finite_element* ufc_sub_element = ufc_element.sub_elements[i];
     _sub_elements.push_back(std::make_shared<FiniteElement>(*ufc_sub_element));
   }
-
 }
 //-----------------------------------------------------------------------------
 std::string FiniteElement::signature() const noexcept { return _signature; }
@@ -164,25 +163,18 @@ void FiniteElement::evaluate_reference_basis(
   assert(_element);
   xt::xtensor<double, 4> basis = _element->tabulate(0, X);
   assert(basis.shape(1) == X.shape(0));
-  for (std::size_t p = 0; p < basis.shape(1); ++p)
-  {
-    for (std::size_t d = 0; d < basis.shape(2); ++d)
-    {
-      for (std::size_t v = 0; v < basis.shape(3); ++v)
-        reference_values(p, d, v) = basis(0, p, d, v);
-    }
-  }
+  reference_values = xt::view(basis, 0, xt::all(), xt::all(), xt::all());
 }
 //-----------------------------------------------------------------------------
-// void FiniteElement::evaluate_reference_basis_derivatives(
-//     std::vector<double>& /*values*/, int /*order*/,
-//     const xt::xtensor<double, 2>& /*X*/) const
-// {
-//   // NOTE: This function is untested. Add tests and re-active
-//   throw std::runtime_error(
-//       "FiniteElement::evaluate_reference_basis_derivatives required
-//       updating");
-// }
+void FiniteElement::evaluate_reference_basis_derivatives(
+    xt::xtensor<double, 4>& reference_values, int order,
+    const xt::xtensor<double, 2>& X) const
+{
+  assert(_element);
+  xt::xtensor<double, 4> basis = _element->tabulate(order, X);
+  assert(basis.shape == values.shape);
+  reference_values = basis;
+}
 //-----------------------------------------------------------------------------
 void FiniteElement::transform_reference_basis(
     xt::xtensor<double, 3>& values,

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -156,24 +156,19 @@ int FiniteElement::value_dimension(int i) const
 //-----------------------------------------------------------------------------
 std::string FiniteElement::family() const noexcept { return _family; }
 //-----------------------------------------------------------------------------
-void FiniteElement::evaluate_reference_basis(
-    xt::xtensor<double, 3>& reference_values,
-    const xt::xtensor<double, 2>& X) const
+xt::xtensor<double, 3>
+FiniteElement::evaluate_reference_basis(const xt::xtensor<double, 2>& X) const
 {
   assert(_element);
   xt::xtensor<double, 4> basis = _element->tabulate(0, X);
-  assert(basis.shape(1) == X.shape(0));
-  reference_values = xt::view(basis, 0, xt::all(), xt::all(), xt::all());
+  return xt::view(basis, 0, xt::all(), xt::all(), xt::all());
 }
 //-----------------------------------------------------------------------------
-void FiniteElement::evaluate_reference_basis_derivatives(
-    xt::xtensor<double, 4>& reference_values, int order,
-    const xt::xtensor<double, 2>& X) const
+xt::xtensor<double, 4> FiniteElement::evaluate_reference_basis_derivatives(
+    int order, const xt::xtensor<double, 2>& X) const
 {
   assert(_element);
-  xt::xtensor<double, 4> basis = _element->tabulate(order, X);
-  assert(basis.shape() == reference_values.shape());
-  reference_values = basis;
+  return _element->tabulate(order, X);
 }
 //-----------------------------------------------------------------------------
 void FiniteElement::transform_reference_basis(

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -172,7 +172,7 @@ void FiniteElement::evaluate_reference_basis_derivatives(
 {
   assert(_element);
   xt::xtensor<double, 4> basis = _element->tabulate(order, X);
-  assert(basis.shape == values.shape);
+  assert(basis.shape() == values.shape());
   reference_values = basis;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -172,7 +172,7 @@ void FiniteElement::evaluate_reference_basis_derivatives(
 {
   assert(_element);
   xt::xtensor<double, 4> basis = _element->tabulate(order, X);
-  assert(basis.shape() == values.shape());
+  assert(basis.shape() == reference_values.shape());
   reference_values = basis;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -83,14 +83,14 @@ public:
 
   /// Evaluate all basis functions at given points in reference cell
   // reference_values[num_points][num_dofs][reference_value_size]
-  void evaluate_reference_basis(xt::xtensor<double, 3>& values,
-                                const xt::xtensor<double, 2>& X) const;
+  xt::xtensor<double, 3>
+  evaluate_reference_basis(const xt::xtensor<double, 2>& X) const;
 
   /// Evaluate all basis function derivatives up to (and including) given order
-  /// at given points in reference cell
-  void
-  evaluate_reference_basis_derivatives(xt::xtensor<double, 4>& reference_values,
-                                       int order,
+  /// at given points in reference cell.
+  /// reference_values[num_derivatives][num_points][num_dofs][reference_value_size]
+  xt::xtensor<double, 4>
+  evaluate_reference_basis_derivatives(int order,
                                        const xt::xtensor<double, 2>& X) const;
 
   /// Push basis functions forward to physical element

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -86,14 +86,12 @@ public:
   void evaluate_reference_basis(xt::xtensor<double, 3>& values,
                                 const xt::xtensor<double, 2>& X) const;
 
-  /// Evaluate all basis function derivatives of given order at given points in
-  /// reference cell
-  // reference_value_derivatives[num_points][num_dofs][reference_value_size][num_derivatives]
-  // void
-  // evaluate_reference_basis_derivatives(std::vector<double>& reference_values,
-  //                                      int order,
-  //                                      const xt::xtensor<double, 2>& X)
-  //                                      const;
+  /// Evaluate all basis function derivatives up to (and including) given order
+  /// at given points in reference cell
+  void
+  evaluate_reference_basis_derivatives(xt::xtensor<double, 4>& reference_values,
+                                       int order,
+                                       const xt::xtensor<double, 2>& X) const;
 
   /// Push basis functions forward to physical element
   void transform_reference_basis(xt::xtensor<double, 3>& values,

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -300,8 +300,6 @@ public:
     xt::xtensor<double, 1> detJ = xt::zeros<double>({1});
 
     // Prepare basis function data structures
-    xt::xtensor<double, 3> basis_reference_values(
-        {1, space_dimension, reference_value_size});
     xt::xtensor<double, 3> basis_values(
         {static_cast<std::size_t>(1), space_dimension, value_size});
 
@@ -345,7 +343,8 @@ public:
       cmap.pull_back(X, J, detJ, K, xp, coordinate_dofs);
 
       // Compute basis on reference element
-      element->evaluate_reference_basis(basis_reference_values, X);
+      xt::xtensor<double, 3> basis_reference_values
+          = element->evaluate_reference_basis(X);
 
       // Permute the reference values to account for the cell's orientation
       element->apply_dof_transformation(


### PR DESCRIPTION
Reimplement `evaluate_reference_basis_derivatives`.
Simplify `evaluate_reference_basis`.

As `evaluate_reference_basis_derivatives` now just directly calls basix, there shouldn't be any need for additional tests of the functionality in DOLFINx.

Exposing these functions will make it easier to create custom assemblers, as one does not have to backwards engineer the basix element from the Mesh/FunctionSpace