### PR TITLE
Add GitHub funding

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: FEniCS


### PR DESCRIPTION
Still need to wait for approval from GitHub. Money ends up with NumFOCUS under the usual terms.