### PR TITLE
Remove topology functions that shouldn't be used

### DIFF
--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -30,11 +30,11 @@ namespace
 //-----------------------------------------------------------------------------
 
 /// Compute list of processes sharing the same index
-/// @param unknown_indices List of indices on each process
+/// @param unknown_idx List of indices on each process
 /// @return a map to sharing processes for each index, with the (random)
 /// owner as the first in the list
 std::unordered_map<std::int64_t, std::vector<int>>
-compute_index_sharing(MPI_Comm comm, std::vector<std::int64_t>& unknown_indices)
+compute_index_sharing(MPI_Comm comm, std::vector<std::int64_t>& unknown_idx)
 {
   const int mpi_size = dolfinx::MPI::size(comm);
 
@@ -42,16 +42,13 @@ compute_index_sharing(MPI_Comm comm, std::vector<std::int64_t>& unknown_indices)
   // algorithm and find the owner of each index within that space
   std::int64_t global_space = 0;
   std::int64_t max_index = 0;
-  if (!unknown_indices.empty())
-  {
-    max_index
-        = *std::max_element(unknown_indices.begin(), unknown_indices.end());
-  }
+  if (!unknown_idx.empty())
+    max_index = *std::max_element(unknown_idx.begin(), unknown_idx.end());
   MPI_Allreduce(&max_index, &global_space, 1, MPI_INT64_T, MPI_SUM, comm);
   global_space += 1;
 
   std::vector<std::vector<std::int64_t>> send_indices(mpi_size);
-  for (std::int64_t global_i : unknown_indices)
+  for (std::int64_t global_i : unknown_idx)
   {
     const int index_owner
         = dolfinx::MPI::index_owner(mpi_size, global_i, global_space);
@@ -95,8 +92,8 @@ compute_index_sharing(MPI_Comm comm, std::vector<std::int64_t>& unknown_indices)
     }
   }
 
-  // Alltoall is necessary because cells which are shared by vertex are not yet
-  // known to this process
+  // Alltoall is necessary because cells which are shared by vertex are
+  // not yet known to this process
   const graph::AdjacencyList<int> recv_owner
       = dolfinx::MPI::all_to_all(comm, graph::AdjacencyList<int>(send_owner));
 
@@ -163,7 +160,7 @@ Topology::Topology(MPI_Comm comm, mesh::CellType type)
   // Do nothing
 }
 //-----------------------------------------------------------------------------
-int Topology::dim() const { return _connectivity.size() - 1; }
+int Topology::dim() const noexcept { return _connectivity.size() - 1; }
 //-----------------------------------------------------------------------------
 void Topology::set_index_map(int dim,
                              const std::shared_ptr<const common::IndexMap>& map)
@@ -288,7 +285,7 @@ const std::vector<std::uint8_t>& Topology::get_facet_permutations() const
   return _facet_permutations;
 }
 //-----------------------------------------------------------------------------
-mesh::CellType Topology::cell_type() const { return _cell_type; }
+mesh::CellType Topology::cell_type() const noexcept { return _cell_type; }
 //-----------------------------------------------------------------------------
 MPI_Comm Topology::mpi_comm() const { return _mpi_comm.comm(); }
 //-----------------------------------------------------------------------------
