### PR TITLE
Fixes for the new Intel Compiler

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -1,10 +1,15 @@
 name: Intel compilers
 
+# on:
+#   schedule:
+#     # '*' is a special character in YAML, so string must be quoted
+#     - cron: "0 2 * * TUE"
+#   workflow_dispatch: ~
+
 on:
-  schedule:
-    # '*' is a special character in YAML, so string must be quoted
-    - cron: "0 2 * * TUE"
-  workflow_dispatch: ~
+  push:
+    branches:
+      - "**"
 
 jobs:
   build:

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -28,9 +28,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: "Classic"
-            c_compiler: icc
-            cxx_compiler: icpc
+          # - compiler: "Classic"
+          #   c_compiler: icc
+          #   cxx_compiler: icpc
           - compiler: "LLVM-based"
             c_compiler: icx
             cxx_compiler: icpx

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container: fenicsproject/test-env:mpich
+    container: fenicsproject/test-env:latest-mpich
 
     defaults:
       run:

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -1,15 +1,9 @@
 name: Intel compilers
 
-# on:
-#   schedule:
-#     # '*' is a special character in YAML, so string must be quoted
-#     - cron: "0 2 * * TUE"
-#   workflow_dispatch: ~
-
 on:
-  push:
+  pull_request:
     branches:
-      - "**"
+      - main
 
 jobs:
   build:

--- a/cpp/dolfinx/generation/BoxMesh.cpp
+++ b/cpp/dolfinx/generation/BoxMesh.cpp
@@ -129,7 +129,8 @@ mesh::Mesh build_tet(MPI_Comm comm,
         = {{v0, v1, v3, v7}, {v0, v1, v7, v5}, {v0, v5, v7, v4},
            {v0, v3, v2, v7}, {v0, v6, v4, v7}, {v0, v2, v6, v7}};
     std::size_t offset = 6 * (i - range_c[0]);
-    xt::view(cells, xt::range(offset, offset + 6), xt::all()) = c;
+    auto _cell = xt::view(cells, xt::range(offset, offset + 6), xt::all());
+    _cell.assign(c);
   }
 
   fem::CoordinateElement element(mesh::CellType::tetrahedron, 1);
@@ -176,7 +177,8 @@ mesh::Mesh build_hex(MPI_Comm comm,
 
     xt::xtensor_fixed<std::int64_t, xt::xshape<8>> cell
         = {v0, v1, v2, v3, v4, v5, v6, v7};
-    xt::view(cells, i - range_c[0], xt::all()) = cell;
+    auto _cell = xt::view(cells, i - range_c[0], xt::all());
+    _cell.assign(cell);
   }
 
   fem::CoordinateElement element(mesh::CellType::hexahedron, 1);

--- a/cpp/dolfinx/generation/BoxMesh.cpp
+++ b/cpp/dolfinx/generation/BoxMesh.cpp
@@ -129,6 +129,10 @@ mesh::Mesh build_tet(MPI_Comm comm,
         = {{v0, v1, v3, v7}, {v0, v1, v7, v5}, {v0, v5, v7, v4},
            {v0, v3, v2, v7}, {v0, v6, v4, v7}, {v0, v2, v6, v7}};
     std::size_t offset = 6 * (i - range_c[0]);
+
+    // Note: we would like to assign to a view, but this does not work
+    // correctly with the Intel icpx compiler
+    // xt::view(cells, xt::range(offset, offset + 6), xt::all()) = c;
     auto _cell = xt::view(cells, xt::range(offset, offset + 6), xt::all());
     _cell.assign(c);
   }
@@ -177,7 +181,10 @@ mesh::Mesh build_hex(MPI_Comm comm,
 
     xt::xtensor_fixed<std::int64_t, xt::xshape<8>> cell
         = {v0, v1, v2, v3, v4, v5, v6, v7};
-    auto _cell = xt::view(cells, i - range_c[0], xt::all());
+    // Note: we would like to assign to a view, but this does not work
+    // correctly with the Intel icpx compiler
+    // _cell = xt::row(cells, i - range_c[0]) = c;
+    auto _cell = xt::row(cells, i - range_c[0]);
     _cell.assign(cell);
   }
 

--- a/cpp/dolfinx/generation/RectangleMesh.cpp
+++ b/cpp/dolfinx/generation/RectangleMesh.cpp
@@ -140,7 +140,9 @@ mesh::Mesh build_tri(MPI_Comm comm,
         xt::xtensor_fixed<std::size_t, xt::xshape<4, 3>> c
             = {{v0, v1, vmid}, {v0, v2, vmid}, {v1, v3, vmid}, {v2, v3, vmid}};
         std::size_t offset = iy * nx + ix;
-        xt::view(cells, xt::range(4 * offset, 4 * offset + 4), xt::all()) = c;
+        auto _cell
+            = xt::view(cells, xt::range(4 * offset, 4 * offset + 4), xt::all());
+        _cell.assign(c);
       }
     }
   }
