### PR TITLE
Bump min CMake version to 3.16. Earlier versions are not tested.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 #------------------------------------------------------------------------------
 # Top level CMakeLists.txt file for DOLFINx
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
 #------------------------------------------------------------------------------
 # Set project name and version number
@@ -8,17 +8,6 @@ cmake_minimum_required(VERSION 3.12)
 project(DOLFINX VERSION "0.1.1.0")
 
 set(DOXYGEN_DOLFINX_VERSION ${DOLFINX_VERSION} CACHE STRING "Version for Doxygen" FORCE)
-
-#------------------------------------------------------------------------------
-# Set CMake options, see `cmake --help-policy CMP000x`
-
-cmake_policy(VERSION 3.12)
-if (POLICY CMP0074)
-  cmake_policy(SET CMP0074 NEW)
-endif()
-if (POLICY CMP0075)
-  cmake_policy(SET CMP0075 NEW)
-endif()
 
 #------------------------------------------------------------------------------
 # Use C++17

--- a/cpp/cmake/scripts/generate-cmakefiles.py
+++ b/cpp/cmake/scripts/generate-cmakefiles.py
@@ -12,7 +12,7 @@ cmakelists_str = \
 #
 #     cmake/scripts/generate-cmakefiles
 #
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
 # Set C++17 standard
 set(CMAKE_CXX_STANDARD 17)

--- a/cpp/test/unit/CMakeLists.txt
+++ b/cpp/test/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 project(dolfinx-tests)
 
 # Find DOLFINx config file

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 PROJECT(dolfinx_pybind11)
 


### PR DESCRIPTION
Earlier versions can cause problems with 'modern' configuration of dependencies.