### PR TITLE
Fix for `interpolate` when some dofs don't belong to a cell on some processes

### DIFF
--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -635,10 +635,14 @@ void interpolate(Function<T>& u, const xt::xarray<T>& f,
           return a;
       });
 
-  // Copy interpolated values (which aren't NAN) back to original vector
-  std::copy_if(temp_x.array().begin(), temp_x.array().end(),
-               u.x()->mutable_array().begin(),
-               [](auto t) { return !std::isnan(std::abs(t)); });
+  // FIXME See if this can be done with something like a copy_if
+  for (int i = 0; i < temp_x.array().size(); ++i)
+  {
+    if (!std::isnan(std::abs(coeffs[i])))
+    {
+      u.x()->mutable_array()[i] = coeffs[i];
+    }
+  }
 }
 
 /// Interpolate from one finite element Function to another on the same

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -12,6 +12,7 @@
 #include "FiniteElement.h"
 #include "FunctionSpace.h"
 #include <dolfinx/common/IndexMap.h>
+#include <dolfinx/la/Vector.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <functional>
 #include <numeric>
@@ -434,10 +435,13 @@ void interpolate(Function<T>& u, const xt::xarray<T>& f,
   const int num_scalar_dofs = element->space_dimension() / element_bs;
   const int value_size = element->value_size() / element_bs;
 
-  // Set vector to zero so that old data does not interfere for ghosts that do
-  // not belong to a cell when ghost values are communicated to owners
-  u.x()->set(0.0);
-  xtl::span<T> coeffs = u.x()->mutable_array();
+  // Create temporary vector to work with and set all values to NAN so
+  // we know which values need to be copied, so that old data does not
+  // interfere for ghosts that do not belong to a cell when ghost
+  // values are communicated to owners
+  la::Vector temp_x(*u.x());
+  temp_x.set(NAN);
+  xtl::span<T> coeffs = temp_x.mutable_array();
   std::vector<T> _coeffs(num_scalar_dofs);
 
   // This assumes that any element with an identity interpolation matrix
@@ -622,14 +626,19 @@ void interpolate(Function<T>& u, const xt::xarray<T>& f,
   // If there are owned dofs on this process that do not belong to a cell on
   // this process, their values will not have been set by the above. Hence,
   // communicate the values of ghost dofs back to their owners.
-  u.x()->scatter_rev(
+  temp_x.scatter_rev(
       [](auto a, auto b)
       {
-        if (abs(b) > 0.0)
+        if (!std::isnan(std::abs(b)))
           return b;
         else
           return a;
       });
+
+  // Copy interpolated values (which aren't NAN) back to original vector
+  std::copy_if(temp_x.array().begin(), temp_x.array().end(),
+               u.x()->mutable_array().begin(),
+               [](auto t) { return !std::isnan(std::abs(t)); });
 }
 
 /// Interpolate from one finite element Function to another on the same

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -435,10 +435,9 @@ void interpolate(Function<T>& u, const xt::xarray<T>& f,
   const int num_scalar_dofs = element->space_dimension() / element_bs;
   const int value_size = element->value_size() / element_bs;
 
-  // Create temporary vector to work with and set all values to NAN so
-  // we know which values need to be copied, so that old data does not
-  // interfere for ghosts that do not belong to a cell when ghost
-  // values are communicated to owners
+  // Create a copy of the function's vector to work with. The values are
+  // initialised to NAN so that only the correct values are copied back
+  // into the original vector later
   la::Vector temp_x(*u.x());
   temp_x.set(NAN);
   xtl::span<T> coeffs = temp_x.mutable_array();
@@ -625,7 +624,7 @@ void interpolate(Function<T>& u, const xt::xarray<T>& f,
 
   // If there are owned dofs on this process that do not belong to a cell on
   // this process, their values will not have been set by the above. Hence,
-  // communicate the values of ghost dofs back to their owners.
+  // communicate the values of ghost dofs to their owners.
   temp_x.scatter_rev(
       [](auto a, auto b)
       {
@@ -635,6 +634,7 @@ void interpolate(Function<T>& u, const xt::xarray<T>& f,
           return a;
       });
 
+  // Copy the data back to the original vector
   // FIXME See if this can be done with something like a copy_if
   for (int i = 0; i < temp_x.array().size(); ++i)
   {

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -14,7 +14,8 @@ import ufl
 from dolfinx.fem import (Expression, Function, FunctionSpace,
                          VectorFunctionSpace, assemble_scalar, form)
 from dolfinx.mesh import (CellType, meshtags, create_mesh, create_unit_cube,
-                          create_unit_square, locate_entities)
+                          create_unit_square, locate_entities, GhostMode,
+                          create_rectangle, create_submesh)
 
 from mpi4py import MPI
 
@@ -542,3 +543,35 @@ def test_interpolate_subset(order, dim, affine):
     assert np.isclose(np.abs(form(assemble_scalar(form(ufl.inner(u - f, u - f) * dx(1))))), 0)
     integral = mesh.comm.allreduce(assemble_scalar(form(u * dx)), op=MPI.SUM)
     assert np.isclose(integral, 1 / (order + 1) * 0.5**(order + 1), 0)
+
+
+@pytest.mark.parametrize("n", [1, 6, 11])
+@pytest.mark.parametrize("ghost_mode", [GhostMode.none,
+                                        GhostMode.shared_facet])
+def test_dof_without_cell(n, ghost_mode):
+    mesh = create_unit_square(
+        MPI.COMM_WORLD, n, n, ghost_mode=ghost_mode)
+    mesh_1 = create_rectangle(
+        MPI.COMM_WORLD, ((0.0, 0.0), (2.0, 1.0)), (2 * n, n),
+        ghost_mode=ghost_mode)
+
+    edim = mesh_1.topology.dim
+    entities = locate_entities(mesh_1, edim, lambda x: x[0] <= 1.0)
+    submesh = create_submesh(mesh_1, edim, entities)[0]
+
+    element = ("Lagrange", 1)
+
+    V_mesh = FunctionSpace(mesh, element)
+    V_submesh = FunctionSpace(submesh, element)
+
+    def f_expr(x): return x[0]**2
+
+    f_mesh = Function(V_mesh)
+    f_mesh.interpolate(f_expr)
+    f_mesh.x.scatter_forward()
+
+    f_submesh = Function(V_submesh)
+    f_submesh.interpolate(f_expr)
+    f_mesh.x.scatter_forward()
+
+    assert(np.isclose(f_mesh.vector.norm(), f_submesh.vector.norm()))

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -564,7 +564,8 @@ def test_dof_without_cell(n, ghost_mode):
     V_mesh = FunctionSpace(mesh, element)
     V_submesh = FunctionSpace(submesh, element)
 
-    def f_expr(x): return x[0]**2
+    def f_expr(x):
+        return x[0]**2
 
     f_mesh = Function(V_mesh)
     f_mesh.interpolate(f_expr)

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -549,24 +549,31 @@ def test_interpolate_subset(order, dim, affine):
 @pytest.mark.parametrize("ghost_mode", [GhostMode.none,
                                         GhostMode.shared_facet])
 def test_dof_without_cell(n, ghost_mode):
-    mesh = create_unit_square(
+    """Test that interpolating a function on a mesh where some dofs
+    owned by this process don't belong to a cell on this process
+    gives the expected result"""
+    # Currently it is not possible to partition a mesh so that a vertex
+    # doesn't belong to a cell, so use create submesh.
+    square_mesh = create_unit_square(
         MPI.COMM_WORLD, n, n, ghost_mode=ghost_mode)
-    mesh_1 = create_rectangle(
+    rect_mesh = create_rectangle(
         MPI.COMM_WORLD, ((0.0, 0.0), (2.0, 1.0)), (2 * n, n),
         ghost_mode=ghost_mode)
 
-    edim = mesh_1.topology.dim
-    entities = locate_entities(mesh_1, edim, lambda x: x[0] <= 1.0)
-    submesh = create_submesh(mesh_1, edim, entities)[0]
+    # Create a unit square submesh from the rectangle mesh
+    edim = rect_mesh.topology.dim
+    entities = locate_entities(rect_mesh, edim, lambda x: x[0] <= 1.0)
+    submesh = create_submesh(rect_mesh, edim, entities)[0]
 
     element = ("Lagrange", 1)
-
-    V_mesh = FunctionSpace(mesh, element)
+    V_mesh = FunctionSpace(square_mesh, element)
     V_submesh = FunctionSpace(submesh, element)
 
     def f_expr(x):
         return x[0]**2
 
+    # Interpolate on the unit square mesh and unit square submesh and
+    # check the result is the same
     f_mesh = Function(V_mesh)
     f_mesh.interpolate(f_expr)
     f_mesh.x.scatter_forward()


### PR DESCRIPTION
This fix is needed for the same reason as https://github.com/FEniCS/dolfinx/pull/2232. 