### PR TITLE
Flatten integral domains in C++

### DIFF
--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -277,8 +277,8 @@ public:
   /// Get the list of (cell_index, local_facet_index) pairs for the ith
   /// integral (kernel) for the exterior facet domain type
   /// @param[in] i Integral ID, i.e. (sub)domain index
-  /// @return List of (cell_index, local_facet_index) pairs. Storage is row
-  /// major.
+  /// @return List of (cell_index, local_facet_index) pairs. This data is
+  /// flattened with row-major layout, shape=(num_facets, 2)
   const std::vector<std::int32_t>& exterior_facet_domains(int i) const
   {
     auto it = _exterior_facet_integrals.find(i);
@@ -288,12 +288,12 @@ public:
   }
 
   /// Get the list of (cell_index_0, local_facet_index_0, cell_index_1,
-  /// local_facet_index_1) tuples for the ith integral (kernel) for the
+  /// local_facet_index_1) quadruplets for the ith integral (kernel) for the
   /// interior facet domain type.
   /// @param[in] i Integral ID, i.e. (sub)domain index
   /// @return List of tuples of the form
   /// (cell_index_0, local_facet_index_0, cell_index_1, local_facet_index_1).
-  /// Storage is row major
+  /// This data is flattened with row-major layout, shape=(num_facets, 4)
   const std::vector<std::int32_t>& interior_facet_domains(int i) const
   {
     auto it = _interior_facet_integrals.find(i);

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -277,9 +277,9 @@ public:
   /// Get the list of (cell_index, local_facet_index) pairs for the ith
   /// integral (kernel) for the exterior facet domain type
   /// @param[in] i Integral ID, i.e. (sub)domain index
-  /// @return List of (cell_index, local_facet_index) pairs
-  const std::vector<std::pair<std::int32_t, int>>&
-  exterior_facet_domains(int i) const
+  /// @return List of (cell_index, local_facet_index) pairs. Storage is row
+  /// major.
+  const std::vector<std::int32_t>& exterior_facet_domains(int i) const
   {
     auto it = _exterior_facet_integrals.find(i);
     if (it == _exterior_facet_integrals.end())
@@ -289,12 +289,12 @@ public:
 
   /// Get the list of (cell_index_0, local_facet_index_0, cell_index_1,
   /// local_facet_index_1) tuples for the ith integral (kernel) for the
-  /// interior facet domain type,
+  /// interior facet domain type.
   /// @param[in] i Integral ID, i.e. (sub)domain index
   /// @return List of tuples of the form
-  /// (cell_index_0, local_facet_index_0, cell_index_1, local_facet_index_1)
-  const std::vector<std::tuple<std::int32_t, int, std::int32_t, int>>&
-  interior_facet_domains(int i) const
+  /// (cell_index_0, local_facet_index_0, cell_index_1, local_facet_index_1).
+  /// Storage is row major
+  const std::vector<std::int32_t>& interior_facet_domains(int i) const
   {
     auto it = _interior_facet_integrals.find(i);
     if (it == _interior_facet_integrals.end())
@@ -365,14 +365,14 @@ private:
   // @param[in] c_to_f Cell to facet connectivity
   // @return Vector of (cell, local_facet) pairs
   template <int num_cells>
-  static std::array<std::pair<std::int32_t, int>, num_cells>
+  static std::array<std::array<std::int32_t, 2>, num_cells>
   get_cell_local_facet_pairs(
       std::int32_t f, const xtl::span<const std::int32_t>& cells,
       const dolfinx::graph::AdjacencyList<std::int32_t>& c_to_f)
   {
     // Loop over cells sharing facet
     assert(cells.size() == num_cells);
-    std::array<std::pair<std::int32_t, int>, num_cells> cell_local_facet_pairs;
+    std::array<std::array<std::int32_t, 2>, num_cells> cell_local_facet_pairs;
     for (int c = 0; c < num_cells; ++c)
     {
       // Get local index of facet with respect to the cell
@@ -407,8 +407,7 @@ private:
   template <typename iterator>
   void set_exterior_facet_domains(
       const mesh::Topology& topology,
-      std::map<int, std::pair<kern, std::vector<std::pair<std::int32_t, int>>>>&
-          integrals,
+      std::map<int, std::pair<kern, std::vector<std::int32_t>>>& integrals,
       const iterator& tagged_facets_begin, const iterator& tagged_facets_end,
       const std::vector<int>& tags)
   {
@@ -445,9 +444,11 @@ private:
           if (auto it = integrals.find(tags[pos]); it != integrals.end())
           {
             // There will only be one pair for an exterior facet integral
-            std::pair<std::int32_t, int> pair = get_cell_local_facet_pairs<1>(
-                *f, f_to_c->links(*f), *c_to_f)[0];
-            it->second.second.push_back(pair);
+            const std::array<std::int32_t, 2> pair
+                = get_cell_local_facet_pairs<1>(*f, f_to_c->links(*f),
+                                                *c_to_f)[0];
+            it->second.second.insert(it->second.second.end(), pair.cbegin(),
+                                     pair.cend());
           }
         }
       }
@@ -458,10 +459,7 @@ private:
   template <typename iterator>
   static void set_interior_facet_domains(
       const mesh::Topology& topology,
-      std::map<int,
-               std::pair<kern, std::vector<std::tuple<std::int32_t, int,
-                                                      std::int32_t, int>>>>&
-          integrals,
+      std::map<int, std::pair<kern, std::vector<std::int32_t>>>& integrals,
       const iterator& tagged_facets_begin, const iterator& tagged_facets_end,
       const std::vector<int>& tags)
   {
@@ -477,10 +475,12 @@ private:
         const std::size_t pos = std::distance(tagged_facets_begin, f);
         if (auto it = integrals.find(tags[pos]); it != integrals.end())
         {
-          std::array<std::pair<std::int32_t, int>, 2> pairs
+          const std::array<std::array<std::int32_t, 2>, 2> pairs
               = get_cell_local_facet_pairs<2>(*f, f_to_c->links(*f), *c_to_f);
-          it->second.second.emplace_back(pairs[0].first, pairs[0].second,
-                                         pairs[1].first, pairs[1].second);
+          it->second.second.insert(it->second.second.end(), pairs[0].cbegin(),
+                                   pairs[0].cend());
+          it->second.second.insert(it->second.second.end(), pairs[1].cbegin(),
+                                   pairs[1].cend());
         }
       }
     }
@@ -576,8 +576,7 @@ private:
     {
       if (domain_id == -1)
       {
-        std::vector<std::pair<std::int32_t, int>>& facets
-            = kernel_facets.second;
+        std::vector<std::int32_t>& facets = kernel_facets.second;
         facets.clear();
 
         auto f_to_c = topology.connectivity(tdim - 1, tdim);
@@ -587,9 +586,9 @@ private:
         for (std::int32_t f : boundary_facets)
         {
           // There will only be one pair for an exterior facet integral
-          std::pair<std::int32_t, int> pair
+          std::array<std::int32_t, 2> pair
               = get_cell_local_facet_pairs<1>(f, f_to_c->links(f), *c_to_f)[0];
-          facets.push_back(pair);
+          facets.insert(facets.end(), pair.cbegin(), pair.cend());
         }
       }
     }
@@ -600,8 +599,7 @@ private:
     {
       if (domain_id == -1)
       {
-        std::vector<std::tuple<std::int32_t, int, std::int32_t, int>>& facets
-            = kernel_facets.second;
+        std::vector<std::int32_t>& facets = kernel_facets.second;
         facets.clear();
 
         mesh.topology_mutable().create_connectivity(tdim - 1, tdim);
@@ -619,10 +617,10 @@ private:
         {
           if (f_to_c->num_links(f) == 2)
           {
-            std::array<std::pair<std::int32_t, int>, 2> pairs
+            const std::array<std::array<std::int32_t, 2>, 2> pairs
                 = get_cell_local_facet_pairs<2>(f, f_to_c->links(f), *c_to_f);
-            facets.emplace_back(pairs[0].first, pairs[0].second, pairs[1].first,
-                                pairs[1].second);
+            facets.insert(facets.end(), pairs[0].cbegin(), pairs[0].cend());
+            facets.insert(facets.end(), pairs[1].cbegin(), pairs[1].cend());
           }
         }
       }
@@ -645,12 +643,11 @@ private:
   std::map<int, std::pair<kern, std::vector<std::int32_t>>> _cell_integrals;
 
   // Exterior facet integrals
-  std::map<int, std::pair<kern, std::vector<std::pair<std::int32_t, int>>>>
+  std::map<int, std::pair<kern, std::vector<std::int32_t>>>
       _exterior_facet_integrals;
 
   // Interior facet integrals
-  std::map<int, std::pair<kern, std::vector<std::tuple<std::int32_t, int,
-                                                       std::int32_t, int>>>>
+  std::map<int, std::pair<kern, std::vector<std::int32_t>>>
       _interior_facet_integrals;
 
   // True if permutation data needs to be passed into these integrals

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -279,12 +279,11 @@ void assemble_interior_facets(
   // Temporaries for joint dofmaps
   std::vector<std::int32_t> dmapjoint0, dmapjoint1;
   assert(facets.size() % 4 == 0);
-  std::array<std::int32_t, 2> cells;
-  std::array<std::int32_t, 2> local_facet;
   for (std::size_t index = 0; index < facets.size(); index += 4)
   {
-    cells = {facets[index], facets[index + 2]};
-    local_facet = {facets[index + 1], facets[index + 3]};
+    std::array<std::int32_t, 2> cells = {facets[index], facets[index + 2]};
+    std::array<std::int32_t, 2> local_facet
+        = {facets[index + 1], facets[index + 3]};
 
     // Get cell geometry
     auto x_dofs0 = x_dofmap.links(cells[0]);

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -174,10 +174,10 @@ void assemble_exterior_facets(
   std::vector<T> Ae(ndim0 * ndim1);
   const xtl::span<T> _Ae(Ae);
   assert(facets.size() % 2 == 0);
-  for (std::size_t index = 0; index < facets.size() / 2; ++index)
+  for (std::size_t index = 0; index < facets.size(); index += 2)
   {
-    std::int32_t cell = facets[2 * index];
-    std::int32_t local_facet = facets[2 * index + 1];
+    std::int32_t cell = facets[index];
+    std::int32_t local_facet = facets[index + 1];
 
     // Get cell coordinates/geometry
     auto x_dofs = x_dofmap.links(cell);
@@ -281,10 +281,10 @@ void assemble_interior_facets(
   assert(facets.size() % 4 == 0);
   std::array<std::int32_t, 2> cells;
   std::array<std::int32_t, 2> local_facet;
-  for (std::size_t index = 0; index < facets.size() / 4; ++index)
+  for (std::size_t index = 0; index < facets.size(); index += 4)
   {
-    cells = {facets[4 * index], facets[4 * index + 2]};
-    local_facet = {facets[4 * index + 1], facets[4 * index + 3]};
+    cells = {facets[index], facets[index + 2]};
+    local_facet = {facets[index + 1], facets[index + 3]};
 
     // Get cell geometry
     auto x_dofs0 = x_dofmap.links(cells[0]);

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -189,7 +189,7 @@ void assemble_exterior_facets(
 
     // Tabulate tensor
     std::fill(Ae.begin(), Ae.end(), 0);
-    kernel(Ae.data(), coeffs.data() + index * cstride, constants.data(),
+    kernel(Ae.data(), coeffs.data() + index / 2 * cstride, constants.data(),
            coordinate_dofs.data(), &local_facet, nullptr);
 
     dof_transform(_Ae, cell_info, cell, ndim1);
@@ -327,7 +327,7 @@ void assemble_interior_facets(
     const std::array perm{
         get_perm(cells[0] * num_cell_facets + local_facet[0]),
         get_perm(cells[1] * num_cell_facets + local_facet[1])};
-    kernel(Ae.data(), coeffs.data() + index * 2 * cstride, constants.data(),
+    kernel(Ae.data(), coeffs.data() + index / 2 * cstride, constants.data(),
            coordinate_dofs.data(), local_facet.data(), perm.data());
 
     const xtl::span<T> _Ae(Ae);

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -66,8 +66,7 @@ T assemble_cells(const mesh::Geometry& geometry,
 /// Execute kernel over exterior facets and accumulate result
 template <typename T>
 T assemble_exterior_facets(
-    const mesh::Mesh& mesh,
-    const xtl::span<const std::pair<std::int32_t, int>>& facets,
+    const mesh::Mesh& mesh, const xtl::span<const std::int32_t>& facets,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*)>& fn,
     const xtl::span<const T>& constants, const xtl::span<const T>& coeffs,
@@ -86,10 +85,11 @@ T assemble_exterior_facets(
   std::vector<double> coordinate_dofs(3 * num_dofs_g);
 
   // Iterate over all facets
-  for (std::size_t index = 0; index < facets.size(); ++index)
+  assert(facets.size() % 2 == 0);
+  for (std::size_t index = 0; index < facets.size() / 2; ++index)
   {
-    std::int32_t cell = facets[index].first;
-    int local_facet = facets[index].second;
+    std::int32_t cell = facets[2 * index];
+    std::int32_t local_facet = facets[2 * index + 1];
 
     // Get cell coordinates/geometry
     auto x_dofs = x_dofmap.links(cell);
@@ -110,9 +110,7 @@ T assemble_exterior_facets(
 /// Assemble functional over interior facets
 template <typename T>
 T assemble_interior_facets(
-    const mesh::Mesh& mesh,
-    const xtl::span<const std::tuple<std::int32_t, int, std::int32_t, int>>&
-        facets,
+    const mesh::Mesh& mesh, const xtl::span<const std::int32_t>& facets,
     const std::function<void(T*, const T*, const T*, const double*, const int*,
                              const std::uint8_t*)>& fn,
     const xtl::span<const T>& constants, const xtl::span<const T>& coeffs,
@@ -139,12 +137,13 @@ T assemble_interior_facets(
       = mesh::cell_num_entities(mesh.topology().cell_type(), tdim - 1);
 
   // Iterate over all facets
-  for (std::size_t index = 0; index < facets.size(); ++index)
+  assert(facets.size() % 4 == 0);
+  std::array<std::int32_t, 2> cells;
+  std::array<std::int32_t, 2> local_facet;
+  for (std::size_t index = 0; index < facets.size() / 4; ++index)
   {
-    const std::array<std::int32_t, 2> cells
-        = {std::get<0>(facets[index]), std::get<2>(facets[index])};
-    const std::array<int, 2> local_facet
-        = {std::get<1>(facets[index]), std::get<3>(facets[index])};
+    cells = {facets[4 * index], facets[4 * index + 2]};
+    local_facet = {facets[4 * index + 1], facets[4 * index + 3]};
 
     // Get cell geometry
     auto x_dofs0 = x_dofmap.links(cells[0]);
@@ -196,8 +195,7 @@ T assemble_scalar(
     const auto& fn = M.kernel(IntegralType::exterior_facet, i);
     const auto& [coeffs, cstride]
         = coefficients.at({IntegralType::exterior_facet, i});
-    const std::vector<std::pair<std::int32_t, int>>& facets
-        = M.exterior_facet_domains(i);
+    const std::vector<std::int32_t>& facets = M.exterior_facet_domains(i);
     value += impl::assemble_exterior_facets(*mesh, facets, fn, constants,
                                             coeffs, cstride);
   }
@@ -215,9 +213,7 @@ T assemble_scalar(
       const auto& fn = M.kernel(IntegralType::interior_facet, i);
       const auto& [coeffs, cstride]
           = coefficients.at({IntegralType::interior_facet, i});
-      const std::vector<std::tuple<std::int32_t, int, std::int32_t, int>>&
-          facets
-          = M.interior_facet_domains(i);
+      const std::vector<std::int32_t>& facets = M.interior_facet_domains(i);
       value += impl::assemble_interior_facets(
           *mesh, facets, fn, constants, coeffs, cstride, c_offsets, perms);
     }

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -138,12 +138,11 @@ T assemble_interior_facets(
 
   // Iterate over all facets
   assert(facets.size() % 4 == 0);
-  std::array<std::int32_t, 2> cells;
-  std::array<std::int32_t, 2> local_facet;
   for (std::size_t index = 0; index < facets.size(); index += 4)
   {
-    cells = {facets[index], facets[index + 2]};
-    local_facet = {facets[index + 1], facets[index + 3]};
+    std::array<std::int32_t, 2> cells = {facets[index], facets[index + 2]};
+    std::array<std::int32_t, 2> local_facet
+        = {facets[index + 1], facets[index + 3]};
 
     // Get cell geometry
     auto x_dofs0 = x_dofmap.links(cells[0]);

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -86,10 +86,10 @@ T assemble_exterior_facets(
 
   // Iterate over all facets
   assert(facets.size() % 2 == 0);
-  for (std::size_t index = 0; index < facets.size() / 2; ++index)
+  for (std::size_t index = 0; index < facets.size(); index += 2)
   {
-    std::int32_t cell = facets[2 * index];
-    std::int32_t local_facet = facets[2 * index + 1];
+    std::int32_t cell = facets[index];
+    std::int32_t local_facet = facets[index + 1];
 
     // Get cell coordinates/geometry
     auto x_dofs = x_dofmap.links(cell);
@@ -140,10 +140,10 @@ T assemble_interior_facets(
   assert(facets.size() % 4 == 0);
   std::array<std::int32_t, 2> cells;
   std::array<std::int32_t, 2> local_facet;
-  for (std::size_t index = 0; index < facets.size() / 4; ++index)
+  for (std::size_t index = 0; index < facets.size(); index += 4)
   {
-    cells = {facets[4 * index], facets[4 * index + 2]};
-    local_facet = {facets[4 * index + 1], facets[4 * index + 3]};
+    cells = {facets[index], facets[index + 2]};
+    local_facet = {facets[index + 1], facets[index + 3]};
 
     // Get cell geometry
     auto x_dofs0 = x_dofmap.links(cells[0]);

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -99,7 +99,7 @@ T assemble_exterior_facets(
                               std::next(coordinate_dofs.begin(), 3 * i));
     }
 
-    const T* coeff_cell = coeffs.data() + index * cstride;
+    const T* coeff_cell = coeffs.data() + index / 2 * cstride;
     fn(&value, coeff_cell, constants.data(), coordinate_dofs.data(),
        &local_facet, nullptr);
   }
@@ -163,7 +163,7 @@ T assemble_interior_facets(
 
     const std::array perm{perms[cells[0] * num_cell_facets + local_facet[0]],
                           perms[cells[1] * num_cell_facets + local_facet[1]]};
-    fn(&value, coeffs.data() + index * 2 * cstride, constants.data(),
+    fn(&value, coeffs.data() + index / 2 * cstride, constants.data(),
        coordinate_dofs.data(), local_facet.data(), perm.data());
   }
 

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -616,7 +616,7 @@ void assemble_exterior_facets(
 
     // Tabulate element vector
     std::fill(be.begin(), be.end(), 0);
-    fn(be.data(), coeffs.data() + index * cstride, constants.data(),
+    fn(be.data(), coeffs.data() + index / 2 * cstride, constants.data(),
        coordinate_dofs.data(), &local_facet, nullptr);
 
     dof_transform(_be, cell_info, cell, 1);
@@ -708,7 +708,7 @@ void assemble_interior_facets(
     const std::array perm{
         get_perm(cells[0] * num_cell_facets + local_facet[0]),
         get_perm(cells[1] * num_cell_facets + local_facet[1])};
-    fn(be.data(), coeffs.data() + index * 2 * cstride, constants.data(),
+    fn(be.data(), coeffs.data() + index / 2 * cstride, constants.data(),
        coordinate_dofs.data(), local_facet.data(), perm.data());
 
     const xtl::span<T> _be(be);

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -267,7 +267,7 @@ void _lift_bc_exterior_facets(
     const int num_rows = bs0 * dmap0.size();
     const int num_cols = bs1 * dmap1.size();
 
-    const T* coeff_array = coeffs.data() + index * cstride;
+    const T* coeff_array = coeffs.data() + index / 2 * cstride;
     Ae.resize(num_rows * num_cols);
     std::fill(Ae.begin(), Ae.end(), 0);
     kernel(Ae.data(), coeff_array, constants.data(), coordinate_dofs.data(),
@@ -425,7 +425,7 @@ void _lift_bc_interior_facets(
     const std::array perm{
         get_perm(cells[0] * num_cell_facets + local_facet[0]),
         get_perm(cells[1] * num_cell_facets + local_facet[1])};
-    kernel(Ae.data(), coeffs.data() + index * 2 * cstride, constants.data(),
+    kernel(Ae.data(), coeffs.data() + index / 4 * cstride, constants.data(),
            coordinate_dofs.data(), local_facet.data(), perm.data());
 
     const xtl::span<T> _Ae(Ae);

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -228,10 +228,10 @@ void _lift_bc_exterior_facets(
   std::vector<double> coordinate_dofs(3 * num_dofs_g);
   std::vector<T> Ae, be;
   assert(facets.size() % 2 == 0);
-  for (std::size_t index = 0; index < facets.size() / 2; ++index)
+  for (std::size_t index = 0; index < facets.size(); index += 2)
   {
-    std::int32_t cell = facets[2 * index];
-    std::int32_t local_facet = facets[2 * index + 1];
+    std::int32_t cell = facets[index];
+    std::int32_t local_facet = facets[index + 1];
 
     // Get dof maps for cell
     auto dmap1 = dofmap1.links(cell);
@@ -350,10 +350,10 @@ void _lift_bc_interior_facets(
   std::array<std::int32_t, 2> cells;
   std::array<std::int32_t, 2> local_facet;
 
-  for (std::size_t index = 0; index < facets.size() / 4; ++index)
+  for (std::size_t index = 0; index < facets.size(); index += 4)
   {
-    cells = {facets[4 * index], facets[4 * index + 2]};
-    local_facet = {facets[4 * index + 1], facets[4 * index + 3]};
+    cells = {facets[index], facets[index + 2]};
+    local_facet = {facets[index + 1], facets[index + 3]};
 
     // Get cell geometry
     auto x_dofs0 = x_dofmap.links(cells[0]);
@@ -601,10 +601,10 @@ void assemble_exterior_facets(
   std::vector<T> be(bs * num_dofs);
   const xtl::span<T> _be(be);
   assert(facets.size() % 2 == 0);
-  for (std::size_t index = 0; index < facets.size() / 2; ++index)
+  for (std::size_t index = 0; index < facets.size(); index += 2)
   {
-    std::int32_t cell = facets[2 * index];
-    std::int32_t local_facet = facets[2 * index + 1];
+    std::int32_t cell = facets[index];
+    std::int32_t local_facet = facets[index + 1];
 
     // Get cell coordinates/geometry
     auto x_dofs = x_dofmap.links(cell);
@@ -675,13 +675,12 @@ void assemble_interior_facets(
   assert(_bs < 0 or _bs == bs);
 
   assert(facets.size() % 4 == 0);
-  const std::size_t num_facets = facets.size() / 4;
   std::array<std::int32_t, 2> cells;
   std::array<std::int32_t, 2> local_facet;
-  for (std::size_t index = 0; index < num_facets; ++index)
+  for (std::size_t index = 0; index < facets.size(); index += 4)
   {
-    cells = {facets[4 * index], facets[4 * index + 2]};
-    local_facet = {facets[4 * index + 1], facets[4 * index + 3]};
+    cells = {facets[index], facets[index + 2]};
+    local_facet = {facets[index + 1], facets[index + 3]};
 
     // Get cell geometry
     auto x_dofs0 = x_dofmap.links(cells[0]);

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -425,7 +425,7 @@ void _lift_bc_interior_facets(
     const std::array perm{
         get_perm(cells[0] * num_cell_facets + local_facet[0]),
         get_perm(cells[1] * num_cell_facets + local_facet[1])};
-    kernel(Ae.data(), coeffs.data() + index / 4 * cstride, constants.data(),
+    kernel(Ae.data(), coeffs.data() + index / 2 * cstride, constants.data(),
            coordinate_dofs.data(), local_facet.data(), perm.data());
 
     const xtl::span<T> _Ae(Ae);

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -347,13 +347,12 @@ void _lift_bc_interior_facets(
   // Temporaries for joint dofmaps
   std::vector<std::int32_t> dmapjoint0, dmapjoint1;
   assert(facets.size() % 4 == 0);
-  std::array<std::int32_t, 2> cells;
-  std::array<std::int32_t, 2> local_facet;
 
   for (std::size_t index = 0; index < facets.size(); index += 4)
   {
-    cells = {facets[index], facets[index + 2]};
-    local_facet = {facets[index + 1], facets[index + 3]};
+    std::array<std::int32_t, 2> cells = {facets[index], facets[index + 2]};
+    std::array<std::int32_t, 2> local_facet
+        = {facets[index + 1], facets[index + 3]};
 
     // Get cell geometry
     auto x_dofs0 = x_dofmap.links(cells[0]);
@@ -673,14 +672,12 @@ void assemble_interior_facets(
 
   const int bs = dofmap.bs();
   assert(_bs < 0 or _bs == bs);
-
   assert(facets.size() % 4 == 0);
-  std::array<std::int32_t, 2> cells;
-  std::array<std::int32_t, 2> local_facet;
   for (std::size_t index = 0; index < facets.size(); index += 4)
   {
-    cells = {facets[index], facets[index + 2]};
-    local_facet = {facets[index + 1], facets[index + 3]};
+    std::array<std::int32_t, 2> cells = {facets[index], facets[index + 2]};
+    std::array<std::int32_t, 2> local_facet
+        = {facets[index + 1], facets[index + 3]};
 
     // Get cell geometry
     auto x_dofs0 = x_dofmap.links(cells[0]);

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -548,38 +548,38 @@ void pack_coefficient_entity(const xtl::span<T>& c, int cstride,
   switch (bs)
   {
   case 1:
-    for (std::size_t e = 0; e < entities.size() / estride; ++e)
+    for (std::size_t e = 0; e < entities.size(); e += estride)
     {
-      auto entity = entities.subspan(e * estride, estride);
+      auto entity = entities.subspan(e, estride);
       std::int32_t cell = fetch_cells(entity);
-      auto cell_coeff = c.subspan(e * cstride + offset, space_dim);
+      auto cell_coeff = c.subspan(e * cstride / estride + offset, space_dim);
       pack<T, 1>(cell_coeff, cell, bs, v, cell_info, dofmap, transformation);
     }
     break;
   case 2:
-    for (std::size_t e = 0; e < entities.size() / estride; ++e)
+    for (std::size_t e = 0; e < entities.size(); e += estride)
     {
-      auto entity = entities.subspan(e * estride, estride);
+      auto entity = entities.subspan(e, estride);
       std::int32_t cell = fetch_cells(entity);
-      auto cell_coeff = c.subspan(e * cstride + offset, space_dim);
+      auto cell_coeff = c.subspan(e * cstride / estride + offset, space_dim);
       pack<T, 2>(cell_coeff, cell, bs, v, cell_info, dofmap, transformation);
     }
     break;
   case 3:
-    for (std::size_t e = 0; e < entities.size() / estride; ++e)
+    for (std::size_t e = 0; e < entities.size(); e += estride)
     {
-      auto entity = entities.subspan(e * estride, estride);
+      auto entity = entities.subspan(e, estride);
       std::int32_t cell = fetch_cells(entity);
-      auto cell_coeff = c.subspan(e * cstride + offset, space_dim);
+      auto cell_coeff = c.subspan(e * cstride / estride + offset, space_dim);
       pack<T, 3>(cell_coeff, cell, bs, v, cell_info, dofmap, transformation);
     }
     break;
   default:
-    for (std::size_t e = 0; e < entities.size() / estride; ++e)
+    for (std::size_t e = 0; e < entities.size(); e += estride)
     {
-      auto entity = entities.subspan(e * estride, estride);
+      auto entity = entities.subspan(e, estride);
       std::int32_t cell = fetch_cells(entity);
-      auto cell_coeff = c.subspan(e * cstride + offset, space_dim);
+      auto cell_coeff = c.subspan(e * cstride / estride + offset, space_dim);
       pack<T, -1>(cell_coeff, cell, bs, v, cell_info, dofmap, transformation);
     }
     break;
@@ -676,7 +676,7 @@ void pack_coefficients(const Form<T>& form, IntegralType integral_type, int id,
     {
     case IntegralType::cell:
     {
-      auto fetch_cell = [](auto entity) { return entity[0]; };
+      auto fetch_cell = [](auto entity) { return entity.front(); };
       const std::vector<std::int32_t>& cells = form.cell_domains(id);
       // Iterate over coefficients
       for (std::size_t coeff = 0; coeff < coefficients.size(); ++coeff)
@@ -692,7 +692,7 @@ void pack_coefficients(const Form<T>& form, IntegralType integral_type, int id,
       const std::vector<std::int32_t>& facets = form.exterior_facet_domains(id);
 
       // Create lambda function fetching cell index from exterior facet entity
-      auto fetch_cell = [](auto& entity) { return entity[0]; };
+      auto fetch_cell = [](auto& entity) { return entity.front(); };
 
       // Iterate over coefficients
       for (std::size_t coeff = 0; coeff < coefficients.size(); ++coeff)

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -552,7 +552,7 @@ void pack_coefficient_entity(const xtl::span<T>& c, int cstride,
     {
       auto entity = entities.subspan(e, estride);
       std::int32_t cell = fetch_cells(entity);
-      auto cell_coeff = c.subspan(e * cstride / estride + offset, space_dim);
+      auto cell_coeff = c.subspan(e / estride * cstride + offset, space_dim);
       pack<T, 1>(cell_coeff, cell, bs, v, cell_info, dofmap, transformation);
     }
     break;
@@ -561,7 +561,7 @@ void pack_coefficient_entity(const xtl::span<T>& c, int cstride,
     {
       auto entity = entities.subspan(e, estride);
       std::int32_t cell = fetch_cells(entity);
-      auto cell_coeff = c.subspan(e * cstride / estride + offset, space_dim);
+      auto cell_coeff = c.subspan(e / estride * cstride + offset, space_dim);
       pack<T, 2>(cell_coeff, cell, bs, v, cell_info, dofmap, transformation);
     }
     break;
@@ -570,7 +570,7 @@ void pack_coefficient_entity(const xtl::span<T>& c, int cstride,
     {
       auto entity = entities.subspan(e, estride);
       std::int32_t cell = fetch_cells(entity);
-      auto cell_coeff = c.subspan(e * cstride / estride + offset, space_dim);
+      auto cell_coeff = c.subspan(e / estride * cstride + offset, space_dim);
       pack<T, 3>(cell_coeff, cell, bs, v, cell_info, dofmap, transformation);
     }
     break;
@@ -579,7 +579,7 @@ void pack_coefficient_entity(const xtl::span<T>& c, int cstride,
     {
       auto entity = entities.subspan(e, estride);
       std::int32_t cell = fetch_cells(entity);
-      auto cell_coeff = c.subspan(e * cstride / estride + offset, space_dim);
+      auto cell_coeff = c.subspan(e / estride * cstride + offset, space_dim);
       pack<T, -1>(cell_coeff, cell, bs, v, cell_info, dofmap, transformation);
     }
     break;
@@ -615,10 +615,10 @@ allocate_coefficient_storage(const Form<T>& form, IntegralType integral_type,
       num_entities = form.cell_domains(id).size();
       break;
     case IntegralType::exterior_facet:
-      num_entities = form.exterior_facet_domains(id).size();
+      num_entities = form.exterior_facet_domains(id).size() / 2;
       break;
     case IntegralType::interior_facet:
-      num_entities = form.interior_facet_domains(id).size() * 2;
+      num_entities = form.interior_facet_domains(id).size() / 2;
       break;
     default:
       throw std::runtime_error(

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -523,15 +523,17 @@ static inline void pack(const xtl::span<T>& coeffs, std::int32_t cell, int bs,
 /// @param[in] cell_info Array of bytes describing which transformation
 /// has to be applied on the cell to map it to the reference element
 /// @param[in] entities The set of active entities
+/// @param[in] estride The stride for each entity in active entities.
 /// @param[in] fetch_cells Function that fetches the cell index for an
 /// entity in active_entities (signature:
 /// `std::function<std::int32_t(E::value_type)>`)
 /// @param[in] offset The offset for c
-template <typename T, typename E, typename Functor>
+template <typename T, typename Functor>
 void pack_coefficient_entity(const xtl::span<T>& c, int cstride,
                              const Function<T>& u,
                              const xtl::span<const std::uint32_t>& cell_info,
-                             const E& entities, Functor fetch_cells,
+                             const xtl::span<const std::int32_t>& entities,
+                             std::size_t estride, Functor fetch_cells,
                              std::int32_t offset)
 {
   // Read data from coefficient "u"
@@ -546,33 +548,37 @@ void pack_coefficient_entity(const xtl::span<T>& c, int cstride,
   switch (bs)
   {
   case 1:
-    for (std::size_t e = 0; e < entities.size(); ++e)
+    for (std::size_t e = 0; e < entities.size() / estride; ++e)
     {
-      std::int32_t cell = fetch_cells(entities[e]);
+      auto entity = entities.subspan(e * estride, estride);
+      std::int32_t cell = fetch_cells(entity);
       auto cell_coeff = c.subspan(e * cstride + offset, space_dim);
       pack<T, 1>(cell_coeff, cell, bs, v, cell_info, dofmap, transformation);
     }
     break;
   case 2:
-    for (std::size_t e = 0; e < entities.size(); ++e)
+    for (std::size_t e = 0; e < entities.size() / estride; ++e)
     {
-      std::int32_t cell = fetch_cells(entities[e]);
+      auto entity = entities.subspan(e * estride, estride);
+      std::int32_t cell = fetch_cells(entity);
       auto cell_coeff = c.subspan(e * cstride + offset, space_dim);
       pack<T, 2>(cell_coeff, cell, bs, v, cell_info, dofmap, transformation);
     }
     break;
   case 3:
-    for (std::size_t e = 0; e < entities.size(); ++e)
+    for (std::size_t e = 0; e < entities.size() / estride; ++e)
     {
-      std::int32_t cell = fetch_cells(entities[e]);
+      auto entity = entities.subspan(e * estride, estride);
+      std::int32_t cell = fetch_cells(entity);
       auto cell_coeff = c.subspan(e * cstride + offset, space_dim);
       pack<T, 3>(cell_coeff, cell, bs, v, cell_info, dofmap, transformation);
     }
     break;
   default:
-    for (std::size_t e = 0; e < entities.size(); ++e)
+    for (std::size_t e = 0; e < entities.size() / estride; ++e)
     {
-      std::int32_t cell = fetch_cells(entities[e]);
+      auto entity = entities.subspan(e * estride, estride);
+      std::int32_t cell = fetch_cells(entity);
       auto cell_coeff = c.subspan(e * cstride + offset, space_dim);
       pack<T, -1>(cell_coeff, cell, bs, v, cell_info, dofmap, transformation);
     }
@@ -670,30 +676,29 @@ void pack_coefficients(const Form<T>& form, IntegralType integral_type, int id,
     {
     case IntegralType::cell:
     {
-      auto fetch_cell = [](auto entity) { return entity; };
+      auto fetch_cell = [](auto entity) { return entity[0]; };
       const std::vector<std::int32_t>& cells = form.cell_domains(id);
       // Iterate over coefficients
       for (std::size_t coeff = 0; coeff < coefficients.size(); ++coeff)
       {
         impl::pack_coefficient_entity(c, cstride, *coefficients[coeff],
-                                      cell_info, cells, fetch_cell,
+                                      cell_info, cells, 1, fetch_cell,
                                       offsets[coeff]);
       }
       break;
     }
     case IntegralType::exterior_facet:
     {
-      const std::vector<std::pair<std::int32_t, int>>& facets
-          = form.exterior_facet_domains(id);
+      const std::vector<std::int32_t>& facets = form.exterior_facet_domains(id);
 
       // Create lambda function fetching cell index from exterior facet entity
-      auto fetch_cell = [](auto& entity) { return entity.first; };
+      auto fetch_cell = [](auto& entity) { return entity[0]; };
 
       // Iterate over coefficients
       for (std::size_t coeff = 0; coeff < coefficients.size(); ++coeff)
       {
         impl::pack_coefficient_entity(c, cstride, *coefficients[coeff],
-                                      cell_info, facets, fetch_cell,
+                                      cell_info, facets, 2, fetch_cell,
                                       offsets[coeff]);
       }
 
@@ -701,23 +706,21 @@ void pack_coefficients(const Form<T>& form, IntegralType integral_type, int id,
     }
     case IntegralType::interior_facet:
     {
-      const std::vector<std::tuple<std::int32_t, int, std::int32_t, int>>&
-          facets
-          = form.interior_facet_domains(id);
+      const std::vector<std::int32_t>& facets = form.interior_facet_domains(id);
       // Lambda functions to fetch cell index from interior facet entity
-      auto fetch_cell0 = [](auto& entity) { return std::get<0>(entity); };
-      auto fetch_cell1 = [](auto& entity) { return std::get<2>(entity); };
+      auto fetch_cell0 = [](auto& entity) { return entity[0]; };
+      auto fetch_cell1 = [](auto& entity) { return entity[2]; };
 
       // Iterate over coefficients
       for (std::size_t coeff = 0; coeff < coefficients.size(); ++coeff)
       {
         // Pack coefficient ['+']
         impl::pack_coefficient_entity(c, 2 * cstride, *coefficients[coeff],
-                                      cell_info, facets, fetch_cell0,
+                                      cell_info, facets, 4, fetch_cell0,
                                       2 * offsets[coeff]);
         // Pack coefficient ['-']
         impl::pack_coefficient_entity(c, 2 * cstride, *coefficients[coeff],
-                                      cell_info, facets, fetch_cell1,
+                                      cell_info, facets, 4, fetch_cell1,
                                       offsets[coeff] + offsets[coeff + 1]);
       }
       break;
@@ -879,8 +882,8 @@ pack_coefficients(const Expression<T>& u,
     // Iterate over coefficients
     for (std::size_t coeff = 0; coeff < coefficients.size(); ++coeff)
       impl::pack_coefficient_entity(
-          xtl::span(c), cstride, *coefficients[coeff], cell_info, cells,
-          [](std::int32_t entity) { return entity; }, offsets[coeff]);
+          xtl::span(c), cstride, *coefficients[coeff], cell_info, cells, 1,
+          [](auto entity) { return entity[0]; }, offsets[coeff]);
   }
   return {std::move(c), cstride};
 }

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -836,7 +836,8 @@ void declare_form(py::module& m, const std::string& type)
                    = self.exterior_facet_domains(i);
                std::array<py::ssize_t, 2> shape
                    = {py::ssize_t(_d.size()) / 2, 2};
-               return dolfinx_wrappers::as_pyarray(std::move(_d), shape);
+               return py::array_t<std::int32_t>(shape, _d.data(),
+                                                py::cast(self));
              }
              case dolfinx::fem::IntegralType::interior_facet:
              {
@@ -844,8 +845,8 @@ void declare_form(py::module& m, const std::string& type)
                    = self.interior_facet_domains(i);
                std::array<py::ssize_t, 3> shape
                    = {py::ssize_t(_d.size()) / 4, 2, 2};
-               py::array_t<std::int32_t> domains(shape);
-               return dolfinx_wrappers::as_pyarray(std::move(_d), shape);
+               return py::array_t<std::int32_t>(shape, _d.data(),
+                                                py::cast(self));
              }
              default:
                throw ::std::runtime_error("Integral type unsupported.");


### PR DESCRIPTION
The current usage of `std::vector<std::int32_t>`, `std::vector<std::pair<std::int32_t, int>>`, `std::vector<std::tuple<std::int32_t, int,std::int32_t, int>` is overly complicated, when we always know the second dimension of the array when accessed.

Additionally, the second int (referring to the local entity index for a facet) can be an `std::int32_t` without adding any new assumptions to the code.

This pull request flattens the C++ layout of all these entities to `std::vector<std::int32_t>`.
The Python interface still reshapes the data to be 1,2 or 3 dimensional.

This change also makes it easier to pass integral entities down to C++ for exterior libraries, as all the entities in DOLFINx has the same type.