### PR TITLE
Faster symmetry tests

### DIFF
--- a/python/test/unit/fem/test_symmetry.py
+++ b/python/test/unit/fem/test_symmetry.py
@@ -174,4 +174,3 @@ def test_mixed_element_vector_element_form(cell_type, sign, order):
     A.assemble()
 
     check_symmetry(A)
-

--- a/python/test/unit/fem/test_symmetry.py
+++ b/python/test/unit/fem/test_symmetry.py
@@ -10,6 +10,7 @@ from mpi4py import MPI
 import pytest
 import dolfinx
 from dolfinx import UnitSquareMesh, UnitCubeMesh, FunctionSpace
+from dolfinx_utils.test.skips import skip_in_parallel
 from dolfinx.cpp.mesh import CellType
 
 import ufl
@@ -23,9 +24,9 @@ def check_symmetry(A):
 
 def run_symmetry_test(cell_type, element, form_f):
     if cell_type == CellType.triangle or cell_type == CellType.quadrilateral:
-        mesh = UnitSquareMesh(MPI.COMM_WORLD, 8, 8, cell_type)
+        mesh = UnitSquareMesh(MPI.COMM_WORLD, 2, 2, cell_type)
     else:
-        mesh = UnitCubeMesh(MPI.COMM_WORLD, 5, 5, 5, cell_type)
+        mesh = UnitCubeMesh(MPI.COMM_WORLD, 2, 2, 2, cell_type)
 
     space = FunctionSpace(mesh, element)
 
@@ -52,7 +53,7 @@ parametrize_lagrange_elements = pytest.mark.parametrize("cell_type, element", [
     (CellType.tetrahedron, "Lagrange"), (CellType.hexahedron, "Lagrange")
 ])
 
-
+@skip_in_parallel
 @parametrize_elements
 @pytest.mark.parametrize("order", range(1, 4))
 def test_mass_matrix_dx(cell_type, element, order):
@@ -60,6 +61,7 @@ def test_mass_matrix_dx(cell_type, element, order):
                       lambda u, v: inner(u, v) * ufl.dx)
 
 
+@skip_in_parallel
 @parametrize_lagrange_elements
 @pytest.mark.parametrize("order", range(1, 4))
 def test_stiffness_matrix_dx(cell_type, element, order):
@@ -67,6 +69,7 @@ def test_stiffness_matrix_dx(cell_type, element, order):
                       lambda u, v: inner(grad(u), grad(v)) * ufl.dx)
 
 
+@skip_in_parallel
 @parametrize_elements
 @pytest.mark.parametrize("order", range(1, 4))
 def test_mass_matrix_ds(cell_type, element, order):
@@ -74,6 +77,7 @@ def test_mass_matrix_ds(cell_type, element, order):
                       lambda u, v: inner(u, v) * ufl.ds)
 
 
+@skip_in_parallel
 @parametrize_lagrange_elements
 @pytest.mark.parametrize("order", range(1, 4))
 def test_stiffness_matrix_ds(cell_type, element, order):
@@ -81,6 +85,7 @@ def test_stiffness_matrix_ds(cell_type, element, order):
                       lambda u, v: inner(grad(u), grad(v)) * ufl.ds)
 
 
+@skip_in_parallel
 @parametrize_elements
 @pytest.mark.parametrize("order", range(1, 4))
 @pytest.mark.parametrize("sign", ["+", "-"])
@@ -89,6 +94,7 @@ def test_mass_matrix_dS(cell_type, element, order, sign):
                       lambda u, v: inner(u, v)(sign) * ufl.dS)
 
 
+@skip_in_parallel
 @parametrize_lagrange_elements
 @pytest.mark.parametrize("order", range(1, 4))
 @pytest.mark.parametrize("sign", ["+", "-"])
@@ -97,15 +103,16 @@ def test_stiffness_matrix_dS(cell_type, element, order, sign):
                       lambda u, v: inner(grad(u), grad(v))(sign) * ufl.dS)
 
 
+@skip_in_parallel
 @pytest.mark.parametrize("cell_type", [CellType.triangle, CellType.quadrilateral,
                                        CellType.tetrahedron, CellType.hexahedron])
 @pytest.mark.parametrize("sign", ["+", "-"])
 @pytest.mark.parametrize("order", range(1, 4))
 def test_mixed_element_form(cell_type, sign, order):
     if cell_type == CellType.triangle or cell_type == CellType.quadrilateral:
-        mesh = UnitSquareMesh(MPI.COMM_WORLD, 8, 8, cell_type)
+        mesh = UnitSquareMesh(MPI.COMM_WORLD, 2, 2, cell_type)
     else:
