### PR TITLE
Make mesh distribution deterministic for a given number of ranks

### DIFF
--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -145,6 +145,8 @@ std::array<std::vector<int>, 2> neighbors(MPI_Comm comm);
 /// \f$p\f$is the number of MPI ranks. It is suitable for modest MPI
 /// rank counts.
 ///
+/// @note The order of the returned ranks is not deterministic.
+///
 /// @note Collective
 ///
 /// @param[in] comm MPI communicator
@@ -170,7 +172,9 @@ std::vector<int> compute_graph_edges_pcx(MPI_Comm comm,
 /// where \f$p\f$is the number of MPI ranks. It is suitable for modest
 /// MPI rank counts.
 ///
-/// @note Collective over ranks that are connected by graph edge.
+/// @note The order of the returned ranks is not deterministic.
+///
+/// @note Collective.
 ///
 /// @param[in] comm MPI communicator
 /// @param[in] edges Edges (ranks) from this rank (the caller).

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -98,9 +98,10 @@ graph::build::distribute(MPI_Comm comm,
     }
   }
 
-  // Determine source ranks
-  const std::vector<int> src
-      = dolfinx::MPI::compute_graph_edges_nbx(comm, dest);
+  // Determine source ranks. Sort ranks to make distribution
+  // deterministic.
+  std::vector<int> src = dolfinx::MPI::compute_graph_edges_nbx(comm, dest);
+  std::sort(src.begin(), src.end());
 
   // Create neighbourhood communicator
   MPI_Comm neigh_comm;
