### PR TITLE
Remedy errant boost behaviour

### DIFF
--- a/cpp/dolfinx/io/utils.cpp
+++ b/cpp/dolfinx/io/utils.cpp
@@ -13,6 +13,6 @@ using namespace dolfinx;
 std::string io::get_filename(const std::string& fullname)
 {
   const boost::filesystem::path p(fullname);
-  return p.filename().string();
+  return std::string(p.filename().c_str());
 }
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
* Ensure that the filename string does not contain any `\0` characters by going through `.c_str()` from boost