### PR TITLE
Remove latest Docker tag, prefer nightly or stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ unit-tests-python-mpi: &unit-tests-python-mpi
 jobs:
   build-real:
     docker:
-      - image: fenicsproject/test-env:latest-mpich
+      - image: fenicsproject/test-env:nightly-mpich
     environment:
       DEBIAN_FRONTEND: "noninteractive"
       PETSC_ARCH: "linux-gnu-real-32"
@@ -122,7 +122,7 @@ jobs:
 
   build-complex:
     docker:
-      - image: fenicsproject/test-env:latest-mpich
+      - image: fenicsproject/test-env:nightly-mpich
     environment:
       DEBIAN_FRONTEND: "noninteractive"
       PETSC_ARCH: "linux-gnu-complex-32"

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -28,7 +28,7 @@ jobs:
   build:
     if: "!(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
     runs-on: ubuntu-20.04
-    container: fenicsproject/test-env:latest-openmpi
+    container: fenicsproject/test-env:nightly-openmpi
 
     env:
       CC: clang

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ on:
     inputs:
       tag_prefix:
         description: "tag prefix for docker images"
-        default: "latest"
+        default: "nightly"
         type: string
 
       dolfinx_ref:
@@ -89,7 +89,7 @@ jobs:
         id: tag_name
         run: |
           USER_INPUT=${{ github.event.inputs.tag_prefix }}
-          echo "::set-output name=TAG_PREFIX::${USER_INPUT:-latest}"
+          echo "::set-output name=TAG_PREFIX::${USER_INPUT:-nightly}"
       - name: Log into the Dockerhub registry
         run: echo ${{ secrets.dockerhub_token }} | docker login -u ${{ secrets.dockerhub_username }} --password-stdin
       - name: Build the Docker image
@@ -124,7 +124,7 @@ jobs:
         id: tag_name
         run: |
           USER_INPUT=${{ github.event.inputs.tag_prefix }}
-          echo "::set-output name=TAG_PREFIX::${USER_INPUT:-latest}"
+          echo "::set-output name=TAG_PREFIX::${USER_INPUT:-nightly}"
       - name: Build the Docker image
         run: docker buildx build ${DOCKER_BUILD_ARGS} --push --cache-from=type=registry,ref=fenicsproject/test-env:${{ steps.tag_name.outputs.TAG_PREFIX }}-${MPI}-${ARCH_TAG} --cache-to=type=inline --file docker/Dockerfile --target dev-env --tag fenicsproject/test-env:${{ steps.tag_name.outputs.TAG_PREFIX }}-${MPI}-${ARCH_TAG} docker/
       - name: Cleanup
@@ -155,7 +155,7 @@ jobs:
         id: tag_name
         run: |
           USER_INPUT=${{ github.event.inputs.tag_prefix }}
-          echo "::set-output name=TAG_PREFIX::${USER_INPUT:-latest}"
+          echo "::set-output name=TAG_PREFIX::${USER_INPUT:-nightly}"
       - name: Log into the DockerHub registry
         run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
       - name: Build the Docker image
@@ -176,7 +176,7 @@ jobs:
         id: tag_name
         run: |
           USER_INPUT=${{ github.event.inputs.tag_prefix }}
-          echo "::set-output name=TAG_PREFIX::${USER_INPUT:-latest}"
+          echo "::set-output name=TAG_PREFIX::${USER_INPUT:-nightly}"
       - name: Log into the DockerHub registry
         run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
       - name: Push multiarch images
@@ -218,7 +218,7 @@ jobs:
         id: tag_name
         run: |
           USER_INPUT=${{ github.event.inputs.tag_prefix }}
-          echo "::set-output name=TAG_PREFIX::${USER_INPUT:-latest}"
+          echo "::set-output name=TAG_PREFIX::${USER_INPUT:-nightly}"
       - name: Get git refs
         id: refs
         run: |
@@ -301,7 +301,7 @@ jobs:
         id: tag_name
         run: |
           USER_INPUT=${{ github.event.inputs.tag_prefix }}
