### PR TITLE
Use pip install pybind11[global]

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -146,7 +146,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 #   documentation or run tests.
 # LLVM_CONFIG required on aarch64, should be removed long-term.
 RUN LLVM_CONFIG=/usr/bin/llvm-config-9 pip3 install --no-cache-dir mpi4py numba && \
-    pip3 install --no-cache-dir cffi cppimport flake8 pybind11==${PYBIND11_VERSION} pytest pytest-xdist sphinx sphinx_rtd_theme
+    pip3 install --no-cache-dir cffi cppimport flake8 pybind11[global]==${PYBIND11_VERSION} pytest pytest-xdist sphinx sphinx_rtd_theme
 
 # Upgrade numpy via pip. Exclude binaries to avoid conflicts with libblas
 # (See issue #126 and #1305)


### PR DESCRIPTION
This change allows downstream packages to find pybind11's cmake find module without passing custom hints.