### PR TITLE
Raise on DirichletBC for None block

### DIFF
--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -369,6 +369,12 @@ def _(A: PETSc.Mat, a: typing.List[typing.List[FormMetaClass]],
             if a_block is not None:
                 Asub = A.getNestSubMatrix(i, j)
                 assemble_matrix(Asub, a_block, bcs, diagonal, const, coeff)
+            elif i == j:
+                for bc in bcs:
+                    if a_row[0].function_spaces[0].contains(bc.function_space):
+                        raise RuntimeError(
+                            f"Diagonal sub-block ({i}, {j}) cannot be 'None' and have DirichletBC applied."
+                            " Consider assembling a zero block.")
     return A
 
 
@@ -405,6 +411,12 @@ def _(A: PETSc.Mat, a: typing.List[typing.List[FormMetaClass]],
                 Asub = A.getLocalSubMatrix(is_rows[i], is_cols[j])
                 _cpp.fem.petsc.assemble_matrix(Asub, a_sub, constants[i][j], coeffs[i][j], bcs, True)
                 A.restoreLocalSubMatrix(is_rows[i], is_cols[j], Asub)
+            elif i == j:
+                for bc in bcs:
+                    if a_row[0].function_spaces[0].contains(bc.function_space):
+                        raise RuntimeError(
+                            f"Diagonal sub-block ({i}, {j}) cannot be 'None' and have DirichletBC applied."
+                            " Consider assembling a zero block.")
 
     # Flush to enable switch from add to set in the matrix
     A.assemble(PETSc.Mat.AssemblyType.FLUSH)


### PR DESCRIPTION
This fixes a potentially dangerous implicit behaviour, where None in list of forms for assemble_matrix_block ignores all DirichletBC applied there. Typical case: pin pressure in the Stokes problem.