### PR TITLE
Do not overwrite UFL id in Function

### DIFF
--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -245,7 +245,7 @@ class Function(ufl.Coefficient):
             self._cpp_object = functiontype(dtype)(V._cpp_object)
 
         # Initialize the ufl.FunctionSpace
-        super().__init__(V.ufl_function_space(), count=id(self))
+        super().__init__(V.ufl_function_space())
 
         # Set name
         if name is None:

--- a/python/test/unit/io/test_xdmf_function.py
+++ b/python/test/unit/io/test_xdmf_function.py
@@ -145,7 +145,6 @@ def test_save_3d_vector_series(tempdir, encoding, cell_type):
         u.vector.set(2.0 + (2j if np.issubdtype(PETSc.ScalarType, np.complexfloating) else 0))
         file.write_function(u, 0.2)
 
-    # NOTE: This is an issue with appending in parallel
-    # with XDMFFile(mesh.comm, filename, "a", encoding=encoding) as file:
-    #     u.vector.set(3.0 + (3j if np.issubdtype(PETSc.ScalarType, np.complexfloating) else 0))
-    #     file.write_function(u, 0.3)
+    with XDMFFile(mesh.comm, filename, "a", encoding=encoding) as file:
+        u.vector.set(3.0 + (3j if np.issubdtype(PETSc.ScalarType, np.complexfloating) else 0))
+        file.write_function(u, 0.3)


### PR DESCRIPTION
Should fix #2074 and #2061 . UFL id generated with unique global generator in UFL should not be overwritten with
dolfinx's Function id. Equality of UFL objects is different to equality of dolfinx cpp objects.

This will make UFL form in #2074 deterministic again (python `id()` is not) and file IO should work as well, as Function names contain the deterministic UFL id.