### PR TITLE
Fixes #1785

### DIFF
--- a/cpp/dolfinx/io/HDF5Interface.h
+++ b/cpp/dolfinx/io/HDF5Interface.h
@@ -15,6 +15,7 @@
 #include <mpi.h>
 #include <string>
 #include <vector>
+
 namespace dolfinx::io
 {
 

--- a/cpp/dolfinx/io/HDF5Interface.h
+++ b/cpp/dolfinx/io/HDF5Interface.h
@@ -15,7 +15,6 @@
 #include <mpi.h>
 #include <string>
 #include <vector>
-
 namespace dolfinx::io
 {
 
@@ -321,7 +320,9 @@ HDF5Interface::read_dataset(const hid_t file_handle,
   std::vector<hsize_t> shape(rank);
 
   // Get size in each dimension
-  assert(H5Sget_simple_extent_dims(dataspace, shape.data(), nullptr) == rank);
+  const int ndims = H5Sget_simple_extent_dims(dataspace, shape.data(), nullptr);
+  if (ndims != rank)
+    throw std::runtime_error("Failed to get dimensionality of dataspace");
 
   // Hyperslab selection
   std::vector<hsize_t> offset(rank, 0);


### PR DESCRIPTION
Function that implicitly finds the size of input data. If only called in assert, this returns data of (0,0).
Fixes #1785  introduced in #1784 