### PR TITLE
Allow sparsity pattern to be built from integration entities

### DIFF
--- a/cpp/dolfinx/fem/sparsitybuild.cpp
+++ b/cpp/dolfinx/fem/sparsitybuild.cpp
@@ -30,6 +30,18 @@ void sparsitybuild::cells(
   }
 }
 //-----------------------------------------------------------------------------
+void cells(la::SparsityPattern& pattern,
+           const xtl::span<const std::int32_t>& cells,
+           const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
+               dofmaps)
+{
+  for (std::int32_t c : cells)
+  {
+    pattern.insert(dofmaps[0].get().cell_dofs(c),
+                   dofmaps[1].get().cell_dofs(c));
+  }
+}
+//-----------------------------------------------------------------------------
 void sparsitybuild::interior_facets(
     la::SparsityPattern& pattern, const mesh::Topology& topology,
     const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&

--- a/cpp/dolfinx/fem/sparsitybuild.cpp
+++ b/cpp/dolfinx/fem/sparsitybuild.cpp
@@ -30,10 +30,10 @@ void sparsitybuild::cells(
   }
 }
 //-----------------------------------------------------------------------------
-void sparsitybuild::cells(la::SparsityPattern& pattern,
-           const xtl::span<const std::int32_t>& cells,
-           const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
-               dofmaps)
+void sparsitybuild::cells(
+    la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& cells,
+    const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
+        dofmaps)
 {
   for (std::int32_t c : cells)
   {
@@ -115,6 +115,19 @@ void sparsitybuild::exterior_facets(
     assert(cells.size() == 1);
     pattern.insert(dofmaps[0].get().cell_dofs(cells[0]),
                    dofmaps[1].get().cell_dofs(cells[0]));
+  }
+}
+//-----------------------------------------------------------------------------
+void sparsitybuild::exterior_facets(
+    la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& facets,
+    const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
+        dofmaps)
+{
+  for (std::size_t index = 0; index < facets.size(); index += 2)
+  {
+    std::int32_t cell = facets[index];
+    pattern.insert(dofmaps[0].get().cell_dofs(cell),
+                   dofmaps[1].get().cell_dofs(cell));
   }
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/sparsitybuild.cpp
+++ b/cpp/dolfinx/fem/sparsitybuild.cpp
@@ -17,8 +17,7 @@ using namespace dolfinx::fem;
 //-----------------------------------------------------------------------------
 void sparsitybuild::cells(
     la::SparsityPattern& pattern, const mesh::Topology& topology,
-    const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
-        dofmaps)
+    const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps)
 {
   const int D = topology.dim();
   auto cells = topology.connectivity(D, 0);
@@ -32,8 +31,7 @@ void sparsitybuild::cells(
 //-----------------------------------------------------------------------------
 void sparsitybuild::cells(
     la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& cells,
-    const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
-        dofmaps)
+    const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps)
 {
   for (std::int32_t c : cells)
   {
@@ -44,8 +42,7 @@ void sparsitybuild::cells(
 //-----------------------------------------------------------------------------
 void sparsitybuild::interior_facets(
     la::SparsityPattern& pattern, const mesh::Topology& topology,
-    const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
-        dofmaps)
+    const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps)
 {
   const int D = topology.dim();
   if (!topology.connectivity(D - 1, 0))
@@ -66,6 +63,7 @@ void sparsitybuild::interior_facets(
   {
     // Get cells incident with facet
     auto cells = connectivity->links(f);
+
     // Proceed to next facet if only ony connection
     if (cells.size() == 1)
       continue;
@@ -90,15 +88,13 @@ void sparsitybuild::interior_facets(
 //-----------------------------------------------------------------------------
 void sparsitybuild::interior_facets(
     la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& facets,
-    const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
-        dofmaps)
+    const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps)
 {
   std::array<std::vector<std::int32_t>, 2> macro_dofs;
   for (std::size_t index = 0; index < facets.size(); index += 4)
   {
     const int cell_0 = facets[index];
     const int cell_1 = facets[index + 2];
-
     for (std::size_t i = 0; i < 2; ++i)
     {
       auto cell_dofs_0 = dofmaps[i].get().cell_dofs(cell_0);
@@ -108,14 +104,14 @@ void sparsitybuild::interior_facets(
       std::copy(cell_dofs_1.begin(), cell_dofs_1.end(),
                 std::next(macro_dofs[i].begin(), cell_dofs_0.size()));
     }
+
     pattern.insert(macro_dofs[0], macro_dofs[1]);
   }
 }
 //-----------------------------------------------------------------------------
 void sparsitybuild::exterior_facets(
     la::SparsityPattern& pattern, const mesh::Topology& topology,
-    const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
-        dofmaps)
+    const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps)
 {
   const int D = topology.dim();
   if (!topology.connectivity(D - 1, 0))
@@ -144,8 +140,7 @@ void sparsitybuild::exterior_facets(
 //-----------------------------------------------------------------------------
 void sparsitybuild::exterior_facets(
     la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& facets,
-    const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
-        dofmaps)
+    const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps)
 {
   for (std::size_t index = 0; index < facets.size(); index += 2)
   {

--- a/cpp/dolfinx/fem/sparsitybuild.cpp
+++ b/cpp/dolfinx/fem/sparsitybuild.cpp
@@ -30,7 +30,7 @@ void sparsitybuild::cells(
   }
 }
 //-----------------------------------------------------------------------------
-void cells(la::SparsityPattern& pattern,
+void sparsitybuild::cells(la::SparsityPattern& pattern,
            const xtl::span<const std::int32_t>& cells,
            const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
                dofmaps)

--- a/cpp/dolfinx/fem/sparsitybuild.h
+++ b/cpp/dolfinx/fem/sparsitybuild.h
@@ -80,5 +80,18 @@ void exterior_facets(
     const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
         dofmaps);
 
+/// @brief Iterate over exterior facets and insert entries into sparsity
+/// pattern.
+///
+/// @param[in,out] pattern The sparsity pattern to insert into
+/// @param[in] facets The facets as (cell, local_index) pairs
+/// @param[in] dofmaps The dofmap to use in building the sparsity
+/// pattern
+/// @note The sparsity pattern is not finalised
+void exterior_facets(
+    la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& facets,
+    const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
+        dofmaps);
+
 } // namespace sparsitybuild
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/sparsitybuild.h
+++ b/cpp/dolfinx/fem/sparsitybuild.h
@@ -66,6 +66,19 @@ void interior_facets(
     const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
         dofmaps);
 
+/// @brief Iterate over interior facets and insert entries into sparsity
+/// pattern.
+///
+/// @param[in,out] pattern The sparsity pattern to insert into
+/// @param[in] facets The facets as (cell, local_index) pairs
+/// @param[in] dofmaps The dofmap to use in building the sparsity
+/// pattern
+/// @note The sparsity pattern is not finalised
+void interior_facets(
+    la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& facets,
+    const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
+        dofmaps);
+
 /// @brief Iterate over exterior facets and insert entries into sparsity
 /// pattern.
 ///

--- a/cpp/dolfinx/fem/sparsitybuild.h
+++ b/cpp/dolfinx/fem/sparsitybuild.h
@@ -36,21 +36,20 @@ namespace sparsitybuild
 /// @param[in] dofmaps The dofmap to use in building the sparsity
 /// pattern
 /// @note The sparsity pattern is not finalised
-void cells(la::SparsityPattern& pattern, const mesh::Topology& topology,
-           const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
-               dofmaps);
+void cells(
+    la::SparsityPattern& pattern, const mesh::Topology& topology,
+    const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps);
 
 /// @brief Iterate over cells and insert entries into sparsity pattern
 ///
 /// @param[in,out] pattern The sparsity pattern to insert into
-/// @param[in] cells The cells
+/// @param[in] cells The cell indices
 /// @param[in] dofmaps The dofmap to use in building the sparsity
 /// pattern
 /// @note The sparsity pattern is not finalised
-void cells(la::SparsityPattern& pattern,
-           const xtl::span<const std::int32_t>& cells,
-           const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
-               dofmaps);
+void cells(
+    la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& cells,
+    const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps);
 
 /// @brief Iterate over interior facets and insert entries into sparsity
 /// pattern.
@@ -63,21 +62,20 @@ void cells(la::SparsityPattern& pattern,
 /// @note The sparsity pattern is not finalised
 void interior_facets(
     la::SparsityPattern& pattern, const mesh::Topology& topology,
-    const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
-        dofmaps);
+    const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps);
 
 /// @brief Iterate over interior facets and insert entries into sparsity
 /// pattern.
 ///
 /// @param[in,out] pattern The sparsity pattern to insert into
-/// @param[in] facets The facets as (cell, local_index) pairs
+/// @param[in] facets The facets as `(cell, local_index)` pairs, where
+/// `local_index` is the index of the facet relative to the `cell`
 /// @param[in] dofmaps The dofmap to use in building the sparsity
 /// pattern
 /// @note The sparsity pattern is not finalised
 void interior_facets(
     la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& facets,
-    const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
-        dofmaps);
+    const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps);
 
 /// @brief Iterate over exterior facets and insert entries into sparsity
 /// pattern.
@@ -90,8 +88,7 @@ void interior_facets(
 /// @note The sparsity pattern is not finalised
 void exterior_facets(
     la::SparsityPattern& pattern, const mesh::Topology& topology,
-    const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
-        dofmaps);
+    const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps);
 
 /// @brief Iterate over exterior facets and insert entries into sparsity
 /// pattern.
@@ -103,8 +100,7 @@ void exterior_facets(
 /// @note The sparsity pattern is not finalised
 void exterior_facets(
     la::SparsityPattern& pattern, const xtl::span<const std::int32_t>& facets,
-    const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
-        dofmaps);
+    const std::array<const std::reference_wrapper<const DofMap>, 2>& dofmaps);
 
 } // namespace sparsitybuild
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/sparsitybuild.h
+++ b/cpp/dolfinx/fem/sparsitybuild.h
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <functional>
+#include <xtl/xspan.hpp>
 
 namespace dolfinx::la
 {
@@ -36,6 +37,18 @@ namespace sparsitybuild
 /// pattern
 /// @note The sparsity pattern is not finalised
 void cells(la::SparsityPattern& pattern, const mesh::Topology& topology,
+           const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
+               dofmaps);
+
+/// @brief Iterate over cells and insert entries into sparsity pattern
+///
+/// @param[in,out] pattern The sparsity pattern to insert into
+/// @param[in] cells The cells
+/// @param[in] dofmaps The dofmap to use in building the sparsity
+/// pattern
+/// @note The sparsity pattern is not finalised
+void cells(la::SparsityPattern& pattern,
+           const xtl::span<const std::int32_t>& cells,
            const std::array<const std::reference_wrapper<const fem::DofMap>, 2>&
                dofmaps);
 

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -12,7 +12,6 @@
 #include "Function.h"
 #include "FunctionSpace.h"
 #include "dofmapbuilder.h"
-#include "sparsitybuild.h"
 #include <array>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/Timer.h>
@@ -33,6 +32,7 @@ la::SparsityPattern fem::create_sparsity_pattern(
     const std::array<std::reference_wrapper<const DofMap>, 2>& dofmaps,
     const std::set<IntegralType>& integrals)
 {
+  // TODO Make this use other function
   common::Timer t0("Build sparsity");
 
   // Get common::IndexMaps for each dimension

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -32,7 +32,6 @@ la::SparsityPattern fem::create_sparsity_pattern(
     const std::array<std::reference_wrapper<const DofMap>, 2>& dofmaps,
     const std::set<IntegralType>& integrals)
 {
-  // TODO Make this use other function
   common::Timer t0("Build sparsity");
 
   // Get common::IndexMaps for each dimension

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -72,7 +72,6 @@ struct scalar_value_type<T, std::void_t<typename T::value_type>>
 template <typename T>
 using scalar_value_type_t = typename scalar_value_type<T>::value_type;
 
-
 } // namespace impl
 
 /// @brief Extract test (0) and trial (1) function spaces pairs for each
@@ -156,16 +155,13 @@ la::SparsityPattern create_sparsity_pattern(const Form<T>& a)
     switch (type)
     {
     case IntegralType::cell:
-    {
       for (int id : ids)
       {
         const std::vector<std::int32_t>& cells = a.cell_domains(id);
         sparsitybuild::cells(pattern, cells, {{dofmaps[0], dofmaps[1]}});
       }
       break;
-    }
     case IntegralType::interior_facet:
-    {
       for (int id : ids)
       {
         const std::vector<std::int32_t>& facets = a.interior_facet_domains(id);
@@ -173,9 +169,7 @@ la::SparsityPattern create_sparsity_pattern(const Form<T>& a)
                                        {{dofmaps[0], dofmaps[1]}});
       }
       break;
-    }
     case IntegralType::exterior_facet:
-    {
       for (int id : ids)
       {
         const std::vector<std::int32_t>& facets = a.exterior_facet_domains(id);
@@ -183,7 +177,6 @@ la::SparsityPattern create_sparsity_pattern(const Form<T>& a)
                                        {{dofmaps[0], dofmaps[1]}});
       }
       break;
-    }
     default:
       throw std::runtime_error("Unsupported integral type");
     }

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -152,9 +152,15 @@ la::SparsityPattern create_sparsity_pattern(const Form<T>& a)
       break;
     }
     case IntegralType::interior_facet:
-      sparsitybuild::interior_facets(pattern, topology,
-                                     {{dofmaps[0], dofmaps[1]}});
+    {
+      for (int id : ids)
+      {
+        const std::vector<std::int32_t>& facets = a.interior_facet_domains(id);
+        sparsitybuild::interior_facets(pattern, facets,
+                                       {{dofmaps[0], dofmaps[1]}});
+      }
       break;
+    }
     case IntegralType::exterior_facet:
     {
       for (int id : ids)

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -28,8 +28,8 @@
 #include <xtensor/xtensor.hpp>
 #include <xtl/xspan.hpp>
 
-#include <xtensor/xio.hpp>
 #include <xtensor/xadapt.hpp>
+#include <xtensor/xio.hpp>
 
 /// @file utils.h
 /// @brief Functions supporting finite element method operations
@@ -156,9 +156,15 @@ la::SparsityPattern create_sparsity_pattern(const Form<T>& a)
                                      {{dofmaps[0], dofmaps[1]}});
       break;
     case IntegralType::exterior_facet:
-      sparsitybuild::exterior_facets(pattern, topology,
-                                     {{dofmaps[0], dofmaps[1]}});
+    {
+      for (int id : ids)
+      {
+        const std::vector<std::int32_t>& facets = a.exterior_facet_domains(id);
+        sparsitybuild::exterior_facets(pattern, facets,
+                                       {{dofmaps[0], dofmaps[1]}});
+      }
       break;
+    }
     default:
       throw std::runtime_error("Unsupported integral type");
     }

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -144,13 +144,11 @@ la::SparsityPattern create_sparsity_pattern(const Form<T>& a)
     {
     case IntegralType::cell:
     {
-      // std::cout << xt::adapt(ids) << "\n";
-      // for (int id : ids)
-      // {
-      //   const std::vector<std::int32_t>& cells = a.cell_domains(id);
-      //   sparsitybuild::cells(pattern, cells, {{dofmaps[0], dofmaps[1]}});
-      // }
-      sparsitybuild::cells(pattern, topology, {{dofmaps[0], dofmaps[1]}});
+      for (int id : ids)
+      {
+        const std::vector<std::int32_t>& cells = a.cell_domains(id);
+        sparsitybuild::cells(pattern, cells, {{dofmaps[0], dofmaps[1]}});
+      }
       break;
     }
     case IntegralType::interior_facet:

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -93,8 +93,6 @@ la::SparsityPattern create_sparsity_pattern(
 template <typename T>
 la::SparsityPattern create_sparsity_pattern(const Form<T>& a)
 {
-  // TODO clean up data access
-
   if (a.rank() != 2)
   {
     throw std::runtime_error(
@@ -107,8 +105,6 @@ la::SparsityPattern create_sparsity_pattern(const Form<T>& a)
       *a.function_spaces().at(1)->dofmap()};
   std::shared_ptr mesh = a.mesh();
   assert(mesh);
-
-  const mesh::Topology& topology = mesh->topology();
 
   const std::set<IntegralType> types = a.integral_types();
   if (types.find(IntegralType::interior_facet) != types.end()

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -28,9 +28,6 @@
 #include <xtensor/xtensor.hpp>
 #include <xtl/xspan.hpp>
 
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xio.hpp>
-
 /// @file utils.h
 /// @brief Functions supporting finite element method operations
 
@@ -96,7 +93,6 @@ la::SparsityPattern create_sparsity_pattern(
 template <typename T>
 la::SparsityPattern create_sparsity_pattern(const Form<T>& a)
 {
-  std::cout << "create_sparsity_pattern\n";
   // TODO clean up data access
 
   if (a.rank() != 2)
@@ -133,10 +129,7 @@ la::SparsityPattern create_sparsity_pattern(const Form<T>& a)
       = {dofmaps[0].get().index_map_bs(), dofmaps[1].get().index_map_bs()};
 
   // Create and build sparsity pattern
-  // TODO Use mesh->comm()?
-  assert(dofmaps[0].get().index_map);
-  la::SparsityPattern pattern(dofmaps[0].get().index_map->comm(), index_maps,
-                              bs);
+  la::SparsityPattern pattern(mesh->comm(), index_maps, bs);
   for (auto type : types)
   {
     std::vector<int> ids = a.integral_ids(type);


### PR DESCRIPTION
This PR makes it possible to build a sparsity pattern from a list of integration entities i.e. cell indices for cell integrals, (cell, local_facet) pairs for exterior facet integrals etc. It also modifies `create_sparsity_pattern` so that it only adds entries for entities in the form's integration domains, rather than for all entities of a particular integration type.

This PR is a step towards allowing the user to specify integration domains by passing a list of integration entities to `Form`, which would allow, for example, one-sided integrals on the interior facets of the mesh. I plan to put in another PR soon to add this functionality.