### PR TITLE
Fix regression in eval

### DIFF
--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -309,19 +309,18 @@ public:
         = element->get_dof_transformation_function<double>();
 
     // -- Lambda function for affine pull-backs
-    auto pull_back_affine =
-        [&cmap, tdim,
-         X0 = xt::xtensor<double, 2>(xt::zeros<double>({std::size_t(1), tdim})),
-         data = xt::xtensor<double, 4>(cmap.tabulate_shape(1, 1)),
-         dphi = xt::xtensor<double, 2>({tdim, cmap.tabulate_shape(1, 1)[2]})](
-            auto&& X, const auto& cell_geometry, auto&& J, auto&& K,
-            const auto& x) mutable
+    xt::xtensor<double, 4> data(cmap.tabulate_shape(1, 1));
+    xt::xtensor<double, 2> X0(xt::zeros<double>({std::size_t(1), tdim}));
+    cmap.tabulate(1, X0, data);
+    xt::xtensor<double, 2> dphi_i
+        = xt::view(data, xt::range(1, tdim + 1), 0, xt::all(), 0);
+    auto pull_back_affine = [&dphi_i](auto&& X, const auto& cell_geometry,
+                                      auto&& J, auto&& K, const auto& x) mutable
     {
-      cmap.tabulate(1, X0, data);
-      dphi = xt::view(data, xt::range(1, tdim + 1), 0, xt::all(), 0);
-      cmap.compute_jacobian(dphi, cell_geometry, J);
-      cmap.compute_jacobian_inverse(J, K);
-      cmap.pull_back_affine(X, K, cmap.x0(cell_geometry), x);
+      fem::CoordinateElement::compute_jacobian(dphi_i, cell_geometry, J);
+      fem::CoordinateElement::compute_jacobian_inverse(J, K);
+      fem::CoordinateElement::pull_back_affine(
+          X, K, fem::CoordinateElement::x0(cell_geometry), x);
     };
 
     xt::xtensor<double, 2> dphi;

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -310,12 +310,12 @@ public:
 
     // -- Lambda function for affine pull-backs
     xt::xtensor<double, 4> data(cmap.tabulate_shape(1, 1));
-    xt::xtensor<double, 2> X0(xt::zeros<double>({std::size_t(1), tdim}));
+    const xt::xtensor<double, 2> X0(xt::zeros<double>({std::size_t(1), tdim}));
     cmap.tabulate(1, X0, data);
-    xt::xtensor<double, 2> dphi_i
+    const xt::xtensor<double, 2> dphi_i
         = xt::view(data, xt::range(1, tdim + 1), 0, xt::all(), 0);
-    auto pull_back_affine = [&dphi_i](auto&& X, const auto& cell_geometry,
-                                      auto&& J, auto&& K, const auto& x) mutable
+    auto pull_back_affine = [dphi_i](auto&& X, const auto& cell_geometry,
+                                     auto&& J, auto&& K, const auto& x) mutable
     {
       fem::CoordinateElement::compute_jacobian(dphi_i, cell_geometry, J);
       fem::CoordinateElement::compute_jacobian_inverse(J, K);


### PR DESCRIPTION
The pull back affine function in `dolfinx::fem::Function::eval` called `cmap.tabulate` for every point, even if it could be tabulated only once.
This causes a huge regression when eval is called on large sets of points, (for instance in `compute_point_values` used for `XDMFFile.write_function`).

MWE:
```python
import dolfinx
import dolfinx.io
import dolfinx.fem
from mpi4py import MPI
import dolfinx.mesh

N = 100
mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, N, N, N)
V = dolfinx.fem.FunctionSpace(mesh, ("CG", 1))
uh = dolfinx.fem.Function(V)
uh.x.array[:] = 1
for i in range(10):
    with dolfinx.common.Timer("~FEM: Compute at nodes"):
        uh.compute_point_values()
t = dolfinx.common.timing("~FEM: Compute at nodes")
print(f"Point values: {t[0]} {t[1]} {t[1]/t[0]}")
```
**main**
```bash
Point values: 10 49.854582906 4.9854582906
```
**This branch**
```bash
Point values: 10 13.206571004 1.3206571004
```