### PR TITLE
Avoid using count/id to name `fem.Functions` in Python

### DIFF
--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -249,7 +249,7 @@ class Function(ufl.Coefficient):
 
         # Set name
         if name is None:
-            self.name = "f_{}".format(self.count())
+            self.name = "f"
         else:
             self.name = name
 

--- a/python/test/unit/fem/test_function.py
+++ b/python/test/unit/fem/test_function.py
@@ -45,7 +45,7 @@ def Q(mesh):
 def test_name_argument(W):
     u = Function(W)
     v = Function(W, name="v")
-    assert u.name == "f_{}".format(u.count())
+    assert u.name == "f"
     assert v.name == "v"
     assert str(v) == "v"
 


### PR DESCRIPTION
Resolves #2061 