### PR TITLE
cpp/test: remove extra semicolon

### DIFF
--- a/cpp/test/matrix.cpp
+++ b/cpp/test/matrix.cpp
@@ -100,7 +100,7 @@ void spmv(la::MatrixCSR<T>& A, la::Vector<T>& x, la::Vector<T>& y)
   // Second stage:  spmv - off-diagonal
   // yi[0] += Ai[1] * xi[1]
   spmv_impl<T>(values, off_diag_offset, row_end, cols, _x, _y);
-};
+}
 
 void test_matrix_apply()
 {


### PR DESCRIPTION
test compilation fails with `-Werror=pedantic`