### PR TITLE
Sandbox PETSc-dependent NewtonSolver class in `nls::petsc` namespace

### DIFF
--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -14,11 +14,6 @@
 #include <xtensor/xview.hpp>
 
 using namespace dolfinx;
-
-// Next:
-//
-// .. code-block:: cpp
-
 using T = PetscScalar;
 
 class HyperElasticProblem
@@ -150,7 +145,7 @@ int main(int argc, char* argv[])
 
     auto u_rotation = std::make_shared<fem::Function<T>>(V);
     u_rotation->interpolate(
-        [](auto& x)
+        [](auto&& x)
         {
           constexpr double scale = 0.005;
 
@@ -177,12 +172,12 @@ int main(int argc, char* argv[])
     // Create Dirichlet boundary conditions
     auto bdofs_left
         = fem::locate_dofs_geometrical({*V},
-                                       [](auto& x) -> xt::xtensor<bool, 1> {
+                                       [](auto&& x) -> xt::xtensor<bool, 1> {
                                          return xt::isclose(xt::row(x, 0), 0.0);
                                        });
     auto bdofs_right
         = fem::locate_dofs_geometrical({*V},
-                                       [](auto& x) -> xt::xtensor<bool, 1> {
+                                       [](auto&& x) -> xt::xtensor<bool, 1> {
                                          return xt::isclose(xt::row(x, 0), 1.0);
                                        });
     auto bcs = std::vector{

--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -190,7 +190,7 @@ int main(int argc, char* argv[])
         std::make_shared<const fem::DirichletBC<T>>(u_rotation, bdofs_right)};
 
     HyperElasticProblem problem(L, a, bcs);
-    nls::NewtonSolver newton_solver(mesh->comm());
+    nls:petsc::NewtonSolver newton_solver(mesh->comm());
     newton_solver.setF(problem.F(), problem.vector());
     newton_solver.setJ(problem.J(), problem.matrix());
     newton_solver.set_form(problem.form());

--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -9,6 +9,7 @@
 #include <dolfinx/la/Vector.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/cell_types.h>
+#include <dolfinx/nls/NewtonSolver.h>
 #include <xtensor/xarray.hpp>
 #include <xtensor/xview.hpp>
 
@@ -190,7 +191,7 @@ int main(int argc, char* argv[])
         std::make_shared<const fem::DirichletBC<T>>(u_rotation, bdofs_right)};
 
     HyperElasticProblem problem(L, a, bcs);
-    nls:petsc::NewtonSolver newton_solver(mesh->comm());
+    nls::petsc::NewtonSolver newton_solver(mesh->comm());
     newton_solver.setF(problem.F(), problem.vector());
     newton_solver.setJ(problem.J(), problem.matrix());
     newton_solver.set_form(problem.form());

--- a/cpp/demo/interpolation-io/main.cpp
+++ b/cpp/demo/interpolation-io/main.cpp
@@ -42,7 +42,7 @@ void interpolate_scalar(const std::shared_ptr<mesh::Mesh>& mesh,
   // Interpolate sin(2 \pi x[0]) in the scalar Lagrange finite element
   // space
   constexpr double PI = xt::numeric_constants<double>::PI;
-  u->interpolate([PI](auto& x) { return xt::sin(2 * PI * xt::row(x, 0)); });
+  u->interpolate([PI](auto&& x) { return xt::sin(2 * PI * xt::row(x, 0)); });
 
   // Write the function to a VTK file for visualisation, e.g. using
   // ParaView
@@ -80,16 +80,16 @@ void interpolate_nedelec(const std::shared_ptr<mesh::Mesh>& mesh,
 
   // Find cells with all vertices satisfying (0) x0 <= 0.5 and (1) x0 >= 0.5
   auto cells0 = mesh::locate_entities(
-      *mesh, 2, [](auto& x) { return xt::row(x, 0) <= 0.5; });
+      *mesh, 2, [](auto&& x) { return xt::row(x, 0) <= 0.5; });
   auto cells1 = mesh::locate_entities(
-      *mesh, 2, [](auto& x) { return xt::row(x, 0) >= 0.5; });
+      *mesh, 2, [](auto&& x) { return xt::row(x, 0) >= 0.5; });
 
   // Interpolation on the two sets of cells
-  u->interpolate([](auto& x) -> xt::xtensor<T, 2>
+  u->interpolate([](auto&& x) -> xt::xtensor<T, 2>
                  { return xt::view(x, xt::range(0, 2), xt::all()); },
                  cells0);
   u->interpolate(
-      [](auto& x) -> xt::xtensor<T, 2>
+      [](auto&& x) -> xt::xtensor<T, 2>
       {
         xt::xtensor<T, 2> v = xt::view(x, xt::range(0, 2), xt::all());
         xt::row(v, 0) += T(1);

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -163,7 +163,7 @@ int main(int argc, char* argv[])
 
     auto facets = mesh::locate_entities_boundary(
         *mesh, 1,
-        [](auto& x) -> xt::xtensor<bool, 1>
+        [](auto&& x) -> xt::xtensor<bool, 1>
         {
           auto x0 = xt::row(x, 0);
           return xt::isclose(x0, 0.0) or xt::isclose(x0, 2.0);
@@ -172,14 +172,14 @@ int main(int argc, char* argv[])
     auto bc = std::make_shared<const fem::DirichletBC<T>>(0.0, bdofs, V);
 
     f->interpolate(
-        [](auto& x) -> xt::xarray<T>
+        [](auto&& x) -> xt::xarray<T>
         {
           auto dx = xt::square(xt::row(x, 0) - 0.5)
                     + xt::square(xt::row(x, 1) - 0.5);
           return 10 * xt::exp(-(dx) / 0.02);
         });
 
-    g->interpolate([](auto& x) -> xt::xarray<T>
+    g->interpolate([](auto&& x) -> xt::xarray<T>
                    { return xt::sin(5 * xt::row(x, 0)); });
 
     // Now, we have specified the variational forms and can consider the

--- a/cpp/dolfinx/nls/NewtonSolver.h
+++ b/cpp/dolfinx/nls/NewtonSolver.h
@@ -22,7 +22,7 @@ namespace la::petsc
 class KrylovSolver;
 } // namespace la::petsc
 
-namespace nls
+namespace nls::petsc
 {
 
 /// This class defines a Newton solver for nonlinear systems of
@@ -88,14 +88,13 @@ public:
   /// Set function that is called at the end of each Newton iteration to
   /// test for convergence.
   /// @param[in] c The function that tests for convergence
-  void
-  set_convergence_check(const std::function<std::pair<double, bool>(
-                            const nls::NewtonSolver& solver, const Vec r)>& c);
+  void set_convergence_check(const std::function<std::pair<double, bool>(
+                                 const NewtonSolver& solver, const Vec r)>& c);
 
   /// Set function that is called after each Newton iteration to update
   /// the solution
   /// @param[in] update The function that updates the solution
-  void set_update(const std::function<void(const nls::NewtonSolver& solver,
+  void set_update(const std::function<void(const NewtonSolver& solver,
                                            const Vec dx, Vec x)>& update);
 
   /// Solve the nonlinear problem \f$`F(x) = 0\f$ for given \f$F\f$ and
@@ -175,12 +174,12 @@ private:
   Mat _matJ = nullptr, _matP = nullptr;
 
   // Function to check for convergence
-  std::function<std::pair<double, bool>(const nls::NewtonSolver& solver,
+  std::function<std::pair<double, bool>(const NewtonSolver& solver,
                                         const Vec r)>
       _converged;
 
   // Function to update the solution once convergence is reached
-  std::function<void(const nls::NewtonSolver& solver, const Vec dx, Vec x)>
+  std::function<void(const NewtonSolver& solver, const Vec dx, Vec x)>
       _update_solution;
 
   // Accumulated number of Krylov iterations since solve began
@@ -201,5 +200,5 @@ private:
   // MPI communicator
   dolfinx::MPI::Comm _comm;
 };
-} // namespace nls
+} // namespace nls::petsc
 } // namespace dolfinx

--- a/python/dolfinx/nls.py
+++ b/python/dolfinx/nls.py
@@ -22,7 +22,7 @@ from dolfinx import fem
 __all__ = ["NewtonSolver"]
 
 
-class NewtonSolver(_cpp.nls.NewtonSolver):
+class NewtonSolver(_cpp.nls.petsc.NewtonSolver):
     def __init__(self, comm: MPI.Intracomm, problem: NonlinearProblem):
         """A Newton solver for non-linear problems."""
         super().__init__(comm)

--- a/python/dolfinx/wrappers/nls.cpp
+++ b/python/dolfinx/wrappers/nls.cpp
@@ -20,39 +20,46 @@ namespace dolfinx_wrappers
 {
 void nls(py::module& m)
 {
+  py::module m_petsc
+      = m.def_submodule("petsc", "PETSc-specific nonlinear solvers");
+
   // dolfinx::NewtonSolver
-  py::class_<dolfinx::nls::NewtonSolver,
-             std::shared_ptr<dolfinx::nls::NewtonSolver>>(m, "NewtonSolver")
+  py::class_<dolfinx::nls::petsc::NewtonSolver,
+             std::shared_ptr<dolfinx::nls::petsc::NewtonSolver>>(m_petsc,
+                                                                 "NewtonSolver")
       .def(py::init(
-          [](const MPICommWrapper comm)
-          { return std::make_unique<dolfinx::nls::NewtonSolver>(comm.get()); }))
+          [](const MPICommWrapper comm) {
+            return std::make_unique<dolfinx::nls::petsc::NewtonSolver>(
+                comm.get());
+          }))
       .def_property_readonly("krylov_solver",
-                             [](const dolfinx::nls::NewtonSolver& self)
+                             [](const dolfinx::nls::petsc::NewtonSolver& self)
                              {
                                const dolfinx::la::petsc::KrylovSolver& solver
                                    = self.get_krylov_solver();
                                return solver.ksp();
                              })
-      .def("setF", &dolfinx::nls::NewtonSolver::setF)
-      .def("setJ", &dolfinx::nls::NewtonSolver::setJ)
-      .def("setP", &dolfinx::nls::NewtonSolver::setP)
-      .def("set_update", &dolfinx::nls::NewtonSolver::set_update)
-      .def("set_form", &dolfinx::nls::NewtonSolver::set_form)
-      .def("solve", &dolfinx::nls::NewtonSolver::solve)
-      .def_readwrite("atol", &dolfinx::nls::NewtonSolver::atol,
+      .def("setF", &dolfinx::nls::petsc::NewtonSolver::setF)
+      .def("setJ", &dolfinx::nls::petsc::NewtonSolver::setJ)
+      .def("setP", &dolfinx::nls::petsc::NewtonSolver::setP)
+      .def("set_update", &dolfinx::nls::petsc::NewtonSolver::set_update)
+      .def("set_form", &dolfinx::nls::petsc::NewtonSolver::set_form)
+      .def("solve", &dolfinx::nls::petsc::NewtonSolver::solve)
+      .def_readwrite("atol", &dolfinx::nls::petsc::NewtonSolver::atol,
                      "Absolute tolerance")
-      .def_readwrite("rtol", &dolfinx::nls::NewtonSolver::rtol,
+      .def_readwrite("rtol", &dolfinx::nls::petsc::NewtonSolver::rtol,
                      "Relative tolerance")
-      .def_readwrite("error_on_nonconvergence",
-                     &dolfinx::nls::NewtonSolver::error_on_nonconvergence)
-      .def_readwrite("report", &dolfinx::nls::NewtonSolver::report)
+      .def_readwrite(
+          "error_on_nonconvergence",
+          &dolfinx::nls::petsc::NewtonSolver::error_on_nonconvergence)
+      .def_readwrite("report", &dolfinx::nls::petsc::NewtonSolver::report)
       .def_readwrite("relaxation_parameter",
-                     &dolfinx::nls::NewtonSolver::relaxation_parameter,
+                     &dolfinx::nls::petsc::NewtonSolver::relaxation_parameter,
                      "Relaxation parameter")
-      .def_readwrite("max_it", &dolfinx::nls::NewtonSolver::max_it,
+      .def_readwrite("max_it", &dolfinx::nls::petsc::NewtonSolver::max_it,
                      "Maximum number of iterations")
       .def_readwrite("convergence_criterion",
-                     &dolfinx::nls::NewtonSolver::convergence_criterion,
+                     &dolfinx::nls::petsc::NewtonSolver::convergence_criterion,
                      "Convergence criterion, either 'residual' (default) or "
                      "'incremental'");
 }

--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -103,7 +103,7 @@ def test_linear_pde():
     problem = NonlinearPDEProblem(F, u, bc)
 
     # Create Newton solver and solve
-    solver = _cpp.nls.NewtonSolver(MPI.COMM_WORLD)
+    solver = _cpp.nls.petsc.NewtonSolver(MPI.COMM_WORLD)
     solver.setF(problem.F, problem.vector())
     solver.setJ(problem.J, problem.matrix())
     solver.set_form(problem.form)
@@ -137,7 +137,7 @@ def test_nonlinear_pde():
 
     # Create Newton solver and solve
     u.x.array[:] = 0.9
-    solver = _cpp.nls.NewtonSolver(MPI.COMM_WORLD)
+    solver = _cpp.nls.petsc.NewtonSolver(MPI.COMM_WORLD)
     solver.setF(problem.F, problem.vector())
     solver.setJ(problem.J, problem.matrix())
     solver.set_form(problem.form)


### PR DESCRIPTION
This is the last(?) C++ class/function that depends directly on PETSc and isn't sequestered inside a `petsc::` namespace. This helps maintain clear interface between DOLFINx and PETSc.

The Newton solver design, including how to possibly abstract away the backend, needs to be reviewed in the future. It's questionable why we have a Newton solver that depends in PETSc when we could just use PETSc SNES.