### PR TITLE
Correct offset to avoid out-of-bounds array access

### DIFF
--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -491,9 +491,10 @@ void _lift_bc_interior_facets(
       for (int k = 0; k < bs0; ++k)
         b[bs0 * dmap0_cell0[i] + k] += be[bs0 * i + k];
 
+    const int offset_be = bs0 * dmap0_cell0.size();
     for (std::size_t i = 0; i < dmap0_cell1.size(); ++i)
       for (int k = 0; k < bs0; ++k)
-        b[bs0 * dmap0_cell1[i] + k] += be[offset + bs0 * i + k];
+        b[bs0 * dmap0_cell1[i] + k] += be[offset_be + bs0 * i + k];
   }
 }
 /// Execute kernel over cells and accumulate result in vector


### PR DESCRIPTION
Certain mixed formulations evaluate interior facet integrals with different function spaces being involved.

This PR fixes the offset used to access the element vector `be` such that out-of-bounds array access is avoided in the above scenario.