### PR TITLE
Fix permuting of Lagrange spaces inside mixed elements

### DIFF
--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -147,14 +147,12 @@ FiniteElement::FiniteElement(const ufcx_finite_element& e)
   {
     ufcx_finite_element* ufcx_sub_element = e.sub_elements[i];
     _sub_elements.push_back(std::make_shared<FiniteElement>(*ufcx_sub_element));
-    if (_sub_elements[i]->needs_dof_permutations()
-        and !_needs_dof_transformations)
+    if (_sub_elements[i]->needs_dof_permutations())
     {
       _needs_dof_permutations = true;
     }
     if (_sub_elements[i]->needs_dof_transformations())
     {
-      _needs_dof_permutations = false;
       _needs_dof_transformations = true;
     }
   }
@@ -519,22 +517,7 @@ FiniteElement::get_dof_permutation_function(bool inverse,
 {
   if (!needs_dof_permutations())
   {
-    if (!needs_dof_transformations())
-    {
-      // If this element shouldn't be permuted, return a function that
-      // does nothing
-      return [](const std::span<std::int32_t>&, std::uint32_t) {};
-    }
-    else
-    {
-      // If this element shouldn't be permuted but needs
-      // transformations, return a function that throws an error
-      return [](const std::span<std::int32_t>&, std::uint32_t)
-      {
-        throw std::runtime_error(
-            "Permutations should not be applied for this element.");
-      };
-    }
+    return [](const std::span<std::int32_t>&, std::uint32_t) {};
   }
 
   if (!_sub_elements.empty())

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -696,8 +696,6 @@ def test_custom_vector_element():
 def test_mixed_interpolation_permuting(cell_type, order):
     random.seed(8)
     mesh = two_cell_mesh(cell_type)
-    V = FunctionSpace(mesh, ("Nedelec 1st kind H(curl)", order))
-    run_vector_test(V, order - 1)
 
     def g(x):
         return np.sin(x[1]) + 2 * x[0]

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -21,6 +21,7 @@ from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
 
 from mpi4py import MPI
 
+
 parametrize_cell_types = pytest.mark.parametrize(
     "cell_type", [
         CellType.interval,
@@ -105,6 +106,41 @@ def one_cell_mesh(cell_type):
 
     domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell_type.name, 1))
     return create_mesh(MPI.COMM_WORLD, cells, ordered_points, domain)
+
+
+def two_cell_mesh(cell_type):
+    if cell_type == CellType.interval:
+        points = np.array([[0.], [1.], [-1.]])
+        cells = [[0, 1], [0, 2]]
+    if cell_type == CellType.triangle:
+        # Define equilateral triangles with area 1
+        root = 3 ** 0.25  # 4th root of 3
+        points = np.array([[0., 0.], [2 / root, 0.],
+                           [1 / root, root], [1 / root, -root]])
+        cells = [[0, 1, 2], [1, 0, 3]]
+    elif cell_type == CellType.tetrahedron:
+        # Define regular tetrahedra with volume 1
+        s = 2 ** 0.5 * 3 ** (1 / 3)  # side length
+        points = np.array([[0., 0., 0.], [s, 0., 0.],
+                           [s / 2, s * np.sqrt(3) / 2, 0.],
+                           [s / 2, s / 2 / np.sqrt(3), s * np.sqrt(2 / 3)],
+                           [s / 2, s / 2 / np.sqrt(3), -s * np.sqrt(2 / 3)]])
+        cells = [[0, 1, 2, 3], [0, 2, 1, 4]]
+    elif cell_type == CellType.quadrilateral:
+        # Define unit quadrilaterals (area 1)
+        points = np.array([[0., 0.], [1., 0.], [0., 1.], [1., 1.], [0., -1.], [1., -1.]])
+        cells = [[0, 1, 2, 3], [5, 1, 4, 0]]
+    elif cell_type == CellType.hexahedron:
+        # Define unit hexahedra (volume 1)
+        points = np.array([[0., 0., 0.], [1., 0., 0.], [0., 1., 0.],
+                           [1., 1., 0.], [0., 0., 1.], [1., 0., 1.],
+                           [0., 1., 1.], [1., 1., 1.], [0., 0., -1.],
+                           [1., 0., -1.], [0., 1., -1.], [1., 1., -1.]])
+        cells = [[0, 1, 2, 3, 4, 5, 6, 7], [9, 11, 8, 10, 1, 3, 0, 2]]
+
+    domain = ufl.Mesh(ufl.VectorElement("Lagrange", cell_type.name, 1))
+    mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
+    return mesh
 
 
 def run_scalar_test(V, poly_order):
@@ -652,3 +688,37 @@ def test_custom_vector_element():
     w.interpolate(lambda x: (x[0], x[1]))
 
     assert np.isclose(np.abs(assemble_scalar(form(ufl.inner(v - w, v - w) * ufl.dx))), 0)
+
+
+@pytest.mark.skip_in_parallel
+@pytest.mark.parametrize("cell_type", [CellType.triangle, CellType.tetrahedron])
+@pytest.mark.parametrize("order", range(1, 5))
+def test_mixed_interpolation_permuting(cell_type, order):
+    random.seed(8)
+    mesh = two_cell_mesh(cell_type)
+    V = FunctionSpace(mesh, ("Nedelec 1st kind H(curl)", order))
+    run_vector_test(V, order - 1)
+
+    def g(x):
+        return np.sin(x[1]) + 2 * x[0]
+
+    x = ufl.SpatialCoordinate(mesh)
+    dgdy = ufl.cos(x[1])
+
+    curl_el = ufl.FiniteElement("N1curl", mesh.ufl_cell(), 1)
+    vlag_el = ufl.VectorElement("Lagrange", mesh.ufl_cell(), 1)
+    lagr_el = ufl.FiniteElement("Lagrange", mesh.ufl_cell(), order)
+
+    V = FunctionSpace(mesh, ufl.MixedElement([curl_el, lagr_el]))
+    Eb_m = Function(V)
+    Eb_m.sub(1).interpolate(g)
+    diff = Eb_m[2].dx(1) - dgdy
+    error = assemble_scalar(form(ufl.dot(diff, diff) * ufl.dx))
+
+    V = FunctionSpace(mesh, ufl.MixedElement([vlag_el, lagr_el]))
+    Eb_m = Function(V)
+    Eb_m.sub(1).interpolate(g)
+    diff = Eb_m[2].dx(1) - dgdy
+    error2 = assemble_scalar(form(ufl.dot(diff, diff) * ufl.dx))
+
+    assert np.isclose(error, error2)


### PR DESCRIPTION
Adjusted how permutations inside mixed elements are handled, so that the dofmap for `MixedElement(Nedelec, Lagrange)` is created correctly.

Fixes #2343.