### PR TITLE
Make checkout refs explicit

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - "**"
     tags:
-      - "*.*.*.*"
-      - "*.*.*"
+      - "v*"
   pull_request:
     branches:
       - main
@@ -133,18 +132,18 @@ jobs:
           if-no-files-found: error
 
       - name: Checkout FEniCS/docs
-        if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') ) && runner.os == 'Linux' }}
+        if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) && runner.os == 'Linux' }}
         uses: actions/checkout@v2
         with:
           repository: "FEniCS/docs"
           path: "docs"
           ssh-key: "${{ secrets.SSH_GITHUB_DOCS_PRIVATE_KEY }}"
       - name: Set version name
-        if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') ) && runner.os == 'Linux' }}
+        if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) && runner.os == 'Linux' }}
         run: |
           echo "VERSION_NAME=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Copy documentation into repository
-        if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') ) && runner.os == 'Linux' }}
+        if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) && runner.os == 'Linux' }}
         run: |
           cd docs
           git rm -r --ignore-unmatch dolfinx/${{ env.VERSION_NAME }}/cpp
@@ -154,7 +153,7 @@ jobs:
           cp -r ../cpp/doc/html/* dolfinx/${{ env.VERSION_NAME }}/cpp
           cp -r ../python/doc/build/html/* dolfinx/${{ env.VERSION_NAME }}/python
       - name: Commit and push documentation to FEniCS/docs
-        if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') ) && runner.os == 'Linux' && matrix.petsc_arch == 'real' && matrix.petsc_int_type == '32' }}
+        if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) && runner.os == 'Linux' && matrix.petsc_arch == 'real' && matrix.petsc_int_type == '32' }}
         run: |
           cd docs
           git config --global user.email "fenics@github.com"

--- a/.github/workflows/docker-end-user.yml
+++ b/.github/workflows/docker-end-user.yml
@@ -65,18 +65,22 @@ jobs:
         with:
           repository: "FEniCS/dolfinx"
           path: "dolfinx"
+          ref: "main"
       - uses: actions/checkout@v2
         with:
           repository: "FEniCS/ffcx"
           path: "ffcx"
+          ref: "main"
       - uses: actions/checkout@v2
         with:
           repository: "FEniCS/basix"
           path: "basix"
+          ref: "main"
       - uses: actions/checkout@v2
         with:
           repository: "FEniCS/ufl"
           path: "ufl"
+          ref: "main"
       - name: Get tag name
         id: tag_name
         run: |

--- a/.github/workflows/docker-end-user.yml
+++ b/.github/workflows/docker-end-user.yml
@@ -65,7 +65,6 @@ jobs:
         with:
           repository: "FEniCS/dolfinx"
           path: "dolfinx"
-          ref: "main"
       - uses: actions/checkout@v2
         with:
           repository: "FEniCS/ffcx"


### PR DESCRIPTION
Can be used to control matching branches for end-user docker images on release tag creation.