### PR TITLE
Fix misunderstanding of MPI dist graph comm reordering

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -178,13 +178,13 @@ find_package(SCOTCH REQUIRED)
 set_package_properties(SCOTCH PROPERTIES TYPE REQUIRED
   DESCRIPTION "Programs and libraries for graph, mesh and hypergraph partitioning"
   URL "https://www.labri.fr/perso/pelegrin/scotch"
-  PURPOSE "Enables parallel graph partitioning")
+  PURPOSE "Parallel graph partitioning and redordering")
 
 # Check for required packages UFC and basix
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 find_package(UFC MODULE ${DOLFINX_VERSION_MAJOR}.${DOLFINX_VERSION_MINOR})
 set_package_properties(UFC PROPERTIES TYPE REQUIRED
-  DESCRIPTION "Unified language for form-compilers (part of FFCx)"
+  DESCRIPTION "Unified interface for form-compilers (part of FFCx)"
   URL "https://github.com/fenics/ffcx")
 
 find_package(Basix 0.0.1 REQUIRED)
@@ -215,7 +215,7 @@ if (DOLFINX_ENABLE_PARMETIS)
   set_package_properties(ParMETIS PROPERTIES TYPE OPTIONAL
     DESCRIPTION "Parallel Graph Partitioning and Fill-reducing Matrix Ordering"
     URL "http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview"
-    PURPOSE "Enables parallel graph partitioning")
+    PURPOSE "Parallel graph partitioning")
 endif()
 
 # Check for KaHIP
@@ -223,8 +223,8 @@ if (DOLFINX_ENABLE_KAHIP)
   find_package(KaHIP)
   set_package_properties(KaHIP PROPERTIES TYPE OPTIONAL
     DESCRIPTION "A family of graph partitioning programs"
-    URL "http://algo2.iti.kit.edu/documents/kahip/index.html"
-    PURPOSE "Enables parallel graph partitioning")
+    URL "https://kahip.github.io/"
+    PURPOSE "Parallel graph partitioning")
 endif()
 
 #------------------------------------------------------------------------------

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -52,8 +52,9 @@ std::vector<int> get_ghost_ranks(MPI_Comm comm, std::int32_t local_size,
   // only includes the parallel version of this algorithm, requiring
   // e.g. Intel TBB.
   std::vector<std::int64_t> all_ranges(mpi_size + 1, 0);
-  std::transform(all_ranges.cbegin(), all_ranges.cend(), local_sizes.cbegin(),
-                 std::next(all_ranges.begin()), std::plus<std::int64_t>());
+  std::transform(all_ranges.cbegin(), std::prev(all_ranges.cend()),
+                 local_sizes.cbegin(), std::next(all_ranges.begin()),
+                 std::plus<std::int64_t>());
 
   // Compute rank of ghost owners
   std::vector<int> ghost_ranks(ghosts.size(), -1);

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -300,10 +300,10 @@ IndexMap::IndexMap(MPI_Comm comm, std::int32_t local_size)
   std::vector<int> ranks(0);
   MPI_Dist_graph_create_adjacent(comm, ranks.size(), ranks.data(),
                                  MPI_UNWEIGHTED, ranks.size(), ranks.data(),
-                                 MPI_UNWEIGHTED, MPI_INFO_NULL, true, &comm0);
+                                 MPI_UNWEIGHTED, MPI_INFO_NULL, false, &comm0);
   MPI_Dist_graph_create_adjacent(comm, ranks.size(), ranks.data(),
                                  MPI_UNWEIGHTED, ranks.size(), ranks.data(),
-                                 MPI_UNWEIGHTED, MPI_INFO_NULL, true, &comm1);
+                                 MPI_UNWEIGHTED, MPI_INFO_NULL, false, &comm1);
   _comm_owner_to_ghost = dolfinx::MPI::Comm(comm0, false);
   _comm_ghost_to_owner = dolfinx::MPI::Comm(comm1, false);
   _shared_indices = std::make_unique<graph::AdjacencyList<std::int32_t>>(0);
