### PR TITLE
Extend pyvista plotting to higher order meshes.

### DIFF
--- a/python/dolfinx/plot.py
+++ b/python/dolfinx/plot.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Jørgen S. Dokken and Garth N. Wells
+# Copyright (C) 2021-2022 Jørgen S. Dokken and Garth N. Wells
 #
 # This file is part of DOLFINx (https://www.fenicsproject.org)
 #
@@ -12,64 +12,65 @@ import numpy as np
 
 from dolfinx import cpp as _cpp
 from dolfinx import fem
-from dolfinx import mesh as _mesh
+from dolfinx import mesh
 
-# NOTE: This dictionary and following function should be revised when
-# pyvista has better support for arbitrary lagrangian elements, see:
-# https://github.com/pyvista/pyvista/issues/947
+# NOTE: This dictionary and the below function that uses it should be
+# revised when pyvista improves rendering of 'arbitrary' Lagrange
+# elements, i.e. for the VTK cell types that define a shape but allow
+# arbitrary degree geometry. See
+# https://github.com/pyvista/pyvista/issues/947.
+#
 # Cell types can be found at
 # https://vtk.org/doc/nightly/html/vtkCellType_8h_source.html
-_first_order_vtk = {_mesh.CellType.interval: 3,
-                    _mesh.CellType.triangle: 5,
-                    _mesh.CellType.quadrilateral: 9,
-                    _mesh.CellType.tetrahedron: 10,
-                    _mesh.CellType.hexahedron: 12}
+_first_order_vtk = {mesh.CellType.interval: 3,
+                    mesh.CellType.triangle: 5,
+                    mesh.CellType.quadrilateral: 9,
+                    mesh.CellType.tetrahedron: 10,
+                    mesh.CellType.hexahedron: 12}
 
 
 @functools.singledispatch
-def create_vtk_mesh(mesh: _mesh.Mesh, dim: int, entities=None):
+def create_vtk_mesh(msh: mesh.Mesh, dim: int, entities=None):
     """Create vtk mesh topology data for mesh entities of a given
     dimension. The vertex indices in the returned topology array are the
     indices for the associated entry in the mesh geometry.
 
     """
-    cell_type = mesh.topology.cell_type
-    degree = mesh.geometry.cmap.degree
-    if cell_type == _mesh.CellType.prism:
+    tdim = msh.topology.dim
+    cell_type = msh.topology.cell_type
+    degree = msh.geometry.cmap.degree
+    if cell_type == mesh.CellType.prism:
         raise RuntimeError("Plotting of prism meshes not supported")
 
-    # Use all cells local to process if not supplied
+    # Use all local cells if not supplied
     if entities is None:
-        num_cells = mesh.topology.index_map(dim).size_local
-        entities = np.arange(num_cells, dtype=np.int32)
-    else:
-        num_cells = len(entities)
+        entities = range(msh.topology.index_map(dim).size_local)
 
-    if dim == mesh.topology.dim:
-        vtk_topology = _cpp.io.extract_vtk_connectivity(mesh)[entities]
+    if dim == tdim:
+        vtk_topology = _cpp.io.extract_vtk_connectivity(msh)[entities]
         num_nodes_per_cell = vtk_topology.shape[1]
     else:
         # NOTE: This linearizes higher order geometries
-        geometry_entities = _cpp.mesh.entities_to_geometry(mesh, dim, entities, False)
+        geometry_entities = _cpp.mesh.entities_to_geometry(msh, dim, entities, False)
         if degree > 1:
             warnings.warn("Linearizing topology for higher order sub entities.")
-        e_type = _cpp.mesh.cell_entity_type(cell_type, dim, 0)
 
         # Get cell data and the DOLFINx -> VTK permutation array
         num_nodes_per_cell = geometry_entities.shape[1]
-        map_vtk = np.argsort(_cpp.io.perm_vtk(e_type, num_nodes_per_cell))
+        map_vtk = np.argsort(_cpp.io.perm_vtk(_cpp.mesh.cell_entity_type(cell_type, dim, 0),
+                                              num_nodes_per_cell))
         vtk_topology = geometry_entities[:, map_vtk]
 
     # Create mesh topology
-    topology = np.empty((num_cells, num_nodes_per_cell + 1), dtype=np.int32)
+    topology = np.empty((len(entities), num_nodes_per_cell + 1), dtype=np.int32)
     topology[:, 0] = num_nodes_per_cell
     topology[:, 1:] = vtk_topology
 
     # Array holding the cell type (shape) for each cell
-    vtk_type = _first_order_vtk[cell_type] if degree == 1 else _cpp.io.get_vtk_cell_type(cell_type, mesh.topology.dim)
-    cell_types = np.full(num_cells, vtk_type)
+    vtk_type = _first_order_vtk[cell_type] if degree == 1 else _cpp.io.get_vtk_cell_type(cell_type, tdim)
+    cell_types = np.full(len(entities), vtk_type)
 
-    return topology.reshape(-1), cell_types, mesh.geometry.x
+    return topology.reshape(-1), cell_types, msh.geometry.x
 
 
 @create_vtk_mesh.register(fem.FunctionSpace)
