### PR TITLE
Permit only required data to be passed to IndexMap scatters

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -343,22 +343,17 @@ IndexMap::IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
   // Create communicators with directed edges: (0) owner -> ghost,
   // (1) ghost -> owner
   {
-    // Dummy weight to work around an MPICH bug. Would prefer to pass
-    // MPI_UNWEIGHTED.
-    // std::vector<int> weights(std::max(halo_src_ranks.size(),
-    // dest_ranks.size()),
-    //                          1);
+    // Dummy weight to work around a bug in older MPICH versions. Issue
+    // appears in MPICH v3.3.2 (Ubuntu 20.04) and not in v3.4 (Ubuntu
+    // 20.10). Would prefer to pass MPI_UNWEIGHTED.
+    std::vector<int> weights(std::max(halo_src_ranks.size(), dest_ranks.size()),
+                             1);
 
     MPI_Comm comm0;
-    // MPI_Dist_graph_create_adjacent(mpi_comm, halo_src_ranks.size(),
-    //                                halo_src_ranks.data(), weights.data(),
-    //                                dest_ranks.size(), dest_ranks.data(),
-    //                                weights.data(), MPI_INFO_NULL, true,
-    //                                &comm0);
     MPI_Dist_graph_create_adjacent(mpi_comm, halo_src_ranks.size(),
-                                   halo_src_ranks.data(), MPI_UNWEIGHTED,
+                                   halo_src_ranks.data(), weights.data(),
                                    dest_ranks.size(), dest_ranks.data(),
-                                   MPI_UNWEIGHTED, MPI_INFO_NULL, true, &comm0);
+                                   weights.data(), MPI_INFO_NULL, true, &comm0);
     _comm_owner_to_ghost = dolfinx::MPI::Comm(comm0, false);
 
     // Update src/dest rank indices in case
@@ -370,13 +365,9 @@ IndexMap::IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
                              MPI_UNWEIGHTED);
 
     MPI_Comm comm1;
-    // MPI_Dist_graph_create_adjacent(
-    //     mpi_comm, _dest_ranks.size(), _dest_ranks.data(), weights.data(),
-    //     halo_src_ranks.size(), halo_src_ranks.data(), weights.data(),
-    //     MPI_INFO_NULL, false, &comm1);
     MPI_Dist_graph_create_adjacent(
-        mpi_comm, _dest_ranks.size(), _dest_ranks.data(), MPI_UNWEIGHTED,
-        halo_src_ranks.size(), halo_src_ranks.data(), MPI_UNWEIGHTED,
+        mpi_comm, _dest_ranks.size(), _dest_ranks.data(), weights.data(),
+        halo_src_ranks.size(), halo_src_ranks.data(), weights.data(),
         MPI_INFO_NULL, false, &comm1);
     _comm_ghost_to_owner = dolfinx::MPI::Comm(comm1, false);
   }

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -531,6 +531,12 @@ IndexMap::scatter_fwd_indices() const noexcept
   return *_shared_indices;
 }
 //-----------------------------------------------------------------------------
