### PR TITLE
Fix refinement and add tests for sub refinement

### DIFF
--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -92,25 +92,24 @@ xt::xtensor<double, 2> create_new_geometry(
     for (std::size_t j = 0; j < x_g.shape(1); ++j)
       new_vertex_coordinates(v, j) = x_g(vertex_to_x[v], j);
 
-  std::vector<int> edges(num_new_vertices);
-  int i = 0;
-  for (auto& e : local_edge_to_new_vertex)
-    edges[i++] = e.first;
-
-  const xt::xtensor<double, 2> midpoints
-      = mesh::compute_midpoints(mesh, 1, edges);
-
-  // Cannot use xt::range(-num_new_vertices, _) to assign midpoints as
-  // num_new_vertices can be 0
-  for (std::size_t i = 0; i < num_new_vertices; i++)
+  // Compute new vertices
+  if (num_new_vertices > 0)
   {
+    std::vector<int> edges(num_new_vertices);
+    int i = 0;
+    for (auto& e : local_edge_to_new_vertex)
+      edges[i++] = e.first;
+
+    const xt::xtensor<double, 2> midpoints
+        = mesh::compute_midpoints(mesh, 1, edges);
+
     // The below should work, but misbehaves with the Intel icpx compiler
-    // xt::view(new_vertex_coordinates, num_vertices + i,
+    // xt::view(new_vertex_coordinates, xt::range(-num_new_vertices, _),
     // xt::all())
-    //     = xt::row(midpoints, i);
-    auto _vertex
-        = xt::view(new_vertex_coordinates, num_vertices + i, xt::all());
-    _vertex.assign(xt::row(midpoints, i));
+    //     = midpoints;
+    auto _vertex = xt::view(new_vertex_coordinates,
+                            xt::range(-num_new_vertices, _), xt::all());
+    _vertex.assign(midpoints);
   }
 
   return xt::view(new_vertex_coordinates, xt::all(),

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -99,13 +99,19 @@ xt::xtensor<double, 2> create_new_geometry(
 
   const xt::xtensor<double, 2> midpoints
       = mesh::compute_midpoints(mesh, 1, edges);
-  // The below should work, but misbehaves with the Intel icpx compiler
-  // xt::view(new_vertex_coordinates, xt::range(-num_new_vertices, _),
-  // xt::all())
-  //     = midpoints;
-  auto _vertex = xt::view(new_vertex_coordinates,
-                          xt::range(-num_new_vertices, _), xt::all());
-  _vertex.assign(midpoints);
+
+  // Cannot use xt::range(-num_new_vertices, _) to assign midpoints as
+  // num_new_vertices can be 0
+  for (std::size_t i = 0; i < num_new_vertices; i++)
+  {
+    // The below should work, but misbehaves with the Intel icpx compiler
+    // xt::view(new_vertex_coordinates, num_vertices + i,
+    // xt::all())
+    //     = xt::row(midpoints, i);
+    auto _vertex
+        = xt::view(new_vertex_coordinates, num_vertices + i, xt::all());
+    _vertex.assign(xt::row(midpoints, i));
+  }
 
   return xt::view(new_vertex_coordinates, xt::all(),
                   xt::range(0, mesh.geometry().dim()));

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -14,12 +14,13 @@ from mpi4py import MPI as _MPI
 
 from dolfinx import cpp as _cpp
 from dolfinx.cpp.mesh import (CellType, GhostMode, build_dual_graph, cell_dim,
-                              compute_midpoints, create_meshtags, compute_boundary_facets)
+                              compute_midpoints, create_meshtags, compute_boundary_facets,
+                              compute_incident_entities)
 
 __all__ = ["create_meshtags", "locate_entities", "locate_entities_boundary",
            "refine", "create_mesh", "create_meshtags", "MeshTags", "CellType",
            "GhostMode", "build_dual_graph", "cell_dim", "compute_midpoints",
-           "compute_boundary_facets"]
+           "compute_boundary_facets", "compute_incident_entities"]
 
 
 class Mesh(_cpp.mesh.Mesh):
@@ -123,15 +124,15 @@ _meshtags_types = {
 }
 
 
-def refine(mesh: Mesh, cell_markers: _cpp.mesh.MeshTags_int8 = None, redistribute: bool = True) -> Mesh:
+def refine(mesh: Mesh, edges: np.ndarray = None, redistribute: bool = True) -> Mesh:
     """Refine a mesh
 
     Parameters
     ----------
     mesh
         The mesh from which to build a refined mesh
-    cell_markers
-        Optional argument to specify which cells should be refined. If
+    edges
+        Optional argument to specify which edges should be refined. If
         not supplied uniform refinement is applied.
     redistribute
         Optional argument to redistribute the refined mesh if mesh is a
@@ -142,10 +143,10 @@ def refine(mesh: Mesh, cell_markers: _cpp.mesh.MeshTags_int8 = None, redistribut
     Mesh
         A refined mesh
     """
-    if cell_markers is None:
+    if edges is None:
         mesh_refined = _cpp.refinement.refine(mesh, redistribute)
     else:
-        mesh_refined = _cpp.refinement.refine(mesh, cell_markers, redistribute)
+        mesh_refined = _cpp.refinement.refine(mesh, edges, redistribute)
 
     coordinate_element = mesh._ufl_domain.ufl_coordinate_element()
     domain = ufl.Mesh(coordinate_element)

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -355,5 +355,13 @@ void mesh(py::module& m)
               orient));
         });
   m.def("exterior_facet_indices", &dolfinx::mesh::exterior_facet_indices);
