### PR TITLE
Remove the  'symmetric' neighbourhood communicator from IndexMap

### DIFF
--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -32,7 +32,7 @@ public:
 
     std::vector<PetscInt> ghosts(map->ghosts().begin(), map->ghosts().end());
     std::int64_t size_global = bs * map->size_global();
-    VecCreateGhostBlockWithArray(map->comm(comm::IndexMap::Direction::forward),
+    VecCreateGhostBlockWithArray(map->comm(common::IndexMap::Direction::forward),
                                  bs, size_local, size_global, ghosts.size(),
                                  ghosts.data(), _b.array().data(), &_b_petsc);
   }

--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -32,9 +32,9 @@ public:
 
     std::vector<PetscInt> ghosts(map->ghosts().begin(), map->ghosts().end());
     std::int64_t size_global = bs * map->size_global();
-    VecCreateGhostBlockWithArray(map->comm(), bs, size_local, size_global,
-                                 ghosts.size(), ghosts.data(),
-                                 _b.array().data(), &_b_petsc);
+    VecCreateGhostBlockWithArray(map->comm(comm::IndexMap::Direction::forward),
+                                 bs, size_local, size_global, ghosts.size(),
+                                 ghosts.data(), _b.array().data(), &_b_petsc);
   }
 
   /// Destructor
