### PR TITLE
Add scalable sparse neighbourhood discovery

### DIFF
--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -6,6 +6,7 @@
 
 #include "MPI.h"
 #include <algorithm>
+#include <dolfinx/common/log.h>
 
 //-----------------------------------------------------------------------------
 dolfinx::MPI::Comm::Comm(MPI_Comm comm, bool duplicate)
@@ -90,6 +91,10 @@ std::vector<int>
 dolfinx::MPI::compute_graph_edges_pcx(MPI_Comm comm,
                                       const xtl::span<const int>& edges)
 {
+  LOG(INFO) << "Computing communicaton graph edges using PCX algorithm. Number "
+               "of input edges "
+            << edges.size();
+
   // Build array with '0' for no outedge and '1' for an outedge for each
   // rank
   const int size = dolfinx::MPI::size(comm);
@@ -132,6 +137,10 @@ dolfinx::MPI::compute_graph_edges_pcx(MPI_Comm comm,
     }
   }
 
+  LOG(INFO) << "Finished graph edge discovery using PCX algorithm. Number "
+               "of discovered edges "
+            << other_ranks.size();
+
   return other_ranks;
 }
 //-----------------------------------------------------------------------------
@@ -139,7 +148,9 @@ std::vector<int>
 dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
                                       const xtl::span<const int>& edges)
 {
-  return compute_graph_edges_pcx(comm, edges);
+  LOG(INFO) << "Computing communicaton graph edges using NBX algorithm. Number "
+               "of input edges "
+            << edges.size();
 
   // Start non-blocking synchronised send
   std::vector<MPI_Request> send_requests(edges.size());
@@ -199,11 +210,18 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
     }
   }
 
+  LOG(INFO) << "Finished graph edge discovery using NBXÎ algorithm. Number "
+               "of discovered edges "
+            << other_ranks.size();
+
   return other_ranks;
 }
 //-----------------------------------------------------------------------------
 std::array<std::vector<int>, 2> dolfinx::MPI::neighbors(MPI_Comm comm)
 {
+  LOG(INFO)
+      << "Getting source/destination edges for neighborhood MPI communicator.";
+
   int status;
   MPI_Topo_test(comm, &status);
   assert(status != MPI_UNDEFINED);

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -108,17 +108,15 @@ std::vector<int> dolfinx::MPI::compute_graph_edges(MPI_Comm comm,
 }
 //-----------------------------------------------------------------------------
 std::vector<int>
-dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, const std::set<int>& edges)
-// const xtl::span<const int>& edges)
+dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
+                                      const xtl::span<const int>& edges)
 {
   // Start non-blocking synchronised send
   std::vector<MPI_Request> send_requests(edges.size());
   std::byte send_buffer;
-  std::vector<int> _edges(edges.begin(), edges.end());
-
-  for (std::size_t e = 0; e < _edges.size(); ++e)
+  for (std::size_t e = 0; e < edges.size(); ++e)
   {
-    MPI_Issend(&send_buffer, 1, MPI_BYTE, _edges[e], 90, comm,
+    MPI_Issend(&send_buffer, 1, MPI_BYTE, edges[e], 90, comm,
                &send_requests[e]);
   }
 

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -116,14 +116,14 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
   std::byte send_buffer;
   for (std::size_t e = 0; e < edges.size(); ++e)
   {
-    MPI_Issend(&send_buffer, 1, MPI_BYTE, edges[e], 90, comm,
-               &send_requests[e]);
+    MPI_Issend(&send_buffer, 1, MPI_BYTE, edges[e],
+               static_cast<int>(tag::consensus_pex), comm, &send_requests[e]);
   }
 
-  // Vector to holder ranks that send data to this rank
+  // Vector to hold ranks that send data to this rank
   std::vector<int> other_ranks;
 
-  // Start receiving
+  // Start sending/receiving
   MPI_Request barrier_request;
   bool comm_complete = false;
   bool barrier_active = false;
@@ -132,7 +132,8 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
     // Check for message
     int request_pending;
     MPI_Status status;
-    MPI_Iprobe(MPI_ANY_SOURCE, 90, comm, &request_pending, &status);
+    MPI_Iprobe(MPI_ANY_SOURCE, static_cast<int>(tag::consensus_pex), comm,
+               &request_pending, &status);
 
     // Check if message is waiting to be procssed
     if (request_pending)
@@ -140,8 +141,8 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
       // Receive it
       int other_rank = status.MPI_SOURCE;
       std::byte buffer_recv;
-      MPI_Recv(&buffer_recv, 1, MPI_BYTE, other_rank, 90, comm,
-               MPI_STATUS_IGNORE);
+      MPI_Recv(&buffer_recv, 1, MPI_BYTE, other_rank,
+               static_cast<int>(tag::consensus_pex), comm, MPI_STATUS_IGNORE);
       other_ranks.push_back(other_rank);
     }
 

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -210,7 +210,7 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
     }
   }
 
