### PR TITLE
Make timing MPI reduction easily selectable, and MPI_MAX by default

### DIFF
--- a/cpp/dolfinx/common/TimeLogger.cpp
+++ b/cpp/dolfinx/common/TimeLogger.cpp
@@ -38,11 +38,12 @@ void TimeLogger::register_timing(std::string task, double wall, double user,
     _timings.insert({task, {1, wall, user, system}});
 }
 //-----------------------------------------------------------------------------
-void TimeLogger::list_timings(MPI_Comm comm, std::set<TimingType> type)
+void TimeLogger::list_timings(MPI_Comm comm, std::set<TimingType> type,
+                              Table::Reduction reduction)
 {
   // Format and reduce to rank 0
   Table timings = this->timings(type);
-  timings = timings.reduce(comm, Table::Reduction::average);
+  timings = timings.reduce(comm, reduction);
   const std::string str = "\n" + timings.str();
 
   // Print just on rank 0

--- a/cpp/dolfinx/common/TimeLogger.h
+++ b/cpp/dolfinx/common/TimeLogger.h
@@ -41,7 +41,7 @@ public:
   /// Return a summary of timings and tasks in a Table
   Table timings(std::set<TimingType> type);
 
-  /// List a summary of timings and tasks. ``MPI_AVG`` reduction is
+  /// List a summary of timings and tasks. Reduction type is
   /// printed.
   /// @param comm MPI Communicator
   /// @param type Set of possible timings: wall, user or system

--- a/cpp/dolfinx/common/TimeLogger.h
+++ b/cpp/dolfinx/common/TimeLogger.h
@@ -45,7 +45,9 @@ public:
   /// printed.
   /// @param comm MPI Communicator
   /// @param type Set of possible timings: wall, user or system
-  void list_timings(MPI_Comm comm, std::set<TimingType> type);
+  /// @param reduction Reduction type (min, max or average)
+  void list_timings(MPI_Comm comm, std::set<TimingType> type,
+                    Table::Reduction reduction);
 
   /// Return timing
   /// @param[in] task The task name to retrieve the timing for

--- a/cpp/dolfinx/common/timing.cpp
+++ b/cpp/dolfinx/common/timing.cpp
@@ -19,9 +19,10 @@ Table dolfinx::timings(std::set<TimingType> type)
   return TimeLogManager::logger().timings(type);
 }
 //-----------------------------------------------------------------------------
-void dolfinx::list_timings(MPI_Comm comm, std::set<TimingType> type)
+void dolfinx::list_timings(MPI_Comm comm, std::set<TimingType> type,
+                           Table::Reduction reduction)
 {
-  TimeLogManager::logger().list_timings(comm, type);
+  TimeLogManager::logger().list_timings(comm, type, reduction);
 }
 //-----------------------------------------------------------------------------
 std::tuple<std::size_t, double, double, double>

--- a/cpp/dolfinx/common/timing.h
+++ b/cpp/dolfinx/common/timing.h
@@ -39,7 +39,7 @@ Table timings(std::set<TimingType> type);
 ///                 TimingType::system }
 /// @param[in] reduction MPI Reduction to apply (min, max or average)
 void list_timings(MPI_Comm comm, std::set<TimingType> type,
-                  Table::Reduction reduction = Table::Reduction::average);
+                  Table::Reduction reduction = Table::Reduction::max);
 
 /// Return timing (count, total wall time, total user time, total system
 /// time) for given task.

--- a/cpp/dolfinx/common/timing.h
+++ b/cpp/dolfinx/common/timing.h
@@ -37,7 +37,9 @@ Table timings(std::set<TimingType> type);
 /// @param[in] comm MPI Communicator
 /// @param[in] type Subset of { TimingType::wall, TimingType::user,
 ///                 TimingType::system }
-void list_timings(MPI_Comm comm, std::set<TimingType> type);
+/// @param[in] reduction MPI Reduction to apply (min, max or average)
+void list_timings(MPI_Comm comm, std::set<TimingType> type,
+                  Table::Reduction reduction = Table::Reduction::average);
 
 /// Return timing (count, total wall time, total user time, total system
 /// time) for given task.

--- a/python/dolfinx/common.py
+++ b/python/dolfinx/common.py
@@ -14,14 +14,19 @@ from dolfinx.cpp.common import (IndexMap, git_commit_hash, has_adios2,  # noqa
 __all__ = ["IndexMap", "Timer", "timed"]
 
 TimingType = _cpp.common.TimingType
+Reduction = _cpp.common.Reduction
 
 
 def timing(task: str):
     return _cpp.common.timing(task)
 
 
-def list_timings(comm, timing_types: list):
-    return _cpp.common.list_timings(comm, timing_types)
+def list_timings(comm, timing_types: list, reduction=Reduction.max):
+    """Print out a summary of all Timer measurements, with a choice of
+    wall time, system time or user time. When used in parallel, a
+    reduction is applied across all processes. By default, the maximum
+    time is shown."""
+    _cpp.common.list_timings(comm, timing_types, reduction)
 
 
 class Timer:


### PR DESCRIPTION
Currently, `list_timings()` produces the average time of a `Timer` across all MPI ranks. This is misleading, and the maximum (or minimum) are more useful.
This PR makes it possible to easily select, and makes max the default.