### PR TITLE
Ignore zero entries - interpolation matrix

### DIFF
--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -18,6 +18,7 @@
 #include <vector>
 #include <xtensor/xadapt.hpp>
 #include <xtensor/xbuilder.hpp>
+#include <xtensor/xindex_view.hpp>
 #include <xtensor/xtensor.hpp>
 #include <xtl/xspan.hpp>
 
@@ -205,6 +206,11 @@ void interpolation_matrix(const fem::FunctionSpace& V0,
   xt::xtensor<double, 4> basis_derivatives_reference0(
       {1, X.shape(0), dim0, value_size_ref0});
   element0->tabulate(basis_derivatives_reference0, X, 0);
+
+  double rtol = 1e-14;
+  double atol = 1e-14;
+  auto inds = xt::isclose(basis_derivatives_reference0, 0.0, rtol, atol);
+  xt::filtration(basis_derivatives_reference0, inds) = 0.0;
 
   // Create working arrays
   xt::xtensor<double, 3> basis_reference0({X.shape(0), dim0, value_size_ref0});

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -690,6 +690,7 @@ void petsc_module(py::module& m)
 
         // Build operator
         Mat A = dolfinx::la::petsc::create_matrix(comm, sp);
+        MatSetOption(A, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE);
         dolfinx::fem::discrete_gradient<PetscScalar>(
             V0, V1, dolfinx::la::petsc::Matrix::set_fn(A, INSERT_VALUES));
         return A;
@@ -723,6 +724,7 @@ void petsc_module(py::module& m)
 
         // Build operator
         Mat A = dolfinx::la::petsc::create_matrix(comm, sp);
+        MatSetOption(A, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE);
         dolfinx::fem::interpolation_matrix<PetscScalar>(
             V0, V1, dolfinx::la::petsc::Matrix::set_block_fn(A, INSERT_VALUES));
         return A;
@@ -1096,7 +1098,8 @@ void fem(py::module& m)
            {
              const std::size_t num_points = x.shape(0);
              const std::size_t gdim = x.shape(1);
-             const std::size_t tdim = dolfinx::mesh::cell_dim(self.cell_shape());;
+             const std::size_t tdim
+                 = dolfinx::mesh::cell_dim(self.cell_shape());
 
              xt::xtensor<double, 2> X = xt::empty<double>({num_points, tdim});
 


### PR DESCRIPTION
Ignoring zeros improves both assembly and matrix-vector product time.


```python3
import ufl
from dolfinx.cpp.fem.petsc import interpolation_matrix
from dolfinx.fem import FunctionSpace
from dolfinx.mesh import create_unit_cube
from scipy.sparse import csr_matrix
from scipy.sparse.linalg import norm

from mpi4py import MPI

comm = MPI.COMM_WORLD
mesh = create_unit_cube(comm, 20, 20, 20)

e0 = ufl.FiniteElement("Lagrange", mesh.ufl_cell(), 5)
e1 = ufl.FiniteElement("Lagrange", mesh.ufl_cell(), 1)


V = FunctionSpace(mesh, e0)
W = FunctionSpace(mesh, e1)

begin = MPI.Wtime()
for i in range(10):
    G = interpolation_matrix(V._cpp_object, W._cpp_object)
    G.assemble()
end = MPI.Wtime()

if (comm.rank == 0):
    print("Assemble: \t", end - begin)

x, y = G.getVecs()

begin = MPI.Wtime()
for i in range(10):
    G.mult(x, y)
end = MPI.Wtime()

if (comm.rank == 0):
    print("Apply: \t\t", end - begin)

indptr, indices, data = G.getValuesCSR()
M = G.sizes[0][0]
N = G.sizes[1][0]
G = csr_matrix((data, indices, indptr),  shape=(M, N))
print("nnz \t\t", G.nnz)
print("shape \t\t", G.shape)

```

### this branch
Approximately 1 nonzero per row, as expected.
```

Assemble:        5.07510232925415 s
Apply:           0.00046825408935546875 s
nnz              9263
shape            (9261, 1030301)
```

### main
Approximately 600 nonzeros per row.
```
Assemble:        8.69235873222351 s
Apply:           0.10639619827270508 s
nnz              5477861
shape            (9261, 1030301) 
```