### PR TITLE
Use std::int8_t in place of bool for bc vectors

### DIFF
--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -308,7 +308,7 @@ public:
   /// V0 had a boundary condition applied, i.e. dofs which are fixed by
   /// a boundary condition. Other entries in @p markers are left
   /// unchanged.
-  void mark_dofs(std::vector<bool>& markers) const
+  void mark_dofs(const xtl::span<std::int8_t>& markers) const
   {
     for (std::size_t i = 0; i < _dofs0.size(); ++i)
     {

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -35,7 +35,8 @@ void assemble_matrix(
     const Form<T>& a, const xtl::span<const T>& constants,
     const std::map<std::pair<IntegralType, int>,
                    std::pair<xtl::span<const T>, int>>& coefficients,
-    const std::vector<bool>& bc0, const std::vector<bool>& bc1);
+    const xtl::span<const std::int8_t>& bc0,
+    const xtl::span<const std::int8_t>& bc1);
 
 /// Execute kernel over cells and accumulate result in matrix
 template <typename T>
@@ -51,7 +52,8 @@ void assemble_cells(
                              const xtl::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform_to_transpose,
     const graph::AdjacencyList<std::int32_t>& dofmap1, int bs1,
-    const std::vector<bool>& bc0, const std::vector<bool>& bc1,
+    const xtl::span<const std::int8_t>& bc0,
+    const xtl::span<const std::int8_t>& bc1,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*)>& kernel,
     const xtl::span<const T>& coeffs, int cstride,
@@ -150,7 +152,8 @@ void assemble_exterior_facets(
                              const xtl::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform_to_transpose,
     const graph::AdjacencyList<std::int32_t>& dofmap1, int bs1,
-    const std::vector<bool>& bc0, const std::vector<bool>& bc1,
+    const xtl::span<const std::int8_t>& bc0,
+    const xtl::span<const std::int8_t>& bc1,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*)>& kernel,
     const xtl::span<const T>& coeffs, int cstride,
@@ -255,8 +258,8 @@ void assemble_interior_facets(
     const std::function<void(const xtl::span<T>&,
                              const xtl::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform_to_transpose,
-    const DofMap& dofmap1, int bs1, const std::vector<bool>& bc0,
-    const std::vector<bool>& bc1,
+    const DofMap& dofmap1, int bs1, const xtl::span<const std::int8_t>& bc0,
+    const xtl::span<const std::int8_t>& bc1,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*)>& kernel,
     const xtl::span<const T>& coeffs, int cstride,
@@ -397,7 +400,8 @@ void assemble_matrix(
     const Form<T>& a, const xtl::span<const T>& constants,
     const std::map<std::pair<IntegralType, int>,
                    std::pair<xtl::span<const T>, int>>& coefficients,
-    const std::vector<bool>& bc0, const std::vector<bool>& bc1)
+    const xtl::span<const std::int8_t>& bc0,
+    const xtl::span<const std::int8_t>& bc1)
 {
   std::shared_ptr<const mesh::Mesh> mesh = a.mesh();
   assert(mesh);

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -51,7 +51,8 @@ void _lift_bc_cells(
     const graph::AdjacencyList<std::int32_t>& dofmap1, int bs1,
     const xtl::span<const T>& constants, const xtl::span<const T>& coeffs,
     int cstride, const xtl::span<const std::uint32_t>& cell_info,
-    const xtl::span<const T>& bc_values1, const std::vector<bool>& bc_markers1,
+    const xtl::span<const T>& bc_values1,
+    const xtl::span<const std::int8_t>& bc_markers1,
     const xtl::span<const T>& x0, double scale)
 {
   assert(_bs0 < 0 or _bs0 == bs0);
@@ -208,7 +209,8 @@ void _lift_bc_exterior_facets(
     const xtl::span<const T>& constants, const xtl::span<const T>& coeffs,
     int cstride, const xtl::span<const std::uint32_t>& cell_info,
     const std::function<std::uint8_t(std::size_t)>& get_perm,
-    const xtl::span<const T>& bc_values1, const std::vector<bool>& bc_markers1,
+    const xtl::span<const T>& bc_values1,
+    const xtl::span<const std::int8_t>& bc_markers1,
     const xtl::span<const T>& x0, double scale)
 {
   const int tdim = mesh.topology().dim();
@@ -325,7 +327,8 @@ void _lift_bc_interior_facets(
     int cstride, const std::vector<int>& offsets,
     const xtl::span<const std::uint32_t>& cell_info,
     const std::function<std::uint8_t(std::size_t)>& get_perm,
-    const xtl::span<const T>& bc_values1, const std::vector<bool>& bc_markers1,
+    const xtl::span<const T>& bc_values1,
+    const xtl::span<const std::int8_t>& bc_markers1,
     const xtl::span<const T>& x0, double scale)
 {
   const int tdim = mesh.topology().dim();
@@ -765,8 +768,8 @@ void lift_bc(xtl::span<T> b, const Form<T>& a,
              const std::map<std::pair<IntegralType, int>,
                             std::pair<xtl::span<const T>, int>>& coefficients,
              const xtl::span<const T>& bc_values1,
-             const std::vector<bool>& bc_markers1, const xtl::span<const T>& x0,
-             double scale)
+             const xtl::span<const std::int8_t>& bc_markers1,
+             const xtl::span<const T>& x0, double scale)
 {
   std::shared_ptr<const mesh::Mesh> mesh = a.mesh();
   assert(mesh);
@@ -922,7 +925,7 @@ void apply_lifting(
 
   for (std::size_t j = 0; j < a.size(); ++j)
   {
-    std::vector<bool> bc_markers1;
+    std::vector<std::int8_t> bc_markers1;
     std::vector<T> bc_values1;
     if (a[j] and !bcs1[j].empty())
     {

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -9,6 +9,7 @@
 #include "assemble_matrix_impl.h"
 #include "assemble_scalar_impl.h"
 #include "assemble_vector_impl.h"
+#include <cstdint>
 #include <memory>
 #include <vector>
 #include <xtl/xspan.hpp>
@@ -208,7 +209,7 @@ void assemble_matrix(
   auto bs1 = a.function_spaces().at(1)->dofmap()->index_map_bs();
 
   // Build dof markers
-  std::vector<bool> dof_marker0, dof_marker1;
+  std::vector<std::int8_t> dof_marker0, dof_marker1;
   assert(map0);
   std::int32_t dim0 = bs0 * (map0->size_local() + map0->num_ghosts());
   assert(map1);
@@ -275,7 +276,8 @@ void assemble_matrix(
     const Form<T>& a, const xtl::span<const T>& constants,
     const std::map<std::pair<IntegralType, int>,
                    std::pair<xtl::span<const T>, int>>& coefficients,
-    const std::vector<bool>& dof_marker0, const std::vector<bool>& dof_marker1)
+    const xtl::span<const std::int8_t>& dof_marker0,
+    const xtl::span<const std::int8_t>& dof_marker1)
 
 {
   impl::assemble_matrix(mat_add, a, constants, coefficients, dof_marker0,
@@ -296,8 +298,8 @@ template <typename T>
 void assemble_matrix(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                             const std::int32_t*, const T*)>& mat_add,
-    const Form<T>& a, const std::vector<bool>& dof_marker0,
-    const std::vector<bool>& dof_marker1)
+    const Form<T>& a, const xtl::span<const std::int8_t>& dof_marker0,
+    const xtl::span<const std::int8_t>& dof_marker1)
 
 {
   // Prepare constants and coefficients

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -324,7 +324,6 @@ std::vector<std::int64_t> graph::build::compute_local_to_global_links(
   // const std::int32_t max_local = _local.maxCoeff();
   const std::int32_t max_local
       = *std::max_element(_local.begin(), _local.end());
-  std::vector<bool> marker(max_local, false);
   std::vector<std::int64_t> local_to_global_list(max_local + 1, -1);
   for (std::size_t i = 0; i < _local.size(); ++i)
   {

--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -184,7 +184,7 @@ compute_nonlocal_dual_graph(
   // Count data items to send to each rank
   p_count.assign(num_ranks, 0);
   bool this_equal, last_equal = false;
-  std::vector<bool> facet_match(num_facets_rcvd, false);
+  std::vector<std::int8_t> facet_match(num_facets_rcvd, false);
   for (int i = 1; i < num_facets_rcvd; ++i)
   {
     const int i0 = perm[i - 1];

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -872,9 +872,16 @@ void fem(py::module& m)
          const std::map<std::pair<dolfinx::fem::IntegralType, int>,
                         py::array_t<PetscScalar, py::array::c_style>>&
              coefficients,
-         const std::vector<bool>& rows0, const std::vector<bool>& rows1,
+         const py::array_t<std::int8_t, py::array::c_style>& rows0,
+         const py::array_t<std::int8_t, py::array::c_style>& rows1,
          bool unrolled)
       {
+        if (rows0.ndim() != 1 or rows1.ndim())
+        {
+          throw std::runtime_error(
+              "Expected 1D arrays for boundary condition rows/columns");
+        }
+
         std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                           const std::int32_t*, const PetscScalar*)>
             set_fn;


### PR DESCRIPTION
The allows interaction with Python/NumPy and xtensor without copies, and testing in a different context indicated that `std::vector<int8_t>` is faster than `std::vector<bool>`.