-          echo "::set-output name=TAG_PREFIX::${USER_INPUT:-latest}"
+          echo "::set-output name=TAG_PREFIX::${USER_INPUT:-nightly}"
       - name: Log into the DockerHub registry
         run: echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
       - name: Push multiarch images

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container: fenicsproject/test-env:latest-mpich
+    container: fenicsproject/test-env:nightly-mpich
 
     defaults:
       run:

--- a/.github/workflows/pyvista.yml
+++ b/.github/workflows/pyvista.yml
@@ -14,7 +14,7 @@ jobs:
   pyvista:
     if: "!(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
     runs-on: ubuntu-22.04
-    container: fenicsproject/test-env:latest-openmpi
+    container: fenicsproject/test-env:nightly-openmpi
 
     env:
       CC: clang

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    container: fenicsproject/test-env:latest-mpich
+    container: fenicsproject/test-env:nightly-mpich
     env:
       SONAR_SCANNER_VERSION:
         4.6.2.2472 # Find the latest version at:

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ comprehensive instructions.
 
 ## conda
 
-To install the Python interface, with pyvista support for visualisation,
-using [conda](https://conda.io):
+To install the latest stable release of the Python interface, with pyvista support for
+visualisation, using [conda](https://conda.io):
 ```shell
 conda install -c conda-forge fenics-dolfinx mpich pyvista
 ```
@@ -82,9 +82,14 @@ recipe is hosted on
 
 ## Docker images
 
+A Docker image with the latest stable release of DOLFINx:
+```shell
+docker run -ti dolfinx/dolfinx:stable
+```
+
 A Docker image with DOLFINx built nightly:
 ```shell
-docker run -ti dolfinx/dolfinx:latest
+docker run -ti dolfinx/dolfinx:nightly
 ```
 
 To switch between real and complex builds of DOLFINx/PETSc.
@@ -93,20 +98,21 @@ source /usr/local/bin/dolfinx-complex-mode
 source /usr/local/bin/dolfinx-real-mode
 ```
 
-A Jupyter Lab environment with DOLFINx built nightly:
+A Jupyter Lab environment with the latest stable release of DOLFINx:
 ```shell
-docker run --init -ti -p 8888:8888 dolfinx/lab:latest  # Access at http://localhost:8888
+docker run --init -ti -p 8888:8888 dolfinx/lab:stable  # Access at http://localhost:8888
 ```
 
 A development image with all of the dependencies required
 to build DOLFINx:
 ```shell
-docker run -ti dolfinx/dev-env:latest
+docker run -ti dolfinx/dev-env:nightly
 ```
 
 All Docker images support arm64 and amd64 architectures.
 
-For more information, see https://hub.docker.com/u/dolfinx
+For a full list of tags, including versioned images, see
+https://hub.docker.com/u/dolfinx
 
 
 ## License

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,17 +6,21 @@
 # Garth N. Wells <gnw20@cam.ac.uk>
 # Jan Blechta <blechta@karlin.mff.cuni.cz>
 #
+# To run the latest stable build:
+#
+#    docker run -ti dolfinx/dolfinx:stable
+#
 # To run a nightly build:
 #
-#    docker run -ti dolfinx/dolfinx:latest
+#    docker run -ti dolfinx/dolfinx:nightly
 #
 # To run a Jupyter lab session:
 #
-#    docker run --init -p 8888:8888 dolfinx/lab:latest
+#    docker run --init -p 8888:8888 dolfinx/lab:stable
 #
 # To run and share the current host directory with the container:
 #
-#    docker run --init -p 8888:8888 -v "$(pwd)":/root/shared dolfinx/lab:latest
+#    docker run --init -p 8888:8888 -v "$(pwd)":/root/shared dolfinx/lab:stable
 #
 # To build from source, first checkout the DOLFINx, FFCx, Basix and UFL
 # repositories into the working directory, e.g.:


### PR DESCRIPTION
This PR removes the use of the latest tag. The latest tag has no clear meaning. Instead, images will either be tagged nightly, stable or specifically versioned e.g. v0.4.1. All public facing documents will prioritise the use 
of the explicit stable tag. There will be further updates to be made in some of the other FEniCS components CI.
