### PR TITLE
Do not modify version header file source code in-place

### DIFF
--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -2,13 +2,6 @@
 include(GNUInstallDirs)
 
 #------------------------------------------------------------------------------
-# Configure the dolfinx/common/version.h file
-
-# NOTE: This modifies a file in the source directory, which probably isn't good
-configure_file(${DOLFINX_SOURCE_DIR}/dolfinx/common/version.h.in
-  ${DOLFINX_SOURCE_DIR}/dolfinx/common/version.h @ONLY)
-
-#------------------------------------------------------------------------------
 # Delcare the library (target)
 
 add_library(dolfinx)
@@ -17,8 +10,6 @@ add_library(dolfinx)
 # Add source files to the target
 
 set(DOLFINX_DIRS common fem geometry graph io la mesh nls refinement)
-
-install(FILES dolfinx.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT Development)
 
 # Add source to dolfinx target, and get sets of header files
 foreach(DIR ${DOLFINX_DIRS})
@@ -29,6 +20,12 @@ endforeach()
 target_include_directories(dolfinx PUBLIC
                            $<INSTALL_INTERFACE:include>
                            "$<BUILD_INTERFACE:${DOLFINX_SOURCE_DIR};${DOLFINX_SOURCE_DIR}/dolfinx>")
+
+#------------------------------------------------------------------------------
+# Configure the common/version.h file
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/common/version.h.in common/version.h @ONLY)
+set_target_properties(dolfinx PROPERTIES PRIVATE_HEADER ${CMAKE_CURRENT_BINARY_DIR}/common/version.h)
 
 #------------------------------------------------------------------------------
 # Set target properties
@@ -144,10 +141,15 @@ install(TARGETS dolfinx
 install(EXPORT DOLFINXTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/dolfinx)
 
 # Install the header files
+install(FILES dolfinx.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT Development)
+
 foreach(DIR ${DOLFINX_DIRS})
   install(FILES ${HEADERS_${DIR}} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dolfinx/${DIR}
     COMPONENT Development)
 endforeach()
+
+install(FILES  ${CMAKE_CURRENT_BINARY_DIR}/common/version.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dolfinx/common}
+COMPONENT Development)
 
 #------------------------------------------------------------------------------
 # Generate CMake config files (DOLFINXConfig{,Version}.cmake)

--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -25,7 +25,6 @@ target_include_directories(dolfinx PUBLIC
 # Configure the common/version.h file
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/common/version.h.in common/version.h @ONLY)
-set_target_properties(dolfinx PROPERTIES PRIVATE_HEADER ${CMAKE_CURRENT_BINARY_DIR}/common/version.h)
 
 #------------------------------------------------------------------------------
 # Set target properties
@@ -148,7 +147,7 @@ foreach(DIR ${DOLFINX_DIRS})
     COMPONENT Development)
 endforeach()
 
-install(FILES  ${CMAKE_CURRENT_BINARY_DIR}/common/version.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dolfinx/common}
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/common/version.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dolfinx/common
 COMPONENT Development)
 
 #------------------------------------------------------------------------------

--- a/cpp/dolfinx/common/CMakeLists.txt
+++ b/cpp/dolfinx/common/CMakeLists.txt
@@ -14,7 +14,6 @@ set(HEADERS_common
   ${CMAKE_CURRENT_SOURCE_DIR}/TimeLogManager.h
   ${CMAKE_CURRENT_SOURCE_DIR}/timing.h
   ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/version.h
   PARENT_SCOPE)
 
 target_sources(dolfinx PRIVATE


### PR DESCRIPTION
Configure `version.h.in` via CMake in the build directory rather than source directory. This preserves a clean separation between source and build code.