### PR TITLE
Throw runtime error for blocked mixed Dirichlet BC with Constant

### DIFF
--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -136,9 +136,10 @@ private:
       assert(*c);
       if ((*c)->value.size() != _function_space->dofmap()->bs())
       {
-        throw std::runtime_error("Constant input to DirichletBC is not "
-                                 "supported for mixed spaces with block size. "
-                                 "Please use a Function as input.");
+        throw std::runtime_error(
+            "Creating a DirichletBC using a Constant is not supported when the "
+            "Constant size is not equal to the block size of the constrained "
+            "(sub-)space. Use a Function to create the DirichletBC.");
       }
     }
 
@@ -175,10 +176,13 @@ public:
   /// `std::vector<std::int32_t>`) to be constrained. The indices must
   /// be sorted.
   /// @param[in] V The function space to be constrained
-  /// @note The indices in `dofs` are for *blocks*, e.g. a block index
-  /// maps to 3 degrees-of-freedom if the dofmap associated with `g` has
-  /// block size 3
   /// @note Can be used only with point-evaluation elements.
+  /// @note The indices in `dofs` are for *blocks*, e.g. a block index
+  /// corresponds to 3 degrees-of-freedom if the dofmap associated with
+  /// `g` has block size 3.
+  /// @note The size of of `g` must be equal to the block size if `V`.
+  /// Use the Function version if this is not the case, e.g. for some
+  /// mixed spaces.
   template <typename S, typename U,
             typename = std::enable_if_t<
                 std::is_convertible_v<
@@ -189,18 +193,21 @@ public:
   {
   }
 
-  /// Create a representation of a Dirichlet boundary condition
-  /// constrained by a fem::Constant
+  /// @brief Create a representation of a Dirichlet boundary condition
+  /// constrained by a fem::Constant.
   ///
   /// @param[in] g The boundary condition value
   /// @param[in] dofs Degree-of-freedom block indices (@p
   /// std::vector<std::int32_t>) to be constrained. The indices must be
   /// sorted.
   /// @param[in] V The function space to be constrained
+  /// @note Can be used only with point-evaluation elements.
   /// @note The indices in `dofs` are for *blocks*, e.g. a block index
-  /// maps to 3 degrees-of-freedom if the dofmap associated with `g` has
-  /// block size 3
-  /// @note Can be used only with point-evaluation elements
+  /// corresponds to 3 degrees-of-freedom if the dofmap associated with
+  /// `g` has block size 3.
+  /// @note The size of of `g` must be equal to the block size if `V`.
+  /// Use the Function version if this is not the case, e.g. for some
+  /// mixed spaces.
   template <typename U>
   DirichletBC(const std::shared_ptr<const Constant<T>>& g, U&& dofs,
               const std::shared_ptr<const FunctionSpace>& V)
@@ -221,41 +228,43 @@ public:
     }
   }
 
-  /// Create a representation of a Dirichlet boundary condition where
-  /// the space being constrained is the same as the function that
+  /// @brief Create a representation of a Dirichlet boundary condition
+  /// where the space being constrained is the same as the function that
   /// defines the constraint Function, i.e. share the same
   /// `fem::FunctionSpace`
   ///
-  /// @param[in] g The boundary condition value
-  /// @param[in] dofs Degree-of-freedom block indices (@p
-  /// std::vector<std::int32_t>) to be constrained. The indices must be
-  /// sorted.
+  /// @param[in] g The boundary condition value.
+  /// @param[in] dofs Degree-of-freedom block indices
+  /// (`std::vector<std::int32_t>`) to be constrained. The indices must
+  /// be sorted.
   /// @note The indices in `dofs` are for *blocks*, e.g. a block index
-  /// maps to 3 degrees-of-freedom if the dofmap associated with `g` has
-  /// block size 3
+  /// corresponds to 3 degrees-of-freedom if the dofmap associated with
+  /// `g` has block size 3.
   template <typename U>
   DirichletBC(const std::shared_ptr<const Function<T>>& g, U&& dofs)
       : DirichletBC(g, dofs, g->function_space(), nullptr)
   {
   }
 
-  /// Create a representation of a Dirichlet boundary condition where
+  /// @brief Create a representation of a Dirichlet boundary condition where
   /// the space being constrained and the function that defines the
-  /// constraint values do not share the same `FunctionSpace`. A typical
-  /// examples is when applying a constraint on a subspace. The
-  /// (sub)space and the constrain function must have the same finite
-  /// element.
+  /// constraint values do not share the same `FunctionSpace`.
+  ///
+  /// A typical examples is when applying a constraint on a subspace.
+  /// The (sub)space and the constrain function must have the same
+  /// finite element.
   ///
   /// @param[in] g The boundary condition value