@@ -353,20 +353,12 @@ IndexMap::IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
     MPI_Dist_graph_create_adjacent(mpi_comm, halo_src_ranks.size(),
                                    halo_src_ranks.data(), weights.data(),
                                    dest_ranks.size(), dest_ranks.data(),
-                                   weights.data(), MPI_INFO_NULL, true, &comm0);
+                                   weights.data(), MPI_INFO_NULL, false, &comm0);
     _comm_owner_to_ghost = dolfinx::MPI::Comm(comm0, false);
-
-    // Update src/dest rank indices in case
-    // MPI_Dist_graph_create_adjacent has re-ordered for efficiency
-    std::vector<int> _dest_ranks(dest_ranks.size());
-    MPI_Dist_graph_neighbors(_comm_owner_to_ghost.comm(), halo_src_ranks.size(),
-                             halo_src_ranks.data(), MPI_UNWEIGHTED,
-                             _dest_ranks.size(), _dest_ranks.data(),
-                             MPI_UNWEIGHTED);
 
     MPI_Comm comm1;
     MPI_Dist_graph_create_adjacent(
-        mpi_comm, _dest_ranks.size(), _dest_ranks.data(), weights.data(),
+        mpi_comm, dest_ranks.size(), dest_ranks.data(), weights.data(),
         halo_src_ranks.size(), halo_src_ranks.data(), weights.data(),
         MPI_INFO_NULL, false, &comm1);
     _comm_ghost_to_owner = dolfinx::MPI::Comm(comm1, false);

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -52,8 +52,8 @@ std::vector<int> get_ghost_ranks(MPI_Comm comm, std::int32_t local_size,
   // only includes the parallel version of this algorithm, requiring
   // e.g. Intel TBB.
   std::vector<std::int64_t> all_ranges(mpi_size + 1, 0);
-  for (int i = 0; i < mpi_size; ++i)
-    all_ranges[i + 1] = all_ranges[i] + local_sizes[i];
+  std::transform(all_ranges.cbegin(), all_ranges.cend(), local_sizes.cbegin(),
+                 std::next(all_ranges.begin()), std::plus<std::int64_t>());
 
   // Compute rank of ghost owners
   std::vector<int> ghost_ranks(ghosts.size(), -1);
@@ -100,8 +100,8 @@ compute_owned_shared(MPI_Comm comm, const xtl::span<const std::int64_t>& ghosts,
 
   // Compute number of ghost indices to send to each owning rank
   std::vector<int> out_edges_num(dest_ranks.size(), 0);
-  for (std::size_t i = 0; i < ghost_src_ranks.size(); ++i)
-    out_edges_num[ghost_src_ranks[i]]++;
+  std::for_each(ghost_src_ranks.cbegin(), ghost_src_ranks.cend(),
+                [&out_edges_num](auto src_rank) { out_edges_num[src_rank]++; });
 
   // Send number of my 'ghost indices' to each owner, and receive number
   // of my 'owned indices' that are ghosted on other ranks
@@ -159,10 +159,11 @@ common::stack_index_maps(
     const std::vector<
         std::pair<std::reference_wrapper<const common::IndexMap>, int>>& maps)
 {
-  // Get process offset
-  std::int64_t process_offset = 0;
-  for (auto& map : maps)
-    process_offset += map.first.get().local_range()[0] * map.second;
+  // Compute process offset
+  const std::int64_t process_offset = std::accumulate(
+      maps.cbegin(), maps.cend(), static_cast<std::int64_t>(0),
+      [](std::int64_t c, auto& map) -> std::int64_t
+      { return c + map.first.get().local_range()[0] * map.second; });
 
   // Get local map offset
   std::vector<std::int32_t> local_offset(maps.size() + 1, 0);
@@ -187,10 +188,10 @@ common::stack_index_maps(
       for (std::int32_t i = 0; i < bs; ++i)
       {
         // Insert field index, global index, composite global index
-        indices.push_back(f);
-        indices.push_back(bs * local_index + i + offset);
-        indices.push_back(bs * local_index + i + local_offset[f]
-                          + process_offset);
+        indices.insert(
+            indices.end(),
+            {static_cast<std::int64_t>(f), bs * local_index + i + offset,
+             bs * local_index + i + local_offset[f] + process_offset});
       }
     }
   }
@@ -350,10 +351,10 @@ IndexMap::IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
                              1);
 
     MPI_Comm comm0;
-    MPI_Dist_graph_create_adjacent(mpi_comm, halo_src_ranks.size(),
-                                   halo_src_ranks.data(), weights.data(),
-                                   dest_ranks.size(), dest_ranks.data(),
-                                   weights.data(), MPI_INFO_NULL, false, &comm0);
+    MPI_Dist_graph_create_adjacent(
+        mpi_comm, halo_src_ranks.size(), halo_src_ranks.data(), weights.data(),
+        dest_ranks.size(), dest_ranks.data(), weights.data(), MPI_INFO_NULL,
+        false, &comm0);
     _comm_owner_to_ghost = dolfinx::MPI::Comm(comm0, false);
 
     MPI_Comm comm1;
@@ -414,8 +415,8 @@ IndexMap::IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
 
   // Create displacement vectors fwd scatter
   _sizes_recv_fwd.resize(indegree, 0);
-  for (std::size_t i = 0; i < _ghosts.size(); ++i)
-    _sizes_recv_fwd[ghost_owners[i]] += 1;
+  std::for_each(ghost_owners.cbegin(), ghost_owners.cend(),
+                [&recv = _sizes_recv_fwd](auto owner) { recv[owner] += 1; });
 
   _displs_recv_fwd.resize(indegree + 1, 0);
   std::partial_sum(_sizes_recv_fwd.begin(), _sizes_recv_fwd.end(),
@@ -466,16 +467,18 @@ void IndexMap::local_to_global(const xtl::span<const std::int32_t>& local,
 {
   assert(local.size() <= global.size());
   const std::int32_t local_size = _local_range[1] - _local_range[0];
-  for (std::size_t i = 0; i < local.size(); ++i)
-  {
-    if (local[i] < local_size)
-      global[i] = _local_range[0] + local[i];
-    else
-    {
-      assert((local[i] - local_size) < (int)_ghosts.size());
-      global[i] = _ghosts[local[i] - local_size];
-    }
-  }
+  std::transform(
+      local.cbegin(), local.cend(), global.begin(),
+      [local_size, local_range = _local_range[0], &ghosts = _ghosts](auto local)
+      {
+        if (local < local_size)
+          return local_range + local;
+        else
+        {
+          assert((local - local_size) < (int)ghosts.size());
+          return ghosts[local - local_size];
+        }
+      });
 }
 //-----------------------------------------------------------------------------
 void IndexMap::global_to_local(const xtl::span<const std::int64_t>& global,
@@ -544,8 +547,9 @@ std::vector<int> IndexMap::ghost_owner_rank() const
   const std::vector<int> ghost_owners
       = compute_ghost_owners(_ghost_pos_recv_fwd, _displs_recv_fwd);
   std::vector<std::int32_t> owners(ghost_owners.size());
-  for (std::size_t i = 0; i < owners.size(); ++i)
-    owners[i] = neighbors_in[ghost_owners[i]];
+  std::transform(ghost_owners.cbegin(), ghost_owners.cend(), owners.begin(),
+                 [&neighbors_in](auto ghost_owner)
+                 { return neighbors_in[ghost_owner]; });
 
   return owners;
 }
@@ -598,11 +602,11 @@ std::map<std::int32_t, std::set<int>> IndexMap::compute_shared_indices() const
       assert(shared_indices.find(idx) != shared_indices.end());
       if (auto it = shared_indices.find(idx); it->second.size() > 1)
       {
-        // Add global index
-        fwd_sharing_data.push_back(idx + _local_range[0]);
-
-        // Add number of sharing ranks
-        fwd_sharing_data.push_back(shared_indices[idx].size());
+        // Add global index and number of sharing ranks
+        fwd_sharing_data.insert(
+            fwd_sharing_data.end(),
+            {idx + _local_range[0],
+             static_cast<std::int64_t>(shared_indices[idx].size())});
 
         // Add sharing ranks
         fwd_sharing_data.insert(fwd_sharing_data.end(), it->second.begin(),

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -503,10 +503,7 @@ void IndexMap::global_to_local(const xtl::span<const std::int64_t>& global,
                    else
                    {
                      auto it = global_to_local.find(index);
-                     if (it != global_to_local.end())
-                       return it->second;
-                     else
-                       return -1;
+                     return it != global_to_local.end() ? it->second : -1;
                    }
                  });
 }

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -75,8 +75,8 @@ graph::build::distribute(MPI_Comm comm,
       data_send[offset[dest]++] = dests[0];
       data_send[offset[dest]++] = i + offset_global;
       data_send[offset[dest]++] = links.size();
-      for (std::size_t k = 0; k < links.size(); ++k)
-        data_send[offset[dest]++] = links[k];
+      for (auto link : links)
+        data_send[offset[dest]++] = link;
     }
   }
 

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -238,13 +238,14 @@ std::vector<std::int64_t> graph::build::compute_ghost_indices(
   for (int i = 0; i < num_local; ++i)
     old_to_new.insert({global_indices[i], offset_local + i});
 
-  for (std::int64_t& r : recv_data)
-  {
-    auto it = old_to_new.find(r);
-    // Must exist on this process!
-    assert(it != old_to_new.end());
-    r = it->second;
-  }
+  std::for_each(recv_data.begin(), recv_data.end(),
+                [&old_to_new](auto& r)
+                {
+                  auto it = old_to_new.find(r);
+                  // Must exist on this process!
+                  assert(it != old_to_new.end());
+                  r = it->second;
+                });
 
   std::vector<std::int64_t> new_recv(send_data.size());
   MPI_Neighbor_alltoallv(recv_data.data(), recv_sizes.data(),
@@ -261,12 +262,13 @@ std::vector<std::int64_t> graph::build::compute_ghost_indices(
     assert(insert);
   }
 
-  for (std::int64_t& q : ghost_global_indices)
-  {
-    const auto it = old_to_new.find(q);
-    assert(it != old_to_new.end());
-    q = it->second;
-  }
+  std::for_each(ghost_global_indices.begin(), ghost_global_indices.end(),
+                [&old_to_new](auto& q)
+                {
+                  const auto it = old_to_new.find(q);
+                  assert(it != old_to_new.end());
+                  q = it->second;
+                });
 
   MPI_Comm_free(&neighbor_comm);
   return ghost_global_indices;
@@ -321,13 +323,15 @@ std::vector<std::int32_t> graph::build::compute_local_to_local(
     global_to_local1.insert({local1_to_global[i], i});
 
   // Compute inverse map for local0_to_local1
-  std::vector<std::int32_t> local0_to_local1(local0_to_global.size());
-  for (std::size_t i = 0; i < local0_to_local1.size(); ++i)
-  {
-    auto it = global_to_local1.find(local0_to_global[i]);
-    assert(it != global_to_local1.end());
-    local0_to_local1[i] = it->second;
-  }
+  std::vector<std::int32_t> local0_to_local1;
+  std::transform(local0_to_global.cbegin(), local0_to_global.cend(),
+                 std::back_inserter(local0_to_local1),
+                 [&global_to_local1](auto l2g)
+                 {
+                   auto it = global_to_local1.find(l2g);
+                   assert(it != global_to_local1.end());
+                   return it->second;
+                 });
 
   return local0_to_local1;
 }

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -75,8 +75,9 @@ graph::build::distribute(MPI_Comm comm,
       data_send[offset[dest]++] = dests[0];
       data_send[offset[dest]++] = i + offset_global;
       data_send[offset[dest]++] = links.size();
-      for (auto link : links)
-        data_send[offset[dest]++] = link;
+      std::copy(links.cbegin(), links.cend(),
+                std::next(data_send.begin(), offset[dest]));
+      offset[dest] += links.size();
     }
   }
 


### PR DESCRIPTION
Set re-ordering flag to false in `MPI_Dist_graph_create_adjacent`. Setting to true allows global ranks to be re-ordered (which would break things), but few, if any, implementation support re-ordering so the issue didn't show up.

Also uses more `std::transform` in place of plain loops.