### PR TITLE
Reduce peak memory use when distributing data in parallel

### DIFF
--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -345,16 +345,29 @@ XDMFFile::read_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh,
   xt::xtensor<std::int64_t, 2> entities1 = io::cells::compute_permutation(
       entities, io::cells::perm_vtk(cell_type, entities.shape(1)));
 
-  const auto [entities_local, values_local]
-      = xdmf_utils::distribute_entity_data(*mesh, mesh::cell_dim(cell_type),
-                                           entities1, values);
+  // const auto [entities_local, values_local]
+  //     = xdmf_utils::distribute_entity_data(*mesh, mesh::cell_dim(cell_type),
+  //                                          entities1, values);
+  std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
+      entities_values = xdmf_utils::distribute_entity_data(
+          *mesh, mesh::cell_dim(cell_type), entities1, values);
 
   LOG(INFO) << "XDMF create meshtags";
-  auto [data, offset] = graph::create_adjacency_data(entities_local);
-  graph::AdjacencyList<std::int32_t> entities_adj(std::move(data),
-                                                  std::move(offset));
+  // auto [data, offset] = graph::create_adjacency_data(entities_local);
+  // graph::AdjacencyList<std::int32_t> entities_adj(std::move(data),
+  //                                                 std::move(offset));
+
+  const std::size_t num_vertices_per_entity = mesh::cell_num_entities(
+      mesh::cell_entity_type(mesh->topology().cell_type(),
+                             mesh::cell_dim(cell_type), 0),
+      0);
+
+  graph::AdjacencyList<std::int32_t> entities_adj
+      = graph::regular_adjacency_list(std::move(entities_values.first),
+                                      num_vertices_per_entity);
   mesh::MeshTags meshtags = mesh::create_meshtags(
-      mesh, mesh::cell_dim(cell_type), entities_adj, xtl::span(values_local));
+      mesh, mesh::cell_dim(cell_type), entities_adj,
+      xtl::span<const std::int32_t>`(entities_values.second));
   meshtags.name = name;
 
   return meshtags;

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -350,7 +350,8 @@ XDMFFile::read_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh,
   //                                          entities1, values);
   std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
       entities_values = xdmf_utils::distribute_entity_data(
-          *mesh, mesh::cell_dim(cell_type), entities1, values);
+          *mesh, mesh::cell_dim(cell_type),
+          xtl::span(entities1.data(), entities1.size()), values);
 
   LOG(INFO) << "XDMF create meshtags";
   // auto [data, offset] = graph::create_adjacency_data(entities_local);

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -345,25 +345,17 @@ XDMFFile::read_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh,
   xt::xtensor<std::int64_t, 2> entities1 = io::cells::compute_permutation(
       entities, io::cells::perm_vtk(cell_type, entities.shape(1)));
 
-  // const auto [entities_local, values_local]
-  //     = xdmf_utils::distribute_entity_data(*mesh, mesh::cell_dim(cell_type),
-  //                                          entities1, values);
   std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
       entities_values = xdmf_utils::distribute_entity_data(
           *mesh, mesh::cell_dim(cell_type),
           xtl::span(entities1.data(), entities1.size()), values);
 
   LOG(INFO) << "XDMF create meshtags";
-  // auto [data, offset] = graph::create_adjacency_data(entities_local);
-  // graph::AdjacencyList<std::int32_t> entities_adj(std::move(data),
-  //                                                 std::move(offset));
-
   const std::size_t num_vertices_per_entity = mesh::cell_num_entities(
       mesh::cell_entity_type(mesh->topology().cell_type(),
                              mesh::cell_dim(cell_type), 0),
       0);
-
-  graph::AdjacencyList<std::int32_t> entities_adj
+  const graph::AdjacencyList<std::int32_t> entities_adj
       = graph::regular_adjacency_list(std::move(entities_values.first),
                                       num_vertices_per_entity);
   mesh::MeshTags meshtags = mesh::create_meshtags(

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -367,7 +367,7 @@ XDMFFile::read_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh,
                                       num_vertices_per_entity);
   mesh::MeshTags meshtags = mesh::create_meshtags(
       mesh, mesh::cell_dim(cell_type), entities_adj,
-      xtl::span<const std::int32_t>`(entities_values.second));
+      xtl::span<const std::int32_t>(entities_values.second));
   meshtags.name = name;
 
   return meshtags;

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -423,14 +423,11 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
       = cmap_dof_layout.entity_closure_dofs(entity_dim, 0);
   assert(entity_layout.size() == entities.shape(1));
 
