### PR TITLE
Fix for `IndexMap` segmentation fault

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -270,7 +270,8 @@ common::stack_index_maps(
 //-----------------------------------------------------------------------------
 IndexMap::IndexMap(MPI_Comm comm, std::int32_t local_size)
     : _comm(comm), _comm_owner_to_ghost(MPI_COMM_NULL),
-      _comm_ghost_to_owner(MPI_COMM_NULL)
+      _comm_ghost_to_owner(MPI_COMM_NULL),
+      _displs_recv_fwd(1, 0)
 {
   // Get global offset (index), using partial exclusive reduction
   std::int64_t offset = 0;

--- a/python/test/unit/common/test_index_map.py
+++ b/python/test/unit/common/test_index_map.py
@@ -7,6 +7,8 @@
 import numpy as np
 
 import dolfinx
+from dolfinx.generation import UnitSquareMesh
+from dolfinx.mesh import GhostMode
 
 from mpi4py import MPI
 
@@ -66,3 +68,12 @@ def test_sub_index_map():
         if submap_ghost.size != 0:
             submap_ghosts.append(submap_ghost[0])
     assert np.allclose(submap.ghosts, submap_ghosts)
+
+
+def test_sub_index_map_ghost_mode_none():
+    n = 2
+    mesh = UnitSquareMesh(MPI.COMM_WORLD, n, n, ghost_mode=GhostMode.none)
+    tdim = mesh.topology.dim
+    cell_index_map = mesh.topology.index_map(tdim)
+    submap_indices = np.array([0, 1], dtype=np.int32)
+    cell_index_map.create_submap(submap_indices)


### PR DESCRIPTION
[This](https://github.com/FEniCS/dolfinx/blob/main/cpp/dolfinx/common/IndexMap.cpp#L271) `IndexMap` constructor does not initialise `_displs_recv_fwd` correctly, which can cause a segmentation fault in `IndexMap::scatter_fwd_begin` due to [this](https://github.com/FEniCS/dolfinx/blob/main/cpp/dolfinx/common/IndexMap.h#L250) check being missed.

This PR fixes the issue and adds a test that fails without the fix. A more direct test might be better, but `IndexMap::scatter_fwd_begin` isn't currently exposed to Python.

Debugged with help from @jorgensd.