### PR TITLE
Compensate for flake8 F822 to check members of `__all__` are implemented

### DIFF
--- a/python/dolfinx/fem/__init__.py
+++ b/python/dolfinx/fem/__init__.py
@@ -43,5 +43,5 @@ __all__ = [
     "VectorFunctionSpace", "create_sparsity_pattern",
     "assemble_scalar", "assemble_matrix", "assemble_vector", "apply_lifting", "set_bc",
     "DirichletBCMetaClass", "dirichletbc", "bcs_by_block", "DofMap", "FormMetaClass", "form", "IntegralType",
-    "adjoint", "locate_dofs_geometrical", "locate_dofs_topological",
+    "locate_dofs_geometrical", "locate_dofs_topological",
     "extract_function_spaces", "petsc"]

--- a/python/dolfinx/io.py
+++ b/python/dolfinx/io.py
@@ -19,7 +19,7 @@ from dolfinx.mesh import CellType, GhostMode, Mesh
 
 from mpi4py import MPI as _MPI
 
-__all__ = ["FidesWriter", "VTKFile", "VTXWriter", "XDMFFile", "cell_perm_gmsh", "distribute_entity_data"]
+__all__ = ["VTKFile", "XDMFFile", "cell_perm_gmsh", "distribute_entity_data"]
 
 
 def _extract_cpp_functions(functions: typing.Union[typing.List[Function], Function]):

--- a/python/dolfinx/nls/__init__.py
+++ b/python/dolfinx/nls/__init__.py
@@ -7,4 +7,4 @@
 
 from dolfinx.nls import petsc
 
-__all__ = ["foo", "petsc"]
+__all__ = ["petsc"]

--- a/python/test/unit/common/test_python_implemented.py
+++ b/python/test/unit/common/test_python_implemented.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2022 Nathan Sime
+#
+# This file is part of DOLFINx (https://www.fenicsproject.org)
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+
+import pytest
+import importlib
+import pkgutil
+
+
+def collect_subpackages_recursive(name):
+    module = importlib.import_module(name)
+    submodules = list(a.name for a in pkgutil.iter_modules(
+        module.__path__, prefix=f"{name}."))
+    subpackages = list(a.name for a in pkgutil.iter_modules(
+        module.__path__, prefix=f"{name}.") if a.ispkg)
+    for subpackage in subpackages:
+        pkg_submodules = collect_subpackages_recursive(subpackage)
+        submodules.extend(pkg_submodules)
+    return list(set(submodules))
+
+
+@pytest.mark.parametrize("module_name",
+                         collect_subpackages_recursive("dolfinx"))
+def test_all_implemented(module_name):
+    module = importlib.import_module(module_name)
+    if hasattr(module, "__all__"):
+        for member in module.__all__:
+            assert hasattr(module, member)

--- a/python/test/unit/common/test_python_implemented.py
+++ b/python/test/unit/common/test_python_implemented.py
@@ -21,10 +21,10 @@ def collect_pkg_modules_recursive(name):
     return list(set(submodules))
 
 
-@pytest.mark.parametrize("module_name",
-                         collect_pkg_modules_recursive("dolfinx"))
-def test_all_implemented(module_name):
-    module = importlib.import_module(module_name)
-    if hasattr(module, "__all__"):
-        for member in module.__all__:
-            assert hasattr(module, member)
+def test_all_implemented():
+    module_names = collect_pkg_modules_recursive("dolfinx")
+    for module_name in module_names:
+        module = importlib.import_module(module_name)
+        if hasattr(module, "__all__"):
+            for member in module.__all__:
+                assert hasattr(module, member)

--- a/python/test/unit/common/test_python_implemented.py
+++ b/python/test/unit/common/test_python_implemented.py
@@ -9,20 +9,20 @@ import importlib
 import pkgutil
 
 
-def collect_subpackages_recursive(name):
+def collect_pkg_modules_recursive(name):
     module = importlib.import_module(name)
     submodules = list(a.name for a in pkgutil.iter_modules(
         module.__path__, prefix=f"{name}."))
     subpackages = list(a.name for a in pkgutil.iter_modules(
         module.__path__, prefix=f"{name}.") if a.ispkg)
     for subpackage in subpackages:
-        pkg_submodules = collect_subpackages_recursive(subpackage)
+        pkg_submodules = collect_pkg_modules_recursive(subpackage)
         submodules.extend(pkg_submodules)
     return list(set(submodules))
 
 
 @pytest.mark.parametrize("module_name",
-                         collect_subpackages_recursive("dolfinx"))
+                         collect_pkg_modules_recursive("dolfinx"))
 def test_all_implemented(module_name):
     module = importlib.import_module(module_name)
     if hasattr(module, "__all__"):

--- a/python/test/unit/common/test_python_implemented.py
+++ b/python/test/unit/common/test_python_implemented.py
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
-import pytest
 import importlib
 import pkgutil
 


### PR DESCRIPTION
It appears that F822 won't be checked in `__init__.py`, see [here](https://github.com/PyCQA/pyflakes/issues/661). Here we check that the members specified in `__all__` in each module are implemented.