### PR TITLE
Get entity dofs from Basix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ install-python-components: &install-python-components
     cmake --install build-dir
     pip3 install ./basix/python
     pip3 install git+https://github.com/FEniCS/ufl.git
-    pip3 install git+https://github.com/FEniCS/ffcx.git@mscroggs/entity_dofs
+    pip3 install git+https://github.com/FEniCS/ffcx.git@mscroggs/get_entity_dofs_from_basix
 
 flake8-python-code: &flake8-python-code
   name: Flake8 checks on Python code

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -52,7 +52,7 @@ jobs:
           cmake --install build-dir
           python3 -m pip install ./basix/python
           python3 -m pip install git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install git+https://github.com/FEniCS/ffcx.git@mscroggs/entity_dofs
+          python3 -m pip install git+https://github.com/FEniCS/ffcx.git@mscroggs/get_entity_dofs_from_basix
 
       - name: Flake8 checks
         run: |

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -393,7 +393,9 @@ FiniteElement::entity_dofs(bool scalar_element) const
       return ed;
     }
   }
-  return _element->entity_dofs();
+  if (_element)
+    return _element->entity_dofs();
+  return {};
 }
 //-----------------------------------------------------------------------------
 std::vector<std::vector<std::set<int>>>
@@ -442,50 +444,42 @@ FiniteElement::entity_closure_dofs(bool scalar_element) const
       return ed;
     }
   }
-  return _element->entity_closure_dofs();
+  if (_element)
+    return _element->entity_closure_dofs();
+  return {};
 }
 //-----------------------------------------------------------------------------
 std::vector<std::vector<int>>
 FiniteElement::num_entity_dofs(bool scalar_element) const
 {
-  if (_sub_elements.size() != 0)
+  std::vector<std::vector<std::set<int>>> ed
+      = FiniteElement::entity_dofs(scalar_element);
+  std::vector<std::vector<int>> num_ed(ed.size());
+  for (std::size_t i = 0; i < ed.size(); ++i)
   {
-    // Mixed or blocked element
-    std::vector<std::vector<std::set<int>>> ed
-        = FiniteElement::entity_dofs(scalar_element);
-    std::vector<std::vector<int>> num_ed(ed.size());
-    for (std::size_t i = 0; i < ed.size(); ++i)
+    num_ed[i].resize(ed[i].size());
+    for (std::size_t j = 0; j < ed[i].size(); ++j)
     {
-      num_ed[i].resize(ed[i].size());
-      for (std::size_t j = 0; j < ed[i].size(); ++j)
-      {
-        num_ed[i][j] = ed[i][j].size();
-      }
+      num_ed[i][j] = ed[i][j].size();
     }
-    return num_ed;
   }
-  return _element->num_entity_closure_dofs();
+  return num_ed;
 }
 //-----------------------------------------------------------------------------
 std::vector<std::vector<int>>
 FiniteElement::num_entity_closure_dofs(bool scalar_element) const
 {
-  if (_sub_elements.size() != 0)
+  std::vector<std::vector<std::set<int>>> ed
+      = FiniteElement::entity_closure_dofs(scalar_element);
+  std::vector<std::vector<int>> num_ed(ed.size());
+  for (std::size_t i = 0; i < ed.size(); ++i)
   {
-    // Mixed or blocked element
-    std::vector<std::vector<std::set<int>>> ed
-        = FiniteElement::entity_closure_dofs(scalar_element);
-    std::vector<std::vector<int>> num_ed(ed.size());
-    for (std::size_t i = 0; i < ed.size(); ++i)
+    num_ed[i].resize(ed[i].size());
+    for (std::size_t j = 0; j < ed[i].size(); ++j)
     {
-      num_ed[i].resize(ed[i].size());
-      for (std::size_t j = 0; j < ed[i].size(); ++j)
-      {
-        num_ed[i][j] = ed[i][j].size();
-      }
+      num_ed[i][j] = ed[i][j].size();
     }
-    return num_ed;
   }
-  return _element->num_entity_closure_dofs();
+  return num_ed;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -629,6 +629,34 @@ public:
   get_dof_permutation_function(bool inverse = false,
                                bool scalar_element = false) const;
 
+  /// Return the DOFs on each entity
+  ///
+  /// @param[in] scalar_element Indicates whether the information for the scalar
+  /// element should be returned for a vector element
+  std::vector<std::vector<std::set<int>>> entity_dofs(bool scalar_element
+                                                      = false) const;
+
+  /// Return the DOFs on the closure of each entity
+  ///
+  /// @param[in] scalar_element Indicates whether the information for the scalar
+  /// element should be returned for a vector element
+  std::vector<std::vector<std::set<int>>>
+  entity_closure_dofs(bool scalar_element = false) const;
+
+  /// Return number of DOFs on each entity
+  ///
+  /// @param[in] scalar_element Indicates whether the information for the scalar
+  /// element should be returned for a vector element
+  std::vector<std::vector<int>> num_entity_dofs(bool scalar_element
+                                                = false) const;
+
+  /// Return number of DOFs on the closure of each entity
+  ///
+  /// @param[in] scalar_element Indicates whether the information for the scalar
+  /// element should be returned for a vector element
+  std::vector<std::vector<int>> num_entity_closure_dofs(bool scalar_element
+                                                        = false) const;
+
 private:
   std::string _signature, _family;
 

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -683,5 +683,11 @@ private:
 
   // Basix Element (nullptr for mixed elements)
   std::unique_ptr<basix::FiniteElement> _element;
+
+  // Entity DOFs
+  std::vector<std::vector<std::set<int>>> _edofs;
+
+  // Entity closure DOFs
+  std::vector<std::vector<std::set<int>>> _e_closure_dofs;
 };
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -71,35 +71,16 @@ la::SparsityPattern fem::create_sparsity_pattern(
   return pattern;
 }
 //-----------------------------------------------------------------------------
