### PR TITLE
Update link to C++ docs

### DIFF
--- a/python/doc/source/api.rst
+++ b/python/doc/source/api.rst
@@ -50,4 +50,4 @@ C++
 ===
 
 The C++ API is documented `here
-<https://fenicsproject.org/docs/dolfinx/dev/cpp/>`_.
+<https://docs.fenicsproject.org/dolfinx/main/cpp/>`_.


### PR DESCRIPTION
The link from the Python docs to the C++ docs is broken. Making this match the URL in the main README.