### PR TITLE
Return neighbourhood ranks with ghost owners from `IndexMap`

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -163,8 +163,6 @@ std::vector<int32_t> dolfinx::common::compute_owned_indices(
   std::vector<std::int32_t> dest_ranks
       = dolfinx::MPI::neighbors(reverse_comm)[1];
 
-  // FIXME: avoid mapping back-and-forth between neighbourhood and
-  // global ranks
   std::vector<int> ghost_owner_rank;
   {
     std::vector<int> neighbors = dolfinx::MPI::neighbors(
@@ -343,8 +341,6 @@ common::stack_index_maps(
     const int bs = maps[f].second;
     const std::vector<std::int64_t>& ghosts = maps[f].first.get().ghosts();
 
-    // FIXME: avoid mapping back-and-forth between neighbourhood and
-    // global ranks
     std::vector<int> ghost_owners;
     {
       std::vector<int> neighbors = dolfinx::MPI::neighbors(
@@ -735,8 +731,6 @@ std::map<std::int32_t, std::set<int>> IndexMap::compute_shared_indices() const
   // For my ghosts, add owning rank to list of sharing ranks
   const std::int32_t size_local = this->size_local();
 
-  // FIXME: avoid mapping back-and-forth between neighbourhood and
-  // global ranks
   std::vector<int> ghost_owners;
   {
     std::vector<int> neighbors

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -642,25 +642,6 @@ std::vector<int> IndexMap::ghost_owner_neighbor_rank() const
   return owners;
 }
 //----------------------------------------------------------------------------
-std::vector<int> IndexMap::ghost_owner_rank() const
-{
-  int indegree(-1), outdegree(-2), weighted(-1);
-  MPI_Dist_graph_neighbors_count(_comm_owner_to_ghost.comm(), &indegree,
-                                 &outdegree, &weighted);
-  std::vector<int> neighbors(indegree), tmp(outdegree);
-  MPI_Dist_graph_neighbors(_comm_owner_to_ghost.comm(), indegree,
-                           neighbors.data(), MPI_UNWEIGHTED, outdegree,
-                           tmp.data(), MPI_UNWEIGHTED);
-
-  // Compute index owner on neighbourhood comm
-  const std::vector<int> ghost_owners = ghost_owner_neighbor_rank();
-  std::vector<std::int32_t> owners(ghost_owners.size());
-  std::transform(ghost_owners.begin(), ghost_owners.end(), owners.begin(),
-                 [&neighbors](auto r) { return neighbors[r]; });
-
-  return owners;
-}
-//----------------------------------------------------------------------------
 MPI_Comm IndexMap::comm() const { return _comm.comm(); }
 //----------------------------------------------------------------------------
 MPI_Comm IndexMap::comm(Direction dir) const
@@ -753,7 +734,6 @@ std::map<std::int32_t, std::set<int>> IndexMap::compute_shared_indices() const
 
   // For my ghosts, add owning rank to list of sharing ranks
   const std::int32_t size_local = this->size_local();
-  // const std::vector<int> ghost_owners = this->ghost_owner_rank();
 
   // FIXME: avoid mapping back-and-forth between neighbourhood and
   // global ranks

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -636,10 +636,10 @@ std::vector<int> IndexMap::ghost_owner_rank() const
   int indegree(-1), outdegree(-2), weighted(-1);
   MPI_Dist_graph_neighbors_count(_comm_owner_to_ghost.comm(), &indegree,
                                  &outdegree, &weighted);
-  std::vector<int> neighbors(indegree), neighbors_out(outdegree);
+  std::vector<int> neighbors(indegree), tmp(outdegree);
   MPI_Dist_graph_neighbors(_comm_owner_to_ghost.comm(), indegree,
-                           neighbors.data(), MPI_UNWEIGHTED, 0, &outdegree,
-                           MPI_UNWEIGHTED);
+                           neighbors.data(), MPI_UNWEIGHTED, outdegree,
+                           tmp.data(), MPI_UNWEIGHTED);
 
   // Compute index owner on neighbourhood comm
   const std::vector<int> ghost_owners = ghost_owner_neighbor_rank();

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -626,7 +626,7 @@ std::vector<int> IndexMap::ghost_owner_rank() const
                                  &outdegree, &weighted);
   std::vector<int> neighbors(indegree);
   MPI_Dist_graph_neighbors(_comm_owner_to_ghost.comm(), indegree,
-                           neighbors.data(), MPI_UNWEIGHTED, 0, &outdegree,
+                           neighbors.data(), MPI_UNWEIGHTED, 0, nullptr,
                            MPI_UNWEIGHTED);
 
   // Compute index owner on neighbourhood comm
@@ -763,7 +763,7 @@ std::map<std::int32_t, std::set<int>> IndexMap::compute_shared_indices() const
     for (int j = 0; j < set_size; ++j)
     {
       if (recv_data[i + 2 + j] != myrank)
-        shared_indices[idx].insert(recv_data[i + 2 + +j]);
+        shared_indices[idx].insert(recv_data[i + 2 + j]);
     }
     i += set_size + 2;
   }

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -169,7 +169,7 @@ std::vector<int32_t> dolfinx::common::compute_owned_indices(
   {
     std::vector<int> neighbors = dolfinx::MPI::neighbors(
         map.comm(common::IndexMap::Direction::forward))[0];
-    ghost_owner_rank = map.ghost_owner_neighbor_rank();
+    ghost_owner_rank = map.ghost_owners();
     std::transform(ghost_owner_rank.cbegin(), ghost_owner_rank.cend(),
                    ghost_owner_rank.begin(),
                    [&neighbors](auto r) { return neighbors[r]; });
@@ -349,7 +349,7 @@ common::stack_index_maps(
     {
       std::vector<int> neighbors = dolfinx::MPI::neighbors(
           maps[f].first.get().comm(common::IndexMap::Direction::forward))[0];
-      ghost_owners = maps[f].first.get().ghost_owner_neighbor_rank();
+      ghost_owners = maps[f].first.get().ghost_owners();
       std::transform(ghost_owners.cbegin(), ghost_owners.cend(),
                      ghost_owners.begin(),
                      [&neighbors](auto r) { return neighbors[r]; });
@@ -628,7 +628,7 @@ IndexMap::scatter_fwd_ghost_positions() const noexcept
   return _ghost_pos_recv_fwd;
 }
 //-----------------------------------------------------------------------------
-std::vector<int> IndexMap::ghost_owner_neighbor_rank() const
+std::vector<int> IndexMap::ghost_owners() const
 {
   std::vector<int> owners(_ghost_pos_recv_fwd.size());
   std::transform(
@@ -741,7 +741,7 @@ std::map<std::int32_t, std::set<int>> IndexMap::compute_shared_indices() const
   {
     std::vector<int> neighbors
         = dolfinx::MPI::neighbors(_comm_owner_to_ghost.comm())[0];
-    ghost_owners = this->ghost_owner_neighbor_rank();
+    ghost_owners = this->ghost_owners();
     std::transform(ghost_owners.cbegin(), ghost_owners.cend(),
                    ghost_owners.begin(),
                    [&neighbors](auto r) { return neighbors[r]; });

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -636,7 +636,7 @@ std::vector<int> IndexMap::ghost_owner_rank() const
   int indegree(-1), outdegree(-2), weighted(-1);
   MPI_Dist_graph_neighbors_count(_comm_owner_to_ghost.comm(), &indegree,
                                  &outdegree, &weighted);
-  std::vector<int> neighbors(indegree);
+  std::vector<int> neighbors(indegree), neighbors_out(outdegree);
   MPI_Dist_graph_neighbors(_comm_owner_to_ghost.comm(), indegree,
                            neighbors.data(), MPI_UNWEIGHTED, 0, &outdegree,
                            MPI_UNWEIGHTED);

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -209,7 +209,7 @@ public:
   /// @brief Compute the owner on the neighborhood communicator of each
   /// ghost index.
   ///
-  /// The neighbourhood ranks are the 'source' ranks on the 'reverse'
+  /// The neighborhood ranks are the 'source' ranks on the 'reverse'
   /// communicator, i.e. the neighbourhood source ranks on the
   /// communicator returned by
   /// IndexMap::comm(IndexMap::Direction::reverse). The source ranks on

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -214,7 +214,7 @@ public:
   /// communicator returned by
   /// IndexMap::comm(IndexMap::Direction::reverse). The source ranks on
   /// IndexMap::comm(IndexMap::Direction::reverse) communicator can be
-  /// used convert the returned neighbour ranks to the rank indices on
+  /// used to convert the returned neighbour ranks to the rank indices on
   /// the full communicator.
   ///
   /// @return The owning rank on the neighbourhood communicator of the

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -206,9 +206,6 @@ public:
   /// @return Position of the ith ghost entry in the received buffer
   const std::vector<std::int32_t>& scatter_fwd_ghost_positions() const noexcept;
 
-  /// Owner rank on the global communicator of each ghost entry
-  std::vector<int> ghost_owner_rank() const;
-
   /// @brief Compute the owner on the neighborhood communicator of each
   /// ghost index.
   ///

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -219,7 +219,7 @@ public:
   ///
   /// @return The owning rank on the neighbourhood communicator of the
   /// ith ghost index.
-  std::vector<int> ghost_owner_neighbor_rank() const;
+  std::vector<int> ghost_owners() const;
 
   /// @todo Aim to remove this function? If it's kept, should it work
   /// with neighborhood ranks?

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -217,7 +217,7 @@ public:
   /// used to convert the returned neighbour ranks to the rank indices on
   /// the full communicator.
   ///
-  /// @return The owning rank on the neighbourhood communicator of the
+  /// @return The owning rank on the neighborhood communicator of the
   /// ith ghost index.
   std::vector<int> ghost_owners() const;
 

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -213,7 +213,7 @@ public:
   /// communicator, i.e. the neighbourhood source ranks on the
   /// communicator returned by
   /// IndexMap::comm(IndexMap::Direction::reverse). The source ranks on
-  /// IndexMap::comm(IndexMap::Direction::reverse communicatorcan be
+  /// IndexMap::comm(IndexMap::Direction::reverse) communicator can be
   /// used convert the returned neighbour ranks to the rank indices on
   /// the full communicator.
   ///

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -210,7 +210,7 @@ public:
   /// ghost index.
   ///
   /// The neighborhood ranks are the 'source' ranks on the 'reverse'
-  /// communicator, i.e. the neighbourhood source ranks on the
+  /// communicator, i.e. the neighborhood source ranks on the
   /// communicator returned by
   /// IndexMap::comm(IndexMap::Direction::reverse). The source ranks on
   /// IndexMap::comm(IndexMap::Direction::reverse) communicator can be

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -209,7 +209,19 @@ public:
   /// Owner rank on the global communicator of each ghost entry
   std::vector<int> ghost_owner_rank() const;
 
-  /// Compute the owner on the neighborhood communicator of ghost indices
+  /// @brief Compute the owner on the neighborhood communicator of each
+  /// ghost index.
+  ///
+  /// The neighbourhood ranks are the 'source' ranks on the 'reverse'
+  /// communicator, i.e. the neighbourhood source ranks on the
+  /// communicator returned by
+  /// IndexMap::comm(IndexMap::Direction::reverse). The source ranks on
+  /// IndexMap::comm(IndexMap::Direction::reverse communicatorcan be
+  /// used convert the returned neighbour ranks to the rank indices on
+  /// the full communicator.
+  ///
+  /// @return The owning rank on the neighbourhood communicator of the
+  /// ith ghost index.
   std::vector<int> ghost_owner_neighbor_rank() const;
 
   /// @todo Aim to remove this function? If it's kept, should it work

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -192,7 +192,19 @@ public:
     const std::array local_range
         = {_index_maps[0]->local_range(), _index_maps[1]->local_range()};
     const std::int32_t num_ghosts0 = _index_maps[0]->num_ghosts();
-    const std::vector<int> ghost_owners0 = _index_maps[0]->ghost_owner_rank();
+
+    // FIXME: avoid mapping back-and-forth between neighbourhood and
+    // global ranks
+    std::vector<int> ghost_owners0;
+    {
+      std::vector<int> neighbors = dolfinx::MPI::neighbors(
+          _index_maps[0]->comm(common::IndexMap::Direction::forward))[0];
+      ghost_owners0 = _index_maps[0]->ghost_owner_neighbor_rank();
+      std::transform(ghost_owners0.cbegin(), ghost_owners0.cend(),
+                     ghost_owners0.begin(),
+                     [&neighbors](auto r) { return neighbors[r]; });
+    }
+
     const std::vector<std::int64_t>& ghosts0 = _index_maps[0]->ghosts();
     const std::vector<std::int64_t>& ghosts1 = _index_maps[1]->ghosts();
 

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -196,10 +196,6 @@ public:
     const std::vector<std::int64_t>& ghosts0 = _index_maps[0]->ghosts();
     const std::vector<std::int64_t>& ghosts1 = _index_maps[1]->ghosts();
 
-    // const std::vector<int> dest_ranks
-    //     = dolfinx::MPI::neighbors(_comm.comm())[1];
-    // const int num_neighbors = dest_ranks.size();
-
     int outdegree(-1);
     {
       int indegree(-1), weighted(-1);

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -173,7 +173,8 @@ public:
         _data(p.num_nonzeros(), 0, alloc),
         _cols(p.graph().array().begin(), p.graph().array().end()),
         _row_ptr(p.graph().offsets().begin(), p.graph().offsets().end()),
-        _comm(p.index_map(0)->comm(common::IndexMap::Direction::reverse))
+        _comm(p.index_map(0)->comm(common::IndexMap::Direction::reverse)),
+        _ghost_row_to_neighbor_rank(_index_maps[0]->ghost_owners())
   {
     // TODO: handle block sizes
     if (_bs[0] > 1 or _bs[1] > 1)
@@ -191,63 +192,43 @@ public:
         = {_index_maps[0]->size_local(), _index_maps[1]->size_local()};
     const std::array local_range
         = {_index_maps[0]->local_range(), _index_maps[1]->local_range()};
-    const std::int32_t num_ghosts0 = _index_maps[0]->num_ghosts();
-
-    // FIXME: avoid mapping back-and-forth between neighbourhood and
-    // global ranks
-    std::vector<int> ghost_owners0;
-    {
-      std::vector<int> neighbors = dolfinx::MPI::neighbors(
-          _index_maps[0]->comm(common::IndexMap::Direction::forward))[0];
-      ghost_owners0 = _index_maps[0]->ghost_owners();
-      std::transform(ghost_owners0.cbegin(), ghost_owners0.cend(),
-                     ghost_owners0.begin(),
-                     [&neighbors](auto r) { return neighbors[r]; });
-    }
 
     const std::vector<std::int64_t>& ghosts0 = _index_maps[0]->ghosts();
     const std::vector<std::int64_t>& ghosts1 = _index_maps[1]->ghosts();
 
-    const std::vector<int> dest_ranks
-        = dolfinx::MPI::neighbors(_comm.comm())[1];
-    const int num_neighbors = dest_ranks.size();
+    // const std::vector<int> dest_ranks
+    //     = dolfinx::MPI::neighbors(_comm.comm())[1];
+    // const int num_neighbors = dest_ranks.size();
 
-    // Global-to-local ranks for neighborhood
-    std::map<int, std::int32_t> dest_proc_to_neighbor;
-    for (std::size_t i = 0; i < dest_ranks.size(); ++i)
-      dest_proc_to_neighbor.insert({dest_ranks[i], i});
-
-    // Ownership of each ghost row using neighbor rank
-    _ghost_row_to_neighbor_rank.resize(num_ghosts0, -1);
-    for (int i = 0; i < num_ghosts0; ++i)
+    int outdegree(-1);
     {
-      const auto it = dest_proc_to_neighbor.find(ghost_owners0[i]);
-      assert(it != dest_proc_to_neighbor.end());
-      _ghost_row_to_neighbor_rank[i] = it->second;
+      int indegree(-1), weighted(-1);
+      MPI_Dist_graph_neighbors_count(_comm.comm(), &indegree, &outdegree,
+                                     &weighted);
     }
 
     // Compute size of data to send to each neighbor
-    std::vector<std::int32_t> data_per_proc(num_neighbors, 0);
-    for (int i = 0; i < num_ghosts0; ++i)
+    std::vector<std::int32_t> data_per_proc(outdegree, 0);
+    for (std::size_t i = 0; i < _ghost_row_to_neighbor_rank.size(); ++i)
     {
-      assert(_ghost_row_to_neighbor_rank[i] < (int)data_per_proc.size());
+      assert(_ghost_row_to_neighbor_rank[i] < data_per_proc.size());
       data_per_proc[_ghost_row_to_neighbor_rank[i]]
           += _row_ptr[local_size[0] + i + 1] - _row_ptr[local_size[0] + i];
     }
 
     // Compute send displacements for values and indices (x2)
-    _val_send_disp.resize(num_neighbors + 1, 0);
+    _val_send_disp.resize(outdegree + 1, 0);
     std::partial_sum(data_per_proc.begin(), data_per_proc.end(),
                      std::next(_val_send_disp.begin()));
 
-    std::vector<int> index_send_disp(num_neighbors + 1);
+    std::vector<int> index_send_disp(outdegree + 1);
     std::transform(_val_send_disp.begin(), _val_send_disp.end(),
                    index_send_disp.begin(), [](int d) { return d * 2; });
 
     // For each ghost row, pack and send indices to neighborhood
     std::vector<int> insert_pos(index_send_disp);
     std::vector<std::int64_t> ghost_index_data(index_send_disp.back());
-    for (int i = 0; i < num_ghosts0; ++i)
+    for (std::size_t i = 0; i < _ghost_row_to_neighbor_rank.size(); ++i)
     {
       const int neighbor_rank = _ghost_row_to_neighbor_rank[i];
       int row_id = local_size[0] + i;

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -199,7 +199,7 @@ public:
     {
       std::vector<int> neighbors = dolfinx::MPI::neighbors(
           _index_maps[0]->comm(common::IndexMap::Direction::forward))[0];
-      ghost_owners0 = _index_maps[0]->ghost_owner_neighbor_rank();
+      ghost_owners0 = _index_maps[0]->ghost_owners();
       std::transform(ghost_owners0.cbegin(), ghost_owners0.cend(),
                      ghost_owners0.begin(),
                      [&neighbors](auto r) { return neighbors[r]; });

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -255,6 +255,7 @@ void SparsityPattern::assemble()
   const std::int32_t local_size0 = _index_maps[0]->size_local();
   const std::array local_range0 = _index_maps[0]->local_range();
   const std::vector<std::int64_t>& ghosts0 = _index_maps[0]->ghosts();
+
   const std::vector<int> ghost_owners0 = _index_maps[0]->ghost_owners();
 
   assert(_index_maps[1]);
@@ -262,33 +263,29 @@ void SparsityPattern::assemble()
   const std::array local_range1 = _index_maps[1]->local_range();
   _col_ghosts = _index_maps[1]->ghosts();
 
-  // Get owner (global rank) for column ghosts
-  _col_ghost_owners = _index_maps[1]->ghost_owners();
+  // FIXME: avoid mapping back-and-forth between neighbourhood and
+  // global ranks
   {
-    std::vector<int> neighbors_src = dolfinx::MPI::neighbors(
+    std::vector<int> neighbors = dolfinx::MPI::neighbors(
         _index_maps[1]->comm(common::IndexMap::Direction::forward))[0];
     _col_ghost_owners = _index_maps[1]->ghost_owners();
     std::transform(_col_ghost_owners.cbegin(), _col_ghost_owners.cend(),
                    _col_ghost_owners.begin(),
-                   [&neighbors_src](auto r) { return neighbors_src[r]; });
+                   [&neighbors](auto r) { return neighbors[r]; });
   }
 
-  // Ghost column indices global-to-local map
+  // Global to local map for ghost column indices
   std::map<std::int64_t, std::int32_t> global_to_local;
   std::int32_t local_i = local_size1;
   for (std::int64_t global_i : _col_ghosts)
     global_to_local.insert({global_i, local_i++});
 
-  // Get number of destination ranks
-  int outdegree(-1);
-  {
-    MPI_Comm comm = _index_maps[0]->comm(common::IndexMap::Direction::reverse);
-    int indegree(-1), weighted(-1);
-    MPI_Dist_graph_neighbors_count(comm, &indegree, &outdegree, &weighted);
-  }
+  // Get ghost->owner communicator for rows
+  MPI_Comm comm = _index_maps[0]->comm(common::IndexMap::Direction::reverse);
+  const auto dest_ranks = dolfinx::MPI::neighbors(comm)[1];
 
   // Compute size of data to send to each process
-  std::vector<std::int32_t> data_per_proc(outdegree, 0);
+  std::vector<std::int32_t> data_per_proc(dest_ranks.size(), 0);
   for (std::size_t i = 0; i < ghost_owners0.size(); ++i)
   {
     // Add to src size
@@ -297,41 +294,37 @@ void SparsityPattern::assemble()
   }
 
   // Compute send displacements
-  std::vector<int> send_disp(outdegree + 1, 0);
+  std::vector<int> send_disp(dest_ranks.size() + 1, 0);
   std::partial_sum(data_per_proc.begin(), data_per_proc.end(),
                    std::next(send_disp.begin(), 1));
 
   // For each ghost row, pack and send (global row, global col,
-  // col_owner) data
+  // col_owner) triplets to send to neighborhood
+  std::vector<int> insert_pos(send_disp);
   std::vector<std::int64_t> ghost_data(send_disp.back());
+  const int rank = dolfinx::MPI::rank(_comm.comm());
+  for (std::size_t i = 0; i < ghost_owners0.size(); ++i)
   {
-    std::vector<int> insert_pos = send_disp;
-    const int rank = dolfinx::MPI::rank(_comm.comm());
-    for (std::size_t i = 0; i < ghost_owners0.size(); ++i)
+    const int neighbour_rank = ghost_owners0[i];
+    for (std::int32_t col_local : _row_cache[i + local_size0])
     {
-      const int neighbour_rank = ghost_owners0[i];
-      for (std::int32_t col_local : _row_cache[i + local_size0])
+      // Get index in send buffer
+      const std::int32_t pos = insert_pos[neighbour_rank];
+
+      // Pack send data
+      ghost_data[pos] = ghosts0[i];
+      if (col_local < local_size1)
       {
-        // Get index in send buffer
-        const std::int32_t pos = insert_pos[neighbour_rank];
-
-        // Pack send data
-        ghost_data[pos] = ghosts0[i];
-        if (col_local < local_size1)
-        {
-          ghost_data[pos + 1] = col_local + local_range1[0];
-          ghost_data[pos + 2] = rank;
-        }
-        else
-        {
-          std::size_t pos = col_local - local_size1;
-          int src = _col_ghost_owners[pos];
-          ghost_data[pos + 1] = _col_ghosts[pos];
-          ghost_data[pos + 2] = src;
-        }
-
-        insert_pos[neighbour_rank] += 3;
+        ghost_data[pos + 1] = col_local + local_range1[0];
+        ghost_data[pos + 2] = rank;
       }
+      else
+      {
+        ghost_data[pos + 1] = _col_ghosts[col_local - local_size1];
+        ghost_data[pos + 2] = _col_ghost_owners[col_local - local_size1];
+      }
+
+      insert_pos[neighbour_rank] += 3;
     }
   }
 
@@ -339,9 +332,7 @@ void SparsityPattern::assemble()
   const graph::AdjacencyList<std::int64_t> ghost_data_out(std::move(ghost_data),
                                                           std::move(send_disp));
   const graph::AdjacencyList<std::int64_t> ghost_data_in
-      = dolfinx::MPI::neighbor_all_to_all(
-          _index_maps[0]->comm(common::IndexMap::Direction::reverse),
-          ghost_data_out);
+      = dolfinx::MPI::neighbor_all_to_all(comm, ghost_data_out);
 
   // Add data received from the neighborhood
   const std::vector<std::int64_t>& in_ghost_data = ghost_data_in.array();

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -263,7 +263,7 @@ void SparsityPattern::assemble()
   {
     std::vector<int> neighbors = dolfinx::MPI::neighbors(
         _index_maps[0]->comm(common::IndexMap::Direction::forward))[0];
-    ghost_owners0 = _index_maps[0]->ghost_owner_neighbor_rank();
+    ghost_owners0 = _index_maps[0]->ghost_owners();
     std::transform(ghost_owners0.cbegin(), ghost_owners0.cend(),
                    ghost_owners0.begin(),
                    [&neighbors](auto r) { return neighbors[r]; });
@@ -279,7 +279,7 @@ void SparsityPattern::assemble()
   {
     std::vector<int> neighbors = dolfinx::MPI::neighbors(
         _index_maps[1]->comm(common::IndexMap::Direction::forward))[0];
-    _col_ghost_owners = _index_maps[1]->ghost_owner_neighbor_rank();
+    _col_ghost_owners = _index_maps[1]->ghost_owners();
     std::transform(_col_ghost_owners.cbegin(), _col_ghost_owners.cend(),
                    _col_ghost_owners.begin(),
                    [&neighbors](auto r) { return neighbors[r]; });

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -253,21 +253,10 @@ void SparsityPattern::assemble()
 
   assert(_index_maps[0]);
   const std::int32_t local_size0 = _index_maps[0]->size_local();
-  const std::int32_t num_ghosts0 = _index_maps[0]->num_ghosts();
   const std::array local_range0 = _index_maps[0]->local_range();
   const std::vector<std::int64_t>& ghosts0 = _index_maps[0]->ghosts();
 
-  // FIXME: avoid mapping back-and-forth between neighbourhood and
-  // global ranks
-  std::vector<int> ghost_owners0;
-  {
-    std::vector<int> neighbors = dolfinx::MPI::neighbors(
-        _index_maps[0]->comm(common::IndexMap::Direction::forward))[0];
-    ghost_owners0 = _index_maps[0]->ghost_owners();
-    std::transform(ghost_owners0.cbegin(), ghost_owners0.cend(),
-                   ghost_owners0.begin(),
-                   [&neighbors](auto r) { return neighbors[r]; });
-  }
+  const std::vector<int> ghost_owners0 = _index_maps[0]->ghost_owners();
 
   assert(_index_maps[1]);
   const std::int32_t local_size1 = _index_maps[1]->size_local();
@@ -285,7 +274,7 @@ void SparsityPattern::assemble()
                    [&neighbors](auto r) { return neighbors[r]; });
   }
 
-  // Global to local map for ghost columns
+  // Global to local map for ghost column indices
   std::map<std::int64_t, std::int32_t> global_to_local;
   std::int32_t local_i = local_size1;
   for (std::int64_t global_i : _col_ghosts)
@@ -295,25 +284,13 @@ void SparsityPattern::assemble()
   MPI_Comm comm = _index_maps[0]->comm(common::IndexMap::Direction::reverse);
   const auto dest_ranks = dolfinx::MPI::neighbors(comm)[1];
 
-  // Global-to-neigbourhood map for destination ranks
-  std::map<int, std::int32_t> dest_proc_to_neighbor;
-  for (std::size_t i = 0; i < dest_ranks.size(); ++i)
-    dest_proc_to_neighbor.insert({dest_ranks[i], i});
-
   // Compute size of data to send to each process
   std::vector<std::int32_t> data_per_proc(dest_ranks.size(), 0);
-  std::vector<int> ghost_to_neighbour_rank(num_ghosts0, -1);
-  for (int i = 0; i < num_ghosts0; ++i)
+  for (std::size_t i = 0; i < ghost_owners0.size(); ++i)
   {
-    // Find rank on neigbourhood comm of ghost owner
-    const auto it = dest_proc_to_neighbor.find(ghost_owners0[i]);
-    assert(it != dest_proc_to_neighbor.end());
-    ghost_to_neighbour_rank[i] = it->second;
-
     // Add to src size
-    assert(ghost_to_neighbour_rank[i] < (int)data_per_proc.size());
-    data_per_proc[ghost_to_neighbour_rank[i]]
-        += 3 * _row_cache[i + local_size0].size();
+    assert(ghost_owners0[i] < (int)data_per_proc.size());
+    data_per_proc[ghost_owners0[i]] += 3 * _row_cache[i + local_size0].size();
   }
 
   // Compute send displacements
@@ -326,9 +303,9 @@ void SparsityPattern::assemble()
   std::vector<int> insert_pos(send_disp);
   std::vector<std::int64_t> ghost_data(send_disp.back());
   const int rank = dolfinx::MPI::rank(_comm.comm());
-  for (int i = 0; i < num_ghosts0; ++i)
+  for (std::size_t i = 0; i < ghost_owners0.size(); ++i)
   {
-    const int neighbour_rank = ghost_to_neighbour_rank[i];
+    const int neighbour_rank = ghost_owners0[i];
     for (std::int32_t col_local : _row_cache[i + local_size0])
     {
       // Get index in send buffer
@@ -380,16 +357,17 @@ void SparsityPattern::assemble()
         _col_ghost_owners.push_back(owner);
         ++local_i;
       }
+
       const std::int32_t col_local = it.first->second;
       _row_cache[row_local].push_back(col_local);
     }
   }
 
   // Sort and remove duplicate column indices in each row
-  std::vector<std::int32_t> adj_counts(local_size0 + num_ghosts0, 0);
+  std::vector<std::int32_t> adj_counts(local_size0 + ghost_owners0.size(), 0);
   std::vector<std::int32_t> adj_data;
-  _off_diagonal_offset.resize(local_size0 + num_ghosts0);
-  for (std::int32_t i = 0; i < local_size0 + num_ghosts0; ++i)
+  _off_diagonal_offset.resize(local_size0 + ghost_owners0.size());
+  for (std::size_t i = 0; i < local_size0 + ghost_owners0.size(); ++i)
   {
     std::vector<std::int32_t>& row = _row_cache[i];
     std::sort(row.begin(), row.end());
@@ -406,7 +384,7 @@ void SparsityPattern::assemble()
   std::vector<std::vector<std::int32_t>>().swap(_row_cache);
 
   // Compute offsets for adjacency list
-  std::vector<std::int32_t> adj_offsets(local_size0 + num_ghosts0 + 1);
+  std::vector<std::int32_t> adj_offsets(local_size0 + ghost_owners0.size() + 1);
   std::partial_sum(adj_counts.begin(), adj_counts.end(),
                    adj_offsets.begin() + 1);
 

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -396,7 +396,7 @@ refinement::adjust_indices(const common::IndexMap& index_map, std::int32_t n)
   MPI_Neighbor_allgather(&global_offset, 1, MPI_INT64_T,
                          neighbor_offsets.data(), 1, MPI_INT64_T, comm_fwd);
 
-  const std::vector<int>& ghost_owners = index_map.ghost_owner_neighbor_rank();
+  const std::vector<int>& ghost_owners = index_map.ghost_owners();
   int local_size = index_map.size_local();
   std::vector<std::int64_t> global_indices = index_map.global_indices();
   std::transform(global_indices.begin(),

--- a/python/dolfinx/common.py
+++ b/python/dolfinx/common.py
@@ -15,6 +15,7 @@ __all__ = ["IndexMap", "Timer", "timed", "ScatterMode"]
 
 TimingType = _cpp.common.TimingType
 Reduction = _cpp.common.Reduction
+Direction = _cpp.common.Direction
 
 
 def timing(task: str):

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -86,9 +86,9 @@ void common(py::module& m)
           { return MPICommWrapper(self.comm(d)); },
           "Return MPI communicator")
       .def(
-          "ghost_owner_rank",
+          "ghost_owners",
           [](const dolfinx::common::IndexMap& self)
-          { return as_pyarray(self.ghost_owner_neighbor_rank()); },
+          { return as_pyarray(self.ghost_owners()); },
           "Return owning process for each ghost index")
       .def_property_readonly(
           "ghosts",

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -75,11 +75,11 @@ void common(py::module& m)
       .def_property_readonly("local_range",
                              &dolfinx::common::IndexMap::local_range,
                              "Range of indices owned by this map")
-      // .def(
-      //     "ghost_owner_rank",
-      //     [](const dolfinx::common::IndexMap& self)
-      //     { return as_pyarray(self.ghost_owner_rank()); },
-      //     "Return owning process for each ghost index")
+      .def(
+          "ghost_owner_rank",
+          [](const dolfinx::common::IndexMap& self)
+          { return as_pyarray(self.ghost_owner_neighbor_rank()); },
+          "Return owning process for each ghost index")
       .def_property_readonly(
           "ghosts",
           [](const dolfinx::common::IndexMap& self)

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -49,6 +49,10 @@ void common(py::module& m)
       .value("add", dolfinx::common::IndexMap::Mode::add)
       .value("insert", dolfinx::common::IndexMap::Mode::insert);
 
+  py::enum_<dolfinx::common::IndexMap::Direction>(m, "Direction")
+      .value("forward", dolfinx::common::IndexMap::Direction::forward)
+      .value("reverse", dolfinx::common::IndexMap::Direction::reverse);
+
   py::enum_<dolfinx::Table::Reduction>(m, "Reduction")
       .value("max", dolfinx::Table::Reduction::max)
       .value("min", dolfinx::Table::Reduction::min)
@@ -75,6 +79,12 @@ void common(py::module& m)
       .def_property_readonly("local_range",
                              &dolfinx::common::IndexMap::local_range,
                              "Range of indices owned by this map")
+      .def(
+          "comm",
+          [](const dolfinx::common::IndexMap& self,
+             dolfinx::common::IndexMap::Direction d)
+          { return MPICommWrapper(self.comm(d)); },
+          "Return MPI communicator")
       .def(
           "ghost_owner_rank",
           [](const dolfinx::common::IndexMap& self)

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -75,11 +75,11 @@ void common(py::module& m)
       .def_property_readonly("local_range",
                              &dolfinx::common::IndexMap::local_range,
                              "Range of indices owned by this map")
-      .def(
-          "ghost_owner_rank",
-          [](const dolfinx::common::IndexMap& self)
-          { return as_pyarray(self.ghost_owner_rank()); },
-          "Return owning process for each ghost index")
+      // .def(
+      //     "ghost_owner_rank",
+      //     [](const dolfinx::common::IndexMap& self)
+      //     { return as_pyarray(self.ghost_owner_rank()); },
+      //     "Return owning process for each ghost index")
       .def_property_readonly(
           "ghosts",
           [](const dolfinx::common::IndexMap& self)

--- a/python/test/unit/common/test_index_map.py
+++ b/python/test/unit/common/test_index_map.py
@@ -55,13 +55,10 @@ def test_sub_index_map():
     owners = map.ghost_owners()
     comm = map.comm(dolfinx.common.Direction.forward)
     ranks = np.array(comm.Get_dist_neighbors()[0])
-
     owners = ranks[owners]
     assert (dest_ranks == owners).all()
 
-    # print(test, owners)
-
-    subowners = submap.ghost_owner_rank()
+    subowners = submap.ghost_owners()
     comm = submap.comm(dolfinx.common.Direction.forward)
     ranks = np.array(comm.Get_dist_neighbors()[0])
     subowners = ranks[subowners]

--- a/python/test/unit/common/test_index_map.py
+++ b/python/test/unit/common/test_index_map.py
@@ -52,9 +52,20 @@ def test_sub_index_map():
 
     # Check that rank on sub-process ghosts is the same as the parent
     # map
-    # owners = map.ghost_owner_rank()
-    # assert (dest_ranks == owners).all()
-    # assert (owners[ghosts_pos_sub] == submap.ghost_owner_rank()).all()
+    owners = map.ghost_owner_rank()
+    comm = map.comm(dolfinx.common.Direction.forward)
+    ranks = np.array(comm.Get_dist_neighbors()[0])
+
+    owners = ranks[owners]
+    assert (dest_ranks == owners).all()
+
+    # print(test, owners)
+
+    subowners = submap.ghost_owner_rank()
+    comm = submap.comm(dolfinx.common.Direction.forward)
+    ranks = np.array(comm.Get_dist_neighbors()[0])
+    subowners = ranks[subowners]
+    assert (owners[ghosts_pos_sub] == subowners).all()
 
     # Check that ghost indices are correct in submap
     # NOTE This assumes size_local is the same for all ranks

--- a/python/test/unit/common/test_index_map.py
+++ b/python/test/unit/common/test_index_map.py
@@ -74,6 +74,6 @@ def test_sub_index_map_ghost_mode_none():
     n = 2
     mesh = create_unit_square(MPI.COMM_WORLD, n, n, ghost_mode=GhostMode.none)
     tdim = mesh.topology.dim
-    cell_index_map = mesh.topology.index_map(tdim)
-    submap_indices = np.array([0, 1], dtype=np.int32)
-    cell_index_map.create_submap(submap_indices)
+    map = mesh.topology.index_map(tdim)
+    submap_indices = range(0, min(2, map.size_local))
+    map.create_submap(submap_indices)

--- a/python/test/unit/common/test_index_map.py
+++ b/python/test/unit/common/test_index_map.py
@@ -21,7 +21,7 @@ def test_sub_index_map():
     assert comm.size < n + 1
     map_local_size = np.math.factorial(n)
 
-    # The ghosts added is the ith ghost from the ith process relative to
+    # The ghosts added are the ith ghost from the ith process relative to
     # the current rank, i.e. rank 0 contains the first index of rank 2,
     # second of rank 3 etc. rank 1 contains the first index of rank 0,
     # the second of rank 2 etc.

--- a/python/test/unit/common/test_index_map.py
+++ b/python/test/unit/common/test_index_map.py
@@ -21,9 +21,10 @@ def test_sub_index_map():
     assert comm.size < n + 1
     map_local_size = np.math.factorial(n)
 
-    # The ghosts added is the ith ghost from the ith process relative to the current rank, i.e.
-    # rank 0 contains the first index of rank 2, second of rank 3 etc.
-    # rank 1 contains the first index of rank 0, the second of rank 2 etc.
+    # The ghosts added is the ith ghost from the ith process relative to
+    # the current rank, i.e. rank 0 contains the first index of rank 2,
+    # second of rank 3 etc. rank 1 contains the first index of rank 0,
+    # the second of rank 2 etc.
     # Ghost one index from from every other rank
     dest_ranks = np.delete(np.arange(0, comm.size, dtype=np.int32), my_rank)
     map_ghosts = np.array([map_local_size * dest_ranks[r] + r % map_local_size for r in range(len(dest_ranks))])

--- a/python/test/unit/common/test_index_map.py
+++ b/python/test/unit/common/test_index_map.py
@@ -52,7 +52,7 @@ def test_sub_index_map():
 
     # Check that rank on sub-process ghosts is the same as the parent
     # map
-    owners = map.ghost_owner_rank()
+    owners = map.ghost_owners()
     comm = map.comm(dolfinx.common.Direction.forward)
     ranks = np.array(comm.Get_dist_neighbors()[0])
 

--- a/python/test/unit/common/test_index_map.py
+++ b/python/test/unit/common/test_index_map.py
@@ -51,9 +51,9 @@ def test_sub_index_map():
 
     # Check that rank on sub-process ghosts is the same as the parent
     # map
-    owners = map.ghost_owner_rank()
-    assert (dest_ranks == owners).all()
-    assert (owners[ghosts_pos_sub] == submap.ghost_owner_rank()).all()
+    # owners = map.ghost_owner_rank()
+    # assert (dest_ranks == owners).all()
+    # assert (owners[ghosts_pos_sub] == submap.ghost_owner_rank()).all()
 
     # Check that ghost indices are correct in submap
     # NOTE This assumes size_local is the same for all ranks

--- a/python/test/unit/la/test_vector_scatter.py
+++ b/python/test/unit/la/test_vector_scatter.py
@@ -46,7 +46,6 @@ def test_scatter_forward(element):
     ranks = np.array(comm.Get_dist_neighbors()[0])
     ghost_owners = ranks[ghost_owners]
 
-
     ghost_owners = np.repeat(ghost_owners, bs)
     local_size = u.function_space.dofmap.index_map.size_local * bs
     assert np.allclose(u.x.array[local_size:], ghost_owners)

--- a/python/test/unit/la/test_vector_scatter.py
+++ b/python/test/unit/la/test_vector_scatter.py
@@ -40,10 +40,10 @@ def test_scatter_forward(element):
 
     # Now the ghosts should have the value of the rank of
     # the owning process
-    ghost_owners = u.function_space.dofmap.index_map.ghost_owner_rank()
-    ghost_owners = np.repeat(ghost_owners, bs)
-    local_size = u.function_space.dofmap.index_map.size_local * bs
-    assert np.allclose(u.x.array[local_size:], ghost_owners)
+    # ghost_owners = u.function_space.dofmap.index_map.ghost_owner_rank()
+    # ghost_owners = np.repeat(ghost_owners, bs)
+    # local_size = u.function_space.dofmap.index_map.size_local * bs
+    # assert np.allclose(u.x.array[local_size:], ghost_owners)
 
 
 @pytest.mark.parametrize("element", [ufl.FiniteElement("Lagrange", "triangle", 1),

--- a/python/test/unit/la/test_vector_scatter.py
+++ b/python/test/unit/la/test_vector_scatter.py
@@ -9,6 +9,7 @@
 import numpy as np
 import pytest
 
+import dolfinx
 import ufl
 from dolfinx import cpp as _cpp
 from dolfinx.fem import Function, FunctionSpace
@@ -38,12 +39,17 @@ def test_scatter_forward(element):
     w0 = u.x.array.copy()
     u.x.scatter_forward()
 
-    # Now the ghosts should have the value of the rank of
-    # the owning process
-    # ghost_owners = u.function_space.dofmap.index_map.ghost_owner_rank()
-    # ghost_owners = np.repeat(ghost_owners, bs)
-    # local_size = u.function_space.dofmap.index_map.size_local * bs
-    # assert np.allclose(u.x.array[local_size:], ghost_owners)
+    # Now the ghosts should have the value of the rank of the owning
+    # process
+    ghost_owners = u.function_space.dofmap.index_map.ghost_owners()
+    comm = u.function_space.dofmap.index_map.comm(dolfinx.common.Direction.forward)
+    ranks = np.array(comm.Get_dist_neighbors()[0])
+    ghost_owners = ranks[ghost_owners]
+
+
+    ghost_owners = np.repeat(ghost_owners, bs)
+    local_size = u.function_space.dofmap.index_map.size_local * bs
+    assert np.allclose(u.x.array[local_size:], ghost_owners)
 
 
 @pytest.mark.parametrize("element", [ufl.FiniteElement("Lagrange", "triangle", 1),
@@ -63,7 +69,8 @@ def test_scatter_reverse(element):
     u.x.scatter_reverse(_cpp.common.ScatterMode.insert)
     assert np.allclose(w0, u.x.array)
 
-    # Fill with MPI rank, and sum all entries in the vector (including ghosts)
+    # Fill with MPI rank, and sum all entries in the vector (including
+    # ghosts)
     u.x.array.fill(comm.rank)
     all_count0 = MPI.COMM_WORLD.allreduce(u.x.array.sum(), op=MPI.SUM)
 
@@ -72,7 +79,7 @@ def test_scatter_reverse(element):
     num_ghosts = V.dofmap.index_map.num_ghosts
     ghost_count = MPI.COMM_WORLD.allreduce(num_ghosts * comm.rank, op=MPI.SUM)
 
-    # New count should have gone up by the number of ghosts times their rank
-    # on all processes
+    # New count should have gone up by the number of ghosts times their
+    # rank on all processes
     all_count1 = MPI.COMM_WORLD.allreduce(u.x.array.sum(), op=MPI.SUM)
     assert all_count1 == (all_count0 + bs * ghost_count)


### PR DESCRIPTION
`IndexMap` previously return the global owning rank, and callers reverse-engineered this back to the neighbourhood rank. This change returns the rank on the neighbourhood communicator, which can we easily converted to the global rank, if needed. 