-fem::ElementDofLayout
-fem::create_element_dof_layout(const ufc_dofmap& dofmap,
-                               const mesh::CellType cell_type,
-                               const std::vector<int>& parent_map)
+fem::ElementDofLayout fem::create_element_dof_layout(
+    const ufc_dofmap& dofmap, const mesh::CellType cell_type,
+    std::shared_ptr<const fem::FiniteElement> element,
+    const std::vector<int>& parent_map)
 {
   const int element_block_size = dofmap.block_size;
 
-  // Copy over number of dofs per entity type
-  std::array<int, 4> num_entity_dofs;
-  std::copy_n(dofmap.num_entity_dofs, 4, num_entity_dofs.data());
-
-  int dof_count = 0;
-
-  // Fill entity dof indices
-  const int tdim = mesh::cell_dim(cell_type);
-  std::vector<std::vector<std::set<int>>> entity_dofs(tdim + 1);
-  std::vector<int> work_array;
-  for (int dim = 0; dim <= tdim; ++dim)
-  {
-    const int num_entities = mesh::cell_num_entities(cell_type, dim);
-    entity_dofs[dim].resize(num_entities);
-    for (int i = 0; i < num_entities; ++i)
-    {
-      work_array.resize(num_entity_dofs[dim]);
-      dofmap.tabulate_entity_dofs(work_array.data(), dim, i);
-      entity_dofs[dim][i] = std::set<int>(work_array.begin(), work_array.end());
-      dof_count += num_entity_dofs[dim];
-    }
-  }
+  std::vector<std::vector<std::set<int>>> entity_dofs = element->entity_dofs();
+  std::vector<std::vector<std::set<int>>> entity_closure_dofs
+      = element->entity_closure_dofs();
 
   // TODO: UFC dofmaps just use simple offset for each field but this
   // could be different for custom dofmaps This data should come
@@ -127,36 +108,8 @@ fem::create_element_dof_layout(const ufc_dofmap& dofmap,
     for (std::size_t j = 0; j < parent_map_sub.size(); ++j)
       parent_map_sub[j] = offsets[i] + element_block_size * j;
     sub_dofmaps.push_back(std::make_shared<fem::ElementDofLayout>(
-        create_element_dof_layout(*ufc_sub_dofmap, cell_type, parent_map_sub)));
-  }
-
-  // TODO: Can we get these from Basix instead of recomputing?
-
-  // Compute closure entities
-  // [dim, entity] -> closure{sub_dim, (sub_entities)}
-  std::map<std::array<int, 2>, std::vector<std::set<int>>> entity_closure
-      = mesh::cell_entity_closure(cell_type);
-
-  std::vector<std::vector<std::set<int>>> entity_closure_dofs = entity_dofs;
-  for (const auto& entity : entity_closure)
-  {
-    const int dim = entity.first[0];
-    const int index = entity.first[1];
-    assert(dim < (int)entity_dofs.size());
-    assert(index < (int)entity_dofs[dim].size());
-    int subdim = 0;
-    for (const auto& sub_entity : entity.second)
-    {
-      assert(subdim < (int)entity_dofs.size());
-      for (auto sub_index : sub_entity)
-      {
-        assert(sub_index < (int)entity_dofs[subdim].size());
-        entity_closure_dofs[dim][index].insert(
-            entity_dofs[subdim][sub_index].begin(),
-            entity_dofs[subdim][sub_index].end());
-      }
-      ++subdim;
-    }
+        create_element_dof_layout(*ufc_sub_dofmap, cell_type,
+                                  element->sub_elements()[i], parent_map_sub)));
   }
 
   // Check for "block structure". This should ultimately be replaced,
