### PR TITLE
Faster way of fetching tdim

### DIFF
--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -72,7 +72,7 @@ mesh::CellType CoordinateElement::cell_shape() const
 //-----------------------------------------------------------------------------
 int CoordinateElement::topological_dimension() const
 {
-  return basix::cell::topology(_element->cell_type()).size() - 1;
+  return basix::cell::topological_dimension(_element->cell_type());
 }
 //-----------------------------------------------------------------------------
 xt::xtensor<double, 4>


### PR DESCRIPTION
Former approach calls `basix::topology` which needs dynamic memory alloc. Topological dimension of coordinate element is easily used in hot loops.