### PR TITLE
Use helper template (from C++ 17 and onwards) for std::is_same<T>::value and std::is_integral<T>::value

### DIFF
--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -265,35 +265,35 @@ struct dependent_false : std::false_type
 template <typename T>
 constexpr MPI_Datatype mpi_type()
 {
-  if constexpr (std::is_same<T, float>::value)
+  if constexpr (std::is_same_v<T, float>)
     return MPI_FLOAT;
-  else if constexpr (std::is_same<T, double>::value)
+  else if constexpr (std::is_same_v<T, double>)
     return MPI_DOUBLE;
-  else if constexpr (std::is_same<T, std::complex<double>>::value)
+  else if constexpr (std::is_same_v<T, std::complex<double>>)
     return MPI_C_DOUBLE_COMPLEX;
-  else if constexpr (std::is_same<T, std::complex<float>>::value)
+  else if constexpr (std::is_same_v<T, std::complex<float>>)
     return MPI_C_FLOAT_COMPLEX;
-  else if constexpr (std::is_same<T, short int>::value)
+  else if constexpr (std::is_same_v<T, short int>)
     return MPI_SHORT;
-  else if constexpr (std::is_same<T, int>::value)
+  else if constexpr (std::is_same_v<T, int>)
     return MPI_INT;
-  else if constexpr (std::is_same<T, unsigned int>::value)
+  else if constexpr (std::is_same_v<T, unsigned int>)
     return MPI_UNSIGNED;
-  else if constexpr (std::is_same<T, long int>::value)
+  else if constexpr (std::is_same_v<T, long int>)
     return MPI_LONG;
-  else if constexpr (std::is_same<T, unsigned long>::value)
+  else if constexpr (std::is_same_v<T, unsigned long>)
     return MPI_UNSIGNED_LONG;
-  else if constexpr (std::is_same<T, long long>::value)
+  else if constexpr (std::is_same_v<T, long long>)
     return MPI_LONG_LONG;
-  else if constexpr (std::is_same<T, unsigned long long>::value)
+  else if constexpr (std::is_same_v<T, unsigned long long>)
     return MPI_UNSIGNED_LONG_LONG;
-  else if constexpr (std::is_same<T, bool>::value)
+  else if constexpr (std::is_same_v<T, bool>)
     return MPI_C_BOOL;
-  else if constexpr (std::is_same<T, std::int8_t>::value)
+  else if constexpr (std::is_same_v<T, std::int8_t>)
     return MPI_INT8_T;
   else
     // Issue compile time error
-    static_assert(!std::is_same<T, T>::value);
+    static_assert(!std::is_same_v<T, T>);
 }
 
 //---------------------------------------------------------------------------