-  auto c_to_v = mesh.topology().connectivity(mesh.topology().dim(), 0);
-  if (!c_to_v)
-    throw std::runtime_error("Missing cell-vertex connectivity.");
-
   // Use ElementDofLayout of the cell to get vertex dof indices (local
   // to a cell), i.e. build a map from local vertex index to associated
   // local dof index
-  const int num_vertices_per_cell = c_to_v->num_links(0);
+  const int num_vertices_per_cell
+      = mesh::cell_num_entities(mesh.topology().cell_type(), 0);
   std::vector<int> cell_vertex_dofs(num_vertices_per_cell);
   for (int i = 0; i < num_vertices_per_cell; ++i)
   {
@@ -439,41 +436,8 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
     cell_vertex_dofs[i] = local_index[0];
   }
 
-  // // Find map from entity vertex to local (w.r.t. dof numbering on the
-  // // entity) dof number. E.g., if there are dofs on entity [0 3 6 7 9]
-  // // and dofs 3 and 7 belong to vertices, then this produces map [1, 3]
-  // std::vector<int> entity_vertex_dofs;
-  // for (std::size_t i = 0; i < cell_vertex_dofs.size(); ++i)
-  // {
-  //   auto it = std::find(entity_layout.begin(), entity_layout.end(),
-  //                       cell_vertex_dofs[i]);
-  //   if (it != entity_layout.end())
-  //     entity_vertex_dofs.push_back(std::distance(entity_layout.begin(), it));
-  // }
-
-  const mesh::CellType entity_type
-      = mesh::cell_entity_type(mesh.topology().cell_type(), entity_dim, 0);
-  const std::size_t num_vertices_per_entity
-      = mesh::cell_num_entities(entity_type, 0);
-  // assert(entity_vertex_dofs.size() == num_vertices_per_entity);
-
-  // Throw away input global indices which do not belong to entity
-  // vertices. This decreases the amount of data needed in parallel
-  // communication.
-  // xt::xtensor<std::int64_t, 2> entities_vertices(
-  //     {entities.shape(0), num_vertices_per_entity});
-  // for (std::size_t e = 0; e < entities_vertices.shape(0); ++e)
-  // {
-  //   for (std::size_t i = 0; i < entities_vertices.shape(1); ++i)
-  //     entities_vertices(e, i) = entities(e, entity_vertex_dofs[i]);
-  // }
-
-  // const MPI_Comm comm = mesh.comm();
-  // const int comm_size = dolfinx::MPI::size(comm);
-  // Get "input" global node indices (as in the input file before any
-  // internal re-ordering)
-  // const std::vector<std::int64_t>& nodes_g
-  //     = mesh.geometry().input_global_indices();
+  const std::size_t num_vertices_per_entity = mesh::cell_num_entities(
+      mesh::cell_entity_type(mesh.topology().cell_type(), entity_dim, 0), 0);
 
   // -------------------
   // 1. Send this rank's global "input" nodes indices to the
@@ -526,8 +490,7 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
   //    communication in Step 1 could be make non-blocking.
 
   auto postmaster_global_ent_sendrecv