@@ -173,7 +126,7 @@ fem::create_dofmap(MPI_Comm comm, const ufc_dofmap& ufc_dofmap,
                    std::shared_ptr<const dolfinx::fem::FiniteElement> element)
 {
   auto element_dof_layout = std::make_shared<ElementDofLayout>(
-      create_element_dof_layout(ufc_dofmap, topology.cell_type()));
+      create_element_dof_layout(ufc_dofmap, topology.cell_type(), element));
   assert(element_dof_layout);
 
   // Create required mesh entities

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -83,6 +83,57 @@ fem::ElementDofLayout fem::create_element_dof_layout(
   std::vector<std::vector<std::set<int>>> entity_closure_dofs
       = element->entity_closure_dofs(true);
 
+  if (entity_dofs.size() == 0)
+  {
+    // Quadrature element
+    int dof_count = 0;
+
+    // Fill entity dof indices
+    const int tdim = mesh::cell_dim(cell_type);
+    entity_dofs.resize(tdim + 1);
+    std::vector<int> work_array;
+    for (int dim = 0; dim <= tdim; ++dim)
+    {
+      const int num_entities = mesh::cell_num_entities(cell_type, dim);
+      entity_dofs[dim].resize(num_entities);
+      for (int i = 0; i < num_entities; ++i)
+      {
+        work_array.resize(num_entity_dofs[dim]);
+        dofmap.tabulate_entity_dofs(work_array.data(), dim, i);
+        entity_dofs[dim][i]
+            = std::set<int>(work_array.begin(), work_array.end());
+        dof_count += num_entity_dofs[dim];
+      }
+    }
+
+    // Compute closure entities
+    // [dim, entity] -> closure{sub_dim, (sub_entities)}
+    std::map<std::array<int, 2>, std::vector<std::set<int>>> entity_closure
+        = mesh::cell_entity_closure(cell_type);
+
+    entity_closure_dofs = entity_dofs;
+    for (const auto& entity : entity_closure)
+    {
+      const int dim = entity.first[0];
+      const int index = entity.first[1];
+      assert(dim < (int)entity_dofs.size());
+      assert(index < (int)entity_dofs[dim].size());
+      int subdim = 0;
+      for (const auto& sub_entity : entity.second)
+      {
+        assert(subdim < (int)entity_dofs.size());
+        for (auto sub_index : sub_entity)
+        {
+          assert(sub_index < (int)entity_dofs[subdim].size());
+          entity_closure_dofs[dim][index].insert(
+              entity_dofs[subdim][sub_index].begin(),
+              entity_dofs[subdim][sub_index].end());
+        }
+        ++subdim;
+      }
+    }
+  }
+
   // TODO: UFC dofmaps just use simple offset for each field but this
   // could be different for custom dofmaps This data should come
   // directly from the UFC interface in place of the the implicit

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -116,10 +116,11 @@ la::SparsityPattern create_sparsity_pattern(
     const std::set<IntegralType>& integrals);
 
 /// Create an ElementDofLayout from a ufc_dofmap
-ElementDofLayout create_element_dof_layout(const ufc_dofmap& dofmap,
-                                           const mesh::CellType cell_type,
-                                           const std::vector<int>& parent_map
-                                           = {});
+ElementDofLayout
+create_element_dof_layout(const ufc_dofmap& dofmap,
+                          const mesh::CellType cell_type,
+                          std::shared_ptr<const fem::FiniteElement> element,
+                          const std::vector<int>& parent_map = {});
 
 /// Create a dof map on mesh from a ufc_dofmap
 /// @param[in] comm MPI communicator

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -99,10 +99,10 @@ void fem(py::module& m)
   m.def(
       "create_element_dof_layout",
       [](const std::uintptr_t dofmap, const dolfinx::mesh::CellType cell_type,
-         const std::vector<int>& parent_map)
-      {
+         std::shared_ptr<const dolfinx::fem::FiniteElement> element,
+         const std::vector<int>& parent_map) {
         const ufc_dofmap* p = reinterpret_cast<const ufc_dofmap*>(dofmap);
-        return dolfinx::fem::create_element_dof_layout(*p, cell_type,
+        return dolfinx::fem::create_element_dof_layout(*p, cell_type, element,
                                                        parent_map);
       },
       "Create ElementDofLayout object from a ufc dofmap.");


### PR DESCRIPTION
These changes follow on from #1582 , but I'm less sure about these.

These changes pass the `FiniteElement` into the function that makes the `ElementDofLayout`, so then entity dofs and entity closure DOFs can be obtained from Basix directly.

This PR is into my other PR so we can either merge this with those changes, or merge that and rework this afterwards.