### PR TITLE
Replace confusing legacy `FiniteElement::value_dimension` with `FiniteElement::value_shape` 

### DIFF
--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -197,7 +197,7 @@ public:
   {
     assert(g);
     assert(V);
-    if (V->element()->value_rank() != g->shape.size())
+    if (V->element()->value_shape().size() != g->shape.size())
     {
       throw std::runtime_error(
           "Rank mis-match between Constant and function space in DirichletBC");

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -122,7 +122,7 @@ FiniteElement::FiniteElement(const ufc_finite_element& ufc_element)
 
   // Fill value dimension
   for (int i = 0; i < ufc_element.value_rank; ++i)
-    _value_dimension.push_back(ufc_element.value_shape[i]);
+    _value_shape.push_back(ufc_element.value_shape[i]);
 
   _needs_dof_transformations = false;
   _needs_dof_permutations = false;
@@ -191,19 +191,11 @@ int FiniteElement::reference_value_size() const noexcept
   return _reference_value_size;
 }
 //-----------------------------------------------------------------------------
-int FiniteElement::value_rank() const noexcept
-{
-  return _value_dimension.size();
-}
-//-----------------------------------------------------------------------------
 int FiniteElement::block_size() const noexcept { return _bs; }
 //-----------------------------------------------------------------------------
-int FiniteElement::value_dimension(int i) const
+xtl::span<const int> FiniteElement::value_shape() const
 {
-  if (i >= (int)_value_dimension.size())
-    return 1;
-  else
-    return _value_dimension.at(i);
+  return _value_shape;
 }
 //-----------------------------------------------------------------------------
 std::string FiniteElement::family() const noexcept { return _family; }

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -78,15 +78,15 @@ _extract_sub_element(const FiniteElement& finite_element,
 } // namespace
 
 //-----------------------------------------------------------------------------
-FiniteElement::FiniteElement(const ufc_finite_element& ufc_element)
-    : _signature(ufc_element.signature), _family(ufc_element.family),
-      _tdim(ufc_element.topological_dimension),
-      _space_dim(ufc_element.space_dimension),
-      _value_size(ufc_element.value_size),
-      _reference_value_size(ufc_element.reference_value_size),
-      _hash(std::hash<std::string>{}(_signature)), _bs(ufc_element.block_size)
+FiniteElement::FiniteElement(const ufc_finite_element& e)
+    : _signature(e.signature), _family(e.family),
+      _tdim(e.topological_dimension), _space_dim(e.space_dimension),
+      _value_size(e.value_size), _reference_value_size(e.reference_value_size),
+      _hash(std::hash<std::string>{}(_signature)),
+      _value_shape(e.value_shape, e.value_shape + e.value_rank),
+      _bs(e.block_size)
 {
-  const ufc_shape _shape = ufc_element.cell_shape;
+  const ufc_shape _shape = e.cell_shape;
   switch (_shape)
   {
   case interval:
@@ -118,18 +118,14 @@ FiniteElement::FiniteElement(const ufc_finite_element& ufc_element)
          {triangle, "triangle"},    {tetrahedron, "tetrahedron"},
          {prism, "prism"},          {quadrilateral, "quadrilateral"},
          {hexahedron, "hexahedron"}};
-  const std::string cell_shape = ufc_to_cell.at(ufc_element.cell_shape);
-
-  // Fill value dimension
-  for (int i = 0; i < ufc_element.value_rank; ++i)
-    _value_shape.push_back(ufc_element.value_shape[i]);
+  const std::string cell_shape = ufc_to_cell.at(e.cell_shape);
 
   _needs_dof_transformations = false;
   _needs_dof_permutations = false;
   // Create all sub-elements
-  for (int i = 0; i < ufc_element.num_sub_elements; ++i)
+  for (int i = 0; i < e.num_sub_elements; ++i)
   {
-    ufc_finite_element* ufc_sub_element = ufc_element.sub_elements[i];
+    ufc_finite_element* ufc_sub_element = e.sub_elements[i];
     _sub_elements.push_back(std::make_shared<FiniteElement>(*ufc_sub_element));
     if (_sub_elements[i]->needs_dof_permutations()
         and !_needs_dof_transformations)
@@ -143,24 +139,22 @@ FiniteElement::FiniteElement(const ufc_finite_element& ufc_element)
     }
   }
 
-  if (is_basix_element(ufc_element))
+  if (is_basix_element(e))
   {
-    if (ufc_element.lagrange_variant != -1)
+    if (e.lagrange_variant != -1)
     {
       _element = std::make_unique<basix::FiniteElement>(basix::create_element(
-          static_cast<basix::element::family>(ufc_element.basix_family),
-          static_cast<basix::cell::type>(ufc_element.basix_cell),
-          ufc_element.degree,
-          static_cast<basix::element::lagrange_variant>(
-              ufc_element.lagrange_variant),
-          ufc_element.discontinuous));
+          static_cast<basix::element::family>(e.basix_family),
+          static_cast<basix::cell::type>(e.basix_cell), e.degree,
+          static_cast<basix::element::lagrange_variant>(e.lagrange_variant),
+          e.discontinuous));
     }
     else
     {
       _element = std::make_unique<basix::FiniteElement>(basix::create_element(
-          static_cast<basix::element::family>(ufc_element.basix_family),
-          static_cast<basix::cell::type>(ufc_element.basix_cell),
-          ufc_element.degree, ufc_element.discontinuous));
+          static_cast<basix::element::family>(e.basix_family),
+          static_cast<basix::cell::type>(e.basix_cell), e.degree,
+          e.discontinuous));
     }
 
     _needs_dof_transformations
