### PR TITLE
Add dtype to constant to avoid importing petsc in demos

### DIFF
--- a/python/demo/stokes-taylor-hood/demo_stokes-taylor-hood.py
+++ b/python/demo/stokes-taylor-hood/demo_stokes-taylor-hood.py
@@ -146,11 +146,11 @@ bcs = [bc0, bc1]
 # Define variational problem
 (u, p) = ufl.TrialFunction(V), ufl.TrialFunction(Q)
 (v, q) = ufl.TestFunction(V), ufl.TestFunction(Q)
-f = Constant(mesh, (PETSc.ScalarType(0), PETSc.ScalarType(0)))
+f = Constant(mesh, (0, 0))
 
 a = form([[inner(grad(u), grad(v)) * dx, inner(p, div(v)) * dx],
           [inner(div(u), q) * dx, None]])
-L = form([inner(f, v) * dx, inner(Constant(mesh, PETSc.ScalarType(0)), q) * dx])
+L = form([inner(f, v) * dx, inner(Constant(mesh, 0), q) * dx])
 
 # We will use a block-diagonal preconditioner to solve this problem::
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -28,7 +28,8 @@ from petsc4py import PETSc
 
 
 class Constant(ufl.Constant):
-    def __init__(self, domain, c: typing.Union[np.ndarray, typing.Sequence, float]):
+    def __init__(self, domain, c: typing.Union[np.ndarray, typing.Sequence, float],
+                 dtype=PETSc.ScalarType):
         """A constant with respect to a domain.
 
         Parameters
@@ -37,7 +38,7 @@ class Constant(ufl.Constant):
         c
             Value of the constant.
         """
-        c_np = np.asarray(c)
+        c_np = np.asarray(c, dtype=dtype)
         super().__init__(domain, c_np.shape)
         if c_np.dtype == np.complex64:
             self._cpp_object = _cpp.fem.Constant_complex64(c_np)

--- a/python/test/unit/fem/test_assemble_domains.py
+++ b/python/test/unit/fem/test_assemble_domains.py
@@ -174,7 +174,7 @@ def test_assembly_ds_domains(mode):
 def test_assembly_dS_domains(mode):
     N = 10
     mesh = create_unit_square(MPI.COMM_WORLD, N, N, ghost_mode=mode)
-    one = Constant(mesh, PETSc.ScalarType(1))
+    one = Constant(mesh, 1)
     val = assemble_scalar(form(one * ufl.dS))
     val = mesh.comm.allreduce(val, op=MPI.SUM)
     assert val == pytest.approx(2 * (N - 1) + N * np.sqrt(2), 1.0e-7)

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -80,8 +80,8 @@ def test_assemble_derivatives():
     v = ufl.TestFunction(Q)
     du = ufl.TrialFunction(Q)
     b = Function(Q)
-    c1 = Constant(mesh, np.array([[1.0, 0.0], [3.0, 4.0]], PETSc.ScalarType))
-    c2 = Constant(mesh, PETSc.ScalarType(2.0))
+    c1 = Constant(mesh, np.array([[1.0, 0.0], [3.0, 4.0]]))
+    c2 = Constant(mesh, 2.0)
 
     b.x.array[:] = 2.0
 
