### PR TITLE
Move file `__enter__`/`__exit__` to the Python layer

### DIFF
--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -316,12 +316,14 @@ std::vector<std::int64_t> graph::build::compute_ghost_indices(
   for (int i = 0; i < num_local; ++i)
     old_to_new.insert({global_indices[i], offset_local + i});
 
-  std::for_each(recv_data.begin(), recv_data.end(), [&old_to_new](auto& r) {
-    auto it = old_to_new.find(r);
-    // Must exist on this process!
-    assert(it != old_to_new.end());
-    r = it->second;
-  });
+  std::for_each(recv_data.begin(), recv_data.end(),
+                [&old_to_new](auto& r)
+                {
+                  auto it = old_to_new.find(r);
+                  // Must exist on this process!
+                  assert(it != old_to_new.end());
+                  r = it->second;
+                });
 
   std::vector<std::int64_t> new_recv(send_data.size());
   MPI_Neighbor_alltoallv(recv_data.data(), recv_sizes.data(),
@@ -339,7 +341,8 @@ std::vector<std::int64_t> graph::build::compute_ghost_indices(
   }
 
   std::for_each(ghost_global_indices.begin(), ghost_global_indices.end(),
-                [&old_to_new](auto& q) {
+                [&old_to_new](auto& q)
+                {
                   const auto it = old_to_new.find(q);
                   assert(it != old_to_new.end());
                   q = it->second;
@@ -403,7 +406,8 @@ std::vector<std::int32_t> graph::build::compute_local_to_local(
   std::vector<std::int32_t> local0_to_local1;
   std::transform(local0_to_global.cbegin(), local0_to_global.cend(),
                  std::back_inserter(local0_to_local1),
-                 [&global_to_local1](auto l2g) {
+                 [&global_to_local1](auto l2g)
+                 {
                    auto it = global_to_local1.find(l2g);
                    assert(it != global_to_local1.end());
                    return it->second;

--- a/cpp/dolfinx/refinement/utils.h
+++ b/cpp/dolfinx/refinement/utils.h
@@ -76,7 +76,8 @@ mesh::Mesh partition(const mesh::Mesh& old_mesh,
                      const xt::xtensor<double, 2>& new_vertex_coordinates,
                      bool redistribute, mesh::GhostMode ghost_mode);
 
-/// @brief brief description indices to account for extra n values on each process.
+/// @brief brief description indices to account for extra n values on each
+/// process.
 ///
 /// This is a utility to help add new topological vertices on each
 /// process into the space of the index map.

--- a/python/demo/interpolation-io/demo_interpolation-io.py
+++ b/python/demo/interpolation-io/demo_interpolation-io.py
@@ -60,9 +60,9 @@ try:
     # Save the interpolated function u0 in VTX format. It should be seen
     # when visualising that the x0-component is discontinuous across
     # x0=0.5 and the x0-component is continuous across x0=0.5
-    from dolfinx.cpp.io import VTXWriter
-    with VTXWriter(msh.comm, "output_nedelec.bp", [u0._cpp_object]) as file:
-        file.write(0.0)
+    from dolfinx.io import VTXWriter
+    with VTXWriter(msh.comm, "output_nedelec.bp", u0) as f:
+        f.write(0.0)
 except ImportError:
     print("ADIOS2 required for VTK output")
 

--- a/python/dolfinx/io.py
+++ b/python/dolfinx/io.py
@@ -33,7 +33,7 @@ def _extract_cpp_functions(functions: typing.Union[typing.List[Function], Functi
 
 
 try:
-    class VTXWriter(_cpp.io.VTXWriter):
+    class VTXWriter(_cpp.io.VTXWriterxx):
         """Interface to VTK files for ADIOS2
 
         VTX supports arbitrary order Lagrange finite elements for the
@@ -114,11 +114,11 @@ try:
 except AttributeError:
     class FidesWriter():
         def __init__(self, *args):
-            raise RuntimeError("DOLFINx has not been configured with ADIOS2 support")
+            raise ImportError("DOLFINx has not been configured with ADIOS2 support")
 
     class VTXWriter():
         def __init__(self, *args):
-            raise RuntimeError("DOLFINx has not been configured with ADIOS2 support")
+            raise ImportError("DOLFINx has not been configured with ADIOS2 support")
 
 
 class VTKFile(_cpp.io.VTKFile):

--- a/python/dolfinx/io.py
+++ b/python/dolfinx/io.py
@@ -13,8 +13,8 @@ import numpy as np
 
 import ufl
 from dolfinx import cpp as _cpp
-from dolfinx.cpp.io import distribute_entity_data  # noqa
-from dolfinx.cpp.io import perm_gmsh as cell_perm_gmsh  # noqa
+from dolfinx.cpp.io import distribute_entity_data  # noqa: F401
+from dolfinx.cpp.io import perm_gmsh as cell_perm_gmsh  # noqa F401
 from dolfinx.fem import Function
 from dolfinx.mesh import GhostMode, Mesh
 

--- a/python/dolfinx/io.py
+++ b/python/dolfinx/io.py
@@ -70,7 +70,7 @@ try:
         def __enter__(self):
             return self
 
-        def __exit__(self, *args):
+        def __exit__(self, exception_type, exception_value, traceback):
             self.close()
 
     class FidesWriter(_cpp.io.FidesWriter):
@@ -107,7 +107,7 @@ try:
         def __enter__(self):
             return self
 
-        def __exit__(self, *args):
+        def __exit__(self, exception_type, exception_value, traceback):
             self.close()
 
 
@@ -133,7 +133,7 @@ class VTKFile(_cpp.io.VTKFile):
     def __enter__(self):
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, exception_type, exception_value, traceback):
         self.close()
 
     def write_mesh(self, mesh: Mesh, t: float = 0.0) -> None:
@@ -149,7 +149,7 @@ class XDMFFile(_cpp.io.XDMFFile):
     def __enter__(self):
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, exception_type, exception_value, traceback):
         self.close()
 
     def write_mesh(self, mesh: Mesh) -> None:

--- a/python/dolfinx/io.py
+++ b/python/dolfinx/io.py
@@ -67,6 +67,12 @@ try:
                 # Input is a single function or a list of functions
                 super().__init__(comm, filename, _extract_cpp_functions(output))
 
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            self.close()
+
     class FidesWriter(_cpp.io.FidesWriter):
         """Interface to Fides file formt.
 
@@ -97,6 +103,14 @@ try:
                 super().__init__(comm, filename, output)
             except (NotImplementedError, TypeError):
                 super().__init__(comm, filename, _extract_cpp_functions(output))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            self.close()
+
+
 except AttributeError:
     class FidesWriter():
         def __init__(self, *args):
@@ -116,6 +130,12 @@ class VTKFile(_cpp.io.VTKFile):
 
     """
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
     def write_mesh(self, mesh: Mesh, t: float = 0.0) -> None:
         """Write mesh to file for a given time (default 0.0)"""
         self.write(mesh, t)
@@ -126,6 +146,12 @@ class VTKFile(_cpp.io.VTKFile):
 
 
 class XDMFFile(_cpp.io.XDMFFile):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
     def write_mesh(self, mesh: Mesh) -> None:
         """Write mesh to file for a given time (default 0.0)"""
         super().write_mesh(mesh)

--- a/python/dolfinx/io.py
+++ b/python/dolfinx/io.py
@@ -20,8 +20,7 @@ from dolfinx.mesh import GhostMode, Mesh
 
 from mpi4py import MPI as _MPI
 
-__all__ = ["FidesWriter", "VTKFile", "VTXWriter", "XDMFFile", "cell_perm_gmsh",
-           "distribute_entity_data"]
+__all__ = ["FidesWriter", "VTKFile", "VTXWriter", "XDMFFile", "cell_perm_gmsh", "distribute_entity_data"]
 
 
 def _extract_cpp_functions(functions: typing.Union[typing.List[Function], Function]):
@@ -32,8 +31,12 @@ def _extract_cpp_functions(functions: typing.Union[typing.List[Function], Functi
         return [getattr(functions, "_cpp_object", functions)]
 
 
-try:
-    class VTXWriter(_cpp.io.VTXWriterxx):
+if _cpp.common.has_adios2:
+    # FidesWriter and VTXWriter require ADIOS2
+
+    __all__ = __all__ + ["FidesWriter", "VTXWriter"]
+
+    class VTXWriter(_cpp.io.VTXWriter):
         """Interface to VTK files for ADIOS2
 
         VTX supports arbitrary order Lagrange finite elements for the
@@ -109,16 +112,6 @@ try:
 
         def __exit__(self, exception_type, exception_value, traceback):
             self.close()
-
-
-except AttributeError:
-    class FidesWriter():
-        def __init__(self, *args):
-            raise ImportError("DOLFINx has not been configured with ADIOS2 support")
-
-    class VTXWriter():
-        def __init__(self, *args):
-            raise ImportError("DOLFINx has not been configured with ADIOS2 support")
 
 
 class VTKFile(_cpp.io.VTKFile):

--- a/python/dolfinx/io.py
+++ b/python/dolfinx/io.py
@@ -13,8 +13,8 @@ import numpy as np
 
 import ufl
 from dolfinx import cpp as _cpp
-from dolfinx.cpp.io import distribute_entity_data
-from dolfinx.cpp.io import perm_gmsh as cell_perm_gmsh
+from dolfinx.cpp.io import distribute_entity_data  # noqa
+from dolfinx.cpp.io import perm_gmsh as cell_perm_gmsh  # noqa
 from dolfinx.fem import Function
 from dolfinx.mesh import GhostMode, Mesh
 

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -98,11 +98,6 @@ void io(py::module& m)
                }),
            py::arg("comm"), py::arg("filename"), py::arg("file_mode"),
            py::arg("encoding") = dolfinx::io::XDMFFile::Encoding::HDF5)
-      .def("__enter__",
-           [](std::shared_ptr<dolfinx::io::XDMFFile>& self) { return self; })
-      .def("__exit__",
-           [](dolfinx::io::XDMFFile& self, py::object exc_type,
-              py::object exc_value, py::object traceback) { self.close(); })
       .def("close", &dolfinx::io::XDMFFile::close)
       .def("write_mesh", &dolfinx::io::XDMFFile::write_mesh, py::arg("mesh"),
            py::arg("xpath") = "/Xdmf/Domain")
@@ -160,11 +155,6 @@ void io(py::module& m)
                                                                filename, mode);
                }),
            py::arg("comm"), py::arg("filename"), py::arg("mode"))
-      .def("__enter__",
-           [](std::shared_ptr<dolfinx::io::VTKFile>& self) { return self; })
-      .def("__exit__",
-           [](dolfinx::io::VTKFile& self, py::object exc_type,
-              py::object exc_value, py::object traceback) { self.close(); })
       .def("close", &dolfinx::io::VTKFile::close)
       .def("write", &dolfinx::io::VTKFile::write<double>, py::arg("u"),
            py::arg("t") = 0.0)
@@ -199,11 +189,6 @@ void io(py::module& m)
             return std::make_unique<dolfinx::io::FidesWriter>(comm.get(),
                                                               filename, u);
           }))
-      .def("__enter__",
-           [](std::shared_ptr<dolfinx::io::FidesWriter>& self) { return self; })
-      .def("__exit__",
-           [](dolfinx::io::FidesWriter& self, py::object exc_type,
-              py::object exc_value, py::object traceback) { self.close(); })
       .def("close", [](dolfinx::io::FidesWriter& self) { self.close(); })
       .def("write",
            [](dolfinx::io::FidesWriter& self, double t) { self.write(t); });
@@ -228,11 +213,6 @@ void io(py::module& m)
             return std::make_unique<dolfinx::io::VTXWriter>(comm.get(),
                                                             filename, u);
           }))
-      .def("__enter__",
-           [](std::shared_ptr<dolfinx::io::VTXWriter>& self) { return self; })
-      .def("__exit__",
-           [](dolfinx::io::VTXWriter& self, py::object exc_type,
-              py::object exc_value, py::object traceback) { self.close(); })
       .def("close", [](dolfinx::io::VTXWriter& self) { self.close(); })
       .def("write",
            [](dolfinx::io::VTXWriter& self, double t) { self.write(t); });


### PR DESCRIPTION
Reduces the pybind11 wrapper code.

Raise an import error rather than a runtime error where appropriate.