### PR TITLE
Gmsh bump + src install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,8 @@
 #    docker build --target dev-env --file dolfinx/docker/Dockerfile --build-arg PETSC_SLEPC_OPTFLAGS="-O2 -march=native" .
 #
 
-ARG GMSH_VERSION=4.6.0
+
+ARG GMSH_VERSION=4_8_4
 ARG PYBIND11_VERSION=2.6.2
 ARG PETSC_VERSION=3.15.0
 ARG SLEPC_VERSION=3.15.0
@@ -128,7 +129,12 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     libglu1 \
     libxcursor-dev \
     libxft2 \
-    libxinerama1 && \
+    libxinerama1 \
+    libfltk1.3-dev \ 
+    libfreetype6-dev  \
+    libgl1-mesa-dev \
+    libocct-foundation-dev \
+    libocct-data-exchange-dev && \
     #
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -192,18 +198,15 @@ RUN wget -nc --quiet https://github.com/ornladios/ADIOS2/archive/v${ADIOS2_VERSI
     cmake --install build-dir && \
     rm -rf /tmp/*
 
-# Download Install gmsh SDK
-# Only compatible with x86-64 (amd64)
-RUN dpkgArch="$(dpkg --print-architecture)"; \
-    case "$dpkgArch" in amd64) \
-    cd /usr/local && \
-    wget -nc --quiet http://gmsh.info/bin/Linux/gmsh-${GMSH_VERSION}-Linux64-sdk.tgz && \
-    tar -xf gmsh-${GMSH_VERSION}-Linux64-sdk.tgz && \
-    rm gmsh-${GMSH_VERSION}-Linux64-sdk.tgz ;; \
-    esac;
+# Install GMSH
+RUN cd /usr/local && \
+    git clone -b gmsh_${GMSH_VERSION} --single-branch https://gitlab.onelab.info/gmsh/gmsh.git && \
+    cd gmsh && \
+    mkdir build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_BUILD_DYNAMIC=1  -DENABLE_OPENMP=1  .. && \
+    make install
 
-ENV PATH=/usr/local/gmsh-${GMSH_VERSION}-Linux64-sdk/bin:$PATH \
-    PYTHONPATH=/usr/local/gmsh-${GMSH_VERSION}-Linux64-sdk/lib:$PYTHONPATH
+ENV PYTHONPATH=/usr/local/lib:$PYTHONPATH
 
 # Install PETSc and petsc4py with real and complex types
 ENV PETSC_DIR=/usr/local/petsc SLEPC_DIR=/usr/local/slepc


### PR DESCRIPTION
Resolves #1328.
GMSH built from source with OpenCascade and OpenMP support.
Instruction set tested locally and in #1500 