### PR TITLE
Fix sub element creation of function space based on basix element

### DIFF
--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -195,7 +195,15 @@ FiniteElement::FiniteElement(const basix::FiniteElement& element, int bs)
   std::transform(_value_shape.cbegin(), _value_shape.cend(),
                  _value_shape.begin(), [bs](auto s) { return bs * s; });
 
+  if (bs > 1)
+  {
+    // Create all sub-elements
+    for (int i = 0; i < bs; ++i)
+      _sub_elements.push_back(std::make_shared<FiniteElement>(element, 1));
+  }
+
   _element = std::make_unique<basix::FiniteElement>(element);
+  assert(_element);
   _needs_dof_transformations
       = !_element->dof_transformations_are_identity()
         and !_element->dof_transformations_are_permutations();
@@ -203,8 +211,6 @@ FiniteElement::FiniteElement(const basix::FiniteElement& element, int bs)
   _needs_dof_permutations
       = !_element->dof_transformations_are_identity()
         and _element->dof_transformations_are_permutations();
-
-  assert(_element);
   switch (_element->family())
   {
   case basix::element::family::P:

--- a/cpp/dolfinx/fem/petsc.cpp
+++ b/cpp/dolfinx/fem/petsc.cpp
@@ -98,7 +98,7 @@ Mat fem::petsc::create_matrix_block(
   {
     for (auto space : V[d])
     {
-      maps[d].emplace_back(*space->dofmap()->index_map.get(),
+      maps[d].emplace_back(*space->dofmap()->index_map,
                            space->dofmap()->index_map_bs());
     }
   }

--- a/cpp/dolfinx/fem/petsc.cpp
+++ b/cpp/dolfinx/fem/petsc.cpp
@@ -98,8 +98,8 @@ Mat fem::petsc::create_matrix_block(
   {
     for (auto space : V[d])
     {
-      maps[d].push_back(
-          {*space->dofmap()->index_map.get(), space->dofmap()->index_map_bs()});
+      maps[d].emplace_back(*space->dofmap()->index_map.get(),
+                           space->dofmap()->index_map_bs());
     }
   }
 

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -110,7 +110,7 @@ fem::create_element_dof_layout(const ufcx_dofmap& dofmap,
 
   // Create UFC subdofmaps and compute offset
   std::vector<int> offsets(1, 0);
-  std::vector<ElementDofLayout> sub_dofmaps;
+  std::vector<ElementDofLayout> sub_doflayout;
   for (int i = 0; i < dofmap.num_sub_dofmaps; ++i)
   {
     ufcx_dofmap* ufcx_sub_dofmap = dofmap.sub_dofmaps[i];
@@ -127,14 +127,14 @@ fem::create_element_dof_layout(const ufcx_dofmap& dofmap,
                                     * ufcx_sub_dofmap->block_size);
     for (std::size_t j = 0; j < parent_map_sub.size(); ++j)
       parent_map_sub[j] = offsets[i] + element_block_size * j;
-    sub_dofmaps.push_back(
+    sub_doflayout.push_back(
         create_element_dof_layout(*ufcx_sub_dofmap, cell_type, parent_map_sub));
   }
 
   // Check for "block structure". This should ultimately be replaced,
   // but keep for now to mimic existing code
   return ElementDofLayout(element_block_size, entity_dofs, entity_closure_dofs,
-                          parent_map, sub_dofmaps);
+                          parent_map, sub_doflayout);
 }
 //-----------------------------------------------------------------------------
 fem::DofMap
@@ -217,24 +217,21 @@ fem::FunctionSpace fem::create_functionspace(
   // Create UFC subdofmaps and compute offset
   assert(_e);
   const int num_sub_elements = _e->num_sub_elements();
-  // As the input element is a Basix element, we know it has a block size of 1
-  std::vector<int> offsets(num_sub_elements + 1);
-  std::iota(offsets.begin(), offsets.end(), 0);
-  std::vector<ElementDofLayout> sub_dofmaps;
-  sub_dofmaps.reserve(num_sub_elements);
+  std::vector<ElementDofLayout> sub_doflayout;
+  sub_doflayout.reserve(num_sub_elements);
   for (int i = 0; i < num_sub_elements; ++i)
   {
     auto sub_element = _e->extract_sub_element({i});
     std::vector<int> parent_map_sub(sub_element->space_dimension());
     for (std::size_t j = 0; j < parent_map_sub.size(); ++j)
-      parent_map_sub[j] = offsets[i] + bs * j;
-    sub_dofmaps.push_back(ElementDofLayout(
+      parent_map_sub[j] = i + bs * j;
+    sub_doflayout.emplace_back(ElementDofLayout(
         1, e.entity_dofs(), e.entity_closure_dofs(), parent_map_sub, {}));
   }
 
   // Create a dofmap
   ElementDofLayout layout(bs, e.entity_dofs(), e.entity_closure_dofs(), {},
-                          sub_dofmaps);
+                          sub_doflayout);
   auto dofmap = std::make_shared<DofMap>(
       create_dofmap(mesh->comm(), layout, mesh->topology(), reorder_fn, *_e));
 

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -225,8 +225,8 @@ fem::FunctionSpace fem::create_functionspace(
     std::vector<int> parent_map_sub(sub_element->space_dimension());
     for (std::size_t j = 0; j < parent_map_sub.size(); ++j)
       parent_map_sub[j] = i + bs * j;
-    sub_doflayout.emplace_back(ElementDofLayout(
-        1, e.entity_dofs(), e.entity_closure_dofs(), parent_map_sub, {}));
+    sub_doflayout.emplace_back(1, e.entity_dofs(), e.entity_closure_dofs(),
+                               parent_map_sub, std::vector<ElementDofLayout>());
   }
 
   // Create a dofmap


### PR DESCRIPTION
Current implementation of `V = create_functionspace(basix_element, bs)` does  not allow for usage of sub spaces, i.e.
`V.sub(i)`. This PR adds the appropriate functionality to create sub spaces of such function-spaces.