### PR TITLE
Add MPI_Type_dup to copy and move

### DIFF
--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -46,17 +46,17 @@ public:
         _buffer_recv_fwd(x._buffer_recv_fwd), _x(x._x)
   {
     MPI_Type_dup(x._datatype, &_datatype);
-  };
+  }
 
   /// Move constructor
   Vector(Vector&& x)
       : _map(std::move(x._map)), _bs(std::move(x._bs)),
-        _request(std::move(x._request)),
+        _datatype(std::exchange(x._datatype, MPI_DATATYPE_NULL)),
+        _request(std::exchange(x._datatype, MPI_REQUEST_NULL)),
         _buffer_send_fwd(std::move(x._buffer_send_fwd)),
         _buffer_recv_fwd(std::move(x._buffer_recv_fwd)), _x(std::move(x._x))
   {
-    MPI_Type_dup(x._datatype, &_datatype);
-  };
+  }
 
   /// Destructor
   ~Vector()

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -52,7 +52,7 @@ public:
   Vector(Vector&& x)
       : _map(std::move(x._map)), _bs(std::move(x._bs)),
         _datatype(std::exchange(x._datatype, MPI_DATATYPE_NULL)),
-        _request(std::exchange(x._datatype, MPI_REQUEST_NULL)),
+        _request(std::exchange(x._request, MPI_REQUEST_NULL)),
         _buffer_send_fwd(std::move(x._buffer_send_fwd)),
         _buffer_recv_fwd(std::move(x._buffer_recv_fwd)), _x(std::move(x._x))
   {


### PR DESCRIPTION
Fixes a double-free memory problem in la::Vector