### PR TITLE
Bump pyvista version

### DIFF
--- a/.github/workflows/pyvista.yml
+++ b/.github/workflows/pyvista.yml
@@ -2,9 +2,9 @@ name: Test visualisation demos
 
 on:
   # Uncomment the below to trigger tests on push
-  # push:
-  #   branches:
-  #     - "**"
+  push:
+    branches:
+      - "**"
   schedule:
     # '*' is a special character in YAML, so string must be quoted
     - cron: "0 1 * * *"
@@ -24,6 +24,7 @@ jobs:
       DISPLAY: ":99.0"
       PYVISTA_OFF_SCREEN: true
       PYVISTA_QT_VERSION: 0.9.0
+      PYVISTA_VERSION: 0.34.2
 
       PETSC_ARCH: linux-gnu-${{ matrix.petsc_arch }}-32
       OMPI_ALLOW_RUN_AS_ROOT: 1
@@ -49,7 +50,7 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends libgl1-mesa-dev xvfb  # pyvista
           apt-get install -y --no-install-recommends python3-pyqt5 libgl1-mesa-glx  # pyvistaqt
-          pip3 install --find-links https://wheels.pyvista.org/ pyvista 
+          pip3 install pyvista==${PYVISTA_VERSION:}
           pip3 install pyvistaqt==${PYVISTA_QT_VERSION}
           pip3 install matplotlib
 

--- a/.github/workflows/pyvista.yml
+++ b/.github/workflows/pyvista.yml
@@ -50,7 +50,7 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends libgl1-mesa-dev xvfb  # pyvista
           apt-get install -y --no-install-recommends python3-pyqt5 libgl1-mesa-glx  # pyvistaqt
-          pip3 install pyvista==${PYVISTA_VERSION:}
+          pip3 install pyvista==${PYVISTA_VERSION}
           pip3 install pyvistaqt==${PYVISTA_QT_VERSION}
           pip3 install matplotlib
 

--- a/.github/workflows/pyvista.yml
+++ b/.github/workflows/pyvista.yml
@@ -2,9 +2,9 @@ name: Test visualisation demos
 
 on:
   # Uncomment the below to trigger tests on push
-  push:
-    branches:
-      - "**"
+  # push:
+  #   branches:
+  #     - "**"
   schedule:
     # '*' is a special character in YAML, so string must be quoted
     - cron: "0 1 * * *"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,7 +51,7 @@ ARG NUMPY_VERSION=1.22.4
 ARG PYBIND11_VERSION=2.9.2
 ARG PETSC_VERSION=3.17.2
 ARG SLEPC_VERSION=3.17.1
-# ARG PYVISTA_VERSION=0.34.1 # Deactivated until https://gitlab.kitware.com/vtk/vtk/-/issues/18335 is resolved
+ARG PYVISTA_VERSION=0.34.2
 ARG XTENSOR_VERSION=0.24.2
 ARG XTL_VERSION=0.7.4
 
@@ -470,7 +470,7 @@ ENV PKG_CONFIG_PATH=/usr/local/dolfinx-real/lib/pkgconfig:$PKG_CONFIG_PATH \
 FROM dolfinx as lab
 LABEL description="DOLFINx Jupyter Lab"
 
-# ARG PYVISTA_VERSION
+ARG PYVISTA_VERSION
 
 WORKDIR /root
 
@@ -486,8 +486,7 @@ RUN apt-get -qq update && \
 # matplotlib improves plotting quality with better color maps and properly rendering colorbars.
 RUN dpkgArch="$(dpkg --print-architecture)"; \
     case "$dpkgArch" in amd64) \
-    # pip3 install --no-cache-dir pyvista==${PYVISTA_VERSION} ;; \
-    pip3 install --find-links https://wheels.pyvista.org/ pyvista ;; \
+    pip3 install --no-cache-dir pyvista==${PYVISTA_VERSION} ;; \
     esac; \
     pip3 install --no-cache-dir matplotlib
 


### PR DESCRIPTION
As https://github.com/pyvista/pyvista/issues/2859 has been closed with  https://github.com/pyvista/pyvista/pull/2912 and vtk has added a python3.10 compatible pypi wheel (https://pypi.org/project/vtk/9.2.0rc1/) the docker file has been simplified