### PR TITLE
Fix parhip build error

### DIFF
--- a/cpp/dolfinx/graph/partitioners.cpp
+++ b/cpp/dolfinx/graph/partitioners.cpp
@@ -538,7 +538,7 @@ std::function<graph::AdjacencyList<std::int32_t>(
 graph::kahip::partitioner(int mode, int seed, double imbalance,
                           bool suppress_output)
 {
-  return [mode, seed, imbalance,
+  return [mode, seed, &imbalance,
           suppress_output](MPI_Comm comm, int nparts,
                            const graph::AdjacencyList<std::int64_t>& graph,
                            std::int32_t, bool ghosting)

--- a/cpp/dolfinx/graph/partitioners.cpp
+++ b/cpp/dolfinx/graph/partitioners.cpp
@@ -570,9 +570,9 @@ graph::kahip::partitioner(int mode, int seed, double imbalance,
     common::Timer timer2("KaHIP: call ParHIPPartitionKWay");
     std::vector<T> part(graph.num_nodes());
     int edgecut = 0;
-    double imbvec = static_cast<double>(imbalance);
+    double _imbalance = imbalance;
     ParHIPPartitionKWay(node_disp.data(), offsets.data(), array.data(), vwgt,
-                        adjcwgt, &nparts, &imbvec, suppress_output, seed, mode,
+                        adjcwgt, &nparts, & _imbalance, suppress_output, seed, mode,
                         &edgecut, part.data(), &comm);
     timer2.stop();
 

--- a/cpp/dolfinx/graph/partitioners.cpp
+++ b/cpp/dolfinx/graph/partitioners.cpp
@@ -538,7 +538,7 @@ std::function<graph::AdjacencyList<std::int32_t>(
 graph::kahip::partitioner(int mode, int seed, double imbalance,
                           bool suppress_output)
 {
-  return [mode, seed, &imbalance,
+  return [mode, seed, imbalance,
           suppress_output](MPI_Comm comm, int nparts,
                            const graph::AdjacencyList<std::int64_t>& graph,
                            std::int32_t, bool ghosting)
@@ -570,9 +570,10 @@ graph::kahip::partitioner(int mode, int seed, double imbalance,
     common::Timer timer2("KaHIP: call ParHIPPartitionKWay");
     std::vector<T> part(graph.num_nodes());
     int edgecut = 0;
+    double imbvec = static_cast<double>(imbalance);
     ParHIPPartitionKWay(node_disp.data(), offsets.data(), array.data(), vwgt,
-                        adjcwgt, &nparts, &imbalance, suppress_output, seed,
-                        mode, &edgecut, part.data(), &comm);
+                        adjcwgt, &nparts, &imbvec, suppress_output, seed, mode,
+                        &edgecut, part.data(), &comm);
     timer2.stop();
 
     if (ghosting)


### PR DESCRIPTION
```
[28/65] Building CXX object dolfinx/CMakeFiles/dolfinx.dir/graph/partitioners.cpp.o
FAILED: dolfinx/CMakeFiles/dolfinx.dir/graph/partitioners.cpp.o
/usr/bin/c++ -DADIOS2_USE_MPI -DBOOST_ALL_NO_LIB -DBOOST_CHRONO_DYN_LINK -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_TIMER_DYN_LINK -DDEBUG -DDOLFINX_VERSION=\"0.3.1.0\" -DHAS_ADIOS2 -DHAS_KAHIP -DHAS_PTSCOTCH -Ddolfinx_EXPORTS -I/root/shared/dolfinx/cpp -I/root/shared/dolfinx/cpp/dolfinx -isystem /root/shared/ffcx/ffcx/codegeneration -isystem /usr/local/petsc/linux-gnu-real-32/include -isystem /usr/local/petsc/include -Ofast -march=native -Wall -Werror -pedantic -g -fPIC -std=c++17 -MD -MT dolfinx/CMakeFiles/dolfinx.dir/graph/partitioners.cpp.o -MF dolfinx/CMakeFiles/dolfinx.dir/graph/partitioners.cpp.o.d -o dolfinx/CMakeFiles/dolfinx.dir/graph/partitioners.cpp.o -c /root/shared/dolfinx/cpp/dolfinx/graph/partitioners.cpp
/root/shared/dolfinx/cpp/dolfinx/graph/partitioners.cpp: In lambda function:
/root/shared/dolfinx/cpp/dolfinx/graph/partitioners.cpp:574:43: error: invalid conversion from 'const double*' to 'double*' [-fpermissive]
574 | adjcwgt, &nparts, &imbalance, suppress_output, seed,
| ^~~~~~~~~~
| |
| const double*
In file included from /root/shared/dolfinx/cpp/dolfinx/graph/partitioners.cpp:32:
/usr/local/include/parhip_interface.h:25:47: note: initializing argument 7 of 'void ParHIPPartitionKWay(idxtype*, idxtype*, idxtype*, idxtype*, idxtype*, int*, double*, bool, int, int, int*, idxtype*, MPI_Comm*)'
25 | int *nparts, double* imbalance, bool suppress_output, int seed, int mode, int *edgecut, idxtype *part,
| ~~~~~~~~^~~~~~~~~
```