### PR TITLE
Use fixed-with Numpy integer types

### DIFF
--- a/python/test/unit/io/test_xdmf_meshtags.py
+++ b/python/test/unit/io/test_xdmf_meshtags.py
@@ -35,18 +35,18 @@ def test_3d(tempdir, cell_type, encoding):
     mesh = UnitCubeMesh(comm, 4, 4, 4, cell_type)
 
     bottom_facets = locate_entities(mesh, 2, lambda x: np.isclose(x[1], 0.0))
-    bottom_values = np.full(bottom_facets.shape, 1, dtype=np.intc)
+    bottom_values = np.full(bottom_facets.shape, 1, dtype=np.int32)
     left_facets = locate_entities(mesh, 2, lambda x: np.isclose(x[0], 0.0))
-    left_values = np.full(left_facets.shape, 2, dtype=np.intc)
+    left_values = np.full(left_facets.shape, 2, dtype=np.int32)
 
     indices, pos = np.unique(np.hstack((bottom_facets, left_facets)), return_index=True)
     mt = MeshTags(mesh, 2, indices, np.hstack((bottom_values, left_values))[pos])
     mt.name = "facets"
 
     top_lines = locate_entities(mesh, 1, lambda x: np.isclose(x[2], 1.0))
-    top_values = np.full(top_lines.shape, 3, dtype=np.intc)
+    top_values = np.full(top_lines.shape, 3, dtype=np.int32)
     right_lines = locate_entities(mesh, 1, lambda x: np.isclose(x[0], 1.0))
-    right_values = np.full(right_lines.shape, 4, dtype=np.intc)
+    right_values = np.full(right_lines.shape, 4, dtype=np.int32)
 
     indices, pos = np.unique(np.hstack((top_lines, right_lines)), return_index=True)
     mt_lines = MeshTags(mesh, 1, indices, np.hstack((top_values, right_values))[pos])


### PR DESCRIPTION
Use `numpy.int32`, etc, in place of `numpy.intc`. Fixes #1289.