### PR TITLE
Add stubs for MeshTagsMetaClass

### DIFF
--- a/python/demo/demo_gmsh.py
+++ b/python/demo/demo_gmsh.py
@@ -121,7 +121,7 @@ entities, values = distribute_entity_data(msh, 2, marked_facets, facet_values)
 
 msh.topology.create_connectivity(2, 0)
 mt = meshtags_from_entities(msh, 2, create_adjacencylist(entities), values)
-mt.name = "ball_d1_surface"
+mt._name = "ball_d1_surface"
 
 with XDMFFile(MPI.COMM_WORLD, "out_gmsh/mesh.xdmf", "w") as file:
     file.write_mesh(msh)
@@ -181,7 +181,7 @@ marked_facets = marked_facets[:, gmsh_triangle6]
 entities, values = distribute_entity_data(msh, 2, marked_facets, facet_values)
 msh.topology.create_connectivity(2, 0)
 mt = meshtags_from_entities(msh, 2, create_adjacencylist(entities), values)
-mt.name = "ball_d2_surface"
+mt._name = "ball_d2_surface"
 with XDMFFile(MPI.COMM_WORLD, "out_gmsh/mesh.xdmf", "a") as file:
     file.write_mesh(msh)
     msh.topology.create_connectivity(2, 3)
@@ -258,7 +258,7 @@ msh.name = "hex_d2"
 entities, values = distribute_entity_data(msh, 2, marked_facets, facet_values)
 msh.topology.create_connectivity(2, 0)
 mt = meshtags_from_entities(msh, 2, create_adjacencylist(entities), values)
-mt.name = "hex_d2_surface"
+mt._name = "hex_d2_surface"
 
 with XDMFFile(MPI.COMM_WORLD, "out_gmsh/mesh.xdmf", "a") as file:
     file.write_mesh(msh)

--- a/python/dolfinx/fem/bcs.py
+++ b/python/dolfinx/fem/bcs.py
@@ -121,21 +121,21 @@ class DirichletBCMetaClass:
 
         if V is not None:
             try:
-                super().__init__(_value, dofs, V)  # type: ignore
+                super().__init__(_value, dofs, V)  # type: ignore[call-arg]
             except TypeError:
-                super().__init__(_value, dofs, V._cpp_object)  # type: ignore
+                super().__init__(_value, dofs, V._cpp_object)  # type: ignore[call-arg]
         else:
-            super().__init__(_value, dofs)  # type: ignore
+            super().__init__(_value, dofs)  # type: ignore[call-arg]
 
     @property
     def g(self):
         """The boundary condition value(s)"""
-        return self.value  # type: ignore
+        return self.value
 
     @property
     def function_space(self) -> dolfinx.fem.FunctionSpace:
         """The function space on which the boundary condition is defined"""
-        return super().function_space  # type: ignore
+        return super().function_space  # type: ignore[misc]
 
 
 def dirichletbc(value: typing.Union[Function, Constant, np.ndarray],

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -51,7 +51,7 @@ class FormMetaClass:
         self._ufcx_form = form
         ffi = cffi.FFI()
         super().__init__(ffi.cast("uintptr_t", ffi.addressof(self._ufcx_form)),
-                         V, coeffs, constants, subdomains, mesh)  # type: ignore
+                         V, coeffs, constants, subdomains, mesh)  # type: ignore[call-arg]
 
     @property
     def ufcx_form(self):
@@ -66,22 +66,22 @@ class FormMetaClass:
     @property
     def function_spaces(self) -> typing.List[FunctionSpace]:
         """Function spaces on which this form is defined"""
-        return super().function_spaces  # type: ignore
+        return super().function_spaces  # type: ignore[misc]
 
     @property
     def dtype(self) -> np.dtype:
         """dtype of this form"""
-        return super().dtype  # type: ignore
+        return super().dtype  # type: ignore[misc]
 
     @property
     def mesh(self) -> Mesh:
         """Mesh on which this form is defined"""
-        return super().mesh  # type: ignore
+        return super().mesh  # type: ignore[misc]
 
     @property
     def integral_types(self):
         """Integral types in the form"""
