### PR TITLE
Pyvista updates

### DIFF
--- a/python/demo/pyvista/demo_pyvista.py
+++ b/python/demo/pyvista/demo_pyvista.py
@@ -62,7 +62,7 @@ if np.iscomplexobj(vertex_values):
     vertex_values = vertex_values.real
 
 # Create point cloud of vertices, and add the vertex values to the cloud
-grid.point_arrays["u"] = vertex_values
+grid.point_data["u"] = vertex_values
 grid.set_active_scalars("u")
 
 # Create a pyvista plotter which is used to visualize the output
@@ -138,7 +138,7 @@ grid = pyvista.UnstructuredGrid(pyvista_cells, cell_types, mesh.geometry.x)
 point_values = u.compute_point_values()
 if np.iscomplexobj(point_values):
     point_values = point_values.real
-grid.point_arrays["u"] = point_values
+grid.point_data["u"] = point_values
 
 # We set the function "u" as the active scalar for the mesh, and warp
 # the mesh in z-direction by its values
@@ -180,7 +180,7 @@ cell_tags = dolfinx.MeshTags(mesh, mesh.topology.dim, np.arange(num_cells), in_c
 
 # As the dolfinx.MeshTag contains a value for every cell in the
 # geometry, we can attach it directly to the grid
-grid.cell_arrays["Marker"] = cell_tags.values
+grid.cell_data["Marker"] = cell_tags.values
 grid.set_active_scalars("Marker")
 
 # We create a plotter consisting of two windows, and add a plot of the
@@ -245,7 +245,7 @@ values = uh.vector.array.real if np.iscomplexobj(uh.vector.array) else uh.vector
 # We create a pyvista mesh from the topology and geometry, and attach
 # the coefficients of the degrees of freedom
 grid = pyvista.UnstructuredGrid(topology, cell_types, geometry)
-grid.point_arrays["DG"] = values
+grid.point_data["DG"] = values
 grid.set_active_scalars("DG")
 
 # We would also like to visualize the underlying mesh and obtain that as

--- a/python/dolfinx/plot.py
+++ b/python/dolfinx/plot.py
@@ -11,19 +11,6 @@ import numpy as np
 
 from dolfinx import cpp, fem
 
-# Permutation for DOLFINx DG layout to VTK
-# Note that third order tetrahedrons has a special ordering:
-# https://gitlab.kitware.com/vtk/vtk/-/issues/17746
-_perm_dg = {cpp.mesh.CellType.triangle: {1: [0, 1, 2], 2: [0, 2, 5, 1, 4, 3], 3: [0, 3, 9, 1, 2, 6, 8, 7, 4, 5],
-                                         4: [0, 4, 14, 1, 2, 3, 8, 11, 13, 12, 9, 5, 6, 7, 10]},
-            cpp.mesh.CellType.tetrahedron: {1: [0, 1, 2, 3], 2: [0, 2, 5, 9, 1, 4, 5, 6, 7, 8],
-                                            3: [0, 3, 9, 19, 1, 2, 6, 8, 7, 4, 10, 16, 12, 17, 15, 18, 11, 14, 13, 5]}}
-_perm_dq = {cpp.mesh.CellType.quadrilateral: {1: [0, 1, 3, 2], 2: [0, 2, 8, 6, 1, 5, 7, 3, 4],
-                                              3: [0, 3, 15, 12, 1, 2, 7, 11, 13, 14, 4, 8, 5, 6, 9, 10]},
-            cpp.mesh.CellType.hexahedron: {1: [0, 1, 3, 2, 4, 5, 7, 6],
-                                           2: [0, 2, 8, 6, 18, 20, 26, 24, 1, 5, 7, 3, 19,
-                                               23, 25, 21, 9, 11, 17, 15, 12, 14, 10, 16, 4, 22, 14]}}
-
 # NOTE: Edge visualization of higher order elements are sketchy, see:
 # https://github.com/pyvista/pyvista/issues/947
 
@@ -122,12 +109,7 @@ def _(V: fem.FunctionSpace, entities=None):
     num_dofs_per_cell = V.dofmap.dof_layout.num_dofs
     degree = V.ufl_element().degree()
     cell_type = mesh.topology.cell_type
-    if family == "Discontinuous Lagrange":
-        perm = np.array(_perm_dg[cell_type][degree], dtype=np.int32)
-    elif family == "DQ":
-        perm = np.array(_perm_dq[cell_type][degree], dtype=np.int32)
-    else:
-        perm = np.argsort(cpp.io.perm_vtk(cell_type, num_dofs_per_cell))
+    perm = np.argsort(cpp.io.perm_vtk(cell_type, num_dofs_per_cell))
 
     if degree == 1:
         cell_types = np.full(num_cells, _first_order_vtk[mesh.topology.cell_type])


### PR DESCRIPTION
Point/Cell_arrays deprecated: https://github.com/pyvista/pyvista/blob/b562517e5046513876059f4f902809b3debc14aa/pyvista/core/dataset.py#L1192-L1193

Basix DG/DQ dof ordering same as Lagrange (https://github.com/FEniCS/dolfinx/pull/1670), simplifies vtk topology creation, and caused the visualization pipeline to fail.