@@ -635,7 +635,7 @@ def test_basic_assembly_constant(mode):
     V = FunctionSpace(mesh, ("Lagrange", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
 
-    c = Constant(mesh, np.array([[1.0, 2.0], [5.0, 3.0]], PETSc.ScalarType))
+    c = Constant(mesh, np.array([[1.0, 2.0], [5.0, 3.0]]))
 
     a = inner(c[1, 0] * u, v) * dx + inner(c[1, 0] * u, v) * ds
     L = inner(c[1, 0], v) * dx + inner(c[1, 0], v) * ds
@@ -699,7 +699,7 @@ def test_pack_coefficients():
     # Non-blocked
     u = Function(V)
     v = ufl.TestFunction(V)
-    c = Constant(mesh, PETSc.ScalarType(12.0))
+    c = Constant(mesh, 12.0)
     F = ufl.inner(c, v) * dx - c * ufl.sqrt(u * u) * ufl.inner(u, v) * dx
     u.x.array[:] = 10.0
     _F = form(F)
@@ -799,7 +799,7 @@ def test_vector_types():
     V = FunctionSpace(mesh, ("Lagrange", 3))
     v = ufl.TestFunction(V)
 
-    c = Constant(mesh, np.float64(1))
+    c = Constant(mesh, 1, dtype=np.float64)
     L = inner(c, v) * ufl.dx
     x0 = _cpp.la.Vector_float64(V.dofmap.index_map, V.dofmap.index_map_bs)
     L = form(L, dtype=x0.array.dtype)
@@ -808,7 +808,7 @@ def test_vector_types():
     _cpp.fem.assemble_vector(x0.array, L, c0, c1)
     x0.scatter_reverse(_cpp.common.ScatterMode.add)
 
-    c = Constant(mesh, np.complex128(1))
+    c = Constant(mesh, 1, dtype=np.complex128)
     L = inner(c, v) * ufl.dx
     x1 = _cpp.la.Vector_complex128(V.dofmap.index_map, V.dofmap.index_map_bs)
     L = form(L, dtype=x1.array.dtype)
@@ -817,7 +817,7 @@ def test_vector_types():
     _cpp.fem.assemble_vector(x1.array, L, c0, c1)
     x1.scatter_reverse(_cpp.common.ScatterMode.add)
 
-    c = Constant(mesh, np.float32(1))
+    c = Constant(mesh, 1, dtype=np.float32)
     L = inner(c, v) * ufl.dx
     x2 = _cpp.la.Vector_float32(V.dofmap.index_map, V.dofmap.index_map_bs)
     L = form(L, dtype=x2.array.dtype)

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -185,7 +185,7 @@ def test_sub_constant_bc(mesh_factory):
     mesh = func(*args)
     tdim = mesh.topology.dim
     V = VectorFunctionSpace(mesh, ("Lagrange", 1))
-    c = Constant(mesh, PETSc.ScalarType(3.14))
+    c = Constant(mesh, 3.14)
     boundary_facets = locate_entities_boundary(mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool))
 
     for i in range(V.num_sub_spaces):
@@ -225,7 +225,7 @@ def test_mixed_constant_bc(mesh_factory):
     U = Function(W)
 
     # Apply BC to component of a mixed space using a Constant
-    c = Constant(mesh, (PETSc.ScalarType(2), PETSc.ScalarType(2)))
+    c = Constant(mesh, (2, 2))
     dofs0 = locate_dofs_topological(W.sub(0), tdim - 1, boundary_facets)
     bc0 = dirichletbc(c, dofs0, W.sub(0))
     u = U.sub(0)

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -19,7 +19,6 @@ from dolfinx.fem import (Constant, Function, FunctionSpace,
 from dolfinx.mesh import CellType, MeshTags, create_mesh
 
 from mpi4py import MPI
-from petsc4py import PETSc
 
 parametrize_cell_types = pytest.mark.parametrize(
     "cell_type",
@@ -503,7 +502,7 @@ def assemble_div_vector(k, offset):
     mesh = create_quad_mesh(offset)
     V = FunctionSpace(mesh, ("RTCF", k + 1))
     v = ufl.TestFunction(V)
-    L = form(ufl.inner(Constant(mesh, PETSc.ScalarType(1)), ufl.div(v)) * ufl.dx)
+    L = form(ufl.inner(Constant(mesh, 1), ufl.div(v)) * ufl.dx)
     b = assemble_vector(L)
     return b[:]
 

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -233,7 +233,7 @@ def test_simple_evaluation():
     expr = Function(P2)
     expr.interpolate(exact_expr)
 
-    ufl_grad_f = Constant(mesh, PETSc.ScalarType(3.0)) * ufl.grad(expr)
+    ufl_grad_f = Constant(mesh, 3.0) * ufl.grad(expr)
     points = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
     grad_f_expr = Expression(ufl_grad_f, points)
     assert grad_f_expr.X.shape[0] == points.shape[0]
@@ -299,8 +299,8 @@ def test_assembly_into_quadrature_function():
 
     T = Function(P2)
     T.interpolate(lambda x: x[0] + 2.0 * x[1])
-    A = Constant(mesh, PETSc.ScalarType(1.0))
-    B = Constant(mesh, PETSc.ScalarType(2.0))
+    A = Constant(mesh, 1.0)
+    B = Constant(mesh, 2.0)
 
     K = 1.0 / (A + B * T)
     e = B * K**2 * ufl.grad(T)

--- a/python/test/unit/fem/test_special_functions.py
+++ b/python/test/unit/fem/test_special_functions.py
@@ -14,7 +14,6 @@ from dolfinx.mesh import (create_unit_cube, create_unit_interval,
                           create_unit_square)
 
 from mpi4py import MPI
-from petsc4py.PETSc import ScalarType
 
 
 def test_facet_area1D():
@@ -22,7 +21,7 @@ def test_facet_area1D():
 
     # NOTE: Area of a vertex is defined to 1 in ufl
     c0 = ufl.FacetArea(mesh)
-    c = Constant(mesh, ScalarType(1))
+    c = Constant(mesh, 1)
 
     ds = ufl.Measure("ds", domain=mesh)
     a0 = mesh.comm.allreduce(assemble_scalar(form(c * ds)), op=MPI.SUM)
@@ -46,7 +45,7 @@ def test_facet_area(mesh_factory):
     func, args, exact_area = mesh_factory
     mesh = func(*args)
     c0 = ufl.FacetArea(mesh)
-    c = Constant(mesh, ScalarType(1))
+    c = Constant(mesh, 1)
     tdim = mesh.topology.dim
     num_faces = 4 if tdim == 2 else 6
 


### PR DESCRIPTION
Similar to function, make it possible to specify dtype through constant construction.
Defaults to `PETSc.ScalarType` as Function and Expression.
This cleans up the user-API for most use-cases, and avoids errors when specifying constants such as `dolfinx.fem.Constant(mesh, 1)`.