### PR TITLE
Only push real32 docs

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Testing real32
         run: echo "Hello there!"
-        if: ${{ matrix.petsc_arch == "real" && matrix.petsc_int_type == "32" }}
+        if: ${{ matrix.petsc_arch == 'real' && matrix.petsc_int_type == '32' }}
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -36,11 +36,6 @@ jobs:
         petsc_int_type: [32, 64]
 
     steps:
-
-      - name: Testing real32
-        run: echo "Hello there!"
-        if: ${{ matrix.petsc_arch == 'real' && matrix.petsc_int_type == '32' }}
-
       - uses: actions/checkout@v2
 
       - name: Get Basix and install
@@ -159,7 +154,7 @@ jobs:
           cp -r ../cpp/doc/html/* dolfinx/${{ env.VERSION_NAME }}/cpp
           cp -r ../python/doc/build/html/* dolfinx/${{ env.VERSION_NAME }}/python
       - name: Commit and push documentation to FEniCS/docs
-        if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') ) && runner.os == 'Linux' }}
+        if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') ) && runner.os == 'Linux' && matrix.petsc_arch == 'real' && matrix.petsc_int_type == '32' }}
         run: |
           cd docs
           git config --global user.email "fenics@github.com"

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
 
       - name: Testing real32
-        run: | echo "Hello there!"
+        run: echo "Hello there!"
         if: ${{ matrix.petsc_arch == "real" && matrix.petsc_int_type == "32" }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -36,6 +36,11 @@ jobs:
         petsc_int_type: [32, 64]
 
     steps:
+
+      - name: Testing real32
+        run: | echo "Hello there!"
+        if: ${{ matrix.petsc_arch == "real" && matrix.petsc_int_type == "32" }}
+
       - uses: actions/checkout@v2
 
       - name: Get Basix and install


### PR DESCRIPTION
This should prevent occasional failing tests (eg https://github.com/FEniCS/dolfinx/runs/3018905856) due to two version pushing at almost the same time