### PR TITLE
Add usr local to complex kernel

### DIFF
--- a/docker/complex-kernel.json
+++ b/docker/complex-kernel.json
@@ -1,20 +1,20 @@
 {
- "argv": [
-     "python",
-     "-m",
-     "ipykernel_launcher",
-     "-f",
-     "{connection_file}"
- ],
- "display_name": "Python 3 (DOLFINx complex)",
- "language": "python",
- "metadata": {
-     "debugger": true
- },
- "env": {
-     "PKG_CONFIG_PATH": "/usr/local/dolfinx-complex/lib/pkgconfig",
-     "PETSC_ARCH": "linux-gnu-complex-32",
-     "PYTHONPATH": "/usr/local/dolfinx-complex/lib/python3.10/dist-packages",
-     "LD_LIBRARY_PATH": "/usr/local/dolfinx-complex/lib"
- }
+    "argv": [
+        "python",
+        "-m",
+        "ipykernel_launcher",
+        "-f",
+        "{connection_file}"
+    ],
+    "display_name": "Python 3 (DOLFINx complex)",
+    "language": "python",
+    "metadata": {
+        "debugger": true
+    },
+    "env": {
+        "PKG_CONFIG_PATH": "/usr/local/dolfinx-complex/lib/pkgconfig",
+        "PETSC_ARCH": "linux-gnu-complex-32",
+        "PYTHONPATH": "/usr/local/dolfinx-complex/lib/python3.10/dist-packages:/usr/local/lib",
+        "LD_LIBRARY_PATH": "/usr/local/dolfinx-complex/lib"
+    }
 }


### PR DESCRIPTION
All packages not installed by DOLFINx gets ignored once we switch to the complex kernel (for instance gmsh).

This adds `/usr/local/lib` to the pythonpath