### PR TITLE
Return empty permutations on ranks with no cells or facets

### DIFF
--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -583,11 +583,10 @@ void Topology::set_connectivity(
 //-----------------------------------------------------------------------------
 const std::vector<std::uint32_t>& Topology::get_cell_permutation_info() const
 {
-  auto i_map = this->index_map(this->dim());
-  assert(i_map);
-
   // Check if this process owns or ghosts any cells
-  if (_cell_permutations.empty()
+  assert(this->index_map(this->dim()));
+  if (auto i_map = this->index_map(this->dim());
+      _cell_permutations.empty()
       and i_map->size_local() + i_map->num_ghosts() > 0)
   {
     throw std::runtime_error(
@@ -599,7 +598,6 @@ const std::vector<std::uint32_t>& Topology::get_cell_permutation_info() const
 //-----------------------------------------------------------------------------
 const std::vector<std::uint8_t>& Topology::get_facet_permutations() const
 {
-
   if (auto i_map = this->index_map(this->dim() - 1);
       !i_map
       or (_facet_permutations.empty()

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -583,7 +583,14 @@ void Topology::set_connectivity(
 //-----------------------------------------------------------------------------
 const std::vector<std::uint32_t>& Topology::get_cell_permutation_info() const
 {
-  if (_cell_permutations.empty())
+  std::cout << "get_cell_permutation_info\n";
+  // TODO Do I need to check this index map exists? It the cell index map should
+  // always exist.
+  auto i_map = this->index_map(this->dim());
+  assert(i_map);
+  const bool has_cells = i_map->size_local() + i_map->num_ghosts() > 0;
+
+  if (_cell_permutations.empty() and has_cells)
   {
     throw std::runtime_error(
         "create_entity_permutations must be called before using this data.");
@@ -593,6 +600,8 @@ const std::vector<std::uint32_t>& Topology::get_cell_permutation_info() const
 //-----------------------------------------------------------------------------
 const std::vector<std::uint8_t>& Topology::get_facet_permutations() const
 {
+  // TODO Same as above
+  std::cout << "get_facet_permutations\n";
   if (_facet_permutations.empty())
   {
     throw std::runtime_error(

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -583,30 +583,37 @@ void Topology::set_connectivity(
 //-----------------------------------------------------------------------------
 const std::vector<std::uint32_t>& Topology::get_cell_permutation_info() const
 {
-  std::cout << "get_cell_permutation_info\n";
-  // TODO Do I need to check this index map exists? It the cell index map should
-  // always exist.
   auto i_map = this->index_map(this->dim());
   assert(i_map);
-  const bool has_cells = i_map->size_local() + i_map->num_ghosts() > 0;
 
+  // Check if this process owns or ghosts any cells
+  const bool has_cells = i_map->size_local() + i_map->num_ghosts() > 0;
   if (_cell_permutations.empty() and has_cells)
   {
     throw std::runtime_error(
         "create_entity_permutations must be called before using this data.");
   }
+
   return _cell_permutations;
 }
 //-----------------------------------------------------------------------------
 const std::vector<std::uint8_t>& Topology::get_facet_permutations() const
 {
-  // TODO Same as above
-  std::cout << "get_facet_permutations\n";
-  if (_facet_permutations.empty())
+  auto i_map = this->index_map(this->dim() - 1);
+  std::string error_message
+      = "create_entity_permutations must be called before using this data.";
+  if (!i_map)
   {
-    throw std::runtime_error(
-        "create_entity_permutations must be called before using this data.");
+    throw std::runtime_error(error_message);
   }
+
+  // Check if this process owns or ghosts any facets
+  const bool has_facets = i_map->size_local() + i_map->num_ghosts() > 0;
+  if (_facet_permutations.empty() and has_facets)
+  {
+    throw std::runtime_error(error_message);
+  }
+
   return _facet_permutations;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -587,8 +587,8 @@ const std::vector<std::uint32_t>& Topology::get_cell_permutation_info() const
   assert(i_map);
 
   // Check if this process owns or ghosts any cells
-  const bool has_cells = i_map->size_local() + i_map->num_ghosts() > 0;
-  if (_cell_permutations.empty() and has_cells)
+  if (_cell_permutations.empty()
+      and i_map->size_local() + i_map->num_ghosts() > 0)
   {
     throw std::runtime_error(
         "create_entity_permutations must be called before using this data.");
@@ -600,18 +600,13 @@ const std::vector<std::uint32_t>& Topology::get_cell_permutation_info() const
 const std::vector<std::uint8_t>& Topology::get_facet_permutations() const
 {
   auto i_map = this->index_map(this->dim() - 1);
-  std::string error_message
-      = "create_entity_permutations must be called before using this data.";
-  if (!i_map)
+  std::string error_message = ;
+  if (!i_map
+      or (_facet_permutations.empty()
+          and i_map->size_local() + i_map->num_ghosts() > 0))
   {
-    throw std::runtime_error(error_message);
-  }
-
-  // Check if this process owns or ghosts any facets
-  const bool has_facets = i_map->size_local() + i_map->num_ghosts() > 0;
-  if (_facet_permutations.empty() and has_facets)
-  {
-    throw std::runtime_error(error_message);
+    throw std::runtime_error(
+        "create_entity_permutations must be called before using this data.");
   }
 
   return _facet_permutations;

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -599,9 +599,9 @@ const std::vector<std::uint32_t>& Topology::get_cell_permutation_info() const
 //-----------------------------------------------------------------------------
 const std::vector<std::uint8_t>& Topology::get_facet_permutations() const
 {
-  auto i_map = this->index_map(this->dim() - 1);
-  std::string error_message = ;
-  if (!i_map
+
+  if (auto i_map = this->index_map(this->dim() - 1);
+      !i_map
       or (_facet_permutations.empty()
           and i_map->size_local() + i_map->num_ghosts() > 0))
   {

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -560,3 +560,9 @@ def test_empty_rank_mesh():
         assert emap.size_local == 0
         assert len(e_to_v.array) == 0
         assert e_to_v.num_nodes == 0
+
+    # Test creating and getting permutations
+    # doesn't throw an error
+    mesh.topology.create_entity_permutations()
+    mesh.topology.get_cell_permutation_info()
+    mesh.topology.get_facet_permutations()

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -561,8 +561,7 @@ def test_empty_rank_mesh():
         assert len(e_to_v.array) == 0
         assert e_to_v.num_nodes == 0
 
-    # Test creating and getting permutations
-    # doesn't throw an error
+    # Test creating and getting permutations doesn't throw an error
     mesh.topology.create_entity_permutations()
     mesh.topology.get_cell_permutation_info()
     mesh.topology.get_facet_permutations()


### PR DESCRIPTION
This PR allows empty permutation vectors to be returned on ranks with no cells or facets, and adds a test which fails on main. 