### PR TITLE
Remove calls to xt::broadcast in interpolation

### DIFF
--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -97,7 +97,7 @@ void CoordinateElement::compute_jacobian(
   {
     xt::noalias(dphi0) = xt::view(dphi, xt::all(), 0, xt::all(), 0);
     math::dot(cell_geom, dphi0, J0, true);
-    // NOTE: Should be using xt::broadcast, but it's about 7 times slower than a
+    // NOTE: Should be using xt::broadcast, but it's much slower than a
     // plain loop.
     for (std::size_t p = 0; p < num_points; ++p)
     {

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -136,7 +136,11 @@ void CoordinateElement::compute_jacobian_inverse(
       math::inv(J0, K0);
     else
       math::pinv(J0, K0);
-    K = xt::broadcast(K0, K.shape());
+    for (std::size_t p = 0; p < J.shape(0); ++p)
+    {
+      auto K_ip = xt::view(K, p, xt::all(), xt::all());
+      K_ip.assign(K0);
+    }
   }
   else
   {

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -97,7 +97,13 @@ void CoordinateElement::compute_jacobian(
   {
     xt::noalias(dphi0) = xt::view(dphi, xt::all(), 0, xt::all(), 0);
     math::dot(cell_geom, dphi0, J0, true);
-    J = xt::broadcast(J0, J.shape());
+    // NOTE: Should be using xt::broadcast, but it's about 7 times slower than a
+    // plain loop.
+    for (std::size_t p = 0; p < num_points; ++p)
+    {
+      auto J_ip = xt::view(J, p, xt::all(), xt::all());
+      J_ip.assign(J0);
+    }
   }
   else
   {


### PR DESCRIPTION
Improvements of about 15% for the following code:
```python
import dolfinx
import numpy as np
from mpi4py import MPI

mesh = dolfinx.UnitCubeMesh(MPI.COMM_WORLD, 20, 20, 20)
V = dolfinx.FunctionSpace(mesh, ("N1curl", 2))

u = dolfinx.Function(V)

with dolfinx.common.Timer("interpolate"):
    u.interpolate(lambda x: x)

dolfinx.list_timings(MPI.COMM_WORLD, [dolfinx.TimingType.wall])

```

GCC 10.3.0
CXX Flags = "-Ofast -march=native"
and `-DXTENSOR_OPTIMIZE=1` in basix

```
this - interpolate                                                     |     1  0.856936  0.856936
main - interpolate                                                     |     1  1.029000  1.029000
```