### PR TITLE
Make mypy blocking and fix error

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -79,7 +79,7 @@ jobs:
           python3 -m isort --check dolfinx
           python3 -m isort --check demo
           python3 -m isort --check test
-      - name: mypy checks (non-blocking)
+      - name: mypy checks
         run: |
           cd python/
           mypy dolfinx

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -80,7 +80,6 @@ jobs:
           python3 -m isort --check demo
           python3 -m isort --check test
       - name: mypy checks (non-blocking)
-        continue-on-error: true
         run: |
           cd python/
           mypy dolfinx

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -81,6 +81,7 @@ jobs:
           python3 -m isort --check test
       - name: mypy checks
         run: |
+          python3 -m pip install types-setuptools
           cd python/
           mypy dolfinx
           mypy demo

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -339,6 +339,7 @@ class Function(ufl.Coefficient):
             _interpolate(u, cells)
         except TypeError:
             # u is callable
+            assert isinstance(u, typing.Callable)
             x = _cpp.fem.interpolation_coords(self._V.element, self._V.mesh, cells)
             self.interpolate(u(x), cells)
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -339,7 +339,7 @@ class Function(ufl.Coefficient):
             _interpolate(u, cells)
         except TypeError:
             # u is callable
-            assert isinstance(u, typing.Callable)
+            assert callable(u)
             x = _cpp.fem.interpolation_coords(self._V.element, self._V.mesh, cells)
             self.interpolate(u(x), cells)
 


### PR DESCRIPTION
The Basix CI runs mypy checks on dolfinx (to check that Basix changes don't break typing in dolfinx), so mypy errors in dolfinx cause failures (eg https://github.com/FEniCS/basix/runs/7538096916?check_suite_focus=true).