### PR TITLE
Support detection of Basix library in Python tree

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -187,6 +187,9 @@ execute_process(
   OUTPUT_VARIABLE BASIX_PY_DIR
   RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
   ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+if (BASIX_PY_DIR)
+  message(STATUS "Adding ${BASIX_PY_DIR} to Basix search hints")
+endif()
 find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
 set_package_properties(basix PROPERTIES TYPE REQUIRED
   DESCRIPTION "FEniCS tabulation library"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -170,14 +170,24 @@ set_package_properties(SCOTCH PROPERTIES TYPE REQUIRED
   URL "https://www.labri.fr/perso/pelegrin/scotch"
   PURPOSE "Parallel graph partitioning and redordering")
 
-# Check for required packages UFC and basix
+# Use Python for detecting UFC and Basix
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+# Check for UFC
 find_package(UFC MODULE ${DOLFINX_VERSION_MAJOR}.${DOLFINX_VERSION_MINOR})
 set_package_properties(UFC PROPERTIES TYPE REQUIRED
   DESCRIPTION "Unified interface for form-compilers (part of FFCx)"
   URL "https://github.com/fenics/ffcx")
 
-find_package(Basix 0.0.1 REQUIRED)
+# Check for Basix
+# Note: Basix may be installed as a standalone C++ library, or in the
+# Basix Python module tre
+execute_process(
+  COMMAND ${Python3_EXECUTABLE} -c "import basix, os, sys; sys.stdout.write(os.path.dirname(basix.__file__))"
+  OUTPUT_VARIABLE BASIX_PY_DIR
+  RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
+  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
 set_package_properties(basix PROPERTIES TYPE REQUIRED
   DESCRIPTION "FEniCS tabulation library"
   URL "https://github.com/fenics/basix")

--- a/cpp/cmake/templates/DOLFINXConfig.cmake.in
+++ b/cpp/cmake/templates/DOLFINXConfig.cmake.in
@@ -31,6 +31,9 @@ if(Python3_Interpreter_FOUND)
     RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()
+if (BASIX_PY_DIR)
+  message(STATUS "Adding ${BASIX_PY_DIR} to Basix search hints")
+endif()
 find_dependency(Basix HINTS ${BASIX_PY_DIR})
 
 # Add xsimd if the C++ interface was compiled with it

--- a/cpp/cmake/templates/DOLFINXConfig.cmake.in
+++ b/cpp/cmake/templates/DOLFINXConfig.cmake.in
@@ -8,7 +8,6 @@
 @PACKAGE_INIT@
 include(CMakeFindDependencyMacro)
 
-include(CMakeFindDependencyMacro)
 find_dependency(MPI REQUIRED)
 
 # Check for Boost
@@ -24,7 +23,15 @@ find_dependency(xtl)
 find_dependency(xtensor)
 
 # Basix
-find_dependency(Basix)
+find_package(Python3 COMPONENTS Interpreter)
+if(Python3_Interpreter_FOUND)
+  execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c "import basix, os, sys; sys.stdout.write(os.path.dirname(basix.__file__))"
+    OUTPUT_VARIABLE BASIX_PY_DIR
+    RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+find_dependency(Basix HINTS ${BASIX_PY_DIR})
 
 # Add xsimd if the C++ interface was compiled with it
 if(@xsimd_FOUND@)

--- a/cpp/cmake/templates/DOLFINXConfig.cmake.in
+++ b/cpp/cmake/templates/DOLFINXConfig.cmake.in
@@ -34,7 +34,7 @@ endif()
 if (BASIX_PY_DIR)
   message(STATUS "Adding ${BASIX_PY_DIR} to Basix search hints")
 endif()
-find_dependency(Basix HINTS ${BASIX_PY_DIR})
+find_dependency(Basix CONFIG HINTS ${BASIX_PY_DIR})
 
 # Add xsimd if the C++ interface was compiled with it
 if(@xsimd_FOUND@)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -5,8 +5,8 @@ PROJECT(dolfinx_pybind11)
 find_package(pybind11 REQUIRED CONFIG HINTS ${PYBIND11_DIR} ${PYBIND11_ROOT}
   $ENV{PYBIND11_DIR} $ENV{PYBIND11_ROOT})
 
-find_package(DOLFINX REQUIRED)
-find_package(Basix REQUIRED)
+find_package(DOLFINX REQUIRED CONFIG)
+find_package(Basix REQUIRED CONFIG)
 find_package(xtensor REQUIRED)
 
 # Check if the Basix C++ library was compiled with xtensor SIMD

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -2,9 +2,12 @@ cmake_minimum_required(VERSION 3.16)
 
 PROJECT(dolfinx_pybind11)
 
-find_package(xtensor REQUIRED)
-find_package(Basix REQUIRED)
+find_package(pybind11 REQUIRED CONFIG HINTS ${PYBIND11_DIR} ${PYBIND11_ROOT}
+  $ENV{PYBIND11_DIR} $ENV{PYBIND11_ROOT})
+
 find_package(DOLFINX REQUIRED)
+find_package(Basix REQUIRED)
+find_package(xtensor REQUIRED)
 
 # Check if the Basix C++ library was compiled with xtensor SIMD
 get_target_property(BASIX_DEFN Basix::basix INTERFACE_COMPILE_DEFINITIONS)
@@ -17,9 +20,6 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
-find_package(pybind11 REQUIRED CONFIG HINTS ${PYBIND11_DIR} ${PYBIND11_ROOT}
-  $ENV{PYBIND11_DIR} $ENV{PYBIND11_ROOT})
 
 # Create the binding library
 pybind11_add_module(cpp SHARED


### PR DESCRIPTION
This support detection of the Basix C++ libraries when installed together with the Basix Python interface.