### PR TITLE
Add CFFI to setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -13,6 +13,7 @@ if sys.version_info < (3, 8):
 VERSION = "0.4.2.dev0"
 
 REQUIREMENTS = [
+    "cffi",
     "numpy>=1.21",
     "mpi4py",
     "petsc4py",


### PR DESCRIPTION
Add cffi to setup.py (as suggested by @minrk), required to make sure we have `libffi` (https://fenicsproject.discourse.group/t/installation-fenicsx-with-conda-on-macos/8492/5)