+const std::vector<std::int32_t>&
+IndexMap::scatter_fwd_ghost_positions() const noexcept
+{
+  return _ghost_pos_recv_fwd;
+}
+//-----------------------------------------------------------------------------
 std::vector<int> IndexMap::ghost_owner_rank() const
 {
   int indegree(-1), outdegree(-2), weighted(-1);

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -180,7 +180,7 @@ common::stack_index_maps(
   {
     const int bs = maps[f].second;
     const std::vector<std::int32_t>& forward_indices
-        = maps[f].first.get().shared_indices().array();
+        = maps[f].first.get().scatter_fwd_indices().array();
     const std::int64_t offset = bs * maps[f].first.get().local_range()[0];
     for (std::int32_t local_index : forward_indices)
     {
@@ -527,12 +527,7 @@ std::vector<std::int64_t> IndexMap::global_indices() const
 const graph::AdjacencyList<std::int32_t>&
 IndexMap::scatter_fwd_indices() const noexcept
 {
-  return *_shared_indices;
-}
-//-----------------------------------------------------------------------------
-const graph::AdjacencyList<std::int32_t>&
-IndexMap::shared_indices() const noexcept
-{
+  assert(_shared_indices);
   return *_shared_indices;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -345,14 +345,20 @@ IndexMap::IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
   {
     // Dummy weight to work around an MPICH bug. Would prefer to pass
     // MPI_UNWEIGHTED.
-    std::vector<int> weights(std::max(halo_src_ranks.size(), dest_ranks.size()),
-                             1);
+    // std::vector<int> weights(std::max(halo_src_ranks.size(),
+    // dest_ranks.size()),
+    //                          1);
 
     MPI_Comm comm0;
+    // MPI_Dist_graph_create_adjacent(mpi_comm, halo_src_ranks.size(),
+    //                                halo_src_ranks.data(), weights.data(),
+    //                                dest_ranks.size(), dest_ranks.data(),
+    //                                weights.data(), MPI_INFO_NULL, true,
+    //                                &comm0);
     MPI_Dist_graph_create_adjacent(mpi_comm, halo_src_ranks.size(),
-                                   halo_src_ranks.data(), weights.data(),
+                                   halo_src_ranks.data(), MPI_UNWEIGHTED,
                                    dest_ranks.size(), dest_ranks.data(),
-                                   weights.data(), MPI_INFO_NULL, true, &comm0);
+                                   MPI_UNWEIGHTED, MPI_INFO_NULL, true, &comm0);
     _comm_owner_to_ghost = dolfinx::MPI::Comm(comm0, false);
 
     // Update src/dest rank indices in case
@@ -364,9 +370,13 @@ IndexMap::IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
                              MPI_UNWEIGHTED);
 
     MPI_Comm comm1;
+    // MPI_Dist_graph_create_adjacent(
+    //     mpi_comm, _dest_ranks.size(), _dest_ranks.data(), weights.data(),
+    //     halo_src_ranks.size(), halo_src_ranks.data(), weights.data(),
+    //     MPI_INFO_NULL, false, &comm1);
     MPI_Dist_graph_create_adjacent(
-        mpi_comm, _dest_ranks.size(), _dest_ranks.data(), weights.data(),
-        halo_src_ranks.size(), halo_src_ranks.data(), weights.data(),
+        mpi_comm, _dest_ranks.size(), _dest_ranks.data(), MPI_UNWEIGHTED,
+        halo_src_ranks.size(), halo_src_ranks.data(), MPI_UNWEIGHTED,
         MPI_INFO_NULL, false, &comm1);
     _comm_ghost_to_owner = dolfinx::MPI::Comm(comm1, false);
   }

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -525,9 +525,14 @@ std::vector<std::int64_t> IndexMap::global_indices() const
 }
 //-----------------------------------------------------------------------------
 const graph::AdjacencyList<std::int32_t>&
+IndexMap::scatter_fwd_indices() const noexcept
+{
+  return *_shared_indices;
+}
+//-----------------------------------------------------------------------------
+const graph::AdjacencyList<std::int32_t>&
 IndexMap::shared_indices() const noexcept
 {
-  assert(_shared_indices);
   return *_shared_indices;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -317,7 +317,7 @@ public:
     // if (static_cast<int>(remote_data.size()) != n * _ghosts.size())
     //   throw std::runtime_error("Inconsistent data size.");
 
-    if (static_cast<int>(recv_buffer.size()) != n * displs_send_fwd.back())
+    if (static_cast<int>(send_buffer.size()) != n * _ghosts.size())
       throw std::runtime_error("Inconsistent data size.");
 
     // Pack send buffer

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -314,24 +314,12 @@ public:
     int n;
     MPI_Type_size(data_type, &n);
     n /= sizeof(T);
-    // if (static_cast<int>(remote_data.size()) != n * _ghosts.size())
-    //   throw std::runtime_error("Inconsistent data size.");
-
     if (static_cast<int>(send_buffer.size()) != n * _ghosts.size())
-      throw std::runtime_error("Inconsistent data size.");
-
-    // Pack send buffer
-    // send_buffer.resize(n * _displs_recv_fwd.back());
-    // std::vector<std::int32_t> displs(_displs_recv_fwd);
-    // for (std::size_t i = 0; i < _ghosts.size(); ++i)
-    // {
-    //   const int pos = _ghost_pos_recv_fwd[i];
-    //   std::copy_n(std::next(remote_data.cbegin(), n * i), n,
-    //               std::next(send_buffer.begin(), n * pos));
-    // }
+      throw std::runtime_error("Inconsistent send buffer size.");
+    if (static_cast<int>(recv_buffer.size()) != n * displs_send_fwd.back())
+      throw std::runtime_error("Inconsistent receive buffer size.");
 
     // Send and receive data
-    // recv_buffer.resize(n * displs_send_fwd.back());
     MPI_Ineighbor_alltoallv(send_buffer.data(), _sizes_recv_fwd.data(),
                             _displs_recv_fwd.data(), data_type,
                             recv_buffer.data(), _sizes_send_fwd.data(),
@@ -354,35 +342,6 @@ public:
 
     // Wait for communication to complete
     MPI_Wait(&request, MPI_STATUS_IGNORE);
-
-    // Copy or accumulate into "local_data"
-    // if (std::int32_t size = this->size_local(); size > 0)
-    // {
-    //   assert(local_data.size() >= size);
-    //   assert(local_data.size() % size == 0);
-    //   const int n = local_data.size() / size;
-    //   const std::vector<std::int32_t>& shared_indices
-    //       = _shared_indices->array();
-    //   switch (op)
-    //   {
-    //   case Mode::insert:
-    //     for (std::size_t i = 0; i < shared_indices.size(); ++i)
-    //     {
-    //       const std::int32_t index = shared_indices[i];
-    //       std::copy_n(std::next(recv_buffer.cbegin(), n * i), n,
-    //                   std::next(local_data.begin(), n * index));
-    //     }
-    //     break;
-    //   case Mode::add:
-    //     for (std::size_t i = 0; i < shared_indices.size(); ++i)
-    //     {
-    //       const std::int32_t index = shared_indices[i];
-    //       for (int j = 0; j < n; ++j)
-    //         local_data[index * n + j] += recv_buffer[i * n + j];
-    //     }
-    //     break;
-    //   }
-    // }
   }
 
   /// Send n values for each ghost index to owning to the process

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -215,12 +215,8 @@ public:
   /// ranks that have the index as a ghost. This function complete the
   /// communication started by IndexMap::scatter_fwd_begin.
   ///
-  /// @param[in] remote_data The data array (ghost region) to fill with
-  /// the received data
   /// @param[in] request The MPI request handle for tracking the status
   /// of the send
-  /// @param[in] recv_buffer The receive buffer. It must be the same as
-  /// the buffer passed to IndexMap::scatter_fwd_begin.
   void scatter_fwd_end(MPI_Request& request) const
   {
     // Return early if there are no incoming or outgoing edges

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -420,7 +420,7 @@ public:
 
     // Exchange data
     MPI_Request request;
-    std::vector<T> buffer_recv;
+    std::vector<T> buffer_recv(n * _shared_indices->array().size());
     scatter_rev_begin(xtl::span<const T>(buffer_send), data_type, request,
                       xtl::span<T>(buffer_recv));
     scatter_rev_end(request);

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -144,21 +144,29 @@ public:
   std::vector<std::int64_t> global_indices() const;
 
   /// Local (owned) indices shared with neighbor processes, i.e. are
-  /// ghosts on other processes, grouped by sharing (neighbor)
-  /// process(destination ranks in forward communicator and source ranks in the
-  /// reverse communicator)
+  /// ghosts on other processes, grouped by sharing (neighbor) process
+  /// (destination ranks in forward communicator and source ranks in the
+  /// reverse communicator). `scatter_fwd_indices().links(p)` gives the
+  /// list of owned indices that needs to be sent to neighbourhood rank
+  /// `p` during a forward scatter.
+  ///
+  /// Entries are ordered such that `scatter_fwd_indices.offsets()` is
+  /// the send displacement array for a forward scatter and
+  /// `scatter_fwd_indices.array()[i]` in the index of the owned index
+  /// that should be placed at position `i` in the send buffer for a
+  /// forward scatter.
   /// @return List of indices that are ghosted on other processes
   const graph::AdjacencyList<std::int32_t>&
   scatter_fwd_indices() const noexcept;
 
-  /// Position of ghost entried in the receive buffer after a forward
+  /// Position of ghost entries in the receive buffer after a forward
   /// scatter, e.g. for a receive buffer `b` and a set operation, the
-  /// ghost values should be updated  by `ghost[i] =
+  /// ghost values should be updated  by `ghost_value[i] =
   /// b[scatter_fwd_ghost_positions[i]]`.
-  /// @return Position of the ghost[i] entry in the received buffer
+  /// @return Position of the ith ghost entry in the received buffer
   const std::vector<std::int32_t>& scatter_fwd_ghost_positions() const noexcept;
 
-  /// Owner rank on global communicator of each ghost entry
+  /// Owner rank on the global communicator of each ghost entry
   std::vector<int> ghost_owner_rank() const;
 
   /// @todo Aim to remove this function? If it's kept, should it work
@@ -169,20 +177,25 @@ public:
   /// @return shared indices
   std::map<std::int32_t, std::set<int>> compute_shared_indices() const;
 
-  /// Start a non-blocking send from the local owner of to process ranks
-  /// that have the index as a ghost. The non-blocking communication is
-  /// completed by calling IndexMap::scatter_fwd_end.
+  /// Start a non-blocking send of owned data to ranks that ghost the
+  /// data. The communication is completed by calling
+  /// IndexMap::scatter_fwd_end. The send and receive buffer should not
+  /// be changed until after IndexMap::scatter_fwd_end has been called.
   ///
   /// @param[in] send_buffer Local data associated with each owned local
-  /// index to be sent to process where the data is ghosted. It must
-  /// not be changed until after a call to IndexMap::scatter_fwd_end.
+  /// index to be sent to process where the data is ghosted. It must not
+  /// be changed until after a call to IndexMap::scatter_fwd_end. The
+  /// order of data in the buffer is given by
+  /// IndexMap::scatter_fwd_indices.
   /// @param data_type The MPI data type. To send data with a block size
   /// use `MPI_Type_contiguous` with size `n`
   /// @param request The MPI request handle for tracking the status of
-  /// the send
-  /// @param recv_buffer  A buffer used for the received data. It must
-  /// not be changed until after a call to IndexMap::scatter_fwd_end. It
-  /// will be resized as required.
+  /// the non-blocking communication
+  /// @param recv_buffer A buffer used for the received data. The
+  /// position of ghost entries in the buffer is given by
+  /// IndexMap::scatter_fwd_ghost_positions. The buffer must not be
+  /// accessed or changed until after a call to
+  /// IndexMap::scatter_fwd_end.
   template <typename T>
   void scatter_fwd_begin(const xtl::span<const T>& send_buffer,
                          MPI_Datatype& data_type, MPI_Request& request,
@@ -266,13 +279,12 @@ public:
                       xtl::span<T>(buffer_recv));
     scatter_fwd_end(request);
 
-    // Copy into ghost area("remote_data")
+    // Copy into ghost area ("remote_data")
     assert(remote_data.size() == n * _ghost_pos_recv_fwd.size());
     for (std::size_t i = 0; i < _ghost_pos_recv_fwd.size(); ++i)
     {
-      const int pos = _ghost_pos_recv_fwd[i];
-      std::copy_n(std::next(buffer_recv.cbegin(), n * pos), n,
-                  std::next(remote_data.begin(), n * i));
+      std::copy_n(std::next(buffer_recv.cbegin(), n * _ghost_pos_recv_fwd[i]),
+                  n, std::next(remote_data.begin(), n * i));
     }
 
     if (n != 1)
@@ -281,18 +293,24 @@ public:
 
   /// Start a non-blocking send of ghost values to the owning rank. The
   /// non-blocking communication is completed by calling
-  /// IndexMap::scatter_rev_end.
+  /// IndexMap::scatter_rev_end. A reverse scatter is the transpose of
+  /// IndexMap::scatter_fwd_begin.
   ///
-  /// @param[in] send_buffer Ghost data on this  process to be sent to
-  /// the owner. Size must be `n * num_ghosts()`, where `n` is the block
-  /// size of the data to send.
+  /// @param[in] send_buffer Send buffer filled with ghost data on this
+  /// process to be sent to the owning rank. The order of the data is
+  /// given by IndexMap::scatter_fwd_ghost_positions, with
+  /// IndexMap::scatter_fwd_ghost_positions()[i] being the index of the
+  /// ghost data that should be placed in position `i` of the buffer.
   /// @param data_type The MPI data type. To send data with a block size
   /// use `MPI_Type_contiguous` with size `n`
   /// @param request The MPI request handle for tracking the status of
   /// the send
-  /// @param recv_buffer  A buffer used for the received data. It must
-  /// not be changed until after a call to IndexMap::scatter_rev_end. It
-  /// will be resized as required.
+  /// @param recv_buffer A buffer used for the received data. It must
+  /// not be changed until after a call to IndexMap::scatter_rev_end.
+  /// The ordering of the data is given by
+  /// IndexMap::scatter_fwd_indices, with
+  /// IndexMap::scatter_fwd_indices()[i] being the position in the owned
+  /// data array that corresponds to position `i` in the buffer.
   template <typename T>
   void scatter_rev_begin(const xtl::span<const T>& send_buffer,
                          MPI_Datatype& data_type, MPI_Request& request,
@@ -367,9 +385,8 @@ public:
     buffer_send.resize(n * _displs_recv_fwd.back());
     for (std::size_t i = 0; i < _ghost_pos_recv_fwd.size(); ++i)
     {
-      const int pos = _ghost_pos_recv_fwd[i];
       std::copy_n(std::next(remote_data.cbegin(), n * i), n,
-                  std::next(buffer_send.begin(), n * pos));
+                  std::next(buffer_send.begin(), n * _ghost_pos_recv_fwd[i]));
     }
 
     // Exchange data

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -201,19 +201,8 @@ public:
     int n;
     MPI_Type_size(data_type, &n);
     n /= sizeof(T);
-    // if (static_cast<int>(local_data.size()) != n * size_local())
-    //   throw std::runtime_error("Inconsistent data size.");
     if (static_cast<int>(send_buffer.size()) < n * displs_send_fwd.back())
       throw std::runtime_error("Send buffer is too small.");
-
-    // Copy data into send buffer
-    // send_buffer.resize(n * displs_send_fwd.back());
-    // const std::vector<std::int32_t>& indices = _shared_indices->array();
-    // for (std::size_t i = 0; i < indices.size(); ++i)
-    // {
-    //   std::copy_n(std::next(local_data.cbegin(), n * indices[i]), n,
-    //               std::next(send_buffer.begin(), n * i));
-    // }
 
     // Start send/receive
     recv_buffer.resize(n * _displs_recv_fwd.back());
@@ -252,7 +241,6 @@ public:
       assert(remote_data.size() >= _ghosts.size());
       assert(remote_data.size() % _ghosts.size() == 0);
       const int n = remote_data.size() / _ghosts.size();
-      // std::vector<std::int32_t> displs = _displs_recv_fwd;
       for (std::size_t i = 0; i < _ghosts.size(); ++i)
       {
         const int pos = _ghost_pos_recv_fwd[i];

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -143,7 +143,6 @@ public:
   ///   this process, including ghosts
   std::vector<std::int64_t> global_indices() const;
 
-  /// @todo Reconsider name
   /// Local (owned) indices shared with neighbor processes, i.e. are
   /// ghosts on other processes, grouped by sharing (neighbor)
   /// process(destination ranks in forward communicator and source ranks in the
@@ -151,14 +150,6 @@ public:
   /// @return List of indices that are ghosted on other processes
   const graph::AdjacencyList<std::int32_t>&
   scatter_fwd_indices() const noexcept;
-
-  /// @todo Reconsider name
-  /// Local (owned) indices shared with neighbor processes, i.e. are
-  /// ghosts on other processes, grouped by sharing (neighbor)
-  /// process(destination ranks in forward communicator and source ranks in the
-  /// reverse communicator)
-  /// @return List of indices that are ghosted on other processes
-  const graph::AdjacencyList<std::int32_t>& shared_indices() const noexcept;
 
   /// Owner rank on global communicator of each ghost entry
   std::vector<int> ghost_owner_rank() const;

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -94,7 +94,15 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
   // Send new global indices for owned dofs to non-owning process, and
   // receive new global indices from owner
 
-  std::vector<std::int64_t> global_index_remote(
+    // // Pack send buffer
+  // const graph::AdjacencyList<std::int32_t>& scatter_fwd_indices
+  //     = dofmap_view.index_map->scatter_fwd_indices();
+  // const std::vector<std::int32_t>& indices = scatter_fwd_indices.array();
+  // std::vector<std::int64_t> send_buffer(scatter_fwd_indices.offsets().back());
+  // for (std::size_t i = 0; i < scatter_fwd_indices.array().size(); ++i)
+  //   send_buffer[i] = global_index[indices[i]];
+
+std::vector<std::int64_t> global_index_remote(
       dofmap_view.index_map->num_ghosts());
   dofmap_view.index_map->scatter_fwd(
       xtl::span<const std::int64_t>(global_index),

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -93,16 +93,7 @@ fem::DofMap build_collapsed_dofmap(MPI_Comm comm, const DofMap& dofmap_view,
 
   // Send new global indices for owned dofs to non-owning process, and
   // receive new global indices from owner
-
-    // // Pack send buffer
-  // const graph::AdjacencyList<std::int32_t>& scatter_fwd_indices
-  //     = dofmap_view.index_map->scatter_fwd_indices();
-  // const std::vector<std::int32_t>& indices = scatter_fwd_indices.array();
-  // std::vector<std::int64_t> send_buffer(scatter_fwd_indices.offsets().back());
-  // for (std::size_t i = 0; i < scatter_fwd_indices.array().size(); ++i)
-  //   send_buffer[i] = global_index[indices[i]];
-
-std::vector<std::int64_t> global_index_remote(
+  std::vector<std::int64_t> global_index_remote(
       dofmap_view.index_map->num_ghosts());
   dofmap_view.index_map->scatter_fwd(
       xtl::span<const std::int64_t>(global_index),

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -315,9 +315,9 @@ private:
         std::set<std::int32_t> fwd_shared;
         if (topology.index_map(tdim)->num_ghosts() == 0)
         {
-          fwd_shared.insert(
-              topology.index_map(tdim - 1)->shared_indices().array().begin(),
-              topology.index_map(tdim - 1)->shared_indices().array().end());
+          const std::vector<std::int32_t>& fwd_indices
+              = topology.index_map(tdim - 1)->scatter_fwd_indices().array();
+          fwd_shared.insert(fwd_indices.begin(), fwd_indices.end());
         }
 
         for (auto f = tagged_entities.begin(); f != entity_end; ++f)
@@ -401,9 +401,9 @@ private:
         // Only need to consider shared facets when there are no ghost cells
         if (topology.index_map(tdim)->num_ghosts() == 0)
         {
-          fwd_shared_facets.insert(
-              topology.index_map(tdim - 1)->shared_indices().array().begin(),
-              topology.index_map(tdim - 1)->shared_indices().array().end());
+          const std::vector<std::int32_t>& fwd_indices
+              = topology.index_map(tdim - 1)->scatter_fwd_indices().array();
+          fwd_shared_facets.insert(fwd_indices.begin(), fwd_indices.end());
         }
 
         const int num_facets = topology.index_map(tdim - 1)->size_local();

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -392,7 +392,7 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
     {
       shared_entity[d] = std::vector<bool>(map->size_local(), false);
       const std::vector<std::int32_t>& forward_indices
-          = map->shared_indices().array();
+          = map->scatter_fwd_indices().array();
       for (auto entity : forward_indices)
         shared_entity[d][entity] = true;
     }

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -163,18 +163,14 @@ public:
     case common::IndexMap::Mode::insert:
       for (std::size_t i = 0; i < shared_indices.size(); ++i)
       {
-        const std::int32_t index = shared_indices[i];
         std::copy_n(std::next(_buffer_send_fwd.cbegin(), _bs * i), _bs,
-                    std::next(_x.begin(), _bs * index));
+                    std::next(_x.begin(), _bs * shared_indices[i]));
       }
       break;
     case common::IndexMap::Mode::add:
       for (std::size_t i = 0; i < shared_indices.size(); ++i)
-      {
-        const std::int32_t index = shared_indices[i];
         for (int j = 0; j < _bs; ++j)
-          _x[index * _bs + j] += _buffer_send_fwd[i * _bs + j];
-      }
+          _x[shared_indices[i] * _bs + j] += _buffer_send_fwd[i * _bs + j];
       break;
     }
   }

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -124,10 +124,10 @@ public:
   /// @note Collective MPI operation
   void scatter_rev_begin()
   {
+    // Pack send buffer
     const std::int32_t local_size = _bs * _map->size_local();
     xtl::span<const T> xremote(_x.data() + local_size,
                                _map->num_ghosts() * _bs);
-    // Pack send buffer
     const std::vector<std::int32_t>& scatter_fwd_ghost_pos
         = _map->scatter_fwd_ghost_positions();
     _buffer_recv_fwd.resize(_bs * scatter_fwd_ghost_pos.size());
@@ -138,6 +138,8 @@ public:
                   std::next(_buffer_recv_fwd.begin(), _bs * pos));
     }
 
+    // Resize receive buffer and begin scatter
+    _buffer_send_fwd.resize(_bs * _map->scatter_fwd_indices().array().size());
     _map->scatter_rev_begin(xtl::span<const T>(_buffer_recv_fwd), _datatype,
                             _request, xtl::span<T>(_buffer_send_fwd));
   }

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -139,7 +139,7 @@ public:
     }
 
     _map->scatter_rev_begin(xtl::span<const T>(_buffer_recv_fwd), _datatype,
-                            _request, _buffer_send_fwd);
+                            _request, xtl::span<T>(_buffer_send_fwd));
   }
 
   /// End scatter of ghost data to owner. This process may receive data from

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -87,8 +87,9 @@ public:
                   std::next(_buffer_send_fwd.begin(), _bs * i));
     }
 