-  /// @param[in] V_g_dofs Two arrays of degree-of-freedom indices (@p
-  /// std::array<std::vector<std::int32_t>, 2>). First array are indices
-  /// in the space where boundary condition is applied (V), second array
-  /// are indices in the space of the boundary condition value function
-  /// g. The arrays must be sorted by the indices in the first array.
-  /// The dof indices are unrolled, i.e. are not by dof block.
+  /// @param[in] V_g_dofs Two arrays of degree-of-freedom indices
+  /// (`std::array<std::vector<std::int32_t>, 2>`). First array are
+  /// indices in the space where boundary condition is applied (V),
+  /// second array are indices in the space of the boundary condition
+  /// value function g. The arrays must be sorted by the indices in the
+  /// first array. The dof indices are unrolled, i.e. are not by dof
+  /// block.
   /// @param[in] V The function (sub)space on which the boundary
   /// condition is applied
-  /// @note The indices in `dofs` are unrolled and not for blocks
+  /// @note The indices in `dofs` are unrolled and not for blocks.
   template <typename U>
   DirichletBC(const std::shared_ptr<const Function<T>>& g, U&& V_g_dofs,
               const std::shared_ptr<const FunctionSpace>& V)

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -140,7 +140,14 @@ private:
     // Find number of owned indices in _dofs0
     auto it0 = std::lower_bound(_dofs0.begin(), _dofs0.end(), owned_size0);
     _owned_indices0 = std::distance(_dofs0.begin(), it0);
