### PR TITLE
Fix bug in topology creation

### DIFF
--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -449,16 +449,19 @@ compute_entities_by_key_matching(
 
   std::vector<std::int32_t> entity_index(entity_list.shape(0), 0);
   std::int32_t entity_count = 0;
-  std::int32_t last = sort_order.empty() ? 0 : sort_order.front();
-  for (std::size_t i = 1; i < sort_order.size(); ++i)
+  if (!sort_order.empty())
   {
-    std::int32_t j = sort_order[i];
-    if (xt::row(entity_list_sorted, j) != xt::row(entity_list_sorted, last))
-      ++entity_count;
-    entity_index[j] = entity_count;
-    last = j;
+    std::int32_t last = sort_order.front();
+    for (std::size_t i = 1; i < sort_order.size(); ++i)
+    {
+      std::int32_t j = sort_order[i];
+      if (xt::row(entity_list_sorted, j) != xt::row(entity_list_sorted, last))
+        ++entity_count;
+      entity_index[j] = entity_count;
+      last = j;
+    }
+    ++entity_count;
   }
-  ++entity_count;
 
   // Communicate with other processes to find out which entities are
   // ghosted and shared. Remap the numbering so that ghosts are at the

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -548,8 +548,15 @@ def test_empty_rank_mesh():
     # Check number of edges
     topology.create_entities(1)
     emap = topology.index_map(1)
+
+    e_to_v = topology.connectivity(1, 0)
+
     assert emap.num_ghosts == 0
     if comm.rank == 0:
         assert emap.size_local == 5
+        assert e_to_v.num_nodes == 5
+        assert len(e_to_v.array) == 10
     else:
         assert emap.size_local == 0
+        assert len(e_to_v.array) == 0
+        assert e_to_v.num_nodes == 0


### PR DESCRIPTION
This PR fixes a bug in topology creation affecting processes with no cells. The bug causes, for example, the facet-vertex connectivity to have one node when it should have zero. This PR also adds a test that fails in parallel on main.