-        return super().integral_types  # type: ignore
+        return super().integral_types  # type: ignore[misc]
 
 
 form_types = typing.Union[FormMetaClass, _cpp.fem.Form_float32, _cpp.fem.Form_float64,

--- a/python/dolfinx/la.py
+++ b/python/dolfinx/la.py
@@ -95,11 +95,11 @@ class VectorMetaClass:
             and not created using the class initialiser.
 
         """
-        super().__init__(map, bs)  # type: ignore
+        super().__init__(map, bs)
 
     @property
     def array(self) -> np.ndarray:
-        return super().array  # type: ignore
+        return super().array  # type: ignore[misc]
 
 
 def vector(map, bs=1, dtype=np.float64) -> VectorMetaClass:

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -216,7 +216,7 @@ class MeshTagsMetaClass:
             directly.
 
         """
-        super().__init__(mesh, dim, indices.astype(np.int32), values)  # type: ignore
+        super().__init__(mesh, dim, indices.astype(np.int32), values)  # type: ignore[call-arg]
 
     def ufl_id(self) -> int:
         """Object identifier.
@@ -229,6 +229,25 @@ class MeshTagsMetaClass:
 
         """
         return id(self)
+
+    @property
+    def dim(self) -> int:
+        """Topological dimension of the entities"""
+        return super().dim  # type: ignore[misc]
+
+    @property
+    def values(self) -> np.ndarray:
+        """ The values corresponding to each entity"""
+        return super().values  # type: ignore[misc]
+
+    @property
+    def indices(self) -> numpy.typing.NDArray[np.int32]:
+        """ Entity indices (local to process)"""
+        return super().indices   # type: ignore[misc]
+
+    def find(self, value: typing.Union[int, np.int8, np.int32, np.int64, np.float64]):
+        """ Find all entities marked with input value"""
+        return super().find(value)  # type:ignore[misc]
 
 
 def meshtags(mesh: Mesh, dim: int, indices: np.ndarray,

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -247,7 +247,11 @@ class MeshTagsMetaClass:
 
     @property
     def name(self) -> str:
-        return super().name  # type: ignore[misc]
+        return super()._name  # type: ignore[misc]
+
+    @name.setter
+    def name(self, name: str):
+        super().__setattr__("_name", name)
 
     def find(self, value: typing.Union[int, np.int8, np.int32, np.int64, np.float64]):
         """ Find all entities marked with input value"""

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -245,6 +245,10 @@ class MeshTagsMetaClass:
         """ Entity indices (local to process)"""
         return super().indices   # type: ignore[misc]
 
+    @property
+    def name(self) -> str:
+        return super().name  # type: ignore[misc]
+
     def find(self, value: typing.Union[int, np.int8, np.int32, np.int64, np.float64]):
         """ Find all entities marked with input value"""
         return super().find(value)  # type:ignore[misc]

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -107,7 +107,7 @@ void declare_meshtags(py::module& m, std::string type)
           }))
       .def_property_readonly("dtype", [](const dolfinx::mesh::MeshTags<T>& self)
                              { return py::dtype::of<T>(); })
-      .def_readwrite("name", &dolfinx::mesh::MeshTags<T>::name)
+      .def_readwrite("_name", &dolfinx::mesh::MeshTags<T>::name)
       .def_property_readonly("dim", &dolfinx::mesh::MeshTags<T>::dim)
       .def_property_readonly("mesh", &dolfinx::mesh::MeshTags<T>::mesh)
       .def_property_readonly("values",

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -120,8 +120,8 @@ def _create_tempdir(request):
 
 
 # Assigning a function member variables is a bit of a nasty hack
-_create_tempdir._sequencenumber = defaultdict(int)  # type: ignore
-_create_tempdir._basepaths = set()  # type: ignore
+_create_tempdir._sequencenumber = defaultdict(int)  # type: ignore[attr-defined]
+_create_tempdir._basepaths = set()  # type: ignore[attr-defined]
 
 
 @pytest.fixture(scope="function")

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -88,8 +88,9 @@ else:
 # Get the PETSc MatSetValuesLocal function via ctypes
 # ctypes does not support static types well, ignore type check errors
 MatSetValues_ctypes = petsc_lib_ctypes.MatSetValuesLocal
-MatSetValues_ctypes.argtypes = [ctypes.c_void_p, ctypes_index, ctypes.POINTER(  # type: ignore
-    ctypes_index), ctypes_index, ctypes.POINTER(ctypes_index), ctypes.c_void_p, ctypes.c_int]  # type: ignore
+MatSetValues_ctypes.argtypes = [
+    ctypes.c_void_p, ctypes_index, ctypes.POINTER(ctypes_index),  # type: ignore[list-item,arg-type]
+    ctypes_index, ctypes.POINTER(ctypes_index), ctypes.c_void_p, ctypes.c_int]  # type: ignore[list-item,arg-type]
 del petsc_lib_ctypes
 
 

--- a/python/test/unit/io/test_xdmf_meshtags.py
+++ b/python/test/unit/io/test_xdmf_meshtags.py
@@ -69,8 +69,8 @@ def test_3d(tempdir, cell_type, encoding):
         mt_lines_in = file.read_meshtags(mesh_in, "lines")
         units = file.read_information("units")
         assert units == "mm"
-        assert mt_in.name == "facets"
-        assert mt_lines_in.name == "lines"
+        assert mt_in._name == "facets"
+        assert mt_lines_in._name == "lines"
 
     with XDMFFile(comm, Path(tempdir, "meshtags_3d_out.xdmf"), "w", encoding=encoding) as file:
         file.write_mesh(mesh_in)


### PR DESCRIPTION
To make it possible to use `mypy` with external libraries.

Otherwise, one would get errors like:
```bash
library/file.py:74: error: "MeshTagsMetaClass" has no attribute "dim"
library/file.py:114: error: "MeshTagsMetaClass" has no attribute "indices"
library/file.py:114: error: "MeshTagsMetaClass" has no attribute "values"
```

Also add the correct ignores to make sure we catch other API changes.