-
+    if (std::holds_alternative<std::shared_ptr<const Constant<T>>>(_g))
+    {
+      auto c = std::get<std::shared_ptr<const Constant<T>>>(_g);
+      if (c->value.size() != _function_space->dofmap()->bs())
+        throw std::runtime_error("Constant input to DirichletBC is not "
+                                 "supported for mixed spaces with block size. "
+                                 "Please use a Function as input.");
+    }
     // Unroll _dofs0 for dofmap block size > 1
     if (const int bs = _function_space->dofmap()->bs(); bs > 1)
     {

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -577,11 +577,12 @@ def test_assembly_solve_taylor_hood(mesh):
 
         a, p_form, L = form(a), form(p_form), form(L)
 
-        bdofsW0_P2_0 = locate_dofs_topological(W.sub(0), facetdim, bndry_facets0)
-        bdofsW0_P2_1 = locate_dofs_topological(W.sub(0), facetdim, bndry_facets1)
-
-        bc0 = dirichletbc(bc_value, bdofsW0_P2_0, W.sub(0))
-        bc1 = dirichletbc(bc_value, bdofsW0_P2_1, W.sub(0))
+        bdofsW0_P2_0 = locate_dofs_topological((W.sub(0), P2), facetdim, bndry_facets0)
+        bdofsW0_P2_1 = locate_dofs_topological((W.sub(0), P2), facetdim, bndry_facets1)
+        u0 = Function(P2)
+        u0.x.array[:] = 1.0
+        bc0 = dirichletbc(u0, bdofsW0_P2_0, W.sub(0))
+        bc1 = dirichletbc(u0, bdofsW0_P2_1, W.sub(0))
 
         A = assemble_matrix(a, bcs=[bc0, bc1])
         A.assemble()

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -217,28 +217,64 @@ def test_mixed_constant_bc(mesh_factory):
     function yields the same result as setting it with a function"""
     func, args = mesh_factory
     mesh = func(*args)
-    tdim, gdim = mesh.topology.dim, mesh.geometry.dim
+    tdim = mesh.topology.dim
     boundary_facets = locate_entities_boundary(mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool))
-    TH = ufl.MixedElement([ufl.VectorElement("Lagrange", mesh.ufl_cell(), 2),
-                           ufl.FiniteElement("Lagrange", mesh.ufl_cell(), 1)])
+    TH = ufl.MixedElement([ufl.FiniteElement("Lagrange", mesh.ufl_cell(), 1),
+                          ufl.FiniteElement("Lagrange", mesh.ufl_cell(), 2)])
     W = FunctionSpace(mesh, TH)
-    U = Function(W)
+    u = Function(W)
 
-    # Apply BC to component of a mixed space using a Constant
-    c = Constant(mesh, (PETSc.ScalarType(2), PETSc.ScalarType(2)))
+    bc_val = PETSc.ScalarType(3)
+    for i in range(2):
+        u.x.array[:] = 0
+
+        # Apply BC to scalar component of a mixed space using a Constant
+        c = Constant(mesh, bc_val)
+        dofs = locate_dofs_topological(W.sub(i), tdim - 1, boundary_facets)
+        bc = dirichletbc(c, dofs, W.sub(i))
+        set_bc(u.vector, [bc])
+
+        # Apply BC to scalar component of a mixed space using a Function
+        ubc = u.sub(i).collapse()
+        ubc.interpolate(lambda x: np.full(x.shape[1], bc_val))
+        dofs_both = locate_dofs_topological((W.sub(i), ubc.function_space), tdim - 1, boundary_facets)
+        bc_func = dirichletbc(ubc, dofs_both, W.sub(i))
+        u_func = Function(W)
+        set_bc(u_func.vector, [bc_func])
+
+        # Check that both approaches yield the same vector
+        assert np.allclose(u.x.array, u_func.x.array)
+
+
+def test_mixed_blocked_constant():
+    """
+    Check that mixed space with blocked component cannot have Dirichlet BC based on a vector valued Constant
+    """
+    mesh = create_unit_square(MPI.COMM_WORLD, 4, 4)
+
+    tdim = mesh.topology.dim
+    boundary_facets = locate_entities_boundary(mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool))
+
+    TH = ufl.MixedElement([ufl.FiniteElement("Lagrange", mesh.ufl_cell(), 1),
+                          ufl.VectorElement("Lagrange", mesh.ufl_cell(), 2)])
+    W = FunctionSpace(mesh, TH)
+    u = Function(W)
+    c0 = PETSc.ScalarType(3)
     dofs0 = locate_dofs_topological(W.sub(0), tdim - 1, boundary_facets)
-    bc0 = dirichletbc(c, dofs0, W.sub(0))
-    u = U.sub(0)
+    bc0 = dirichletbc(c0, dofs0, W.sub(0))
     set_bc(u.vector, [bc0])
 
-    # Apply BC to component of a mixed space using a Function
-    ubc1 = u.collapse()
-    ubc1.interpolate(lambda x: np.full((gdim, x.shape[1]), 2.0))
-    dofs1 = locate_dofs_topological((W.sub(0), ubc1.function_space), tdim - 1, boundary_facets)
-    bc1 = dirichletbc(ubc1, dofs1, W.sub(0))
-    U1 = Function(W)
-    u1 = U1.sub(0)
-    set_bc(u1.vector, [bc1])
+    # Apply BC to scalar component of a mixed space using a Function
+    ubc = u.sub(0).collapse()
+    ubc.interpolate(lambda x: np.full(x.shape[1], c0))
+    dofs_both = locate_dofs_topological((W.sub(0), ubc.function_space), tdim - 1, boundary_facets)
+    bc_func = dirichletbc(ubc, dofs_both, W.sub(0))
+    u_func = Function(W)
+    set_bc(u_func.vector, [bc_func])
+    assert np.allclose(u.x.array, u_func.x.array)
 
-    # Check that both approaches yield the same vector
-    assert np.allclose(u.x.array, u1.x.array)
+    # Check that vector space throws error
+    c1 = PETSc.ScalarType((5, 7))
+    with pytest.raises(RuntimeError):
+        dofs1 = locate_dofs_topological(W.sub(1), tdim - 1, boundary_facets)
+        dirichletbc(c1, dofs1, W.sub(1))

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -225,11 +225,13 @@ def test_mixed_constant_bc(mesh_factory):
     u = Function(W)
 
     bc_val = PETSc.ScalarType(3)
+    c = Constant(mesh, bc_val)
+    u_func = Function(W)
     for i in range(2):
+        u_func.x.array[:] = 0
         u.x.array[:] = 0
 
         # Apply BC to scalar component of a mixed space using a Constant
-        c = Constant(mesh, bc_val)
         dofs = locate_dofs_topological(W.sub(i), tdim - 1, boundary_facets)
         bc = dirichletbc(c, dofs, W.sub(i))
         set_bc(u.vector, [bc])
@@ -239,7 +241,6 @@ def test_mixed_constant_bc(mesh_factory):
         ubc.interpolate(lambda x: np.full(x.shape[1], bc_val))
         dofs_both = locate_dofs_topological((W.sub(i), ubc.function_space), tdim - 1, boundary_facets)
         bc_func = dirichletbc(ubc, dofs_both, W.sub(i))
-        u_func = Function(W)
         set_bc(u_func.vector, [bc_func])
 
         # Check that both approaches yield the same vector
@@ -247,9 +248,8 @@ def test_mixed_constant_bc(mesh_factory):
 
 
 def test_mixed_blocked_constant():
-    """
-    Check that mixed space with blocked component cannot have Dirichlet BC based on a vector valued Constant
-    """
+    """Check that mixed space with blocked component cannot have
+    Dirichlet BC based on a vector valued Constant."""
     mesh = create_unit_square(MPI.COMM_WORLD, 4, 4)
 
     tdim = mesh.topology.dim


### PR DESCRIPTION
As I see no way of easily fixing #2022, this PR adds a runtime error to make sure that people do not use the function when it is not working as intended. 

Fixes #2022.