### PR TITLE
Fix for exterior facet integrals on a submesh

### DIFF
--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -577,9 +577,10 @@ private:
         assert(c_to_f);
 
         // Only need to consider shared facets when there are no ghost
-        // cells and none of cells owned by this process are shared (the
+        // cells and none of cells owned by this process are shared. The
         // latter check is required because a submesh could have no ghost
-        // cells but another process could share one of this process cells)
+        // cells on this process but another process could ghost some of
+        // those cells)
         std::set<std::int32_t> fwd_shared_facets;
         assert(topology.index_map(tdim - 1));
         if (topology.index_map(tdim)->num_ghosts() == 0

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -582,10 +582,8 @@ private:
         // cells but another process could share one of this process cells)
         std::set<std::int32_t> fwd_shared_facets;
         assert(topology.index_map(tdim - 1));
-        const bool owned_cells_shared =
-          topology.index_map(tdim)->scatter_fwd_indices().array().size() > 0;
         if (topology.index_map(tdim)->num_ghosts() == 0
-            and !owned_cells_shared)
+            and topology.index_map(tdim)->scatter_fwd_indices().array().empty())
         {
           const std::vector<std::int32_t>& fwd_indices
               = topology.index_map(tdim - 1)->scatter_fwd_indices().array();

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -577,10 +577,15 @@ private:
         assert(c_to_f);
 
         // Only need to consider shared facets when there are no ghost
-        // cells
+        // cells and none of cells owned by this process are shared (the
+        // latter check is required because a submesh could have no ghost
+        // cells but another process could share one of this process cells)
         std::set<std::int32_t> fwd_shared_facets;
         assert(topology.index_map(tdim - 1));
-        if (topology.index_map(tdim)->num_ghosts() == 0)
+        const bool owned_cells_shared =
+          topology.index_map(tdim)->scatter_fwd_indices().array().size() > 0;
+        if (topology.index_map(tdim)->num_ghosts() == 0
+            and !owned_cells_shared)
         {
           const std::vector<std::int32_t>& fwd_indices
               = topology.index_map(tdim - 1)->scatter_fwd_indices().array();

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -201,7 +201,7 @@ def _(b: np.ndarray, L: FormMetaClass, constants=None, coeffs=None):
 
 
 @functools.singledispatch
-def assemble_matrix(a: FormMetaClass, bcs: typing.List[DirichletBCMetaClass] = [],
+def assemble_matrix(a: FormMetaClass, bcs: typing.List[DirichletBCMetaClass] = None,
                     diagonal: float = 1.0,
                     constants=None, coeffs=None) -> la.MatrixCSRMetaClass:
     """Assemble bilinear form into a matrix.
@@ -225,6 +225,7 @@ def assemble_matrix(a: FormMetaClass, bcs: typing.List[DirichletBCMetaClass] = [
         accumulated.
 
     """
+    bcs = [] if bcs is None else bcs
     A = create_matrix(a)
     assemble_matrix(A, a, bcs, diagonal, constants, coeffs)
     return A
@@ -232,7 +233,7 @@ def assemble_matrix(a: FormMetaClass, bcs: typing.List[DirichletBCMetaClass] = [
 
 @assemble_matrix.register(la.MatrixCSRMetaClass)
 def _(A: la.MatrixCSRMetaClass, a: FormMetaClass,
-      bcs: typing.List[DirichletBCMetaClass] = [],
+      bcs: typing.List[DirichletBCMetaClass] = None,
       diagonal: float = 1.0, constants=None, coeffs=None) -> la.MatrixCSRMetaClass:
     """Assemble bilinear form into a matrix.
 
@@ -252,6 +253,7 @@ def _(A: la.MatrixCSRMetaClass, a: FormMetaClass,
         accumulated.
 
     """
+    bcs = [] if bcs is None else bcs
     constants = _pack_constants(a) if constants is None else constants
     coeffs = _pack_coefficients(a) if coeffs is None else coeffs
     _cpp.fem.assemble_matrix(A, a, constants, coeffs, bcs)
@@ -268,7 +270,7 @@ def _(A: la.MatrixCSRMetaClass, a: FormMetaClass,
 
 def apply_lifting(b: np.ndarray, a: typing.List[FormMetaClass],
                   bcs: typing.List[typing.List[DirichletBCMetaClass]],
-                  x0: typing.Optional[typing.List[np.ndarray]] = [],
+                  x0: typing.Optional[typing.List[np.ndarray]] = None,
                   scale: float = 1.0, constants=None, coeffs=None) -> None:
     """Modify RHS vector b for lifting of Dirichlet boundary conditions.
 
@@ -289,6 +291,7 @@ def apply_lifting(b: np.ndarray, a: typing.List[FormMetaClass],
         Caller is responsible for calling VecGhostUpdateBegin/End.
 
     """
+    x0 = [] if x0 is None else x0
     constants = [form and _pack_constants(form) for form in a] if constants is None else constants
     coeffs = [{} if form is None else _pack_coefficients(form) for form in a] if coeffs is None else coeffs
     _cpp.fem.apply_lifting(b, a, constants, coeffs, bcs, x0, scale)

--- a/python/test/unit/fem/test_assemble_submesh.py
+++ b/python/test/unit/fem/test_assemble_submesh.py
@@ -22,7 +22,8 @@ def assemble(mesh):
     V = fem.FunctionSpace(mesh, ("Lagrange", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     dx = ufl.Measure("dx", domain=mesh)
-    a = fem.form(ufl.inner(u, v) * dx)
+    ds = ufl.Measure("ds", domain=mesh)
+    a = fem.form(ufl.inner(u, v) * (dx + ds))
 
     A = fem.petsc.assemble_matrix(a)
     A.assemble()


### PR DESCRIPTION
This PR fixes a bug where some exterior facets are not detected in `set_default_domains` when one process owns all the cells in a submesh but other processes ghost some of those cells.  It also adds a test that fails on main.