### PR TITLE
Add test for "RTCF" elements 

### DIFF
--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -11,7 +11,8 @@ from itertools import combinations, product
 import numpy as np
 import pytest
 import ufl
-from dolfinx import Function, FunctionSpace, VectorFunctionSpace, cpp, fem
+from dolfinx import (Function, FunctionSpace, VectorFunctionSpace, cpp, fem,
+                     Constant)
 from dolfinx.cpp.mesh import CellType
 from dolfinx.mesh import MeshTags, create_mesh
 from dolfinx_utils.test.skips import skip_in_parallel
@@ -469,3 +470,79 @@ def test_curl(space_type, order):
             else:
                 continue
             break
+
+
+def create_quad_mesh(offset):
+    """Creates a mesh of a single square element if offset = 0, or a
+    trapezium element if |offset| > 0.
+    """
+    x = np.array([[0, 0],
+                  [1, 0],
+                  [0, 0.5 + offset],
+                  [1, 0.5 - offset]])
+    cells = np.array([[0, 1, 2, 3]])
+
+    ufl_mesh = ufl.Mesh(ufl.VectorElement("Lagrange", "quadrilateral", 1))
+    mesh = create_mesh(MPI.COMM_WORLD, cells, x, ufl_mesh)
+    return mesh
+
+
+def assemble_div_matrix(k, offset):
+    mesh = create_quad_mesh(offset)
+
+    V = FunctionSpace(mesh, ("DQ", k))
+    W = FunctionSpace(mesh, ("RTCF", k + 1))
+
+    u = ufl.TrialFunction(V)
+    w = ufl.TestFunction(W)
+
+    form = ufl.inner(u, ufl.div(w)) * ufl.dx
+    A = fem.assemble_matrix(form)
+    A.assemble()
+    return A[:, :]
+
+
+def assemble_div_vector(k, offset):
+    mesh = create_quad_mesh(offset)
+
+    V = FunctionSpace(mesh, ("RTCF", k + 1))
+    v = ufl.TestFunction(V)
+
+    form = ufl.inner(Constant(mesh, 1), ufl.div(v)) * ufl.dx
+    L = fem.assemble_vector(form)
+
+    return L[:]
+
+
+@pytest.mark.parametrize("k", [0, 1, 2])
+def test_div_general_quads_mat(k):
+    """Tests that assembling inner(u, div(w)) * dx, where u is from a
+    "DQ" space and w is from an "RTCF" space, gives the same matrix
+    for square and trapezoidal elements. This should be the case due
+    to the properties of the Piola transform."""
+
+    # Assemble matrix on a mesh of square elements
+    A_square = assemble_div_matrix(k, 0)
+    # Assemble matrix on a mesh of trapezium elements
+    A_trap = assemble_div_matrix(k, 0.25)
+
+    # Due to the properties of the Piola transform, A_square and A_trap
+    # should be equal
+    assert np.allclose(A_square, A_trap, atol=1e-8)
+
+
+@pytest.mark.parametrize("k", [0, 1, 2])
+def test_div_general_quads_vec(k):
+    """Tests that assembling inner(1, div(w)) * dx, where w is from an
+    "RTCF" space, gives the same matrix for square and trapezoidal
+    elements. This should be the case due to the properties of the
+    Piola transform."""
+
+    # Assemble vector on a mesh of square elements
+    L_square = assemble_div_vector(k, 0)
+    # Assemble matrix on a mesh of trapezium elements
+    L_trap = assemble_div_vector(k, 0.25)
+
+    # Due to the properties of the Piola transform, L_square and L_trap
+    # should be equal
+    assert np.allclose(L_square, L_trap, atol=1e-8)

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -513,6 +513,7 @@ def assemble_div_vector(k, offset):
     return L[:]
 
 
+@skip_in_parallel
 @pytest.mark.parametrize("k", [0, 1, 2])
 def test_div_general_quads_mat(k):
     """Tests that assembling inner(u, div(w)) * dx, where u is from a
@@ -530,6 +531,7 @@ def test_div_general_quads_mat(k):
     assert np.allclose(A_square, A_trap, atol=1e-8)
 
 
+@skip_in_parallel
 @pytest.mark.parametrize("k", [0, 1, 2])
 def test_div_general_quads_vec(k):
     """Tests that assembling inner(1, div(w)) * dx, where w is from an

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -510,7 +510,6 @@ def assemble_div_vector(k, offset):
 
     form = ufl.inner(Constant(mesh, 1), ufl.div(v)) * ufl.dx
     L = fem.assemble_vector(form)
-
     return L[:]
 
 

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -11,8 +11,8 @@ from itertools import combinations, product
 import numpy as np
 import pytest
 import ufl
