### PR TITLE
Reduce number of GPS re-ordering passes for mesh cells

### DIFF
--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -114,7 +114,7 @@ Mesh mesh::create_mesh(MPI_Comm comm,
       tdim);
 
   // Compute re-ordering of local dual graph
-  const std::vector<int> remap = graph::scotch::compute_gps(g, 25).first;
+  const std::vector<int> remap = graph::scotch::compute_gps(g, 2).first;
 
   // Create re-ordered cell lists
   std::vector<std::int64_t> original_cell_index(original_cell_index0);
@@ -163,10 +163,9 @@ Mesh mesh::create_mesh(MPI_Comm comm,
                                                  std::move(off1));
   if (element.needs_dof_permutations())
     topology.create_entity_permutations();
-  Geometry geometry
-      = mesh::create_geometry(comm, topology, element, cell_nodes1, x);
 
-  return Mesh(comm, std::move(topology), std::move(geometry));
+  return Mesh(comm, std::move(topology),
+              mesh::create_geometry(comm, topology, element, cell_nodes1, x));
 }
 //-----------------------------------------------------------------------------
 

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -105,7 +105,7 @@ Mesh mesh::create_mesh(MPI_Comm comm,
   // Build local dual graph for owned cells to apply re-ordering to
   const std::int32_t num_owned_cells
       = cells_extracted0.num_nodes() - ghost_owners.size();
-  auto [g, m] = mesh::build_local_dual_graph(
+  const auto [g, m] = mesh::build_local_dual_graph(
       xtl::span<const std::int64_t>(
           cells_extracted0.array().data(),
           cells_extracted0.offsets()[num_owned_cells]),

--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -48,9 +48,6 @@ compute_local_dual_graph_keyed(
     ++count[num_cell_vertices];
   }
 
-  int num_facets = 0;
-  int num_facet_vertices = 0;
-
   // For each topological dimension, there is a limited set of allowed
   // cell types. In 1D, interval; 2D: tri or quad, 3D: tet, prism,
   // pyramid or hex.
@@ -62,6 +59,8 @@ compute_local_dual_graph_keyed(
   std::vector<graph::AdjacencyList<int>> nv_to_facets(
       9, graph::AdjacencyList<int>(0));
 
+  int num_facets = 0;
+  int num_facet_vertices = 0;
   switch (tdim)
   {
   case 1:
@@ -140,7 +139,8 @@ compute_local_dual_graph_keyed(
   // Sort facet indices
   std::sort(facets.begin(), facets.end(),
             [num_facet_vertices](const std::array<std::int64_t, 5>& fa,
-                                 const std::array<std::int64_t, 5>& fb) {
+                                 const std::array<std::int64_t, 5>& fb)
+            {
               return std::lexicographical_compare(
                   fa.begin(), fa.begin() + num_facet_vertices, fb.begin(),
                   fb.begin() + num_facet_vertices);
@@ -346,11 +346,15 @@ compute_nonlocal_dual_graph(
   // Get permutation that takes facets into sorted order
   std::vector<int> perm(num_facets);
   std::iota(perm.begin(), perm.end(), 0);
-  std::sort(perm.begin(), perm.end(), [&recvd_buffer](int a, int b) {
-    return std::lexicographical_compare(
-        recvd_buffer.links(a).begin(), std::prev(recvd_buffer.links(a).end()),
-        recvd_buffer.links(b).begin(), std::prev(recvd_buffer.links(b).end()));
-  });
+  std::sort(perm.begin(), perm.end(),
+            [&recvd_buffer](int a, int b)
+            {
+              return std::lexicographical_compare(
+                  recvd_buffer.links(a).begin(),
+                  std::prev(recvd_buffer.links(a).end()),
+                  recvd_buffer.links(b).begin(),
+                  std::prev(recvd_buffer.links(b).end()));
+            });
 
   // Count data items to send to each rank
   p_count.assign(num_processes, 0);

--- a/cpp/dolfinx/mesh/graphbuild.h
+++ b/cpp/dolfinx/mesh/graphbuild.h
@@ -19,8 +19,8 @@ namespace dolfinx::mesh
 enum class CellType;
 
 /// Build distributed dual graph (cell-cell connections) from minimal
-/// mesh data, and return (graph, ghost_vertices, [num local edges,
-/// num non-local edges])
+/// mesh data, and return (graph, ghost_vertices, [num local edges, num
+/// non-local edges])
 std::pair<graph::AdjacencyList<std::int64_t>, std::array<std::int32_t, 2>>
 build_dual_graph(const MPI_Comm comm,
                  const graph::AdjacencyList<std::int64_t>& cell_vertices,
@@ -35,8 +35,7 @@ build_dual_graph(const MPI_Comm comm,
 /// @param[in] offsets Index of the first entry of cell `i` in
 /// `cell_vertices` `is offsets[i]`
 /// @param[in] tdim The topological dimension if the cells
-/// @return (local_graph, facet_cell_map, number of local edges in the
-/// graph (undirected)
+/// @return (local_graph, facet-to-cell)
 std::pair<graph::AdjacencyList<std::int32_t>, xt::xtensor<std::int64_t, 2>>
 build_local_dual_graph(const xtl::span<const std::int64_t>& cell_vertices,
                        const xtl::span<const std::int32_t>& offsets, int tdim);


### PR DESCRIPTION
Number of passes was 25, which was a left over from testing.