### PR TITLE
Fix unexpected behaviour of CoordinateElement::pull_back

### DIFF
--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -236,10 +236,9 @@ void CoordinateElement::pull_back(
                     xt::all(), xt::all());
 
     // Compute Jacobian, its inverse and determinant
-    xt::xtensor<double, 3> J0 = xt::view(J, xt::keep(0), xt::all(), xt::all());
-    xt::xtensor<double, 3> K0 = xt::view(K, xt::keep(0), xt::all(), xt::all());
-    xt::xtensor<double, 1> detJ0 = xt::view(detJ, xt::keep(0));
-
+    xt::xtensor<double, 3> J0 = xt::zeros<double>({std::size_t(1), gdim, tdim});
+    xt::xtensor<double, 3> K0 = xt::zeros<double>({std::size_t(1), tdim, gdim});
+    xt::xtensor<double, 1> detJ0 = xt::zeros<double>({std::size_t(1)});
     compute_jacobian(dphi, cell_geometry, J0);
     compute_jacobian_inverse(J0, K0);
     compute_jacobian_determinant(J0, detJ0);
@@ -271,14 +270,12 @@ void CoordinateElement::pull_back(
     xt::xtensor<double, 2> Xk({1, tdim});
     std::vector<double> xk(cell_geometry.shape(1));
     xt::xtensor<double, 1> dX = xt::empty<double>({tdim});
+    xt::xtensor<double, 3> J0 = xt::zeros<double>({std::size_t(1), gdim, tdim});
+    xt::xtensor<double, 3> K0 = xt::zeros<double>({std::size_t(1), tdim, gdim});
+    xt::xtensor<double, 1> detJ0 = xt::zeros<double>({std::size_t(1)});
     for (std::size_t ip = 0; ip < num_points; ++ip)
     {
       Xk.fill(0);
-      xt::xtensor<double, 3> J0
-          = xt::view(J, xt::keep(ip), xt::all(), xt::all());
-      xt::xtensor<double, 3> K0
-          = xt::view(K, xt::keep(ip), xt::all(), xt::all());
-      xt::xtensor<double, 1> detJ0 = xt::view(detJ, xt::keep(ip));
       int k;
       for (k = 0; k < non_affine_max_its; ++k)
       {
@@ -309,6 +306,14 @@ void CoordinateElement::pull_back(
         Xk += dX;
       }
       xt::row(X, ip) = xt::row(Xk, 0);
+      // Copy J0, K0, detJ0 into J, K, detJ for ip-th point
+      for (std::size_t i = 0; i < K0.shape(1); ++i)
+        for (std::size_t j = 0; j < K0.shape(2); ++j)
+        {
+          K(ip, i, j) = K0(0, i, j);
+          J(ip, j, i) = J0(0, j, i);
+          detJ(ip) = detJ0(0);
+        }
 
       if (k == non_affine_max_its)
       {


### PR DESCRIPTION
In CoordinateElement::pull_back, J, K, and detJ are input/output with shape(0) = number of points.
The same xtensors (J, K, detJ) are used as input to compute_jacobian, compute_jacobian_inverse, and compute_jacobian_determinant. However, J, K, and detJ are always only computed at a single point at a time rather than all points simultaneously. This is true if the mesh is affine since J, K and detJ are constant and therefore only computed once. It is also true if the mesh is non-affine since they are computed inside the loop over the points. This creates the following two issues:
(1) In compute_jacobian the assertion "assert(J.shape(0) == num_points); " will fail.
(2) The output is not as expected since J, K, detJ will only have a valid entry in the first row.

This pull request addresses these issues by
(1) Changing the input to compute_jacobian, compute_jacobian_inverse and compute_jacobian_determinant to J0, K0, detJ0, which are xtensors with shape(0) = 1.
(2) Copying J0, K0, detJ0 into J, K, detJ for each point.