-from dolfinx import (Function, FunctionSpace, VectorFunctionSpace, cpp, fem,
-                     Constant)
+from dolfinx import (Constant, Function, FunctionSpace, VectorFunctionSpace,
+                     cpp, fem)
 from dolfinx.cpp.mesh import CellType
 from dolfinx.mesh import MeshTags, create_mesh
 from dolfinx_utils.test.skips import skip_in_parallel
@@ -331,8 +331,8 @@ def test_plus_minus_vector(cell_type, pm1, pm2):
             results.append(result)
             orders.append(order)
 
-    # Check that the above vectors all have the same values as the first one,
-    # but permuted due to differently ordered dofs
+    # Check that the above vectors all have the same values as the first
+    # one, but permuted due to differently ordered dofs
     dofmap0 = spaces[0].mesh.geometry.dofmap
     for result, space in zip(results[1:], spaces[1:]):
         # Get the data relating to two results
@@ -474,14 +474,12 @@ def test_curl(space_type, order):
 
 def create_quad_mesh(offset):
     """Creates a mesh of a single square element if offset = 0, or a
-    trapezium element if |offset| > 0.
-    """
+    trapezium element if |offset| > 0."""
     x = np.array([[0, 0],
                   [1, 0],
                   [0, 0.5 + offset],
                   [1, 0.5 - offset]])
     cells = np.array([[0, 1, 2, 3]])
-
     ufl_mesh = ufl.Mesh(ufl.VectorElement("Lagrange", "quadrilateral", 1))
     mesh = create_mesh(MPI.COMM_WORLD, cells, x, ufl_mesh)
     return mesh
@@ -489,13 +487,9 @@ def create_quad_mesh(offset):
 
 def assemble_div_matrix(k, offset):
     mesh = create_quad_mesh(offset)
-
     V = FunctionSpace(mesh, ("DQ", k))
     W = FunctionSpace(mesh, ("RTCF", k + 1))
-
-    u = ufl.TrialFunction(V)
-    w = ufl.TestFunction(W)
-
+    u, w = ufl.TrialFunction(V), ufl.TestFunction(W)
     form = ufl.inner(u, ufl.div(w)) * ufl.dx
     A = fem.assemble_matrix(form)
     A.assemble()
@@ -504,10 +498,8 @@ def assemble_div_matrix(k, offset):
 
 def assemble_div_vector(k, offset):
     mesh = create_quad_mesh(offset)
-
     V = FunctionSpace(mesh, ("RTCF", k + 1))
     v = ufl.TestFunction(V)
-
     form = ufl.inner(Constant(mesh, 1), ufl.div(v)) * ufl.dx
     L = fem.assemble_vector(form)
     return L[:]
@@ -517,13 +509,13 @@ def assemble_div_vector(k, offset):
 @pytest.mark.parametrize("k", [0, 1, 2])
 def test_div_general_quads_mat(k):
     """Tests that assembling inner(u, div(w)) * dx, where u is from a
-    "DQ" space and w is from an "RTCF" space, gives the same matrix
-    for square and trapezoidal elements. This should be the case due
-    to the properties of the Piola transform."""
+    "DQ" space and w is from an "RTCF" space, gives the same matrix for
+    square and trapezoidal elements. This should be the case due to the
+    properties of the Piola transform."""
 
-    # Assemble matrix on a mesh of square elements
+    # Assemble matrix on a mesh of square elements and on a mesh of
+    # trapezium elements
     A_square = assemble_div_matrix(k, 0)
-    # Assemble matrix on a mesh of trapezium elements
     A_trap = assemble_div_matrix(k, 0.25)
 
     # Due to the properties of the Piola transform, A_square and A_trap
@@ -536,12 +528,12 @@ def test_div_general_quads_mat(k):
 def test_div_general_quads_vec(k):
     """Tests that assembling inner(1, div(w)) * dx, where w is from an
     "RTCF" space, gives the same matrix for square and trapezoidal
-    elements. This should be the case due to the properties of the
-    Piola transform."""
+    elements. This should be the case due to the properties of the Piola
+    transform."""
 
-    # Assemble vector on a mesh of square elements
+    # Assemble vector on a mesh of square elements and on a mesh of
+    # trapezium elements
     L_square = assemble_div_vector(k, 0)
-    # Assemble matrix on a mesh of trapezium elements
     L_trap = assemble_div_vector(k, 0.25)
 
     # Due to the properties of the Piola transform, L_square and L_trap


### PR DESCRIPTION
This PR adds a test for "RTCF" elements. See https://github.com/FEniCS/ffcx/issues/373 for more information. This test failed before https://github.com/FEniCS/ufl/pull/63 was merged.