@@ -46,7 +46,8 @@ public:
 
   auto form()
   {
-    return [](Vec x) {
+    return [](Vec x)
+    {
       VecGhostUpdateBegin(x, INSERT_VALUES, SCATTER_FORWARD);
       VecGhostUpdateEnd(x, INSERT_VALUES, SCATTER_FORWARD);
     };
@@ -55,7 +56,8 @@ public:
   /// Compute F at current point x
   auto F()
   {
-    return [&](const Vec x, Vec) {
+    return [&](const Vec x, Vec)
+    {
       // Assemble b and update ghosts
       xtl::span<PetscScalar> b(_b.mutable_array());
       std::fill(b.begin(), b.end(), 0.0);
@@ -70,7 +72,8 @@ public:
       VecGetSize(x_local, &n);
       const PetscScalar* array = nullptr;
       VecGetArrayRead(x_local, &array);
-      fem::set_bc<PetscScalar>(b, _bcs, xtl::span<const PetscScalar>(array, n), -1.0);
+      fem::set_bc<PetscScalar>(b, _bcs, xtl::span<const PetscScalar>(array, n),
+                               -1.0);
       VecRestoreArrayRead(x, &array);
     };
   }
@@ -78,7 +81,8 @@ public:
   /// Compute J = F' at current point x
   auto J()
   {
-    return [&](const Vec, Mat A) {
+    return [&](const Vec, Mat A)
+    {
       MatZeroEntries(A);
       fem::assemble_matrix(la::PETScMatrix::set_block_fn(A, ADD_VALUES), *_j,
                            _bcs);
@@ -129,8 +133,8 @@ int main(int argc, char* argv[])
         MPI_COMM_WORLD, {{{0.0, 0.0, 0.0}, {1.0, 1.0, 1.0}}}, {10, 10, 10},
         mesh::CellType::tetrahedron, mesh::GhostMode::none));
 
-    auto V = fem::create_functionspace(
-        functionspace_form_hyperelasticity_F, "u", mesh);
+    auto V = fem::create_functionspace(functionspace_form_hyperelasticity_F,
+                                       "u", mesh);
 
     // Define solution function
     auto u = std::make_shared<fem::Function<PetscScalar>>(V);
@@ -142,31 +146,33 @@ int main(int argc, char* argv[])
                                       {}, {}));
 
     auto u_rotation = std::make_shared<fem::Function<PetscScalar>>(V);
-    u_rotation->interpolate([](auto& x) {
-      constexpr double scale = 0.005;
+    u_rotation->interpolate(
+        [](auto& x)
+        {
+          constexpr double scale = 0.005;
 
-      // Center of rotation
-      constexpr double y0 = 0.5;
-      constexpr double z0 = 0.5;
+          // Center of rotation
+          constexpr double y0 = 0.5;
+          constexpr double z0 = 0.5;
 
-      // Large angle of rotation (60 degrees)
-      constexpr double theta = 1.04719755;
-      xt::xarray<double> values = xt::zeros_like(x);
-      for (std::size_t i = 0; i < x.shape(1); ++i)
-      {
-        // New coordinates
-        double y = y0 + (x(1, i) - y0) * std::cos(theta)
-                   - (x(2, i) - z0) * std::sin(theta);
-        double z = z0 + (x(1, i) - y0) * std::sin(theta)
-                   + (x(2, i) - z0) * std::cos(theta);
+          // Large angle of rotation (60 degrees)
+          constexpr double theta = 1.04719755;
+          xt::xarray<double> values = xt::zeros_like(x);
+          for (std::size_t i = 0; i < x.shape(1); ++i)
+          {
+            // New coordinates
+            double y = y0 + (x(1, i) - y0) * std::cos(theta)
+                       - (x(2, i) - z0) * std::sin(theta);
+            double z = z0 + (x(1, i) - y0) * std::sin(theta)
+                       + (x(2, i) - z0) * std::cos(theta);
 
-        // Rotate at right end
-        values(1, i) = scale * (y - x(1, i));
-        values(2, i) = scale * (z - x(2, i));
-      }
+            // Rotate at right end
+            values(1, i) = scale * (y - x(1, i));
+            values(2, i) = scale * (z - x(2, i));
+          }
 
-      return values;
-    });
+          return values;
+        });
 
     auto u_clamp = std::make_shared<fem::Function<PetscScalar>>(V);
     u_clamp->interpolate(
@@ -175,14 +181,16 @@ int main(int argc, char* argv[])
     // Create Dirichlet boundary conditions
     auto u0 = std::make_shared<fem::Function<PetscScalar>>(V);
 
-    const auto bdofs_left = fem::locate_dofs_geometrical(
-        {*V}, [](auto& x) -> xt::xtensor<bool, 1> {
-          return xt::isclose(xt::row(x, 0), 0.0);
-        });
-    const auto bdofs_right = fem::locate_dofs_geometrical(
-        {*V}, [](auto& x) -> xt::xtensor<bool, 1> {
-          return xt::isclose(xt::row(x, 0), 1.0);
-        });
+    const auto bdofs_left
+        = fem::locate_dofs_geometrical({*V},
+                                       [](auto& x) -> xt::xtensor<bool, 1> {
+                                         return xt::isclose(xt::row(x, 0), 0.0);
+                                       });
+    const auto bdofs_right
+        = fem::locate_dofs_geometrical({*V},
+                                       [](auto& x) -> xt::xtensor<bool, 1> {
+                                         return xt::isclose(xt::row(x, 0), 1.0);
+                                       });
 
     auto bcs
         = std::vector({std::make_shared<const fem::DirichletBC<PetscScalar>>(

--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -160,11 +160,9 @@ int main(int argc, char* argv[])
           constexpr double theta = 1.04719755;
           xt::xarray<double> values = xt::zeros_like(x);
 
-          auto x0 = xt::row(x, 0);
+          // New coordinates
           auto x1 = xt::row(x, 1);
           auto x2 = xt::row(x, 2);
-
-          // New coordinates
           xt::row(values, 1) = scale
                                * (x1_c + (x1 - x1_c) * std::cos(theta)
                                   - (x2 - x2_c) * std::sin(theta) - x1);

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -58,9 +58,8 @@ public:
   /// Edge directions of neighborhood communicator
   enum class Direction
   {
-    reverse,  // Ghost to owner
-    forward,  // Owner to ghost
-    symmetric // Symmetric. NOTE: To be removed
+    reverse, // Ghost to owner
+    forward, // Owner to ghost
   };
 
   /// Create an non-overlapping index map with local_size owned on this
@@ -122,10 +121,9 @@ public:
 
   /// Return a MPI communicator with attached distributed graph topology
   /// information
-  /// @param[in] dir Edge direction of communicator (forward, reverse,
-  /// symmetric)
+  /// @param[in] dir Edge direction of communicator (forward, reverse)
   /// @return A neighborhood communicator for the specified edge direction
-  MPI_Comm comm(Direction dir = Direction::symmetric) const;
+  MPI_Comm comm(Direction dir) const;
 
   /// Compute global indices for array of local indices
   /// @param[in] local Local indices
@@ -462,9 +460,6 @@ private:
 
   // MPI sizes and displacements for forward (owner -> ghost) scatter
   std::vector<int> _sizes_recv_fwd, _sizes_send_fwd, _displs_recv_fwd;
-
-  // TODO: remove
-  dolfinx::MPI::Comm _comm_symmetric;
 
   // Local-to-global map for ghost indices
   std::vector<std::int64_t> _ghosts;

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -27,7 +27,7 @@ dolfinx::MPI::Comm::Comm(MPI_Comm comm, bool duplicate)
     _comm = comm;
 }
 //-----------------------------------------------------------------------------
-dolfinx::MPI::Comm::Comm(const Comm& comm) : Comm(comm._comm)
+dolfinx::MPI::Comm::Comm(const Comm& comm) noexcept : Comm(comm._comm)
 {
   // Do nothing
 }
@@ -72,7 +72,7 @@ dolfinx::MPI::Comm::operator=(dolfinx::MPI::Comm&& comm) noexcept
   return *this;
 }
 //-----------------------------------------------------------------------------
-MPI_Comm dolfinx::MPI::Comm::comm() const { return _comm; }
+MPI_Comm dolfinx::MPI::Comm::comm() const noexcept { return _comm; }
 //-----------------------------------------------------------------------------
 int dolfinx::MPI::rank(const MPI_Comm comm)
 {

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -39,7 +39,7 @@ public:
     explicit Comm(MPI_Comm comm, bool duplicate = true);
 
     /// Copy constructor
-    Comm(const Comm& comm);
+    Comm(const Comm& comm) noexcept;
 
     /// Move constructor
     Comm(Comm&& comm) noexcept;
@@ -54,7 +54,7 @@ public:
     ~Comm();
 
     /// Return the underlying MPI_Comm object
-    MPI_Comm comm() const;
+    MPI_Comm comm() const noexcept;
 
   private:
     // MPI communicator

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -33,6 +33,7 @@ namespace
 /// input neighbourhood communicator
 dolfinx::MPI::Comm create_symmetric_comm(MPI_Comm comm)
 {
+  // assert(comm != MPI_COMM_NULL);
   int indegree(-1), outdegree(-2), weighted(-1);
   MPI_Dist_graph_neighbors_count(comm, &indegree, &outdegree, &weighted);
 
@@ -53,7 +54,7 @@ dolfinx::MPI::Comm create_symmetric_comm(MPI_Comm comm)
                                  neighbors.data(), destweights.data(),
                                  MPI_INFO_NULL, false, &comm_sym);
 
-  return dolfinx::MPI::Comm(comm, false);
+  return dolfinx::MPI::Comm(comm_sym, false);
 }
 
 //-----------------------------------------------------------------------------
@@ -448,7 +449,8 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
 
   std::vector<int> requests_dim;
   std::vector<MPI_Request> requests(D + 1);
-  std::vector<dolfinx::MPI::Comm> comm(D + 1, dolfinx::MPI::Comm(MPI_COMM_NULL));
+  std::vector<dolfinx::MPI::Comm> comm(D + 1,
+                                       dolfinx::MPI::Comm(MPI_COMM_NULL));
   std::vector<std::vector<std::int64_t>> all_dofs_received(D + 1);
   std::vector<std::vector<int>> recv_offsets(D + 1);
   for (int d = 0; d <= D; ++d)

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -31,31 +31,31 @@ namespace
 
 /// Create a symmetric MPI neighbourhood communciator from an
 /// input neighbourhood communicator
-dolfinx::MPI::Comm create_symmetric_comm(MPI_Comm comm)
-{
-  // assert(comm != MPI_COMM_NULL);
-  int indegree(-1), outdegree(-2), weighted(-1);
-  MPI_Dist_graph_neighbors_count(comm, &indegree, &outdegree, &weighted);
+// dolfinx::MPI::Comm create_symmetric_comm(MPI_Comm comm)
+// {
+//   // assert(comm != MPI_COMM_NULL);
+//   int indegree(-1), outdegree(-2), weighted(-1);
+//   MPI_Dist_graph_neighbors_count(comm, &indegree, &outdegree, &weighted);
 
-  std::vector<int> neighbors(indegree + outdegree);
-  MPI_Dist_graph_neighbors(comm, indegree, neighbors.data(), MPI_UNWEIGHTED,
-                           outdegree, neighbors.data() + indegree,
-                           MPI_UNWEIGHTED);
+//   std::vector<int> neighbors(indegree + outdegree);
+//   MPI_Dist_graph_neighbors(comm, indegree, neighbors.data(), MPI_UNWEIGHTED,
+//                            outdegree, neighbors.data() + indegree,
+//                            MPI_UNWEIGHTED);
 
-  std::sort(neighbors.begin(), neighbors.end());
-  neighbors.erase(std::unique(neighbors.begin(), neighbors.end()),
-                  neighbors.end());
+//   std::sort(neighbors.begin(), neighbors.end());
+//   neighbors.erase(std::unique(neighbors.begin(), neighbors.end()),
+//                   neighbors.end());
 
-  MPI_Comm comm_sym;
-  std::vector<int> sourceweights(neighbors.size(), 1);
-  std::vector<int> destweights(neighbors.size(), 1);
-  MPI_Dist_graph_create_adjacent(comm, neighbors.size(), neighbors.data(),
-                                 sourceweights.data(), neighbors.size(),
-                                 neighbors.data(), destweights.data(),
-                                 MPI_INFO_NULL, false, &comm_sym);
+//   MPI_Comm comm_sym;
+//   std::vector<int> sourceweights(neighbors.size(), 1);
+//   std::vector<int> destweights(neighbors.size(), 1);
+//   MPI_Dist_graph_create_adjacent(comm, neighbors.size(), neighbors.data(),
+//                                  sourceweights.data(), neighbors.size(),
+//                                  neighbors.data(), destweights.data(),
+//                                  MPI_INFO_NULL, false, &comm_sym);
 
-  return dolfinx::MPI::Comm(comm_sym, false);
-}
+//   return dolfinx::MPI::Comm(comm_sym, false);
+// }
 
 //-----------------------------------------------------------------------------
 
@@ -459,8 +459,10 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
     auto map = topology.index_map(d);
     if (map)
     {
-      comm[d] = create_symmetric_comm(
-          map->comm(common::IndexMap::Direction::forward));
+      // comm[d] = create_symmetric_comm(
+      //     map->comm(common::IndexMap::Direction::forward));
+      comm[d] = dolfinx::MPI::Comm(
+          map->comm(common::IndexMap::Direction::forward), true);
 
       // Get number of neighbors
       int indegree(-1), outdegree(-2), weighted(-1);

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -469,8 +469,7 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
 
       // Number and values to send and receive
       const int num_indices = global[d].size();
-      // Note: add 1 for OpenMPI to ensure vector is allocated when
-      // indegree = 0
+      // Note: add 1 for OpenMPI bug when indegree = 0
       std::vector<int> num_indices_recv(indegree + 1);
       MPI_Neighbor_allgather(&num_indices, 1, MPI_INT, num_indices_recv.data(),
                              1, MPI_INT, comm[d].comm());
@@ -483,7 +482,7 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
                        num_indices_recv.begin() + indegree, disp.begin() + 1);
 
       // TODO: use MPI_Ineighbor_alltoallv
-      // Send global index of dofs with bcs to all neighbors
+      // Send global index of dofs to neighbors
       std::vector<std::int64_t>& dofs_received = all_dofs_received[d];
       dofs_received.resize(disp.back());
       MPI_Ineighbor_allgatherv(global[d].data(), global[d].size(), MPI_INT64_T,

--- a/cpp/dolfinx/fem/petsc.cpp
+++ b/cpp/dolfinx/fem/petsc.cpp
@@ -243,8 +243,9 @@ Vec fem::create_vector_block(
                    dest_ranks.end());
 
   // Create map for combined problem, and create vector
-  common::IndexMap index_map(maps[0].first.get().comm(), local_size, dest_ranks,
-                             ghosts, ghost_owners);
+  common::IndexMap index_map(
+      maps[0].first.get().comm(common::IndexMap::Direction::forward),
+      local_size, dest_ranks, ghosts, ghost_owners);
 
   return la::create_petsc_vector(index_map, 1);
 }

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -46,8 +46,9 @@ la::SparsityPattern fem::create_sparsity_pattern(
 
   // Create and build sparsity pattern
   assert(dofmaps[0].get().index_map);
-  la::SparsityPattern pattern(dofmaps[0].get().index_map->comm(), index_maps,
-                              bs);
+  la::SparsityPattern pattern(
+      dofmaps[0].get().index_map->comm(common::IndexMap::Direction::forward),
+      index_maps, bs);
   for (auto type : integrals)
   {
     if (type == fem::IntegralType::cell)

--- a/cpp/dolfinx/la/PETScVector.cpp
+++ b/cpp/dolfinx/la/PETScVector.cpp
@@ -68,15 +68,16 @@ Vec la::create_ghosted_vector(const common::IndexMap& map, int bs,
   const std::int64_t size_global = bs * map.size_global();
   const std::vector<PetscInt> ghosts(map.ghosts().begin(), map.ghosts().end());
   Vec vec;
-  VecCreateGhostBlockWithArray(map.comm(), bs, size_local, size_global,
-                               ghosts.size(), ghosts.data(), x.data(), &vec);
+  VecCreateGhostBlockWithArray(map.comm(common::IndexMap::Direction::forward),
+                               bs, size_local, size_global, ghosts.size(),
+                               ghosts.data(), x.data(), &vec);
   return vec;
 }
 //-----------------------------------------------------------------------------
 Vec la::create_petsc_vector(const dolfinx::common::IndexMap& map, int bs)
 {
-  return la::create_petsc_vector(map.comm(), map.local_range(), map.ghosts(),
-                                 bs);
+  return la::create_petsc_vector(map.comm(common::IndexMap::Direction::forward),
+                                 map.local_range(), map.ghosts(), bs);
 }
 //-----------------------------------------------------------------------------
 Vec la::create_petsc_vector(MPI_Comm comm, std::array<std::int64_t, 2> range,

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -146,7 +146,8 @@ public:
       }
 
       double linf = 0.0;
-      MPI_Allreduce(&local_linf, &linf, 1, MPI_DOUBLE, MPI_MAX, _map->comm());
+      MPI_Allreduce(&local_linf, &linf, 1, MPI_DOUBLE, MPI_MAX,
+                    _map->comm(common::IndexMap::Direction::forward));
       return linf;
     }
     default:
@@ -163,7 +164,8 @@ public:
         _x.begin(), std::next(_x.begin(), size_local), 0.0, std::plus<double>(),
         [](T val) { return std::norm(val); });
     double norm2;
-    MPI_Allreduce(&result, &norm2, 1, MPI_DOUBLE, MPI_SUM, _map->comm());
+    MPI_Allreduce(&result, &norm2, 1, MPI_DOUBLE, MPI_SUM,
+                  _map->comm(common::IndexMap::Direction::forward));
     return norm2;
   }
 
@@ -224,7 +226,7 @@ T inner_product(const Vector<T, Allocator>& a, const Vector<T, Allocator>& b)
 
   T result;
   MPI_Allreduce(&local, &result, 1, dolfinx::MPI::mpi_type<T>(), MPI_SUM,
-                a.map()->comm());
+                a.map()->comm(common::IndexMap::Direction::forward));
   return result;
 }
 

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -284,11 +284,11 @@ std::vector<std::int64_t> refinement::adjust_indices(
   // of "index_map", and adjust existing indices to match.
 
   // Get number of new indices on all processes
-  int mpi_size = dolfinx::MPI::size(index_map->comm());
-  int mpi_rank = dolfinx::MPI::rank(index_map->comm());
+  MPI_Comm comm = index_map->comm(common::IndexMap::Direction::forward);
+  int mpi_size = dolfinx::MPI::size(comm);
+  int mpi_rank = dolfinx::MPI::rank(comm);
   std::vector<std::int32_t> recvn(mpi_size);
-  MPI_Allgather(&n, 1, MPI_INT32_T, recvn.data(), 1, MPI_INT32_T,
-                index_map->comm());
+  MPI_Allgather(&n, 1, MPI_INT32_T, recvn.data(), 1, MPI_INT32_T, comm);
   std::vector<std::int64_t> global_offsets = {0};
   for (std::int32_t r : recvn)
     global_offsets.push_back(global_offsets.back() + r);
@@ -321,7 +321,8 @@ refinement::partition(const mesh::Mesh& old_mesh,
 
   auto partitioner = [](MPI_Comm mpi_comm, int, int tdim,
                         const graph::AdjacencyList<std::int64_t>& cell_topology,
-                        mesh::GhostMode) {
+                        mesh::GhostMode)
+  {
     // Find out the ghosting information
     auto [graph, info] = mesh::build_dual_graph(mpi_comm, cell_topology, tdim);
 


### PR DESCRIPTION
Very rarely needed and often mis-used.