### PR TITLE
Spack CI updates and improvements

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -65,6 +65,7 @@ jobs:
         run: |
           . ./spack/share/spack/setup-env.sh
           spack env activate cpp-main
+          spack install py-fenics-ffcx
           cd dolfinx-main/cpp/
           cd demo/poisson
           cmake .
@@ -81,6 +82,7 @@ jobs:
         run: |
           . ./spack/share/spack/setup-env.sh
           spack env activate cpp-release
+          spack install py-fenics-ffcx
           cd dolfinx-release/cpp/
           cd demo/poisson
           cmake .

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -16,10 +16,10 @@ on:
         type: string
       spack_branch:
         description: "Spack repository branch to test"
-        default: "developer"
+        default: "develop"
         type: string
       dolfinx_version:
-        description: "DOLFINx release to test"
+        description: "DOLFINx release to test (leave blank for latest)"
         default: ""
         type: string
 

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -109,9 +109,9 @@ jobs:
         run: |
           . ./spack/share/spack/setup-env.sh
           spack env activate py-main
-          mpirun -np 2 python3 ./dolfinx-main/python/demo/demo_elasticity.py
+          mpirun -np 2 python3 ./dolfinx-main/python/demo_elasticity.py
       - name: Run DOLFINx (Python, release) test
         run: |
           . ./spack/share/spack/setup-env.sh
           spack env activate py-release
-          mpirun -np 2 python3 ./dolfinx-release/python/demo/elasticity/demo_elasticity.py
+          mpirun -np 2 python3 ./dolfinx-release/python/demo/demo_elasticity.py

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     env:
-      release_version: 0.3.0
+      release_version: 0.4.1
     strategy:
       matrix:
         # os: [ubuntu-20.04, macos-10.15]
@@ -26,8 +26,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ./spack
-          repository: spack/spack
-          ref: develop
+          repository: FEniCS/spack
+          ref: ufcx_0.4.0
+          # repository: spack/spack
+          # ref: develop
       - name: Build DOLFINx (C++) development version via Spack
         run: |
           . ./spack/share/spack/setup-env.sh
@@ -63,17 +65,16 @@ jobs:
         with:
           ref: v${{ env.release_version }}
           path: ./dolfinx-release
-      # - name: Run a C++ test (release version)
-      #   run: |
-      #     . ./spack/share/spack/setup-env.sh
-      #     spack env activate cpp-release
-      #     cd dolfinx-release/cpp/
-      #     cd demo/poisson
-      #     ffcx poisson.ufl
-      #     cmake .
-      #     export VERBOSE=1
-      #     make -j2
-      #     mpirun -np 2 ./demo_poisson
+      - name: Run a C++ test (release version)
+        run: |
+          . ./spack/share/spack/setup-env.sh
+          spack env activate cpp-release
+          cd dolfinx-release/cpp/
+          cd demo/poisson
+          cmake .
+          export VERBOSE=1
+          make -j2
+          mpirun -np 2 ./demo_poisson
 
       - name: Build DOLFINx (Python, development)
         run: |

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -8,12 +8,25 @@ on:
   schedule:
     # '*' is a special character in YAML, so string must be quoted
     - cron: "0 2 * * THU"
-  workflow_dispatch: ~
+  workflow_dispatch:
+    inputs:
+      spack_repo:
+        description: "Spack repository to test"
+        default: "spack/spack"
+        type: string
+      spack_branch:
+        description: "Spack repository branch to test"
+        default: "developer"
+        type: string
+      dolfinx_version:
+        description: "DOLFINx release to test"
+        default: ""
+        type: string
 
 jobs:
   build:
-    env:
-      release_version: 0.4.1
+    # env:
+    #   release_version: 0.4.1
     strategy:
       matrix:
         # os: [ubuntu-20.04, macos-10.15]
@@ -26,10 +39,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ./spack
-          repository: FEniCS/spack
-          ref: ufcx_0.4.0
-          # repository: spack/spack
-          # ref: develop
+          repository: ${{ github.event.inputs.spack_repo }}
+          ref: ${{ github.event.inputs.spack_branch }}
       - name: Build DOLFINx (C++) development version via Spack
         run: |
           . ./spack/share/spack/setup-env.sh
@@ -63,7 +74,8 @@ jobs:
       - name: Get DOLFINx code (to access test files)
         uses: actions/checkout@v2
         with:
-          ref: v${{ env.release_version }}
+          ref: main
+          # ref: v${{ github.event.inputs.spack_branch }}
           path: ./dolfinx-release
       - name: Run a C++ test (release version)
         run: |

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -14,19 +14,13 @@ on:
         description: "Spack repository to test"
         default: "spack/spack"
         type: string
-      spack_branch:
-        description: "Spack repository branch to test"
+      spack_ref:
+        description: "Spack repository branch/tag to test"
         default: "develop"
-        type: string
-      dolfinx_version:
-        description: "DOLFINx release to test (leave blank for latest)"
-        default: ""
         type: string
 
 jobs:
   build:
-    # env:
-    #   release_version: 0.4.1
     strategy:
       matrix:
         # os: [ubuntu-20.04, macos-10.15]
@@ -40,7 +34,7 @@ jobs:
         with:
           path: ./spack
           repository: ${{ github.event.inputs.spack_repo }}
-          ref: ${{ github.event.inputs.spack_branch }}
+          ref: ${{ github.event.inputs.spack_ref }}
       - name: Build DOLFINx (C++) development version via Spack
         run: |
           . ./spack/share/spack/setup-env.sh
@@ -72,7 +66,8 @@ jobs:
           export VERBOSE=1
           make -j2
           mpirun -np 2 ./demo_poisson
-      - name: Get DOLFINx code (to access test files)
+
+      - name: Get DOLFINx release code (to access test files)
         uses: actions/checkout@v2
         with:
           ref: main


### PR DESCRIPTION
Allow Spack repository and branch to be specified when manually triggering CI