### PR TITLE
Update for name of KaHIP library

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -70,18 +70,11 @@ add_feature_info(XTENSOR_OPTIMIZE XTENSOR_OPTIMIZE "Enable architecture-specific
 # Enable or disable optional packages
 
 # List optional packages
-list(APPEND OPTIONAL_PACKAGES "ADIOS2")
-list(APPEND OPTIONAL_PACKAGES "ParMETIS")
-list(APPEND OPTIONAL_PACKAGES "SCOTCH")
-list(APPEND OPTIONAL_PACKAGES "SLEPc")
-list(APPEND OPTIONAL_PACKAGES "KaHIP")
-
-# Add options
-foreach (OPTIONAL_PACKAGE ${OPTIONAL_PACKAGES})
-  string(TOUPPER "DOLFINX_ENABLE_${OPTIONAL_PACKAGE}" OPTION_NAME)
-  option(${OPTION_NAME} "Compile with support for ${OPTIONAL_PACKAGE}." ON)
-  add_feature_info(${OPTION_NAME} ${OPTION_NAME} "Compile with support for ${OPTIONAL_PACKAGE}.")
-endforeach()
+option(DOLFINX_ENABLE_ADIOS2 "Compile with support for ADIOS2." ON)
+option(DOLFINX_ENABLE_PARMETIS "Compile with support for ParMETIS." ON)
+option(DOLFINX_ENABLE_SCOTCH "Compile with support for SCOTCH." ON)
+option(DOLFINX_ENABLE_SLEPC "Compile with support for SLEPc." ON)
+option(DOLFINX_ENABLE_KAHIP "Compile with support for KaHIP." OFF)
 
 #------------------------------------------------------------------------------
 # Check for MPI

--- a/cpp/cmake/modules/FindKaHIP.cmake
+++ b/cpp/cmake/modules/FindKaHIP.cmake
@@ -67,7 +67,6 @@ if (MPI_CXX_FOUND)
         #include <mpi.h>
         #include <vector>
         #include <kaHIP_interface.h>
-
         int main()
         {
           int n = 5;
@@ -80,8 +79,8 @@ if (MPI_CXX_FOUND)
           int *vwgt = nullptr;;
           int *adjcwgt = nullptr;;
           kaffpa(&n, vwgt, xadj.data(), adjcwgt, adjncy.data(),
-                &nparts, &imbalance, false, 0, ECO, &edge_cut,
-                part.data());
+                 &nparts, &imbalance, false, 0, ECO, &edge_cut,
+                 part.data());
         return 0;
         }
         " KAHIP_TEST_RUNS)

--- a/cpp/cmake/modules/FindKaHIP.cmake
+++ b/cpp/cmake/modules/FindKaHIP.cmake
@@ -40,54 +40,57 @@ message(STATUS "Checking for package 'KaHIP'")
 
 if (MPI_CXX_FOUND)
   find_path(KAHIP_INCLUDE_DIRS parhip_interface.h
-    HINTS ${KAHIP_DIR}/include $ENV{KAHIP_DIR}/include PATH_SUFFIXES kahip
-    DOC "Directory where the KaHIP header files are located.")
-
-  find_library(PARHIP_LIBRARY parhip_interface HINTS ${KAHIP_DIR}/lib $ENV{KAHIP_DIR}/lib
-    DOC "Path to the ParHIP library")
-
-  find_library(KAHIP_LIBRARY interface HINTS ${KAHIP_DIR}/lib $ENV{KAHIP_DIR}/lib
-    DOC "Path to the KaHIP library")
+    HINTS ${KAHIP_DIR}/include $ENV{KAHIP_DIR}/include PATH_SUFFIXES kahip)
+  find_library(PARHIP_LIBRARY parhip_interface HINTS ${KAHIP_DIR}/lib $ENV{KAHIP_DIR}/lib)
+  find_library(KAHIP_LIBRARY kahip HINTS ${KAHIP_DIR}/lib $ENV{KAHIP_DIR}/lib)
 
   set(KAHIP_LIBRARIES ${PARHIP_LIBRARY} ${KAHIP_LIBRARY})
