### PR TITLE
Consistent method/property name for accessing the MPI communicator for an object

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -305,28 +305,28 @@ IndexMap::IndexMap(MPI_Comm comm, std::int32_t local_size)
   _shared_indices = std::make_unique<graph::AdjacencyList<std::int32_t>>(0);
 }
 //-----------------------------------------------------------------------------
-IndexMap::IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
+IndexMap::IndexMap(MPI_Comm comm, std::int32_t local_size,
                    const xtl::span<const int>& dest_ranks,
                    const xtl::span<const std::int64_t>& ghosts,
                    const xtl::span<const int>& src_ranks)
-    : _comm(mpi_comm), _comm_owner_to_ghost(MPI_COMM_NULL),
+    : _comm(comm), _comm_owner_to_ghost(MPI_COMM_NULL),
       _comm_ghost_to_owner(MPI_COMM_NULL), _ghosts(ghosts.begin(), ghosts.end())
 {
   assert(size_t(ghosts.size()) == src_ranks.size());
   assert(std::equal(src_ranks.begin(), src_ranks.end(),
-                    get_ghost_ranks(mpi_comm, local_size, _ghosts).begin()));
+                    get_ghost_ranks(comm, local_size, _ghosts).begin()));
 
   // Get global offset (index), using partial exclusive reduction
   std::int64_t offset = 0;
   const std::int64_t local_size_tmp = (std::int64_t)local_size;
   MPI_Request request_scan;