+  m.def("compute_incident_entities",
+        [](const dolfinx::mesh::Mesh& mesh,
+           py::array_t<std::int32_t, py::array::c_style> entity_list, int d0,
+           int d1)
+        {
+          return as_pyarray(dolfinx::mesh::compute_incident_entities(
+              mesh, xtl::span(entity_list.data(), entity_list.size()), d0, d1));
+        });
 }
 } // namespace dolfinx_wrappers

--- a/python/test/unit/mesh/test_refinement.py
+++ b/python/test/unit/mesh/test_refinement.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 Chris N Richardson
+# Copyright (C) 2018-2021 Chris N Richardson and Jørgen S. Dokken
 #
 # This file is part of DOLFINx (https://www.fenicsproject.org)
 #
@@ -6,9 +6,11 @@
 
 import ufl
 from dolfinx.fem import FunctionSpace, assemble_matrix
-from dolfinx.generation import UnitSquareMesh, UnitCubeMesh
-from dolfinx.mesh import GhostMode, refine
+from dolfinx.generation import DiagonalType, UnitCubeMesh, UnitSquareMesh
+from dolfinx.mesh import (GhostMode, compute_incident_entities, locate_entities,
+                          locate_entities_boundary, refine)
 from mpi4py import MPI
+from numpy import diag, isclose, logical_and
 
 
 def test_RefineUnitSquareMesh():
@@ -64,8 +66,49 @@ def test_refine_create_form():
     assemble_matrix(a)
 
 
-def xtest_refinement_gdim():
+def test_refinement_gdim():
     """Test that 2D refinement is still 2D"""
     mesh = UnitSquareMesh(MPI.COMM_WORLD, 3, 4, ghost_mode=GhostMode.none)
+    mesh.topology.create_entities(1)
     mesh2 = refine(mesh, redistribute=True)
     assert mesh.geometry.dim == mesh2.geometry.dim
+
+
+def test_sub_refine():
+    """Test that refinement of a subset of edges works"""
+    mesh = UnitSquareMesh(MPI.COMM_WORLD, 3, 4, diagonal=DiagonalType.left,
+                          ghost_mode=GhostMode.none)
+    mesh.topology.create_entities(1)
+
+    def left_corner_edge(x, tol=1e-16):
+        return logical_and(isclose(x[0], 0), x[1] < 1 / 4 + tol)
+
+    edges = locate_entities_boundary(mesh, 1, left_corner_edge)
+    if MPI.COMM_WORLD.size == 0:
+        assert(edges == 1)
+
+    mesh2 = refine(mesh, edges, redistribute=False)
+    assert(mesh.topology.index_map(2).size_global + 3 == mesh2.topology.index_map(2).size_global)
+
+
+def test_refine_from_cells():
+    """Check user interface for using local cells to define edges"""
+    Nx = 8
+    Ny = 3
+    assert(Nx % 2 == 0)
+    mesh = UnitSquareMesh(MPI.COMM_WORLD, Nx, Ny, diagonal=DiagonalType.left, ghost_mode=GhostMode.none)
+    mesh.topology.create_entities(1)
+
+    def left_side(x, tol=1e-16):
+        return x[0] <= 0.5 + tol
+    cells = locate_entities(mesh, mesh.topology.dim, left_side)
+    if MPI.COMM_WORLD.size == 0:
+        assert(cells.__len__() == Nx * Ny)
+    edges = compute_incident_entities(mesh, cells, 2, 1)
+    if MPI.COMM_WORLD.size == 0:
+        assert(edges.__len__() == Nx // 2 * (2 * Ny + 1) + (Nx // 2 + 1) * Ny)
+    mesh2 = refine(mesh, edges, redistribute=True)
+
+    num_cells_global = mesh2.topology.index_map(2).size_global
+    actual_cells = 3 * (Nx * Ny) + 3 * Ny + 2 * Nx * Ny
+    assert(num_cells_global == actual_cells)

--- a/python/test/unit/mesh/test_refinement.py
+++ b/python/test/unit/mesh/test_refinement.py
@@ -10,7 +10,7 @@ from dolfinx.generation import DiagonalType, UnitCubeMesh, UnitSquareMesh
 from dolfinx.mesh import (GhostMode, compute_incident_entities, locate_entities,
                           locate_entities_boundary, refine)
 from mpi4py import MPI
-from numpy import diag, isclose, logical_and
+from numpy import isclose, logical_and
 
 
 def test_RefineUnitSquareMesh():


### PR DESCRIPTION
Fixing bug in Python interface reported at: https://fenicsproject.discourse.group/t/what-is-the-latest-api-for-mesh-refinement-in-dolfinx/7201

Fixing bug in C++ refinement when number of new vertices on a process is 0.

Add tests for refinement using list of edges.

Reactivate gdim refinement test

Expose `compute_incident_entities` to use with refinement