### PR TITLE
Fix regression introduced in #2337 for dolfinx.mesh.create_interval

### DIFF
--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -321,7 +321,7 @@ def create_interval(comm: _MPI.Comm, nx: int, points: numpy.typing.ArrayLike, gh
 
     """
     if partitioner is None:
-        partitioner = _cpp.mesh.create_cell_partitioner()
+        partitioner = _cpp.mesh.create_cell_partitioner(ghost_mode)
     domain = ufl.Mesh(ufl.VectorElement("Lagrange", "interval", 1))
     mesh = _cpp.mesh.create_interval(comm, nx, points, ghost_mode, partitioner)
     return Mesh.from_cpp(mesh, domain)


### PR DESCRIPTION
Hi,
I believe this was introduced yesterday in #2337.

pybind11 wrappers for `dolfinx.mesh.create_mesh_partitioner` with no input arguments have been removed,
compare
https://github.com/FEniCS/dolfinx/blame/main/python/dolfinx/wrappers/mesh.cpp#L369
to
https://github.com/FEniCS/dolfinx/blame/4a5d20a9577b73052667644611fc014cd17257c1/python/dolfinx/wrappers/mesh.cpp#L380

which on main, at least for my local installation, makes a simple code such as
```
import dolfinx.mesh
import mpi4py.MPI
dolfinx.mesh.create_interval(mpi4py.MPI.COMM_WORLD, 30, [1, 5])
```
fail with
```
Traceback (most recent call last):
  File "test.py", line 3, in <module>
    dolfinx.mesh.create_interval(mpi4py.MPI.COMM_WORLD, 30, [1, 5])
  File "dolfinx/mesh.py", line 324, in create_interval
    partitioner = _cpp.mesh.create_cell_partitioner()
TypeError: create_cell_partitioner(): incompatible function arguments. The following argument types are supported:
    1. (arg0: dolfinx.cpp.mesh.GhostMode) -> Callable[[MPICommWrapper, int, int, dolfinx::graph::AdjacencyList<long>], dolfinx::graph::AdjacencyList<int>]
    2. (part: Callable[[MPICommWrapper, int, dolfinx::graph::AdjacencyList<long>, bool], dolfinx::graph::AdjacencyList<int>]) -> Callable[[MPICommWrapper, int, int, dolfinx::graph::AdjacencyList<long>], dolfinx::graph::AdjacencyList<int>]
```

I am not sure why CI did not catch this. I cannot even reproduce on `dolfinx/dolfinx:nightly` docker image.