### PR TITLE
Add uniform weights to MPI neighbor communicator

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -296,17 +296,12 @@ common::stack_index_maps(
   const std::vector<int> out_neighbors(out_neighbor_set.begin(),
                                        out_neighbor_set.end());
 
-  // NOTE: create uniform weights as a workaround to issue
-  // https://github.com/pmodels/mpich/issues/5764
-  const std::vector<int> in_weights(in_neighbors.size(), 1);
-  const std::vector<int> out_weights(out_neighbors.size(), 1);
-
   // Create neighborhood communicator
   MPI_Comm comm;
   MPI_Dist_graph_create_adjacent(
       maps.at(0).first.get().comm(), in_neighbors.size(), in_neighbors.data(),
-      in_weights.data(), out_neighbors.size(), out_neighbors.data(),
-      out_weights.data(), MPI_INFO_NULL, false, &comm);
+      MPI_UNWEIGHTED, out_neighbors.size(), out_neighbors.data(),
+      MPI_UNWEIGHTED, MPI_INFO_NULL, false, &comm);
 
   int indegree(-1), outdegree(-2), weighted(-1);
   MPI_Dist_graph_neighbors_count(comm, &indegree, &outdegree, &weighted);

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -440,7 +440,7 @@ IndexMap::IndexMap(MPI_Comm comm, std::int32_t local_size,
     // NOTE: create uniform weights as a workaround to issue
     // https://github.com/pmodels/mpich/issues/5764
     std::vector<int> src_weights(halo_src_ranks.size(), 1);
-    std::vector<int> dest_weights(halo_src_ranks.size(), 1);
+    std::vector<int> dest_weights(dest_ranks.size(), 1);
 
     MPI_Comm comm0;
     MPI_Dist_graph_create_adjacent(


### PR DESCRIPTION
Workaround to issue https://github.com/pmodels/mpich/issues/5764 .
`MPI_Comm_dup` fails for unweighted graph communicators.

The issue has been fixed in https://github.com/pmodels/mpich/pull/5629 and it's available in mpich 4.0rc3( a release candidate).
