### PR TITLE
Fix sub component name

### DIFF
--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -382,7 +382,7 @@ class Function(ufl.Coefficient):
             the total number of sub spaces.
 
         """
-        return Function(self._V.sub(i), self.x, name="{}-{}".format(str(self), i))
+        return Function(self._V.sub(i), self.x, name=f"{str(self)}_{i}")
 
     def split(self) -> tuple[Function, ...]:
         """Extract any sub functions.


### PR DESCRIPTION
We should not use `-` in function names, as it will cause ffcx to fail compiling as it is interpreted as the `minus` operator
MWE.
```python
from dolfinx import mesh as msh, fem
import ufl
from mpi4py import MPI

mesh = msh.create_unit_square(MPI.COMM_WORLD, 10, 10)
el = ufl.VectorElement("Lagrange", mesh.ufl_cell(), 1, dim=2)
V = fem.FunctionSpace(mesh, el)

u = fem.Function(V)
ux, uy = u.split()

fem.form(ux*ufl.dx)


```