### PR TITLE
Fix minor inconsistency in `compute_jacobian_inverse`

### DIFF
--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -108,8 +108,8 @@ public:
   template <typename U, typename V>
   static void compute_jacobian_inverse(const U& J, V&& K)
   {
-    const int gdim = J.extent(1);
-    const int tdim = K.extent(1);
+    const int gdim = J.extent(0);
+    const int tdim = K.extent(0);
     if (gdim == tdim)
       math::inv(J, K);
     else


### PR DESCRIPTION
In `compute_jacobian_inverse`, `gdim` and `tdim` are inconsistent with documentation for shape of `J` and `K`.
This fixes the inconsistency. Behaviour of code is unchanged.