### PR TITLE
Fill output matrix with 0.0 in math::pinv

### DIFF
--- a/cpp/dolfinx/common/math.h
+++ b/cpp/dolfinx/common/math.h
@@ -176,7 +176,8 @@ void pinv(const U& A, V&& P)
     xt::xtensor_fixed<T, xt::xshape<2, 2>> ATA;
     xt::xtensor_fixed<T, xt::xshape<2, 2>> Inv;
     AT = xt::transpose(A);
-    ATA.fill(0);
+    std::fill(ATA.begin(), ATA.end(), 0.0);
+    std::fill(P.begin(), P.end(), 0.0);
 
     // pinv(A) = (A^T * A)^-1 * A^T
     dolfinx::math::dot(AT, A, ATA);

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -142,7 +142,8 @@ void CoordinateElement::pull_back_nonaffine(
           xk[i] += cell_geometry(j, i) * phi[j];
 
       // Compute Jacobian, its inverse and determinant
-      J.fill(0);
+      std::fill(J.begin(), J.end(), 0.0);
+      std::fill(K.begin(), K.end(), 0.0);
       dphi = xt::view(basis, xt::range(1, tdim + 1), 0, xt::all(), 0);
       compute_jacobian(dphi, cell_geometry, J);
       compute_jacobian_inverse(J, K);

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -143,7 +143,6 @@ void CoordinateElement::pull_back_nonaffine(
 
       // Compute Jacobian, its inverse and determinant
       std::fill(J.begin(), J.end(), 0.0);
-      std::fill(K.begin(), K.end(), 0.0);
       dphi = xt::view(basis, xt::range(1, tdim + 1), 0, xt::all(), 0);
       compute_jacobian(dphi, cell_geometry, J);
       compute_jacobian_inverse(J, K);


### PR DESCRIPTION
Fix #2109.
Make behaviour of math::pinv consistent for all admissible matrix shapes and consistent with math::inv.
The behaviour of math::pinv is currently different depending on the shape of the input matrix:
3x1, 2x1: B_pinv = pinv(B)
3x2: B_pinv +=pinv(B)