-      = [num_vertices_per_entity,
-         &cell_vertex_dofs](const mesh::Mesh& mesh, int entity_dim,
+      = [&cell_vertex_dofs](const mesh::Mesh& mesh, int entity_dim,
                             const xt::xtensor<std::int64_t, 2>& entities,
                             const xtl::span<const std::int32_t>& data)
   {
@@ -535,6 +498,8 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
     const int comm_size = dolfinx::MPI::size(comm);
     const std::int64_t num_nodes_g = mesh.geometry().index_map()->size_global();
 
+    const std::size_t num_vertices_per_entity = mesh::cell_num_entities(
+        mesh::cell_entity_type(mesh.topology().cell_type(), entity_dim, 0), 0);
     auto c_to_v = mesh.topology().connectivity(mesh.topology().dim(), 0);
     if (!c_to_v)
       throw std::runtime_error("Missing cell-vertex connectivity.");
@@ -544,15 +509,6 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
     const std::vector<int> entity_layout
         = cmap_dof_layout.entity_closure_dofs(entity_dim, 0);
     assert(entity_layout.size() == entities.shape(1));
-
-    // const int num_vertices_per_cell = c_to_v->num_links(0);
-    // std::vector<int> cell_vertex_dofs(num_vertices_per_cell);
-    // for (int i = 0; i < num_vertices_per_cell; ++i)
-    // {
-    //   const std::vector<int>& local_index = cmap_dof_layout.entity_dofs(0,
-    //   i); assert(local_index.size() == 1); cell_vertex_dofs[i] =
-    //   local_index[0];
-    // }
 
     // Find map from entity vertex to local (w.r.t. dof numbering on the
     // entity) dof number. E.g., if there are dofs on entity [0 3 6 7 9]
@@ -569,10 +525,8 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
     xt::xtensor<std::int64_t, 2> entities_vertices(
         {entities.shape(0), num_vertices_per_entity});
     for (std::size_t e = 0; e < entities_vertices.shape(0); ++e)
-    {
       for (std::size_t i = 0; i < entities_vertices.shape(1); ++i)
         entities_vertices(e, i) = entities(e, entity_vertex_dofs[i]);
-    }
 
     std::vector<std::vector<std::int64_t>> entities_send(comm_size);
     std::vector<std::vector<std::int32_t>> data_send(comm_size);
@@ -617,16 +571,16 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
   // end.
 
   auto postmaster_send_to_candidates
-      = [num_vertices_per_entity](
-            const mesh::Mesh& mesh,
-            const graph::AdjacencyList<std::int64_t>& nodes_g_recv,
-            const graph::AdjacencyList<std::int64_t>& entities_recv,
-            const graph::AdjacencyList<std::int32_t>& data_recv)
+      = [](const mesh::Mesh& mesh, int entity_dim,
+           const graph::AdjacencyList<std::int64_t>& nodes_g_recv,
+           const graph::AdjacencyList<std::int64_t>& entities_recv,
+           const graph::AdjacencyList<std::int32_t>& data_recv)
   {
     const MPI_Comm comm = mesh.comm();
     const int comm_size = dolfinx::MPI::size(comm);
-    // const std::int64_t num_nodes_g =
-    // mesh.geometry().index_map()->size_global();
+
+    const std::size_t num_vertices_per_entity = mesh::cell_num_entities(
+        mesh::cell_entity_type(mesh.topology().cell_type(), entity_dim, 0), 0);
 
     // Build map from global node index to ranks that have the node
     std::multimap<std::int64_t, int> node_to_rank;
@@ -679,7 +633,7 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
   };
 
   const auto [recv_ents, recv_vals] = postmaster_send_to_candidates(
-      mesh, nodes_g_recv, entities_recv, data_recv);
+      mesh, entity_dim, nodes_g_recv, entities_recv, data_recv);
 
   // -------------------
   // 4. From the received (key, value) data, determine which keys
@@ -696,14 +650,15 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
   //       entities.
 
   auto determine_my_entities
-      = [num_vertices_per_entity,
-         &cell_vertex_dofs](const mesh::Mesh& mesh,
+      = [&cell_vertex_dofs](const mesh::Mesh& mesh, int entity_dim,
                             const graph::AdjacencyList<std::int64_t>& recv_ents,
                             const graph::AdjacencyList<std::int32_t>& recv_vals)
   {
     // Build map from input global indices to local vertex numbers
     LOG(INFO) << "XDMF build map";
 
+    const std::size_t num_vertices_per_entity = mesh::cell_num_entities(
+        mesh::cell_entity_type(mesh.topology().cell_type(), entity_dim, 0), 0);
     auto c_to_v = mesh.topology().connectivity(mesh.topology().dim(), 0);
     if (!c_to_v)
       throw std::runtime_error("Missing cell-vertex connectivity.");
@@ -757,7 +712,7 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
   };
 
   auto [entities_new, data_new]
-      = determine_my_entities(mesh, recv_ents, recv_vals);
+      = determine_my_entities(mesh, entity_dim, recv_ents, recv_vals);
 
   std::vector<std::size_t> shape_r = {
       entities_new.size() / num_vertices_per_entity, num_vertices_per_entity};

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -407,7 +407,7 @@ std::string xdmf_utils::vtk_cell_type_str(mesh::CellType cell_type,
   return cell_str->second;
 }
 //-----------------------------------------------------------------------------
-std::pair<xt::xtensor<std::int32_t, 2>, std::vector<std::int32_t>>
+std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
 xdmf_utils::distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
                                    const xt::xtensor<std::int64_t, 2>& entities,
                                    const xtl::span<const std::int32_t>& data)
@@ -707,12 +707,6 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
   auto [entities_new, data_new]
       = determine_my_entities(mesh, entity_dim, recv_ents, recv_vals);
 
-  const std::size_t num_vertices_per_entity = mesh::cell_num_entities(
-      mesh::cell_entity_type(mesh.topology().cell_type(), entity_dim, 0), 0);
-  std::vector<std::size_t> shape_r = {
-      entities_new.size() / num_vertices_per_entity, num_vertices_per_entity};
-  auto e_new = xt::adapt(entities_new.data(), entities_new.size(),
-                         xt::no_ownership(), shape_r);
-  return {e_new, std::move(data_new)};
+  return {std::move(entities_new), std::move(data_new)};
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -414,8 +414,6 @@ xdmf_utils::distribute_entity_data(
     const xtl::span<const std::int32_t>& data)
 {
   LOG(INFO) << "XDMF distribute entity data";
-  // if (entities.shape(0) != data.size())
-  //   throw std::runtime_error("Number of entities and data size must match");
 
   // Use ElementDofLayout of the cell to get vertex dof indices (local
   // to a cell), i.e. build a map from local vertex index to associated
@@ -433,6 +431,7 @@ xdmf_utils::distribute_entity_data(
       cell_vertex_dofs.push_back(local_index[0]);
     }
   }
+
   // -------------------
   // 1. Send this rank's global "input" nodes indices to the
   //    'postmaster' rank, and receive global "input" nodes for which
@@ -502,7 +501,6 @@ xdmf_utils::distribute_entity_data(
         = mesh.geometry().cmap().create_dof_layout();
     const std::vector<int> entity_layout
         = cmap_dof_layout.entity_closure_dofs(entity_dim, 0);
-    // assert(entity_layout.size() == entities.shape(1));
 
     // Find map from entity vertex to local (w.r.t. dof numbering on the
     // entity) dof number. E.g., if there are dofs on entity [0 3 6 7 9]
@@ -526,7 +524,6 @@ xdmf_utils::distribute_entity_data(
       {
         entities_vertices(e, i)
             = entities[e * shape_e_1 + entity_vertex_dofs[i]];
-        // entities_vertices(e, i) = entities(e, entity_vertex_dofs[i]);
       }
     }
 

--- a/cpp/dolfinx/io/xdmf_utils.h
+++ b/cpp/dolfinx/io/xdmf_utils.h
@@ -88,6 +88,8 @@ std::string vtk_cell_type_str(mesh::CellType cell_type, int num_nodes);
 /// triangle (using local indexing). Each vertex has a 'node' (geometry
 /// dof) index, and each node has a persistent input global index, so
 /// the triangle [gi0, gi1, gi2] could be identified with [v0, v1, v2].
+/// The data is flattened and the shape is `(num_entities,
+/// nodes_per_entity)`.
 /// @param[in] data Data associated with each entity in `entities`.
 /// @return (entity-vertex connectivity of owned entities, associated
 /// data (values) with each entity)
@@ -100,7 +102,7 @@ std::string vtk_cell_type_str(mesh::CellType cell_type, int num_nodes);
 /// for this triangle.
 std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
 distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
-                       const xt::xtensor<std::int64_t, 2>& entities,
+                       const xtl::span<const std::int64_t>& entities,
                        const xtl::span<const std::int32_t>& data);
 
 /// TODO: Document

--- a/cpp/dolfinx/io/xdmf_utils.h
+++ b/cpp/dolfinx/io/xdmf_utils.h
@@ -89,7 +89,7 @@ std::string vtk_cell_type_str(mesh::CellType cell_type, int num_nodes);
 /// dof) index, and each node has a persistent input global index, so
 /// the triangle [gi0, gi1, gi2] could be identified with [v0, v1, v2].
 /// @param[in] data Data associated with each entity in `entities`.
-/// @return (Cell-vertex connectivity of owned entities, associated
+/// @return (entity-vertex connectivity of owned entities, associated
 /// data (values) with each entity)
 /// @note This function involves parallel distribution and must be
 /// called collectively. Global input indices for entities which are not
@@ -98,7 +98,7 @@ std::string vtk_cell_type_str(mesh::CellType cell_type, int num_nodes);
 /// this identifies a triangle that is owned by rank1. It will be
 /// distributed and rank1 will receive (local) cell-vertex connectivity
 /// for this triangle.
-std::pair<xt::xtensor<std::int32_t, 2>, std::vector<std::int32_t>>
+std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
 distribute_entity_data(const mesh::Mesh& mesh, int entity_dim,
                        const xt::xtensor<std::int64_t, 2>& entities,
                        const xtl::span<const std::int32_t>& data);

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -52,42 +52,30 @@ void io(py::module& m)
         "Permutation array to map from Gmsh to DOLFINx node ordering");
 
   // TODO: Template for different values dtypes
