### PR TITLE
Add [[maybe_unused]] to variables unused in "Release" mode.

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -37,8 +37,9 @@ compute_ghost_owners(const std::vector<int>& ghost_pos_recv_fwd,
 //----------------------------------------------------------------------------
 
 /// Compute the owning rank of ghost indices
-std::vector<int> get_ghost_ranks(MPI_Comm comm, std::int32_t local_size,
-                                 const xtl::span<const std::int64_t>& ghosts)
+[[maybe_unused]] std::vector<int>
+get_ghost_ranks(MPI_Comm comm, std::int32_t local_size,
+                const xtl::span<const std::int64_t>& ghosts)
 {
   int mpi_size = -1;
   MPI_Comm_size(comm, &mpi_size);

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -190,7 +190,7 @@ std::vector<std::int64_t> graph::build::compute_ghost_indices(
   std::vector<int> neighbors;
   std::map<int, int> proc_to_neighbor;
   int np = 0;
-  int mpi_rank = MPI::rank(comm);
+  [[maybe_unused]] int mpi_rank = MPI::rank(comm);
   for (int p : ghost_owners)
   {
     assert(p != mpi_rank);
@@ -275,7 +275,7 @@ std::vector<std::int64_t> graph::build::compute_ghost_indices(
   {
     std::int64_t old_idx = send_data[i];
     std::int64_t new_idx = new_recv[i];
-    auto [it, insert] = old_to_new.insert({old_idx, new_idx});
+    [[maybe_unused]] auto [it, insert] = old_to_new.insert({old_idx, new_idx});
     assert(insert);
   }
 

--- a/cpp/dolfinx/io/HDF5Interface.h
+++ b/cpp/dolfinx/io/HDF5Interface.h
@@ -185,9 +185,6 @@ inline void HDF5Interface::write_dataset(
   // Dataset dimensions
   const std::vector<hsize_t> dimsf(global_size.begin(), global_size.end());
 
-  // Generic status report
-  herr_t status;
-
   // Create a global data space
   const hid_t filespace0 = H5Screate_simple(rank, dimsf.data(), nullptr);
   assert(filespace0 != HDF5_FAIL);
@@ -219,6 +216,9 @@ inline void HDF5Interface::write_dataset(
       = H5Dcreate2(file_handle, dataset_path.c_str(), h5type, filespace0,
                    H5P_DEFAULT, chunking_properties, H5P_DEFAULT);
   assert(dset_id != HDF5_FAIL);
+
+  // Generic status report
+  [[maybe_unused]] herr_t status;
 
   // Close global data space
   status = H5Sclose(filespace0);
@@ -302,7 +302,8 @@ HDF5Interface::read_dataset(const hid_t file_handle,
   std::vector<hsize_t> shape(rank);
 
   // Get size in each dimension
-  const int ndims = H5Sget_simple_extent_dims(dataspace, shape.data(), nullptr);
+  [[maybe_unused]] const int ndims
+      = H5Sget_simple_extent_dims(dataspace, shape.data(), nullptr);
   assert(ndims == rank);
 
   // Hyperslab selection
@@ -318,8 +319,8 @@ HDF5Interface::read_dataset(const hid_t file_handle,
 
   // Select a block in the dataset beginning at offset[], with
   // size=count[]
-  herr_t status = H5Sselect_hyperslab(dataspace, H5S_SELECT_SET, offset.data(),
-                                      nullptr, count.data(), nullptr);
+  [[maybe_unused]] herr_t status = H5Sselect_hyperslab(
+      dataspace, H5S_SELECT_SET, offset.data(), nullptr, count.data(), nullptr);
   assert(status != HDF5_FAIL);
 
   // Create a memory dataspace

--- a/cpp/dolfinx/io/HDF5Interface.h
+++ b/cpp/dolfinx/io/HDF5Interface.h
@@ -162,9 +162,8 @@ inline void HDF5Interface::write_dataset(
     const std::vector<int64_t>& global_size, bool use_mpi_io, bool use_chunking)
 {
   // Data rank
-  const std::size_t rank = global_size.size();
+  const int rank = global_size.size();
   assert(rank != 0);
-
   if (rank > 2)
   {
     throw std::runtime_error("Cannot write dataset to HDF5 file"
@@ -187,7 +186,8 @@ inline void HDF5Interface::write_dataset(
 
   // Create a global data space
   const hid_t filespace0 = H5Screate_simple(rank, dimsf.data(), nullptr);
-  assert(filespace0 != HDF5_FAIL);
+  if (filespace0 == HDF5_FAIL)
+    throw std::runtime_error("Failed to create HDF5 data space");
 
   // Set chunking parameters
   hid_t chunking_properties;
@@ -216,7 +216,7 @@ inline void HDF5Interface::write_dataset(
       = H5Dcreate2(file_handle, dataset_path.c_str(), h5type, filespace0,
                    H5P_DEFAULT, chunking_properties, H5P_DEFAULT);
   if (dset_id == HDF5_FAIL)
-    throw std::runtime_error("Failed to create global dataset.");
+    throw std::runtime_error("Failed to create HDF5 global dataset.");
 
   // Generic status report
   herr_t status;
@@ -224,20 +224,19 @@ inline void HDF5Interface::write_dataset(
   // Close global data space
   status = H5Sclose(filespace0);
   if (status == HDF5_FAIL)
-    throw std::runtime_error("Failed to close global data space.");
+    throw std::runtime_error("Failed to close HDF5 global data space.");
 
   // Create a local data space
   const hid_t memspace = H5Screate_simple(rank, count.data(), nullptr);
   if (memspace == HDF5_FAIL)
-    throw std::runtime_error("Failed to create local data space.");
+    throw std::runtime_error("Failed to create HDF5 local data space.");
 
   // Create a file dataspace within the global space - a hyperslab
   const hid_t filespace1 = H5Dget_space(dset_id);
   status = H5Sselect_hyperslab(filespace1, H5S_SELECT_SET, offset.data(),
                                nullptr, count.data(), nullptr);
   if (status == HDF5_FAIL)
-    throw std::runtime_error(
-        "Failed to create file dataspace within the global space.");
+    throw std::runtime_error("Failed to create HDF5 dataspace.");
 
   // Set parallel access
   const hid_t plist_id = H5Pcreate(H5P_DATASET_XFER);
@@ -246,7 +245,10 @@ inline void HDF5Interface::write_dataset(
 #ifdef H5_HAVE_PARALLEL
     status = H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
     if (status == HDF5_FAIL)
-      throw std::runtime_error("Failed to set data transfer property list.");
+    {
+      throw std::runtime_error(
+          "Failed to set HDF5 data transfer property list.");
+    }
 
 #else
     throw std::runtime_error("HDF5 library has not been configured with MPI");
@@ -256,35 +258,38 @@ inline void HDF5Interface::write_dataset(
   // Write local dataset into selected hyperslab
   status = H5Dwrite(dset_id, h5type, memspace, filespace1, plist_id, data);
   if (status == HDF5_FAIL)
-    throw std::runtime_error("Failed to write local dataset into hyperslab.");
+  {
+    throw std::runtime_error(
+        "Failed to write HDF5 local dataset into hyperslab.");
+  }
 
   if (use_chunking)
   {
     // Close chunking properties
     status = H5Pclose(chunking_properties);
     if (status == HDF5_FAIL)
-      throw std::runtime_error("Failed to close chunking properties.");
+      throw std::runtime_error("Failed to close HDF5 chunking properties.");
   }
 
   // Close dataset collectively
   status = H5Dclose(dset_id);
   if (status == HDF5_FAIL)
-    throw std::runtime_error("Failed to close dataset.");
+    throw std::runtime_error("Failed to close HDF5 dataset.");
 
   // Close hyperslab
   status = H5Sclose(filespace1);
   if (status == HDF5_FAIL)
-    throw std::runtime_error("Failed to close hyperslab.");
+    throw std::runtime_error("Failed to close HDF5 hyperslab.");
 
   // Close local dataset
   status = H5Sclose(memspace);
   if (status == HDF5_FAIL)
-    throw std::runtime_error("Failed to close local dataset.");
+    throw std::runtime_error("Failed to close local HDF5 dataset.");
 
   // Release file-access template
   status = H5Pclose(plist_id);
   if (status == HDF5_FAIL)
-    throw std::runtime_error("Failed to release file-access template.");
+    throw std::runtime_error("Failed to release HDF5 file-access template.");
 }
 //---------------------------------------------------------------------------
 template <typename T>
@@ -298,16 +303,17 @@ HDF5Interface::read_dataset(const hid_t file_handle,
   // Open the dataset
   const hid_t dset_id
       = H5Dopen2(file_handle, dataset_path.c_str(), H5P_DEFAULT);
-  assert(dset_id != HDF5_FAIL);
+  if (dset_id == HDF5_FAIL)
+    throw std::runtime_error("Failed to open HDF5 global dataset.");
 
   // Open dataspace
   const hid_t dataspace = H5Dget_space(dset_id);
-  assert(dataspace != HDF5_FAIL);
+  if (dataspace == HDF5_FAIL)
+    throw std::runtime_error("Failed to open HDF5 data space.");
 
   // Get rank of data set
   const int rank = H5Sget_simple_extent_ndims(dataspace);
   assert(rank >= 0);
-
   if (rank > 2)
     LOG(WARNING) << "HDF5Interface::read_dataset untested for rank > 2.";
 
@@ -315,9 +321,7 @@ HDF5Interface::read_dataset(const hid_t file_handle,
   std::vector<hsize_t> shape(rank);
 
   // Get size in each dimension
-  [[maybe_unused]] const int ndims
-      = H5Sget_simple_extent_dims(dataspace, shape.data(), nullptr);
-  assert(ndims == rank);
+  assert(H5Sget_simple_extent_dims(dataspace, shape.data(), nullptr) == rank);
 
   // Hyperslab selection
   std::vector<hsize_t> offset(rank, 0);
@@ -334,11 +338,13 @@ HDF5Interface::read_dataset(const hid_t file_handle,
   // size=count[]
   [[maybe_unused]] herr_t status = H5Sselect_hyperslab(
       dataspace, H5S_SELECT_SET, offset.data(), nullptr, count.data(), nullptr);
-  assert(status != HDF5_FAIL);
+  if (status == HDF5_FAIL)
+    throw std::runtime_error("Failed to select HDF5 hyperslab.");
 
   // Create a memory dataspace
   const hid_t memspace = H5Screate_simple(rank, count.data(), nullptr);
-  assert(memspace != HDF5_FAIL);
+  if (memspace == HDF5_FAIL)
+    throw std::runtime_error("Failed to create HDF5 dataspace.");
 
   // Create local data to read into
   std::size_t data_size = 1;
@@ -350,19 +356,23 @@ HDF5Interface::read_dataset(const hid_t file_handle,
   const hid_t h5type = hdf5_type<T>();
   status
       = H5Dread(dset_id, h5type, memspace, dataspace, H5P_DEFAULT, data.data());
-  assert(status != HDF5_FAIL);
+  if (status == HDF5_FAIL)
+    throw std::runtime_error("Failed to read HDF5 data.");
 
   // Close dataspace
   status = H5Sclose(dataspace);
-  assert(status != HDF5_FAIL);
+  if (status == HDF5_FAIL)
+    throw std::runtime_error("Failed to close HDF5 dataspace.");
 
   // Close memspace
   status = H5Sclose(memspace);
-  assert(status != HDF5_FAIL);
+  if (status == HDF5_FAIL)
+    throw std::runtime_error("Failed to close HDF5 memory space.");
 
   // Close dataset
   status = H5Dclose(dset_id);
-  assert(status != HDF5_FAIL);
+  if (status == HDF5_FAIL)
+    throw std::runtime_error("Failed to close HDF5 dataset.");
 
   auto timer_end = std::chrono::system_clock::now();
   std::chrono::duration<double> dt = (timer_end - timer_start);

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -118,9 +118,9 @@ XDMFFile::XDMFFile(MPI_Comm comm, const std::string filename,
   if (_file_mode == "r")
   {
     // Load XML doc from file
-    [[maybe_unused]] pugi::xml_parse_result result
-        = _xml_doc->load_file(_filename.c_str());
-    assert(result);
+    pugi::xml_parse_result result = _xml_doc->load_file(_filename.c_str());
+    if (!result)
+      throw std::runtime_error("Failed to load xml document from file.");
 
     if (_xml_doc->child("Xdmf").empty())
       throw std::runtime_error("Empty <Xdmf> root node.");

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -118,7 +118,8 @@ XDMFFile::XDMFFile(MPI_Comm comm, const std::string filename,
   if (_file_mode == "r")
   {
     // Load XML doc from file
-    pugi::xml_parse_result result = _xml_doc->load_file(_filename.c_str());
+    [[maybe_unused]] pugi::xml_parse_result result
+        = _xml_doc->load_file(_filename.c_str());
     assert(result);
 
     if (_xml_doc->child("Xdmf").empty())
@@ -139,7 +140,8 @@ XDMFFile::XDMFFile(MPI_Comm comm, const std::string filename,
     xdmf_node.append_attribute("Version") = "3.0";
     xdmf_node.append_attribute("xmlns:xi") = "http://www.w3.org/2001/XInclude";
 
-    pugi::xml_node domain_node = xdmf_node.append_child("Domain");
+    [[maybe_unused]] pugi::xml_node domain_node
+        = xdmf_node.append_child("Domain");
     assert(domain_node);
   }
   else if (_file_mode == "a")
@@ -147,7 +149,8 @@ XDMFFile::XDMFFile(MPI_Comm comm, const std::string filename,
     if (boost::filesystem::exists(_filename))
     {
       // Load XML doc from file
-      pugi::xml_parse_result result = _xml_doc->load_file(_filename.c_str());
+      [[maybe_unused]] pugi::xml_parse_result result
+          = _xml_doc->load_file(_filename.c_str());
       assert(result);
 
       if (_xml_doc->child("Xdmf").empty())
@@ -169,7 +172,8 @@ XDMFFile::XDMFFile(MPI_Comm comm, const std::string filename,
       xdmf_node.append_attribute("xmlns:xi")
           = "http://www.w3.org/2001/XInclude";
 
-      pugi::xml_node domain_node = xdmf_node.append_child("Domain");
+      [[maybe_unused]] pugi::xml_node domain_node
+          = xdmf_node.append_child("Domain");
       assert(domain_node);
     }
   }

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -140,9 +140,9 @@ XDMFFile::XDMFFile(MPI_Comm comm, const std::string filename,
     xdmf_node.append_attribute("Version") = "3.0";
     xdmf_node.append_attribute("xmlns:xi") = "http://www.w3.org/2001/XInclude";
 
-    [[maybe_unused]] pugi::xml_node domain_node
-        = xdmf_node.append_child("Domain");
-    assert(domain_node);
+    pugi::xml_node domain_node = xdmf_node.append_child("Domain");
+    if (!domain_node)
+      throw std::runtime_error("Failed to append xml/xdmf Domain.");
   }
   else if (_file_mode == "a")
   {
@@ -172,9 +172,9 @@ XDMFFile::XDMFFile(MPI_Comm comm, const std::string filename,
       xdmf_node.append_attribute("xmlns:xi")
           = "http://www.w3.org/2001/XInclude";
 
-      [[maybe_unused]] pugi::xml_node domain_node
-          = xdmf_node.append_child("Domain");
-      assert(domain_node);
+      pugi::xml_node domain_node = xdmf_node.append_child("Domain");
+      if (!domain_node)
+        throw std::runtime_error("Failed to append xml/xdmf Domain.");
     }
   }
 }

--- a/cpp/dolfinx/la/PETScMatrix.cpp
+++ b/cpp/dolfinx/la/PETScMatrix.cpp
@@ -193,7 +193,7 @@ PETScMatrix::set_fn(Mat A, InsertMode mode)
              std::int32_t m, const std::int32_t* rows, std::int32_t n,
              const std::int32_t* cols, const PetscScalar* vals) mutable
   {
-    [[maybe_unused]] PetscErrorCode ierr;
+    PetscErrorCode ierr;
 #ifdef PETSC_USE_64BIT_INDICES
     cache.resize(m + n);
     std::copy_n(rows, m, cache.begin());
@@ -204,10 +204,8 @@ PETScMatrix::set_fn(Mat A, InsertMode mode)
     ierr = MatSetValuesLocal(A, m, rows, n, cols, vals, mode);
 #endif
 
-#ifdef DEBUG
     if (ierr != 0)
       la::petsc_error(ierr, __FILE__, "MatSetValuesLocal");
-#endif
     return 0;
   };
 }

--- a/cpp/dolfinx/la/PETScMatrix.cpp
+++ b/cpp/dolfinx/la/PETScMatrix.cpp
@@ -32,7 +32,8 @@ Mat la::create_petsc_matrix(
     petsc_error(ierr, __FILE__, "MatCreate");
 
   // Get IndexMaps from sparsity patterm, and block size
-  std::array maps = {sparsity_pattern.index_map(0), sparsity_pattern.index_map(1)};
+  std::array maps
+      = {sparsity_pattern.index_map(0), sparsity_pattern.index_map(1)};
   const std::array bs
       = {sparsity_pattern.block_size(0), sparsity_pattern.block_size(1)};
 
@@ -190,8 +191,9 @@ PETScMatrix::set_fn(Mat A, InsertMode mode)
 {
   return [A, mode, cache = std::vector<PetscInt>()](
              std::int32_t m, const std::int32_t* rows, std::int32_t n,
-             const std::int32_t* cols, const PetscScalar* vals) mutable {
-    PetscErrorCode ierr;
+             const std::int32_t* cols, const PetscScalar* vals) mutable
+  {
+    [[maybe_unused]] PetscErrorCode ierr;
 #ifdef PETSC_USE_64BIT_INDICES
     cache.resize(m + n);
     std::copy_n(rows, m, cache.begin());
@@ -216,8 +218,9 @@ PETScMatrix::set_block_fn(Mat A, InsertMode mode)
 {
   return [A, mode, cache = std::vector<PetscInt>()](
              std::int32_t m, const std::int32_t* rows, std::int32_t n,
-             const std::int32_t* cols, const PetscScalar* vals) mutable {
-    PetscErrorCode ierr;
+             const std::int32_t* cols, const PetscScalar* vals) mutable
+  {
+    [[maybe_unused]] PetscErrorCode ierr;
 #ifdef PETSC_USE_64BIT_INDICES
     cache.resize(m + n);
     std::copy_n(rows, m, cache.begin());
@@ -246,8 +249,9 @@ PETScMatrix::set_block_expand_fn(Mat A, int bs0, int bs1, InsertMode mode)
   return [A, bs0, bs1, mode, cache0 = std::vector<PetscInt>(),
           cache1 = std::vector<PetscInt>()](
              std::int32_t m, const std::int32_t* rows, std::int32_t n,
-             const std::int32_t* cols, const PetscScalar* vals) mutable {
-    PetscErrorCode ierr;
+             const std::int32_t* cols, const PetscScalar* vals) mutable
+  {
+    [[maybe_unused]] PetscErrorCode ierr;
     cache0.resize(bs0 * m);
     cache1.resize(bs1 * n);
     for (std::int32_t i = 0; i < m; ++i)

--- a/cpp/dolfinx/la/PETScMatrix.cpp
+++ b/cpp/dolfinx/la/PETScMatrix.cpp
@@ -201,6 +201,12 @@ PETScMatrix::set_fn(Mat A, InsertMode mode)
 #else
     ierr = MatSetValuesLocal(A, m, rows, n, cols, vals, mode);
 #endif
+
+#ifdef DEBUG
+    if (ierr != 0)
+      la::petsc_error(ierr, __FILE__, "MatSetValuesLocal");
+#endif
+
     return ierr;
   };
 }
@@ -223,6 +229,12 @@ PETScMatrix::set_block_fn(Mat A, InsertMode mode)
 #else
     ierr = MatSetValuesBlockedLocal(A, m, rows, n, cols, vals, mode);
 #endif
+
+#ifdef DEBUG
+    if (ierr != 0)
+      la::petsc_error(ierr, __FILE__, "MatSetValuesBlockedLocal");
+#endif
+
     return ierr;
   };
 }
@@ -251,6 +263,10 @@ PETScMatrix::set_block_expand_fn(Mat A, int bs0, int bs1, InsertMode mode)
 
     ierr = MatSetValuesLocal(A, cache0.size(), cache0.data(), cache1.size(),
                              cache1.data(), vals, mode);
+#ifdef DEBUG
+    if (ierr != 0)
+      la::petsc_error(ierr, __FILE__, "MatSetValuesLocal");
+#endif
     return ierr;
   };
 }

--- a/cpp/dolfinx/la/PETScMatrix.cpp
+++ b/cpp/dolfinx/la/PETScMatrix.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2004-2018 Johan Hoffman, Johan Jansson, Anders Logg and Garth
-// N. Wells
+// Copyright (C) 2004-2018 Johan Hoffman, Johan Jansson, Anders Logg and
+// Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -21,9 +21,9 @@ using namespace dolfinx;
 using namespace dolfinx::la;
 
 //-----------------------------------------------------------------------------
-Mat la::create_petsc_matrix(
-    MPI_Comm comm, const dolfinx::la::SparsityPattern& sparsity_pattern,
-    const std::string& type)
+Mat la::create_petsc_matrix(MPI_Comm comm,
+                            const dolfinx::la::SparsityPattern& sp,
+                            const std::string& type)
 {
   PetscErrorCode ierr;
   Mat A;
@@ -32,10 +32,8 @@ Mat la::create_petsc_matrix(
     petsc_error(ierr, __FILE__, "MatCreate");
 
   // Get IndexMaps from sparsity patterm, and block size
-  std::array maps
-      = {sparsity_pattern.index_map(0), sparsity_pattern.index_map(1)};
-  const std::array bs
-      = {sparsity_pattern.block_size(0), sparsity_pattern.block_size(1)};
+  std::array maps = {sp.index_map(0), sp.index_map(1)};
+  const std::array bs = {sp.block_size(0), sp.block_size(1)};
 
   if (!type.empty())
     MatSetType(A, type.c_str());
@@ -53,9 +51,9 @@ Mat la::create_petsc_matrix(
 
   // Get number of nonzeros for each row from sparsity pattern
   const graph::AdjacencyList<std::int32_t>& diagonal_pattern
-      = sparsity_pattern.diagonal_pattern();
+      = sp.diagonal_pattern();
   const graph::AdjacencyList<std::int32_t>& off_diagonal_pattern
-      = sparsity_pattern.off_diagonal_pattern();
+      = sp.off_diagonal_pattern();
 
   // Apply PETSc options from the options database to the matrix (this
   // includes changing the matrix type to one specified by the user)
@@ -191,7 +189,7 @@ PETScMatrix::set_fn(Mat A, InsertMode mode)
 {
   return [A, mode, cache = std::vector<PetscInt>()](
              std::int32_t m, const std::int32_t* rows, std::int32_t n,
-             const std::int32_t* cols, const PetscScalar* vals) mutable
+             const std::int32_t* cols, const PetscScalar* vals) mutable -> int
   {
     PetscErrorCode ierr;
 #ifdef PETSC_USE_64BIT_INDICES
@@ -203,10 +201,7 @@ PETScMatrix::set_fn(Mat A, InsertMode mode)
 #else
     ierr = MatSetValuesLocal(A, m, rows, n, cols, vals, mode);
 #endif
-
-    if (ierr != 0)
-      la::petsc_error(ierr, __FILE__, "MatSetValuesLocal");
-    return 0;
+    return ierr;
   };
 }
 //-----------------------------------------------------------------------------
@@ -216,9 +211,9 @@ PETScMatrix::set_block_fn(Mat A, InsertMode mode)
 {
   return [A, mode, cache = std::vector<PetscInt>()](
              std::int32_t m, const std::int32_t* rows, std::int32_t n,
-             const std::int32_t* cols, const PetscScalar* vals) mutable
+             const std::int32_t* cols, const PetscScalar* vals) mutable -> int
   {
-    [[maybe_unused]] PetscErrorCode ierr;
+    PetscErrorCode ierr;
 #ifdef PETSC_USE_64BIT_INDICES
     cache.resize(m + n);
     std::copy_n(rows, m, cache.begin());
@@ -228,12 +223,7 @@ PETScMatrix::set_block_fn(Mat A, InsertMode mode)
 #else
     ierr = MatSetValuesBlockedLocal(A, m, rows, n, cols, vals, mode);
 #endif
-
-#ifdef DEBUG
-    if (ierr != 0)
-      la::petsc_error(ierr, __FILE__, "MatSetValuesBlockedLocal");
-#endif
-    return 0;
+    return ierr;
   };
 }
 //-----------------------------------------------------------------------------
@@ -247,9 +237,9 @@ PETScMatrix::set_block_expand_fn(Mat A, int bs0, int bs1, InsertMode mode)
   return [A, bs0, bs1, mode, cache0 = std::vector<PetscInt>(),
           cache1 = std::vector<PetscInt>()](
              std::int32_t m, const std::int32_t* rows, std::int32_t n,
-             const std::int32_t* cols, const PetscScalar* vals) mutable
+             const std::int32_t* cols, const PetscScalar* vals) mutable -> int
   {
-    [[maybe_unused]] PetscErrorCode ierr;
+    PetscErrorCode ierr;
     cache0.resize(bs0 * m);
     cache1.resize(bs1 * n);
     for (std::int32_t i = 0; i < m; ++i)
@@ -261,18 +251,13 @@ PETScMatrix::set_block_expand_fn(Mat A, int bs0, int bs1, InsertMode mode)
 
     ierr = MatSetValuesLocal(A, cache0.size(), cache0.data(), cache1.size(),
                              cache1.data(), vals, mode);
-
-#ifdef DEBUG
-    if (ierr != 0)
-      la::petsc_error(ierr, __FILE__, "MatSetValuesLocal");
-#endif
-    return 0;
+    return ierr;
   };
 }
 //-----------------------------------------------------------------------------
-PETScMatrix::PETScMatrix(MPI_Comm comm, const SparsityPattern& sparsity_pattern,
+PETScMatrix::PETScMatrix(MPI_Comm comm, const SparsityPattern& sp,
                          const std::string& type)
-    : PETScOperator(create_petsc_matrix(comm, sparsity_pattern, type), false)
+    : PETScOperator(create_petsc_matrix(comm, sp, type), false)
 {
   // Do nothing
 }
@@ -292,22 +277,19 @@ double PETScMatrix::norm(la::Norm norm_type) const
   {
   case la::Norm::l1:
     ierr = MatNorm(_matA, NORM_1, &value);
-    if (ierr != 0)
-      petsc_error(ierr, __FILE__, "MatNorm");
     break;
   case la::Norm::linf:
     ierr = MatNorm(_matA, NORM_INFINITY, &value);
-    if (ierr != 0)
-      petsc_error(ierr, __FILE__, "MatNorm");
     break;
   case la::Norm::frobenius:
     ierr = MatNorm(_matA, NORM_FROBENIUS, &value);
-    if (ierr != 0)
-      petsc_error(ierr, __FILE__, "MatNorm");
     break;
   default:
     throw std::runtime_error("Unknown PETSc Mat norm type");
   }
+
+  if (ierr != 0)
+    petsc_error(ierr, __FILE__, "MatNorm");
 
   return value;
 }

--- a/cpp/dolfinx/la/PETScMatrix.h
+++ b/cpp/dolfinx/la/PETScMatrix.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2004-2018 Johan Hoffman, Johan Jansson, Anders Logg and Garth
-// N. Wells
+// Copyright (C) 2004-2018 Johan Hoffman, Johan Jansson, Anders Logg and
+// Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -20,7 +20,7 @@ class VectorSpaceBasis;
 
 /// Create a PETSc Mat. Caller is responsible for destroying the
 /// returned object.
-Mat create_petsc_matrix(MPI_Comm comm, const SparsityPattern& sparsity_pattern,
+Mat create_petsc_matrix(MPI_Comm comm, const SparsityPattern& sp,
                         const std::string& type = std::string());
 
 /// Create PETSc MatNullSpace. Caller is responsible for destruction
@@ -67,7 +67,7 @@ public:
   set_block_expand_fn(Mat A, int bs0, int bs1, InsertMode mode);
 
   /// Create holder for a PETSc Mat object from a sparsity pattern
-  PETScMatrix(MPI_Comm comm, const SparsityPattern& sparsity_pattern,
+  PETScMatrix(MPI_Comm comm, const SparsityPattern& sp,
               const std::string& type = std::string());
 
   /// Create holder of a PETSc Mat object/pointer. The Mat A object

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -178,7 +178,8 @@ compute_vertex_markers(const graph::AdjacencyList<std::int64_t>& cells,
     else
     {
       // This vertex is not shared: set to -2
-      auto [it_ignore, insert] = global_to_local_v.insert({global_index, -2});
+      [[maybe_unused]] auto [it_ignore, insert]
+          = global_to_local_v.insert({global_index, -2});
       assert(insert);
     }
   }

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -210,7 +210,7 @@ refinement::create_new_vertices(
   {
     if (marked_edges[local_i] == true)
     {
-      auto it = local_edge_to_new_vertex.insert({local_i, n});
+      [[maybe_unused]] auto it = local_edge_to_new_vertex.insert({local_i, n});
       assert(it.second);
       ++n;
     }
@@ -274,7 +274,7 @@ refinement::create_new_vertices(
   for (std::size_t i = 0; i < received_values.size() / 2; ++i)
   {
     assert(recv_local_edge[i] != -1);
-    auto it = local_edge_to_new_vertex.insert(
+    [[maybe_unused]] auto it = local_edge_to_new_vertex.insert(
         {recv_local_edge[i], received_values[i * 2 + 1]});
     assert(it.second);
   }


### PR DESCRIPTION
Running Release mode with -Werror -Wall -pedantic shows quite a few possible unused variables, as they are only used in asserts. This commit fixes it.