### PR TITLE
Correct order of args in pybind

### DIFF
--- a/python/dolfinx/wrappers/geometry.cpp
+++ b/python/dolfinx/wrappers/geometry.cpp
@@ -62,8 +62,8 @@ void geometry(py::module& m)
         return as_pyarray(dolfinx::geometry::compute_closest_entity(
             tree, midpoint_tree, mesh, p));
       },
-      py::arg("tree"), py::arg("midpoint_tree"), py::arg("points"),
-      py::arg("mesh"));
+      py::arg("tree"), py::arg("midpoint_tree"), py::arg("mesh"),
+      py::arg("points"));
 
   m.def("compute_collisions",
         [](const dolfinx::geometry::BoundingBoxTree& tree,


### PR DESCRIPTION
Having these in the wrong order gave the function confusing pybind documentation