### PR TITLE
Add missing attribute to Fides files

### DIFF
--- a/cpp/dolfinx/io/ADIOS2Writers.cpp
+++ b/cpp/dolfinx/io/ADIOS2Writers.cpp
@@ -586,6 +586,8 @@ void fides_initialize_mesh_attributes(adios2::IO& io, const mesh::Mesh& mesh)
 
   std::string cell_type = to_fides_cell(topology.cell_type());
   define_attribute<std::string>(io, "Fides_Cell_Type", cell_type);
+
+  define_attribute<std::string>(io, "Fides_Time_Variable", "step");
 }
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
As per the discussion at https://gitlab.kitware.com/paraview/paraview/-/issues/21369 , Fides files need an attribute `Fides_Time_Variable` that tells what variable specifies the time step values. This pull request adds this missing attribute.