### PR TITLE
Zero work array in `fem::CoordinateElement::compute_jacobian_determinant`

### DIFF
--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -129,7 +129,6 @@ public:
       return math::det(J);
     else
     {
-      // TODO: pass buffers for B and BA
       assert(w.size() >= 2 * J.extent(0) * J.extent(1));
 
       using T = typename U::element_type;
@@ -143,6 +142,11 @@ public:
         for (std::size_t j = 0; j < B.extent(1); ++j)
           B(i, j) = J(j, i);
 
+      // Zero working memory of BA
+      std::fill(std::next(w.begin(), J.extent(0) * J.extent(1)),
+                std::next(w.begin(), J.extent(0) * J.extent(1)
+                                         + B.extent(0) * J.extent(1)),
+                0);
       math::dot(B, J, BA);
       return std::sqrt(math::det(BA));
     }

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "ElementDofLayout.h"
+#include <algorithm>
 #include <array>
 #include <basix/element-families.h>
 #include <basix/mdspan.hpp>
@@ -143,10 +144,7 @@ public:
           B(i, j) = J(j, i);
 
       // Zero working memory of BA
-      std::fill(std::next(w.begin(), J.extent(0) * J.extent(1)),
-                std::next(w.begin(), J.extent(0) * J.extent(1)
-                                         + B.extent(0) * J.extent(1)),
-                0);
+      std::fill_n(BA.data_handle(), BA.size(), 0);
       math::dot(B, J, BA);
       return std::sqrt(math::det(BA));
     }


### PR DESCRIPTION
Currently we have an implicit assumption that the working memory contains zeros.

This PR zeros out the bit of the working memory used in the BA dot product.