-  MPI_Iexscan(&local_size_tmp, &offset, 1, MPI_INT64_T, MPI_SUM, mpi_comm,
+  MPI_Iexscan(&local_size_tmp, &offset, 1, MPI_INT64_T, MPI_SUM, comm,
               &request_scan);
 
   // Send local size to sum reduction to get global size
   MPI_Request request;
-  MPI_Iallreduce(&local_size_tmp, &_size_global, 1, MPI_INT64_T, MPI_SUM,
-                 mpi_comm, &request);
+  MPI_Iallreduce(&local_size_tmp, &_size_global, 1, MPI_INT64_T, MPI_SUM, comm,
+                 &request);
 
   // Build set of src ranks for ghosts, i.e. the ranks that own the
   // callers ghosts
@@ -341,22 +341,22 @@ IndexMap::IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
   {
     MPI_Comm comm0;
     MPI_Dist_graph_create_adjacent(
-        mpi_comm, halo_src_ranks.size(), halo_src_ranks.data(), MPI_UNWEIGHTED,
+        comm, halo_src_ranks.size(), halo_src_ranks.data(), MPI_UNWEIGHTED,
         dest_ranks.size(), dest_ranks.data(), MPI_UNWEIGHTED, MPI_INFO_NULL,
         false, &comm0);
     _comm_owner_to_ghost = dolfinx::MPI::Comm(comm0, false);
 
     MPI_Comm comm1;
-    MPI_Dist_graph_create_adjacent(
-        mpi_comm, dest_ranks.size(), dest_ranks.data(), MPI_UNWEIGHTED,
-        halo_src_ranks.size(), halo_src_ranks.data(), MPI_UNWEIGHTED,
-        MPI_INFO_NULL, false, &comm1);
+    MPI_Dist_graph_create_adjacent(comm, dest_ranks.size(), dest_ranks.data(),
+                                   MPI_UNWEIGHTED, halo_src_ranks.size(),
+                                   halo_src_ranks.data(), MPI_UNWEIGHTED,
+                                   MPI_INFO_NULL, false, &comm1);
     _comm_ghost_to_owner = dolfinx::MPI::Comm(comm1, false);
   }
 
   // Map ghost owner rank to the rank on neighborhood communicator
   int myrank = -1;
-  MPI_Comm_rank(mpi_comm, &myrank);
+  MPI_Comm_rank(comm, &myrank);
   assert(std::find(src_ranks.begin(), src_ranks.end(), myrank)
          == src_ranks.end());
   std::vector<std::int32_t> ghost_owners(ghosts.size());

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -74,7 +74,7 @@ public:
   /// Create an index map with local_size owned indiced on this process
   ///
   /// @note Collective
-  /// @param[in] mpi_comm The MPI communicator
+  /// @param[in] comm The MPI communicator
   /// @param[in] local_size Local size of the IndexMap, i.e. the number
   /// of owned entries
   /// @param[in] dest_ranks Ranks that 'ghost' indices that are owned by
@@ -83,7 +83,7 @@ public:
   /// @param[in] ghosts The global indices of ghost entries
   /// @param[in] src_ranks Owner rank (on global communicator) of each
   /// entry in @p ghosts
-  IndexMap(MPI_Comm mpi_comm, std::int32_t local_size,
+  IndexMap(MPI_Comm comm, std::int32_t local_size,
            const xtl::span<const int>& dest_ranks,
            const xtl::span<const std::int64_t>& ghosts,
            const xtl::span<const int>& src_ranks);

--- a/cpp/dolfinx/fem/FunctionSpace.cpp
+++ b/cpp/dolfinx/fem/FunctionSpace.cpp
@@ -89,7 +89,7 @@ FunctionSpace::collapse() const
   std::shared_ptr<fem::DofMap> collapsed_dofmap;
   std::vector<std::int32_t> collapsed_dofs;
   std::tie(collapsed_dofmap, collapsed_dofs)
-      = _dofmap->collapse(_mesh->mpi_comm(), _mesh->topology());
+      = _dofmap->collapse(_mesh->comm(), _mesh->topology());
 
   // Create new FunctionSpace and return
   return {FunctionSpace(_mesh, _element, collapsed_dofmap),

--- a/cpp/dolfinx/fem/discreteoperators.cpp
+++ b/cpp/dolfinx/fem/discreteoperators.cpp
@@ -65,7 +65,7 @@ fem::create_sparsity_discrete_gradient(const fem::FunctionSpace& V0,
   assert(block_sizes[0] == block_sizes[1]);
 
   // Initialise sparsity pattern
-  la::SparsityPattern pattern(mesh->mpi_comm(), index_maps, block_sizes);
+  la::SparsityPattern pattern(mesh->comm(), index_maps, block_sizes);
 
   // Initialize required connectivities
   const int tdim = mesh->topology().dim();

--- a/cpp/dolfinx/fem/petsc.cpp
+++ b/cpp/dolfinx/fem/petsc.cpp
@@ -26,7 +26,7 @@ Mat dolfinx::fem::create_matrix(const Form<PetscScalar>& a,
   // Finalise communication
   pattern.assemble();
 
-  return la::create_petsc_matrix(a.mesh()->mpi_comm(), pattern, type);
+  return la::create_petsc_matrix(a.mesh()->comm(), pattern, type);
 }
 //-----------------------------------------------------------------------------
 Mat fem::create_matrix_block(
@@ -62,7 +62,7 @@ Mat fem::create_matrix_block(
       {
         // Create sparsity pattern for block
         patterns[row].push_back(std::make_unique<la::SparsityPattern>(
-            mesh->mpi_comm(), index_maps, bs));
+            mesh->comm(), index_maps, bs));
 
         // Build sparsity pattern for block
         assert(V[0][row]->dofmap());
@@ -116,14 +116,14 @@ Mat fem::create_matrix_block(
   for (std::size_t row = 0; row < V[0].size(); ++row)
     for (std::size_t col = 0; col < V[1].size(); ++col)
       p[row].push_back(patterns[row][col].get());
-  la::SparsityPattern pattern(mesh->mpi_comm(), p, maps, bs_dofs);
+  la::SparsityPattern pattern(mesh->comm(), p, maps, bs_dofs);
   pattern.assemble();
 
   // FIXME: Add option to pass customised local-to-global map to PETSc
   // Mat constructor
 
   // Initialise matrix
-  Mat A = la::create_petsc_matrix(mesh->mpi_comm(), pattern, type);
+  Mat A = la::create_petsc_matrix(mesh->comm(), pattern, type);
 
   // Create row and column local-to-global maps (field0, field1, field2,
   // etc), i.e. ghosts of field0 appear before owned indices of field1
@@ -198,7 +198,7 @@ Mat fem::create_matrix_nest(
 
   // Initialise block (MatNest) matrix
   Mat A;
-  MatCreate(V[0][0]->mesh()->mpi_comm(), &A);
+  MatCreate(V[0][0]->mesh()->comm(), &A);
   MatSetType(A, MATNEST);
   MatNestSetSubMats(A, rows, nullptr, cols, nullptr, mats.data());
   MatSetUp(A);
@@ -266,8 +266,8 @@ Vec fem::create_vector_nest(
 
   // Create nested (VecNest) vector
   Vec y;
-  VecCreateNest(vecs[0]->mpi_comm(), petsc_vecs.size(), nullptr,
-                petsc_vecs.data(), &y);
+  VecCreateNest(vecs[0]->comm(), petsc_vecs.size(), nullptr, petsc_vecs.data(),
+                &y);
   return y;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -231,6 +231,6 @@ fem::FunctionSpace fem::create_functionspace(
   return fem::FunctionSpace(
       mesh, element,
       std::make_shared<fem::DofMap>(fem::create_dofmap(
-          mesh->mpi_comm(), *ufc_map, mesh->topology(), reorder_fn, element)));
+          mesh->comm(), *ufc_map, mesh->topology(), reorder_fn, element)));
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/io/VTKFile.cpp
+++ b/cpp/dolfinx/io/VTKFile.cpp
@@ -412,7 +412,7 @@ void write_function(
     }
   }
   // Get MPI comm
-  const MPI_Comm comm = mesh->mpi_comm();
+  const MPI_Comm comm = mesh->comm();
   const int mpi_rank = dolfinx::MPI::rank(comm);
   boost::filesystem::path p(filename);
 

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -89,7 +89,7 @@ void _write_function(dolfinx::MPI::Comm& comm,
 //-----------------------------------------------------------------------------
 XDMFFile::XDMFFile(MPI_Comm comm, const std::string filename,
                    const std::string file_mode, const Encoding encoding)
-    : _mpi_comm(comm), _filename(filename), _file_mode(file_mode),
+    : _comm(comm), _filename(filename), _file_mode(file_mode),
       _xml_doc(new pugi::xml_document), _encoding(encoding)
 {
   // Handle HDF5 and XDMF files with the file mode. At the end of this
@@ -103,8 +103,8 @@ XDMFFile::XDMFFile(MPI_Comm comm, const std::string filename,
 
     // Open HDF5 file
     const std::string hdf5_filename = xdmf_utils::get_hdf5_filename(_filename);
-    const bool mpi_io = MPI::size(_mpi_comm.comm()) > 1 ? true : false;
-    _h5_id = HDF5Interface::open_file(_mpi_comm.comm(), hdf5_filename,
+    const bool mpi_io = MPI::size(_comm.comm()) > 1 ? true : false;
+    _h5_id = HDF5Interface::open_file(_comm.comm(), hdf5_filename,
                                       file_mode, mpi_io);
     assert(_h5_id > 0);
     LOG(INFO) << "Opened HDF5 file with id \"" << _h5_id << "\"";
@@ -195,10 +195,10 @@ void XDMFFile::write_mesh(const mesh::Mesh& mesh, const std::string xpath)
     throw std::runtime_error("XML node '" + xpath + "' not found.");
 
   // Add the mesh Grid to the domain
-  xdmf_mesh::add_mesh(_mpi_comm.comm(), node, _h5_id, mesh, mesh.name);
+  xdmf_mesh::add_mesh(_comm.comm(), node, _h5_id, mesh, mesh.name);
 
   // Save XML file (on process 0 only)
-  if (MPI::rank(_mpi_comm.comm()) == 0)
+  if (MPI::rank(_comm.comm()) == 0)
     _xml_doc->save_file(_filename.c_str(), "  ");
 }
 //-----------------------------------------------------------------------------
@@ -216,11 +216,11 @@ void XDMFFile::write_geometry(const mesh::Geometry& geometry,
   grid_node.append_attribute("GridType") = "Uniform";
 
   const std::string path_prefix = "/Geometry/" + name;
-  xdmf_mesh::add_geometry_data(_mpi_comm.comm(), grid_node, _h5_id, path_prefix,
+  xdmf_mesh::add_geometry_data(_comm.comm(), grid_node, _h5_id, path_prefix,
                                geometry);
 
   // Save XML file (on process 0 only)
-  if (MPI::rank(_mpi_comm.comm()) == 0)
+  if (MPI::rank(_comm.comm()) == 0)
     _xml_doc->save_file(_filename.c_str(), "  ");
 }
 //-----------------------------------------------------------------------------
@@ -240,7 +240,7 @@ mesh::Mesh XDMFFile::read_mesh(const fem::CoordinateElement& element,
                                                std::move(offset));
 
   mesh::Mesh mesh
-      = mesh::create_mesh(_mpi_comm.comm(), cells_adj, element, x, mode);
+      = mesh::create_mesh(_comm.comm(), cells_adj, element, x, mode);
   mesh.name = name;
   return mesh;
 }
@@ -259,7 +259,7 @@ XDMFFile::read_topology_data(const std::string name,
     throw std::runtime_error("<Grid> with name '" + name + "' not found.");
 
   LOG(INFO) << "Read topology data \"" << name << "\" at \"" << xpath << "\"";
-  return xdmf_mesh::read_topology_data(_mpi_comm.comm(), _h5_id, grid_node);
+  return xdmf_mesh::read_topology_data(_comm.comm(), _h5_id, grid_node);
 }
 //-----------------------------------------------------------------------------
 xt::xtensor<double, 2>
@@ -276,19 +276,19 @@ XDMFFile::read_geometry_data(const std::string name,
     throw std::runtime_error("<Grid> with name '" + name + "' not found.");
 
   LOG(INFO) << "Read geometry data \"" << name << "\" at \"" << xpath << "\"";
-  return xdmf_mesh::read_geometry_data(_mpi_comm.comm(), _h5_id, grid_node);
+  return xdmf_mesh::read_geometry_data(_comm.comm(), _h5_id, grid_node);
 }
 //-----------------------------------------------------------------------------
 void XDMFFile::write_function(const fem::Function<double>& u, double t,
                               const std::string& mesh_xpath)
 {
-  _write_function(_mpi_comm, u, t, mesh_xpath, *_xml_doc, _h5_id, _filename);
+  _write_function(_comm, u, t, mesh_xpath, *_xml_doc, _h5_id, _filename);
 }
 //-----------------------------------------------------------------------------
 void XDMFFile::write_function(const fem::Function<std::complex<double>>& u,
                               double t, const std::string& mesh_xpath)
 {
-  _write_function(_mpi_comm, u, t, mesh_xpath, *_xml_doc, _h5_id, _filename);
+  _write_function(_comm, u, t, mesh_xpath, *_xml_doc, _h5_id, _filename);
 }
 //-----------------------------------------------------------------------------
 void XDMFFile::write_meshtags(const mesh::MeshTags<std::int32_t>& meshtags,
@@ -308,11 +308,11 @@ void XDMFFile::write_meshtags(const mesh::MeshTags<std::int32_t>& meshtags,
   pugi::xml_node geo_ref_node = grid_node.append_child("xi:include");
   geo_ref_node.append_attribute("xpointer") = geo_ref_path.c_str();
   assert(geo_ref_node);
-  xdmf_meshtags::add_meshtags(_mpi_comm.comm(), meshtags, grid_node, _h5_id,
+  xdmf_meshtags::add_meshtags(_comm.comm(), meshtags, grid_node, _h5_id,
                               meshtags.name);
 
   // Save XML file (on process 0 only)
-  if (MPI::rank(_mpi_comm.comm()) == 0)
+  if (MPI::rank(_comm.comm()) == 0)
     _xml_doc->save_file(_filename.c_str(), "  ");
 }
 //-----------------------------------------------------------------------------
@@ -333,7 +333,7 @@ XDMFFile::read_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh,
   pugi::xml_node values_data_node
       = grid_node.child("Attribute").child("DataItem");
   const std::vector values = xdmf_read::get_dataset<std::int32_t>(
-      _mpi_comm.comm(), values_data_node, _h5_id);
+      _comm.comm(), values_data_node, _h5_id);
 
   const std::pair<std::string, int> cell_type_str
       = xdmf_utils::get_cell_type(grid_node.child("Topology"));
@@ -396,7 +396,7 @@ void XDMFFile::write_information(const std::string name,
   info_node.append_attribute("Value") = value.c_str();
 
   // Save XML file (on process 0 only)
-  if (MPI::rank(_mpi_comm.comm()) == 0)
+  if (MPI::rank(_comm.comm()) == 0)
     _xml_doc->save_file(_filename.c_str(), "  ");
 }
 //-----------------------------------------------------------------------------
@@ -417,5 +417,5 @@ std::string XDMFFile::read_information(const std::string name,
   return value_str;
 }
 //-----------------------------------------------------------------------------
-MPI_Comm XDMFFile::comm() const { return _mpi_comm.comm(); }
+MPI_Comm XDMFFile::comm() const { return _comm.comm(); }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -183,7 +183,7 @@ public:
 
 private:
   // MPI communicator
-  dolfinx::MPI::Comm _mpi_comm;
+  dolfinx::MPI::Comm _comm;
 
   // Cached filename
   std::string _filename;

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -428,7 +428,7 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
   // Send input global indices to 'post master' rank, based on input
   // global index value
   const std::int64_t num_nodes_g = mesh.geometry().index_map()->size_global();
-  const MPI_Comm comm = mesh.mpi_comm();
+  const MPI_Comm comm = mesh.comm();
   const int comm_size = MPI::size(comm);
   // NOTE: could make this int32_t be sending: index <- index - dest_rank_offset
   std::vector<std::vector<std::int64_t>> nodes_g_send(comm_size);

--- a/cpp/dolfinx/la/PETScKrylovSolver.cpp
+++ b/cpp/dolfinx/la/PETScKrylovSolver.cpp
@@ -165,7 +165,7 @@ int PETScKrylovSolver::solve(Vec x, const Vec b, bool transpose) const
   }
 
   // Report results
-  // if (report && dolfinx::MPI::rank(this->mpi_comm()) == 0)
+  // if (report && dolfinx::MPI::rank(this->comm()) == 0)
   //  write_report(num_iterations, reason);
 
   return num_iterations;

--- a/cpp/dolfinx/la/PETScVector.cpp
+++ b/cpp/dolfinx/la/PETScVector.cpp
@@ -250,7 +250,7 @@ std::array<std::int64_t, 2> PETScVector::local_range() const
   return {{n0, n1}};
 }
 //-----------------------------------------------------------------------------
-MPI_Comm PETScVector::mpi_comm() const
+MPI_Comm PETScVector::comm() const
 {
   assert(_x);
   MPI_Comm mpi_comm = MPI_COMM_NULL;

--- a/cpp/dolfinx/la/PETScVector.h
+++ b/cpp/dolfinx/la/PETScVector.h
@@ -144,7 +144,7 @@ public:
   std::array<std::int64_t, 2> local_range() const;
 
   /// Return MPI communicator
-  MPI_Comm mpi_comm() const;
+  MPI_Comm comm() const;
 
   /// Compute norm of vector
   ///

--- a/cpp/dolfinx/la/SLEPcEigenSolver.cpp
+++ b/cpp/dolfinx/la/SLEPcEigenSolver.cpp
@@ -199,7 +199,7 @@ int SLEPcEigenSolver::get_iteration_number() const
 //-----------------------------------------------------------------------------
 EPS SLEPcEigenSolver::eps() const { return _eps; }
 //-----------------------------------------------------------------------------
-MPI_Comm SLEPcEigenSolver::mpi_comm() const
+MPI_Comm SLEPcEigenSolver::comm() const
 {
   assert(_eps);
   MPI_Comm mpi_comm = MPI_COMM_NULL;

--- a/cpp/dolfinx/la/SLEPcEigenSolver.h
+++ b/cpp/dolfinx/la/SLEPcEigenSolver.h
@@ -84,7 +84,7 @@ public:
   EPS eps() const;
 
   /// Return MPI communicator
-  MPI_Comm mpi_comm() const;
+  MPI_Comm comm() const;
 
 private:
   // SLEPc solver pointer

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -21,7 +21,7 @@ SparsityPattern::SparsityPattern(
     MPI_Comm comm,
     const std::array<std::shared_ptr<const common::IndexMap>, 2>& maps,
     const std::array<int, 2>& bs)
-    : _mpi_comm(comm), _index_maps(maps), _bs(bs)
+    : _comm(comm), _index_maps(maps), _bs(bs)
 {
   assert(maps[0]);
   _cache_owned.resize(maps[0]->size_local());
@@ -35,7 +35,7 @@ SparsityPattern::SparsityPattern(
                          std::reference_wrapper<const common::IndexMap>, int>>,
                      2>& maps,
     const std::array<std::vector<int>, 2>& bs)
-    : _mpi_comm(comm), _bs({1, 1})
+    : _comm(comm), _bs({1, 1})
 {
   // FIXME: - Add range/bound checks for each block
   //        - Check for compatible block sizes for each block
@@ -410,5 +410,5 @@ SparsityPattern::off_diagonal_pattern() const
   return *_off_diagonal;
 }
 //-----------------------------------------------------------------------------
-MPI_Comm SparsityPattern::mpi_comm() const { return _mpi_comm.comm(); }
+MPI_Comm SparsityPattern::comm() const { return _comm.comm(); }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -111,11 +111,11 @@ public:
   const graph::AdjacencyList<std::int32_t>& off_diagonal_pattern() const;
 
   /// Return MPI communicator
-  MPI_Comm mpi_comm() const;
+  MPI_Comm comm() const;
 
 private:
   // MPI communicator
-  dolfinx::MPI::Comm _mpi_comm;
+  dolfinx::MPI::Comm _comm;
 
   // Index maps for each dimension
   std::array<std::shared_ptr<const common::IndexMap>, 2> _index_maps;

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -186,5 +186,5 @@ Geometry& Mesh::geometry() { return _geometry; }
 //-----------------------------------------------------------------------------
 const Geometry& Mesh::geometry() const { return _geometry; }
 //-----------------------------------------------------------------------------
-MPI_Comm Mesh::mpi_comm() const { return _mpi_comm.comm(); }
+MPI_Comm Mesh::comm() const { return _comm.comm(); }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/mesh/Mesh.h
+++ b/cpp/dolfinx/mesh/Mesh.h
@@ -57,7 +57,7 @@ public:
   template <typename Topology, typename Geometry>
   Mesh(MPI_Comm comm, Topology&& topology, Geometry&& geometry)
       : _topology(std::forward<Topology>(topology)),
-        _geometry(std::forward<Geometry>(geometry)), _mpi_comm(comm)
+        _geometry(std::forward<Geometry>(geometry)), _comm(comm)
   {
     // Do nothing
   }
@@ -109,7 +109,7 @@ public:
 
   /// Mesh MPI communicator
   /// @return The communicator on which the mesh is distributed
-  MPI_Comm mpi_comm() const;
+  MPI_Comm comm() const;
 
   /// Name
   std::string name = "mesh";
@@ -126,7 +126,7 @@ private:
   Geometry _geometry;
 
   // MPI communicator
-  dolfinx::MPI::Comm _mpi_comm;
+  dolfinx::MPI::Comm _comm;
 
   // Unique identifier
   std::size_t _unique_id = common::UniqueIdGenerator::id();

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -443,7 +443,7 @@ std::vector<bool> mesh::compute_boundary_facets(const Topology& topology)
 }
 //-----------------------------------------------------------------------------
 Topology::Topology(MPI_Comm comm, mesh::CellType type)
-    : _mpi_comm(comm), _cell_type(type),
+    : _comm(comm), _cell_type(type),
       _connectivity(
           mesh::cell_dim(type) + 1,
           std::vector<std::shared_ptr<graph::AdjacencyList<std::int32_t>>>(
@@ -478,7 +478,7 @@ std::int32_t Topology::create_entities(int dim)
 
   // Create local entities
   const auto [cell_entity, entity_vertex, index_map]
-      = mesh::compute_entities(_mpi_comm.comm(), *this, dim);
+      = mesh::compute_entities(_comm.comm(), *this, dim);
 
   if (cell_entity)
     set_connectivity(cell_entity, this->dim(), dim);
@@ -579,7 +579,7 @@ const std::vector<std::uint8_t>& Topology::get_facet_permutations() const
 //-----------------------------------------------------------------------------
 mesh::CellType Topology::cell_type() const noexcept { return _cell_type; }
 //-----------------------------------------------------------------------------
-MPI_Comm Topology::mpi_comm() const { return _mpi_comm.comm(); }
+MPI_Comm Topology::comm() const { return _comm.comm(); }
 //-----------------------------------------------------------------------------
 Topology
 mesh::create_topology(MPI_Comm comm,

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -139,11 +139,11 @@ public:
 
   /// Mesh MPI communicator
   /// @return The communicator on which the topology is distributed
-  MPI_Comm mpi_comm() const;
+  MPI_Comm comm() const;
 
 private:
   // MPI communicator
-  dolfinx::MPI::Comm _mpi_comm;
+  dolfinx::MPI::Comm _comm;
 
   // Cell type
   mesh::CellType _cell_type;

--- a/cpp/dolfinx/nls/NewtonSolver.cpp
+++ b/cpp/dolfinx/nls/NewtonSolver.cpp
@@ -31,7 +31,7 @@ std::pair<double, bool> converged(const nls::NewtonSolver& solver, const Vec r)
   const double relative_residual = residual / solver.residual0();
 
   // Output iteration number and residual
-  if (solver.report and dolfinx::MPI::rank(solver.mpi_comm()) == 0)
+  if (solver.report and dolfinx::MPI::rank(solver.comm()) == 0)
   {
     LOG(INFO) << "Newton iteration " << solver.iteration()
               << ": r (abs) = " << residual << " (tol = " << solver.atol
@@ -65,7 +65,7 @@ void update_solution(const nls::NewtonSolver& solver, const Vec dx, Vec x)
 nls::NewtonSolver::NewtonSolver(MPI_Comm comm)
     : _converged(converged), _update_solution(update_solution),
       _krylov_iterations(0), _iteration(0), _residual(0.0), _residual0(0.0),
-      _solver(comm), _dx(nullptr), _mpi_comm(comm)
+      _solver(comm), _dx(nullptr), _comm(comm)
 {
   // Create linear solver if not already created. Default to LU.
   _solver.set_options_prefix("nls_solve_");
@@ -247,7 +247,7 @@ std::pair<int, bool> dolfinx::nls::NewtonSolver::solve(Vec x)
 
   if (newton_converged)
   {
-    if (dolfinx::MPI::rank(_mpi_comm.comm()) == 0)
+    if (dolfinx::MPI::rank(_comm.comm()) == 0)
     {
       LOG(INFO) << "Newton solver finished in " << _iteration
                 << " iterations and " << _krylov_iterations
@@ -281,5 +281,5 @@ double nls::NewtonSolver::residual() const { return _residual; }
 //-----------------------------------------------------------------------------
 double nls::NewtonSolver::residual0() const { return _residual0; }
 //-----------------------------------------------------------------------------
-MPI_Comm nls::NewtonSolver::mpi_comm() const { return _mpi_comm.comm(); }
+MPI_Comm nls::NewtonSolver::comm() const { return _comm.comm(); }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/nls/NewtonSolver.h
+++ b/cpp/dolfinx/nls/NewtonSolver.h
@@ -124,7 +124,7 @@ public:
   double residual0() const;
 
   /// Return MPI communicator
-  MPI_Comm mpi_comm() const;
+  MPI_Comm comm() const;
 
   /// Maximum number of iterations
   int max_it = 50;
@@ -199,7 +199,7 @@ private:
   Vec _dx = nullptr;
 
   // MPI communicator
-  dolfinx::MPI::Comm _mpi_comm;
+  dolfinx::MPI::Comm _comm;
 };
 } // namespace nls
 } // namespace dolfinx

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -95,7 +95,7 @@ void enforce_rules(
 
     const std::int32_t update_count_old = update_count;
     MPI_Allreduce(&update_count_old, &update_count, 1, MPI_INT32_T, MPI_SUM,
-                  mesh.mpi_comm());
+                  mesh.comm());
   }
 }
 //-----------------------------------------------------------------------------
@@ -516,9 +516,9 @@ mesh::Mesh plaza::refine(const mesh::Mesh& mesh, bool redistribute)
   auto [cell_adj, new_vertex_coordinates, parent_cell]
       = plaza::compute_refinement_data(mesh);
 
-  if (dolfinx::MPI::size(mesh.mpi_comm()) == 1)
+  if (dolfinx::MPI::size(mesh.comm()) == 1)
   {
-    return mesh::create_mesh(mesh.mpi_comm(), cell_adj, mesh.geometry().cmap(),
+    return mesh::create_mesh(mesh.comm(), cell_adj, mesh.geometry().cmap(),
                              new_vertex_coordinates, mesh::GhostMode::none);
   }
 
@@ -529,7 +529,7 @@ mesh::Mesh plaza::refine(const mesh::Mesh& mesh, bool redistribute)
   // FIXME: this is not a robust test. Should be user option.
   int max_ghost_cells = 0;
   MPI_Allreduce(&num_ghost_cells, &max_ghost_cells, 1, MPI_INT, MPI_MAX,
-                mesh.mpi_comm());
+                mesh.comm());
 
   // Build mesh
   const mesh::GhostMode ghost_mode = max_ghost_cells == 0
@@ -547,9 +547,9 @@ mesh::Mesh plaza::refine(const mesh::Mesh& mesh,
   auto [cell_adj, new_vertex_coordinates, parent_cell]
       = plaza::compute_refinement_data(mesh, refinement_marker);
 
-  if (dolfinx::MPI::size(mesh.mpi_comm()) == 1)
+  if (dolfinx::MPI::size(mesh.comm()) == 1)
   {
-    return mesh::create_mesh(mesh.mpi_comm(), cell_adj, mesh.geometry().cmap(),
+    return mesh::create_mesh(mesh.comm(), cell_adj, mesh.geometry().cmap(),
                              new_vertex_coordinates, mesh::GhostMode::none);
   }
 
@@ -560,7 +560,7 @@ mesh::Mesh plaza::refine(const mesh::Mesh& mesh,
   // FIXME: this is not a robust test. Should be user option.
   int max_ghost_cells = 0;
   MPI_Allreduce(&num_ghost_cells, &max_ghost_cells, 1, MPI_INT, MPI_MAX,
-                mesh.mpi_comm());
+                mesh.comm());
 
   // Build mesh
   const mesh::GhostMode ghost_mode = max_ghost_cells == 0

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -136,7 +136,7 @@ refinement::compute_edge_sharing(const mesh::Mesh& mesh)
 
   MPI_Comm neighbor_comm;
   MPI_Dist_graph_create_adjacent(
-      mesh.mpi_comm(), neighbors.size(), neighbors.data(), MPI_UNWEIGHTED,
+      mesh.comm(), neighbors.size(), neighbors.data(), MPI_UNWEIGHTED,
       neighbors.size(), neighbors.data(), MPI_UNWEIGHTED, MPI_INFO_NULL, false,
       &neighbor_comm);
 
@@ -220,7 +220,7 @@ refinement::create_new_vertices(
   const std::int64_t num_local = n;
   std::int64_t global_offset = 0;
   MPI_Exscan(&num_local, &global_offset, 1,
-             dolfinx::MPI::mpi_type<std::int64_t>(), MPI_SUM, mesh.mpi_comm());
+             dolfinx::MPI::mpi_type<std::int64_t>(), MPI_SUM, mesh.comm());
   global_offset += mesh.topology().index_map(0)->local_range()[1];
   std::for_each(local_edge_to_new_vertex.begin(),
                 local_edge_to_new_vertex.end(),
@@ -294,7 +294,7 @@ refinement::partition(const mesh::Mesh& old_mesh,
   if (redistribute)
   {
     xt::xtensor<double, 2> new_coords(new_vertex_coordinates);
-    return mesh::create_mesh(old_mesh.mpi_comm(), cell_topology,
+    return mesh::create_mesh(old_mesh.comm(), cell_topology,
                              old_mesh.geometry().cmap(), new_coords, gm);
   }
 
@@ -354,7 +354,7 @@ refinement::partition(const mesh::Mesh& old_mesh,
                                               std::move(dest_offsets));
   };
 
-  return mesh::create_mesh(old_mesh.mpi_comm(), cell_topology,
+  return mesh::create_mesh(old_mesh.comm(), cell_topology,
                            old_mesh.geometry().cmap(), new_vertex_coordinates,
                            gm, partitioner);
 }

--- a/cpp/test/unit/io.cpp
+++ b/cpp/test/unit/io.cpp
@@ -20,7 +20,7 @@ void test_fides_mesh()
   auto mesh = std::make_shared<mesh::Mesh>(generation::RectangleMesh::create(
       MPI_COMM_WORLD, {{{0.0, 0.0, 0.0}, {1.0, 1.0, 0.0}}}, {22, 12},
       mesh::CellType::triangle, mesh::GhostMode::shared_facet));
-  io::FidesWriter writer(mesh->mpi_comm(), "test_mesh.bp", mesh);
+  io::FidesWriter writer(mesh->comm(), "test_mesh.bp", mesh);
   writer.write(0.0);
   xt::xtensor<double, 2>& points = mesh->geometry().x();
   // Move all coordinates of the mesh geometry

--- a/python/demo/elasticity/demo_elasticity.py
+++ b/python/demo/elasticity/demo_elasticity.py
@@ -173,5 +173,5 @@ with XDMFFile(MPI.COMM_WORLD, "elasticity.xdmf", "w") as file:
     file.write_function(u)
 
 unorm = u.vector.norm()
-if mesh.mpi_comm.rank == 0:
+if mesh.comm.rank == 0:
     print("Solution vector norm:", unorm)

--- a/python/demo/helmholtz2D/demo_helmholtz_2d.py
+++ b/python/demo/helmholtz2D/demo_helmholtz_2d.py
@@ -73,11 +73,11 @@ u_exact.interpolate(lambda x: A * np.cos(k0 * x[0]) * np.cos(k0 * x[1]))
 
 # H1 errors
 diff = uh - u_exact
-H1_diff = mesh.mpi_comm.allreduce(assemble_scalar(inner(grad(diff), grad(diff)) * dx), op=MPI.SUM)
-H1_exact = mesh.mpi_comm.allreduce(assemble_scalar(inner(grad(u_exact), grad(u_exact)) * dx), op=MPI.SUM)
+H1_diff = mesh.comm.allreduce(assemble_scalar(inner(grad(diff), grad(diff)) * dx), op=MPI.SUM)
+H1_exact = mesh.comm.allreduce(assemble_scalar(inner(grad(u_exact), grad(u_exact)) * dx), op=MPI.SUM)
 print("Relative H1 error of FEM solution:", abs(np.sqrt(H1_diff) / np.sqrt(H1_exact)))
 
 # L2 errors
-L2_diff = mesh.mpi_comm.allreduce(assemble_scalar(inner(diff, diff) * dx), op=MPI.SUM)
-L2_exact = mesh.mpi_comm.allreduce(assemble_scalar(inner(u_exact, u_exact) * dx), op=MPI.SUM)
+L2_diff = mesh.comm.allreduce(assemble_scalar(inner(diff, diff) * dx), op=MPI.SUM)
+L2_exact = mesh.comm.allreduce(assemble_scalar(inner(u_exact, u_exact) * dx), op=MPI.SUM)
 print("Relative L2 error of FEM solution:", abs(np.sqrt(L2_diff) / np.sqrt(L2_exact)))

--- a/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
+++ b/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
@@ -96,11 +96,11 @@ b1 = - ufl.inner(f, v) * ds(1)
 # JIT compile individual blocks tabulation kernels
 nptype = "complex128" if np.issubdtype(PETSc.ScalarType, np.complexfloating) else "float64"
 ffcxtype = "double _Complex" if np.issubdtype(PETSc.ScalarType, np.complexfloating) else "double"
-ufc_form00, _, _ = ffcx_jit(mesh.mpi_comm, a00, form_compiler_parameters={"scalar_type": ffcxtype})
+ufc_form00, _, _ = ffcx_jit(mesh.comm, a00, form_compiler_parameters={"scalar_type": ffcxtype})
 kernel00 = getattr(ufc_form00.integrals(0)[0], f"tabulate_tensor_{nptype}")
-ufc_form01, _, _ = ffcx_jit(mesh.mpi_comm, a01, form_compiler_parameters={"scalar_type": ffcxtype})
+ufc_form01, _, _ = ffcx_jit(mesh.comm, a01, form_compiler_parameters={"scalar_type": ffcxtype})
 kernel01 = getattr(ufc_form01.integrals(0)[0], f"tabulate_tensor_{nptype}")
-ufc_form10, _, _ = ffcx_jit(mesh.mpi_comm, a10, form_compiler_parameters={"scalar_type": ffcxtype})
+ufc_form10, _, _ = ffcx_jit(mesh.comm, a10, form_compiler_parameters={"scalar_type": ffcxtype})
 kernel10 = getattr(ufc_form10.integrals(0)[0], f"tabulate_tensor_{nptype}")
 
 ffi = cffi.FFI()

--- a/python/demo/stokes-taylor-hood/demo_stokes-taylor-hood.py
+++ b/python/demo/stokes-taylor-hood/demo_stokes-taylor-hood.py
@@ -219,7 +219,7 @@ A.setNullSpace(nsp)
 # the MINRES method, and a block-diagonal preconditioner using PETSc's
 # additive fieldsplit type preconditioner::
 
-ksp = PETSc.KSP().create(mesh.mpi_comm)
+ksp = PETSc.KSP().create(mesh.comm)
 ksp.setOperators(A, P)
 ksp.setType("minres")
 ksp.setTolerances(rtol=1e-8)
@@ -305,7 +305,7 @@ is_u = PETSc.IS().createStride(V_map.size_local * V.dofmap.index_map_bs, offset_
 is_p = PETSc.IS().createStride(Q_map.size_local, offset_p, 1, comm=PETSc.COMM_SELF)
 
 # Create Krylov solver
-ksp = PETSc.KSP().create(mesh.mpi_comm)
+ksp = PETSc.KSP().create(mesh.comm)
 ksp.setOperators(A, P)
 ksp.setTolerances(rtol=1e-8)
 ksp.setType("minres")
@@ -357,7 +357,7 @@ assert np.isclose(norm_p_1, norm_p_0)
 # Solve same problem, but now with monolithic matrices and a direct solver
 
 # Create LU solver
-ksp = PETSc.KSP().create(mesh.mpi_comm)
+ksp = PETSc.KSP().create(mesh.comm)
 ksp.setOperators(A)
 ksp.setType("preonly")
 ksp.getPC().setType("lu")
@@ -444,7 +444,7 @@ b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
 dolfinx.fem.assemble.set_bc(b, bcs)
 
 # Create and configure solver
-ksp = PETSc.KSP().create(mesh.mpi_comm)
+ksp = PETSc.KSP().create(mesh.comm)
 ksp.setOperators(A)
 ksp.setType("preonly")
 ksp.getPC().setType("lu")

--- a/python/dolfinx/common.py
+++ b/python/dolfinx/common.py
@@ -20,8 +20,8 @@ def timing(task: str):
     return _cpp.common.timing(task)
 
 
-def list_timings(mpi_comm, timing_types: list):
-    return _cpp.common.list_timings(mpi_comm, timing_types)
+def list_timings(comm, timing_types: list):
+    return _cpp.common.list_timings(comm, timing_types)
 
 
 class Timer:
@@ -55,7 +55,7 @@ class Timer:
     may be printed using functions ``timing``, ``timings``,
     ``list_timings``, ``dump_timings_to_xml``, e.g.::
 
-        list_timings(mpi_comm, [TimingType.wall, TimingType.user])
+        list_timings(comm, [TimingType.wall, TimingType.user])
     """
 
     def __init__(self, name: str = None):

--- a/python/dolfinx/fem/form.py
+++ b/python/dolfinx/fem/form.py
@@ -55,7 +55,7 @@ class Form:
         else:
             raise RuntimeError(f"Unsupported scalar type {dtype} for Form.")
         self._ufc_form, module, self._code = jit.ffcx_jit(
-            mesh.mpi_comm,
+            mesh.comm,
             form,
             form_compiler_parameters=form_compiler_parameters,
             jit_parameters=jit_parameters)

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -96,7 +96,7 @@ class Expression:
             form_compiler_parameters["scalar_type"] = "double _Complex"
         else:
             raise RuntimeError(f"Unsupported scalar type {dtype} for Form.")
-        self._ufc_expression, module, self._code = jit.ffcx_jit(mesh.mpi_comm, (ufl_expression, x),
+        self._ufc_expression, module, self._code = jit.ffcx_jit(mesh.comm, (ufl_expression, x),
                                                                 form_compiler_parameters=form_compiler_parameters,
                                                                 jit_parameters=jit_parameters)
         self._ufl_expression = ufl_expression
@@ -415,12 +415,12 @@ class FunctionSpace(ufl.FunctionSpace):
 
         # Compile dofmap and element and create DOLFIN objects
         (self._ufc_element, self._ufc_dofmap), module, code = jit.ffcx_jit(
-            mesh.mpi_comm, self.ufl_element(), form_compiler_parameters=form_compiler_parameters,
+            mesh.comm, self.ufl_element(), form_compiler_parameters=form_compiler_parameters,
             jit_parameters=jit_parameters)
 
         ffi = cffi.FFI()
         cpp_element = _cpp.fem.FiniteElement(ffi.cast("uintptr_t", ffi.addressof(self._ufc_element)))
-        cpp_dofmap = _cpp.fem.create_dofmap(mesh.mpi_comm, ffi.cast(
+        cpp_dofmap = _cpp.fem.create_dofmap(mesh.comm, ffi.cast(
             "uintptr_t", ffi.addressof(self._ufc_dofmap)), mesh.topology, cpp_element)
 
         # Initialize the cpp.FunctionSpace

--- a/python/dolfinx/fem/problem.py
+++ b/python/dolfinx/fem/problem.py
@@ -71,7 +71,7 @@ class LinearProblem():
             self.u = u
         self.bcs = bcs
 
-        self._solver = PETSc.KSP().create(self.u.function_space.mesh.mpi_comm)
+        self._solver = PETSc.KSP().create(self.u.function_space.mesh.comm)
         self._solver.setOperators(self._A)
 
         # Give PETSc solver options a unique prefix

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -270,8 +270,8 @@ void mesh(py::module& m)
       .def_property_readonly("cell_type", &dolfinx::mesh::Topology::cell_type)
       .def("cell_name", [](const dolfinx::mesh::Topology& self)
            { return dolfinx::mesh::to_string(self.cell_type()); })
-      .def_property_readonly("mpi_comm", [](dolfinx::mesh::Mesh& self)
-                             { return MPICommWrapper(self.mpi_comm()); });
+      .def_property_readonly("comm", [](dolfinx::mesh::Mesh& self)
+                             { return MPICommWrapper(self.comm()); });
 
   // dolfinx::mesh::Mesh
   py::class_<dolfinx::mesh::Mesh, std::shared_ptr<dolfinx::mesh::Mesh>>(
@@ -286,8 +286,8 @@ void mesh(py::module& m)
       .def_property_readonly(
           "topology", py::overload_cast<>(&dolfinx::mesh::Mesh::topology),
           "Mesh topology", py::return_value_policy::reference_internal)
-      .def_property_readonly("mpi_comm", [](dolfinx::mesh::Mesh& self)
-                             { return MPICommWrapper(self.mpi_comm()); })
+      .def_property_readonly("comm", [](dolfinx::mesh::Mesh& self)
+                             { return MPICommWrapper(self.comm()); })
       .def_property_readonly("id", &dolfinx::mesh::Mesh::id)
       .def_readwrite("name", &dolfinx::mesh::Mesh::name);
 

--- a/python/test/unit/common/test_mpi.py
+++ b/python/test/unit/common/test_mpi.py
@@ -24,7 +24,7 @@ def test_mpi_comm_wrapper():
     """Test MPICommWrapper <-> mpi4py.MPI.Comm conversion"""
     w1 = MPI.COMM_WORLD
     m = UnitSquareMesh(w1, 4, 4)
-    w2 = m.mpi_comm
+    w2 = m.comm
     assert isinstance(w1, MPI.Comm)
     assert isinstance(w2, MPI.Comm)
 
@@ -70,7 +70,7 @@ PYBIND11_MODULE(mpi_comm_wrapper, m)
         path = pathlib.Path(tempdir)
         open(pathlib.Path(tempdir, "mpi_comm_wrapper.cpp"), "w").write(cpp_code + cpp_code_header)
         rel_path = path.relative_to(pathlib.Path(__file__).parent)
-        p = str(rel_path).replace("/", ".") + ".mpi_comm_wrapper"
+        p = str(rel_path).replace("/", ".") + ".comm_wrapper"
         return cppimport.imp(p)
 
     module = compile_module(MPI.COMM_WORLD)

--- a/python/test/unit/common/test_mpi.py
+++ b/python/test/unit/common/test_mpi.py
@@ -24,7 +24,7 @@ def test_mpi_comm_wrapper():
     """Test MPICommWrapper <-> mpi4py.MPI.Comm conversion"""
     w1 = MPI.COMM_WORLD
     m = UnitSquareMesh(w1, 4, 4)
-    w2 = m.mpi_comm
+    w2 = m.comm
     assert isinstance(w1, MPI.Comm)
     assert isinstance(w2, MPI.Comm)
 

--- a/python/test/unit/common/test_mpi.py
+++ b/python/test/unit/common/test_mpi.py
@@ -2,20 +2,18 @@
 
 # Copyright (C) 2017 Garth N. Wells
 #
-# This file is part of DOLFINx (https://www.fenicsproject.org)
+# This file is part of DOLFINX (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
-import pathlib
+import os
+import sys
 
-import cppimport
 import dolfinx
-import dolfinx.pkgconfig
 import mpi4py
 import pytest
 from dolfinx import wrappers
-from dolfinx.generation import UnitSquareMesh
-from dolfinx.jit import mpi_jit_decorator
+from dolfinx.jit import dolfinx_pc, mpi_jit_decorator
 from dolfinx_utils.test.fixtures import tempdir  # noqa: F401
 from mpi4py import MPI
 
@@ -23,57 +21,51 @@ from mpi4py import MPI
 def test_mpi_comm_wrapper():
     """Test MPICommWrapper <-> mpi4py.MPI.Comm conversion"""
     w1 = MPI.COMM_WORLD
-    m = UnitSquareMesh(w1, 4, 4)
-    w2 = m.comm
+    m = dolfinx.UnitSquareMesh(w1, 4, 4)
+    w2 = m.mpi_comm()
     assert isinstance(w1, MPI.Comm)
     assert isinstance(w2, MPI.Comm)
 
 
-@pytest.mark.skipif(not dolfinx.pkgconfig.exists("dolfinx"),
-                    reason="This test needs DOLFINx pkg-config.")
 def test_mpi_comm_wrapper_cppimport(tempdir):  # noqa: F811
     """Test MPICommWrapper <-> mpi4py.MPI.Comm conversion for code compiled with cppimport"""
 
-    dolfinx_pc = dolfinx.pkgconfig.parse("dolfinx")
+    cppimport = pytest.importorskip("cppimport")
 
     @mpi_jit_decorator
     def compile_module():
         cpp_code_header = f"""
-/*
-<%
-setup_pybind11(cfg)
-cfg['compiler_args'] = ['-std=c++17']
-cfg['include_dirs'] += {dolfinx_pc["include_dirs"]
-                        + [mpi4py.get_include()]
-                        + [str(wrappers.get_include_path())]}
-%>
-*/
-"""
+        <%
+        setup_pybind11(cfg)
+        cfg['include_dirs'] += {dolfinx_pc["include_dirs"]
+                                + [mpi4py.get_include()]
+                                + [str(wrappers.get_include_path())]}
+        %>
+        """
 
         cpp_code = """
-#include <pybind11/pybind11.h>
-#include <caster_mpi.h>
+        #include <pybind11/pybind11.h>
+        #include <caster_mpi.h>
 
-dolfinx_wrappers::MPICommWrapper
-test_comm_passing(const dolfinx_wrappers::MPICommWrapper comm)
-{
-    MPI_Comm c = comm.get();
-    return dolfinx_wrappers::MPICommWrapper(c);
-}
+        dolfinx_wrappers::MPICommWrapper
+        test_comm_passing(const dolfinx_wrappers::MPICommWrapper comm)
+        {
+          MPI_Comm c = comm.get();
+          return dolfinx_wrappers::MPICommWrapper(c);
+        }
 
-PYBIND11_MODULE(mpi_comm_wrapper, m)
-{
-    m.def("test_comm_passing", &test_comm_passing);
-}
-"""
+        PYBIND11_MODULE(test_mpi_comm_wrapper, m)
+        {
+            m.def("test_comm_passing", &test_comm_passing);
+        }
+        """
 
-        path = pathlib.Path(tempdir)
-        open(pathlib.Path(tempdir, "mpi_comm_wrapper.cpp"), "w").write(cpp_code + cpp_code_header)
-        rel_path = path.relative_to(pathlib.Path(__file__).parent)
-        p = str(rel_path).replace("/", ".") + ".comm_wrapper"
-        return cppimport.imp(p)
+        open(os.path.join(tempdir, "test_mpi_comm_wrapper.cpp"), "w").write(cpp_code_header + cpp_code)
 
-    module = compile_module(MPI.COMM_WORLD)
+        sys.path.append(tempdir)
+        return cppimport.imp("test_mpi_comm_wrapper")
+
+    module = compile_module()
 
     w1 = MPI.COMM_WORLD
     w2 = module.test_comm_passing(w1)

--- a/python/test/unit/common/test_mpi.py
+++ b/python/test/unit/common/test_mpi.py
@@ -2,18 +2,20 @@
 
 # Copyright (C) 2017 Garth N. Wells
 #
-# This file is part of DOLFINX (https://www.fenicsproject.org)
+# This file is part of DOLFINx (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
-import os
-import sys
+import pathlib
 
+import cppimport
 import dolfinx
+import dolfinx.pkgconfig
 import mpi4py
 import pytest
 from dolfinx import wrappers
-from dolfinx.jit import dolfinx_pc, mpi_jit_decorator
+from dolfinx.generation import UnitSquareMesh
+from dolfinx.jit import mpi_jit_decorator
 from dolfinx_utils.test.fixtures import tempdir  # noqa: F401
 from mpi4py import MPI
 
@@ -21,51 +23,57 @@ from mpi4py import MPI
 def test_mpi_comm_wrapper():
     """Test MPICommWrapper <-> mpi4py.MPI.Comm conversion"""
     w1 = MPI.COMM_WORLD
-    m = dolfinx.UnitSquareMesh(w1, 4, 4)
-    w2 = m.mpi_comm()
+    m = UnitSquareMesh(w1, 4, 4)
+    w2 = m.mpi_comm
     assert isinstance(w1, MPI.Comm)
     assert isinstance(w2, MPI.Comm)
 
 
+@pytest.mark.skipif(not dolfinx.pkgconfig.exists("dolfinx"),
+                    reason="This test needs DOLFINx pkg-config.")
 def test_mpi_comm_wrapper_cppimport(tempdir):  # noqa: F811
     """Test MPICommWrapper <-> mpi4py.MPI.Comm conversion for code compiled with cppimport"""
 
-    cppimport = pytest.importorskip("cppimport")
+    dolfinx_pc = dolfinx.pkgconfig.parse("dolfinx")
 
     @mpi_jit_decorator
     def compile_module():
         cpp_code_header = f"""
-        <%
-        setup_pybind11(cfg)
-        cfg['include_dirs'] += {dolfinx_pc["include_dirs"]
-                                + [mpi4py.get_include()]
-                                + [str(wrappers.get_include_path())]}
-        %>
-        """
+/*
+<%
+setup_pybind11(cfg)
+cfg['compiler_args'] = ['-std=c++17']
+cfg['include_dirs'] += {dolfinx_pc["include_dirs"]
+                        + [mpi4py.get_include()]
+                        + [str(wrappers.get_include_path())]}
+%>
+*/
+"""
 
         cpp_code = """
-        #include <pybind11/pybind11.h>
-        #include <caster_mpi.h>
+#include <pybind11/pybind11.h>
+#include <caster_mpi.h>
 
-        dolfinx_wrappers::MPICommWrapper
-        test_comm_passing(const dolfinx_wrappers::MPICommWrapper comm)
-        {
-          MPI_Comm c = comm.get();
-          return dolfinx_wrappers::MPICommWrapper(c);
-        }
+dolfinx_wrappers::MPICommWrapper
+test_comm_passing(const dolfinx_wrappers::MPICommWrapper comm)
+{
+    MPI_Comm c = comm.get();
+    return dolfinx_wrappers::MPICommWrapper(c);
+}
 
-        PYBIND11_MODULE(test_mpi_comm_wrapper, m)
-        {
-            m.def("test_comm_passing", &test_comm_passing);
-        }
-        """
+PYBIND11_MODULE(mpi_comm_wrapper, m)
+{
+    m.def("test_comm_passing", &test_comm_passing);
+}
+"""
 
-        open(os.path.join(tempdir, "test_mpi_comm_wrapper.cpp"), "w").write(cpp_code_header + cpp_code)
+        path = pathlib.Path(tempdir)
+        open(pathlib.Path(tempdir, "mpi_comm_wrapper.cpp"), "w").write(cpp_code + cpp_code_header)
+        rel_path = path.relative_to(pathlib.Path(__file__).parent)
+        p = str(rel_path).replace("/", ".") + ".mpi_comm_wrapper"
+        return cppimport.imp(p)
 
-        sys.path.append(tempdir)
-        return cppimport.imp("test_mpi_comm_wrapper")
-
-    module = compile_module()
+    module = compile_module(MPI.COMM_WORLD)
 
     w1 = MPI.COMM_WORLD
     w2 = module.test_comm_passing(w1)

--- a/python/test/unit/fem/test_assemble_domains.py
+++ b/python/test/unit/fem/test_assemble_domains.py
@@ -81,11 +81,11 @@ def test_assembly_dx_domains(mode):
     # Assemble scalar
     L = w * (dx(1) + dx(2) + dx(3))
     s = assemble_scalar(L)
-    s = mesh.mpi_comm.allreduce(s, op=MPI.SUM)
+    s = mesh.comm.allreduce(s, op=MPI.SUM)
     assert s == pytest.approx(0.5, 1.0e-12)
     L2 = w * dx
     s2 = assemble_scalar(L2)
-    s2 = mesh.mpi_comm.allreduce(s2, op=MPI.SUM)
+    s2 = mesh.comm.allreduce(s2, op=MPI.SUM)
     assert s == pytest.approx(s2, 1.0e-12)
 
 
@@ -163,10 +163,10 @@ def test_assembly_ds_domains(mode):
     # Assemble scalar
     L = w * (ds(1) + ds(2) + ds(3) + ds(6))
     s = assemble_scalar(L)
-    s = mesh.mpi_comm.allreduce(s, op=MPI.SUM)
+    s = mesh.comm.allreduce(s, op=MPI.SUM)
     L2 = w * ds
     s2 = assemble_scalar(L2)
-    s2 = mesh.mpi_comm.allreduce(s2, op=MPI.SUM)
+    s2 = mesh.comm.allreduce(s2, op=MPI.SUM)
     assert (s == pytest.approx(s2, 1.0e-12) and 2.0 == pytest.approx(s, 1.0e-12))
 
 
@@ -176,7 +176,7 @@ def test_assembly_dS_domains(mode):
     mesh = UnitSquareMesh(MPI.COMM_WORLD, N, N, ghost_mode=mode)
     one = Constant(mesh, PETSc.ScalarType(1))
     val = assemble_scalar(one * ufl.dS)
-    val = mesh.mpi_comm.allreduce(val, op=MPI.SUM)
+    val = mesh.comm.allreduce(val, op=MPI.SUM)
     assert val == pytest.approx(2 * (N - 1) + N * numpy.sqrt(2), 1.0e-7)
 
 
@@ -199,15 +199,15 @@ def test_additivity(mode):
     j3 = ufl.inner(ufl.avg(f3), ufl.avg(f3)) * ufl.dS(mesh)
 
     # Assemble each scalar form separately
-    J1 = mesh.mpi_comm.allreduce(assemble_scalar(j1), op=MPI.SUM)
-    J2 = mesh.mpi_comm.allreduce(assemble_scalar(j2), op=MPI.SUM)
-    J3 = mesh.mpi_comm.allreduce(assemble_scalar(j3), op=MPI.SUM)
+    J1 = mesh.comm.allreduce(assemble_scalar(j1), op=MPI.SUM)
+    J2 = mesh.comm.allreduce(assemble_scalar(j2), op=MPI.SUM)
+    J3 = mesh.comm.allreduce(assemble_scalar(j3), op=MPI.SUM)
 
     # Sum forms and assemble the result
-    J12 = mesh.mpi_comm.allreduce(assemble_scalar(j1 + j2), op=MPI.SUM)
-    J13 = mesh.mpi_comm.allreduce(assemble_scalar(j1 + j3), op=MPI.SUM)
-    J23 = mesh.mpi_comm.allreduce(assemble_scalar(j2 + j3), op=MPI.SUM)
-    J123 = mesh.mpi_comm.allreduce(assemble_scalar(j1 + j2 + j3), op=MPI.SUM)
+    J12 = mesh.comm.allreduce(assemble_scalar(j1 + j2), op=MPI.SUM)
+    J13 = mesh.comm.allreduce(assemble_scalar(j1 + j3), op=MPI.SUM)
+    J23 = mesh.comm.allreduce(assemble_scalar(j2 + j3), op=MPI.SUM)
+    J123 = mesh.comm.allreduce(assemble_scalar(j1 + j2 + j3), op=MPI.SUM)
 
     # Compare assembled values
     assert (J1 + J2) == pytest.approx(J12)

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -50,12 +50,12 @@ def test_assemble_functional_dx(mode):
     mesh = UnitSquareMesh(MPI.COMM_WORLD, 12, 12, ghost_mode=mode)
     M = 1.0 * dx(domain=mesh)
     value = assemble_scalar(M)
-    value = mesh.mpi_comm.allreduce(value, op=MPI.SUM)
+    value = mesh.comm.allreduce(value, op=MPI.SUM)
     assert value == pytest.approx(1.0, 1e-12)
     x = ufl.SpatialCoordinate(mesh)
     M = x[0] * dx(domain=mesh)
     value = assemble_scalar(M)
-    value = mesh.mpi_comm.allreduce(value, op=MPI.SUM)
+    value = mesh.comm.allreduce(value, op=MPI.SUM)
     assert value == pytest.approx(0.5, 1e-12)
 
 
@@ -64,7 +64,7 @@ def test_assemble_functional_ds(mode):
     mesh = UnitSquareMesh(MPI.COMM_WORLD, 12, 12, ghost_mode=mode)
     M = 1.0 * ds(domain=mesh)
     value = assemble_scalar(M)
-    value = mesh.mpi_comm.allreduce(value, op=MPI.SUM)
+    value = mesh.comm.allreduce(value, op=MPI.SUM)
     assert value == pytest.approx(4.0, 1e-12)
 
 
@@ -366,7 +366,7 @@ def test_assembly_solve_block(mode):
     b0norm = b0.norm()
     x0 = A0.createVecLeft()
     ksp = PETSc.KSP()
-    ksp.create(mesh.mpi_comm)
+    ksp.create(mesh.comm)
     ksp.setOperators(A0)
     ksp.setMonitor(monitor)
     ksp.setType('cg')
@@ -393,7 +393,7 @@ def test_assembly_solve_block(mode):
 
     x1 = b1.copy()
     ksp = PETSc.KSP()
-    ksp.create(mesh.mpi_comm)
+    ksp.create(mesh.comm)
     ksp.setMonitor(monitor)
     ksp.setOperators(A1)
     ksp.setType('cg')
@@ -436,7 +436,7 @@ def test_assembly_solve_block(mode):
 
     x2 = b2.copy()
     ksp = PETSc.KSP()
-    ksp.create(mesh.mpi_comm)
+    ksp.create(mesh.comm)
     ksp.setMonitor(monitor)
     ksp.setOperators(A2)
     ksp.setType('cg')
@@ -518,7 +518,7 @@ def test_assembly_solve_taylor_hood(mesh):
         b.assemble()
 
         ksp = PETSc.KSP()
-        ksp.create(mesh.mpi_comm)
+        ksp.create(mesh.comm)
         ksp.setOperators(A, P)
         nested_IS = P.getNestISs()
         ksp.setType("minres")
@@ -551,7 +551,7 @@ def test_assembly_solve_taylor_hood(mesh):
         b = assemble_vector_block([L0, L1], [[a00, a01], [a10, a11]], bcs=[bc0, bc1])
 
         ksp = PETSc.KSP()
-        ksp.create(mesh.mpi_comm)
+        ksp.create(mesh.comm)
         ksp.setOperators(A, P)
         ksp.setType("minres")
         pc = ksp.getPC()
@@ -603,7 +603,7 @@ def test_assembly_solve_taylor_hood(mesh):
         set_bc(b, [bc0, bc1])
 
         ksp = PETSc.KSP()
-        ksp.create(mesh.mpi_comm)
+        ksp.create(mesh.comm)
         ksp.setOperators(A, P)
         ksp.setType("minres")
         pc = ksp.getPC()

--- a/python/test/unit/fem/test_complex_assembler.py
+++ b/python/test/unit/fem/test_complex_assembler.py
@@ -103,7 +103,7 @@ def test_complex_assembly_solve():
     b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
 
     # Create solver
-    solver = PETSc.KSP().create(mesh.mpi_comm)
+    solver = PETSc.KSP().create(mesh.comm)
     solver.setOptionsPrefix("test_lu_")
     opts = PETSc.Options("test_lu_")
     opts["ksp_type"] = "preonly"

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -350,7 +350,7 @@ def test_custom_mesh_loop_rank1():
     ffcxtype = "double _Complex" if np.issubdtype(PETSc.ScalarType, np.complexfloating) else "double"
     b3 = Function(V)
     ufc_form, module, code = dolfinx.jit.ffcx_jit(
-        mesh.mpi_comm, L, form_compiler_parameters={"scalar_type": ffcxtype})
+        mesh.comm, L, form_compiler_parameters={"scalar_type": ffcxtype})
 
     nptype = "complex128" if np.issubdtype(PETSc.ScalarType, np.complexfloating) else "float64"
     # First 0 for "cell" integrals, second 0 for the first one, i.e. default domain

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -118,7 +118,7 @@ def test_cffi_assembly():
     mesh = UnitSquareMesh(MPI.COMM_WORLD, 13, 13)
     V = FunctionSpace(mesh, ("Lagrange", 1))
 
-    if mesh.mpi_comm.rank == 0:
+    if mesh.comm.rank == 0:
         from cffi import FFI
         ffibuilder = FFI()
         ffibuilder.set_source("_cffi_kernelA", r"""
@@ -215,7 +215,7 @@ def test_cffi_assembly():
 
         ffibuilder.compile(verbose=True)
 
-    mesh.mpi_comm.Barrier()
+    mesh.comm.Barrier()
     from _cffi_kernelA import ffi, lib
 
     ptrA = ffi.cast("intptr_t", ffi.addressof(lib, "tabulate_tensor_poissonA"))

--- a/python/test/unit/fem/test_fem_pipeline.py
+++ b/python/test/unit/fem/test_fem_pipeline.py
@@ -78,7 +78,7 @@ def run_scalar_test(mesh, V, degree):
     M = (u_exact - uh)**2 * dx
     M = Form(M)
 
-    error = mesh.mpi_comm.allreduce(assemble_scalar(M), op=MPI.SUM)
+    error = mesh.comm.allreduce(assemble_scalar(M), op=MPI.SUM)
     assert np.absolute(error) < 1.0e-14
 
 
@@ -116,7 +116,7 @@ def run_vector_test(mesh, V, degree):
         M += uh[i]**2 * dx
     M = Form(M)
 
-    error = mesh.mpi_comm.allreduce(assemble_scalar(M), op=MPI.SUM)
+    error = mesh.comm.allreduce(assemble_scalar(M), op=MPI.SUM)
     assert np.absolute(error) < 1.0e-14
 
 
@@ -187,7 +187,7 @@ def run_dg_test(mesh, V, degree):
     M = (u_exact - uh)**2 * dx
     M = Form(M)
 
-    error = mesh.mpi_comm.allreduce(assemble_scalar(M), op=MPI.SUM)
+    error = mesh.comm.allreduce(assemble_scalar(M), op=MPI.SUM)
     assert np.absolute(error) < 1.0e-14
 
 
@@ -268,9 +268,9 @@ def test_biharmonic():
                            mode=PETSc.ScatterMode.FORWARD)
 
     # Recall that x_h has flattened indices.
-    u_error_numerator = np.sqrt(mesh.mpi_comm.allreduce(assemble_scalar(
+    u_error_numerator = np.sqrt(mesh.comm.allreduce(assemble_scalar(
         inner(u_exact - x_h[4], u_exact - x_h[4]) * dx(mesh, metadata={"quadrature_degree": 5})), op=MPI.SUM))
-    u_error_denominator = np.sqrt(mesh.mpi_comm.allreduce(assemble_scalar(
+    u_error_denominator = np.sqrt(mesh.comm.allreduce(assemble_scalar(
         inner(u_exact, u_exact) * dx(mesh, metadata={"quadrature_degree": 5})), op=MPI.SUM))
 
     assert(np.absolute(u_error_numerator / u_error_denominator) < 0.05)
@@ -278,9 +278,9 @@ def test_biharmonic():
     # Reconstruct tensor from flattened indices.
     # Apply inverse transform. In 2D we have S^{-1} = S.
     sigma_h = S(ufl.as_tensor([[x_h[0], x_h[1]], [x_h[2], x_h[3]]]))
-    sigma_error_numerator = np.sqrt(mesh.mpi_comm.allreduce(assemble_scalar(
+    sigma_error_numerator = np.sqrt(mesh.comm.allreduce(assemble_scalar(
         inner(sigma_exact - sigma_h, sigma_exact - sigma_h) * dx(mesh, metadata={"quadrature_degree": 5})), op=MPI.SUM))
-    sigma_error_denominator = np.sqrt(mesh.mpi_comm.allreduce(assemble_scalar(
+    sigma_error_denominator = np.sqrt(mesh.comm.allreduce(assemble_scalar(
         inner(sigma_exact, sigma_exact) * dx(mesh, metadata={"quadrature_degree": 5})), op=MPI.SUM))
 
     assert(np.absolute(sigma_error_numerator / sigma_error_denominator) < 0.005)

--- a/python/test/unit/function/test_expression_evaluation.py
+++ b/python/test/unit/function/test_expression_evaluation.py
@@ -49,7 +49,7 @@ def test_rank0():
     ufl_expr = ufl.grad(f)
     points = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
 
-    compiled_expr, module, code = dolfinx.jit.ffcx_jit(mesh.mpi_comm, (ufl_expr, points))
+    compiled_expr, module, code = dolfinx.jit.ffcx_jit(mesh.comm, (ufl_expr, points))
 
     ffi = cffi.FFI()
 

--- a/python/test/unit/geometry/test_bounding_box_tree.py
+++ b/python/test/unit/geometry/test_bounding_box_tree.py
@@ -383,7 +383,7 @@ def test_sub_bbtree():
     bbtree = BoundingBoxTree(mesh, tdim, cells)
 
     # Compute a BBtree for all processes
-    process_bbtree = bbtree.create_global_tree(mesh.mpi_comm)
+    process_bbtree = bbtree.create_global_tree(mesh.comm)
 
     # Find possible ranks for this point
     point = numpy.array([0.2, 0.2, 1.0])

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -31,7 +31,7 @@ def test_second_order_fides(tempdir):
     domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell, 2))
     mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
     with pytest.raises(RuntimeError):
-        FidesWriter(mesh.mpi_comm, filename, mesh)
+        FidesWriter(mesh.comm, filename, mesh)
 
 
 @pytest.mark.skipif(not has_adios2, reason="Requires ADIOS2.")
@@ -45,7 +45,7 @@ def test_functions_from_different_meshes_fides(tempdir):
     u0 = Function(FunctionSpace(mesh0, ("Lagrange", 1)))
     u1 = Function(FunctionSpace(mesh1, ("Lagrange", 1)))
     with pytest.raises(RuntimeError):
-        FidesWriter(mesh0.mpi_comm, filename, [u0._cpp_object, u1._cpp_object])
+        FidesWriter(mesh0.comm, filename, [u0._cpp_object, u1._cpp_object])
 
 
 def generate_mesh(dim: int, simplex: bool, N: int = 3):
@@ -72,7 +72,7 @@ def test_fides_mesh(tempdir, dim, simplex):
     from dolfinx.cpp.io import FidesWriter
     filename = os.path.join(tempdir, "mesh_fides.bp")
     mesh = generate_mesh(dim, simplex)
-    with FidesWriter(mesh.mpi_comm, filename, mesh) as f:
+    with FidesWriter(mesh.comm, filename, mesh) as f:
         f.write(0.0)
         mesh.geometry.x[:, 1] += 0.1
         f.write(0.1)
@@ -89,7 +89,7 @@ def test_mixed_fides_functions(tempdir, dim, simplex):
     q = Function(FunctionSpace(mesh, ("Lagrange", 1)))
     filename = os.path.join(tempdir, "v.bp")
     with pytest.raises(RuntimeError):
-        FidesWriter(mesh.mpi_comm, filename, [v._cpp_object, q._cpp_object])
+        FidesWriter(mesh.comm, filename, [v._cpp_object, q._cpp_object])
 
 
 @pytest.mark.skipif(not has_adios2, reason="Requires ADIOS2.")
@@ -102,7 +102,7 @@ def test_two_fides_functions(tempdir, dim, simplex):
     v = Function(VectorFunctionSpace(mesh, ("Lagrange", 1)))
     q = Function(FunctionSpace(mesh, ("Lagrange", 1)))
     filename = os.path.join(tempdir, "v.bp")
-    with FidesWriter(mesh.mpi_comm, filename, [v._cpp_object, q._cpp_object]) as f:
+    with FidesWriter(mesh.comm, filename, [v._cpp_object, q._cpp_object]) as f:
         f.write(0)
 
         def vel(x):
@@ -126,7 +126,7 @@ def test_fides_function_at_nodes(tempdir, dim, simplex):
     q = Function(FunctionSpace(mesh, ("Lagrange", 1)))
 
     filename = os.path.join(tempdir, "v.bp")
-    with FidesWriter(mesh.mpi_comm, filename, [v._cpp_object, q._cpp_object]) as f:
+    with FidesWriter(mesh.comm, filename, [v._cpp_object, q._cpp_object]) as f:
         for t in [0.1, 0.5, 1]:
             # Only change one function
             q.interpolate(lambda x: t * (x[0] - 0.5)**2)
@@ -150,7 +150,7 @@ def test_second_order_vtx(tempdir):
     cell = ufl.Cell("interval", geometric_dimension=points.shape[1])
     domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell, 2))
     mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
-    with VTXWriter(mesh.mpi_comm, filename, mesh) as f:
+    with VTXWriter(mesh.comm, filename, mesh) as f:
         f.write(0.0)
 
 
@@ -161,7 +161,7 @@ def test_vtx_mesh(tempdir, dim, simplex):
     from dolfinx.cpp.io import VTXWriter
     filename = os.path.join(tempdir, "mesh_vtx.bp")
     mesh = generate_mesh(dim, simplex)
-    with VTXWriter(mesh.mpi_comm, filename, mesh) as f:
+    with VTXWriter(mesh.comm, filename, mesh) as f:
         f.write(0.0)
         mesh.geometry.x[:, 1] += 0.1
         f.write(0.1)
@@ -178,7 +178,7 @@ def test_vtx_functions_fail(tempdir, dim, simplex):
     w = Function(FunctionSpace(mesh, ("Lagrange", 1)))
     filename = os.path.join(tempdir, "v.bp")
     with pytest.raises(RuntimeError):
-        VTXWriter(mesh.mpi_comm, filename, [v._cpp_object, w._cpp_object])
+        VTXWriter(mesh.comm, filename, [v._cpp_object, w._cpp_object])
 
 
 @pytest.mark.skipif(not has_adios2, reason="Requires ADIOS2.")
@@ -193,7 +193,7 @@ def test_vtx_different_meshes_function(tempdir, dim, simplex):
     w = Function(FunctionSpace(mesh2, ("Lagrange", 1)))
     filename = os.path.join(tempdir, "v.bp")
     with pytest.raises(RuntimeError):
-        VTXWriter(mesh.mpi_comm, filename, [v._cpp_object, w._cpp_object])
+        VTXWriter(mesh.comm, filename, [v._cpp_object, w._cpp_object])
 
 
 @pytest.mark.skipif(not has_adios2, reason="Requires ADIOS2.")
@@ -219,7 +219,7 @@ def test_vtx_functions(tempdir, dim, simplex):
     w.interpolate(lambda x: x[0] + x[1])
 
     filename = os.path.join(tempdir, "v.bp")
-    f = VTXWriter(mesh.mpi_comm, filename, [v._cpp_object, w._cpp_object])
+    f = VTXWriter(mesh.comm, filename, [v._cpp_object, w._cpp_object])
 
     # Set two cells to 0
     for c in [0, 1]:

--- a/python/test/unit/io/test_vtk.py
+++ b/python/test/unit/io/test_vtk.py
@@ -151,7 +151,7 @@ def test_save_2d_vector_CG2(tempdir):
         return vals
     u.interpolate(func)
     filename = os.path.join(tempdir, "u.pvd")
-    with VTKFile(mesh.mpi_comm, filename, "w") as vtk:
+    with VTKFile(mesh.comm, filename, "w") as vtk:
         vtk.write_function(u, 0.)
 
 
@@ -178,7 +178,7 @@ def test_save_2d_mixed(tempdir):
     U.vector.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
     filename = os.path.join(tempdir, "u.pvd")
-    with VTKFile(mesh.mpi_comm, filename, "w") as vtk:
+    with VTKFile(mesh.comm, filename, "w") as vtk:
         vtk.write_function([U.sub(i) for i in range(W.num_sub_spaces())], 0.)
 
 
@@ -189,7 +189,7 @@ def test_save_1d_tensor(tempdir):
     with u.vector.localForm() as loc:
         loc.set(1.0)
     filename = os.path.join(tempdir, "u.pvd")
-    with VTKFile(mesh.mpi_comm, filename, "w") as vtk:
+    with VTKFile(mesh.comm, filename, "w") as vtk:
         vtk.write_function(u, 0.)
 
 
@@ -200,7 +200,7 @@ def test_save_2d_tensor(tempdir):
         loc.set(1.0)
 
     filename = os.path.join(tempdir, "u.pvd")
-    with VTKFile(mesh.mpi_comm, filename, "w") as vtk:
+    with VTKFile(mesh.comm, filename, "w") as vtk:
 
         vtk.write_function(u, 0.)
         with u.vector.localForm() as loc:
@@ -215,5 +215,5 @@ def test_save_3d_tensor(tempdir):
         loc.set(1.0)
 
     filename = os.path.join(tempdir, "u.pvd")
-    with VTKFile(mesh.mpi_comm, filename, "w") as vtk:
+    with VTKFile(mesh.comm, filename, "w") as vtk:
         vtk.write_function(u, 0.)

--- a/python/test/unit/io/test_xdmf_function.py
+++ b/python/test/unit/io/test_xdmf_function.py
@@ -58,7 +58,7 @@ def test_save_1d_scalar(tempdir, encoding):
     V = FunctionSpace(mesh, ("Lagrange", 2))
     u = Function(V)
     u.vector.set(1.0 + (1j if np.issubdtype(PETSc.ScalarType, np.complexfloating) else 0))
-    with XDMFFile(mesh.mpi_comm, filename2, "w", encoding=encoding) as file:
+    with XDMFFile(mesh.comm, filename2, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
         file.write_function(u)
 
@@ -71,7 +71,7 @@ def test_save_2d_scalar(tempdir, encoding, cell_type):
     V = FunctionSpace(mesh, ("Lagrange", 2))
     u = Function(V)
     u.vector.set(1.0)
-    with XDMFFile(mesh.mpi_comm, filename, "w", encoding=encoding) as file:
+    with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
         file.write_function(u)
 
@@ -84,7 +84,7 @@ def test_save_3d_scalar(tempdir, encoding, cell_type):
     V = FunctionSpace(mesh, ("Lagrange", 2))
     u = Function(V)
     u.vector.set(1.0)
-    with XDMFFile(mesh.mpi_comm, filename, "w", encoding=encoding) as file:
+    with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
         file.write_function(u)
 
@@ -97,7 +97,7 @@ def test_save_2d_vector(tempdir, encoding, cell_type):
     V = VectorFunctionSpace(mesh, ("Lagrange", 2))
     u = Function(V)
     u.vector.set(1.0 + (1j if np.issubdtype(PETSc.ScalarType, np.complexfloating) else 0))
-    with XDMFFile(mesh.mpi_comm, filename, "w", encoding=encoding) as file:
+    with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
         file.write_function(u)
 
@@ -109,7 +109,7 @@ def test_save_3d_vector(tempdir, encoding, cell_type):
     mesh = UnitCubeMesh(MPI.COMM_WORLD, 2, 2, 2, cell_type)
     u = Function(VectorFunctionSpace(mesh, ("Lagrange", 1)))
     u.vector.set(1.0 + (1j if np.issubdtype(PETSc.ScalarType, np.complexfloating) else 0))
-    with XDMFFile(mesh.mpi_comm, filename, "w", encoding=encoding) as file:
+    with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
         file.write_function(u)
 
@@ -121,7 +121,7 @@ def test_save_2d_tensor(tempdir, encoding, cell_type):
     mesh = UnitSquareMesh(MPI.COMM_WORLD, 16, 16, cell_type)
     u = Function(TensorFunctionSpace(mesh, ("Lagrange", 2)))
     u.vector.set(1.0 + (1j if np.issubdtype(PETSc.ScalarType, np.complexfloating) else 0))
-    with XDMFFile(mesh.mpi_comm, filename, "w", encoding=encoding) as file:
+    with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
         file.write_function(u)
 
@@ -133,7 +133,7 @@ def test_save_3d_tensor(tempdir, encoding, cell_type):
     mesh = UnitCubeMesh(MPI.COMM_WORLD, 4, 4, 4, cell_type)
     u = Function(TensorFunctionSpace(mesh, ("Lagrange", 2)))
     u.vector.set(1.0 + (1j if np.issubdtype(PETSc.ScalarType, np.complexfloating) else 0))
-    with XDMFFile(mesh.mpi_comm, filename, "w", encoding=encoding) as file:
+    with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
         file.write_function(u)
 
@@ -144,13 +144,13 @@ def test_save_3d_vector_series(tempdir, encoding, cell_type):
     filename = os.path.join(tempdir, "u_3D.xdmf")
     mesh = UnitCubeMesh(MPI.COMM_WORLD, 2, 2, 2, cell_type)
     u = Function(VectorFunctionSpace(mesh, ("Lagrange", 2)))
-    with XDMFFile(mesh.mpi_comm, filename, "w", encoding=encoding) as file:
+    with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
         u.vector.set(1.0 + (1j if np.issubdtype(PETSc.ScalarType, np.complexfloating) else 0))
         file.write_function(u, 0.1)
         u.vector.set(2.0 + (2j if np.issubdtype(PETSc.ScalarType, np.complexfloating) else 0))
         file.write_function(u, 0.2)
 
-    with XDMFFile(mesh.mpi_comm, filename, "a", encoding=encoding) as file:
+    with XDMFFile(mesh.comm, filename, "a", encoding=encoding) as file:
         u.vector.set(3.0 + (3j if np.issubdtype(PETSc.ScalarType, np.complexfloating) else 0))
         file.write_function(u, 0.3)

--- a/python/test/unit/io/test_xdmf_mesh.py
+++ b/python/test/unit/io/test_xdmf_mesh.py
@@ -50,7 +50,7 @@ def worker_id(request):
 def test_save_and_load_1d_mesh(tempdir, encoding):
     filename = os.path.join(tempdir, "mesh.xdmf")
     mesh = UnitIntervalMesh(MPI.COMM_WORLD, 32)
-    with XDMFFile(mesh.mpi_comm, filename, "w", encoding=encoding) as file:
+    with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
     with XDMFFile(MPI.COMM_WORLD, filename, "r", encoding=encoding) as file:
         mesh2 = file.read_mesh()
@@ -66,7 +66,7 @@ def test_save_and_load_2d_mesh(tempdir, encoding, cell_type):
     mesh = UnitSquareMesh(MPI.COMM_WORLD, 12, 12, cell_type)
     mesh.name = "square"
 
-    with XDMFFile(mesh.mpi_comm, filename, "w", encoding=encoding) as file:
+    with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
 
     with XDMFFile(MPI.COMM_WORLD, filename, "r", encoding=encoding) as file:
@@ -83,7 +83,7 @@ def test_save_and_load_2d_mesh(tempdir, encoding, cell_type):
 def test_save_and_load_3d_mesh(tempdir, encoding, cell_type):
     filename = os.path.join(tempdir, "mesh.xdmf")
     mesh = UnitCubeMesh(MPI.COMM_WORLD, 12, 12, 8, cell_type)
-    with XDMFFile(mesh.mpi_comm, filename, "w", encoding=encoding) as file:
+    with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
 
     with XDMFFile(MPI.COMM_WORLD, filename, "r", encoding=encoding) as file:
@@ -135,9 +135,9 @@ def test_read_write_p2_mesh(tempdir, encoding):
     mesh = create_mesh(MPI.COMM_WORLD, cells, x, domain)
 
     filename = os.path.join(tempdir, "tet10_mesh.xdmf")
-    with XDMFFile(mesh.mpi_comm, filename, "w", encoding=encoding) as xdmf:
+    with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as xdmf:
         xdmf.write_mesh(mesh)
-    with XDMFFile(mesh.mpi_comm, filename, "r", encoding=encoding) as xdmf:
+    with XDMFFile(mesh.comm, filename, "r", encoding=encoding) as xdmf:
         mesh2 = xdmf.read_mesh()
 
     assert mesh.topology.index_map(0).size_global == mesh2.topology.index_map(0).size_global

--- a/python/test/unit/io/test_xdmf_meshdata.py
+++ b/python/test/unit/io/test_xdmf_meshdata.py
@@ -50,7 +50,7 @@ def test_read_mesh_data(tempdir, tdim, n):
     filename = os.path.join(tempdir, "mesh.xdmf")
     mesh = mesh_factory(tdim, n)
     encoding = XDMFFile.Encoding.HDF5
-    with XDMFFile(mesh.mpi_comm, filename, "w", encoding) as file:
+    with XDMFFile(mesh.comm, filename, "w", encoding) as file:
         file.write_mesh(mesh)
 
     with XDMFFile(MPI.COMM_WORLD, filename, "r") as file:
@@ -60,5 +60,5 @@ def test_read_mesh_data(tempdir, tdim, n):
 
     assert cell_shape == mesh.topology.cell_type
     assert cell_degree == 1
-    assert mesh.topology.index_map(tdim).size_global == mesh.mpi_comm.allreduce(cells.shape[0], op=MPI.SUM)
-    assert mesh.geometry.index_map().size_global == mesh.mpi_comm.allreduce(x.shape[0], op=MPI.SUM)
+    assert mesh.topology.index_map(tdim).size_global == mesh.comm.allreduce(cells.shape[0], op=MPI.SUM)
+    assert mesh.geometry.index_map().size_global == mesh.comm.allreduce(x.shape[0], op=MPI.SUM)

--- a/python/test/unit/la/test_krylov_solver.py
+++ b/python/test/unit/la/test_krylov_solver.py
@@ -38,7 +38,7 @@ def test_krylov_solver_lu():
 
     norm = 13.0
 
-    solver = PETSc.KSP().create(mesh.mpi_comm)
+    solver = PETSc.KSP().create(mesh.comm)
     solver.setOptionsPrefix("test_lu_")
     opts = PETSc.Options("test_lu_")
     opts["ksp_type"] = "preonly"
@@ -133,7 +133,7 @@ def test_krylov_samg_solver_elasticity():
 
         # Create PETSC smoothed aggregation AMG preconditioner, and
         # create CG solver
-        solver = PETSc.KSP().create(mesh.mpi_comm)
+        solver = PETSc.KSP().create(mesh.comm)
         solver.setType("cg")
 
         # Set matrix operator

--- a/python/test/unit/mesh/test_cell.py
+++ b/python/test/unit/mesh/test_cell.py
@@ -62,7 +62,7 @@ def test_volume_cells(mesh):
     map = mesh.topology.index_map(tdim)
     num_cells = map.size_local
     v = _cpp.mesh.volume_entities(mesh, range(num_cells), mesh.topology.dim)
-    assert mesh.mpi_comm.allreduce(v.sum(), MPI.SUM) == pytest.approx(1.0, rel=1e-9)
+    assert mesh.comm.allreduce(v.sum(), MPI.SUM) == pytest.approx(1.0, rel=1e-9)
 
 
 @ pytest.mark.skip("volume_entities needs fixing")

--- a/python/test/unit/mesh/test_ghost_mesh.py
+++ b/python/test/unit/mesh/test_ghost_mesh.py
@@ -32,10 +32,10 @@ def test_ghost_2d(mode):
     N = 8
     num_cells = N * N * 2
     mesh = UnitSquareMesh(MPI.COMM_WORLD, N, N, ghost_mode=mode)
-    if mesh.mpi_comm.size > 1:
+    if mesh.comm.size > 1:
         map = mesh.topology.index_map(2)
         num_cells_local = map.size_local + map.num_ghosts
-        assert mesh.mpi_comm.allreduce(num_cells_local, op=MPI.SUM) > num_cells
+        assert mesh.comm.allreduce(num_cells_local, op=MPI.SUM) > num_cells
     assert mesh.topology.index_map(0).size_global == 81
     assert mesh.topology.index_map(2).size_global == num_cells
 
@@ -45,10 +45,10 @@ def test_ghost_3d(mode):
     N = 2
     num_cells = N * N * N * 6
     mesh = UnitCubeMesh(MPI.COMM_WORLD, N, N, N, ghost_mode=mode)
-    if mesh.mpi_comm.size > 1:
+    if mesh.comm.size > 1:
         map = mesh.topology.index_map(3)
         num_cells_local = map.size_local + map.num_ghosts
-        assert mesh.mpi_comm.allreduce(num_cells_local, op=MPI.SUM) > num_cells
+        assert mesh.comm.allreduce(num_cells_local, op=MPI.SUM) > num_cells
     assert mesh.topology.index_map(0).size_global == 27
     assert mesh.topology.index_map(3).size_global == num_cells
 

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -528,7 +528,7 @@ def test_xdmf_input_tri(datadir):
     with XDMFFile(MPI.COMM_WORLD, os.path.join(datadir, "mesh.xdmf"), "r", encoding=XDMFFile.Encoding.ASCII) as xdmf:
         mesh = xdmf.read_mesh(name="Grid")
     surface = assemble_scalar(1 * dx(mesh))
-    assert mesh.mpi_comm.allreduce(surface, op=MPI.SUM) == pytest.approx(4 * np.pi, rel=1e-4)
+    assert mesh.comm.allreduce(surface, op=MPI.SUM) == pytest.approx(4 * np.pi, rel=1e-4)
 
 
 @skip_in_parallel
@@ -576,14 +576,14 @@ def test_gmsh_input_2d(order, cell_type):
     mesh = create_mesh(MPI.COMM_WORLD, cells, x, ufl_mesh_from_gmsh(gmsh_cell_id, x.shape[1]))
     surface = assemble_scalar(1 * dx(mesh))
 
-    assert mesh.mpi_comm.allreduce(surface, op=MPI.SUM) == pytest.approx(4 * np.pi, rel=10 ** (-1 - order))
+    assert mesh.comm.allreduce(surface, op=MPI.SUM) == pytest.approx(4 * np.pi, rel=10 ** (-1 - order))
 
     # Bug related to VTK output writing
     # def e2(x):
     #     values = np.empty((x.shape[0], 1))
     #     values[:, 0] = x[:, 0]
     #     return values
-    # cmap = fem.create_coordinate_map(mesh.mpi_comm, mesh.ufl_domain())
+    # cmap = fem.create_coordinate_map(mesh.comm, mesh.ufl_domain())
     # mesh.geometry.coord_mapping = cmap
     # V = FunctionSpace(mesh, ("Lagrange", order))
     # u = Function(V)
@@ -651,7 +651,7 @@ def test_gmsh_input_3d(order, cell_type):
 
     volume = assemble_scalar(1 * dx(mesh))
 
-    assert mesh.mpi_comm.allreduce(volume, op=MPI.SUM) == pytest.approx(np.pi, rel=10 ** (-1 - order))
+    assert mesh.comm.allreduce(volume, op=MPI.SUM) == pytest.approx(np.pi, rel=10 ** (-1 - order))
 
 
 @skip_in_parallel

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -179,7 +179,7 @@ def test_UnitSquareMeshDistributed():
     assert mesh.topology.index_map(0).size_global == 48
     assert mesh.topology.index_map(2).size_global == 70
     assert mesh.geometry.dim == 2
-    assert mesh.mpi_comm.allreduce(mesh.topology.index_map(0).size_local, MPI.SUM) == 48
+    assert mesh.comm.allreduce(mesh.topology.index_map(0).size_local, MPI.SUM) == 48
 
 
 def test_UnitSquareMeshLocal():
@@ -196,7 +196,7 @@ def test_UnitCubeMeshDistributed():
     assert mesh.topology.index_map(0).size_global == 480
     assert mesh.topology.index_map(3).size_global == 1890
     assert mesh.geometry.dim == 3
-    assert mesh.mpi_comm.allreduce(mesh.topology.index_map(0).size_local, MPI.SUM) == 480
+    assert mesh.comm.allreduce(mesh.topology.index_map(0).size_local, MPI.SUM) == 480
 
 
 def test_UnitCubeMeshLocal():
@@ -214,7 +214,7 @@ def test_UnitQuadMesh():
     assert mesh.topology.index_map(0).size_global == 48
     assert mesh.topology.index_map(2).size_global == 35
     assert mesh.geometry.dim == 2
-    assert mesh.mpi_comm.allreduce(mesh.topology.index_map(0).size_local, MPI.SUM) == 48
+    assert mesh.comm.allreduce(mesh.topology.index_map(0).size_local, MPI.SUM) == 48
 
 
 def test_UnitHexMesh():
@@ -222,7 +222,7 @@ def test_UnitHexMesh():
     assert mesh.topology.index_map(0).size_global == 480
     assert mesh.topology.index_map(3).size_global == 315
     assert mesh.geometry.dim == 3
-    assert mesh.mpi_comm.allreduce(mesh.topology.index_map(0).size_local, MPI.SUM) == 480
+    assert mesh.comm.allreduce(mesh.topology.index_map(0).size_local, MPI.SUM) == 480
 
 
 def test_BoxMeshPrism():
@@ -401,5 +401,5 @@ def test_small_mesh():
 def test_UnitHexMesh_assemble():
     mesh = UnitCubeMesh(MPI.COMM_WORLD, 6, 7, 5, CellType.hexahedron)
     vol = assemble_scalar(1 * dx(mesh))
-    vol = mesh.mpi_comm.allreduce(vol, MPI.SUM)
+    vol = mesh.comm.allreduce(vol, MPI.SUM)
     assert vol == pytest.approx(1, rel=1e-9)

--- a/python/test/unit/ufl-jit-assemble-chain/test_assembly_derivatives.py
+++ b/python/test/unit/ufl-jit-assemble-chain/test_assembly_derivatives.py
@@ -134,7 +134,7 @@ def test_diff_then_integrate():
         # (also passes through form compilation and jit)
         M = f * dx
         f_integral = assemble_scalar(M)  # noqa
-        f_integral = mesh.mpi_comm.allreduce(f_integral, op=MPI.SUM)
+        f_integral = mesh.comm.allreduce(f_integral, op=MPI.SUM)
 
         # Compute integral of f manually from anti-derivative F
         # (passes through pybind11 interface and uses UFL evaluation)


### PR DESCRIPTION
We had a mix of `mpi_comm()` and `comm()`. The PR implements consistent use of `comm`.