### PR TITLE
Add test for packing coeffs for form without coeffs

### DIFF
--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -69,8 +69,9 @@ void fem(py::module& m)
       [](dolfinx::fem::Form<PetscScalar>& form)
       {
         auto [coeffs, cstride] = dolfinx::fem::pack_coefficients(form);
-        return as_pyarray(std::move(coeffs),
-                          std::array{int(coeffs.size() / cstride), cstride});
+        return as_pyarray(
+            std::move(coeffs),
+            std::array{int(coeffs.size() / std::max(cstride, 1)), cstride});
       },
       "Pack coefficients for a Form.");
   m.def(
@@ -78,8 +79,9 @@ void fem(py::module& m)
       [](dolfinx::fem::Expression<PetscScalar>& expr)
       {
         auto [coeffs, cstride] = dolfinx::fem::pack_coefficients(expr);
-        return as_pyarray(std::move(coeffs),
-                          std::array{int(coeffs.size() / cstride), cstride});
+        return as_pyarray(
+            std::move(coeffs),
+            std::array{int(coeffs.size() / std::max(cstride, 1)), cstride});
       },
       "Pack coefficients for an Expression.");
   m.def(

--- a/python/test/unit/fem/test_coefficients.py
+++ b/python/test/unit/fem/test_coefficients.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2021 Jørgen S. Dokken
+#
+# This file is part of DOLFINx (https://www.fenicsproject.org)
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+"""Unit tests for packing coefficients"""
+
+
+from mpi4py import MPI
+import dolfinx
+import ufl
+
+
+def test_no_coeffs():
+    mesh = dolfinx.UnitSquareMesh(MPI.COMM_WORLD, 5, 5)
+    V = dolfinx.FunctionSpace(mesh, ("CG", 1))
+
+    u = ufl.TrialFunction(V)
+    v = ufl.TestFunction(V)
+    a = ufl.inner(u, v) * ufl.dx
+
+    cpp_form = dolfinx.Form(a)._cpp_object
+    form_coeffs = dolfinx.cpp.fem.pack_coefficients(cpp_form)
+    assert form_coeffs.shape == (0, 0)


### PR DESCRIPTION
The commit 1b1df970f13acfe022975a2eea225f1df1e50b2b introduced a bug that causes form without coefficients to segfault, as we divide by cstride (0) in the python layer.

This PR fixes the issue, and adds an additional test