@@ -316,14 +317,12 @@ std::vector<std::int64_t> graph::build::compute_ghost_indices(
   for (int i = 0; i < num_local; ++i)
     old_to_new.insert({global_indices[i], offset_local + i});
 
-  std::for_each(recv_data.begin(), recv_data.end(),
-                [&old_to_new](auto& r)
-                {
-                  auto it = old_to_new.find(r);
-                  // Must exist on this process!
-                  assert(it != old_to_new.end());
-                  r = it->second;
-                });
+  std::for_each(recv_data.begin(), recv_data.end(), [&old_to_new](auto& r) {
+    auto it = old_to_new.find(r);
+    // Must exist on this process!
+    assert(it != old_to_new.end());
+    r = it->second;
+  });
 
   std::vector<std::int64_t> new_recv(send_data.size());
   MPI_Neighbor_alltoallv(recv_data.data(), recv_sizes.data(),
@@ -341,8 +340,7 @@ std::vector<std::int64_t> graph::build::compute_ghost_indices(
   }
 
   std::for_each(ghost_global_indices.begin(), ghost_global_indices.end(),
-                [&old_to_new](auto& q)
-                {
+                [&old_to_new](auto& q) {
                   const auto it = old_to_new.find(q);
                   assert(it != old_to_new.end());
                   q = it->second;
@@ -406,8 +404,7 @@ std::vector<std::int32_t> graph::build::compute_local_to_local(
   std::vector<std::int32_t> local0_to_local1;
   std::transform(local0_to_global.cbegin(), local0_to_global.cend(),
                  std::back_inserter(local0_to_local1),
-                 [&global_to_local1](auto l2g)
-                 {
+                 [&global_to_local1](auto l2g) {
                    auto it = global_to_local1.find(l2g);
                    assert(it != global_to_local1.end());
                    return it->second;

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -317,12 +317,14 @@ std::vector<std::int64_t> graph::build::compute_ghost_indices(
   for (int i = 0; i < num_local; ++i)
     old_to_new.insert({global_indices[i], offset_local + i});
 
-  std::for_each(recv_data.begin(), recv_data.end(), [&old_to_new](auto& r) {
-    auto it = old_to_new.find(r);
-    // Must exist on this process!
-    assert(it != old_to_new.end());
-    r = it->second;
-  });
+  std::for_each(recv_data.begin(), recv_data.end(),
+                [&old_to_new](auto& r)
+                {
+                  auto it = old_to_new.find(r);
+                  // Must exist on this process!
+                  assert(it != old_to_new.end());
+                  r = it->second;
+                });
 
   std::vector<std::int64_t> new_recv(send_data.size());
   MPI_Neighbor_alltoallv(recv_data.data(), recv_sizes.data(),
@@ -340,7 +342,8 @@ std::vector<std::int64_t> graph::build::compute_ghost_indices(
   }
 
   std::for_each(ghost_global_indices.begin(), ghost_global_indices.end(),
-                [&old_to_new](auto& q) {
+                [&old_to_new](auto& q)
+                {
                   const auto it = old_to_new.find(q);
                   assert(it != old_to_new.end());
                   q = it->second;
@@ -404,7 +407,8 @@ std::vector<std::int32_t> graph::build::compute_local_to_local(
   std::vector<std::int32_t> local0_to_local1;
   std::transform(local0_to_global.cbegin(), local0_to_global.cend(),
                  std::back_inserter(local0_to_local1),
-                 [&global_to_local1](auto l2g) {
+                 [&global_to_local1](auto l2g)
+                 {
                    auto it = global_to_local1.find(l2g);
                    assert(it != global_to_local1.end());
                    return it->second;

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -83,8 +83,8 @@ Mesh mesh::create_mesh(MPI_Comm comm,
 
   // Function top build geometry. Used to scope memory operations.
   auto build_topology = [](auto comm, auto& element, auto& dof_layout,
-                           auto& cells, auto ghost_mode,
-                           auto& cell_partitioner) {
+                           auto& cells, auto ghost_mode, auto& cell_partitioner)
+  {
     // -- Partition topology
 
     // Note: the function extract_topology (returns an
@@ -181,8 +181,9 @@ Mesh mesh::create_mesh(MPI_Comm comm,
   }
 
   // Function top build geometry. Used to scope memory operations.
-  auto build_geometry = [](auto comm, auto& cell_nodes, auto& topology,
-                           auto& element, auto& x) {
+  auto build_geometry
+      = [](auto comm, auto& cell_nodes, auto& topology, auto& element, auto& x)
+  {
     int tdim = topology.dim();
     int num_cells = topology.index_map(tdim)->size_local()
                     + topology.index_map(tdim)->num_ghosts();
@@ -244,9 +245,8 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   std::vector<std::int32_t> submesh_owned_entities;
   std::copy_if(entities.begin(), entities.end(),
                std::back_inserter(submesh_owned_entities),
-               [mesh_entity_index_map](std::int32_t e) {
-                 return e < mesh_entity_index_map->size_local();
-               });
+               [mesh_entity_index_map](std::int32_t e)
+               { return e < mesh_entity_index_map->size_local(); });
 
   // Create submesh entity index map
   // TODO Call dolfinx::common::get_owned_indices here? Do we want to
@@ -324,13 +324,12 @@ mesh::create_submesh(const Mesh& mesh, int dim,
                                                  submesh_owned_x_dofs.end());
   submesh_to_mesh_x_dof_map.reserve(submesh_x_dof_index_map->size_local()
                                     + submesh_x_dof_index_map->num_ghosts());
-  std::transform(submesh_x_dof_index_map_pair.second.begin(),
-                 submesh_x_dof_index_map_pair.second.end(),
-                 std::back_inserter(submesh_to_mesh_x_dof_map),
-                 [mesh_geometry_dof_index_map](std::int32_t x_dof_index) {
-                   return mesh_geometry_dof_index_map->size_local()
-                          + x_dof_index;
-                 });
+  std::transform(
+      submesh_x_dof_index_map_pair.second.begin(),
+      submesh_x_dof_index_map_pair.second.end(),
+      std::back_inserter(submesh_to_mesh_x_dof_map),
+      [mesh_geometry_dof_index_map](std::int32_t x_dof_index)
+      { return mesh_geometry_dof_index_map->size_local() + x_dof_index; });
 
   // Create submesh geometry coordinates
   xtl::span<const double> mesh_x = mesh.geometry().x();
@@ -379,11 +378,11 @@ mesh::create_submesh(const Mesh& mesh, int dim,
       = mesh.geometry().input_global_indices();
   std::vector<std::int64_t> submesh_igi;
   submesh_igi.reserve(submesh_to_mesh_x_dof_map.size());
-  std::transform(
-      submesh_to_mesh_x_dof_map.begin(), submesh_to_mesh_x_dof_map.end(),
-      std::back_inserter(submesh_igi), [&mesh_igi](std::int32_t submesh_x_dof) {
-        return mesh_igi[submesh_x_dof];
-      });
+  std::transform(submesh_to_mesh_x_dof_map.begin(),
+                 submesh_to_mesh_x_dof_map.end(),
+                 std::back_inserter(submesh_igi),
+                 [&mesh_igi](std::int32_t submesh_x_dof)
+                 { return mesh_igi[submesh_x_dof]; });
 
   // Create geometry
   Geometry submesh_geometry(

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -83,8 +83,8 @@ Mesh mesh::create_mesh(MPI_Comm comm,
 
   // Function top build geometry. Used to scope memory operations.
   auto build_topology = [](auto comm, auto& element, auto& dof_layout,
-                           auto& cells, auto ghost_mode, auto& cell_partitioner)
-  {
+                           auto& cells, auto ghost_mode,
+                           auto& cell_partitioner) {
     // -- Partition topology
 
     // Note: the function extract_topology (returns an
@@ -181,9 +181,8 @@ Mesh mesh::create_mesh(MPI_Comm comm,
   }
 
   // Function top build geometry. Used to scope memory operations.
-  auto build_geometry
-      = [](auto comm, auto& cell_nodes, auto& topology, auto& element, auto& x)
-  {
+  auto build_geometry = [](auto comm, auto& cell_nodes, auto& topology,
+                           auto& element, auto& x) {
     int tdim = topology.dim();
     int num_cells = topology.index_map(tdim)->size_local()
                     + topology.index_map(tdim)->num_ghosts();
@@ -245,8 +244,9 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   std::vector<std::int32_t> submesh_owned_entities;
   std::copy_if(entities.begin(), entities.end(),
                std::back_inserter(submesh_owned_entities),
-               [mesh_entity_index_map](std::int32_t e)
-               { return e < mesh_entity_index_map->size_local(); });
+               [mesh_entity_index_map](std::int32_t e) {
+                 return e < mesh_entity_index_map->size_local();
+               });
 
   // Create submesh entity index map
   // TODO Call dolfinx::common::get_owned_indices here? Do we want to
@@ -324,12 +324,13 @@ mesh::create_submesh(const Mesh& mesh, int dim,
                                                  submesh_owned_x_dofs.end());
   submesh_to_mesh_x_dof_map.reserve(submesh_x_dof_index_map->size_local()
                                     + submesh_x_dof_index_map->num_ghosts());
-  std::transform(
-      submesh_x_dof_index_map_pair.second.begin(),
-      submesh_x_dof_index_map_pair.second.end(),
-      std::back_inserter(submesh_to_mesh_x_dof_map),
-      [mesh_geometry_dof_index_map](std::int32_t x_dof_index)
-      { return mesh_geometry_dof_index_map->size_local() + x_dof_index; });
+  std::transform(submesh_x_dof_index_map_pair.second.begin(),
+                 submesh_x_dof_index_map_pair.second.end(),
+                 std::back_inserter(submesh_to_mesh_x_dof_map),
+                 [mesh_geometry_dof_index_map](std::int32_t x_dof_index) {
+                   return mesh_geometry_dof_index_map->size_local()
+                          + x_dof_index;
+                 });
 
   // Create submesh geometry coordinates
   xtl::span<const double> mesh_x = mesh.geometry().x();
@@ -378,11 +379,11 @@ mesh::create_submesh(const Mesh& mesh, int dim,
       = mesh.geometry().input_global_indices();
   std::vector<std::int64_t> submesh_igi;
   submesh_igi.reserve(submesh_to_mesh_x_dof_map.size());
-  std::transform(submesh_to_mesh_x_dof_map.begin(),
-                 submesh_to_mesh_x_dof_map.end(),
-                 std::back_inserter(submesh_igi),
-                 [&mesh_igi](std::int32_t submesh_x_dof)
-                 { return mesh_igi[submesh_x_dof]; });
+  std::transform(
+      submesh_to_mesh_x_dof_map.begin(), submesh_to_mesh_x_dof_map.end(),
+      std::back_inserter(submesh_igi), [&mesh_igi](std::int32_t submesh_x_dof) {
+        return mesh_igi[submesh_x_dof];
+      });
 
   // Create geometry
   Geometry submesh_geometry(

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -91,6 +91,8 @@ determine_sharing_ranks(MPI_Comm comm,
     }
   }
 
+  // Determine src ranks. Sort ranks so that ownership determination is
+  // deterministic for a given number of ranks.
   std::vector<int> src = dolfinx::MPI::compute_graph_edges_nbx(comm, dest);
   std::sort(src.begin(), src.end());
 


### PR DESCRIPTION
Ensures that mesh distribution and ownership determination is deterministic for a given number of MPI ranks. The issue is the new functions in #2050 are not deterministic in terms of the ordering of the returned ranks. This is a natural consequence of the MPI nonblocking sends. This PR make mesh creation deterministic by sorted the array of ranks in two specific places.

Also fixes hash functions.