### PR TITLE
Template la::Vector over allocator

### DIFF
--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -27,13 +27,10 @@ public:
   /// Create a distributed vector
   Vector(const std::shared_ptr<const common::IndexMap>& map, int bs,
          const Allocator& alloc = Allocator())
-      : _map(map), _bs(bs)
+      : _map(map), _bs(bs),
+        _x(bs * (map->size_local() + map->num_ghosts()), alloc)
   {
     assert(map);
-    const std::int32_t local_size
-        = bs * (map->size_local() + map->num_ghosts());
-    // _x.resize(local_size);
-    _x = std::vector<T, Allocator>(local_size, T(), alloc);
   }
 
   /// Copy constructor
@@ -125,10 +122,10 @@ public:
   constexpr int bs() const { return _bs; }
 
   /// Get local part of the vector (const version)
-  const std::vector<T>& array() const { return _x; }
+  const std::vector<T, Allocator>& array() const { return _x; }
 
   /// Get local part of the vector
-  std::vector<T>& mutable_array() { return _x; }
+  std::vector<T, Allocator>& mutable_array() { return _x; }
 
 private:
   // Map describing the data layout
@@ -147,8 +144,8 @@ private:
 /// @param a A vector
 /// @param b A vector
 /// @return Returns `a^{H} b` (`a^{T} b` if `a` and `b` are real)
-template <typename T>
-T inner_product(const Vector<T>& a, const Vector<T>& b)
+template <typename T, class Allocator = std::allocator<T>>
+T inner_product(const Vector<T, Allocator>& a, const Vector<T, Allocator>& b)
 {
   const std::int32_t local_size = a.bs() * a.map()->size_local();
   if (local_size != b.bs() * b.map()->size_local())

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -20,18 +20,20 @@ namespace dolfinx::la
 
 /// Distributed vector
 
-template <typename T>
+template <typename T, class Allocator = std::allocator<T>>
 class Vector
 {
 public:
   /// Create a distributed vector
-  Vector(const std::shared_ptr<const common::IndexMap>& map, int bs)
+  Vector(const std::shared_ptr<const common::IndexMap>& map, int bs,
+         const Allocator& alloc = Allocator())
       : _map(map), _bs(bs)
   {
     assert(map);
     const std::int32_t local_size
         = bs * (map->size_local() + map->num_ghosts());
-    _x.resize(local_size);
+    // _x.resize(local_size);
+    _x = std::vector<T, Allocator>(local_size, T(), alloc);
   }
 
   /// Copy constructor
@@ -136,7 +138,7 @@ private:
   int _bs;
 
   // Data
-  std::vector<T> _x;
+  std::vector<T, Allocator> _x;
 };
 
 /// Compute the inner product of two vectors. The two vectors must have


### PR DESCRIPTION
One can use usm_allocator and use SYCL kernels:
```c++
    using usm_alloc = cl::sycl::usm_allocator<double, cl::sycl::usm::alloc::shared>;
    
    auto map = V->dofmap()->index_map;
    int bs = V->dofmap()->bs();
   
    cl::sycl::queue q;
    usm_alloc myAlloc(q);

    dolfinx::la::Vector<double, usm_alloc> b(map, bs, myAlloc);
    auto&& vec = b.mutable_array();

    // Get pointer to vector data for access in SYCL kernel
    double* data = vec.data();
    int size = vec.size();

    q.submit([&](cl::sycl::handler& h) {
       h.parallel_for(cl::sycl::range<1>(size), [=](cl::sycl::id<1> idx) { data[idx] = idx; });
     }).wait();

    for (auto e : vec)
      std::cout << e << " ";

```