-  LOG(INFO) << "Finished graph edge discovery using NBXÎ algorithm. Number "
+  LOG(INFO) << "Finished graph edge discovery using NBX algorithm. Number "
                "of discovered edges "
             << other_ranks.size();
 

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -80,18 +80,17 @@ graph::AdjacencyList<T> all_to_all(MPI_Comm comm,
 /// algorithm.
 ///
 /// Given a list of outgoing edges (destination ranks) from this rank,
-/// this function returns the incoming edges (source ranks) to this rank
-/// that are outgoing eddges on other ranks.
+/// this function returns the incoming edges (source ranks) to this rank.
 ///
 /// @note This function is for sparse communication patterns, i.e. where
 /// the number of ranks that communicate with each other is relatively
-/// small. It is scalable, i.e. no arrays the size of the communicator
-/// are constructed and the communication pattern is sparse It
-/// implements the PCX algorithm described in
+/// small. It **is not** scalable as arrays the size of the communicator
+/// are allocated. It implements the PCX algorithm described in
 /// https://dx.doi.org/10.1145/1837853.1693476.
 ///
-/// @note For sparse graphs, this function has O(p) cost, where p is the
-/// number of MPI ranks. It is suitable for modest MPI rank counts.
+/// @note For sparse graphs, this function has \f$O(p)\f$ cost, where
+/// \f$p\f$is the number of MPI ranks. It is suitable for modest MPI
+/// rank counts.
 ///
 /// @note Collective
 ///
@@ -105,18 +104,18 @@ std::vector<int> compute_graph_edges_pcx(MPI_Comm comm,
 /// algorithm.
 ///
 /// Given a list of outgoing edges (destination ranks) from this rank,
-/// this function returns the incoming edges (source ranks) to this rank
-/// that are outgoing eddges on other ranks.
+/// this function returns the incoming edges (source ranks) to this rank.
 ///
 /// @note This function is for sparse communication patterns, i.e. where
 /// the number of ranks that communicate with each other is relatively
 /// small. It is scalable, i.e. no arrays the size of the communicator
-/// are constructed and the communication pattern is sparse It
+/// are constructed and the communication pattern is sparse. It
 /// implements the NBX algorithm presented in
 /// https://dx.doi.org/10.1145/1837853.1693476.
 ///
-/// @note For sparse graphs, this function has O(log(p)) const, where p
-/// is the number of MPI ranks.
+/// @note For sparse graphs, this function has \f$O(\log p)\f$ cost,
+/// where \f$p\f$is the number of MPI ranks. It is suitable for modest
+/// MPI rank counts.
 ///
 /// @note Collective over ranks that are connected by graph edge.
 ///

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -25,6 +25,12 @@
 namespace dolfinx::MPI
 {
 
+/// MPI communication tags
+enum class tag : int
+{
+  consensus_pex
+};
+
 /// A duplicate MPI communicator and manage lifetime of the
 /// communicator
 class Comm

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -82,6 +82,30 @@ graph::AdjacencyList<T> all_to_all(MPI_Comm comm,
 /// @return Ranks that have defined edges from them to this rank
 std::vector<int> compute_graph_edges(MPI_Comm comm, const std::set<int>& edges);
 
+/// @brief Compute communication graph edges via sparse MPI
+/// communication.
+///
+/// Given a list of outgoing edges (destination ranks) from this rank,
+/// this function returns the incoming edges (source ranks) to this rank
+/// that are outgoing eddges on other ranks.
+///
+/// @note This function is for sparse communication patterns, i.e. where
+/// the number of ranks that communicate with each other is relatively
+/// small. It is scalable, i.e. no arrays the size of the communicator
+/// are constructed and the communication pattern is sparse It
+/// implements the NBX algorithm presented in
+/// https://dx.doi.org/10.1145/1837853.1693476.
+///
+/// @note Collective
+///
+/// @param[in] comm MPI communicator
+/// @param[in] edges Edges (ranks) from this rank (the caller).
+/// @return Ranks that have defined edges from them to this rank.
+std::vector<int> compute_graph_edges_nbx(MPI_Comm comm,
+                                         const std::set<int>& edges);
+// std::vector<int> compute_graph_edges_nbx(MPI_Comm comm,
+//                                          const xtl::span<const int>& edges);
+
 /// Neighborhood all-to-all. Send data to neighbors.
 /// Send in_values[n0] to neighbor process n0 and receive values from neighbor
 /// process n1 in out_values[n1]

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -48,8 +48,7 @@ graph::build::distribute(MPI_Comm comm,
   std::int64_t offset_global = 0;
   const std::int64_t num_owned = list.num_nodes();
   MPI_Request request_offset_scan;
-  MPI_Iexscan(&num_owned, &offset_global, 1,
-              dolfinx::MPI::mpi_type<std::int64_t>(), MPI_SUM, comm,
+  MPI_Iexscan(&num_owned, &offset_global, 1, MPI_INT64_T, MPI_SUM, comm,
               &request_offset_scan);
 
   const int size = dolfinx::MPI::size(comm);
@@ -189,8 +188,7 @@ std::vector<std::int64_t> graph::build::compute_ghost_indices(
 
   std::int64_t offset_local = 0;
   MPI_Request request_offset_scan;
-  MPI_Iexscan(&num_local, &offset_local, 1,
-              dolfinx::MPI::mpi_type<std::int64_t>(), MPI_SUM, comm,
+  MPI_Iexscan(&num_local, &offset_local, 1, MPI_INT64_T, MPI_SUM, comm,
               &request_offset_scan);
 
   // Find out how many ghosts are on each neighboring process

--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -157,8 +157,7 @@ void _add_function(MPI_Comm comm, const fem::Function<Scalar>& u,
       // Add data item of component
       const std::int64_t num_local = component_data_values.size() / width;
       std::int64_t offset = 0;
-      MPI_Exscan(&num_local, &offset, 1, dolfinx::MPI::mpi_type<std::int64_t>(),
-                 MPI_SUM, comm);
+      MPI_Exscan(&num_local, &offset, 1, MPI_INT64_T, MPI_SUM, comm);
       xdmf_utils::add_data_item(attribute_node, h5_id, dataset_name,
                                 component_data_values, offset,
                                 {num_values, width}, "", use_mpi_io);
@@ -170,8 +169,7 @@ void _add_function(MPI_Comm comm, const fem::Function<Scalar>& u,
       // Add data item
       const std::int64_t num_local = data_values.size() / width;
       std::int64_t offset = 0;
-      MPI_Exscan(&num_local, &offset, 1, dolfinx::MPI::mpi_type<std::int64_t>(),
-                 MPI_SUM, comm);
+      MPI_Exscan(&num_local, &offset, 1, MPI_INT64_T, MPI_SUM, comm);
       xdmf_utils::add_data_item(attribute_node, h5_id, dataset_name,
                                 data_values, offset, {num_values, width}, "",
                                 use_mpi_io);

--- a/cpp/dolfinx/io/xdmf_mesh.cpp
+++ b/cpp/dolfinx/io/xdmf_mesh.cpp
@@ -138,8 +138,7 @@ void xdmf_mesh::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
 
   const std::int64_t num_local = num_entities_local;
   std::int64_t offset = 0;
-  MPI_Exscan(&num_local, &offset, 1, dolfinx::MPI::mpi_type<std::int64_t>(),
-             MPI_SUM, comm);
+  MPI_Exscan(&num_local, &offset, 1, MPI_INT64_T, MPI_SUM, comm);
   const bool use_mpi_io = (dolfinx::MPI::size(comm) > 1);
   xdmf_utils::add_data_item(topology_node, h5_id, h5_path, topology_data,
                             offset, shape, number_type, use_mpi_io);
@@ -192,8 +191,7 @@ void xdmf_mesh::add_geometry_data(MPI_Comm comm, pugi::xml_node& xml_node,
 
   const std::int64_t num_local = num_points_local;
   std::int64_t offset = 0;
-  MPI_Exscan(&num_local, &offset, 1, dolfinx::MPI::mpi_type<std::int64_t>(),
-             MPI_SUM, comm);
+  MPI_Exscan(&num_local, &offset, 1, MPI_INT64_T, MPI_SUM, comm);
   const bool use_mpi_io = (dolfinx::MPI::size(comm) > 1);
   xdmf_utils::add_data_item(geometry_node, h5_id, h5_path, x, offset, shape, "",
                             use_mpi_io);

--- a/cpp/dolfinx/io/xdmf_meshtags.h
+++ b/cpp/dolfinx/io/xdmf_meshtags.h
@@ -65,8 +65,7 @@ void add_meshtags(MPI_Comm comm, const mesh::MeshTags<T>& meshtags,
                 comm);
   const std::int64_t num_local = num_active_entities;
   std::int64_t offset = 0;
-  MPI_Exscan(&num_local, &offset, 1, dolfinx::MPI::mpi_type<std::int64_t>(),
-             MPI_SUM, comm);
+  MPI_Exscan(&num_local, &offset, 1, MPI_INT64_T, MPI_SUM, comm);
   const bool use_mpi_io = (dolfinx::MPI::size(comm) > 1);
   xdmf_utils::add_data_item(
       attribute_node, h5_id, path_prefix + std::string("/Values"),

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -631,14 +631,13 @@ mesh::create_topology(MPI_Comm comm,
         comm, original_cell_index, ghost_owners);
 
     // Determine src ranks
-    std::vector<int> neigh_out(ghost_owners.begin(), ghost_owners.end());
-    std::sort(neigh_out.begin(), neigh_out.end());
-    neigh_out.erase(std::unique(neigh_out.begin(), neigh_out.end()),
-                    neigh_out.end());
-    auto src_ranks = dolfinx::MPI::compute_graph_edges_nbx(comm, neigh_out);
-
+    std::vector<int> src_ranks(ghost_owners.begin(), ghost_owners.end());
+    std::sort(src_ranks.begin(), src_ranks.end());
+    src_ranks.erase(std::unique(src_ranks.begin(), src_ranks.end()),
+                    src_ranks.end());
+    auto dest_ranks = dolfinx::MPI::compute_graph_edges_nbx(comm, src_ranks);
     index_map_c = std::make_shared<common::IndexMap>(
-        comm, num_local_cells, src_ranks, cell_ghost_indices, ghost_owners);
+        comm, num_local_cells, dest_ranks, cell_ghost_indices, ghost_owners);
   }
 
   // Create a map from global index to a label, using labels

--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -64,8 +64,7 @@ compute_nonlocal_dual_graph(
   const std::int64_t num_local = local_graph.num_nodes();
   std::int64_t cell_offset = 0;
   MPI_Request request_cell_offset;
-  MPI_Iexscan(&num_local, &cell_offset, 1,
-              dolfinx::MPI::mpi_type<std::int64_t>(), MPI_SUM, comm,
+  MPI_Iexscan(&num_local, &cell_offset, 1, MPI_INT64_T, MPI_SUM, comm,
               &request_cell_offset);
 
   // At this stage facet_cell map only contains facets->cells with edge

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -300,8 +300,7 @@ get_local_indexing(MPI_Comm comm, const common::IndexMap& cell_indexmap,
   {
     const std::int64_t _num_local = num_local;
     std::int64_t local_offset = 0;
-    MPI_Exscan(&_num_local, &local_offset, 1,
-               dolfinx::MPI::mpi_type<std::int64_t>(), MPI_SUM, comm);
+    MPI_Exscan(&_num_local, &local_offset, 1, MPI_INT64_T, MPI_SUM, comm);
 
     std::vector<std::int64_t> send_global_index_data;
     std::vector<int> send_global_index_offsets = {0};

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -227,8 +227,7 @@ refinement::create_new_vertices(
 
   const std::int64_t num_local = n;
   std::int64_t global_offset = 0;
-  MPI_Exscan(&num_local, &global_offset, 1,
-             dolfinx::MPI::mpi_type<std::int64_t>(), MPI_SUM, mesh.comm());
+  MPI_Exscan(&num_local, &global_offset, 1, MPI_INT64_T, MPI_SUM, mesh.comm());
   global_offset += mesh.topology().index_map(0)->local_range()[1];
   std::for_each(local_edge_to_new_vertex.begin(),
                 local_edge_to_new_vertex.end(),

--- a/cpp/test/unit/common/index_map.cpp
+++ b/cpp/test/unit/common/index_map.cpp
@@ -30,12 +30,14 @@ void test_scatter_fwd(int n)
   std::vector<int> global_ghost_owner(ghosts.size(), (mpi_rank + 1) % mpi_size);
 
   // Create an IndexMap
-  common::IndexMap idx_map(
-      MPI_COMM_WORLD, size_local,
-      dolfinx::MPI::compute_graph_edges(
-          MPI_COMM_WORLD,
-          std::set<int>(global_ghost_owner.begin(), global_ghost_owner.end())),
-      ghosts, global_ghost_owner);
+  std::vector<int> src_ranks = global_ghost_owner;
+  std::sort(src_ranks.begin(), src_ranks.end());
+  src_ranks.erase(std::unique(src_ranks.begin(), src_ranks.end()),
+                  src_ranks.end());
+  auto dest_ranks
+      = dolfinx::MPI::compute_graph_edges_nbx(MPI_COMM_WORLD, src_ranks);
+  common::IndexMap idx_map(MPI_COMM_WORLD, size_local, dest_ranks, ghosts,
+                           global_ghost_owner);
 
   // Create some data to scatter
   const std::int64_t val = 11;
@@ -69,12 +71,14 @@ void test_scatter_rev()
   std::vector<int> global_ghost_owner(ghosts.size(), (mpi_rank + 1) % mpi_size);
 
   // Create an IndexMap
-  common::IndexMap idx_map(
-      MPI_COMM_WORLD, size_local,
-      dolfinx::MPI::compute_graph_edges(
-          MPI_COMM_WORLD,
-          std::set<int>(global_ghost_owner.begin(), global_ghost_owner.end())),
-      ghosts, global_ghost_owner);
+  std::vector<int> src_ranks = global_ghost_owner;
+  std::sort(src_ranks.begin(), src_ranks.end());
+  src_ranks.erase(std::unique(src_ranks.begin(), src_ranks.end()),
+                  src_ranks.end());
+  auto dest_ranks
+      = dolfinx::MPI::compute_graph_edges_nbx(MPI_COMM_WORLD, src_ranks);
+  common::IndexMap idx_map(MPI_COMM_WORLD, size_local, dest_ranks, ghosts,
+                           global_ghost_owner);
 
   // Create some data, setting ghost values
   std::int64_t value = 15;

--- a/cpp/test/unit/vector.cpp
+++ b/cpp/test/unit/vector.cpp
@@ -38,12 +38,14 @@ void test_vector()
                                             (mpi_rank + 1) % mpi_size);
 
   // Create an IndexMap
+  std::vector<int> src_ranks = global_ghost_owner;
+  std::sort(src_ranks.begin(), src_ranks.end());
+  src_ranks.erase(std::unique(src_ranks.begin(), src_ranks.end()),
+                  src_ranks.end());
+  auto dest_ranks
+      = dolfinx::MPI::compute_graph_edges_nbx(MPI_COMM_WORLD, src_ranks);
   const auto index_map = std::make_shared<common::IndexMap>(
-      MPI_COMM_WORLD, size_local,
-      dolfinx::MPI::compute_graph_edges(
-          MPI_COMM_WORLD,
-          std::set<int>(global_ghost_owner.begin(), global_ghost_owner.end())),
-      ghosts, global_ghost_owner);
+      MPI_COMM_WORLD, size_local, dest_ranks, ghosts, global_ghost_owner);
 
   la::Vector<PetscScalar> v(index_map, 1);
   std::fill(v.mutable_array().begin(), v.mutable_array().end(), 1.0);


### PR DESCRIPTION
Implements the algorithm in https://dx.doi.org/10.1145/1837853.1693476 for dynamic computation of a sparse neighbourhood. Replaces non-scalable discovery that uses all-to-all.

There are more places where this, or similar, algorithm should be used.

See #60.

Also fixes a bug in the computation of cell ghost/halo layers. 