@@ -331,28 +328,28 @@ mesh::create_topology(MPI_Comm comm,
   common::Timer t0("TOPOLOGY: Create sets");
 
   // Build a set of 'local' cell vertices
-  std::vector<std::int64_t> local_vertices_set(
+  std::vector<std::int64_t> local_vertex_set(
       cells.array().begin(),
       std::next(cells.array().begin(), cells.offsets()[num_local_cells]));
-  dolfinx::radix_sort(xtl::span(local_vertices_set));
-  local_vertices_set.erase(
-      std::unique(local_vertices_set.begin(), local_vertices_set.end()),
-      local_vertices_set.end());
+  dolfinx::radix_sort(xtl::span(local_vertex_set));
+  local_vertex_set.erase(
+      std::unique(local_vertex_set.begin(), local_vertex_set.end()),
+      local_vertex_set.end());
 
   // Build a set of ghost cell vertices
-  std::vector<std::int64_t> ghost_vertices_set(
+  std::vector<std::int64_t> ghost_vertex_set(
       std::next(cells.array().begin(), cells.offsets()[num_local_cells]),
       cells.array().end());
-  dolfinx::radix_sort(xtl::span(ghost_vertices_set));
-  ghost_vertices_set.erase(
-      std::unique(ghost_vertices_set.begin(), ghost_vertices_set.end()),
-      ghost_vertices_set.end());
+  dolfinx::radix_sort(xtl::span(ghost_vertex_set));
+  ghost_vertex_set.erase(
+      std::unique(ghost_vertex_set.begin(), ghost_vertex_set.end()),
+      ghost_vertex_set.end());
 
   // Compute the intersection of local cell vertices and ghost cell
   // vertices
   std::vector<std::int64_t> unknown_indices_set;
-  std::set_intersection(local_vertices_set.begin(), local_vertices_set.end(),
-                        ghost_vertices_set.begin(), ghost_vertices_set.end(),
+  std::set_intersection(local_vertex_set.begin(), local_vertex_set.end(),
+                        ghost_vertex_set.begin(), ghost_vertex_set.end(),
                         std::back_inserter(unknown_indices_set));
 
   // Create map from existing global vertex index to local index,
@@ -361,7 +358,7 @@ mesh::create_topology(MPI_Comm comm,
 
   // Any vertices which are in ghost cells set to -1 since we need to
   // determine ownership
-  for (std::int64_t idx : ghost_vertices_set)
+  for (std::int64_t idx : ghost_vertex_set)
     global_to_local_vertices.insert({idx, -1});
 
   // For each vertex whose ownership needs determining, compute list of
@@ -373,7 +370,7 @@ mesh::create_topology(MPI_Comm comm,
   std::int32_t v = 0;
 
   // Number all vertex indices which this process now owns
-  for (std::int64_t global_index : local_vertices_set)
+  for (std::int64_t global_index : local_vertex_set)
   {
     // Check if other ranks have this vertex
     const auto it = global_vertex_to_ranks.find(global_index);
@@ -417,7 +414,7 @@ mesh::create_topology(MPI_Comm comm,
               dolfinx::MPI::mpi_type<std::int64_t>(), MPI_SUM, comm,
               &request_scan_v);
 
-  // Re-order vertices by looping through cells in order
+  // Re-order vertices by iterating over cells in order
 
   std::vector<std::int32_t> node_remap(nlocal, -1);
   std::size_t counter = 0;
@@ -543,17 +540,15 @@ mesh::create_topology(MPI_Comm comm,
     }
 
     // Precompute sizes and offsets
-    std::vector<int> send_sizes(neighbors.size()),
-        send_offsets(neighbors.size() + 1);
+    std::vector<int> send_sizes(neighbors.size()), sdispl(neighbors.size() + 1);
     for (const auto& q : fwd_shared_vertices)
       for (int p : q.second)
         send_sizes[proc_to_neighbors[p]] += 2;
-    std::partial_sum(send_sizes.begin(), send_sizes.end(),
-                     send_offsets.begin() + 1);
-    std::vector<int> tmp_offsets(send_offsets.begin(), send_offsets.end());
+    std::partial_sum(send_sizes.begin(), send_sizes.end(), sdispl.begin() + 1);
+    std::vector<int> tmp_offsets(sdispl.begin(), sdispl.end());
 
     // Fill data for neighbor alltoall
-    std::vector<std::int64_t> send_pair_data(send_offsets.back());
+    std::vector<std::int64_t> send_pair_data(sdispl.back());
     for (const auto& q : fwd_shared_vertices)
     {
       const auto it = global_to_local_vertices.find(q.first);
@@ -574,7 +569,7 @@ mesh::create_topology(MPI_Comm comm,
     const std::vector<std::int64_t> recv_pairs
         = dolfinx::MPI::neighbor_all_to_all(
               neighbor_comm,
-              graph::AdjacencyList<std::int64_t>(send_pair_data, send_offsets))
+              graph::AdjacencyList<std::int64_t>(send_pair_data, sdispl))
               .array();
 
     // Unpack received data and add to ghosts
@@ -592,7 +587,7 @@ mesh::create_topology(MPI_Comm comm,
   }
 
   // Get global owners of ghost vertices
-  // TODO: Get vertice owner from cell owner? Can use neighborhood
+  // TODO: Get vertex owner from cell owner? Can use neighborhood
   // communication?
   int mpi_size = -1;
   MPI_Comm_size(neighbor_comm, &mpi_size);

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -252,18 +252,6 @@ void Topology::create_entity_permutations()
   _cell_permutations = std::move(cell_permutations);
 }
 //-----------------------------------------------------------------------------
-void Topology::create_connectivity_all()
-{
-  // Compute all entities
-  for (int d = 0; d <= dim(); d++)
-    create_entities(d);
-
-  // Compute all connectivity
-  for (int d0 = 0; d0 <= dim(); d0++)
-    for (int d1 = 0; d1 <= dim(); d1++)
-      create_connectivity(d0, d1);
-}
-//-----------------------------------------------------------------------------
 std::shared_ptr<const graph::AdjacencyList<std::int32_t>>
 Topology::connectivity(int d0, int d1) const
 {

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -73,7 +73,7 @@ public:
   /// Assignment
   Topology& operator=(Topology&& topology) = default;
 
-  /// Return topological dimension
+  /// Return the topological dimension of the mesh
   int dim() const;
 
   /// @todo Merge with set_connectivity
@@ -115,6 +115,8 @@ public:
   /// Each column of the returned array represents a cell, and each row
   /// a facet of that cell.
   /// @return The permutation number
+  /// @note An exception i raised if the permutations have not been
+  /// computed
   const std::vector<std::uint8_t>& get_facet_permutations() const;
 
   /// Cell type
@@ -125,11 +127,10 @@ public:
   // Currently, there is no clear caching policy implemented and no way of
   // discarding cached data.
 
-  // creation of entities
   /// Create entities of given topological dimension.
   /// @param[in] dim Topological dimension
   /// @return Number of newly created entities, returns -1 if entities
-  ///   already existed
+  /// already existed
   std::int32_t create_entities(int dim);
 
   /// Create connectivity between given pair of dimensions, d0 -> d1
@@ -139,9 +140,6 @@ public:
 
   /// Compute entity permutations and reflections
   void create_entity_permutations();
-
-  /// Compute all entities and connectivity
-  void create_connectivity_all();
 
   /// Mesh MPI communicator
   /// @return The communicator on which the topology is distributed

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -74,7 +74,7 @@ public:
   Topology& operator=(Topology&& topology) = default;
 
   /// Return the topological dimension of the mesh
-  int dim() const;
+  int dim() const noexcept;
 
   /// @todo Merge with set_connectivity
   ///
@@ -86,7 +86,8 @@ public:
   /// Get the IndexMap that described the parallel distribution of the
   /// mesh entities
   /// @param[in] dim Topological dimension
-  /// @return Index map for the entities of dimension @p dim
+  /// @return Index map for the entities of dimension @p dim. Returns
+  /// `nullptr` if index map has not been set.
   std::shared_ptr<const common::IndexMap> index_map(int dim) const;
 
   /// Return connectivity from entities of dimension d0 to entities of
@@ -94,7 +95,8 @@ public:
   /// @param[in] d0
   /// @param[in] d1
   /// @return The adjacency list that for each entity of dimension d0
-  ///   gives the list of incident entities of dimension d1
+  /// gives the list of incident entities of dimension d1. Returns
+  /// `nullptr` if connectivity has not been computed.
   std::shared_ptr<const graph::AdjacencyList<std::int32_t>>
   connectivity(int d0, int d1) const;
 
@@ -115,13 +117,13 @@ public:
   /// Each column of the returned array represents a cell, and each row
   /// a facet of that cell.
   /// @return The permutation number
-  /// @note An exception i raised if the permutations have not been
+  /// @note An exception is raised if the permutations have not been
   /// computed
   const std::vector<std::uint8_t>& get_facet_permutations() const;
 
   /// Cell type
   /// @return Cell type that the topology is for
-  mesh::CellType cell_type() const;
+  mesh::CellType cell_type() const noexcept;
 
   // TODO: Rework memory management and associated API
   // Currently, there is no clear caching policy implemented and no way of
@@ -152,10 +154,10 @@ private:
   // Cell type
   mesh::CellType _cell_type;
 
-  // IndexMap to store ghosting for each entity dimension
+  // Parallel layout of entities for each dimension
   std::array<std::shared_ptr<const common::IndexMap>, 4> _index_map;
 
-  // AdjacencyList for pairs of topological dimensions
+  // AdjacencyList for pairs [d0][d1] == d0 -> d1 connectivity
   std::vector<std::vector<std::shared_ptr<graph::AdjacencyList<std::int32_t>>>>
       _connectivity;
 
@@ -173,10 +175,10 @@ private:
 ///
 /// @param[in] comm MPI communicator across which the topology is
 /// distributed
-/// @param[in] cells The cell topology (list of cell vertices) using
-/// global indices for the vertices. It contains cells that have been
-/// distributed to this rank, e.g. via a graph partitioner. It must also
-/// contain all ghost cells via facet, i.e. cells that are on a
+/// @param[in] cells The cell topology (list of vertices for each cell)
+/// using global indices for the vertices. It contains cells that have
+/// been distributed to this rank, e.g. via a graph partitioner. It must
+/// also contain all ghost cells via facet, i.e. cells that are on a
 /// neighboring process and share a facet with a local cell.
 /// @param[in] original_cell_index The original global index associated
 /// with each cell

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -247,8 +247,6 @@ void mesh(py::module& m)
       .def("create_entity_permutations",
            &dolfinx::mesh::Topology::create_entity_permutations)
       .def("create_connectivity", &dolfinx::mesh::Topology::create_connectivity)
-      .def("create_connectivity_all",
-           &dolfinx::mesh::Topology::create_connectivity_all)
       .def("get_facet_permutations",
            [](const dolfinx::mesh::Topology& self)
            {

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -62,7 +62,6 @@ def unit_cell(cell_type, random_order=True):
 
     domain = ufl.Mesh(ufl.VectorElement("Lagrange", cpp.mesh.to_string(cell_type), 1))
     mesh = create_mesh(MPI.COMM_WORLD, cells, ordered_points, domain)
-    mesh.topology.create_connectivity_all()
     return mesh
 
 
@@ -123,7 +122,6 @@ def two_unit_cells(cell_type, agree=False, random_order=True, return_order=False
 
     domain = ufl.Mesh(ufl.VectorElement("Lagrange", cpp.mesh.to_string(cell_type), 1))
     mesh = create_mesh(MPI.COMM_WORLD, ordered_cells, ordered_points, domain)
-    mesh.topology.create_connectivity_all()
     if return_order:
         return mesh, order
     return mesh
@@ -140,6 +138,7 @@ def test_facet_integral(cell_type):
         V = FunctionSpace(mesh, ("Lagrange", 2))
         v = Function(V)
 
+        mesh.topology.create_entities(tdim - 1)
         map_f = mesh.topology.index_map(tdim - 1)
         num_facets = map_f.size_local + map_f.num_ghosts
         indices = np.arange(0, num_facets)
@@ -175,12 +174,14 @@ def test_facet_normals(cell_type):
     """Test that FacetNormal is outward facing"""
     for count in range(5):
         mesh = unit_cell(cell_type)
-        tdim = mesh.topology.dim
+        tdim = mesh.topology.dim        mesh.topology.create_entities(tdim - 1)
+
 
         V = VectorFunctionSpace(mesh, ("Lagrange", 1))
         normal = ufl.FacetNormal(mesh)
         v = Function(V)
 
+        mesh.topology.create_entities(tdim - 1)
         map_f = mesh.topology.index_map(tdim - 1)
         num_facets = map_f.size_local + map_f.num_ghosts
         indices = np.arange(0, num_facets)
@@ -431,7 +432,6 @@ def test_curl(space_type, order):
 
         domain = ufl.Mesh(ufl.VectorElement("Lagrange", cpp.mesh.to_string(CellType.tetrahedron), 1))
         mesh = create_mesh(MPI.COMM_WORLD, [cell], points, domain)
-        mesh.topology.create_connectivity_all()
 
         V = FunctionSpace(mesh, (space_type, order))
         v = ufl.TestFunction(V)

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -174,8 +174,8 @@ def test_facet_normals(cell_type):
     """Test that FacetNormal is outward facing"""
     for count in range(5):
         mesh = unit_cell(cell_type)
-        tdim = mesh.topology.dim        mesh.topology.create_entities(tdim - 1)
-
+        tdim = mesh.topology.dim
+        mesh.topology.create_entities(tdim - 1)
 
         V = VectorFunctionSpace(mesh, ("Lagrange", 1))
         normal = ufl.FacetNormal(mesh)

--- a/python/test/unit/fem/test_fem_pipeline.py
+++ b/python/test/unit/fem/test_fem_pipeline.py
@@ -47,8 +47,8 @@ def run_scalar_test(mesh, V, degree):
     u_bc.interpolate(lambda x: x[1]**degree)
 
     # Create Dirichlet boundary condition
-    mesh.topology.create_connectivity_all()
     facetdim = mesh.topology.dim - 1
+    mesh.topology.create_connectivity(facetdim, mesh.topology.dim)
     bndry_facets = np.where(np.array(cpp.mesh.compute_boundary_facets(mesh.topology)) == 1)[0]
     bdofs = locate_dofs_topological(V, facetdim, bndry_facets)
     bc = DirichletBC(u_bc, bdofs)
@@ -254,7 +254,7 @@ def test_biharmonic():
     solver = PETSc.KSP().create(MPI.COMM_WORLD)
     PETSc.Options()["ksp_type"] = "preonly"
     PETSc.Options()["pc_type"] = "lu"
-    PETSc.Options()["pc_factor_mat_solver_type"] = "mumps"
+    # PETSc.Options()["pc_factor_mat_solver_type"] = "mumps"
     solver.setFromOptions()
     solver.setOperators(A)
 

--- a/python/test/unit/function/test_interpolation.py
+++ b/python/test/unit/function/test_interpolation.py
@@ -96,10 +96,7 @@ def one_cell_mesh(cell_type):
     cells = np.array([order])
 
     domain = ufl.Mesh(ufl.VectorElement("Lagrange", cpp.mesh.to_string(cell_type), 1))
-    mesh = create_mesh(MPI.COMM_WORLD, cells, ordered_points, domain)
-
-    mesh.topology.create_connectivity_all()
-    return mesh
+    return create_mesh(MPI.COMM_WORLD, cells, ordered_points, domain)
 
 
 def run_scalar_test(V, poly_order):

--- a/python/test/unit/geometry/test_bounding_box_tree.py
+++ b/python/test/unit/geometry/test_bounding_box_tree.py
@@ -166,7 +166,6 @@ def test_compute_collisions_tree_1d(point):
         return x[0] >= point[0]
     # Locate all vertices of mesh A that should collide
     vertices_A = cpp.mesh.locate_entities(mesh_A, 0, locator_A)
-    mesh_A.topology.create_connectivity_all()
     v_to_c = mesh_A.topology.connectivity(0, mesh_A.topology.dim)
     # Find all cells connected to vertex in the collision bounding box
     cells_A = numpy.sort(numpy.unique(numpy.hstack([v_to_c.links(vertex) for vertex in vertices_A])))
@@ -179,7 +178,6 @@ def test_compute_collisions_tree_1d(point):
         return x[0] <= 1
     # Locate all vertices of mesh B that should collide
     vertices_B = cpp.mesh.locate_entities(mesh_B, 0, locator_B)
-    mesh_B.topology.create_connectivity_all()
     v_to_c = mesh_B.topology.connectivity(0, mesh_B.topology.dim)
     # Find all cells connected to vertex in the collision bounding box
     cells_B = numpy.sort(numpy.unique(numpy.hstack([v_to_c.links(vertex) for vertex in vertices_B])))

--- a/python/test/unit/geometry/test_bounding_box_tree.py
+++ b/python/test/unit/geometry/test_bounding_box_tree.py
@@ -166,7 +166,9 @@ def test_compute_collisions_tree_1d(point):
         return x[0] >= point[0]
     # Locate all vertices of mesh A that should collide
     vertices_A = cpp.mesh.locate_entities(mesh_A, 0, locator_A)
+    mesh_A.topology.create_connectivity(0, mesh_A.topology.dim)
     v_to_c = mesh_A.topology.connectivity(0, mesh_A.topology.dim)
+
     # Find all cells connected to vertex in the collision bounding box
     cells_A = numpy.sort(numpy.unique(numpy.hstack([v_to_c.links(vertex) for vertex in vertices_A])))
 
@@ -176,9 +178,12 @@ def test_compute_collisions_tree_1d(point):
 
     def locator_B(x):
         return x[0] <= 1
+
     # Locate all vertices of mesh B that should collide
     vertices_B = cpp.mesh.locate_entities(mesh_B, 0, locator_B)
+    mesh_B.topology.create_connectivity(0, mesh_B.topology.dim)
     v_to_c = mesh_B.topology.connectivity(0, mesh_B.topology.dim)
+
     # Find all cells connected to vertex in the collision bounding box
     cells_B = numpy.sort(numpy.unique(numpy.hstack([v_to_c.links(vertex) for vertex in vertices_B])))
 

--- a/python/test/unit/io/test_xdmf_meshtags.py
+++ b/python/test/unit/io/test_xdmf_meshtags.py
@@ -33,6 +33,7 @@ def test_3d(tempdir, cell_type, encoding):
     filename = os.path.join(tempdir, "meshtags_3d.xdmf")
     comm = MPI.COMM_WORLD
     mesh = UnitCubeMesh(comm, 4, 4, 4, cell_type)
+    mesh.topology.create_entities(2)
 
     bottom_facets = locate_entities(mesh, 2, lambda x: np.isclose(x[1], 0.0))
     bottom_values = np.full(bottom_facets.shape, 1, dtype=np.int32)
@@ -52,6 +53,9 @@ def test_3d(tempdir, cell_type, encoding):
     mt_lines = MeshTags(mesh, 1, indices, np.hstack((top_values, right_values))[pos])
     mt_lines.name = "lines"
 
+    mesh.topology.create_connectivity(1, 3)
+    mesh.topology.create_connectivity(2, 3)
+
     with XDMFFile(comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
         file.write_meshtags(mt)
@@ -60,6 +64,10 @@ def test_3d(tempdir, cell_type, encoding):
 
     with XDMFFile(comm, filename, "r", encoding=encoding) as file:
         mesh_in = file.read_mesh()
+        tdim = mesh_in.topology.dim
+        mesh_in.topology.create_connectivity(tdim - 1, tdim)
+        mesh_in.topology.create_connectivity(1, tdim)
+
         mt_in = file.read_meshtags(mesh_in, "facets")
         mt_lines_in = file.read_meshtags(mesh_in, "lines")
         units = file.read_information("units")

--- a/python/test/unit/io/test_xdmf_meshtags.py
+++ b/python/test/unit/io/test_xdmf_meshtags.py
@@ -53,7 +53,6 @@ def test_3d(tempdir, cell_type, encoding):
     mt_lines.name = "lines"
 
     with XDMFFile(comm, filename, "w", encoding=encoding) as file:
-        mesh.topology.create_connectivity_all()
         file.write_mesh(mesh)
         file.write_meshtags(mt)
         file.write_meshtags(mt_lines)
@@ -61,7 +60,6 @@ def test_3d(tempdir, cell_type, encoding):
 
     with XDMFFile(comm, filename, "r", encoding=encoding) as file:
         mesh_in = file.read_mesh()
-        mesh_in.topology.create_connectivity_all()
         mt_in = file.read_meshtags(mesh_in, "facets")
         mt_lines_in = file.read_meshtags(mesh_in, "lines")
         units = file.read_information("units")

--- a/python/test/unit/mesh/test_cell.py
+++ b/python/test/unit/mesh/test_cell.py
@@ -89,7 +89,6 @@ def test_volume_quadrilateralR3(coordinates):
     cells = numpy.array([[0, 1, 2, 3]], dtype=numpy.int32)
     domain = ufl.Mesh(ufl.VectorElement("Lagrange", "quadrilateral", 1))
     mesh = create_mesh(MPI.COMM_SELF, cells, x, domain)
-    mesh.topology.create_connectivity_all()
     assert cpp.mesh.volume_entities(mesh, [0], mesh.topology.dim) == 1.0
 
 
@@ -106,7 +105,6 @@ def test_volume_quadrilateral_coplanarity_check_1(scaling):
         cells = numpy.array([[0, 1, 2, 3]], dtype=numpy.int32)
         domain = ufl.Mesh(ufl.VectorElement("Lagrange", "quadrilateral", 1))
         mesh = create_mesh(MPI.COMM_SELF, cells, x, domain)
-        mesh.topology.create_connectivity_all()
         cpp.mesh.volume_entities(mesh, [0], mesh.topology.dim)
 
     assert "Not coplanar" in str(error.value)
@@ -126,7 +124,6 @@ def test_volume_quadrilateral_coplanarity_check_2(scaling):
         cells = numpy.array([[0, 1, 2, 3]], dtype=numpy.int32)
         domain = ufl.Mesh(ufl.VectorElement("Lagrange", "quadrilateral", 1))
         mesh = create_mesh(MPI.COMM_SELF, cells, x, domain)
-        mesh.topology.create_connectivity_all()
         cpp.mesh.volume_entities(mesh, [0], mesh.topology.dim)
 
     assert "Not coplanar" in str(error.value)

--- a/python/test/unit/mesh/test_custom_partitioners.py
+++ b/python/test/unit/mesh/test_custom_partitioners.py
@@ -78,7 +78,6 @@ def test_custom_partitioner(tempdir, Nx, cell_type):
 
     ghost_mode = GhostMode.none
     new_mesh = dolfinx.mesh.create_mesh(mpi_comm, topo, x, domain, ghost_mode, partitioner)
-    new_mesh.topology.create_connectivity_all()
 
     tdim = new_mesh.topology.dim
     assert mesh.topology.index_map(tdim).size_global == new_mesh.topology.index_map(tdim).size_global

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -341,9 +341,6 @@ def xtest_mesh_topology_against_basix(mesh_factory, ghost_mode):
     cell_name = cpp.mesh.to_string(mesh.topology.cell_type)
     basix_celltype = getattr(basix.CellType, cell_name)
 
-    # Initialize all mesh entities and connectivities
-    mesh.topology.create_connectivity_all()
-
     map = mesh.topology.index_map(mesh.topology.dim)
     num_cells = map.size_local + map.num_ghosts
     for i in range(num_cells):

--- a/python/test/unit/mesh/test_meshtags.py
+++ b/python/test/unit/mesh/test_meshtags.py
@@ -14,7 +14,6 @@ def test_create(cell_type):
     comm = MPI.COMM_WORLD
 
     mesh = UnitCubeMesh(comm, 6, 6, 6, cell_type)
-    mesh.topology.create_connectivity_all()
 
     marked_lines = locate_entities(mesh, 1, lambda x: numpy.isclose(x[1], 0.5))
     f_v = mesh.topology.connectivity(1, 0).array.reshape(-1, 2)


### PR DESCRIPTION
Removes the lazy `compute_connectivity_all()`, which is usually mis-used and is expensive (in time and memory)