### PR TITLE
Fix sparsity pattern creation in python 

### DIFF
--- a/python/dolfinx/fem/__init__.py
+++ b/python/dolfinx/fem/__init__.py
@@ -24,14 +24,17 @@ from dolfinx.fem.function import (Constant, Expression, Function,
                                   FunctionSpace, TensorFunctionSpace,
                                   VectorFunctionSpace)
 from dolfinx.fem.problem import LinearProblem, NonlinearProblem
-from dolfinx.cpp.fem import create_sparsity_pattern as _create_sparsity_pattern
+import typing
+from dolfinx.cpp.fem import (create_sparsity_pattern as _create_sparsity_pattern,
+                             Form_complex128 as _FormComplex,
+                             Form_float64 as _FormReal)
 
 
-def create_sparsity_pattern(a):
+def create_sparsity_pattern(a: typing.Union[_FormComplex, _FormReal]):
     """Create a sparsity pattern from a bilinear form"""
     topology = a.mesh.topology
-    dofmap0 = a.function_space[0].dofmap
-    dofmap1 = a.function_space[1].dofmap
+    dofmap0 = a.function_spaces[0].dofmap
+    dofmap1 = a.function_spaces[1].dofmap
     types = a.integral_types
     return _create_sparsity_pattern(topology, [dofmap0, dofmap1], types)
 

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -497,6 +497,8 @@ void declare_form(py::module& m, const std::string& type)
       .def_property_readonly("function_spaces",
                              &dolfinx::fem::Form<T>::function_spaces)
       .def("integral_ids", &dolfinx::fem::Form<T>::integral_ids)
+      .def_property_readonly("integral_types",
+                             &dolfinx::fem::Form<T>::integral_types)
       .def_property_readonly("needs_facet_permutations",
                              &dolfinx::fem::Form<T>::needs_facet_permutations)
       .def(


### PR DESCRIPTION
Bug introduced in #1749, which made it impossible to create a sparsity pattern from the python layer.

This PR fixes it, and adds type hints to highlight that one needs to pass in the compiled cpp form.