### PR TITLE
Fix `compute_boundary_facets` for `GhostMode.none`

### DIFF
--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -619,3 +619,29 @@ def test_boundary_facets(n, d, ghost_mode):
     num_boundary_facets = compute_num_boundary_facets(mesh)
 
     assert(num_boundary_facets == expected_num_boundary_facets)
+
+
+@pytest.mark.parametrize("n", [2, 5])
+@pytest.mark.parametrize("d", [2, 3])
+@pytest.mark.parametrize("ghost_mode", [GhostMode.none,
+                                        GhostMode.shared_facet])
+def test_submesh_codim_0_boundary_facets(n, d, ghost_mode):
+    if d == 2:
+        mesh_0 = create_unit_square(
+            MPI.COMM_WORLD, n, n, ghost_mode=ghost_mode)
+        mesh_1 = create_rectangle(
+            MPI.COMM_WORLD, ((0.0, 0.0), (2.0, 1.0)), (2 * n, n),
+            ghost_mode=ghost_mode)
+    else:
+        mesh_0 = create_unit_cube(
+            MPI.COMM_WORLD, n, n, n, ghost_mode=ghost_mode)
+        mesh_1 = create_box(
+            MPI.COMM_WORLD, ((0.0, 0.0, 0.0), (2.0, 1.0, 1.0)),
+            (2 * n, n, n), ghost_mode=ghost_mode)
+
+    edim = mesh_1.topology.dim
+    entities = locate_entities(mesh_1, edim, lambda x: x[0] <= 1.0)
+    submesh = create_submesh(mesh_1, edim, entities)[0]
+
+    assert(compute_num_boundary_facets(submesh)
+           == compute_num_boundary_facets(mesh_0))

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -647,3 +647,22 @@ def test_submesh_codim_0_boundary_facets(n, d, ghost_mode):
 
     assert(compute_num_boundary_facets(submesh)
            == compute_num_boundary_facets(mesh_0))
+
+
+@pytest.mark.parametrize("n", [2, 5])
+@pytest.mark.parametrize("ghost_mode", [GhostMode.none,
+                                        GhostMode.shared_facet])
+def test_submesh_codim_1_boundary_facets(n, ghost_mode):
+    """Test that the correct number of boundary facets are computed
+    for a submesh of codim 1"""
+    mesh = create_unit_cube(
+        MPI.COMM_WORLD, n, n, n, ghost_mode=ghost_mode)
+    edim = mesh.topology.dim - 1
+    entities = locate_entities_boundary(
+        mesh, edim, lambda x: np.isclose(x[2], 0.0))
+    submesh = create_submesh(mesh, edim, entities)[0]
+
+    num_boundary_facets = compute_num_boundary_facets(submesh)
+    expected_num_boundary_facets = 4 * n
+
+    assert(num_boundary_facets == expected_num_boundary_facets)

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -626,6 +626,8 @@ def test_boundary_facets(n, d, ghost_mode):
 @pytest.mark.parametrize("ghost_mode", [GhostMode.none,
                                         GhostMode.shared_facet])
 def test_submesh_codim_0_boundary_facets(n, d, ghost_mode):
+    """Test that the correct number of boundary facets are computed
+    for a submesh of codim 0"""
     if d == 2:
         mesh_0 = create_unit_square(
             MPI.COMM_WORLD, n, n, ghost_mode=ghost_mode)

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -629,24 +629,24 @@ def test_submesh_codim_0_boundary_facets(n, d, ghost_mode):
     """Test that the correct number of boundary facets are computed
     for a submesh of codim 0"""
     if d == 2:
-        mesh_0 = create_unit_square(
-            MPI.COMM_WORLD, n, n, ghost_mode=ghost_mode)
         mesh_1 = create_rectangle(
             MPI.COMM_WORLD, ((0.0, 0.0), (2.0, 1.0)), (2 * n, n),
             ghost_mode=ghost_mode)
+        expected_num_boundary_facets = 4 * n
     else:
-        mesh_0 = create_unit_cube(
-            MPI.COMM_WORLD, n, n, n, ghost_mode=ghost_mode)
         mesh_1 = create_box(
             MPI.COMM_WORLD, ((0.0, 0.0, 0.0), (2.0, 1.0, 1.0)),
             (2 * n, n, n), ghost_mode=ghost_mode)
+        expected_num_boundary_facets = 6 * n**2 * 2
 
+    # Create submesh of half of the rectangle / box mesh to get unit
+    # square / cube mesh
     edim = mesh_1.topology.dim
     entities = locate_entities(mesh_1, edim, lambda x: x[0] <= 1.0)
     submesh = create_submesh(mesh_1, edim, entities)[0]
 
     assert(compute_num_boundary_facets(submesh)
-           == compute_num_boundary_facets(mesh_0))
+           == expected_num_boundary_facets)
 
 
 @pytest.mark.parametrize("n", [2, 5])


### PR DESCRIPTION
This PR fixes a bug in `compute_boundary_facets` for `GhostMode.none` meshes, where some facets would be incorrectly identified as boundary facets. It also addresses the same issue  as  https://github.com/FEniCS/dolfinx/pull/2120, and removes some duplicate code.

@jorgensd perhaps we could add a more general version of the test in https://github.com/FEniCS/dolfinx/pull/2120 to make sure this isn't accidentally broken again?