-  if (KAHIP_LIBRARIES AND KAHIP_LIBRARIES)
 
-    # Build and run test program
-    include(CheckCXXSourceRuns)
+  include (FindPackageHandleStandardArgs)
+  if (DOLFINX_SKIP_BUILD_TESTS)
+    find_package_handle_standard_args(KaHIP
+                                     "KaHIP could not be found/configured."
+                                      KAHIP_INCLUDE_DIRS
+                                      KAHIP_LIBRARIES)
+  else()
+    if (KAHIP_LIBRARIES AND KAHIP_LIBRARIES)
 
-    # Set flags for building test program
-    set(CMAKE_REQUIRED_INCLUDES  ${KAHIP_INCLUDE_DIRS} ${MPI_CXX_INCLUDE_PATH})
-    set(CMAKE_REQUIRED_LIBRARIES ${KAHIP_LIBRARIES} ${MPI_CXX_LIBRARIES})
-    set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS} ${MPI_CXX_COMPILE_FLAGS})
-    check_cxx_source_runs("
-      #define MPICH_IGNORE_CXX_SEEK 1
-      #include <mpi.h>
-      #include <vector>
-      #include <kaHIP_interface.h>
+      # Build and run test program
+      include(CheckCXXSourceRuns)
 
-      int main()
-      {
-        int n = 5;
-        std::vector<int> xadj = {0, 2, 5, 7, 9, 12};
-        std::vector<int> adjncy = {1, 4, 0, 2, 4, 1, 3, 2, 4, 0, 1, 3};
-        std::vector<int> part(n);
-        double imbalance = 0.03;
-        int edge_cut = 0;
-        int nparts = 2;
-        int *vwgt = nullptr;;
-        int *adjcwgt = nullptr;;
-        kaffpa(&n, vwgt, xadj.data(), adjcwgt, adjncy.data(),
-               &nparts, &imbalance, false, 0, ECO, &edge_cut,
-               part.data());
-      return 0;
-      }
-      " KAHIP_TEST_RUNS)
+      # Set flags for building test program
+      set(CMAKE_REQUIRED_INCLUDES  ${KAHIP_INCLUDE_DIRS} ${MPI_CXX_INCLUDE_PATH})
+      set(CMAKE_REQUIRED_LIBRARIES ${KAHIP_LIBRARIES} ${MPI_CXX_LIBRARIES})
+      set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS} ${MPI_CXX_COMPILE_FLAGS})
+      check_cxx_source_runs("
+        #define MPICH_IGNORE_CXX_SEEK 1
+        #include <mpi.h>
+        #include <vector>
+        #include <kaHIP_interface.h>
+
+        int main()
+        {
+          int n = 5;
+          std::vector<int> xadj = {0, 2, 5, 7, 9, 12};
+          std::vector<int> adjncy = {1, 4, 0, 2, 4, 1, 3, 2, 4, 0, 1, 3};
+          std::vector<int> part(n);
+          double imbalance = 0.03;
+          int edge_cut = 0;
+          int nparts = 2;
+          int *vwgt = nullptr;;
+          int *adjcwgt = nullptr;;
+          kaffpa(&n, vwgt, xadj.data(), adjcwgt, adjncy.data(),
+                &nparts, &imbalance, false, 0, ECO, &edge_cut,
+                part.data());
+        return 0;
+        }
+        " KAHIP_TEST_RUNS)
+    endif()
   endif()
-endif()
 
-include (FindPackageHandleStandardArgs)
-find_package_handle_standard_args(KaHIP
-                                  "KaHIP could not be found/configured."
-                                  KAHIP_INCLUDE_DIRS
-                                  KAHIP_LIBRARIES
-                                  KAHIP_TEST_RUNS)
+  find_package_handle_standard_args(KaHIP
+                                    "KaHIP could not be found/configured."
+                                    KAHIP_INCLUDE_DIRS
+                                    KAHIP_LIBRARIES
+                                    KAHIP_TEST_RUNS)
+endif()


### PR DESCRIPTION
KaHIP changed its library name from `interface` to `kahip`.