+    _buffer_recv_fwd.resize(_bs * _map->num_ghosts());
     _map->scatter_fwd_begin(xtl::span<const T>(_buffer_send_fwd), _datatype,
-                            _request, _buffer_recv_fwd);
+                            _request, xtl::span<T>(_buffer_recv_fwd));
   }
 
   /// End scatter of local data from owner to ghosts on other ranks
@@ -103,10 +104,6 @@ public:
     // Copy received data into ghost positions
     const std::vector<std::int32_t>& scatter_fwd_ghost_pos
         = _map->scatter_fwd_ghost_positions();
-
-    // assert(xremote.size() >= _ghosts.size());
-    // assert(xremote.size() % _ghosts.size() == 0);
-    // const int n = xremote.size() / _ghosts.size();
     for (std::size_t i = 0; i < _map->num_ghosts(); ++i)
     {
       const int pos = scatter_fwd_ghost_pos[i];

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -148,12 +148,40 @@ public:
   /// @param op The operation to perform when adding/setting received
   /// values (add or insert)
   /// @note Collective MPI operation
-  void scatter_rev_end(dolfinx::common::IndexMap::Mode op)
+  void scatter_rev_end(common::IndexMap::Mode op)
   {
     const std::int32_t local_size = _bs * _map->size_local();
     xtl::span xlocal(_x.data(), local_size);
-    _map->scatter_rev_end(xlocal, _request,
-                          xtl::span<const T>(_buffer_send_fwd), op);
+    _map->scatter_rev_end(_request);
+
+    // Copy or accumulate into "local_data"
+    if (std::int32_t size = _map->size_local(); size > 0)
+    {
+      // assert(local_data.size() >= size);
+      // assert(local_data.size() % size == 0);
+      // const int n = local_data.size() / size;
+      const std::vector<std::int32_t>& shared_indices
+          = _map->scatter_fwd_indices().array();
+      switch (op)
+      {
+      case common::IndexMap::Mode::insert:
+        for (std::size_t i = 0; i < shared_indices.size(); ++i)
+        {
+          const std::int32_t index = shared_indices[i];
+          std::copy_n(std::next(_buffer_send_fwd.cbegin(), _bs * i), _bs,
+                      std::next(_x.begin(), _bs * index));
+        }
+        break;
+      case common::IndexMap::Mode::add:
+        for (std::size_t i = 0; i < shared_indices.size(); ++i)
+        {
+          const std::int32_t index = shared_indices[i];
+          for (int j = 0; j < _bs; ++j)
+            _x[index * _bs + j] += _buffer_send_fwd[i * _bs + j];
+        }
+        break;
+      }
+    }
   }
 
   /// Scatter ghost data to owner. This process may receive data from

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -131,8 +131,8 @@ std::vector<bool> mesh::compute_boundary_facets(const Topology& topology)
   if (facets->num_ghosts() == 0)
   {
     fwd_shared_facets
-        = std::set<std::int32_t>(facets->shared_indices().array().begin(),
-                                 facets->shared_indices().array().end());
+        = std::set<std::int32_t>(facets->scatter_fwd_indices().array().begin(),
+                                 facets->scatter_fwd_indices().array().end());
   }
 
   std::shared_ptr<const graph::AdjacencyList<std::int32_t>> fc
@@ -439,7 +439,8 @@ mesh::create_topology(MPI_Comm comm,
          == node_remap.end());
   std::for_each(global_to_local_vertices.begin(),
                 global_to_local_vertices.end(),
-                [&remap = std::as_const(node_remap)](auto& v) {
+                [&remap = std::as_const(node_remap)](auto& v)
+                {
                   if (v.second >= 0)
                     v.second = remap[v.second];
                 });

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -468,14 +468,14 @@ std::vector<std::int32_t> mesh::exterior_facet_indices(const Mesh& mesh)
   mesh.topology_mutable().create_connectivity(tdim - 1, tdim);
   auto f_to_c = topology.connectivity(tdim - 1, tdim);
   assert(topology.index_map(tdim - 1));
-  std::set<std::int32_t> fwd_shared_facets;
 
   // Only need to consider shared facets when there are no ghost cells
+  std::set<std::int32_t> fwd_shared_facets;
   if (topology.index_map(tdim)->num_ghosts() == 0)
   {
     fwd_shared_facets.insert(
-        topology.index_map(tdim - 1)->shared_indices().array().begin(),
-        topology.index_map(tdim - 1)->shared_indices().array().end());
+        topology.index_map(tdim - 1)->scatter_fwd_indices().array().begin(),
+        topology.index_map(tdim - 1)->scatter_fwd_indices().array().end());
   }
 
   // Find all owned facets (not ghost) with only one attached cell, which are


### PR DESCRIPTION
This gives lower-level control over scatters, and allows us to work with just the required data and doesn't force callers to pass other data.