### PR TITLE
Residual0 now initialized for residual method.

### DIFF
--- a/cpp/dolfinx/nls/NewtonSolver.cpp
+++ b/cpp/dolfinx/nls/NewtonSolver.cpp
@@ -218,6 +218,13 @@ std::pair<int, bool> dolfinx::nls::NewtonSolver::solve(Vec x)
     if (_system)
       _system(x);
     _fnF(x, _b);
+    // Initialize _residual0
+    if (_iteration == 1)
+    {
+      PetscReal _r = 0.0;
+      VecNorm(_dx, NORM_2, &_r);
+      _residual0 = _r;
+    }
 
     // Test for convergence
     if (convergence_criterion == "residual")
@@ -228,9 +235,6 @@ std::pair<int, bool> dolfinx::nls::NewtonSolver::solve(Vec x)
       // set.
       if (_iteration == 1)
       {
-        PetscReal _r = 0.0;
-        VecNorm(_dx, NORM_2, &_r);
-        _residual0 = _r;
         _residual = 1.0;
         newton_converged = false;
       }


### PR DESCRIPTION
Issue reported by Sandeep:
Using the NewtonSolver with `convergence_check` residual leaves the rtol to infinity, as `_residual0` is never initialized. 