### PR TITLE
Fix questionable `std::move` in mesh construction

### DIFF
--- a/cpp/dolfinx/geometry/BoundingBoxTree.cpp
+++ b/cpp/dolfinx/geometry/BoundingBoxTree.cpp
@@ -13,6 +13,7 @@
 #include <dolfinx/mesh/Geometry.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/utils.h>
+#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 using namespace dolfinx::geometry;

--- a/cpp/dolfinx/geometry/utils.cpp
+++ b/cpp/dolfinx/geometry/utils.cpp
@@ -14,6 +14,8 @@
 #include <dolfinx/mesh/utils.h>
 #include <xtensor/xfixed.hpp>
 #include <xtensor/xnorm.hpp>
+#include <xtensor/xview.hpp>
+
 using namespace dolfinx;
 
 namespace

--- a/cpp/dolfinx/graph/AdjacencyList.h
+++ b/cpp/dolfinx/graph/AdjacencyList.h
@@ -151,6 +151,9 @@ public:
   /// Offset for each node in array() (const version)
   const std::vector<std::int32_t>& offsets() const { return _offsets; }
 
+  /// Offset for each node in array()
+  std::vector<std::int32_t>& offsets() { return _offsets; }
+
   /// Return informal string representation (pretty-print)
   std::string str() const
   {

--- a/cpp/dolfinx/graph/partition.h
+++ b/cpp/dolfinx/graph/partition.h
@@ -82,19 +82,22 @@ compute_ghost_indices(MPI_Comm comm,
                       const xtl::span<const std::int64_t>& global_indices,
                       const xtl::span<const int>& ghost_owners);
 
-/// Distribute data to process ranks where it it required
+/// Distribute rows of a rectangular data array to process ranks where
+/// it it required
 ///
 /// @param[in] comm The MPI communicator
-/// @param[in] indices Global indices of the data required by this
-///   process
-/// @param[in] x Data on this process which may be distributed (by
-///   row). The global index for the [0, ..., n) local rows is assumed
-///   to be the local index plus the offset for this rank
-/// @return The data for each index in @p indices
+/// @param[in] indices Global indices of the data (rows) required by
+/// this process
+/// @param[in] x Data on this process which may be distributed (by row).
+/// The global index for the [0, ..., n) local rows is assumed to be the
+/// local index plus the offset for this rank. Layout is row-major.
+/// @param[in] shape1 The number of columns of the data array
+/// @return The data for each index in @p indices (row-major storage)
+/// @pre `shape1 > 0`
 template <typename T>
-xt::xtensor<T, 2> distribute_data(MPI_Comm comm,
-                                  const xtl::span<const std::int64_t>& indices,
-                                  const xt::xtensor<T, 2>& x);
+std::vector<T> distribute_data(MPI_Comm comm,
+                               const xtl::span<const std::int64_t>& indices,
+                               const xtl::span<const T>& x, int shape1);
 
 /// Given an adjacency list with global, possibly non-contiguous, link
 /// indices and a local adjacency list with contiguous link indices
@@ -128,19 +131,21 @@ compute_local_to_local(const xtl::span<const std::int64_t>& local0_to_global,
 // Implementation
 //---------------------------------------------------------------------------
 template <typename T>
-xt::xtensor<T, 2>
+std::vector<T>
 build::distribute_data(MPI_Comm comm,
                        const xtl::span<const std::int64_t>& indices,
-                       const xt::xtensor<T, 2>& x)
+                       const xtl::span<const T>& x, int shape1)
 {
   common::Timer timer("Fetch float data from remote processes");
+  assert(shape1 > 0);
 
-  const std::int64_t num_points_local = x.shape(0);
+  assert(x.size() % shape1 == 0);
+  const std::int64_t shape0 = x.size() / shape1;
   const int size = dolfinx::MPI::size(comm);
   const int rank = dolfinx::MPI::rank(comm);
   std::vector<std::int64_t> global_sizes(size);
-  MPI_Allgather(&num_points_local, 1, MPI_INT64_T, global_sizes.data(), 1,
-                MPI_INT64_T, comm);
+  MPI_Allgather(&shape0, 1, MPI_INT64_T, global_sizes.data(), 1, MPI_INT64_T,
+                comm);
   std::vector<std::int64_t> global_offsets(size + 1, 0);
   std::partial_sum(global_sizes.begin(), global_sizes.end(),
                    global_offsets.begin() + 1);
@@ -194,27 +199,25 @@ build::distribute_data(MPI_Comm comm,
                 number_index_recv.data(), disp_index_recv.data(), MPI_INT64_T,
                 comm);
 
-  assert(x.shape(1) != 0);
   // Pack point data to send back (transpose)
-  xt::xtensor<T, 2> x_return({indices_recv.size(), x.shape(1)});
+  std::vector<T> x_return(indices_recv.size() * shape1);
   for (int p = 0; p < size; ++p)
   {
     for (int i = disp_index_recv[p]; i < disp_index_recv[p + 1]; ++i)
     {
       const std::int32_t index_local = indices_recv[i] - global_offsets[rank];
       assert(index_local >= 0);
-      for (std::size_t j = 0; j < x.shape(1); ++j)
-        x_return(i, j) = x(index_local, j);
+      std::copy_n(std::next(x.cbegin(), shape1 * index_local), shape1,
+                  std::next(x_return.begin(), shape1 * i));
     }
   }
 
   MPI_Datatype compound_type;
-  MPI_Type_contiguous(x.shape(1), dolfinx::MPI::mpi_type<T>(), &compound_type);
+  MPI_Type_contiguous(shape1, dolfinx::MPI::mpi_type<T>(), &compound_type);
   MPI_Type_commit(&compound_type);
 
   // Send back point data
-  xt::xtensor<T, 2> my_x(
-      {static_cast<std::size_t>(disp_index_send.back()), x.shape(1)});
+  std::vector<T> my_x(disp_index_send.back() * shape1);
   MPI_Alltoallv(x_return.data(), number_index_recv.data(),
                 disp_index_recv.data(), compound_type, my_x.data(),
                 number_index_send.data(), disp_index_send.data(), compound_type,

--- a/cpp/dolfinx/io/ADIOS2Writers.cpp
+++ b/cpp/dolfinx/io/ADIOS2Writers.cpp
@@ -7,6 +7,7 @@
 #ifdef HAS_ADIOS2
 
 #include "ADIOS2Writers.h"
+#include "cells.h"
 #include "pugixml.hpp"
 #include <adios2.h>
 #include <algorithm>
@@ -14,7 +15,6 @@
 #include <dolfinx/fem/FiniteElement.h>
 #include <dolfinx/fem/Function.h>
 #include <dolfinx/fem/FunctionSpace.h>
-#include <dolfinx/io/cells.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/utils.h>
 #include <xtensor/xtensor.hpp>

--- a/cpp/dolfinx/la/SLEPcEigenSolver.cpp
+++ b/cpp/dolfinx/la/SLEPcEigenSolver.cpp
@@ -7,10 +7,10 @@
 #ifdef HAS_SLEPC
 
 #include "SLEPcEigenSolver.h"
+#include "petsc.h"
 #include "utils.h"
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/log.h>
-#include <dolfinx/la/petsc.h>
 #include <petscmat.h>
 #include <slepcversion.h>
 

--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -6,13 +6,13 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "petsc.h"
+#include "SparsityPattern.h"
 #include "Vector.h"
 #include "utils.h"
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/common/log.h>
-#include <dolfinx/la/SparsityPattern.h>
 #include <iostream>
 #include <sstream>
 

--- a/cpp/dolfinx/mesh/Geometry.cpp
+++ b/cpp/dolfinx/mesh/Geometry.cpp
@@ -107,10 +107,11 @@ mesh::Geometry mesh::create_geometry(
   // Build coordinate dof array, copying coordinates to correct
   // position
   std::vector<double> xg(3 * coords.shape(0), 0.0);
+  const std::size_t shape1 = coords.shape(1);
   for (std::size_t i = 0; i < coords.shape(0); ++i)
   {
-    auto row = xt::view(coords, l2l[i]);
-    std::copy(row.cbegin(), row.cend(), std::next(xg.begin(), 3 * i));
+    std::copy_n(std::next(coords.cbegin(), shape1 * l2l[i]), shape1,
+                std::next(xg.begin(), 3 * i));
   }
 
   return Geometry(dof_index_map, std::move(dofmap), coordinate_element,

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -117,6 +117,7 @@ private:
 /// Build Geometry from input data
 ///
 /// @param[in] comm The MPI communicator to build the Geometry on
+/// @param[in] topology The mesh topology
 /// @param[in] element The element that defines the geometry map for
 /// each cell
 /// @param[in] cells The mesh cells, including higher-ordder geometry 'nodes'

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -12,7 +12,6 @@
 #include <functional>
 #include <memory>
 #include <vector>
-#include <xtensor/xtensor.hpp>
 #include <xtl/xspan.hpp>
 
 namespace dolfinx::common
@@ -115,13 +114,22 @@ private:
   std::vector<std::int64_t> _input_global_indices;
 };
 
-/// Build Geometry
-/// @todo document
+/// Build Geometry from input data
+///
+/// @param[in] comm The MPI communicator to build the Geometry on
+/// @param[in] element The element that defines the geometry map for
+/// each cell
+/// @param[in] cells The mesh cells, including higher-ordder geometry 'nodes'
+/// @param[in] x The node coordinates (row-major, with shape (num_nodes,
+/// geometric dimension)
+/// @param[in] dim The geometric dimensions (1, 2, or 3)
+/// @param[in] reorder_fn Function for re-ordering the degree-of-freedom
+/// map associated with the geometry data
 mesh::Geometry
 create_geometry(MPI_Comm comm, const Topology& topology,
-                const fem::CoordinateElement& coordinate_element,
+                const fem::CoordinateElement& element,
                 const graph::AdjacencyList<std::int64_t>& cells,
-                const xt::xtensor<double, 2>& x,
+                const xtl::span<const double>& x, int dim,
                 const std::function<std::vector<int>(
                     const graph::AdjacencyList<std::int32_t>&)>& reorder_fn
                 = nullptr);

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -12,10 +12,7 @@
 #include <functional>
 #include <memory>
 #include <vector>
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xbuilder.hpp>
 #include <xtensor/xtensor.hpp>
-#include <xtensor/xview.hpp>
 #include <xtl/xspan.hpp>
 
 namespace dolfinx::common
@@ -53,7 +50,7 @@ public:
   {
     assert(_x.size() % 3 == 0);
     if (_x.size() / 3 != _input_global_indices.size())
-      throw std::runtime_error("Size mis-match");
+      throw std::runtime_error("Geometry size mis-match");
   }
 
   /// Copy constructor
@@ -110,7 +107,8 @@ private:
   // The coordinate element
   fem::CoordinateElement _cmap;
 
-  // Coordinates for all points stored as a contiguous array
+  // Coordinates for all points stored as a contiguous array (roe-major,
+  // column size = 3)
   std::vector<double> _x;
 
   // Global indices as provided on Geometry creation

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -76,10 +76,12 @@ Mesh mesh::create_mesh(MPI_Comm comm,
                        mesh::GhostMode ghost_mode,
                        const mesh::CellPartitionFunction& cell_partitioner)
 {
-  if (ghost_mode == mesh::GhostMode::shared_vertex)
+  if (ghost_mode == GhostMode::shared_vertex)
     throw std::runtime_error("Ghost mode via vertex currently disabled.");
 
   const fem::ElementDofLayout dof_layout = element.create_dof_layout();
+
+  // -- Prepare topology for partitioning
 
   // TODO: This step can be skipped for 'P1' elements
   //
@@ -88,28 +90,36 @@ Mesh mesh::create_mesh(MPI_Comm comm,
   // filtered lists may have 'gaps', i.e. the indices might not be
   // contiguous.
   const graph::AdjacencyList<std::int64_t> cells_topology
-      = mesh::extract_topology(element.cell_shape(), dof_layout, cells);
+      = extract_topology(element.cell_shape(), dof_layout, cells);
+
+  // -- Partition topology
 
   // Compute the destination rank for cells on this process via graph
   // partitioning. Always get the ghost cells via facet, though these
   // may be discarded later.
   const int size = dolfinx::MPI::size(comm);
-  const int tdim = mesh::cell_dim(element.cell_shape());
+  const int tdim = cell_dim(element.cell_shape());
   const graph::AdjacencyList<std::int32_t> dest = cell_partitioner(
       comm, size, tdim, cells_topology, GhostMode::shared_facet);
+
+  // -- Distribute cells (topology, includes higher-order 'nodes')
 
   // Distribute cells to destination rank
   const auto [cell_nodes0, src, original_cell_index0, ghost_owners]
       = graph::build::distribute(comm, cells, dest);
 
+  // -- Extra cell topology
+
   // Extract cell 'topology', i.e. the vertices for each cell
   const graph::AdjacencyList<std::int64_t> cells_extracted0
-      = mesh::extract_topology(element.cell_shape(), dof_layout, cell_nodes0);
+      = extract_topology(element.cell_shape(), dof_layout, cell_nodes0);
+
+  // -- Re-order cells
 
   // Build local dual graph for owned cells to apply re-ordering to
   const std::int32_t num_owned_cells
       = cells_extracted0.num_nodes() - ghost_owners.size();
-  const auto [g, m] = mesh::build_local_dual_graph(
+  const auto [g, m] = build_local_dual_graph(
       xtl::span<const std::int64_t>(
           cells_extracted0.array().data(),
           cells_extracted0.offsets()[num_owned_cells]),
@@ -129,12 +139,14 @@ Mesh mesh::create_mesh(MPI_Comm comm,
   const graph::AdjacencyList<std::int64_t> cell_nodes
       = reorder_list(cell_nodes0, remap);
 
+  // -- Create Topology
+
   // Create cells and vertices with the ghosting requested. Input
   // topology includes cells shared via facet, but ghosts will be
   // removed later if not required by ghost_mode.
   Topology topology
-      = mesh::create_topology(comm, cells_extracted, original_cell_index,
-                              ghost_owners, element.cell_shape(), ghost_mode);
+      = create_topology(comm, cells_extracted, original_cell_index,
+                        ghost_owners, element.cell_shape(), ghost_mode);
 
   // Create connectivity required to compute the Geometry (extra
   // connectivities for higher-order geometries)
@@ -143,7 +155,7 @@ Mesh mesh::create_mesh(MPI_Comm comm,
     if (dof_layout.num_entity_dofs(e) > 0)
     {
       auto [cell_entity, entity_vertex, index_map]
-          = mesh::compute_entities(comm, topology, e);
+          = compute_entities(comm, topology, e);
       if (cell_entity)
         topology.set_connectivity(cell_entity, tdim, e);
       if (entity_vertex)
@@ -167,9 +179,8 @@ Mesh mesh::create_mesh(MPI_Comm comm,
                                                  std::move(off1));
   if (element.needs_dof_permutations())
     topology.create_entity_permutations();
-
-  return Mesh(comm, std::move(topology),
-              mesh::create_geometry(comm, topology, element, cell_nodes1, x));
+  Geometry geometry = create_geometry(comm, topology, element, cell_nodes1, x);
+  return Mesh(comm, std::move(topology), std::move(geometry));
 }
 //-----------------------------------------------------------------------------
 std::tuple<Mesh, std::vector<std::int32_t>, std::vector<std::int32_t>>
@@ -179,7 +190,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   // Submesh topology
   // Get the verticies in the submesh
   std::vector<std::int32_t> submesh_vertices
-      = mesh::compute_incident_entities(mesh, entities, dim, 0);
+      = compute_incident_entities(mesh, entities, dim, 0);
 
   // Get the vertices in the submesh owned by this process
   auto mesh_vertex_index_map = mesh.topology().index_map(0);
@@ -235,8 +246,8 @@ mesh::create_submesh(const Mesh& mesh, int dim,
 
   // Submesh entity to vertex connectivity
   const CellType entity_type
-      = mesh::cell_entity_type(mesh.topology().cell_type(), dim, 0);
-  const int num_vertices_per_entity = mesh::cell_num_entities(entity_type, 0);
+      = cell_entity_type(mesh.topology().cell_type(), dim, 0);
+  const int num_vertices_per_entity = cell_num_entities(entity_type, 0);
   auto mesh_e_to_v = mesh.topology().connectivity(dim, 0);
   std::vector<std::int32_t> submesh_e_to_v_vec;
   submesh_e_to_v_vec.reserve(entities.size() * num_vertices_per_entity);
@@ -259,7 +270,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
       std::move(submesh_e_to_v_vec), std::move(submesh_e_to_v_offsets));
 
   // Create submesh topology
-  mesh::Topology submesh_topology(mesh.comm(), entity_type);
+  Topology submesh_topology(mesh.comm(), entity_type);
   submesh_topology.set_index_map(0, submesh_vertex_index_map);
   submesh_topology.set_index_map(dim, submesh_entity_index_map);
   submesh_topology.set_connectivity(submesh_v_to_v, 0, 0);
@@ -269,7 +280,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   // Get the geometry dofs in the submesh based on the entities in
   // submesh
   xt::xtensor<std::int32_t, 2> e_to_g
-      = mesh::entities_to_geometry(mesh, dim, entities, false);
+      = entities_to_geometry(mesh, dim, entities, false);
   // FIXME Find better way to do this
   xt::xarray<int32_t> submesh_x_dofs_xt = xt::unique(e_to_g);
   std::vector<int32_t> submesh_x_dofs(submesh_x_dofs_xt.begin(),
@@ -338,7 +349,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
 
   // Create submesh coordinate element
   CellType submesh_coord_cell
-      = mesh::cell_entity_type(mesh.geometry().cmap().cell_shape(), dim, 0);
+      = cell_entity_type(mesh.geometry().cmap().cell_shape(), dim, 0);
   auto submesh_coord_ele = fem::CoordinateElement(
       submesh_coord_cell, mesh.geometry().cmap().degree());
 
@@ -355,7 +366,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
                  { return mesh_igi[submesh_x_dof]; });
 
   // Create geometry
-  mesh::Geometry submesh_geometry(
+  Geometry submesh_geometry(
       submesh_x_dof_index_map, std::move(submesh_x_dofmap), submesh_coord_ele,
       std::move(submesh_x), mesh.geometry().dim(), std::move(submesh_igi));
 

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -8,6 +8,7 @@
 #include "Mesh.h"
 #include "Geometry.h"
 #include "Topology.h"
+#include "graphbuild.h"
 #include "topologycomputation.h"
 #include "utils.h"
 #include <dolfinx/common/IndexMap.h>
@@ -19,8 +20,7 @@
 #include <dolfinx/mesh/cell_types.h>
 #include <memory>
 #include <xtensor/xsort.hpp>
-
-#include "graphbuild.h"
+#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 using namespace dolfinx::mesh;

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -188,7 +188,7 @@ Mesh mesh::create_mesh(MPI_Comm comm,
     if (element.needs_dof_permutations())
       topology.create_entity_permutations();
 
-    return create_geometry(comm, topology, element, cell_nodes, x);
+    return create_geometry(comm, topology, element, cell_nodes, x, x.shape(1));
   };
 
   Geometry geometry = build_geometry(comm, cell_nodes, topology, element, x);

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -8,6 +8,7 @@
 #include "Mesh.h"
 #include "Geometry.h"
 #include "Topology.h"
+#include "cell_types.h"
 #include "graphbuild.h"
 #include "topologycomputation.h"
 #include "utils.h"
@@ -17,7 +18,6 @@
 #include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/graph/ordering.h>
 #include <dolfinx/graph/partition.h>
-#include <dolfinx/mesh/cell_types.h>
 #include <memory>
 #include <xtensor/xsort.hpp>
 #include <xtensor/xview.hpp>

--- a/cpp/dolfinx/mesh/Mesh.h
+++ b/cpp/dolfinx/mesh/Mesh.h
@@ -27,13 +27,6 @@ class AdjacencyList;
 
 namespace dolfinx::mesh
 {
-/// Enum for different partitioning ghost modes
-enum class GhostMode : int
-{
-  none,
-  shared_facet,
-  shared_vertex
-};
 
 /// A Mesh consists of a set of connected and numbered mesh topological
 /// entities, and geometry data

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -135,10 +135,9 @@ private:
 /// @param[in] values Tag values for each entity in @ entities. The
 /// length of @ values  must be equal to number of rows in @ entities.
 template <typename T>
-mesh::MeshTags<T>
-create_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh, int dim,
-                const graph::AdjacencyList<std::int32_t>& entities,
-                const xtl::span<const T>& values)
+MeshTags<T> create_meshtags(const std::shared_ptr<const Mesh>& mesh, int dim,
+                            const graph::AdjacencyList<std::int32_t>& entities,
+                            const xtl::span<const T>& values)
 {
   assert(mesh);
   if ((std::size_t)entities.num_nodes() != values.size())
@@ -191,7 +190,7 @@ create_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh, int dim,
 
   auto [indices_sorted, values_sorted]
       = common::sort_unique(indices_new, values_new);
-  return mesh::MeshTags<T>(mesh, dim, std::move(indices_sorted),
-                           std::move(values_sorted));
+  return MeshTags<T>(mesh, dim, std::move(indices_sorted),
+                     std::move(values_sorted));
 }
 } // namespace dolfinx::mesh

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -50,7 +50,7 @@ class Topology
 {
 public:
   /// Create empty mesh topology
-  Topology(MPI_Comm comm, mesh::CellType type);
+  Topology(MPI_Comm comm, CellType type);
 
   /// Copy constructor
   Topology(const Topology& topology) = default;
@@ -117,7 +117,7 @@ public:
 
   /// Cell type
   /// @return Cell type that the topology is for
-  mesh::CellType cell_type() const noexcept;
+  CellType cell_type() const noexcept;
 
   // TODO: Rework memory management and associated API
   // Currently, there is no clear caching policy implemented and no way of
@@ -146,7 +146,7 @@ private:
   dolfinx::MPI::Comm _comm;
 
   // Cell type
-  mesh::CellType _cell_type;
+  CellType _cell_type;
 
   // Parallel layout of entities for each dimension
   std::array<std::shared_ptr<const common::IndexMap>, 4> _index_map;
@@ -186,5 +186,5 @@ Topology
 create_topology(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
                 const xtl::span<const std::int64_t>& original_cell_index,
                 const xtl::span<const int>& ghost_owners,
-                const CellType& cell_type, mesh::GhostMode ghost_mode);
+                const CellType& cell_type, GhostMode ghost_mode);
 } // namespace dolfinx::mesh

--- a/cpp/dolfinx/mesh/cell_types.h
+++ b/cpp/dolfinx/mesh/cell_types.h
@@ -67,7 +67,7 @@ int cell_dim(CellType type);
 /// @param[in] dim Entity dimension
 /// @param[in] type Cell type
 /// @return Number of entities in cell
-int cell_num_entities(mesh::CellType type, int dim);
+int cell_num_entities(CellType type, int dim);
 
 /// Check if cell is a simplex
 /// @param[in] type Cell type
@@ -85,7 +85,7 @@ int num_cell_vertices(CellType type);
 /// attached to a cell entity. Map from entity {dim_e, entity_e} to
 /// closure{sub_dim, (sub_entities)}
 std::map<std::array<int, 2>, std::vector<std::set<int>>>
-cell_entity_closure(mesh::CellType cell_type);
+cell_entity_closure(CellType cell_type);
 
 /// Convert a cell type to a Basix cell type
 basix::cell::type cell_type_to_basix_type(CellType celltype);

--- a/cpp/dolfinx/mesh/generation.cpp
+++ b/cpp/dolfinx/mesh/generation.cpp
@@ -89,8 +89,8 @@ create_geom(MPI_Comm comm, const std::array<std::array<double, 3>, 2>& p,
 //-----------------------------------------------------------------------------
 mesh::Mesh build_tet(MPI_Comm comm,
                      const std::array<std::array<double, 3>, 2>& p,
-                     std::array<std::size_t, 3> n, mesh::GhostMode ghost_mode,
-                     const mesh::CellPartitionFunction& partitioner)
+                     std::array<std::size_t, 3> n, GhostMode ghost_mode,
+                     const CellPartitionFunction& partitioner)
 {
   common::Timer timer("Build BoxMesh");
 
@@ -135,9 +135,9 @@ mesh::Mesh build_tet(MPI_Comm comm,
     _cell.assign(c);
   }
 
-  fem::CoordinateElement element(mesh::CellType::tetrahedron, 1);
+  fem::CoordinateElement element(CellType::tetrahedron, 1);
   auto [data, offset] = graph::create_adjacency_data(cells);
-  return mesh::create_mesh(
+  return create_mesh(
       comm,
       graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
       element, geom, ghost_mode, partitioner);
@@ -145,8 +145,8 @@ mesh::Mesh build_tet(MPI_Comm comm,
 //-----------------------------------------------------------------------------
 mesh::Mesh build_hex(MPI_Comm comm,
                      const std::array<std::array<double, 3>, 2>& p,
-                     std::array<std::size_t, 3> n, mesh::GhostMode ghost_mode,
-                     const mesh::CellPartitionFunction& partitioner)
+                     std::array<std::size_t, 3> n, GhostMode ghost_mode,
+                     const CellPartitionFunction& partitioner)
 {
   xt::xtensor<double, 2> geom = create_geom(comm, p, n);
 
@@ -185,9 +185,9 @@ mesh::Mesh build_hex(MPI_Comm comm,
     _cell.assign(cell);
   }
 
-  fem::CoordinateElement element(mesh::CellType::hexahedron, 1);
+  fem::CoordinateElement element(CellType::hexahedron, 1);
   auto [data, offset] = graph::create_adjacency_data(cells);
-  return mesh::create_mesh(
+  return create_mesh(
       comm,
       graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
       element, geom, ghost_mode, partitioner);
@@ -195,8 +195,8 @@ mesh::Mesh build_hex(MPI_Comm comm,
 //-----------------------------------------------------------------------------
 mesh::Mesh build_prism(MPI_Comm comm,
                        const std::array<std::array<double, 3>, 2>& p,
-                       std::array<std::size_t, 3> n, mesh::GhostMode ghost_mode,
-                       const mesh::CellPartitionFunction& partitioner)
+                       std::array<std::size_t, 3> n, GhostMode ghost_mode,
+                       const CellPartitionFunction& partitioner)
 {
   xt::xtensor<double, 2> geom = create_geom(comm, p, n);
 
@@ -235,9 +235,9 @@ mesh::Mesh build_prism(MPI_Comm comm,
     xt::view(cells, (i - range_c[0]) * 2 + 1, xt::all()) = cell1;
   }
 
-  fem::CoordinateElement element(mesh::CellType::prism, 1);
+  fem::CoordinateElement element(CellType::prism, 1);
   auto [data, offset] = graph::create_adjacency_data(cells);
-  return mesh::create_mesh(
+  return create_mesh(
       comm,
       graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
       element, geom, ghost_mode, partitioner);
@@ -249,17 +249,17 @@ mesh::Mesh build_prism(MPI_Comm comm,
 //-----------------------------------------------------------------------------
 mesh::Mesh mesh::create_box(MPI_Comm comm,
                             const std::array<std::array<double, 3>, 2>& p,
-                            std::array<std::size_t, 3> n,
-                            mesh::CellType celltype, mesh::GhostMode ghost_mode,
-                            const mesh::CellPartitionFunction& partitioner)
+                            std::array<std::size_t, 3> n, CellType celltype,
+                            GhostMode ghost_mode,
+                            const CellPartitionFunction& partitioner)
 {
   switch (celltype)
   {
-  case mesh::CellType::tetrahedron:
+  case CellType::tetrahedron:
     return build_tet(comm, p, n, ghost_mode, partitioner);
-  case mesh::CellType::hexahedron:
+  case CellType::hexahedron:
     return build_hex(comm, p, n, ghost_mode, partitioner);
-  case mesh::CellType::prism:
+  case CellType::prism:
     return build_prism(comm, p, n, ghost_mode, partitioner);
   default:
     throw std::runtime_error("Generate box mesh. Wrong cell type");
@@ -269,10 +269,9 @@ mesh::Mesh mesh::create_box(MPI_Comm comm,
 namespace
 {
 mesh::Mesh build(MPI_Comm comm, std::size_t nx, std::array<double, 2> x,
-                 mesh::GhostMode ghost_mode,
-                 const mesh::CellPartitionFunction& partitioner)
+                 GhostMode ghost_mode, const CellPartitionFunction& partitioner)
 {
-  fem::CoordinateElement element(mesh::CellType::interval, 1);
+  fem::CoordinateElement element(CellType::interval, 1);
 
   // Receive mesh according to parallel policy
   if (dolfinx::MPI::rank(comm) != 0)
@@ -280,7 +279,7 @@ mesh::Mesh build(MPI_Comm comm, std::size_t nx, std::array<double, 2> x,
     xt::xtensor<double, 2> geom({0, 1});
     xt::xtensor<std::int64_t, 2> cells({0, 2});
     auto [data, offset] = graph::create_adjacency_data(cells);
-    return mesh::create_mesh(
+    return create_mesh(
         comm,
         graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
         element, geom, ghost_mode, partitioner);
@@ -317,7 +316,7 @@ mesh::Mesh build(MPI_Comm comm, std::size_t nx, std::array<double, 2> x,
       cells(ix, j) = ix + j;
 
   auto [data, offset] = graph::create_adjacency_data(cells);
-  return mesh::create_mesh(
+  return create_mesh(
       comm,
       graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
       element, geom, ghost_mode, partitioner);
@@ -326,9 +325,8 @@ mesh::Mesh build(MPI_Comm comm, std::size_t nx, std::array<double, 2> x,
 
 //-----------------------------------------------------------------------------
 mesh::Mesh mesh::create_interval(MPI_Comm comm, std::size_t n,
-                                 std::array<double, 2> x,
-                                 mesh::GhostMode ghost_mode,
-                                 const mesh::CellPartitionFunction& partitioner)
+                                 std::array<double, 2> x, GhostMode ghost_mode,
+                                 const CellPartitionFunction& partitioner)
 {
   return build(comm, n, x, ghost_mode, partitioner);
 }
@@ -338,11 +336,11 @@ namespace
 //-----------------------------------------------------------------------------
 mesh::Mesh build_tri(MPI_Comm comm,
                      const std::array<std::array<double, 2>, 2>& p,
-                     std::array<std::size_t, 2> n, mesh::GhostMode ghost_mode,
-                     const mesh::CellPartitionFunction& partitioner,
+                     std::array<std::size_t, 2> n, GhostMode ghost_mode,
+                     const CellPartitionFunction& partitioner,
                      DiagonalType diagonal)
 {
-  fem::CoordinateElement element(mesh::CellType::triangle, 1);
+  fem::CoordinateElement element(CellType::triangle, 1);
 
   // Receive mesh if not rank 0
   if (dolfinx::MPI::rank(comm) != 0)
@@ -350,7 +348,7 @@ mesh::Mesh build_tri(MPI_Comm comm,
     xt::xtensor<double, 2> geom({0, 2});
     xt::xtensor<std::int64_t, 2> cells({0, 3});
     auto [data, offset] = graph::create_adjacency_data(cells);
-    return mesh::create_mesh(
+    return create_mesh(
         comm,
         graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
         element, geom, ghost_mode, partitioner);
@@ -543,7 +541,7 @@ mesh::Mesh build_tri(MPI_Comm comm,
   }
 
   auto [data, offset] = graph::create_adjacency_data(cells);
-  return mesh::create_mesh(
+  return create_mesh(
       comm,
       graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
       element, geom, ghost_mode, partitioner);
@@ -552,10 +550,10 @@ mesh::Mesh build_tri(MPI_Comm comm,
 //-----------------------------------------------------------------------------
 mesh::Mesh build_quad(MPI_Comm comm,
                       const std::array<std::array<double, 2>, 2> p,
-                      std::array<std::size_t, 2> n, mesh::GhostMode ghost_mode,
-                      const mesh::CellPartitionFunction& partitioner)
+                      std::array<std::size_t, 2> n, GhostMode ghost_mode,
+                      const CellPartitionFunction& partitioner)
 {
-  fem::CoordinateElement element(mesh::CellType::quadrilateral, 1);
+  fem::CoordinateElement element(CellType::quadrilateral, 1);
 
   // Receive mesh if not rank 0
   if (dolfinx::MPI::rank(comm) != 0)
@@ -563,7 +561,7 @@ mesh::Mesh build_quad(MPI_Comm comm,
     xt::xtensor<double, 2> geom({0, 2});
     xt::xtensor<std::int64_t, 2> cells({0, 4});
     auto [data, offset] = graph::create_adjacency_data(cells);
-    return mesh::create_mesh(
+    return create_mesh(
         comm,
         graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
         element, geom, ghost_mode, partitioner);
@@ -613,7 +611,7 @@ mesh::Mesh build_quad(MPI_Comm comm,
   }
 
   auto [data, offset] = graph::create_adjacency_data(cells);
-  return mesh::create_mesh(
+  return create_mesh(
       comm,
       graph::AdjacencyList<std::int64_t>(std::move(data), std::move(offset)),
       element, geom, ghost_mode, partitioner);
@@ -624,25 +622,25 @@ mesh::Mesh build_quad(MPI_Comm comm,
 mesh::Mesh mesh::create_rectangle(MPI_Comm comm,
                                   const std::array<std::array<double, 2>, 2>& p,
                                   std::array<std::size_t, 2> n,
-                                  mesh::CellType celltype,
-                                  mesh::GhostMode ghost_mode,
-                                  mesh::DiagonalType diagonal)
+                                  CellType celltype, GhostMode ghost_mode,
+                                  DiagonalType diagonal)
 {
   return create_rectangle(comm, p, n, celltype, ghost_mode,
-                          mesh::create_cell_partitioner(), diagonal);
+                          create_cell_partitioner(), diagonal);
 }
 //-----------------------------------------------------------------------------
-mesh::Mesh mesh::create_rectangle(
-    MPI_Comm comm, const std::array<std::array<double, 2>, 2>& p,
-    std::array<std::size_t, 2> n, mesh::CellType celltype,
-    mesh::GhostMode ghost_mode, const mesh::CellPartitionFunction& partitioner,
-    mesh::DiagonalType diagonal)
+mesh::Mesh mesh::create_rectangle(MPI_Comm comm,
+                                  const std::array<std::array<double, 2>, 2>& p,
+                                  std::array<std::size_t, 2> n,
+                                  CellType celltype, GhostMode ghost_mode,
+                                  const CellPartitionFunction& partitioner,
+                                  DiagonalType diagonal)
 {
   switch (celltype)
   {
-  case mesh::CellType::triangle:
+  case CellType::triangle:
     return build_tri(comm, p, n, ghost_mode, partitioner, diagonal);
-  case mesh::CellType::quadrilateral:
+  case CellType::quadrilateral:
     return build_quad(comm, p, n, ghost_mode, partitioner);
   default:
     throw std::runtime_error("Generate rectangle mesh. Wrong cell type");

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -6,11 +6,11 @@
 
 #pragma once
 
+#include "Mesh.h"
+#include "cell_types.h"
+#include "utils.h"
 #include <array>
 #include <cstddef>
-#include <dolfinx/mesh/Mesh.h>
-#include <dolfinx/mesh/cell_types.h>
-#include <dolfinx/mesh/utils.h>
 #include <mpi.h>
 
 /// Right cuboid mesh creation
@@ -32,12 +32,11 @@ namespace dolfinx::mesh
 /// @param[in] partitioner Partitioning function to use for
 /// determining the parallel distribution of cells across MPI ranks
 /// @return Mesh
-mesh::Mesh create_box(MPI_Comm comm,
-                      const std::array<std::array<double, 3>, 2>& p,
-                      std::array<std::size_t, 3> n, mesh::CellType celltype,
-                      mesh::GhostMode ghost_mode,
-                      const mesh::CellPartitionFunction& partitioner
-                      = mesh::create_cell_partitioner());
+Mesh create_box(MPI_Comm comm, const std::array<std::array<double, 3>, 2>& p,
+                std::array<std::size_t, 3> n, CellType celltype,
+                GhostMode ghost_mode,
+                const mesh::CellPartitionFunction& partitioner
+                = create_cell_partitioner());
 
 /// Interval mesh of the 1D line `[a, b]`.  Given @p n cells in the
 /// axial direction, the total number of intervals will be `n` and the
@@ -50,10 +49,10 @@ mesh::Mesh create_box(MPI_Comm comm,
 /// @param[in] partitioner Partitioning function to use for determining
 /// the parallel distribution of cells across MPI ranks
 /// @return A mesh
-mesh::Mesh create_interval(MPI_Comm comm, std::size_t n,
-                           std::array<double, 2> x, mesh::GhostMode ghost_mode,
-                           const mesh::CellPartitionFunction& partitioner
-                           = mesh::create_cell_partitioner());
+Mesh create_interval(MPI_Comm comm, std::size_t n, std::array<double, 2> x,
+                     GhostMode ghost_mode,
+                     const CellPartitionFunction& partitioner
+                     = create_cell_partitioner());
 
 /// Enum for different diagonal types
 enum class DiagonalType
@@ -80,11 +79,11 @@ enum class DiagonalType
 /// @param[in] ghost_mode Mesh ghosting mode
 /// @param[in] diagonal Direction of diagonals
 /// @return Mesh
-mesh::Mesh create_rectangle(MPI_Comm comm,
-                            const std::array<std::array<double, 2>, 2>& p,
-                            std::array<std::size_t, 2> n,
-                            mesh::CellType celltype, mesh::GhostMode ghost_mode,
-                            DiagonalType diagonal = DiagonalType::right);
+Mesh create_rectangle(MPI_Comm comm,
+                      const std::array<std::array<double, 2>, 2>& p,
+                      std::array<std::size_t, 2> n, CellType celltype,
+                      GhostMode ghost_mode,
+                      DiagonalType diagonal = DiagonalType::right);
 
 /// Create a uniform mesh::Mesh over the rectangle spanned by the two
 /// points @p p. The order of the two points is not important in terms
@@ -102,10 +101,10 @@ mesh::Mesh create_rectangle(MPI_Comm comm,
 /// the parallel distribution of cells across MPI ranks
 /// @param[in] diagonal Direction of diagonals
 /// @return Mesh
-mesh::Mesh create_rectangle(MPI_Comm comm,
-                            const std::array<std::array<double, 2>, 2>& p,
-                            std::array<std::size_t, 2> n,
-                            mesh::CellType celltype, mesh::GhostMode ghost_mode,
-                            const mesh::CellPartitionFunction& partitioner,
-                            DiagonalType diagonal = DiagonalType::right);
+Mesh create_rectangle(MPI_Comm comm,
+                      const std::array<std::array<double, 2>, 2>& p,
+                      std::array<std::size_t, 2> n, CellType celltype,
+                      GhostMode ghost_mode,
+                      const CellPartitionFunction& partitioner,
+                      DiagonalType diagonal = DiagonalType::right);
 } // namespace dolfinx::mesh

--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "graphbuild.h"
+#include "cell_types.h"
 #include <algorithm>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/common/log.h>
 #include <dolfinx/common/sort.h>
 #include <dolfinx/graph/AdjacencyList.h>
-#include <dolfinx/mesh/cell_types.h>
 #include <utility>
 #include <vector>
 #include <xtensor/xview.hpp>
@@ -171,11 +171,15 @@ compute_nonlocal_dual_graph(
   // Get permutation that takes facets into sorted order
   std::vector<int> perm(num_facets_rcvd);
   std::iota(perm.begin(), perm.end(), 0);
-  std::sort(perm.begin(), perm.end(), [&recvd_buffer](int a, int b) {
-    return std::lexicographical_compare(
-        recvd_buffer.links(a).begin(), std::prev(recvd_buffer.links(a).end()),
-        recvd_buffer.links(b).begin(), std::prev(recvd_buffer.links(b).end()));
-  });
+  std::sort(perm.begin(), perm.end(),
+            [&recvd_buffer](int a, int b)
+            {
+              return std::lexicographical_compare(
+                  recvd_buffer.links(a).begin(),
+                  std::prev(recvd_buffer.links(a).end()),
+                  recvd_buffer.links(b).begin(),
+                  std::prev(recvd_buffer.links(b).end()));
+            });
 
   // Count data items to send to each rank
   p_count.assign(num_ranks, 0);
@@ -432,9 +436,8 @@ mesh::build_local_dual_graph(const xtl::span<const std::int64_t>& cell_vertices,
       assert(facet_vertices.size() <= std::size_t(max_num_facet_vertices));
       std::transform(facet_vertices.cbegin(), facet_vertices.cend(),
                      facet.begin(),
-                     [&cell_vertices_local, offset = cell_offsets[c]](auto fv) {
-                       return cell_vertices_local[offset + fv];
-                     });
+                     [&cell_vertices_local, offset = cell_offsets[c]](auto fv)
+                     { return cell_vertices_local[offset + fv]; });
 
       // Sort facet "indices"
       std::sort(facet.begin(), facet.end());

--- a/cpp/dolfinx/mesh/permutationcomputation.cpp
+++ b/cpp/dolfinx/mesh/permutationcomputation.cpp
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "permutationcomputation.h"
+#include "Topology.h"
+#include "cell_types.h"
 #include <algorithm>
 #include <bitset>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/graph/AdjacencyList.h>
-#include <dolfinx/mesh/Topology.h>
-#include <dolfinx/mesh/cell_types.h>
 
 namespace
 {

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -398,20 +398,19 @@ compute_entities_by_key_matching(
   common::Timer timer("Compute entities of dim = " + std::to_string(dim));
 
   // Initialize local array of entities
-  const std::int8_t num_entities_per_cell
-      = mesh::cell_num_entities(cell_type, dim);
+  const std::int8_t num_entities_per_cell = cell_num_entities(cell_type, dim);
 
   // For some cells, the num_vertices varies per facet (3 or 4)
   int max_vertices_per_entity = 0;
   for (int i = 0; i < num_entities_per_cell; ++i)
   {
-    max_vertices_per_entity = std::max(
-        max_vertices_per_entity,
-        mesh::num_cell_vertices(mesh::cell_entity_type(cell_type, dim, i)));
+    max_vertices_per_entity
+        = std::max(max_vertices_per_entity,
+                   num_cell_vertices(cell_entity_type(cell_type, dim, i)));
   }
 
   // Create map from cell vertices to entity vertices
-  auto e_vertices = mesh::get_entity_vertices(cell_type, dim);
+  auto e_vertices = get_entity_vertices(cell_type, dim);
 
   // List of vertices for each entity in each cell
   const std::size_t num_cells = cells.num_nodes();
@@ -580,9 +579,9 @@ compute_from_map(const graph::AdjacencyList<std::int32_t>& c_d0_0,
 
   // Search for edges of facet in map, and recover index
   const auto tri_vertices_ref
-      = mesh::get_entity_vertices(mesh::CellType::triangle, 1);
+      = get_entity_vertices(mesh::CellType::triangle, 1);
   const auto quad_vertices_ref
-      = mesh::get_entity_vertices(mesh::CellType::quadrilateral, 1);
+      = get_entity_vertices(mesh::CellType::quadrilateral, 1);
 
   for (int e = 0; e < c_d0_0.num_nodes(); ++e)
   {

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -6,6 +6,7 @@
 
 #include "utils.h"
 #include "Geometry.h"
+#include "Mesh.h"
 #include "cell_types.h"
 #include "graphbuild.h"
 #include <algorithm>
@@ -15,7 +16,6 @@
 #include <dolfinx/common/math.h>
 #include <dolfinx/fem/ElementDofLayout.h>
 #include <dolfinx/graph/partition.h>
-#include <dolfinx/mesh/Mesh.h>
 #include <stdexcept>
 #include <unordered_set>
 #include <xtensor/xadapt.hpp>
@@ -109,7 +109,7 @@ xt::xtensor<double, 2>
 mesh::cell_normals(const mesh::Mesh& mesh, int dim,
                    const xtl::span<const std::int32_t>& entities)
 {
-  if (mesh.topology().cell_type() == mesh::CellType::prism and dim == 2)
+  if (mesh.topology().cell_type() == CellType::prism and dim == 2)
     throw std::runtime_error("More work needed for prism cell");
 
   const int gdim = mesh.geometry().dim();
@@ -123,7 +123,7 @@ mesh::cell_normals(const mesh::Mesh& mesh, int dim,
 
   // Orient cells if they are tetrahedron
   bool orient = false;
-  if (mesh.topology().cell_type() == mesh::CellType::tetrahedron)
+  if (mesh.topology().cell_type() == CellType::tetrahedron)
     orient = true;
   xt::xtensor<std::int32_t, 2> geometry_entities
       = entities_to_geometry(mesh, dim, entities, orient);
@@ -226,7 +226,7 @@ std::vector<std::int32_t> mesh::locate_entities(
     const std::function<xt::xtensor<bool, 1>(const xt::xtensor<double, 2>&)>&
         marker)
 {
-  const mesh::Topology& topology = mesh.topology();
+  const Topology& topology = mesh.topology();
   const int tdim = topology.dim();
 
   // Create entities and connectivities
@@ -413,11 +413,8 @@ mesh::entities_to_geometry(const Mesh& mesh, int dim,
   xt::xtensor<std::int32_t, 2> entity_geometry(
       {entity_list.size(), num_entity_vertices});
 
-  if (orient
-      and (cell_type != dolfinx::mesh::CellType::tetrahedron or dim != 2))
-  {
+  if (orient and (cell_type != CellType::tetrahedron or dim != 2))
     throw std::runtime_error("Can only orient facets of a tetrahedral mesh");
-  }
 
   const Geometry& geometry = mesh.geometry();
   auto geom_dofs
@@ -535,7 +532,7 @@ mesh::create_cell_partitioner(const graph::partition_fn& partfn)
         = build_dual_graph(comm, cells, tdim);
 
     // Just flag any kind of ghosting for now
-    bool ghosting = (ghost_mode != mesh::GhostMode::none);
+    bool ghosting = (ghost_mode != GhostMode::none);
 
     // Compute partition
     return partfn(comm, nparts, dual_graph, num_ghost_edges, ghosting);

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -20,8 +20,15 @@ class ElementDofLayout;
 namespace dolfinx::mesh
 {
 enum class CellType;
-enum class GhostMode : int;
 class Mesh;
+
+/// Enum for different partitioning ghost modes
+enum class GhostMode : int
+{
+  none,
+  shared_facet,
+  shared_vertex
+};
 
 /// Signature for the cell partitioning function. The function should
 /// compute the destination rank for cells currently on this rank.

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -16,7 +16,9 @@
 #include <limits>
 #include <map>
 #include <vector>
+#include <xtensor/xadapt.hpp>
 #include <xtensor/xnorm.hpp>
+#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 using namespace dolfinx::refinement;

--- a/cpp/test/unit/io.cpp
+++ b/cpp/test/unit/io.cpp
@@ -12,6 +12,7 @@
 #include <dolfinx/mesh/generation.h>
 #include <mpi.h>
 #include <xtensor/xadapt.hpp>
+#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 

--- a/cpp/test/unit/mesh/distributed_mesh.cpp
+++ b/cpp/test/unit/mesh/distributed_mesh.cpp
@@ -92,8 +92,8 @@ void test_distributed_mesh(mesh::CellPartitionFunction partitioner)
       mpi_comm, cell_nodes, original_cell_index, ghost_owners,
       cmap.cell_shape(), mesh::GhostMode::shared_facet);
   int tdim = topology.dim();
-  dolfinx::mesh::Geometry geometry
-      = mesh::create_geometry(mpi_comm, topology, cmap, cell_nodes, x);
+  dolfinx::mesh::Geometry geometry = mesh::create_geometry(
+      mpi_comm, topology, cmap, cell_nodes, x, x.shape(1));
 
   auto mesh = std::make_shared<dolfinx::mesh::Mesh>(
       mpi_comm, std::move(topology), std::move(geometry));


### PR DESCRIPTION
Also removes some xtensor views and introduces some memory scoping in the mesh construction to reduce peak memory usage.