### PR TITLE
Return interprocess boundary vertices from non-local dual graph computation

### DIFF
--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -522,7 +522,8 @@ mesh::build_local_dual_graph(const xtl::span<const std::int64_t>& cell_vertices,
           std::move(unmatched_facet_data)};
 }
 //-----------------------------------------------------------------------------
-std::pair<graph::AdjacencyList<std::int64_t>, std::int32_t>
+std::tuple<graph::AdjacencyList<std::int64_t>, std::int32_t,
+           std::vector<std::int64_t>>
 mesh::build_dual_graph(const MPI_Comm comm,
                        const graph::AdjacencyList<std::int64_t>& cells,
                        int tdim)
@@ -543,6 +544,6 @@ mesh::build_dual_graph(const MPI_Comm comm,
             << ", non-local:"
             << graph.offsets().back() - local_graph.offsets().back() << ")";
 
-  return {std::move(graph), num_ghost_edges};
+  return {std::move(graph), num_ghost_edges, std::move(boundary_vertices)};
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/mesh/graphbuild.h
+++ b/cpp/dolfinx/mesh/graphbuild.h
@@ -42,9 +42,10 @@ build_local_dual_graph(const xtl::span<const std::int64_t>& cells,
 /// @param[in] cells Collection of cells, defined by the cell vertices
 /// from which to build the dual graph
 /// @param[in] tdim The topological dimension of the cells
-/// @return The (0) dual graph and (1) number of  ghost edges
+/// @return The (0) dual graph, (1) number of  ghost edges, and (2)
+/// the inter-process boundary vertices
 /// @note Collective function
-std::pair<graph::AdjacencyList<std::int64_t>, std::int32_t>
+std::tuple<graph::AdjacencyList<std::int64_t>, std::int32_t, std::vector<std::int64_t>>
 build_dual_graph(const MPI_Comm comm,
                  const graph::AdjacencyList<std::int64_t>& cells, int tdim);
 

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -528,7 +528,7 @@ mesh::create_cell_partitioner(const graph::partition_fn& partfn)
     LOG(INFO) << "Compute partition of cells across ranks";
 
     // Compute distributed dual graph (for the cells on this process)
-    const auto [dual_graph, num_ghost_edges]
+    const auto [dual_graph, num_ghost_edges, boundary_vertices]
         = build_dual_graph(comm, cells, tdim);
 
     // Just flag any kind of ghosting for now

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -311,7 +311,8 @@ refinement::partition(const mesh::Mesh& old_mesh,
                         mesh::GhostMode)
   {
     // Find out the ghosting information
-    auto [graph, _] = mesh::build_dual_graph(comm, cell_topology, tdim);
+    auto [graph, num_ghosts_edges, boundary_vertices] =
+      mesh::build_dual_graph(comm, cell_topology, tdim);
 
     // FIXME: much of this is reverse engineering of data that is already
     // known in the GraphBuilder


### PR DESCRIPTION
* Reduces code in non-local dual graph
* Returns additional data: list of vertices which lie on the inter-process boundary

This PR is a step towards a new strategy for computing the vertex IndexMap (i.e. vertex ownership and sharing)