### PR TITLE
Add non-recursive collision algorithm

### DIFF
--- a/cpp/dolfinx/geometry/utils.cpp
+++ b/cpp/dolfinx/geometry/utils.cpp
@@ -141,8 +141,10 @@ void _compute_collisions_point(
     next = -1;
 
     if (is_leaf(bbox))
+    {
       // If box is a leaf node then add it to the list of colliding entities
       entities.push_back(bbox[1]);
+    }
     else
     {
       // Check whether the point collides with child nodes (left and right)
@@ -157,11 +159,15 @@ void _compute_collisions_point(
         next = bbox[0];
       }
       else if (left)
+      {
         // Traverse the current node's left subtree
         next = bbox[0];
+      }
       else if (right)
+      {
         // Traverse the current node's right subtree
         next = bbox[1];
+      }
     }
     // If tree traversal reaches a dead end (box is a leaf node or no collision
     // detected), check the stack for deferred subtrees.

--- a/cpp/dolfinx/geometry/utils.cpp
+++ b/cpp/dolfinx/geometry/utils.cpp
@@ -134,7 +134,6 @@ void _compute_collisions_point(
 {
   std::deque<std::int32_t> stack;
   int next = tree.num_bboxes() - 1;
-  int top = -1;
 
   while (next != -1)
   {

--- a/cpp/dolfinx/geometry/utils.cpp
+++ b/cpp/dolfinx/geometry/utils.cpp
@@ -171,7 +171,7 @@ void _compute_collisions_point(
     }
     // If tree traversal reaches a dead end (box is a leaf node or no collision
     // detected), check the stack for deferred subtrees.
-    if (next == -1 && !stack.empty())
+    if (next == -1 and !stack.empty())
     {
       next = stack.back();
       stack.pop_back();

--- a/cpp/dolfinx/geometry/utils.cpp
+++ b/cpp/dolfinx/geometry/utils.cpp
@@ -29,6 +29,9 @@ constexpr bool is_leaf(const std::array<int, 2>& bbox)
   return bbox[0] == bbox[1];
 }
 //-----------------------------------------------------------------------------
+// A point `x` is inside a bounding box `b` if each component of its coordinates
+// lies within the range `[b(0,i), b(1,i)]` that defines the bounds of the
+// bounding box, b(0,i) <= x[i] <= b(1,i) for i = 0, 1, 2
 bool point_in_bbox(const xt::xtensor_fixed<double, xt::xshape<2, 3>>& b,
                    const xt::xtensor_fixed<double, xt::xshape<3>>& x)
 {
@@ -45,6 +48,9 @@ bool point_in_bbox(const xt::xtensor_fixed<double, xt::xshape<2, 3>>& b,
   return in;
 }
 //-----------------------------------------------------------------------------
+// A bounding box "a" is contained inside another bounding box "b", if each
+// of its intervals [a(0,i), a(1,i)] is contained in [b(0,i), b(1,i)],
+// a(0,i) <= b(1, i) and a(1,i) >= b(0, i)
 bool bbox_in_bbox(const xt::xtensor_fixed<double, xt::xshape<2, 3>>& a,
                   const xt::xtensor_fixed<double, xt::xshape<2, 3>>& b)
 {

--- a/cpp/dolfinx/geometry/utils.cpp
+++ b/cpp/dolfinx/geometry/utils.cpp
@@ -29,9 +29,9 @@ constexpr bool is_leaf(const std::array<int, 2>& bbox)
   return bbox[0] == bbox[1];
 }
 //-----------------------------------------------------------------------------
-// A point `x` is inside a bounding box `b` if each component of its coordinates
-// lies within the range `[b(0,i), b(1,i)]` that defines the bounds of the
-// bounding box, b(0,i) <= x[i] <= b(1,i) for i = 0, 1, 2
+/// A point `x` is inside a bounding box `b` if each component of its coordinates
+/// lies within the range `[b(0,i), b(1,i)]` that defines the bounds of the
+/// bounding box, b(0,i) <= x[i] <= b(1,i) for i = 0, 1, 2
 bool point_in_bbox(const xt::xtensor_fixed<double, xt::xshape<2, 3>>& b,
                    const xt::xtensor_fixed<double, xt::xshape<3>>& x)
 {
@@ -48,9 +48,9 @@ bool point_in_bbox(const xt::xtensor_fixed<double, xt::xshape<2, 3>>& b,
   return in;
 }
 //-----------------------------------------------------------------------------
-// A bounding box "a" is contained inside another bounding box "b", if each
-// of its intervals [a(0,i), a(1,i)] is contained in [b(0,i), b(1,i)],
-// a(0,i) <= b(1, i) and a(1,i) >= b(0, i)
+/// A bounding box "a" is contained inside another bounding box "b", if each
+/// of its intervals [a(0,i), a(1,i)] is contained in [b(0,i), b(1,i)],
+/// a(0,i) <= b(1, i) and a(1,i) >= b(0, i)
 bool bbox_in_bbox(const xt::xtensor_fixed<double, xt::xshape<2, 3>>& a,
                   const xt::xtensor_fixed<double, xt::xshape<2, 3>>& b)
 {

--- a/cpp/dolfinx/geometry/utils.cpp
+++ b/cpp/dolfinx/geometry/utils.cpp
@@ -146,7 +146,7 @@ void _compute_collisions_point(
       bool right = point_in_bbox(tree.get_bbox(bbox[1]), p);
       if (left && right)
       {
-        // If the point collides with the two child nodes, add a node to the
+        // If the point collides with both child nodes, add the right node to the
         // stack (for later visiting) and continue the tree traversal with
         // the left subtree
         stack[++top] = bbox[1];


### PR DESCRIPTION
Also remove some expensive xtensor computations, and avoid allocating intermediate arrays.

```python
import dolfinx.mesh
import ufl

from dolfinx import geometry
from dolfinx import common
from dolfinx import fem
from mpi4py import MPI

comm = MPI.COMM_WORLD
mesh = dolfinx.mesh.create_unit_cube(comm, 50, 50, 50)

el = ufl.FiniteElement("Lagrange", mesh.ufl_cell(), 2)
V = fem.FunctionSpace(mesh, el)

x = V.tabulate_dof_coordinates()

tree = geometry.BoundingBoxTree(mesh, mesh.geometry.dim)

with common.Timer("compute_collisions") as t:
    cell_candidates = geometry.compute_collisions(tree, x)

common.list_timings(comm, [common.TimingType.wall])
```


This branch:
``` 
compute_collisions                                                          |     1  1.582766  1.582766
```

main:
```
compute_collisions                                                          |     1  14.208511  14.208511
```
