### PR TITLE
move algorithm header from MPI.cpp to MPI.h

### DIFF
--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "MPI.h"
-#include <algorithm>
 #include <dolfinx/common/log.h>
 #include <iostream>
 

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <complex>


### PR DESCRIPTION
#2319 