### PR TITLE
Add MyST option to enable 'dollarmath'

### DIFF
--- a/python/doc/README.md
+++ b/python/doc/README.md
@@ -1,0 +1,16 @@
+# Building the DOLFINx Python documentation
+
+To build the documentation:
+
+1. Install DOLFINx (Python interface). It must be possible to import
+   the module ``dolfinx``.
+2. Run ``make html``.
+
+## Processing demo programs
+
+Python demo programs are written in Python, with MyST-flavoured
+Markdown syntax for comments.
+
+1. `jupytext` reads the Python demo code, then converts to and writes a
+   Markdown file.
+2. `myst_parser` allows Sphinx to process the Markdown file.

--- a/python/doc/README.rst
+++ b/python/doc/README.rst
@@ -1,8 +1,0 @@
-Building the DOLFINx Python documentation
-=========================================
-
-To build the documentation:
-
-1. Install DOLFINx (Python interface). It must be possible to import
-   the module ``dolfinx``.
-2. Run ``make html``.

--- a/python/doc/source/conf.py
+++ b/python/doc/source/conf.py
@@ -146,3 +146,5 @@ autoclass_content = "both"
 
 napoleon_google_docstring = True
 napoleon_use_admonition_for_notes = False
+
+myst_enable_extensions = ["dollarmath",]

--- a/python/doc/source/jupytext_process.py
+++ b/python/doc/source/jupytext_process.py
@@ -11,7 +11,7 @@ import jupytext
 
 
 def process():
-    """Convert light format demo Python files into myrst flavoured markdown and
+    """Convert light format demo Python files into MyST flavoured markdown and
     ipynb using Jupytext. These files can then be included in Sphinx
     documentation"""
     # Directories to scan


### PR DESCRIPTION
Required after change in MyST defaults: https://myst-parser.readthedocs.io/en/latest/develop/_changelog.html#dollarmath-is-now-disabled-by-default.

Fixes #2098.