-  m.def(
-      "distribute_entity_data",
-      [](const dolfinx::mesh::Mesh& mesh, int entity_dim,
-         const py::array_t<std::int64_t, py::array::c_style>& entities,
-         const py::array_t<std::int32_t, py::array::c_style>& values)
-      {
-        assert(entities.ndim() == 2);
-        std::array shape
-            = {std::size_t(entities.shape(0)), std::size_t(entities.shape(1))};
+  m.def("distribute_entity_data",
+        [](const dolfinx::mesh::Mesh& mesh, int entity_dim,
+           const py::array_t<std::int64_t, py::array::c_style>& entities,
+           const py::array_t<std::int32_t, py::array::c_style>& values)
+        {
+          assert(entities.ndim() == 2);
+          assert(values.ndim() == 1);
+          assert(entities.shape(0) == values.shape(0));
+          std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
+              entities_values = dolfinx::io::xdmf_utils::distribute_entity_data(
+                  mesh, entity_dim, xtl::span(entities.data(), entities.size()),
+                  xtl::span(values.data(), values.size()));
 
-        // The below should work, but misbehaves with the Intel icpx
-        // compiler
-        // auto _entities = xt::adapt(entities.data(), entities.size(),
-        //                            xt::no_ownership(), shape);
-        xt::xtensor<std::int64_t, 2> _entities(shape);
-        std::copy_n(entities.data(), entities.size(), _entities.data());
-
-        // auto [e, v] = dolfinx::io::xdmf_utils::distribute_entity_data(
-        //     mesh, entity_dim, _entities,
-        //     xtl::span(values.data(), values.size()));
-        std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
-            entities_values = dolfinx::io::xdmf_utils::distribute_entity_data(
-                mesh, entity_dim, _entities,
-                xtl::span(values.data(), values.size()));
-
-        std::size_t num_vertices_per_entity = dolfinx::mesh::cell_num_entities(
-            dolfinx::mesh::cell_entity_type(mesh.topology().cell_type(),
-                                            entity_dim, 0),
-            0);
-
-        std::array shape_e
-            = {entities_values.first.size() / num_vertices_per_entity,
-               num_vertices_per_entity};
-        return std::pair(as_pyarray(std::move(entities_values.first), shape_e),
-                         as_pyarray(std::move(entities_values.second)));
-      });
+          std::size_t num_vert_per_entity = dolfinx::mesh::cell_num_entities(
+              dolfinx::mesh::cell_entity_type(mesh.topology().cell_type(),
+                                              entity_dim, 0),
+              0);
+          std::array shape_e
+              = {entities_values.first.size() / num_vert_per_entity,
+                 num_vert_per_entity};
+          return std::pair(
+              as_pyarray(std::move(entities_values.first), shape_e),
+              as_pyarray(std::move(entities_values.second)));
+        });
 
   // dolfinx::io::XDMFFile
   py::class_<dolfinx::io::XDMFFile, std::shared_ptr<dolfinx::io::XDMFFile>>


### PR DESCRIPTION
Introduce some scoping in `xdmf_utils::distribute_entity_data` to reduce peak memory usage.

Also:
- Remove some xtensor in favour of `std::vector`
- Fix bug in gmsh demo