### PR TITLE
Add adios2 files (.bp) and pngs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,8 @@ cpp/demo/documented/cahn-hilliard/CahnHilliard3D.cpp
 *.h5
 *.xdmf
 *.bin
+*.bp
+*.png
 
 # CMake files
 CMakeLists.txt


### PR DESCRIPTION
Since usage of VTX/Fides is quite common now, we should ignore the corresponding output files.