### PR TITLE
Remove non-existent function from C++ docs

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -138,7 +138,7 @@ jobs:
         run: python3 -m pip -v install --global-option build --global-option --debug python/
       - name: Build Python interface documentation
         run: |
-          python3 -m pip sphinx==5.0.2
+          python3 -m pip install sphinx==5.0.2
           cd python/doc
           make html
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -138,6 +138,7 @@ jobs:
         run: python3 -m pip -v install --global-option build --global-option --debug python/
       - name: Build Python interface documentation
         run: |
+          python3 -m pip sphinx==5.0.2
           cd python/doc
           make html
 

--- a/cpp/doc/source/graph.rst
+++ b/cpp/doc/source/graph.rst
@@ -15,9 +15,6 @@ Adjacency list builders
 .. doxygenfunction:: dolfinx::graph::regular_adjacency_list
    :project: DOLFINx
 
-.. doxygenfunction:: dolfinx::graph::create_adjacency_data
-   :project: DOLFINx
-
 
 Re-ordering
 -----------


### PR DESCRIPTION
`dolfinx::graph::create_adjacency_data` has been deprecated and is replaced by `dolfinx::graph::regular_adjacency_list` in the C++ demos