@@ -193,7 +187,7 @@ int FiniteElement::reference_value_size() const noexcept
 //-----------------------------------------------------------------------------
 int FiniteElement::block_size() const noexcept { return _bs; }
 //-----------------------------------------------------------------------------
-xtl::span<const int> FiniteElement::value_shape() const
+xtl::span<const int> FiniteElement::value_shape() const noexcept
 {
   return _value_shape;
 }

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -74,12 +74,9 @@ public:
   /// @return The value size for the reference element
   int reference_value_size() const noexcept;
 
-  /// Rank of the value space
-  /// @return The value rank
-  int value_rank() const noexcept;
-
-  /// Return the dimension of the value space for axis i
-  int value_dimension(int i) const;
+  /// Shape of the value space. The rank is the size of the
+  /// `value_shape`.
+  xtl::span<const int> value_shape() const noexcept;
 
   /// The finite element family
   /// @return The string of the finite element family
@@ -670,7 +667,7 @@ private:
   std::size_t _hash;
 
   // Dimension of each value space
-  std::vector<int> _value_dimension;
+  std::vector<int> _value_shape;
 
   // Block size for VectorElements and TensorElements. This gives the
   // number of DOFs colocated at each point.

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -24,8 +24,8 @@ class FiniteElement
 {
 public:
   /// Create finite element from UFC finite element
-  /// @param[in] ufc_element UFC finite element
-  explicit FiniteElement(const ufc_finite_element& ufc_element);
+  /// @param[in] e UFC finite element
+  explicit FiniteElement(const ufc_finite_element& e);
 
   /// Copy constructor
   FiniteElement(const FiniteElement& element) = delete;

--- a/cpp/dolfinx/io/ADIOS2Writers.cpp
+++ b/cpp/dolfinx/io/ADIOS2Writers.cpp
@@ -131,7 +131,7 @@ void vtx_write_data(adios2::IO& io, adios2::Engine& engine,
   // Get function data array and information about layout
   assert(u.x());
   xtl::span<const Scalar> u_vector = u.x()->array();
-  const int rank = u.function_space()->element()->value_rank();
+  const int rank = u.function_space()->element()->value_shape().size();
   const std::uint32_t num_comp = std::pow(3, rank);
   std::shared_ptr<const fem::DofMap> dofmap = u.function_space()->dofmap();
   assert(dofmap);
@@ -520,7 +520,7 @@ std::vector<Scalar> pack_function_data(const fem::Function<Scalar>& u)
   const std::uint32_t num_vertices
       = vertex_map->size_local() + vertex_map->num_ghosts();
 
-  const int rank = u.function_space()->element()->value_rank();
+  const int rank = u.function_space()->element()->value_shape().size();
   const std::uint32_t num_components = std::pow(3, rank);
 
   // Get dof array and pack into array (padded where appropriate)
@@ -563,7 +563,7 @@ void fides_write_data(adios2::IO& io, adios2::Engine& engine,
   const int gdim = mesh->geometry().dim();
 
   // Vectors and tensor need padding in gdim < 3
-  const int rank = u.function_space()->element()->value_rank();
+  const int rank = u.function_space()->element()->value_shape().size();
   const bool need_padding = rank > 0 and gdim != 3 ? true : false;
 
   // Get vertex data. If the mesh and function dofmaps are the same we

--- a/cpp/dolfinx/io/VTKFile.cpp
+++ b/cpp/dolfinx/io/VTKFile.cpp
@@ -35,7 +35,7 @@ bool _is_cellwise(const fem::Function<Scalar>& u)
   assert(u.function_space());
 
   assert(u.function_space()->element());
-  const int rank = u.function_space()->element()->value_rank();
+  const int rank = u.function_space()->element()->value_shape().size();
   assert(u.function_space()->mesh());
   const int tdim = u.function_space()->mesh()->topology().dim();
   int cell_based_dim = 1;
@@ -126,7 +126,7 @@ template <typename Scalar>
 void _add_data(const fem::Function<Scalar>& u,
                const xt::xtensor<Scalar, 2>& values, pugi::xml_node& data_node)
 {
-  const int rank = u.function_space()->element()->value_rank();
+  const int rank = u.function_space()->element()->value_shape().size();
   const int dim = u.function_space()->element()->value_size();
   if (rank == 1)
   {
@@ -461,7 +461,7 @@ void write_function(
     // as Paraview only supports one active type
     if (piece_node.child(data_type.c_str()).empty())
       piece_node.append_child(data_type.c_str());
-    const int rank = _u.get().function_space()->element()->value_rank();
+    const int rank = _u.get().function_space()->element()->value_shape().size();
     pugi::xml_node data_node = piece_node.child(data_type.c_str());
     std::string rank_type;
     if (rank == 0)
@@ -667,7 +667,8 @@ void write_function(
     {
       std::string d_type = is_cellwise(_u) ? "PCellData" : "PPointData";
       pugi::xml_node data_pnode = grid_node.child(d_type.c_str());
-      const int rank = _u.get().function_space()->element()->value_rank();
+      const int rank
+          = _u.get().function_space()->element()->value_shape().size();
       int ncomps = 0;
       if (rank == 1)
         ncomps = 3;

--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -48,7 +48,7 @@ template <typename Scalar>
 bool has_cell_centred_data(const fem::Function<Scalar>& u)
 {
   int cell_based_dim = 1;
-  const int rank = u.function_space()->element()->value_rank();
+  const int rank = u.function_space()->element()->value_shape().size();
   for (int i = 0; i < rank; i++)
     cell_based_dim *= u.function_space()->mesh()->topology().dim();
 
@@ -66,7 +66,7 @@ bool has_cell_centred_data(const fem::Function<Scalar>& u)
 int get_padded_width(const fem::FiniteElement& e)
 {
   const int width = e.value_size();
-  const int rank = e.value_rank();
+  const int rank = e.value_shape().size();
   if (rank == 1 and width == 2)
     return 3;
   else if (rank == 2 and width == 4)
@@ -104,7 +104,7 @@ void _add_function(MPI_Comm comm, const fem::Function<Scalar>& u,
   const int num_values
       = cell_centred ? map_c->size_global() : map_v->size_global();
 
-  const int value_rank = u.function_space()->element()->value_rank();
+  const int value_rank = u.function_space()->element()->value_shape().size();
 
   std::vector<std::string> components = {""};
   if constexpr (!std::is_scalar<Scalar>::value)

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -37,7 +37,7 @@ namespace
 std::int64_t get_padded_width(const fem::FiniteElement& e)
 {
   const int width = e.value_size();
-  const int rank = e.value_rank();
+  const int rank = e.value_shape().size();
   if (rank == 1 and width == 2)
     return 3;
   else if (rank == 2 and width == 4)
@@ -62,7 +62,7 @@ std::vector<Scalar> _get_point_data_values(const fem::Function<Scalar>& u)
   // FIXME: Unpick the below code for the new layout of data from
   //        GenericFunction::compute_vertex_values
   std::vector<Scalar> _data_values(width * num_local_points, 0.0);
-  const int value_rank = u.function_space()->element()->value_rank();
+  const int value_rank = u.function_space()->element()->value_shape().size();
   if (value_rank > 0)
   {
     // Transpose vector/tensor data arrays
@@ -93,7 +93,7 @@ std::vector<Scalar> _get_cell_data_values(const fem::Function<Scalar>& u)
   assert(u.function_space()->dofmap());
   const auto mesh = u.function_space()->mesh();
   const int value_size = u.function_space()->element()->value_size();
-  const int value_rank = u.function_space()->element()->value_rank();
+  const int value_rank = u.function_space()->element()->value_shape().size();
 
   // Allocate memory for function values at cell centres
   const int tdim = mesh->topology().dim();

--- a/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
+++ b/python/demo/mixed-elasticity-sc/static-condensation-elasticity.py
@@ -44,8 +44,8 @@ S = FunctionSpace(mesh, Se)
 U = FunctionSpace(mesh, Ue)
 
 # Get local dofmap sizes for later local tensor tabulations
-Ssize = S.dolfin_element().space_dimension()
-Usize = U.dolfin_element().space_dimension()
+Ssize = S.element.space_dimension
+Usize = U.element.space_dimension
 
 sigma, tau = ufl.TrialFunction(S), ufl.TestFunction(S)
 u, v = ufl.TrialFunction(U), ufl.TestFunction(U)

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -395,7 +395,7 @@ class Function(ufl.Coefficient):
         function resides in the subspace of the mixed space.
 
         """
-        num_sub_spaces = self.function_space.num_sub_spaces()
+        num_sub_spaces = self.function_space.num_sub_spaces
         if num_sub_spaces == 1:
             raise RuntimeError("No subfunctions to extract")
         return tuple(self.sub(i) for i in range(num_sub_spaces))
@@ -472,17 +472,14 @@ class FunctionSpace(ufl.FunctionSpace):
         Vcpp = _cpp.fem.FunctionSpace(self._cpp_object.mesh, self._cpp_object.element, self._cpp_object.dofmap)
         return FunctionSpace(None, self.ufl_element(), Vcpp)
 
-    def dolfin_element(self):
-        """DOLFINx element."""
-        return self._cpp_object.element
-
+    @property
     def num_sub_spaces(self) -> int:
-        """Number of sub spaces."""
-        return self.dolfin_element().num_sub_elements
+        """Number of sub spaces"""
+        return self.element.num_sub_elements
 
     def sub(self, i: int) -> "FunctionSpace":
         """Return the i-th sub space."""
-        assert self.ufl_element().num_sub_elements > i
+        assert self.ufl_element().num_sub_elements() > i
         sub_element = self.ufl_element().sub_elements()[i]
         cppV_sub = self._cpp_object.sub([i])
         return FunctionSpace(None, sub_element, cppV_sub)

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -478,11 +478,11 @@ class FunctionSpace(ufl.FunctionSpace):
 
     def num_sub_spaces(self) -> int:
         """Number of sub spaces."""
-        return self.dolfin_element().num_sub_elements()
+        return self.dolfin_element().num_sub_elements
 
     def sub(self, i: int) -> "FunctionSpace":
         """Return the i-th sub space."""
-        assert self.ufl_element().num_sub_elements() > i
+        assert self.ufl_element().num_sub_elements > i
         sub_element = self.ufl_element().sub_elements()[i]
         cppV_sub = self._cpp_object.sub([i])
         return FunctionSpace(None, sub_element, cppV_sub)

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -144,12 +144,12 @@ def test_vector_constant_bc(mesh_factory):
     mesh = func(*args)
     tdim = mesh.topology.dim
     V = VectorFunctionSpace(mesh, ("Lagrange", 1))
-    assert(V.num_sub_spaces() == mesh.geometry.dim)
+    assert V.num_sub_spaces == mesh.geometry.dim
     c = np.arange(1, mesh.geometry.dim + 1, dtype=PETSc.ScalarType)
     boundary_facets = locate_entities_boundary(mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool))
 
     # Set using sub-functions
-    Vs = [V.sub(i).collapse() for i in range(V.num_sub_spaces())]
+    Vs = [V.sub(i).collapse() for i in range(V.num_sub_spaces)]
     boundary_dofs = [locate_dofs_topological((V.sub(i), Vs[i]), tdim - 1, boundary_facets)
                      for i in range(len(Vs))]
     u_bcs = [Function(Vs[i]) for i in range(len(Vs))]
@@ -188,7 +188,7 @@ def test_sub_constant_bc(mesh_factory):
     c = Constant(mesh, PETSc.ScalarType(3.14))
     boundary_facets = locate_entities_boundary(mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool))
 
-    for i in range(V.num_sub_spaces()):
+    for i in range(V.num_sub_spaces):
         Vi = V.sub(i).collapse()
         u_bci = Function(Vi)
         u_bci.x.array[:] = PETSc.ScalarType(c.value)

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -67,8 +67,8 @@ def test_python_interface(V, V2, W, W2, Q):
 
     assert V.ufl_cell() == V2.ufl_cell()
     assert W.ufl_cell() == W2.ufl_cell()
-    assert V.dolfin_element().signature() == V2.dolfin_element().signature()
-    assert W.dolfin_element().signature() == W2.dolfin_element().signature()
+    assert V.element.signature() == V2.element.signature()
+    assert W.element.signature() == W2.element.signature()
     assert V.ufl_element() == V2.ufl_element()
     assert W.ufl_element() == W2.ufl_element()
     assert W.id == W2.id

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -109,9 +109,9 @@ def test_sub(Q, W):
     assert W.dofmap.dof_layout.block_size() == X.dofmap.dof_layout.block_size()
     assert W.dofmap.bs * len(W.dofmap.cell_dofs(0)) == len(X.dofmap.cell_dofs(0))
 
-    assert W.element.num_sub_elements() == X.element.num_sub_elements()
-    assert W.element.space_dimension() == X.element.space_dimension()
-    assert W.element.value_rank == X.element.value_rank
+    assert W.element.num_sub_elements == X.element.num_sub_elements
+    assert W.element.space_dimension == X.element.space_dimension
+    assert W.element.value_shape == X.element.value_shape
     assert W.element.interpolation_points.shape == X.element.interpolation_points.shape
     assert W.element.signature() == X.element.signature()
 

--- a/python/test/unit/io/test_vtk.py
+++ b/python/test/unit/io/test_vtk.py
@@ -178,7 +178,7 @@ def test_save_2d_mixed(tempdir):
     U.vector.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
     filename = os.path.join(tempdir, "u.pvd")
     with VTKFile(mesh.comm, filename, "w") as vtk:
-        vtk.write_function([U.sub(i) for i in range(W.num_sub_spaces())], 0.)
+        vtk.write_function([U.sub(i) for i in range(W.num_sub_spaces)], 0.)
 
 
 def test_save_1d_tensor(tempdir):


### PR DESCRIPTION
Also removes `FiniteElement::value_rank` since this is just `value_shape.size()`. 