### PR TITLE
Rewrite GMSH interface

### DIFF
--- a/cpp/dolfinx/io/cells.cpp
+++ b/cpp/dolfinx/io/cells.cpp
@@ -238,7 +238,7 @@ std::vector<std::uint8_t> gmsh_triangle(int num_nodes)
   case 10:
     return {0, 1, 2, 7, 8, 3, 4, 6, 5, 9};
   default:
-    throw std::runtime_error("Higher order GMSH triangle not supported");
+    throw std::runtime_error("Higher order Gmsh triangle not supported");
   }
 }
 //-----------------------------------------------------------------------------
@@ -254,7 +254,7 @@ std::vector<std::uint8_t> gmsh_tetrahedron(int num_nodes)
     return {0,  1,  2, 3, 14, 15, 8,  9,  13, 12,
             11, 10, 5, 4, 7,  6,  19, 18, 17, 16};
   default:
-    throw std::runtime_error("Higher order GMSH tetrahedron not supported");
+    throw std::runtime_error("Higher order Gmsh tetrahedron not supported");
   }
 }
 //-----------------------------------------------------------------------------
@@ -268,7 +268,7 @@ std::vector<std::uint8_t> gmsh_hexahedron(int num_nodes)
     return {0,  1,  3,  2,  4,  5,  7,  6,  8,  9,  10, 11, 12, 13,
             15, 14, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26};
   default:
-    throw std::runtime_error("Higher order GMSH hexahedron not supported");
+    throw std::runtime_error("Higher order Gmsh hexahedron not supported");
   }
 }
 //-----------------------------------------------------------------------------
@@ -283,7 +283,7 @@ std::vector<std::uint8_t> gmsh_quadrilateral(int num_nodes)
   case 16:
     return {0, 1, 3, 2, 4, 5, 8, 9, 11, 10, 7, 6, 12, 13, 15, 14};
   default:
-    throw std::runtime_error("Higher order GMSH quadrilateral not supported");
+    throw std::runtime_error("Higher order Gmsh quadrilateral not supported");
   }
 }
 } // namespace