@@ -178,7 +180,8 @@ mesh::Mesh build_tri(MPI_Comm comm,
         {
           xt::xtensor_fixed<std::size_t, xt::xshape<2, 3>> c
               = {{v0, v1, v2}, {v1, v2, v3}};
-          xt::view(cells, xt::range(2 * offset, 2 * offset + 2)) = c;
+          auto _cell = xt::view(cells, xt::range(2 * offset, 2 * offset + 2));
+          _cell.assign(c);
           if (diagonal == "right/left" || diagonal == "left/right")
             local_diagonal = "right";
         }
@@ -186,7 +189,8 @@ mesh::Mesh build_tri(MPI_Comm comm,
         {
           xt::xtensor_fixed<std::size_t, xt::xshape<2, 3>> c
               = {{v0, v1, v3}, {v0, v2, v3}};
-          xt::view(cells, xt::range(2 * offset, 2 * offset + 2)) = c;
+          auto _cell = xt::view(cells, xt::range(2 * offset, 2 * offset + 2));
+          _cell.assign(c);
           if (diagonal == "right/left" || diagonal == "left/right")
             local_diagonal = "left";
         }
@@ -258,7 +262,8 @@ mesh::Mesh build_quad(MPI_Comm comm,
       std::size_t cell = ix * ny + iy;
       xt::xtensor_fixed<std::size_t, xt::xshape<4>> c
           = {i0 + iy, i0 + iy + 1, i0 + iy + ny + 1, i0 + iy + ny + 2};
-      xt::view(cells, cell, xt::all()) = c;
+      auto _cell = xt::view(cells, cell, xt::all());
+      _cell.assign(c);
     }
   }
 

--- a/cpp/dolfinx/generation/RectangleMesh.cpp
+++ b/cpp/dolfinx/generation/RectangleMesh.cpp
@@ -140,14 +140,19 @@ mesh::Mesh build_tri(MPI_Comm comm,
         xt::xtensor_fixed<std::size_t, xt::xshape<4, 3>> c
             = {{v0, v1, vmid}, {v0, v2, vmid}, {v1, v3, vmid}, {v2, v3, vmid}};
         std::size_t offset = iy * nx + ix;
+
+        // Note: we would like to assign to a view, but this does not
+        // work correctly with the Intel icpx compiler
+        // xt::view(cells, xt::range(4 * offset, 4 * offset + 4), xt::all()) =
+        // c;
         auto _cell
             = xt::view(cells, xt::range(4 * offset, 4 * offset + 4), xt::all());
         _cell.assign(c);
       }
     }
   }