@@ -80,33 +81,30 @@ def _(V: fem.FunctionSpace, entities=None):
     discontinuous) only.
 
     """
-    family = V.ufl_element().family()
+    if not (V.ufl_element().family() in ['Discontinuous Lagrange', "Lagrange", "DQ", "Q"]):
+        raise RuntimeError("Can only create meshes from continuous or discontinuous Lagrange spaces")
+
     degree = V.ufl_element().degree()
-    if not (family in ['Discontinuous Lagrange', "Lagrange", "DQ", "Q"]):
-        raise RuntimeError("Can only create meshes from Continuous or Discontinuous function-spaces")
     if degree == 0:
         raise RuntimeError("Cannot create topology from cellwise constants.")
-    elif degree > 1:
-        warnings.warn("Plotting of higher order Lagrange functions are experimental.")
 
-    mesh = V.mesh
+    # Use all local cells if not supplied
+    msh = V.mesh
+    tdim = msh.topology.dim
     if entities is None:
-        num_cells = mesh.topology.index_map(mesh.topology.dim).size_local
-        entities = np.arange(num_cells, dtype=np.int32)
-    else:
-        num_cells = entities.size
+        entities = range(msh.topology.index_map(tdim).size_local)
 
     dofmap = V.dofmap
     num_dofs_per_cell = V.dofmap.dof_layout.num_dofs
-    cell_type = mesh.topology.cell_type
+    cell_type = msh.topology.cell_type
     perm = np.argsort(_cpp.io.perm_vtk(cell_type, num_dofs_per_cell))
 
-    vtk_type = _first_order_vtk[cell_type] if degree == 1 else _cpp.io.get_vtk_cell_type(cell_type, mesh.topology.dim)
-    cell_types = np.full(num_cells, vtk_type)
+    vtk_type = _first_order_vtk[cell_type] if degree == 1 else _cpp.io.get_vtk_cell_type(cell_type, tdim)
+    cell_types = np.full(len(entities), vtk_type)
 
-    topology = np.zeros((num_cells, num_dofs_per_cell + 1), dtype=np.int32)
+    topology = np.zeros((len(entities), num_dofs_per_cell + 1), dtype=np.int32)
     topology[:, 0] = num_dofs_per_cell
     dofmap_ = dofmap.list.array.reshape(dofmap.list.num_nodes, num_dofs_per_cell)
 
-    topology[:, 1:] = dofmap_[:num_cells, perm]
+    topology[:, 1:] = dofmap_[:len(entities), perm]
     return topology.reshape(1, -1)[0], cell_types, V.tabulate_dof_coordinates()

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -36,15 +36,20 @@ namespace dolfinx_wrappers
 void io(py::module& m)
 {
   // dolfinx::io::cell vtk cell type converter
-  m.def("get_vtk_cell_type", &dolfinx::io::cells::get_vtk_cell_type);
+  m.def("get_vtk_cell_type", &dolfinx::io::cells::get_vtk_cell_type,
+        "Get VTK cell identifier");
 
-  // dolfinx::io VTK mesh topology converter
-  m.def("extract_vtk_connectivity", [](const dolfinx::mesh::Mesh& mesh)
-        { return xt_as_pyarray(dolfinx::io::extract_vtk_connectivity(mesh)); });
+  m.def(
+      "extract_vtk_connectivity",
+      [](const dolfinx::mesh::Mesh& mesh)
+      { return xt_as_pyarray(dolfinx::io::extract_vtk_connectivity(mesh)); },
+      "Extract the mesh topology with VTK ordering using geometry indices");
 
   // dolfinx::io::cell permutation functions
-  m.def("perm_vtk", &dolfinx::io::cells::perm_vtk);
-  m.def("perm_gmsh", &dolfinx::io::cells::perm_gmsh);
+  m.def("perm_vtk", &dolfinx::io::cells::perm_vtk,
+        "Permutation array to map from VTK to DOLFINx node ordering");
+  m.def("perm_gmsh", &dolfinx::io::cells::perm_gmsh,
+        "Permutation array to map from Gmsh to DOLFINx node ordering");
 
   // TODO: Template for different values dtypes
   m.def(

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -14,6 +14,7 @@
 #include <dolfinx/io/VTKFile.h>
 #include <dolfinx/io/XDMFFile.h>
 #include <dolfinx/io/cells.h>
+#include <dolfinx/io/vtk_utils.h>
 #include <dolfinx/io/xdmf_utils.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/MeshTags.h>
@@ -36,6 +37,10 @@ void io(py::module& m)
 {
   // dolfinx::io::cell vtk cell type converter
   m.def("get_vtk_cell_type", &dolfinx::io::cells::get_vtk_cell_type);
+
+  // dolfinx::io VTK mesh topology converter
+  m.def("extract_vtk_connectivity", [](const dolfinx::mesh::Mesh& mesh)
+        { return xt_as_pyarray(dolfinx::io::extract_vtk_connectivity(mesh)); });
 
   // dolfinx::io::cell permutation functions
   m.def("perm_vtk", &dolfinx::io::cells::perm_vtk);


### PR DESCRIPTION
Reuse some functionality from #1990 to properly plot higher order meshes with Pyvista.

Plotting of sub entities (edges, facets) are linearised based on the topology.