### PR TITLE
Neigh comm with null_ptr needs 0 as input size

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -311,9 +311,9 @@ common::stack_index_maps(
   // Figure out how much data to receive from each neighbor
   const int num_my_rows = indices.size();
   std::vector<int> num_rows_recv(indegree);
-  const int num_recv = (indegree > 0) ? 1 : 0;
+  const int recvcount = num_rows_recv.empty() ? 0 : 1;
   MPI_Neighbor_allgather(&num_my_rows, 1, MPI_INT, num_rows_recv.data(),
-                         num_recv, MPI_INT, comm);
+                         recvcount, MPI_INT, comm);
 
   // Compute displacements for data to receive
   std::vector<int> disp(indegree + 1, 0);

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -309,8 +309,9 @@ common::stack_index_maps(
   // Figure out how much data to receive from each neighbor
   const int num_my_rows = indices.size();
   std::vector<int> num_rows_recv(indegree);
-  MPI_Neighbor_allgather(&num_my_rows, 1, MPI_INT, num_rows_recv.data(), 1,
-                         MPI_INT, comm);
+  const int num_recv = (indegree > 0) ? 1 : 0;
+  MPI_Neighbor_allgather(&num_my_rows, 1, MPI_INT, num_rows_recv.data(),
+                         num_recv, MPI_INT, comm);
 
   // Compute displacements for data to receive
   std::vector<int> disp(indegree + 1, 0);
@@ -707,10 +708,11 @@ std::map<std::int32_t, std::set<int>> IndexMap::compute_shared_indices() const
   // Send data size to send, and get to-receive sizes
   std::vector<int> send_sizes(outdegree, 0);
   std::vector<int> recv_sizes(indegree);
+  const int num_recv = (indegree > 0) ? 1 : 0;
   std::adjacent_difference(fwd_sharing_offsets.begin() + 1,
                            fwd_sharing_offsets.end(), send_sizes.begin());
-  MPI_Neighbor_alltoall(send_sizes.data(), 1, MPI_INT, recv_sizes.data(), 1,
-                        MPI_INT, _comm_owner_to_ghost.comm());
+  MPI_Neighbor_alltoall(send_sizes.data(), 1, MPI_INT, recv_sizes.data(),
+                        num_recv, MPI_INT, _comm_owner_to_ghost.comm());
 
   // Work out recv offsets and send/receive
   std::vector<int> recv_offsets(recv_sizes.size() + 1, 0);

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -234,8 +234,9 @@ neighbor_all_to_all(MPI_Comm neighbor_comm,
   std::adjacent_difference(std::next(send_data.offsets().begin()),
                            send_data.offsets().end(), send_sizes.begin());
   // Get receive sizes
+  const int num_recv = (indegree > 0) : 1 ? 0;
   MPI_Neighbor_alltoall(send_sizes.data(), 1, MPI::mpi_type<int>(),
-                        recv_sizes.data(), 1, MPI::mpi_type<int>(),
+                        recv_sizes.data(), num_recv, MPI::mpi_type<int>(),
                         neighbor_comm);
 
   // Work out recv offsets. Note use of std::prev to handle OpenMPI

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -234,9 +234,10 @@ neighbor_all_to_all(MPI_Comm neighbor_comm,
   std::adjacent_difference(std::next(send_data.offsets().begin()),
                            send_data.offsets().end(), send_sizes.begin());
   // Get receive sizes
-  const int num_recv = (indegree > 0) ? 1 : 0;
-  MPI_Neighbor_alltoall(send_sizes.data(), 1, MPI::mpi_type<int>(),
-                        recv_sizes.data(), num_recv, MPI::mpi_type<int>(),
+  const int sendcount = send_sizes.empty() ? 0 : 1;
+  const int recvcount = recv_sizes.empty() ? 0 : 1;
+  MPI_Neighbor_alltoall(send_sizes.data(), sendcount, MPI::mpi_type<int>(),
+                        recv_sizes.data(), recvcount, MPI::mpi_type<int>(),
                         neighbor_comm);
 
   // Work out recv offsets. Note use of std::prev to handle OpenMPI

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -234,7 +234,7 @@ neighbor_all_to_all(MPI_Comm neighbor_comm,
   std::adjacent_difference(std::next(send_data.offsets().begin()),
                            send_data.offsets().end(), send_sizes.begin());
   // Get receive sizes
-  const int num_recv = (indegree > 0) : 1 ? 0;
+  const int num_recv = (indegree > 0) ? 1 : 0;
   MPI_Neighbor_alltoall(send_sizes.data(), 1, MPI::mpi_type<int>(),
                         recv_sizes.data(), num_recv, MPI::mpi_type<int>(),
                         neighbor_comm);

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -439,11 +439,9 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
       // Number and values to send and receive
       const int num_indices = global[d].size();
       std::vector<int> size_recv(indegree);
-      // Note: add 1 for OpenMPI bug when indegree = 0
-      if (size_recv.empty())
-        size_recv.push_back(0);
-      MPI_Neighbor_allgather(&num_indices, 1, MPI_INT, size_recv.data(), 1,
-                             MPI_INT, comm[d]);
+      const int num_recv = (indegree > 0) ? 1 : 0;
+      MPI_Neighbor_allgather(&num_indices, 1, MPI_INT, size_recv.data(),
+                             num_recv, MPI_INT, comm[d]);
 
       // Compute displacements for data to receive. Last entry has total
       // number of received items.

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -439,9 +439,9 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
       // Number and values to send and receive
       const int num_indices = global[d].size();
       std::vector<int> size_recv(indegree);
-      const int num_recv = (indegree > 0) ? 1 : 0;
+      const int recvcount = size_recv.empty() ? 0 : 1;
       MPI_Neighbor_allgather(&num_indices, 1, MPI_INT, size_recv.data(),
-                             num_recv, MPI_INT, comm[d]);
+                             recvcount, MPI_INT, comm[d]);
 
       // Compute displacements for data to receive. Last entry has total
       // number of received items.

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -243,7 +243,7 @@ std::vector<std::int64_t> graph::build::compute_ghost_indices(
   }
 
   std::vector<int> recv_sizes(neighbors.size());
-  const int num_recv = (recv_sizes.size() > 0) ? 1 ? 0;
+  const int num_recv = (recv_sizes.size() > 0) ? 1 : 0;
   MPI_Neighbor_alltoall(ghost_index_count.data(), 1, MPI_INT, recv_sizes.data(),
                         num_recv, MPI_INT, neighbor_comm);
   std::vector<int> recv_offsets = {0};

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -243,9 +243,10 @@ std::vector<std::int64_t> graph::build::compute_ghost_indices(
   }
 
   std::vector<int> recv_sizes(neighbors.size());
-  const int num_recv = (recv_sizes.size() > 0) ? 1 : 0;
-  MPI_Neighbor_alltoall(ghost_index_count.data(), 1, MPI_INT, recv_sizes.data(),
-                        num_recv, MPI_INT, neighbor_comm);
+  const int sendcount = ghost_index_count.empty() ? 0 : 1;
+  const int recvcount = recv_sizes.empty() ? 0 : 1;
+  MPI_Neighbor_alltoall(ghost_index_count.data(), sendcount, MPI_INT,
+                        recv_sizes.data(), recvcount, MPI_INT, neighbor_comm);
   std::vector<int> recv_offsets = {0};
   for (int q : recv_sizes)
     recv_offsets.push_back(recv_offsets.back() + q);

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -243,8 +243,9 @@ std::vector<std::int64_t> graph::build::compute_ghost_indices(
   }
 
   std::vector<int> recv_sizes(neighbors.size());
+  const int num_recv = (recv_sizes.size() > 0) ? 1 ? 0;
   MPI_Neighbor_alltoall(ghost_index_count.data(), 1, MPI_INT, recv_sizes.data(),
-                        1, MPI_INT, neighbor_comm);
+                        num_recv, MPI_INT, neighbor_comm);
   std::vector<int> recv_offsets = {0};
   for (int q : recv_sizes)
     recv_offsets.push_back(recv_offsets.back() + q);


### PR DESCRIPTION
Causes segfault with MPICH 4.0.
Has also been an issue with OPENMPI for a longer time.