--- a/cpp/dolfinx/io/xdmf_meshtags.h
+++ b/cpp/dolfinx/io/xdmf_meshtags.h
@@ -36,9 +36,14 @@ void add_meshtags(MPI_Comm comm, const mesh::MeshTags<T>& meshtags,
   assert(meshtags.mesh());
   std::shared_ptr<const mesh::Mesh> mesh = meshtags.mesh();
   const int dim = meshtags.dim();
-
-  const std::int32_t num_local_entities
-      = mesh->topology().index_map(dim)->size_local();
+  std::shared_ptr<const common::IndexMap> entity_map
+      = mesh->topology().index_map(dim);
+  if (!entity_map)
+  {
+    throw std::runtime_error("Missing entities. Did you forget to call "
+                             "dolfinx::mesh::Topology::create_entities?");
+  }
+  const std::int32_t num_local_entities = entity_map->size_local();
 
   // Find number of tagged entities in local range
   auto it = std::lower_bound(meshtags.indices().begin(),

--- a/python/demo/demo_gmsh.py
+++ b/python/demo/demo_gmsh.py
@@ -29,13 +29,14 @@ from mpi4py import MPI
 
 # -
 
-# Generate a mesh on each rank with the GMSH API, and create a DOLFINx
-# mesh on each rank with corresponding mesh tags for the cells of the mesh.
+# Generate a mesh on each rank with the Gmsh API, and create a DOLFINx
+# mesh on each rank with corresponding mesh tags for the cells of the
+# mesh.
 
 # +
 gmsh.initialize()
 
-# Choose if GMSH output is verbose
+# Choose if Gmsh output is verbose
 gmsh.option.setNumber("General.Terminal", 0)
 model = gmsh.model()
 model.add("Sphere")
@@ -45,7 +46,8 @@ sphere = model.occ.addSphere(0, 0, 0, 1, tag=1)
 # Synchronize OpenCascade representation with gmsh model
 model.occ.synchronize()
 
-# Add physical marker for cells. It is important to call this function after OpenCascade synchronization
+# Add physical marker for cells. It is important to call this function
+# after OpenCascade synchronization
 model.add_physical_group(3, [sphere])
 
 
@@ -66,7 +68,8 @@ with XDMFFile(msh.comm, f"out_gmsh/mesh_rank_{MPI.COMM_WORLD.rank}.xdmf", "w") a
 # -
 
 # Create a distributed (parallel) mesh with affine geometry. Generate
-# mesh on rank 0, then build a distributed mesh. Create mesh tags on exterior facets.
+# mesh on rank 0, then build a distributed mesh. Create mesh tags on
+# exterior facets.
 
 # +
 
@@ -149,6 +152,7 @@ if mesh_comm.rank == model_rank:
     # Generate
     model.add("Hexahedral mesh")
     model.setCurrent("Hexahedral mesh")
+
     # Recombine tetrahedrons to hexahedrons
     gmsh.option.setNumber("Mesh.RecombinationAlgorithm", 2)
     gmsh.option.setNumber("Mesh.RecombineAll", 2)

--- a/python/demo/demo_gmsh.py
+++ b/python/demo/demo_gmsh.py
@@ -12,7 +12,7 @@
 #
 # # Mesh generation with Gmsh
 #
-# Copyright (C) 2020 Garth N. Wells and Jørgen S. Dokken
+# Copyright (C) 2020-2022 Garth N. Wells and Jørgen S. Dokken
 
 # +
 import sys
@@ -23,53 +23,56 @@ except ImportError:
     print("This demo requires gmsh to be installed")
     sys.exit(0)
 
-import numpy as np
 
-from dolfinx.graph import create_adjacencylist
-from dolfinx.io import XDMFFile, distribute_entity_data, gmshio
-from dolfinx.mesh import CellType, create_mesh, meshtags_from_entities
-
+from dolfinx.io import XDMFFile, gmshio
 from mpi4py import MPI
 
 # -
 
-# Generate a mesh on each rank with the gmsh API, and create a DOLFINx
-# mesh on each rank.
+# Generate a mesh on each rank with the GMSH API, and create a DOLFINx
+# mesh on each rank with corresponding mesh tags for the cells of the mesh.
 
 # +
 gmsh.initialize()
+
+# Choose if GMSH output is verbose
 gmsh.option.setNumber("General.Terminal", 0)
 model = gmsh.model()
 model.add("Sphere")
 model.setCurrent("Sphere")
-model.occ.addSphere(0, 0, 0, 1, tag=1)
+sphere = model.occ.addSphere(0, 0, 0, 1, tag=1)
 
-# Generate mesh
+# Synchronize OpenCascade representation with gmsh model
 model.occ.synchronize()
+
+# Add physical marker for cells. It is important to call this function after OpenCascade synchronization
+model.add_physical_group(3, [sphere])
+
+
+# Generate the mesh
 model.mesh.generate(3)
 
+msh, cell_markers, facet_markers = gmshio.model_to_mesh(model, MPI.COMM_SELF, 0)
+msh.name = "Sphere"
+cell_markers.name = f"{msh.name}_cells"
+facet_markers.name = f"{msh.name}_facets"
 
-# Extract the mesh geometry from the GMSH model as a (num_nodes, 3) array,
-# where the i-th row corresponds to the i-th node in the mesh
-x = gmshio.extract_geometry(model, name="Sphere")
-
-# Extract cells from gmsh (Only interested in tetrahedrons)
-element_types, element_tags, node_tags = model.mesh.getElements(dim=3)
-assert len(element_types) == 1
-name, dim, order, num_nodes, local_coords, num_first_order_nodes = model.mesh.getElementProperties(element_types[0])
-cells = node_tags[0].reshape(-1, num_nodes) - 1
-
-msh = create_mesh(MPI.COMM_SELF, cells, x, gmshio.ufl_mesh(element_types[0], x.shape[1]))
-
-with XDMFFile(MPI.COMM_SELF, f"out_gmsh/mesh_rank_{MPI.COMM_WORLD.rank}.xdmf", "w") as file:
+with XDMFFile(msh.comm, f"out_gmsh/mesh_rank_{MPI.COMM_WORLD.rank}.xdmf", "w") as file:
     file.write_mesh(msh)
+    file.write_meshtags(cell_markers)
+    msh.topology.create_connectivity(msh.topology.dim - 1, msh.topology.dim)
+    file.write_meshtags(facet_markers)
+
 # -
 
 # Create a distributed (parallel) mesh with affine geometry. Generate
-# mesh on rank 0, then build a distributed mesh
+# mesh on rank 0, then build a distributed mesh. Create mesh tags on exterior facets.
 
 # +
-if MPI.COMM_WORLD.rank == 0:
+
+mesh_comm = MPI.COMM_WORLD
+model_rank = 0
+if mesh_comm.rank == model_rank:
     # Generate a mesh
 
     model.add("Sphere minus box")
@@ -93,46 +96,26 @@ if MPI.COMM_WORLD.rank == 0:
 
     model.mesh.generate(3)
 
-    # Get mesh geometry from GMSH model
-    x = gmshio.extract_geometry(model, name="Sphere minus box")
-
-    # Broadcast cell type data and geometric dimension
-    gmsh_cell_id = MPI.COMM_WORLD.bcast(model.mesh.getElementType("tetrahedron", 1), root=0)
-
-    # Get mesh topology for all physically marked entities of dimension 0 to tdim
-    topologies = gmshio.extract_topology_and_markers(model, "Sphere minus box")
-    cells = topologies[gmsh_cell_id]["topology"]
-    cell_data = topologies[gmsh_cell_id]["cell_data"]
-    num_nodes = MPI.COMM_WORLD.bcast(cells.shape[1], root=0)
-    gmsh_facet_id = model.mesh.getElementType("triangle", 1)
-    marked_facets = topologies[gmsh_facet_id]["topology"].astype(np.int64)
-    facet_values = topologies[gmsh_facet_id]["cell_data"].astype(np.int32)
-else:
-    gmsh_cell_id = MPI.COMM_WORLD.bcast(None, root=0)
-    num_nodes = MPI.COMM_WORLD.bcast(None, root=0)
-    cells, x = np.empty([0, num_nodes]), np.empty([0, 3])
-    marked_facets, facet_values = np.empty((0, 3), dtype=np.int64), np.empty((0,), dtype=np.int32)
-
-
-msh = create_mesh(MPI.COMM_WORLD, cells, x, gmshio.ufl_mesh(gmsh_cell_id, 3))
+msh, mt, ft = gmshio.model_to_mesh(model, mesh_comm, model_rank)
 msh.name = "ball_d1"
-entities, values = distribute_entity_data(msh, 2, marked_facets, facet_values)
+mt.name = f"{msh.name}_cells"
+ft.name = f"{msh.name}_facets"
 
-msh.topology.create_connectivity(2, 0)
-mt = meshtags_from_entities(msh, 2, create_adjacencylist(entities), values)
-mt.name = "ball_d1_surface"
-
-with XDMFFile(MPI.COMM_WORLD, "out_gmsh/mesh.xdmf", "w") as file:
+with XDMFFile(msh.comm, "out_gmsh/mesh.xdmf", "w") as file:
     file.write_mesh(msh)
     msh.topology.create_connectivity(2, 3)
-    file.write_meshtags(mt, geometry_xpath="/Xdmf/Domain/Grid[@Name='ball_d1']/Geometry")
+    file.write_meshtags(mt, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
+    file.write_meshtags(ft, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
 # -
 
 # Create a distributed (parallel) mesh with quadratic geometry. Generate
 # mesh on rank 0, then build a distributed mesh.
 
 # +
-if MPI.COMM_WORLD.rank == 0:
+
+mesh_comm = MPI.COMM_WORLD
+model_rank = 0
+if mesh_comm.rank == model_rank:
     # Using model.setCurrent(name) lets you change between models
     model.setCurrent("Sphere minus box")
 
@@ -142,52 +125,28 @@ if MPI.COMM_WORLD.rank == 0:
     model.mesh.setOrder(2)
     gmsh.option.setNumber("General.Terminal", 0)
 
-    # Sort mesh nodes according to their index in gmsh
-    x = gmshio.extract_geometry(model, model.getCurrent())
-
-    # Broadcast cell type data and geometric dimension
-    gmsh_cell_id = MPI.COMM_WORLD.bcast(model.mesh.getElementType("tetrahedron", 2), root=0)
-
-    # Get mesh topology for all entities entities with physical tags of dimension [0, tdim]
-    topologies = gmshio.extract_topology_and_markers(model, model.getCurrent())
-    cells = topologies[gmsh_cell_id]["topology"]
-    cell_data = topologies[gmsh_cell_id]["cell_data"]
-
-    num_nodes = MPI.COMM_WORLD.bcast(cells.shape[1], root=0)
-    gmsh_facet_id = model.mesh.getElementType("triangle", 2)
-    marked_facets = topologies[gmsh_facet_id]["topology"].astype(np.int64)
-    facet_values = topologies[gmsh_facet_id]["cell_data"].astype(np.int32)
-
-else:
-    gmsh_cell_id = MPI.COMM_WORLD.bcast(None, root=0)
-    num_nodes = MPI.COMM_WORLD.bcast(None, root=0)
-    cells, x = np.empty([0, num_nodes]), np.empty([0, 3])
-    marked_facets, facet_values = np.empty((0, 6)).astype(np.int64), np.empty((0,)).astype(np.int32)
-
-# Permute the topology from GMSH to DOLFINx ordering
-domain = gmshio.ufl_mesh(gmsh_cell_id, 3)
-
-gmsh_tetra10 = gmshio.cell_perm_array(CellType.tetrahedron, 10)
-cells = cells[:, gmsh_tetra10]
-
-msh = create_mesh(MPI.COMM_WORLD, cells, x, domain)
+msh, ct, ft = gmshio.model_to_mesh(model, mesh_comm, model_rank)
 msh.name = "ball_d2"
+ct.name = f"{msh.name}_cells"
+ft.name = f"{msh.name}_surface"
 
-# Permute also entities which are tagged
-gmsh_triangle6 = gmshio.cell_perm_array(CellType.triangle, 6)
-marked_facets = marked_facets[:, gmsh_triangle6]
 
-entities, values = distribute_entity_data(msh, 2, marked_facets, facet_values)
-msh.topology.create_connectivity(2, 0)
-mt = meshtags_from_entities(msh, 2, create_adjacencylist(entities), values)
-mt.name = "ball_d2_surface"
-with XDMFFile(MPI.COMM_WORLD, "out_gmsh/mesh.xdmf", "a") as file:
+with XDMFFile(msh.comm, "out_gmsh/mesh.xdmf", "a") as file:
     file.write_mesh(msh)
-    msh.topology.create_connectivity(2, 3)
-    file.write_meshtags(mt, geometry_xpath="/Xdmf/Domain/Grid[@Name='ball_d2']/Geometry")
+    file.write_meshtags(ct, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
+    file.write_meshtags(ft, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
 
-if MPI.COMM_WORLD.rank == 0:
-    # Generate a mesh with 2nd-order hexahedral cells using gmsh
+# -
+
+# Create a distributed (parallel) 2nd order hexahedral mesh. Generate
+# mesh on rank 0, then build a distributed mesh.
+
+# +
+
+model_rank = 0
+mesh_comm = MPI.COMM_WORLD
+if mesh_comm.rank == model_rank:
+    # Generate
     model.add("Hexahedral mesh")
     model.setCurrent("Hexahedral mesh")
     # Recombine tetrahedrons to hexahedrons
@@ -220,46 +179,13 @@ if MPI.COMM_WORLD.rank == 0:
     model.addPhysicalGroup(3, volume_entities, tag=1)
     model.setPhysicalName(3, 1, "Mesh volume")
 
-    # Sort mesh nodes according to their index in gmsh
-    x = gmshio.extract_geometry(model, model.getCurrent())
-
-    # Broadcast cell type data and geometric dimension
-    gmsh_cell_id = MPI.COMM_WORLD.bcast(model.mesh.getElementType("hexahedron", 2), root=0)
-
-    # Get mesh data for dim (0, tdim) for all physical entities
-    topologies = gmshio.extract_topology_and_markers(model, model.getCurrent())
-    cells = topologies[gmsh_cell_id]["topology"]
-    cell_data = topologies[gmsh_cell_id]["cell_data"]
-
-    num_nodes = MPI.COMM_WORLD.bcast(cells.shape[1], root=0)
-    gmsh_facet_id = model.mesh.getElementType("quadrangle", 2)
-    marked_facets = topologies[gmsh_facet_id]["topology"].astype(np.int64)
-    facet_values = topologies[gmsh_facet_id]["cell_data"].astype(np.int32)
-    gmsh.finalize()
-
-    # Permute tagged entities
-    gmsh_quad9 = gmshio.cell_perm_array(CellType.quadrilateral, 9)
-    marked_facets = marked_facets[:, gmsh_quad9]
-else:
-    gmsh_cell_id = MPI.COMM_WORLD.bcast(None, root=0)
-    num_nodes = MPI.COMM_WORLD.bcast(None, root=0)
-    cells, x = np.empty([0, num_nodes]), np.empty([0, 3])
-    marked_facets, facet_values = np.empty((0, 9)).astype(np.int64), np.empty((0,)).astype(np.int32)
-
-# Permute the mesh topology from GMSH ordering to DOLFINx ordering
-domain = gmshio.ufl_mesh(gmsh_cell_id, 3)
-gmsh_hex27 = gmshio.cell_perm_array(CellType.hexahedron, 27)
-cells = cells[:, gmsh_hex27]
-
-msh = create_mesh(MPI.COMM_WORLD, cells, x, domain)
+msh, mt, ft = gmshio.model_to_mesh(gmsh.model, mesh_comm, model_rank)
 msh.name = "hex_d2"
+mt.name = f"{msh.name}_cells"
+ft.name = f"{msh.name}_surface"
 
-entities, values = distribute_entity_data(msh, 2, marked_facets, facet_values)
-msh.topology.create_connectivity(2, 0)
-mt = meshtags_from_entities(msh, 2, create_adjacencylist(entities), values)
-mt.name = "hex_d2_surface"
 
-with XDMFFile(MPI.COMM_WORLD, "out_gmsh/mesh.xdmf", "a") as file:
+with XDMFFile(msh.comm, "out_gmsh/mesh.xdmf", "a") as file:
     file.write_mesh(msh)
-    msh.topology.create_connectivity(2, 3)
-    file.write_meshtags(mt, geometry_xpath="/Xdmf/Domain/Grid[@Name='hex_d2']/Geometry")
+    file.write_meshtags(mt, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
+    file.write_meshtags(ft, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -3,7 +3,7 @@
 # This file is part of DOLFINx (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
-"""Tools to extract data from GMSH models"""
+"""Tools to extract data from Gmsh models"""
 import typing
 
 import numpy as np
@@ -11,8 +11,8 @@ import numpy.typing as npt
 
 import ufl
 from dolfinx import cpp as _cpp
-from dolfinx.mesh import (CellType, Mesh, create_mesh,
-                          meshtags_from_entities, meshtags)
+from dolfinx.mesh import (CellType, Mesh, create_mesh, meshtags,
+                          meshtags_from_entities)
 
 from mpi4py import MPI as _MPI
 
@@ -27,6 +27,7 @@ except ModuleNotFoundError:
 
 def ufl_mesh(gmsh_cell: int, gdim: int) -> ufl.Mesh:
     """Create a UFL mesh from a Gmsh cell identifier and the geometric dimension.
+
     See: http://gmsh.info//doc/texinfo/gmsh.html#MSH-file-format.
 
     Args:
@@ -34,7 +35,8 @@ def ufl_mesh(gmsh_cell: int, gdim: int) -> ufl.Mesh:
         gdim: The geometric dimension of the mesh
 
     Returns:
-        A ufl Mesh using Lagrange elements (equispaced) of the corresponding DOLFINx cell
+        A ufl Mesh using Lagrange elements (equispaced) of the
+        corresponding DOLFINx cell
     """
     shape, degree = _gmsh_to_cells[gmsh_cell]
     cell = ufl.Cell(shape, geometric_dimension=gdim)
@@ -43,7 +45,7 @@ def ufl_mesh(gmsh_cell: int, gdim: int) -> ufl.Mesh:
 
 
 def cell_perm_array(cell_type: CellType, num_nodes: int) -> typing.List[int]:
-    """The permuation array for permuting Gmsh ordering to DOLFINx ordering.
+    """The permutation array for permuting Gmsh ordering to DOLFINx ordering.
 
     Args:
         cell_type: The DOLFINx cell type
@@ -66,13 +68,14 @@ if _has_gmsh:
         the elements and corresponding markers.
 
         Args:
-            model: The GMSH model
+            model: The Gmsh model
             name: The name of the gmsh model. If not set the current model will be used
 
         Returns:
-            A nested dictionary where each key corresponds to a gmsh cell type.
-            Each cell type found in the mesh has a 2D array containing the topology
-            of the marked cell and a list with the corresponding markers.
+            A nested dictionary where each key corresponds to a gmsh
+            cell type. Each cell type found in the mesh has a 2D array
+            containing the topology of the marked cell and a list with
+            the corresponding markers.
 
         """
         if name is not None:
@@ -83,14 +86,15 @@ if _has_gmsh:
         phys_grps = model.getPhysicalGroups()
         topologies: typing.Dict[int, typing.Dict[str, npt.NDArray[typing.Any]]] = {}
         for dim, tag in phys_grps:
-            # Get the entities of dimension `dim`
-            # dim=0->Points, dim=1->Lines, dim=2->Triangles/Quadrilaterals,
-            # etc.
+            # Get the entities of dimension `dim`, dim=0 -> Points,
+            # dim=1 - >Lines, dim=2 -> Triangles/Quadrilaterals, etc.
             entities = model.getEntitiesForPhysicalGroup(dim, tag)
             for entity in entities:
-                # Get cell type, list of cells with given tag and topology of tagged cells
-                # NOTE: Assumes that each entity only have one cell-type, i.e. facets of prisms
-                # and pyramid meshes are not supported
+                # Get cell type, list of cells with given tag and
+                # topology of tagged cells
+                # NOTE: Assumes that each entity only have one
+                # cell-type, i.e. facets of prisms and pyramid meshes
+                # are not supported
                 (entity_types, entity_tags, entity_topologies) = model.mesh.getElements(dim, tag=entity)
                 assert len(entity_types) == 1
 
@@ -100,9 +104,10 @@ if _has_gmsh:
                 name, dim, _, num_nodes, _, _ = properties
 
                 # Array of shape (num_elements,num_nodes_per_element)
-                # containing the topology of the elements on this entity.
-                # NOTE: GMSH indexing starts with one, we therefore subtract 1 from
-                # each node to use zero-based numbering
+                # containing the topology of the elements on this
+                # entity.
+                # NOTE: Gmsh indexing starts with one, we therefore
+                # subtract 1 from each node to use zero-based numbering
                 topology = entity_topologies[0].reshape(-1, num_nodes) - 1
 
                 # Create marker array of length of number of tagged cells
@@ -111,13 +116,11 @@ if _has_gmsh:
                 # Group element topology and markers of the same entity type
                 entity_type = entity_types[0]
                 if entity_type in topologies.keys():
-                    topologies[entity_type]["topology"] = np.concatenate(
-                        (topologies[entity_type]["topology"], topology), axis=0)
-                    topologies[entity_type]["cell_data"] = np.hstack(
-                        [topologies[entity_type]["cell_data"], marker])
+                    topologies[entity_type]["topology"] = np.concatenate((topologies[entity_type]["topology"],
+                                                                          topology), axis=0)
+                    topologies[entity_type]["cell_data"] = np.hstack([topologies[entity_type]["cell_data"], marker])
                 else:
-                    topologies[entity_type] = {"topology": topology,
-                                               "cell_data": marker}
+                    topologies[entity_type] = {"topology": topology, "cell_data": marker}
 
         return topologies
 
@@ -127,7 +130,7 @@ if _has_gmsh:
         mesh.
 
         Args:
-            model: The GMSH model
+            model: The Gmsh model
             name: The name of the gmsh model. If not set the current model will be used
 
         Returns:
@@ -142,11 +145,13 @@ if _has_gmsh:
         indices, points, _ = model.mesh.getNodes()
         points = points.reshape(-1, 3)
 
-        # GMSH indices starts at 1. We therefore subtract one to use zero-based numbering
+        # Gmsh indices starts at 1. We therefore subtract one to use
+        # zero-based numbering
         indices -= 1
 
-        # In some cases, GMSH does not return the points in the same order as their unique node index.
-        # We therefore sort nodes in geometry according to the unique index
+        # In some cases, Gmsh does not return the points in the same
+        # order as their unique node index. We therefore sort nodes in
+        # geometry according to the unique index
         perm_sort = np.argsort(indices)
         assert np.all(indices[perm_sort] == np.arange(len(indices)))
         return points[perm_sort]
@@ -154,19 +159,25 @@ if _has_gmsh:
     def model_to_mesh(model: gmsh.model, comm: _MPI.Comm, rank: int,
                       gdim: int = 3) -> typing.Tuple[Mesh, _cpp.mesh.MeshTags_int32, _cpp.mesh.MeshTags_int32]:
         """
-        Given a GMSH model, take all physical entities of the highest topological dimension and
-        create the corresponding DOLFINx mesh.
-        NOTE: It is assumed that the gmsh model lives on a single rank, and is then read into DOLFINx on a
-        single process to be distributed. This means that this function should only be called once for large problems.
-        It is recommened to save the mesh and corresponding tags to XDMFFile after creation for efficient access.
+        Given a Gmsh model, take all physical entities of the highest
+        topological dimension and create the corresponding DOLFINx mesh.
+        NOTE: It is assumed that the gmsh model lives on a single rank,
+        and is then read into DOLFINx on a single process to be
+        distributed. This means that this function should only be called
+        once for large problems. It is recommended to save the mesh and
+        corresponding tags to XDMFFile after creation for efficient
+        access.
+
         Args:
             comm: The MPI communicator to use for mesh creation
-            rank: The rank the GMSH model is initialized on
-            model: The GMSH model
+            rank: The rank the Gmsh model is initialized on
+            model: The Gmsh model
             gdim: Geometrical dimension of the mesh
+
         Returns:
-            A triplet (mesh, cell_tags, facet_tags) where cell_tags contains the markers for the cells,
-            facet tags contains markers for facets if found in GMSH model.
+            A triplet (mesh, cell_tags, facet_tags) where cell_tags hold
+            markers for the cells, facet tags holds markers for facets
+            if found in Gmsh model.
         """
 
         if comm.rank == rank:
@@ -176,15 +187,15 @@ if _has_gmsh:
             # Get mesh topology for each element
             topologies = extract_topology_and_markers(model)
 
-            # Extract GMSH cell id, dimension of cell and number of nodes to cell for each
+            # Extract Gmsh cell id, dimension of cell and number of
+            # nodes to cell for each
             num_cell_types = len(topologies.keys())
             cell_information = {}
             cell_dimensions = np.zeros(num_cell_types, dtype=np.int32)
             for i, element in enumerate(topologies.keys()):
                 properties = model.mesh.getElementProperties(element)
                 _, dim, _, num_nodes, _, _ = properties
-                cell_information[i] = {"id": element, "dim": dim,
-                                       "num_nodes": num_nodes}
+                cell_information[i] = {"id": element, "dim": dim, "num_nodes": num_nodes}
                 cell_dimensions[i] = dim
 
             # Sort elements by ascending dimension
@@ -200,20 +211,16 @@ if _has_gmsh:
             has_facet_data = False
             if tdim - 1 in cell_dimensions:
                 has_facet_data = True
+
             has_facet_data = comm.bcast(has_facet_data, root=rank)
             if has_facet_data:
-                num_facet_nodes = comm.bcast(
-                    cell_information[perm_sort[-2]]["num_nodes"], root=rank)
+                num_facet_nodes = comm.bcast(cell_information[perm_sort[-2]]["num_nodes"], root=rank)
                 gmsh_facet_id = cell_information[perm_sort[-2]]["id"]
-                marked_facets = np.asarray(
-                    topologies[gmsh_facet_id]["topology"], dtype=np.int64)
-                facet_values = np.asarray(
-                    topologies[gmsh_facet_id]["cell_data"], dtype=np.int32)
+                marked_facets = np.asarray(topologies[gmsh_facet_id]["topology"], dtype=np.int64)
+                facet_values = np.asarray(topologies[gmsh_facet_id]["cell_data"], dtype=np.int32)
 
-            cells = np.asarray(
-                topologies[cell_id]["topology"], dtype=np.int64)
-            cell_values = np.asarray(
-                topologies[cell_id]["cell_data"], dtype=np.int32)
+            cells = np.asarray(topologies[cell_id]["topology"], dtype=np.int64)
+            cell_values = np.asarray(topologies[cell_id]["cell_data"], dtype=np.int32)
 
         else:
             cell_id, num_nodes = comm.bcast([None, None], root=rank)
@@ -232,51 +239,51 @@ if _has_gmsh:
         mesh = create_mesh(comm, cells, x[:, :gdim], ufl_domain)
 
         # Create MeshTags for cells
-        local_entities, local_values = _cpp.io.distribute_entity_data(
-            mesh, mesh.topology.dim, cells, cell_values)
+        local_entities, local_values = _cpp.io.distribute_entity_data(mesh, mesh.topology.dim, cells, cell_values)
         mesh.topology.create_connectivity(mesh.topology.dim, 0)
         adj = _cpp.graph.AdjacencyList_int32(local_entities)
-        ct = meshtags_from_entities(mesh, mesh.topology.dim,
-                                    adj, local_values.astype(np.int32))
+        ct = meshtags_from_entities(mesh, mesh.topology.dim, adj, local_values.astype(np.int32))
         ct.name = "Cell tags"
 
         # Create MeshTags for facets
+        topology = mesh.topology
         if has_facet_data:
             # Permute facets from MSH to Dolfin-X ordering
             # FIXME: This does not work for prism meshes
-            if mesh.topology.cell_type == CellType.prism or mesh.topology.cell_type == CellType.pyramid:
-                raise RuntimeError(f"Unsupported cell type {mesh.topology.cell_type}")
-            facet_type = _cpp.mesh.cell_entity_type(
-                _cpp.mesh.to_type(str(ufl_domain.ufl_cell())),
-                mesh.topology.dim - 1, 0)
+            if topology.cell_type == CellType.prism or topology.cell_type == CellType.pyramid:
+                raise RuntimeError(f"Unsupported cell type {topology.cell_type}")
+
+            facet_type = _cpp.mesh.cell_entity_type(_cpp.mesh.to_type(str(ufl_domain.ufl_cell())), topology.dim - 1, 0)
             gmsh_facet_perm = cell_perm_array(facet_type, num_facet_nodes)
             marked_facets = marked_facets[:, gmsh_facet_perm]
 
             local_entities, local_values = _cpp.io.distribute_entity_data(
                 mesh, mesh.topology.dim - 1, marked_facets, facet_values)
-            mesh.topology.create_connectivity(
-                mesh.topology.dim - 1, mesh.topology.dim)
+            mesh.topology.create_connectivity(topology.dim - 1, topology.dim)
             adj = _cpp.graph.AdjacencyList_int32(local_entities)
-            ft = meshtags_from_entities(mesh, mesh.topology.dim - 1,
-                                        adj, local_values.astype(np.int32))
+            ft = meshtags_from_entities(mesh, topology.dim - 1, adj, local_values.astype(np.int32))
             ft.name = "Facet tags"
         else:
-            ft = meshtags(mesh, mesh.topology.dim - 1, np.empty(0, dtype=np.int32), np.empty(0, dtype=np.int32))
+            ft = meshtags(mesh, topology.dim - 1, np.empty(0, dtype=np.int32), np.empty(0, dtype=np.int32))
 
         return (mesh, ct, ft)
 
     def read_from_msh(filename: str, comm: _MPI.Comm, rank: int = 0,
                       gdim: int = 3) -> typing.Tuple[Mesh, _cpp.mesh.MeshTags_int32, _cpp.mesh.MeshTags_int32]:
-        """
-        Reads a mesh from a msh-file and returns the distributed DOLFINx mesh and
-        cell and facet markers associated with physical groups in the msh file.
+        """Reads a mesh from a msh-file and returns the distributed DOLFINx
+        mesh and cell and facet markers associated with physical groups
+        in the msh file.
+
         Args:
             filename: Name of msh file
             comm: The MPI communciator to initialize the mesh with
             rank: Rank for `comm` responsible for reading the msh file
             gdim: Geometrical dimension of the mesh
+
         Returns:
-            A triplet (mesh, cell_tags, facet_tags) with meshtags for associated physical groups for cells and facets
+            A triplet (mesh, cell_tags, facet_tags) with meshtags for
+            associated physical groups for cells and facets
+
         """
         if comm.rank == rank:
             gmsh.initialize()
@@ -287,8 +294,8 @@ if _has_gmsh:
             gmsh.finalize()
         return output
 
-    # Map from Gmsh cell type identifier (integer) to DOLFINx cell type and degree
-    # http://gmsh.info//doc/texinfo/gmsh.html#MSH-file-format
+    # Map from Gmsh cell type identifier (integer) to DOLFINx cell type
+    # and degree http://gmsh.info//doc/texinfo/gmsh.html#MSH-file-format
     _gmsh_to_cells = {1: ("interval", 1), 2: ("triangle", 1),
                       3: ("quadrilateral", 1), 4: ("tetrahedron", 1),
                       5: ("hexahedron", 1), 8: ("interval", 2),

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -201,7 +201,8 @@ del _ufl_id
 
 
 class MeshTagsMetaClass:
-    def __init__(self, mesh: Mesh, dim: int, indices: np.ndarray, values: np.ndarray):
+    def __init__(self, mesh: Mesh, dim: int, indices: numpy.typing.NDArray[typing.Any],
+                 values: numpy.typing.NDArray[typing.Any]):
         """A distributed sparse matrix that uses compressed sparse row storage.
 
         Args:
@@ -272,7 +273,8 @@ def meshtags(mesh: Mesh, dim: int, indices: np.ndarray,
     return tags(mesh, dim, indices, values)
 
 
-def meshtags_from_entities(mesh: Mesh, dim: int, entities: _cpp.graph.AdjacencyList_int32, values: np.ndarray):
+def meshtags_from_entities(mesh: Mesh, dim: int, entities: _cpp.graph.AdjacencyList_int32,
+                           values: numpy.typing.NDArray[typing.Any]):
     """Create a MeshTags object that associates data with a subset of
     mesh entities, where the entities are defined by their vertices.
 

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -574,7 +574,7 @@ def test_gmsh_input_3d(order, cell_type):
     except ImportError:
         pytest.skip()
     if cell_type == CellType.hexahedron and order > 2:
-        pytest.xfail("GMSH permutation for order > 2 hexahedra not implemented in DOLFINx.")
+        pytest.xfail("Gmsh permutation for order > 2 hexahedra not implemented in DOLFINx.")
 
     res = 0.2
 
@@ -614,7 +614,7 @@ def test_gmsh_input_3d(order, cell_type):
         gmsh_cell_id = MPI.COMM_WORLD.bcast(gmsh.model.mesh.getElementType("hexahedron", order), root=0)
     gmsh.finalize()
 
-    # Permute the mesh topology from GMSH ordering to DOLFINx ordering
+    # Permute the mesh topology from Gmsh ordering to DOLFINx ordering
     domain = ufl_mesh(gmsh_cell_id, 3)
     cells = cells[:, cell_perm_array(cell_type, cells.shape[1])]
 


### PR DESCRIPTION
Add error handling for missing entity index map in outputting.
Add convenience functions reading meshes from gmsh models or directly from msh files.

The GMSH models are read in from file on a single process, to be distributed with the MPI communicator of the user's choice.

When read from the gmsh python interface, it is assumed that the gmsh model is generated on a single rank (or on every rank using comm self), and can then be distributed by supplying an appropriate communicator to `gmshio.model_to_mesh`.

This would greatly simplify more complex demos, such as #2237, as we do not need lengthy conversion/mpi-broadcast scripts to be repeated in every demo.

As in #2131, these convenience functions are only exposed to the user if the have the GMSH python bindings installed.