### PR TITLE
Fix various typos

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -207,7 +207,7 @@ set_package_properties(HDF5 PROPERTIES TYPE REQUIRED
 # Note: we use the case (ufcx vs UFCx) elsewhere to determine by which
 # method UFCx was found
 if(NOT DOLFINX_UFCX_PYTHON)
-  # Check in CONFIG mode, i.e. look for instaled ufcxConfig.cmake
+  # Check in CONFIG mode, i.e. look for installed ufcxConfig.cmake
   find_package(ufcx ${DOLFINX_VERSION_MAJOR}.${DOLFINX_VERSION_MINOR} REQUIRED CONFIG)
 else()
   # Check in MODULE mode (using FindUFCX.cmake)
@@ -309,7 +309,7 @@ install(FILES ${CMAKE_BINARY_DIR}/dolfinx.conf
   COMPONENT Development)
 
 # ------------------------------------------------------------------------------
-# Copy data in demo/test direcories to the build directories
+# Copy data in demo/test directories to the build directories
 set(GENERATE_DEMO_TEST_DATA FALSE)
 
 if(Python3_Interpreter_FOUND AND(${DOLFINX_SOURCE_DIR}/demo IS_NEWER_THAN ${CMAKE_CURRENT_BINARY_DIR}/demo OR ${DOLFINX_SOURCE_DIR}/test IS_NEWER_THAN ${CMAKE_CURRENT_BINARY_DIR}/test))

--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -2,7 +2,7 @@
 include(GNUInstallDirs)
 
 #------------------------------------------------------------------------------
-# Delcare the library (target)
+# Declare the library (target)
 
 add_library(dolfinx)
 
@@ -38,7 +38,7 @@ set_source_files_properties(common/defines.cpp PROPERTIES
   COMPILE_DEFINITIONS "UFCX_SIGNATURE=\"${UFCX_SIGNATURE}\";DOLFINX_GIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"")
 
 #------------------------------------------------------------------------------
-# Set compiler options and defintions
+# Set compiler options and definitions
 
 # Set 'Developer' build type flags
 target_compile_options(dolfinx PRIVATE $<$<CONFIG:Developer>:${DOLFINX_CXX_DEVELOPER_FLAGS}>)

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -201,7 +201,7 @@ public:
   /// @brief Build a list of owned indices that are ghosted by another
   /// rank.
   /// @return The local index of owned indices that are ghosts on other
-  /// rank(s). The indicies are unique and sorted.
+  /// rank(s). The indices are unique and sorted.
   std::vector<std::int32_t> shared_indices() const;
 
   /// @brief Ordered set of MPI ranks that own caller's ghost indices.

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -92,7 +92,7 @@ dolfinx::MPI::compute_graph_edges_pcx(MPI_Comm comm,
                                       const std::span<const int>& edges)
 {
   LOG(INFO)
-      << "Computing communicaton graph edges (using PCX algorithm). Number "
+      << "Computing communication graph edges (using PCX algorithm). Number "
          "of input edges: "
       << edges.size();
 
@@ -152,7 +152,7 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
                                       const std::span<const int>& edges)
 {
   LOG(INFO)
-      << "Computing communicaton graph edges (using NBX algorithm). Number "
+      << "Computing communication graph edges (using NBX algorithm). Number "
          "of input edges: "
       << edges.size();
 

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -209,7 +209,7 @@ distribute_to_postoffice(MPI_Comm comm, const std::span<const T>& x,
 /// This function determines local neighborhoods for communication, and
 /// then using MPI neighbourhood collectives to exchange data. It is
 /// scalable if the neighborhoods are relatively small, i.e. each
-/// process communicated with a modest number of othe processes/
+/// process communicated with a modest number of other processes
 ///
 /// @param[in] comm The MPI communicator
 /// @param[in] indices Global indices of the data (row indices) required
@@ -236,7 +236,7 @@ std::vector<T> distribute_from_postoffice(
 /// This function determines local neighborhoods for communication, and
 /// then using MPI neighbourhood collectives to exchange data. It is
 /// scalable if the neighborhoods are relatively small, i.e. each
-/// process communicated with a modest number of othe processes.
+/// process communicated with a modest number of other processes.
 ///
 /// @note The non-scalable version of this function,
 /// MPI::distribute_data1, can be faster up to some number of MPI ranks

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -355,7 +355,7 @@ private:
   // Communicator where the source ranks have ghost indices that are
   // owned by the caller, and the destination ranks are the owners of
   // indices in the callers halo region. I.e.,
-  // - in-edges (src) are from ranks that 'ghost' my owned indicies
+  // - in-edges (src) are from ranks that 'ghost' my owned indices
   // - out-edges (dest) are to the owning ranks of my ghost indices
   dolfinx::MPI::Comm _comm1;
 

--- a/cpp/dolfinx/common/loguru.cpp
+++ b/cpp/dolfinx/common/loguru.cpp
@@ -274,7 +274,7 @@ namespace loguru
 	const char* terminal_light_red()  { return s_terminal_has_color ? VTSEQ(91) : ""; }
 	const char* terminal_dim()        { return s_terminal_has_color ? VTSEQ(2)  : ""; }
 
-	// Formating
+	// Formatting
 	const char* terminal_bold()       { return s_terminal_has_color ? VTSEQ(1) : ""; }
 	const char* terminal_underline()  { return s_terminal_has_color ? VTSEQ(4) : ""; }
 
@@ -394,7 +394,7 @@ namespace loguru
 		}
 
 		// Note: We don't add the time info.
-		// This is done automatically by the syslog deamon.
+		// This is done automatically by the syslog daemon.
 		// Otherwise log all information that the file log does.
 		syslog(level, "%s%s%s", message.indentation, message.prefix, message.message);
 	}
@@ -556,7 +556,7 @@ namespace loguru
 			else if (c == '\'') { out += "\\\'"; }
 			else if (c == '\"') { out += "\\\""; }
 			else if (c == ' ')  { out += "\\ ";  }
-			else if (0 <= c && c < 0x20) { // ASCI control character:
+			else if (0 <= c && c < 0x20) { // ASCII control character:
 			// else if (c < 0x20 || c != (c & 127)) { // ASCII control character or UTF-8:
 				out += "\\x";
 				write_hex_byte(out, static_cast<uint8_t>(c));
@@ -1088,7 +1088,7 @@ namespace loguru
 			#elif LOGURU_PTHREADS
 				uint64_t thread_id = pthread_self();
 			#else
-				// This ID does not correllate to anything we can get from the OS,
+				// This ID does not correlate to anything we can get from the OS,
 				// so this is the worst way to get the ID.
 				const auto thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
 			#endif

--- a/cpp/dolfinx/common/loguru.hpp
+++ b/cpp/dolfinx/common/loguru.hpp
@@ -45,7 +45,7 @@ Website: www.ilikebigbits.com
 	* Version 1.3.1 - 2016-07-20 - Add LOGURU_UNSAFE_SIGNAL_HANDLER to toggle stacktrace on signals.
 	* Version 1.3.2 - 2016-07-20 - Add loguru::arguments()
 	* Version 1.4.0 - 2016-09-15 - Semantic versioning + add loguru::create_directories
-	* Version 1.4.1 - 2016-09-29 - Customize formating with LOGURU_FILENAME_WIDTH
+	* Version 1.4.1 - 2016-09-29 - Customize formatting with LOGURU_FILENAME_WIDTH
 	* Version 1.5.0 - 2016-12-22 - LOGURU_USE_FMTLIB by kolis and LOGURU_WITH_FILEABS by scinart
 	* Version 1.5.1 - 2017-08-08 - Terminal colors on Windows 10 thanks to looki
 	* Version 1.6.0 - 2018-01-03 - Add LOGURU_RTTI and LOGURU_STACKTRACES settings
@@ -281,7 +281,7 @@ namespace loguru
 		char* _str;
 	};
 
-	// Like printf, but returns the formated text.
+	// Like printf, but returns the formatted text.
 #if LOGURU_USE_FMTLIB
 	LOGURU_EXPORT
 	Text vtextprintf(const char* format, fmt::format_args args);
@@ -344,7 +344,7 @@ namespace loguru
 
 	struct Message
 	{
-		// You would generally print a Message by just concating the buffers without spacing.
+		// You would generally print a Message by just concatenating the buffers without spacing.
 		// Optionally, ignore preamble and indentation.
 		Verbosity   verbosity;   // Already part of preamble
 		const char* filename;    // Already part of preamble
@@ -800,7 +800,7 @@ namespace loguru
 	LOGURU_EXPORT const char* terminal_light_red();
 	LOGURU_EXPORT const char* terminal_white();
 
-	// Formating
+	// Formatting
 	LOGURU_EXPORT const char* terminal_bold();
 	LOGURU_EXPORT const char* terminal_underline();
 
@@ -1191,11 +1191,11 @@ namespace loguru
 
 namespace loguru
 {
-	// Like sprintf, but returns the formated text.
+	// Like sprintf, but returns the formatted text.
 	LOGURU_EXPORT
 	std::string strprintf(LOGURU_FORMAT_STRING_TYPE format, ...) LOGURU_PRINTF_LIKE(1, 2);
 
-	// Like vsprintf, but returns the formated text.
+	// Like vsprintf, but returns the formatted text.
 	LOGURU_EXPORT
 	std::string vstrprintf(LOGURU_FORMAT_STRING_TYPE format, va_list) LOGURU_PRINTF_LIKE(1, 0);
 

--- a/cpp/dolfinx/common/sort.h
+++ b/cpp/dolfinx/common/sort.h
@@ -183,7 +183,7 @@ std::vector<std::int32_t> sort_by_perm(const std::span<const T>& x,
   std::vector<std::int32_t> perm(shape0);
   std::iota(perm.begin(), perm.end(), 0);
 
-  // Sort by each column, right to left. Col 0 has the most signficant
+  // Sort by each column, right to left. Col 0 has the most significant
   // "digit".
   std::vector<T> column(shape0);
   for (std::size_t i = 0; i < shape1; ++i)

--- a/cpp/dolfinx/common/utils.h
+++ b/cpp/dolfinx/common/utils.h
@@ -81,7 +81,7 @@ std::size_t hash_local(const T& x)
 
 /// @brief Compute a hash for a distributed (MPI) object.
 ///
-/// A hash is computed on each process for the local part of the obejct.
+/// A hash is computed on each process for the local part of the object.
 /// Then, a hash of the std::vector containing each local hash key in
 /// rank order is returned.
 ///

--- a/cpp/dolfinx/fem/DirichletBC.cpp
+++ b/cpp/dolfinx/fem/DirichletBC.cpp
@@ -139,7 +139,7 @@ get_remote_dofs(MPI_Comm comm, const common::IndexMap& map, int bs_map,
                            disp.data(), MPI_INT64_T, comm, &request);
 
   // FIXME: check that dofs is sorted
-  // Build vector of local dof indicies that have been marked by another
+  // Build vector of local dof indices that have been marked by another
   // process
   const std::array<std::int64_t, 2> range = map.local_range();
   const std::vector<std::int64_t>& ghosts = map.ghosts();

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -103,7 +103,7 @@ std::vector<std::int32_t> locate_dofs_geometrical(
 /// @param[in] marker_fn Function marking tabulated degrees of freedom
 /// @return Array of DOF indices (local to the MPI rank) in the spaces
 /// V[0] and V[1]. The array[0](i) entry is the DOF index in the space
-/// V[0] and array[1](i) is the correspinding DOF entry in the space
+/// V[0] and array[1](i) is the corresponding DOF entry in the space
 /// V[1]. The returned dofs are 'unrolled', i.e. block size = 1.
 std::array<std::vector<std::int32_t>, 2> locate_dofs_geometrical(
     const std::array<std::reference_wrapper<const FunctionSpace>, 2>& V,

--- a/cpp/dolfinx/fem/DofMap.h
+++ b/cpp/dolfinx/fem/DofMap.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 /// @file DofMap.h
-/// @brief Degree-of-freedeom map representations ans tools
+/// @brief Degree-of-freedom map representations and tools
 
 #pragma once
 

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -77,7 +77,7 @@ public:
   /// @brief Create a finite element form.
   ///
   /// @note User applications will normally call a fem::Form builder
-  /// function rather using this interfcae directly.
+  /// function rather using this interface directly.
   ///
   /// @param[in] function_spaces Function spaces for the form arguments
   /// @param[in] integrals The integrals in the form. The first key is

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -274,7 +274,7 @@ public:
       }
     }
 
-    // Array to hold evaluted Expression
+    // Array to hold evaluated Expression
     std::size_t num_cells = cells.size();
     std::size_t num_points = e.X().second[0];
     xt::xtensor<T, 3> f({num_cells, num_points, value_size});

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -342,7 +342,7 @@ void set_diagonal(U set_fn, const std::span<const std::int32_t>& rows,
 /// @param[in] V The function space for the rows and columns of the
 ///   matrix. It is used to extract only the Dirichlet boundary conditions
 ///   that are define on V or subspaces of V.
-/// @param[in] bcs The Dirichlet boundary condtions
+/// @param[in] bcs The Dirichlet boundary conditions
 /// @param[in] diagonal The value to add to the diagonal for rows with a
 ///   boundary condition applied
 template <typename T, typename U>

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -65,7 +65,7 @@ void discrete_gradient(const FunctionSpace& V0, const FunctionSpace& V1,
   if (e0->map_type() != basix::maps::type::identity)
     throw std::runtime_error("Wrong finite element space for V0.");
   if (e0->block_size() != 1)
-    throw std::runtime_error("Block size is greather than 1 for V0.");
+    throw std::runtime_error("Block size is greater than 1 for V0.");
   if (e0->reference_value_size() != 1)
     throw std::runtime_error("Wrong value size for V0.");
 
@@ -74,7 +74,7 @@ void discrete_gradient(const FunctionSpace& V0, const FunctionSpace& V1,
   if (e1->map_type() != basix::maps::type::covariantPiola)
     throw std::runtime_error("Wrong finite element space for V1.");
   if (e1->block_size() != 1)
-    throw std::runtime_error("Block size is greather than 1 for V1.");
+    throw std::runtime_error("Block size is greater than 1 for V1.");
 
   // Get V0 (H(curl)) space interpolation points
   const auto [X, Xshape] = e1->interpolation_points();

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -122,7 +122,7 @@ void interpolate_same_map(Function<T>& u1, const Function<T>& u0,
   auto apply_inverse_dof_transform
       = element1->get_dof_transformation_function<T>(true, true, false);
 
-  // Creat working array
+  // Create working array
   std::vector<T> local0(element0->space_dimension());
   std::vector<T> local1(element1->space_dimension());
 

--- a/cpp/dolfinx/fem/sparsitybuild.cpp
+++ b/cpp/dolfinx/fem/sparsitybuild.cpp
@@ -64,7 +64,7 @@ void sparsitybuild::interior_facets(
     // Get cells incident with facet
     auto cells = connectivity->links(f);
 
-    // Proceed to next facet if only ony connection
+    // Proceed to next facet if only connection
     if (cells.size() == 1)
       continue;
 

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -53,7 +53,7 @@ graph::build::distribute(MPI_Comm comm,
   }
 
   // TODO: Do this on the neighbourhood only
-  // Get the maximum number of eddges for a node
+  // Get the maximum number of edges for a node
   int shape1 = 0;
   {
     int shape1_local = list.num_nodes() > 0 ? list.links(0).size() : 0;
@@ -379,7 +379,7 @@ std::vector<std::int64_t> graph::build::compute_local_to_global_links(
   common::Timer timer(
       "Compute-local-to-global links for global/local adjacency list");
 
-  // Return if gloabl and local are empty
+  // Return if global and local are empty
   if (global.num_nodes() == 0 and local.num_nodes() == 0)
     return std::vector<std::int64_t>();
 

--- a/cpp/dolfinx/graph/partitioners.cpp
+++ b/cpp/dolfinx/graph/partitioners.cpp
@@ -117,7 +117,7 @@ graph::AdjacencyList<int> compute_destination_ranks(
 
   // Discover src ranks. ParMETIS/KaHIP are not scalable (holding an
   // array of size equal to the comm size), so no extra harm in using
-  // non-scalable neighbourgood detection (which might be faster for
+  // non-scalable neighbourhood detection (which might be faster for
   // small rank counts).
   const std::vector<int> src
       = dolfinx::MPI::compute_graph_edges_pcx(comm, dest);

--- a/cpp/dolfinx/io/ADIOS2Writers.cpp
+++ b/cpp/dolfinx/io/ADIOS2Writers.cpp
@@ -738,12 +738,12 @@ FidesWriter::FidesWriter(MPI_Comm comm, const std::filesystem::path& filename,
         "Piecewise constants are not (yet) supported by VTXWriter");
   }
 
-  // FIXME: is the below check adequate for dectecting a
+  // FIXME: is the below check adequate for detecting a
   // Lagrange element? Check that element is Lagrange
   if (!element0->interpolation_ident())
   {
     throw std::runtime_error("Only Lagrange functions are "
-                             "supported. Interpolate Functions before ouput.");
+                             "supported. Interpolate Functions before output.");
   }
 
   // Check that all functions are first order Lagrange
@@ -827,13 +827,13 @@ VTXWriter::VTXWriter(MPI_Comm comm, const std::filesystem::path& filename,
         "https://gitlab.kitware.com/vtk/vtk/-/issues/18458.");
   }
 
-  // FIXME: is the below check adequate for dectecting a Lagrange
+  // FIXME: is the below check adequate for detecting a Lagrange
   // element?
   // Check that element is Lagrange
   if (!element0->interpolation_ident())
   {
     throw std::runtime_error("Only (discontinuous) Lagrange functions are "
-                             "supported. Interpolate Functions before ouput.");
+                             "supported. Interpolate Functions before output.");
   }
 
   // Check that all functions come from same element type

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -136,7 +136,7 @@ public:
   /// used in finite element assembly functions.
   /// @param A Matrix to insert into
   /// @return Function for inserting values into `A`
-  /// @todo clarify setting on non-owned enrties
+  /// @todo clarify setting on non-owned entries
   auto mat_set_values()
   {
     return [&](const std::span<const std::int32_t>& rows,
@@ -197,7 +197,7 @@ public:
     const std::vector<int>& src_ranks = _index_maps[0]->src();
     const std::vector<int>& dest_ranks = _index_maps[0]->dest();
 
-    // Create neigbourhood communicator (owner <- ghost)
+    // Create neighbourhood communicator (owner <- ghost)
     MPI_Comm comm;
     MPI_Dist_graph_create_adjacent(_index_maps[0]->comm(), dest_ranks.size(),
                                    dest_ranks.data(), MPI_UNWEIGHTED,

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -50,7 +50,7 @@ public:
   ///
   /// @param[in] comm The MPI communicator
   /// @param[in] patterns Rectangular array of sparsity pattern. The
-  ///   patterns must not be finalised. Null block are permited
+  ///   patterns must not be finalised. Null block are permitted
   /// @param[in] maps Pairs of (index map, block size) for each row
   ///   block (maps[0]) and column blocks (maps[1])
   /// @param[in] bs Block sizes for the sparsity pattern entries

--- a/cpp/dolfinx/la/slepc.h
+++ b/cpp/dolfinx/la/slepc.h
@@ -44,7 +44,7 @@ public:
   /// Move assignment
   SLEPcEigenSolver& operator=(SLEPcEigenSolver&& solver);
 
-  /// Set opeartors (B may be nullptr for regular eigenvalues
+  /// Set operators (B may be nullptr for regular eigenvalues
   /// problems)
   void set_operators(const Mat A, const Mat B);
 

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -215,7 +215,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
 {
   // -- Submesh topology
 
-  // Get the verticies in the submesh
+  // Get the vertices in the submesh
   std::vector<std::int32_t> submesh_vertices
       = compute_incident_entities(mesh, entities, dim, 0);
 
@@ -266,7 +266,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
 
   // Create submesh entity index map
   // TODO Call dolfinx::common::get_owned_indices here? Do we want to
-  // support `entities` possibly haveing a ghost on one process that is
+  // support `entities` possibly having a ghost on one process that is
   // not in `entities` on the owning process?
   std::pair<common::IndexMap, std::vector<int32_t>>
       submesh_entity_index_map_pair

--- a/cpp/dolfinx/mesh/Mesh.h
+++ b/cpp/dolfinx/mesh/Mesh.h
@@ -141,7 +141,7 @@ Mesh create_mesh(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
 /// Create a new mesh consisting of a subset of entities in a mesh.
 /// @param[in] mesh The mesh
 /// @param[in] dim Entity dimension
-/// @param[in] entities List of entity indicies in `mesh` to include in
+/// @param[in] entities List of entity indices in `mesh` to include in
 /// the new mesh
 /// @return The new mesh, and maps from the new mesh entities, vertices,
 /// and geometry to the input mesh entities, vertices, and geometry.

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -131,7 +131,7 @@ private:
 /// @param[in] values Tag values for each entity in `entities`. The
 /// length of `values` must be equal to number of rows in `entities`.
 /// @note Entities that do not exist on this rank are ignored.
-/// @warning `entities` must not conatined duplicate entities.
+/// @warning `entities` must not contain duplicate entities.
 template <typename T>
 MeshTags<T> create_meshtags(const std::shared_ptr<const Mesh>& mesh, int dim,
                             const graph::AdjacencyList<std::int32_t>& entities,

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -282,11 +282,11 @@ get_local_indexing(MPI_Comm comm, const common::IndexMap& cell_map,
   }
 
   // List of (local index, sorted global vertices) pairs received from
-  // othe ranks. The list is eventually sorted.
+  // other ranks. The list is eventually sorted.
   std::vector<std::pair<std::int32_t, std::int64_t>>
       shared_entity_to_global_vertices_data;
 
-  // List of (local enity index, global MPI ranks)
+  // List of (local entity index, global MPI ranks)
   std::vector<std::pair<std::int32_t, int>> shared_entities_data;
 
   // Compare received and sent entity keys. Any received entities

--- a/cpp/dolfinx/nls/NewtonSolver.h
+++ b/cpp/dolfinx/nls/NewtonSolver.h
@@ -104,7 +104,7 @@ public:
   /// @return (number of Newton iterations, whether iteration converged)
   std::pair<int, bool> solve(Vec x);
 
-  /// The number of Newton interations. It can can called by functions
+  /// The number of Newton iterations. It can can called by functions
   /// that check for convergence during a solve.
   /// @return The number of Newton iterations performed
   int iteration() const;

--- a/cpp/test/common/sort.cpp
+++ b/cpp/test/common/sort.cpp
@@ -14,7 +14,7 @@ TEMPLATE_TEST_CASE("Test radix sort", "[vector][template]", std::int32_t,
   std::vector<TestType> vec;
   vec.reserve(vec_size);
 
-  // Gererate a vector of ints with a Uniform Int distribution
+  // Generate a vector of ints with a Uniform Int distribution
   std::uniform_int_distribution<TestType> distribution(0, 10000);
   std::mt19937 engine;
   auto generator = std::bind(distribution, engine);
@@ -34,7 +34,7 @@ TEST_CASE("Test argsort bitset")
 
   std::vector<std::int32_t> arr(shape0 * shape1);
 
-  // Gererate a vector of ints with a Uniform Int distribution
+  // Generate a vector of ints with a Uniform Int distribution
   std::uniform_int_distribution<std::int32_t> distribution(0, 10000);
   std::mt19937 engine;
   auto generator = std::bind(distribution, engine);

--- a/cpp/test/matrix.cpp
+++ b/cpp/test/matrix.cpp
@@ -55,7 +55,7 @@ void spmv_impl(std::span<const T> values,
 // decomposed into diagonal (Ai[0]) and off diagonal (Ai[1]) blocks:
 //  Ai = |Ai[0] Ai[1]|
 //
-// If A is square, the diagonal block Ai[0] is also square and countains
+// If A is square, the diagonal block Ai[0] is also square and contains
 // only owned columns and rows. The block Ai[1] contains ghost columns
 // (unowned dofs).
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -212,7 +212,7 @@ RUN wget -nc --quiet https://github.com/kahip/kahip/archive/v${KAHIP_VERSION}.ta
 #     rm -rf /tmp/*
 
 # Note: HDF5 CMake install has numerous bugs and inconsistencies. Test carefully.
-# HDF5 overides CMAKE_INSTALL_PREFIX by default, hence it is set
+# HDF5 overrides CMAKE_INSTALL_PREFIX by default, hence it is set
 # below to ensure that HDF5 is installed into a path where it can be
 # found.
 RUN wget -nc --quiet https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${HDF5_SERIES}/hdf5-${HDF5_SERIES}.${HDF5_PATCH}/src/hdf5-${HDF5_SERIES}.${HDF5_PATCH}.tar.gz && \

--- a/python/demo/demo_pyvista.py
+++ b/python/demo/demo_pyvista.py
@@ -71,7 +71,7 @@ def plot_scalar():
     # values, and one where the mesh is warped by these values
     subplotter = pyvista.Plotter(shape=(1, 2))
     subplotter.subplot(0, 0)
-    subplotter.add_text("Scalar countour field", font_size=14, color="black", position="upper_edge")
+    subplotter.add_text("Scalar contour field", font_size=14, color="black", position="upper_edge")
     subplotter.add_mesh(grid, show_edges=True, show_scalar_bar=True)
     subplotter.view_xy()
 

--- a/python/dolfinx/common.py
+++ b/python/dolfinx/common.py
@@ -41,7 +41,7 @@ class Timer:
         with Timer() as t:
             costly_call_1()
             costly_call_2()
-            print(\"Ellapsed time so far: %s\" % t.elapsed()[0])
+            print(\"Elapsed time so far: %s\" % t.elapsed()[0])
 
     The timer is started when entering context manager and timing
     ends when exiting it. It is also possible to start and stop a

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -43,7 +43,7 @@ class FormMetaClass:
             coeffs: Finite element coefficients that appear in the form
             constants: Constants appearing in the form
             subdomains: Subdomains for integrals
-            mesh: The mesh that the form is deined on
+            mesh: The mesh that the form is defined on
 
         """
         self._code = code

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -74,7 +74,7 @@ if _cpp.common.has_adios2:
             self.close()
 
     class FidesWriter(_cpp.io.FidesWriter):
-        """Interface to Fides file formt.
+        """Interface to Fides file format.
 
         Fides supports first order Lagrange finite elements for the
         geometry descriptionand first order Lagrange finite elements for

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -891,7 +891,7 @@ def test_assemble_empty_rank_mesh():
     domain = ufl.Mesh(ufl.VectorElement("Lagrange", ufl.Cell(cell_type.name), 1))
 
     def partitioner(comm, nparts, local_graph, num_ghost_nodes, ghosting):
-        """Leave cells on the curent rank"""
+        """Leave cells on the current rank"""
         dest = np.full(len(cells), comm.rank, dtype=np.int32)
         return graph.create_adjacencylist(dest)
 

--- a/python/test/unit/geometry/test_bounding_box_tree.py
+++ b/python/test/unit/geometry/test_bounding_box_tree.py
@@ -373,7 +373,7 @@ def test_surface_bbtree():
 
 
 def test_sub_bbtree():
-    """Testing point collision with a BoundingBoxTree of sub entitites"""
+    """Testing point collision with a BoundingBoxTree of sub entities"""
     mesh = create_unit_cube(MPI.COMM_WORLD, 4, 4, 4, cell_type=CellType.hexahedron)
     tdim = mesh.topology.dim
     fdim = tdim - 1

--- a/python/test/unit/geometry/test_gjk.py
+++ b/python/test/unit/geometry/test_gjk.py
@@ -186,7 +186,7 @@ def test_collision_2nd_order_triangle():
     point = np.array([0.2, line_func(0.2), 0])
 
     # Point inside 2nd order geometry, outside linear approximation
-    # Usefull for debugging on a later stage
+    # Useful for debugging on a later stage
     # point = np.array([0.25, 0.89320760, 0])
     distance = geometry.squared_distance(mesh, mesh.topology.dim - 1, [2], point)
     assert np.isclose(distance, 0)

--- a/python/test/unit/la/test_krylov_solver.py
+++ b/python/test/unit/la/test_krylov_solver.py
@@ -135,7 +135,7 @@ def test_krylov_samg_solver_elasticity():
         # Compute solution and return number of iterations
         return solver.solve(b, u.vector)
 
-    # Set some multigrid smoother paramete rs
+    # Set some multigrid smoother parameters
     opts = PETSc.Options()
     opts["mg_levels_ksp_type"] = "chebyshev"
     opts["mg_levels_pc_type"] = "jacobi"

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -540,7 +540,7 @@ def test_empty_rank_mesh():
     domain = ufl.Mesh(ufl.VectorElement("Lagrange", ufl.Cell(cell_type.name), 1))
 
     def partitioner(comm, nparts, local_graph, num_ghost_nodes, ghosting):
-        """Leave cells on the curent rank"""
+        """Leave cells on the current rank"""
         dest = np.full(len(cells), comm.rank, dtype=np.int32)
         return graph.create_adjacencylist(dest)
 


### PR DESCRIPTION
Found via `codespell -q 3 -S ./ChangeLog.rst -L nce,nd,strat,ue`