### PR TITLE
Fix interpolation for non-affine geometries for discrete operator (interpolation_matrix) and non-matching maps in function.interpolate

### DIFF
--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -221,8 +221,6 @@ void interpolation_matrix(const FunctionSpace& V0, const FunctionSpace& V1,
       std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
   cmdspan4_t phi(phi_b.data(), phi_shape);
   cmap.tabulate(1, X, Xshape, phi_b);
-  auto dphi
-      = stdex::submdspan(phi, std::pair(1, tdim + 1), 0, stdex::full_extent, 0);
 
   // Evaluate V0 basis functions at reference interpolation points for V1
   std::vector<double> basis_derivatives_reference0_b(Xshape[0] * dim0
@@ -303,6 +301,8 @@ void interpolation_matrix(const FunctionSpace& V0, const FunctionSpace& V1,
     std::fill(J_b.begin(), J_b.end(), 0);
     for (std::size_t p = 0; p < Xshape[0]; ++p)
     {
+      auto dphi = stdex::submdspan(phi, std::pair(1, tdim + 1), p,
+                                   stdex::full_extent, 0);
       auto _J = stdex::submdspan(J, p, stdex::full_extent, stdex::full_extent);
       cmap.compute_jacobian(dphi, coord_dofs, _J);
       auto _K = stdex::submdspan(K, p, stdex::full_extent, stdex::full_extent);

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -237,8 +237,6 @@ void interpolate_nonmatching_maps(Function<T>& u1, const Function<T>& u0,
       std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
   cmdspan4_t phi(phi_b.data(), phi_shape);
   cmap.tabulate(1, X, Xshape, phi_b);
-  auto dphi
-      = stdex::submdspan(phi, std::pair(1, tdim + 1), 0, stdex::full_extent, 0);
 
   // Evaluate v basis functions at reference interpolation points
   const auto [_basis_derivatives_reference0, b0shape]
@@ -303,14 +301,13 @@ void interpolate_nonmatching_maps(Function<T>& u1, const Function<T>& u0,
         coord_dofs(i, j) = x_g[pos + j];
     }
 
-    // TODO: the below has a bug for non-affine cells - the geometry
-    // basis should be evaluated at every point. See
-    // https://github.com/FEniCS/dolfinx/issues/2275.
-
     // Compute Jacobians and reference points for current cell
     std::fill(J_b.begin(), J_b.end(), 0);
     for (std::size_t p = 0; p < Xshape[0]; ++p)
     {
+      auto dphi = stdex::submdspan(phi, std::pair(1, tdim + 1), p,
+                                   stdex::full_extent, 0);
+
       auto _J = stdex::submdspan(J, p, stdex::full_extent, stdex::full_extent);
       cmap.compute_jacobian(dphi, coord_dofs, _J);
       auto _K = stdex::submdspan(K, p, stdex::full_extent, stdex::full_extent);

--- a/python/test/unit/fem/test_discrete_operators.py
+++ b/python/test/unit/fem/test_discrete_operators.py
@@ -10,8 +10,9 @@ import pytest
 
 import ufl
 from dolfinx.cpp.fem.petsc import discrete_gradient, interpolation_matrix
-from dolfinx.fem import Expression, Function, FunctionSpace
-from dolfinx.mesh import (CellType, GhostMode, create_unit_cube,
+from dolfinx.fem import (Expression, Function, FunctionSpace,
+                         VectorFunctionSpace, assemble_scalar, form)
+from dolfinx.mesh import (CellType, GhostMode, create_mesh, create_unit_cube,
                           create_unit_square)
 
 from mpi4py import MPI
@@ -149,3 +150,41 @@ def test_interpolation_matrix(cell_type, p, q, from_lagrange):
     w.x.scatter_forward()
 
     assert np.allclose(w_vec.x.array, w.x.array)
+
+
+@pytest.mark.skip_in_parallel
+def test_nonaffine_discrete_operator():
+    """
+    Check that discrete operator is consistent with normal interpolation between non-matching
+    maps on non-affine geometries
+    """
+    points = np.array([[0, 0, 0], [1, 0, 0], [0, 2, 0], [1, 2, 0],
+                       [0, 0, 3], [1, 0, 3], [0, 2, 3], [1, 2, 3],
+                       [0.5, 0, 0], [0, 1, 0], [0, 0, 1.5], [1, 1, 0],
+                       [1, 0, 1.5], [0.5, 2, 0], [0, 2, 1.5], [1, 2, 1.5],
+                       [0.5, 0, 3], [0, 1, 3], [1, 1, 3], [0.5, 2, 3],
+                       [0.5, 1, 0], [0.5, -0.1, 1.5], [0, 1, 1.5], [1, 1, 1.5],
+                       [0.5, 2, 1.5], [0.5, 1, 3], [0.5, 1, 1.5]], dtype=np.float64)
+
+    cells = np.array([range(len(points))], dtype=np.int32)
+    cell_type = CellType.hexahedron
+    domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell_type.name, 2))
+    mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
+    W = VectorFunctionSpace(mesh, ("DG", 1))
+    V = FunctionSpace(mesh, ("NCE", 4))
+    w, v = Function(W), Function(V)
+    w.interpolate(lambda x: x)
+    v.interpolate(w)
+
+    G = interpolation_matrix(W._cpp_object, V._cpp_object)
+    G.assemble()
+
+    # Compute global matrix vector product
+    v_vec = Function(V)
+    G.mult(w.vector, v_vec.vector)
+    v_vec.x.scatter_forward()
+
+    assert np.allclose(v_vec.x.array, v.x.array)
+
+    s = assemble_scalar(form(ufl.inner(w - v, w - v) * ufl.dx))
+    assert np.isclose(s, 0)

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -419,6 +419,28 @@ def test_interpolation_non_affine():
     assert np.isclose(s, 0)
 
 
+@pytest.mark.skip_in_parallel
+def test_interpolation_non_affine_nonmatching_maps():
+    points = np.array([[0, 0, 0], [1, 0, 0], [0, 2, 0], [1, 2, 0],
+                       [0, 0, 3], [1, 0, 3], [0, 2, 3], [1, 2, 3],
+                       [0.5, 0, 0], [0, 1, 0], [0, 0, 1.5], [1, 1, 0],
+                       [1, 0, 1.5], [0.5, 2, 0], [0, 2, 1.5], [1, 2, 1.5],
+                       [0.5, 0, 3], [0, 1, 3], [1, 1, 3], [0.5, 2, 3],
+                       [0.5, 1, 0], [0.5, -0.1, 1.5], [0, 1, 1.5], [1, 1, 1.5],
+                       [0.5, 2, 1.5], [0.5, 1, 3], [0.5, 1, 1.5]], dtype=np.float64)
+
+    cells = np.array([range(len(points))], dtype=np.int32)
+    cell_type = CellType.hexahedron
+    domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell_type.name, 2))
+    mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
+    W = VectorFunctionSpace(mesh, ("DG", 1))
+    V = FunctionSpace(mesh, ("NCE", 4))
+    w, v = Function(W), Function(V)
+    w.interpolate(lambda x: x)
+    v.interpolate(w)
+    s = assemble_scalar(form(ufl.inner(w - v, w - v) * ufl.dx))
+
+
 @pytest.mark.parametrize("order", [2, 3, 4])
 @pytest.mark.parametrize("dim", [2, 3])
 def test_nedelec_spatial(order, dim):


### PR DESCRIPTION
Fixes #2275 