--- a/cpp/dolfinx/common/sort.h
+++ b/cpp/dolfinx/common/sort.h
@@ -99,7 +99,7 @@ template <typename T, int BITS = 16>
 void argsort_radix(const xtl::span<const T>& array,
                    xtl::span<std::int32_t> perm)
 {
-  static_assert(std::is_integral<T>::value, "Integral required.");
+  static_assert(std::is_integral_v<T>, "Integral required.");
 
   if (array.size() <= 1)
     return;
@@ -178,7 +178,7 @@ template <typename T, int BITS = 16>
 std::vector<std::int32_t> sort_by_perm(const xtl::span<const T>& x,
                                        std::size_t shape1)
 {
-  static_assert(std::is_integral<T>::value, "Integral required.");
+  static_assert(std::is_integral_v<T>, "Integral required.");
   assert(shape1 > 0);
   assert(x.size() % shape1 == 0);
   const std::size_t shape0 = x.size() / shape1;

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -285,18 +285,18 @@ Form<T> create_form(
     assert(integral);
 
     kern k = nullptr;
-    if constexpr (std::is_same<T, float>::value)
+    if constexpr (std::is_same_v<T, float>)
       k = integral->tabulate_tensor_float32;
-    else if constexpr (std::is_same<T, std::complex<float>>::value)
+    else if constexpr (std::is_same_v<T, std::complex<float>>)
     {
       k = reinterpret_cast<void (*)(
           T*, const T*, const T*,
           const typename impl::scalar_value_type<T>::value_type*, const int*,
           const unsigned char*)>(integral->tabulate_tensor_complex64);
     }
-    else if constexpr (std::is_same<T, double>::value)
+    else if constexpr (std::is_same_v<T, double>)
       k = integral->tabulate_tensor_float64;
-    else if constexpr (std::is_same<T, std::complex<double>>::value)
+    else if constexpr (std::is_same_v<T, std::complex<double>>)
     {
       k = reinterpret_cast<void (*)(
           T*, const T*, const T*,
@@ -343,18 +343,18 @@ Form<T> create_form(
     assert(integral);
 
     kern k = nullptr;
-    if constexpr (std::is_same<T, float>::value)
+    if constexpr (std::is_same_v<T, float>)
       k = integral->tabulate_tensor_float32;
-    else if constexpr (std::is_same<T, std::complex<float>>::value)
+    else if constexpr (std::is_same_v<T, std::complex<float>>)
     {
       k = reinterpret_cast<void (*)(
           T*, const T*, const T*,
           const typename impl::scalar_value_type<T>::value_type*, const int*,
           const unsigned char*)>(integral->tabulate_tensor_complex64);
     }
-    else if constexpr (std::is_same<T, double>::value)
+    else if constexpr (std::is_same_v<T, double>)
       k = integral->tabulate_tensor_float64;
-    else if constexpr (std::is_same<T, std::complex<double>>::value)
+    else if constexpr (std::is_same_v<T, std::complex<double>>)
     {
       k = reinterpret_cast<void (*)(
           T*, const T*, const T*,
@@ -387,18 +387,18 @@ Form<T> create_form(
     assert(integral);
 
     kern k = nullptr;
-    if constexpr (std::is_same<T, float>::value)
+    if constexpr (std::is_same_v<T, float>)
       k = integral->tabulate_tensor_float32;
-    else if constexpr (std::is_same<T, std::complex<float>>::value)
+    else if constexpr (std::is_same_v<T, std::complex<float>>)
     {
       k = reinterpret_cast<void (*)(
           T*, const T*, const T*,
           const typename impl::scalar_value_type<T>::value_type*, const int*,
           const unsigned char*)>(integral->tabulate_tensor_complex64);
     }
-    else if constexpr (std::is_same<T, double>::value)
+    else if constexpr (std::is_same_v<T, double>)
       k = integral->tabulate_tensor_float64;
-    else if constexpr (std::is_same<T, std::complex<double>>::value)
+    else if constexpr (std::is_same_v<T, std::complex<double>>)
     {
       k = reinterpret_cast<void (*)(
           T*, const T*, const T*,
@@ -840,18 +840,18 @@ fem::Expression<T> create_expression(
                      const typename impl::scalar_value_type<T>::value_type*,
                      const int*, const std::uint8_t*)>
       tabulate_tensor = nullptr;
-  if constexpr (std::is_same<T, float>::value)
+  if constexpr (std::is_same_v<T, float>)
     tabulate_tensor = expression.tabulate_tensor_float32;
-  else if constexpr (std::is_same<T, std::complex<float>>::value)
+  else if constexpr (std::is_same_v<T, std::complex<float>>)
   {
     tabulate_tensor = reinterpret_cast<void (*)(
         T*, const T*, const T*,
         const typename impl::scalar_value_type<T>::value_type*, const int*,
         const unsigned char*)>(expression.tabulate_tensor_complex64);
   }
-  else if constexpr (std::is_same<T, double>::value)
+  else if constexpr (std::is_same_v<T, double>)
     tabulate_tensor = expression.tabulate_tensor_float64;
-  else if constexpr (std::is_same<T, std::complex<double>>::value)
+  else if constexpr (std::is_same_v<T, std::complex<double>>)
   {
     tabulate_tensor = reinterpret_cast<void (*)(
         T*, const T*, const T*,

--- a/cpp/dolfinx/io/ADIOS2Writers.cpp
+++ b/cpp/dolfinx/io/ADIOS2Writers.cpp
@@ -104,7 +104,7 @@ void vtx_write_data(adios2::IO& io, adios2::Engine& engine,
       = index_map_bs * (index_map->size_local() + index_map->num_ghosts())
         / dofmap_bs;
 
-  if constexpr (std::is_scalar<T>::value)
+  if constexpr (std::is_scalar_v<T>)
   {
     // ---- Real
     std::vector<T> data(num_dofs * num_comp, 0);
@@ -489,7 +489,7 @@ void fides_write_data(adios2::IO& io, adios2::Engine& engine,
   // Write each real and imaginary part of the function
   const std::uint32_t num_components = std::pow(3, rank);
   assert(data.size() % num_components == 0);
-  if constexpr (std::is_scalar<T>::value)
+  if constexpr (std::is_scalar_v<T>)
   {
     // ---- Real
     const std::string u_name = u.name;

--- a/cpp/dolfinx/io/VTKFile.cpp
+++ b/cpp/dolfinx/io/VTKFile.cpp
@@ -165,7 +165,7 @@ template <typename T>
 void add_data(const std::string& name, int rank,
               const xtl::span<const T>& values, pugi::xml_node& node)
 {
-  if constexpr (std::is_scalar<T>::value)
+  if constexpr (std::is_scalar_v<T>)
     add_data_float(name, rank, values, node);
   else
   {

--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -106,7 +106,7 @@ void _add_function(MPI_Comm comm, const fem::Function<Scalar>& u,
   const int value_rank = u.function_space()->element()->value_shape().size();
 
   std::vector<std::string> components = {""};
-  if constexpr (!std::is_scalar<Scalar>::value)
+  if constexpr (!std::is_scalar_v<Scalar>)
     components = {"real", "imag"};
 
   std::string t_str = boost::lexical_cast<std::string>(t);
@@ -137,7 +137,7 @@ void _add_function(MPI_Comm comm, const fem::Function<Scalar>& u,
     attribute_node.append_attribute("Center") = cell_centred ? "Cell" : "Node";
 
     const bool use_mpi_io = (dolfinx::MPI::size(comm) > 1);
-    if constexpr (!std::is_scalar<Scalar>::value)
+    if constexpr (!std::is_scalar_v<Scalar>)
     {
       // Complex case
 


### PR DESCRIPTION
See:
https://en.cppreference.com/w/cpp/types/is_same
https://en.cppreference.com/w/cpp/types/is_integral
https://en.cppreference.com/w/cpp/types/is_scalar