-        mesh = UnitCubeMesh(MPI.COMM_WORLD, 5, 5, 5, cell_type)
+        mesh = UnitCubeMesh(MPI.COMM_WORLD, 2, 2, 2, cell_type)
 
     if cell_type == CellType.triangle:
         U_el = MixedElement([FiniteElement("Lagrange", ufl.triangle, order),
@@ -132,14 +139,15 @@ def test_mixed_element_form(cell_type, sign, order):
     check_symmetry(A)
 
 
+@skip_in_parallel
 @pytest.mark.parametrize("cell_type", [CellType.triangle, CellType.quadrilateral])
 @pytest.mark.parametrize("sign", ["+", "-"])
 @pytest.mark.parametrize("order", range(1, 4))
 def test_mixed_element_vector_element_form(cell_type, sign, order):
     if cell_type == CellType.triangle or cell_type == CellType.quadrilateral:
-        mesh = UnitSquareMesh(MPI.COMM_WORLD, 8, 8, cell_type)
+        mesh = UnitSquareMesh(MPI.COMM_WORLD, 2, 2, cell_type)
     else:
-        mesh = UnitCubeMesh(MPI.COMM_WORLD, 5, 5, 5, cell_type)
+        mesh = UnitCubeMesh(MPI.COMM_WORLD, 2, 2, 2, cell_type)
 
     if cell_type == CellType.triangle:
         U_el = MixedElement([VectorElement("Lagrange", ufl.triangle, order),

--- a/python/test/unit/fem/test_symmetry.py
+++ b/python/test/unit/fem/test_symmetry.py
@@ -56,7 +56,7 @@ parametrize_lagrange_elements = pytest.mark.parametrize("cell_type, element", [
 
 @skip_in_parallel
 @parametrize_elements
-@pytest.mark.parametrize("order", range(1, 4))
+@pytest.mark.parametrize("order", range(1, 2))
 def test_mass_matrix_dx(cell_type, element, order):
     run_symmetry_test(cell_type, (element, order),
                       lambda u, v: inner(u, v) * ufl.dx)
@@ -64,7 +64,7 @@ def test_mass_matrix_dx(cell_type, element, order):
 
 @skip_in_parallel
 @parametrize_lagrange_elements
-@pytest.mark.parametrize("order", range(1, 4))
+@pytest.mark.parametrize("order", range(1, 2))
 def test_stiffness_matrix_dx(cell_type, element, order):
     run_symmetry_test(cell_type, (element, order),
                       lambda u, v: inner(grad(u), grad(v)) * ufl.dx)
@@ -72,7 +72,7 @@ def test_stiffness_matrix_dx(cell_type, element, order):
 
 @skip_in_parallel
 @parametrize_elements
-@pytest.mark.parametrize("order", range(1, 4))
+@pytest.mark.parametrize("order", range(1, 2))
 def test_mass_matrix_ds(cell_type, element, order):
     run_symmetry_test(cell_type, (element, order),
                       lambda u, v: inner(u, v) * ufl.ds)
@@ -80,7 +80,7 @@ def test_mass_matrix_ds(cell_type, element, order):
 
 @skip_in_parallel
 @parametrize_lagrange_elements
-@pytest.mark.parametrize("order", range(1, 4))
+@pytest.mark.parametrize("order", range(1, 2))
 def test_stiffness_matrix_ds(cell_type, element, order):
     run_symmetry_test(cell_type, (element, order),
                       lambda u, v: inner(grad(u), grad(v)) * ufl.ds)
@@ -88,7 +88,7 @@ def test_stiffness_matrix_ds(cell_type, element, order):
 
 @skip_in_parallel
 @parametrize_elements
-@pytest.mark.parametrize("order", range(1, 4))
+@pytest.mark.parametrize("order", range(1, 2))
 @pytest.mark.parametrize("sign", ["+", "-"])
 def test_mass_matrix_dS(cell_type, element, order, sign):
     run_symmetry_test(cell_type, (element, order),
@@ -97,7 +97,7 @@ def test_mass_matrix_dS(cell_type, element, order, sign):
 
 @skip_in_parallel
 @parametrize_lagrange_elements
-@pytest.mark.parametrize("order", range(1, 4))
+@pytest.mark.parametrize("order", range(1, 2))
 @pytest.mark.parametrize("sign", ["+", "-"])
 def test_stiffness_matrix_dS(cell_type, element, order, sign):
     run_symmetry_test(cell_type, (element, order),
@@ -108,7 +108,7 @@ def test_stiffness_matrix_dS(cell_type, element, order, sign):
 @pytest.mark.parametrize("cell_type", [CellType.triangle, CellType.quadrilateral,
                                        CellType.tetrahedron, CellType.hexahedron])
 @pytest.mark.parametrize("sign", ["+", "-"])
-@pytest.mark.parametrize("order", range(1, 4))
+@pytest.mark.parametrize("order", range(1, 2))
 def test_mixed_element_form(cell_type, sign, order):
     if cell_type == CellType.triangle or cell_type == CellType.quadrilateral:
         mesh = UnitSquareMesh(MPI.COMM_WORLD, 2, 2, cell_type)
@@ -143,7 +143,7 @@ def test_mixed_element_form(cell_type, sign, order):
 @skip_in_parallel
 @pytest.mark.parametrize("cell_type", [CellType.triangle, CellType.quadrilateral])
 @pytest.mark.parametrize("sign", ["+", "-"])
-@pytest.mark.parametrize("order", range(1, 4))
+@pytest.mark.parametrize("order", range(1, 2))
 def test_mixed_element_vector_element_form(cell_type, sign, order):
     if cell_type == CellType.triangle or cell_type == CellType.quadrilateral:
         mesh = UnitSquareMesh(MPI.COMM_WORLD, 2, 2, cell_type)
@@ -174,3 +174,4 @@ def test_mixed_element_vector_element_form(cell_type, sign, order):
     A.assemble()
 
     check_symmetry(A)
+

--- a/python/test/unit/fem/test_symmetry.py
+++ b/python/test/unit/fem/test_symmetry.py
@@ -53,6 +53,7 @@ parametrize_lagrange_elements = pytest.mark.parametrize("cell_type, element", [
     (CellType.tetrahedron, "Lagrange"), (CellType.hexahedron, "Lagrange")
 ])
 
+
 @skip_in_parallel
 @parametrize_elements
 @pytest.mark.parametrize("order", range(1, 4))


### PR DESCRIPTION
Make meshes in symmetry tests smaller and turn them off in parallel, reduced the maximum order that is tested