### PR TITLE
Convert std::vector<bool> to std::vector<int8_t>

### DIFF
--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -140,7 +140,7 @@ build_basic_dofmap(const mesh::Topology& topology,
   const int D = topology.dim();
 
   // Generate and number required mesh entities
-  std::vector<bool> needs_entities(D + 1, false);
+  std::vector<std::int8_t> needs_entities(D + 1, false);
   std::vector<std::int32_t> num_mesh_entities_local(D + 1, 0),
       num_mesh_entities_global(D + 1, 0);
   for (int d = 0; d <= D; ++d)
@@ -386,13 +386,13 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
 
   // Build list flag for owned mesh entities that are shared, i.e. are a
   // ghost on a neighbor
-  std::vector<std::vector<bool>> shared_entity(D + 1);
+  std::vector<std::vector<std::int8_t>> shared_entity(D + 1);
   for (std::size_t d = 0; d < shared_entity.size(); ++d)
   {
     auto map = topology.index_map(d);
     if (map)
     {
-      shared_entity[d] = std::vector<bool>(map->size_local(), false);
+      shared_entity[d] = std::vector<std::int8_t>(map->size_local(), false);
       const std::vector<std::int32_t>& forward_indices
           = map->scatter_fwd_indices().array();
       for (auto entity : forward_indices)

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -411,7 +411,7 @@ graph::AdjacencyList<std::int32_t> convert_cells_to_local_indexing(
 } // namespace
 
 //-----------------------------------------------------------------------------
-std::vector<bool> mesh::compute_boundary_facets(const Topology& topology)
+std::vector<std::int8_t> mesh::compute_boundary_facets(const Topology& topology)
 {
   const int tdim = topology.dim();
   auto facets = topology.index_map(tdim - 1);
@@ -429,7 +429,7 @@ std::vector<bool> mesh::compute_boundary_facets(const Topology& topology)
   auto fc = topology.connectivity(tdim - 1, tdim);
   if (!fc)
     throw std::runtime_error("Facet-cell connectivity missing.");
-  std::vector<bool> _boundary_facet(facets->size_local(), false);
+  std::vector<std::int8_t> _boundary_facet(facets->size_local(), false);
   for (std::size_t f = 0; f < _boundary_facet.size(); ++f)
   {
     if (fc->num_links(f) == 1

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -38,7 +38,7 @@ class Topology;
 /// @return Vector with length equal to the number of owned facets on
 ///   this this process. True if the ith facet (local index) is on the
 ///   exterior of the domain.
-std::vector<bool> compute_boundary_facets(const Topology& topology);
+std::vector<std::int8_t> compute_boundary_facets(const Topology& topology);
 
 /// Topology stores the topology of a mesh, consisting of mesh entities
 /// and connectivity (incidence relations for the mesh entities).

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -171,7 +171,7 @@ refinement::compute_edge_sharing(const mesh::Mesh& mesh)
 void refinement::update_logical_edgefunction(
     const MPI_Comm& neighbor_comm,
     const std::vector<std::vector<std::int32_t>>& marked_for_update,
-    std::vector<bool>& marked_edges, const common::IndexMap& map_e)
+    std::vector<std::int8_t>& marked_edges, const common::IndexMap& map_e)
 {
   std::vector<std::int32_t> send_offsets = {0};
   std::vector<std::int64_t> data_to_send;
@@ -206,7 +206,7 @@ std::pair<std::map<std::int32_t, std::int64_t>, xt::xtensor<double, 2>>
 refinement::create_new_vertices(
     const MPI_Comm& neighbor_comm,
     const std::map<std::int32_t, std::vector<std::int32_t>>& shared_edges,
-    const mesh::Mesh& mesh, const std::vector<bool>& marked_edges)
+    const mesh::Mesh& mesh, const std::vector<std::int8_t>& marked_edges)
 {
   // Take marked_edges and use to create new vertices
   const std::shared_ptr<const common::IndexMap> edge_index_map

--- a/cpp/dolfinx/refinement/utils.h
+++ b/cpp/dolfinx/refinement/utils.h
@@ -45,7 +45,7 @@ compute_edge_sharing(const mesh::Mesh& mesh);
 void update_logical_edgefunction(
     const MPI_Comm& neighbor_comm,
     const std::vector<std::vector<std::int32_t>>& marked_for_update,
-    std::vector<bool>& marked_edges, const common::IndexMap& map_e);
+    std::vector<std::int8_t>& marked_edges, const common::IndexMap& map_e);
 
 /// Add new vertex for each marked edge, and create
 /// new_vertex_coordinates and global_edge->new_vertex map.
@@ -59,7 +59,7 @@ std::pair<std::map<std::int32_t, std::int64_t>, xt::xtensor<double, 2>>
 create_new_vertices(
     const MPI_Comm& neighbor_comm,
     const std::map<std::int32_t, std::vector<std::int32_t>>& shared_edges,
-    const mesh::Mesh& mesh, const std::vector<bool>& marked_edges);
+    const mesh::Mesh& mesh, const std::vector<std::int8_t>& marked_edges);
 
 /// Use vertex and topology data to partition new mesh across
 /// processes


### PR DESCRIPTION
`vector<bool>` is a possibly space-efficient specialization of `vector<T>` .
In exchange for this optimization, it doesn't offer all the capabilities and interface of a normal standard container(it doen't have `vector<T>::data` or  `vector<T>::iterator` members).

https://en.cppreference.com/w/cpp/container/vector_bool

This can be confusing and inhibits the use of some stl functions, and IndexMap scatter functions.

