### PR TITLE
Add the case of a pair (str, int) to dolfinx.fem.TensorFunctionSpace type hints, second argument

### DIFF
--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -573,7 +573,7 @@ def VectorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typin
     return FunctionSpace(mesh, ufl_element)
 
 
-def TensorFunctionSpace(mesh: Mesh, element: ElementMetaData, shape=None,
+def TensorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typing.Tuple[str, int]], shape=None,
                         symmetry: typing.Optional[bool] = None, restriction=None) -> FunctionSpace:
     """Create tensor finite element (composition of scalar elements) function space."""
 


### PR DESCRIPTION
Mimics what is already there for `dolfinx.fem.VectorFunctionSpace`, just a few lines above.

Got this while running `mypy` on one of my projects, not sure why `dolfinx` CI did not complain, as such case is used in the tests (e.g., `python/test/unit/io/test_vtk.py`)