-  else if (diagonal == "left" || diagonal == "right" || diagonal == "right/left"
-           || diagonal == "left/right")
+  else if (diagonal == "left" or diagonal == "right" or diagonal == "right/left"
+           or diagonal == "left/right")
   {
     std::string local_diagonal = diagonal;
     for (std::size_t iy = 0; iy < ny; iy++)
@@ -180,7 +185,12 @@ mesh::Mesh build_tri(MPI_Comm comm,
         {
           xt::xtensor_fixed<std::size_t, xt::xshape<2, 3>> c
               = {{v0, v1, v2}, {v1, v2, v3}};
-          auto _cell = xt::view(cells, xt::range(2 * offset, 2 * offset + 2));
+          // Note: we would like to assign to a view, but this does not
+          // work correctly with the Intel icpx compiler
+          // xt::view(cells, xt::range(2 * offset, 2 * offset + 2), xt::all()) =
+          // c;
+          auto _cell = xt::view(cells, xt::range(2 * offset, 2 * offset + 2),
+                                xt::all());
           _cell.assign(c);
           if (diagonal == "right/left" || diagonal == "left/right")
             local_diagonal = "right";
@@ -189,7 +199,12 @@ mesh::Mesh build_tri(MPI_Comm comm,
         {
           xt::xtensor_fixed<std::size_t, xt::xshape<2, 3>> c
               = {{v0, v1, v3}, {v0, v2, v3}};
-          auto _cell = xt::view(cells, xt::range(2 * offset, 2 * offset + 2));
+          // Note: we would like to assign to a view, but this does not
+          // work correctly with the Intel icpx compiler
+          // xt::view(cells, xt::range(2 * offset, 2 * offset + 2), xt::all()) =
+          // c;
+          auto _cell = xt::view(cells, xt::range(2 * offset, 2 * offset + 2),
+                                xt::all());
           _cell.assign(c);
           if (diagonal == "right/left" || diagonal == "left/right")
             local_diagonal = "left";
@@ -262,7 +277,10 @@ mesh::Mesh build_quad(MPI_Comm comm,
       std::size_t cell = ix * ny + iy;
       xt::xtensor_fixed<std::size_t, xt::xshape<4>> c
           = {i0 + iy, i0 + iy + 1, i0 + iy + ny + 1, i0 + iy + ny + 2};
-      auto _cell = xt::view(cells, cell, xt::all());
+      // Note: we would like to assign to a view, but this does not
+      // work correctly with the Intel icpx compiler
+      // xt::row(cells, cell) = c;
+      auto _cell = xt::row(cells, cell);
       _cell.assign(c);
     }
   }

--- a/cpp/dolfinx/io/VTKFile.cpp
+++ b/cpp/dolfinx/io/VTKFile.cpp
@@ -107,9 +107,7 @@ std::string xt_to_string(const T& x, int precision)
 {
   std::stringstream s;
   s.precision(precision);
-
   std::for_each(x.begin(), x.end(), [&s](auto e) { s << e << " "; });
-
   return s.str();
 }
 

--- a/cpp/dolfinx/io/xdmf_mesh.cpp
+++ b/cpp/dolfinx/io/xdmf_mesh.cpp
@@ -265,8 +265,12 @@ xt::xtensor<double, 2> xdmf_mesh::read_geometry_data(MPI_Comm comm,
       = xdmf_read::get_dataset<double>(comm, geometry_data_node, h5_id);
   const std::size_t num_local_nodes = geometry_data.size() / gdim;
   std::array<std::size_t, 2> shape = {num_local_nodes, gdim};
-  return xt::adapt(geometry_data.data(), geometry_data.size(),
-                   xt::no_ownership(), shape);
+
+  // Explicitly copy to an xtensor
+  xt::xtensor<double, 2> x = xt::empty<double>(shape);
+  std::copy(geometry_data.begin(), geometry_data.end(), x.begin());
+
+  return x;
 }
 //----------------------------------------------------------------------------
 xt::xtensor<std::int64_t, 2>
@@ -296,8 +300,10 @@ xdmf_mesh::read_topology_data(MPI_Comm comm, const hid_t h5_id,
   const std::size_t num_local_cells = topology_data.size() / npoint_per_cell;
 
   std::array<std::size_t, 2> shape = {num_local_cells, npoint_per_cell};
-  auto cells_vtk = xt::adapt(topology_data.data(), topology_data.size(),
-                             xt::no_ownership(), shape);
+
+  // Explicitly copy to an xtensor
+  xt::xtensor<std::int64_t, 2> cells_vtk = xt::empty<std::int64_t>(shape);
+  std::copy(topology_data.begin(), topology_data.end(), cells_vtk.begin());
 
   //  Permute cells from VTK to DOLFINx ordering
   return io::cells::compute_permutation(

--- a/cpp/dolfinx/io/xdmf_mesh.cpp
+++ b/cpp/dolfinx/io/xdmf_mesh.cpp
@@ -266,10 +266,13 @@ xt::xtensor<double, 2> xdmf_mesh::read_geometry_data(MPI_Comm comm,
   const std::size_t num_local_nodes = geometry_data.size() / gdim;
   std::array<std::size_t, 2> shape = {num_local_nodes, gdim};
 
+  // The below should work, but misbehaves with the Intel icpx compiler
+  // return xt::adapt(geometry_data.data(), geometry_data.size(),
+  //                  xt::no_ownership(), shape);
+
   // Explicitly copy to an xtensor
   xt::xtensor<double, 2> x = xt::empty<double>(shape);
   std::copy(geometry_data.begin(), geometry_data.end(), x.begin());
-
   return x;
 }
 //----------------------------------------------------------------------------
@@ -300,6 +303,10 @@ xdmf_mesh::read_topology_data(MPI_Comm comm, const hid_t h5_id,
   const std::size_t num_local_cells = topology_data.size() / npoint_per_cell;
 
   std::array<std::size_t, 2> shape = {num_local_cells, npoint_per_cell};
+
+  // The below should work, but misbehaves with the Intel icpx compiler
+  // auto cells_vtk = xt::adapt(topology_data.data(), topology_data.size(),
+  //                            xt::no_ownership(), shape);
 
   // Explicitly copy to an xtensor
   xt::xtensor<std::int64_t, 2> cells_vtk = xt::empty<std::int64_t>(shape);

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -586,8 +586,13 @@ xdmf_utils::extract_local_entities(const mesh::Mesh& mesh, const int entity_dim,
 
   std::array<std::size_t, 2> shape_r = {
       entities_new.size() / num_vertices_per_entity, num_vertices_per_entity};
+
+  // The below should work, but misbehaves with the Intel icpx compiler
+  // auto e_new = xt::adapt(entities_new.data(), entities_new.size(),
+  //                        xt::no_ownership(), shape_r);
   xt::xtensor<std::int32_t, 2> e_new(shape_r);
   std::copy_n(entities_new.data(), entities_new.size(), e_new.data());
-  return {e_new, values_new};
+
+  return {std::move(e_new), std::move(values_new)};
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -586,8 +586,8 @@ xdmf_utils::extract_local_entities(const mesh::Mesh& mesh, const int entity_dim,
 
   std::array<std::size_t, 2> shape_r = {
       entities_new.size() / num_vertices_per_entity, num_vertices_per_entity};
-  auto e_new = xt::adapt(entities_new.data(), entities_new.size(),
-                         xt::no_ownership(), shape_r);
+  xt::xtensor<std::int32_t, 2> e_new(shape_r);
+  std::copy_n(entities_new.data(), entities_new.size(), e_new.data());
   return {e_new, values_new};
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -54,7 +54,8 @@ public:
     {
       xt::xtensor<double, 2> c
           = xt::zeros<double>({_x.shape(0), static_cast<std::size_t>(3)});
-      xt::view(c, xt::all(), xt::range(0, _dim)) = _x;
+      auto x_view = xt::view(c, xt::all(), xt::range(0, _dim));
+      x_view.assign(_x);
       std::swap(c, _x);
     }
   }

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -54,8 +54,12 @@ public:
     {
       xt::xtensor<double, 2> c
           = xt::zeros<double>({_x.shape(0), static_cast<std::size_t>(3)});
+
+      // The below should work, but misbehaves with the Intel icpx compiler
+      // xt::view(c, xt::all(), xt::range(0, _dim)) = _x;
       auto x_view = xt::view(c, xt::all(), xt::range(0, _dim));
       x_view.assign(_x);
+
       std::swap(c, _x);
     }
   }

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -80,8 +80,8 @@ std::vector<double> mesh::h(const Mesh& mesh,
   {
     // Get the coordinates  of the vertices
     auto dofs = x_dofs.links(entities[e]);
-    xt::view(points, xt::range(0, num_vertices), xt::all())
-        = xt::view(geom_dofs, xt::keep(dofs), xt::all());
+    auto points_view = xt::view(points, xt::range(0, num_vertices), xt::all());
+    points_view.assign(xt::view(geom_dofs, xt::keep(dofs), xt::all()));
 
     // Get maximum edge length
     for (int i = 0; i < num_vertices; ++i)
@@ -197,7 +197,8 @@ mesh::midpoints(const mesh::Mesh& mesh, int dim,
   for (std::size_t e = 0; e < entity_to_geometry.shape(0); ++e)
   {
     auto rows = xt::row(entity_to_geometry, e);
-    xt::row(x_mid, e) = xt::mean(xt::view(x, xt::keep(rows)), 0);
+    auto _x = xt::row(x_mid, e);
+    _x.assign(xt::mean(xt::view(x, xt::keep(rows)), 0));
   }
 
   return x_mid;

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -80,6 +80,10 @@ std::vector<double> mesh::h(const Mesh& mesh,
   {
     // Get the coordinates  of the vertices
     auto dofs = x_dofs.links(entities[e]);
+
+    // The below should work, but misbehaves with the Intel icpx compiler
+    // xt::view(points, xt::range(0, num_vertices), xt::all())
+    //     = xt::view(geom_dofs, xt::keep(dofs), xt::all());
     auto points_view = xt::view(points, xt::range(0, num_vertices), xt::all());
     points_view.assign(xt::view(geom_dofs, xt::keep(dofs), xt::all()));
 
@@ -197,6 +201,8 @@ mesh::midpoints(const mesh::Mesh& mesh, int dim,
   for (std::size_t e = 0; e < entity_to_geometry.shape(0); ++e)
   {
     auto rows = xt::row(entity_to_geometry, e);
+    // The below should work, but misbehaves with the Intel icpx compiler
+    // xt::row(x_mid, e) = xt::mean(xt::view(x, xt::keep(rows)), 0);
     auto _x = xt::row(x_mid, e);
     _x.assign(xt::mean(xt::view(x, xt::keep(rows)), 0));
   }

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -99,8 +99,10 @@ xt::xtensor<double, 2> create_new_geometry(
     edges[i++] = e.first;
 
   const xt::xtensor<double, 2> midpoints = mesh::midpoints(mesh, 1, edges);
-  xt::view(new_vertex_coordinates, xt::range(-num_new_vertices, _), xt::all())
-      = midpoints;
+
+  auto _vertex = xt::view(new_vertex_coordinates,
+                          xt::range(-num_new_vertices, _), xt::all());
+  _vertex.assign(midpoints);
 
   const std::size_t gdim = mesh.geometry().dim();
   return xt::view(new_vertex_coordinates, xt::all(), xt::range(0, gdim));

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -99,13 +99,16 @@ xt::xtensor<double, 2> create_new_geometry(
     edges[i++] = e.first;
 
   const xt::xtensor<double, 2> midpoints = mesh::midpoints(mesh, 1, edges);
-
+  // The below should work, but misbehaves with the Intel icpx compiler
+  // xt::view(new_vertex_coordinates, xt::range(-num_new_vertices, _),
+  // xt::all())
+  //     = midpoints;
   auto _vertex = xt::view(new_vertex_coordinates,
                           xt::range(-num_new_vertices, _), xt::all());
   _vertex.assign(midpoints);
 
-  const std::size_t gdim = mesh.geometry().dim();
-  return xt::view(new_vertex_coordinates, xt::all(), xt::range(0, gdim));
+  return xt::view(new_vertex_coordinates, xt::all(),
+                  xt::range(0, mesh.geometry().dim()));
 }
 } // namespace
 

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -110,7 +110,8 @@ void fem(py::module& m)
       "create_dofmap",
       [](const MPICommWrapper comm, const std::uintptr_t dofmap,
          dolfinx::mesh::Topology& topology,
-         std::shared_ptr<dolfinx::fem::FiniteElement> element) {
+         std::shared_ptr<dolfinx::fem::FiniteElement> element)
+      {
         const ufc_dofmap* p = reinterpret_cast<const ufc_dofmap*>(dofmap);
         return dolfinx::fem::create_dofmap(comm.get(), *p, topology, nullptr,
                                            element);
@@ -737,8 +738,8 @@ void fem(py::module& m)
             std::array<std::size_t, 2> shape_u
                 = {static_cast<std::size_t>(u.shape(0)),
                    static_cast<std::size_t>(u.shape(1))};
-            xt::xtensor<PetscScalar, 2> _u = xt::adapt(
-                u.mutable_data(), u.size(), xt::no_ownership(), shape_u);
+            xt::xtensor<PetscScalar, 2> _u(shape_u);
+            std::copy_n(u.data(), u.size(), _u.data());
             self.eval(_x, xtl::span(cells.data(), cells.size()), _u);
             std::copy_n(_u.data(), _u.size(), u.mutable_data());
           },

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -738,8 +738,14 @@ void fem(py::module& m)
             std::array<std::size_t, 2> shape_u
                 = {static_cast<std::size_t>(u.shape(0)),
                    static_cast<std::size_t>(u.shape(1))};
+
+            // The below should work, but misbehaves with the Intel icpx
+            // compiler
+            // xt::xtensor<PetscScalar, 2> _u = xt::adapt(
+            //     u.mutable_data(), u.size(), xt::no_ownership(), shape_u);
             xt::xtensor<PetscScalar, 2> _u(shape_u);
             std::copy_n(u.data(), u.size(), _u.data());
+
             self.eval(_x, xtl::span(cells.data(), cells.size()), _u);
             std::copy_n(_u.data(), _u.size(), u.mutable_data());
           },

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -50,6 +50,11 @@ void io(py::module& m)
           std::array<std::size_t, 2> shape
               = {static_cast<std::size_t>(entities.shape(0)),
                  static_cast<std::size_t>(entities.shape(1))};
+
+          // The below should work, but misbehaves with the Intel icpx
+          // compiler
+          // auto _entities = xt::adapt(entities.data(), entities.size(),
+          //                            xt::no_ownership(), shape);
           xt::xtensor<std::int64_t, 2> _entities(shape);
           std::copy_n(entities.data(), entities.size(), _entities.data());
 

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -44,19 +44,21 @@ void io(py::module& m)
   m.def("extract_local_entities",
         [](const dolfinx::mesh::Mesh& mesh, int entity_dim,
            const py::array_t<std::int64_t, py::array::c_style>& entities,
-           const py::array_t<std::int32_t, py::array::c_style>& values) {
+           const py::array_t<std::int32_t, py::array::c_style>& values)
+        {
           assert(entities.ndim() == 2);
           std::array<std::size_t, 2> shape
               = {static_cast<std::size_t>(entities.shape(0)),
                  static_cast<std::size_t>(entities.shape(1))};
-          auto _entities = xt::adapt(entities.data(), entities.size(),
-                                     xt::no_ownership(), shape);
-          std::pair<xt::xtensor<std::int32_t, 2>, std::vector<std::int32_t>> e
-              = dolfinx::io::xdmf_utils::extract_local_entities(
-                  mesh, entity_dim, _entities,
-                  xtl::span(values.data(), values.size()));
-          return std::pair(xt_as_pyarray(std::move(e.first)),
-                           as_pyarray(std::move(e.second)));
+          xt::xtensor<std::int64_t, 2> _entities(shape);
+          std::copy_n(entities.data(), entities.size(), _entities.data());
+
+          auto [e, v] = dolfinx::io::xdmf_utils::extract_local_entities(
+              mesh, entity_dim, _entities,
+              xtl::span(values.data(), values.size()));
+
+          return std::pair(xt_as_pyarray(std::move(e)),
+                           as_pyarray(std::move(v)));
         });
 
   // dolfinx::io::XDMFFile
@@ -69,12 +71,14 @@ void io(py::module& m)
       .value("ASCII", dolfinx::io::XDMFFile::Encoding::ASCII);
 
   xdmf_file
-      .def(py::init([](const MPICommWrapper comm, const std::string filename,
-                       const std::string file_mode,
-                       dolfinx::io::XDMFFile::Encoding encoding) {
-             return std::make_unique<dolfinx::io::XDMFFile>(
-                 comm.get(), filename, file_mode, encoding);
-           }),
+      .def(py::init(
+               [](const MPICommWrapper comm, const std::string filename,
+                  const std::string file_mode,
+                  dolfinx::io::XDMFFile::Encoding encoding)
+               {
+                 return std::make_unique<dolfinx::io::XDMFFile>(
+                     comm.get(), filename, file_mode, encoding);
+               }),
            py::arg("comm"), py::arg("filename"), py::arg("file_mode"),
            py::arg("encoding") = dolfinx::io::XDMFFile::Encoding::HDF5)
       .def("__enter__",
@@ -91,16 +95,14 @@ void io(py::module& m)
       .def(
           "read_topology_data",
           [](dolfinx::io::XDMFFile& self, const std::string& name,
-             const std::string& xpath) {
-            return xt_as_pyarray(self.read_topology_data(name, xpath));
-          },
+             const std::string& xpath)
+          { return xt_as_pyarray(self.read_topology_data(name, xpath)); },
           py::arg("name") = "mesh", py::arg("xpath") = "/Xdmf/Domain")
       .def(
           "read_geometry_data",
           [](dolfinx::io::XDMFFile& self, const std::string& name,
-             const std::string& xpath) {
-            return xt_as_pyarray(self.read_geometry_data(name, xpath));
-          },
+             const std::string& xpath)
+          { return xt_as_pyarray(self.read_geometry_data(name, xpath)); },
           py::arg("name") = "mesh", py::arg("xpath") = "/Xdmf/Domain")
       .def("read_geometry_data", &dolfinx::io::XDMFFile::read_geometry_data,
            py::arg("name") = "mesh", py::arg("xpath") = "/Xdmf/Domain")
@@ -127,18 +129,18 @@ void io(py::module& m)
            py::arg("name"), py::arg("value"), py::arg("xpath") = "/Xdmf/Domain")
       .def("read_information", &dolfinx::io::XDMFFile::read_information,
            py::arg("name"), py::arg("xpath") = "/Xdmf/Domain")
-      .def("comm", [](dolfinx::io::XDMFFile& self) {
-        return MPICommWrapper(self.comm());
-      });
+      .def("comm", [](dolfinx::io::XDMFFile& self)
+           { return MPICommWrapper(self.comm()); });
 
   // dolfinx::io::VTKFile
   py::class_<dolfinx::io::VTKFile, std::shared_ptr<dolfinx::io::VTKFile>>(
       m, "VTKFile")
-      .def(py::init([](const MPICommWrapper comm, const std::string& filename,
-                       const std::string& mode) {
-             return std::make_unique<dolfinx::io::VTKFile>(comm.get(),
-                                                              filename, mode);
-           }),
+      .def(py::init(
+               [](const MPICommWrapper comm, const std::string& filename,
+                  const std::string& mode) {
+                 return std::make_unique<dolfinx::io::VTKFile>(comm.get(),
+                                                               filename, mode);
+               }),
            py::arg("comm"), py::arg("filename"), py::arg("mode"))
       .def("__enter__",
            [](std::shared_ptr<dolfinx::io::VTKFile>& self) { return self; })

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -44,7 +44,8 @@ void declare_meshtags(py::module& m, std::string type)
       .def(py::init(
           [](const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh, int dim,
              const py::array_t<std::int32_t, py::array::c_style>& indices,
-             const py::array_t<T, py::array::c_style>& values) {
+             const py::array_t<T, py::array::c_style>& values)
+          {
             std::vector<std::int32_t> indices_vec(
                 indices.data(), indices.data() + indices.size());
             std::vector<T> values_vec(values.data(),
@@ -57,20 +58,25 @@ void declare_meshtags(py::module& m, std::string type)
       .def_property_readonly("mesh", &dolfinx::mesh::MeshTags<T>::mesh)
       .def("ufl_id", &dolfinx::mesh::MeshTags<T>::id)
       .def_property_readonly("values",
-                             [](dolfinx::mesh::MeshTags<T>& self) {
+                             [](dolfinx::mesh::MeshTags<T>& self)
+                             {
                                return py::array_t<T>(self.values().size(),
                                                      self.values().data(),
                                                      py::cast(self));
                              })
-      .def_property_readonly("indices", [](dolfinx::mesh::MeshTags<T>& self) {
-        return py::array_t<std::int32_t>(self.indices().size(),
-                                         self.indices().data(), py::cast(self));
-      });
+      .def_property_readonly("indices",
+                             [](dolfinx::mesh::MeshTags<T>& self)
+                             {
+                               return py::array_t<std::int32_t>(
+                                   self.indices().size(), self.indices().data(),
+                                   py::cast(self));
+                             });
 
   m.def("create_meshtags",
         [](const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh, int dim,
            const dolfinx::graph::AdjacencyList<std::int32_t>& entities,
-           const py::array_t<T, py::array::c_style>& values) {
+           const py::array_t<T, py::array::c_style>& values)
+        {
           return dolfinx::mesh::create_meshtags(
               mesh, dim, entities, xtl::span(values.data(), values.size()));
         });
@@ -99,7 +105,8 @@ void mesh(py::module& m)
   m.def("cell_num_vertices", &dolfinx::mesh::num_cell_vertices);
   m.def("cell_normals",
         [](const dolfinx::mesh::Mesh& mesh, int dim,
-           const py::array_t<std::int32_t, py::array::c_style>& entities) {
+           const py::array_t<std::int32_t, py::array::c_style>& entities)
+        {
           return xt_as_pyarray(dolfinx::mesh::cell_normals(
               mesh, dim, xtl::span(entities.data(), entities.size())));
         });
@@ -109,7 +116,8 @@ void mesh(py::module& m)
   m.def(
       "h",
       [](const dolfinx::mesh::Mesh& mesh, int dim,
-         const py::array_t<std::int32_t, py::array::c_style>& entities) {
+         const py::array_t<std::int32_t, py::array::c_style>& entities)
+      {
         return as_pyarray(dolfinx::mesh::h(
             mesh, xtl::span(entities.data(), entities.size()), dim));
       },
@@ -117,7 +125,8 @@ void mesh(py::module& m)
 
   m.def("midpoints",
         [](const dolfinx::mesh::Mesh& mesh, int dim,
-           py::array_t<std::int32_t, py::array::c_style> entity_list) {
+           py::array_t<std::int32_t, py::array::c_style> entity_list)
+        {
           return xt_as_pyarray(dolfinx::mesh::midpoints(
               mesh, dim, xtl::span(entity_list.data(), entity_list.size())));
         });
@@ -131,9 +140,8 @@ void mesh(py::module& m)
 
   m.def("build_dual_graph",
         [](const MPICommWrapper comm,
-           const dolfinx::graph::AdjacencyList<std::int64_t>& cells, int tdim) {
-          return dolfinx::mesh::build_dual_graph(comm.get(), cells, tdim);
-        });
+           const dolfinx::graph::AdjacencyList<std::int64_t>& cells, int tdim)
+        { return dolfinx::mesh::build_dual_graph(comm.get(), cells, tdim); });
 
   m.def(
       "create_mesh",
@@ -142,15 +150,16 @@ void mesh(py::module& m)
          const dolfinx::fem::CoordinateElement& element,
          const py::array_t<double, py::array::c_style>& x,
          dolfinx::mesh::GhostMode ghost_mode,
-         PythonPartitioningFunction partitioner) {
+         PythonPartitioningFunction partitioner)
+      {
         auto partitioner_wrapper
             = [partitioner](
                   MPI_Comm comm, int n, int tdim,
                   const dolfinx::graph::AdjacencyList<std::int64_t>& cells,
-                  dolfinx::mesh::GhostMode ghost_mode) {
-                return partitioner(MPICommWrapper(comm), n, tdim, cells,
-                                   ghost_mode);
-              };
+                  dolfinx::mesh::GhostMode ghost_mode)
+        {
+          return partitioner(MPICommWrapper(comm), n, tdim, cells, ghost_mode);
+        };
 
         const std::size_t shape1 = x.ndim() == 1 ? 1 : x.shape()[1];
         std::array<std::size_t, 2> shape
@@ -176,7 +185,8 @@ void mesh(py::module& m)
              const dolfinx::fem::CoordinateElement& element,
              const py::array_t<double, py::array::c_style>& x,
              const py::array_t<std::int64_t, py::array::c_style>&
-                 global_indices) {
+                 global_indices)
+          {
             std::vector<std::int64_t> indices(global_indices.data(),
                                               global_indices.data()
                                                   + global_indices.size());
@@ -207,7 +217,8 @@ void mesh(py::module& m)
       .def("index_map", &dolfinx::mesh::Geometry::index_map)
       .def_property_readonly(
           "x",
-          [](const dolfinx::mesh::Geometry& self) {
+          [](const dolfinx::mesh::Geometry& self)
+          {
             const xt::xtensor<double, 2>& x = self.x();
             return py::array_t<double>(x.shape(), x.data(), py::cast(self));
           },
@@ -219,20 +230,17 @@ void mesh(py::module& m)
                              &dolfinx::mesh::Geometry::input_global_indices);
 
   // dolfinx::mesh::TopologyComputation
-  m.def("compute_entities",
-        [](const MPICommWrapper comm, const dolfinx::mesh::Topology& topology,
-           int dim) {
-          return dolfinx::mesh::compute_entities(comm.get(), topology, dim);
-        });
+  m.def("compute_entities", [](const MPICommWrapper comm,
+                               const dolfinx::mesh::Topology& topology, int dim)
+        { return dolfinx::mesh::compute_entities(comm.get(), topology, dim); });
   m.def("compute_connectivity", &dolfinx::mesh::compute_connectivity);
 
   // dolfinx::mesh::Topology class
   py::class_<dolfinx::mesh::Topology, std::shared_ptr<dolfinx::mesh::Topology>>(
       m, "Topology", "Topology object")
-      .def(py::init([](const MPICommWrapper comm,
-                       const dolfinx::mesh::CellType cell_type) {
-        return dolfinx::mesh::Topology(comm.get(), cell_type);
-      }))
+      .def(py::init(
+          [](const MPICommWrapper comm, const dolfinx::mesh::CellType cell_type)
+          { return dolfinx::mesh::Topology(comm.get(), cell_type); }))
       .def("set_connectivity", &dolfinx::mesh::Topology::set_connectivity)
       .def("set_index_map", &dolfinx::mesh::Topology::set_index_map)
       .def("create_entities", &dolfinx::mesh::Topology::create_entities)
@@ -242,13 +250,15 @@ void mesh(py::module& m)
       .def("create_connectivity_all",
            &dolfinx::mesh::Topology::create_connectivity_all)
       .def("get_facet_permutations",
-           [](const dolfinx::mesh::Topology& self) {
+           [](const dolfinx::mesh::Topology& self)
+           {
              const std::vector<std::uint8_t>& p = self.get_facet_permutations();
              return py::array_t<std::uint8_t>(p.size(), p.data(),
                                               py::cast(self));
            })
       .def("get_cell_permutation_info",
-           [](const dolfinx::mesh::Topology& self) {
+           [](const dolfinx::mesh::Topology& self)
+           {
              const std::vector<std::uint32_t>& p
                  = self.get_cell_permutation_info();
              return py::array_t<std::uint32_t>(p.size(), p.data(),
@@ -261,29 +271,23 @@ void mesh(py::module& m)
                                        py::const_))
       .def("index_map", &dolfinx::mesh::Topology::index_map)
       .def_property_readonly("cell_type", &dolfinx::mesh::Topology::cell_type)
-      .def("cell_name",
-           [](const dolfinx::mesh::Topology& self) {
-             return dolfinx::mesh::to_string(self.cell_type());
-           })
-      .def("mpi_comm", [](dolfinx::mesh::Mesh& self) {
-        return MPICommWrapper(self.mpi_comm());
-      });
+      .def("cell_name", [](const dolfinx::mesh::Topology& self)
+           { return dolfinx::mesh::to_string(self.cell_type()); })
+      .def("mpi_comm", [](dolfinx::mesh::Mesh& self)
+           { return MPICommWrapper(self.mpi_comm()); });
 
   // dolfinx::mesh::Mesh
   py::class_<dolfinx::mesh::Mesh, std::shared_ptr<dolfinx::mesh::Mesh>>(
       m, "Mesh", py::dynamic_attr(), "Mesh object")
-      .def(py::init([](const MPICommWrapper comm,
-                       const dolfinx::mesh::Topology& topology,
-                       dolfinx::mesh::Geometry& geometry) {
-        return dolfinx::mesh::Mesh(comm.get(), topology, geometry);
-      }))
+      .def(py::init(
+          [](const MPICommWrapper comm, const dolfinx::mesh::Topology& topology,
+             dolfinx::mesh::Geometry& geometry)
+          { return dolfinx::mesh::Mesh(comm.get(), topology, geometry); }))
       .def_property_readonly(
           "geometry", py::overload_cast<>(&dolfinx::mesh::Mesh::geometry),
           "Mesh geometry")
-      .def("mpi_comm",
-           [](dolfinx::mesh::Mesh& self) {
-             return MPICommWrapper(self.mpi_comm());
-           })
+      .def("mpi_comm", [](dolfinx::mesh::Mesh& self)
+           { return MPICommWrapper(self.mpi_comm()); })
       .def_property_readonly(
           "topology", py::overload_cast<>(&dolfinx::mesh::Mesh::topology),
           "Mesh topology", py::return_value_policy::reference_internal)
@@ -311,10 +315,11 @@ void mesh(py::module& m)
   m.def("locate_entities",
         [](const dolfinx::mesh::Mesh& mesh, int dim,
            const std::function<py::array_t<bool>(
-               const py::array_t<double, py::array::c_style>&)>& marker) {
-          auto cpp_marker
-              = [&marker](
-                    const xt::xtensor<double, 2>& x) -> xt::xtensor<bool, 1> {
+               const py::array_t<double, py::array::c_style>&)>& marker)
+        {
+          auto cpp_marker =
+              [&marker](const xt::xtensor<double, 2>& x) -> xt::xtensor<bool, 1>
+          {
             py::array_t<double> x_view(x.shape(), x.data(), py::none());
             py::array_t<bool> marked = marker(x_view);
             std::array shape = {static_cast<std::size_t>(marked.size())};
@@ -328,10 +333,11 @@ void mesh(py::module& m)
   m.def("locate_entities_boundary",
         [](const dolfinx::mesh::Mesh& mesh, int dim,
            const std::function<py::array_t<bool>(
-               const py::array_t<double, py::array::c_style>&)>& marker) {
-          auto cpp_marker
-              = [&marker](
-                    const xt::xtensor<double, 2>& x) -> xt::xtensor<bool, 1> {
+               const py::array_t<double, py::array::c_style>&)>& marker)
+        {
+          auto cpp_marker =
+              [&marker](const xt::xtensor<double, 2>& x) -> xt::xtensor<bool, 1>
+          {
             py::array_t<double> x_view(x.shape(), x.data(), py::none());
             py::array_t<bool> marked = marker(x_view);
             std::array shape = {static_cast<std::size_t>(marked.size())};
@@ -345,7 +351,8 @@ void mesh(py::module& m)
   m.def("entities_to_geometry",
         [](const dolfinx::mesh::Mesh& mesh, int dim,
            py::array_t<std::int32_t, py::array::c_style> entity_list,
-           bool orient) {
+           bool orient)
+        {
           return xt_as_pyarray(dolfinx::mesh::entities_to_geometry(
               mesh, dim, xtl::span(entity_list.data(), entity_list.size()),
               orient));


### PR DESCRIPTION
xtensor/icpx issues:
- Assign to a view (using `operator=()`)
- Return an `xt::adapt` instead of an `xtensor<T, 2>`.
- `operator[]` has unpredictable behavior for 2d/3d tensors.

I'm working in a new PR for `icpc`.