### PR TITLE
Remove xtensor

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,10 +21,10 @@ jobs:
       # runner but included here for completeness
       - name: Install Homebrew dependencies
         run: |
-          brew install boost cmake hdf5-mpi ninja open-mpi pkg-config pugixml python@3.10 xtensor # FEniCS
+          brew install boost cmake hdf5-mpi ninja open-mpi pkg-config pugixml python@3.10 # FEniCS
           brew install bison flex # PETSc
           brew list --versions
-      
+
       # This 'activates' Python 3.10 from Homebrew
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -56,10 +56,6 @@ add_feature_info(DOLFINX_SKIP_BUILD_TESTS DOLFINX_SKIP_BUILD_TESTS "Skip build t
 option(CMAKE_INSTALL_RPATH_USE_LINK_PATH "Add paths to linker search and installed rpath." ON)
 add_feature_info(CMAKE_INSTALL_RPATH_USE_LINK_PATH CMAKE_INSTALL_RPATH_USE_LINK_PATH "Add paths to linker search and installed rpath.")
 
-# Enable xtensor with target-specific optimization, i.e. -march=native
-option(XTENSOR_OPTIMIZE "Enable xtensor target-specific optimization" OFF)
-add_feature_info(XTENSOR_OPTIMIZE XTENSOR_OPTIMIZE "Enable architecture-specific optimizations as defined by xtensor.")
-
 # Control UFCx discovery
 option(DOLFINX_UFCX_PYTHON "Enable UFCx discovery using Python. Disable if UFCx should be found using CMake." ON)
 add_feature_info(DOLFINX_UFCX_PYTHON DOLFINX_UFCX_PYTHON "Enable UFCx discovery using Python. Disable if UFCx should be found using a CMake config file.")
@@ -148,7 +144,6 @@ execute_process(
 
 if(BASIX_PY_DIR)
   message(STATUS "Adding ${BASIX_PY_DIR} to Basix search hints")
-  set(xtensor_ROOT "${BASIX_PY_DIR};${xtensor_ROOT}")
 
   # Basix installed from manylinux wheel
   if(IS_DIRECTORY ${BASIX_PY_DIR}/../fenics_basix.libs)
@@ -161,11 +156,6 @@ set_package_properties(basix PROPERTIES TYPE REQUIRED
   DESCRIPTION "FEniCS tabulation library"
   URL "https://github.com/fenics/basix")
 
-# Check for xtensor
-find_package(xtensor 0.23.10 REQUIRED)
-set_package_properties(xtensor PROPERTIES TYPE REQUIRED
-  DESCRIPTION "C++ library for numerical analysis with multi-dimensional array expressions."
-  URL "https://xtensor.readthedocs.io/")
 
 # Check for PETSc
 find_package(PkgConfig REQUIRED)

--- a/cpp/cmake/templates/DOLFINXConfig.cmake.in
+++ b/cpp/cmake/templates/DOLFINXConfig.cmake.in
@@ -19,9 +19,6 @@ set(Boost_USE_MULTITHREADED $ENV{BOOST_USE_MULTITHREADED})
 set(Boost_VERBOSE TRUE)
 find_dependency(Boost 1.70 REQUIRED COMPONENTS timer filesystem)
 
-# xtensor
-find_dependency(xtensor)
-
 if (@ufcx_FOUND@)
   find_dependency(ufcx)
 endif()

--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -157,9 +157,9 @@ int main(int argc, char* argv[])
 
           // New coordinates
           std::vector<double> fdata(3 * x.extent(1), 0.0);
-          std::experimental::mdspan<
-              double, std::experimental::extents<
-                          std::size_t, 3, std::experimental::dynamic_extent>>
+          namespace stdex = std::experimental;
+          stdex::mdspan<double,
+                        stdex::extents<std::size_t, 3, stdex::dynamic_extent>>
               f(fdata.data(), 3, x.extent(1));
           for (std::size_t p = 0; p < x.extent(1); ++p)
           {
@@ -184,8 +184,10 @@ int main(int argc, char* argv[])
           constexpr double eps = 1.0e-8;
           std::vector<std::int8_t> marker(x.extent(1), false);
           for (std::size_t p = 0; p < x.extent(1); ++p)
+          {
             if (std::abs(x(0, p)) < eps)
               marker[p] = true;
+          }
           return marker;
         });
     auto bdofs_right = fem::locate_dofs_geometrical(
@@ -195,8 +197,10 @@ int main(int argc, char* argv[])
           constexpr double eps = 1.0e-8;
           std::vector<std::int8_t> marker(x.extent(1), false);
           for (std::size_t p = 0; p < x.extent(1); ++p)
+          {
             if (std::abs(x(0, p) - 1) < eps)
               marker[p] = true;
+          }
           return marker;
         });
     auto bcs = std::vector{

--- a/cpp/demo/interpolation-io/main.cpp
+++ b/cpp/demo/interpolation-io/main.cpp
@@ -42,13 +42,12 @@ void interpolate_scalar(const std::shared_ptr<mesh::Mesh>& mesh,
 
   // Interpolate sin(2 \pi x[0]) in the scalar Lagrange finite element
   // space
-  constexpr double PI = std::numbers::pi;
   u->interpolate(
-      [PI](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
+      [](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
       {
         std::vector<T> f(x.extent(1));
         for (std::size_t p = 0; p < x.extent(1); ++p)
-          f[p] = std::sin(2 * PI * x(0, p));
+          f[p] = std::sin(2 * std::numbers::pi * x(0, p));
         return {f, {f.size()}};
       });
 

--- a/cpp/demo/interpolation-io/main.cpp
+++ b/cpp/demo/interpolation-io/main.cpp
@@ -84,9 +84,23 @@ void interpolate_nedelec(const std::shared_ptr<mesh::Mesh>& mesh,
 
   // Find cells with all vertices satisfying (0) x0 <= 0.5 and (1) x0 >= 0.5
   auto cells0 = mesh::locate_entities(
-      *mesh, 2, [](auto&& x) { return xt::row(x, 0) <= 0.5; });
+      *mesh, 2,
+      [](auto x) -> std::vector<std::int8_t>
+      {
+        std::vector<std::int8_t> marked(x.extent(1), false);
+        for (std::size_t i = 0; i < marked.size(); ++i)
+          marked[i] = x(0, i) <= 0.5;
+        return marked;
+      });
   auto cells1 = mesh::locate_entities(
-      *mesh, 2, [](auto&& x) { return xt::row(x, 0) >= 0.5; });
+      *mesh, 2,
+      [](auto x) -> std::vector<std::int8_t>
+      {
+        std::vector<std::int8_t> marked(x.extent(1), false);
+        for (std::size_t i = 0; i < marked.size(); ++i)
+          marked[i] = x(0, i) >= 0.5;
+        return marked;
+      });
 
   // Interpolation on the two sets of cells
   u->interpolate([](auto&& x) -> xt::xtensor<T, 2>

--- a/cpp/demo/interpolation-io/main.cpp
+++ b/cpp/demo/interpolation-io/main.cpp
@@ -121,9 +121,8 @@ void interpolate_nedelec(const std::shared_ptr<mesh::Mesh>& mesh,
       {
         std::vector<T> f(2 * x.extent(1), 0.0);
         std::copy_n(x.data_handle(), f.size(), f.begin());
-        for (std::size_t p = 0; p < x.extent(1); ++p)
-          f[p] += T(1);
-
+        std::transform(f.cbegin(), f.cend(), f.begin(),
+                       [](auto x) { return x + T(1); });
         return {f, {2, x.extent(1)}};
       },
       cells1);

--- a/cpp/demo/interpolation-io/main.cpp
+++ b/cpp/demo/interpolation-io/main.cpp
@@ -83,24 +83,24 @@ void interpolate_nedelec(const std::shared_ptr<mesh::Mesh>& mesh,
   // the Nedelec space when there are cell edges aligned to x0 = 0.5.
 
   // Find cells with all vertices satisfying (0) x0 <= 0.5 and (1) x0 >= 0.5
-  auto cells0 = mesh::locate_entities(
-      *mesh, 2,
-      [](auto x) -> std::vector<std::int8_t>
-      {
-        std::vector<std::int8_t> marked(x.extent(1), false);
-        for (std::size_t i = 0; i < marked.size(); ++i)
-          marked[i] = x(0, i) <= 0.5;
-        return marked;
-      });
-  auto cells1 = mesh::locate_entities(
-      *mesh, 2,
-      [](auto x) -> std::vector<std::int8_t>
-      {
-        std::vector<std::int8_t> marked(x.extent(1), false);
-        for (std::size_t i = 0; i < marked.size(); ++i)
-          marked[i] = x(0, i) >= 0.5;
-        return marked;
-      });
+  auto cells0
+      = mesh::locate_entities(*mesh, 2,
+                              [](auto x)
+                              {
+                                std::vector<std::int8_t> marked;
+                                for (std::size_t i = 0; i < x.extent(1); ++i)
+                                  marked.push_back(x(0, i) <= 0.5);
+                                return marked;
+                              });
+  auto cells1
+      = mesh::locate_entities(*mesh, 2,
+                              [](auto x)
+                              {
+                                std::vector<std::int8_t> marked;
+                                for (std::size_t i = 0; i < x.extent(1); ++i)
+                                  marked.push_back(x(0, i) >= 0.5);
+                                return marked;
+                              });
 
   // Interpolation on the two sets of cells
   u->interpolate([](auto&& x) -> xt::xtensor<T, 2>

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -92,6 +92,8 @@
 #include <dolfinx.h>
 #include <dolfinx/fem/Constant.h>
 #include <dolfinx/fem/petsc.h>
+#include <xtensor/xarray.hpp>
+#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 using T = PetscScalar;

--- a/cpp/demo/poisson_matrix_free/main.cpp
+++ b/cpp/demo/poisson_matrix_free/main.cpp
@@ -30,8 +30,6 @@
 #include <cmath>
 #include <dolfinx.h>
 #include <dolfinx/fem/Constant.h>
-#include <xtensor/xarray.hpp>
-#include <xtensor/xview.hpp>
 
 using namespace dolfinx;
 
@@ -145,8 +143,12 @@ int main(int argc, char* argv[])
     // Define boundary condition
     auto u_D = std::make_shared<fem::Function<T>>(V);
     u_D->interpolate(
-        [](auto&& x) {
-          return 1 + xt::square(xt::row(x, 0)) + 2 * xt::square(xt::row(x, 1));
+        [](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
+        {
+          std::vector<T> f;
+          for (std::size_t p = 0; p < x.extent(1); ++p)
+            f.push_back(1 + x(0, p) * x(0, p) + +2 * x(1, p) * x(1, p));
+          return {f, {f.size()}};
         });
 
     mesh->topology_mutable().create_connectivity(1, 2);

--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -1,14 +1,12 @@
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 include(GNUInstallDirs)
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Declare the library (target)
-
 add_library(dolfinx)
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Add source files to the target
-
 set(DOLFINX_DIRS common fem geometry graph io la mesh nls refinement)
 
 # Add source to dolfinx target, and get sets of header files
@@ -18,17 +16,15 @@ endforeach()
 
 # Set target include location (for build and installed)
 target_include_directories(dolfinx PUBLIC
-                           $<INSTALL_INTERFACE:include>
-                           "$<BUILD_INTERFACE:${DOLFINX_SOURCE_DIR};${DOLFINX_SOURCE_DIR}/dolfinx>")
+  $<INSTALL_INTERFACE:include>
+  "$<BUILD_INTERFACE:${DOLFINX_SOURCE_DIR};${DOLFINX_SOURCE_DIR}/dolfinx>")
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Configure the common/version.h file
-
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/common/version.h.in common/version.h @ONLY)
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Set target properties
-
 set_target_properties(dolfinx PROPERTIES
   VERSION ${DOLFINX_VERSION}
   SOVERSION ${DOLFINX_VERSION_MAJOR}.${DOLFINX_VERSION_MINOR})
@@ -37,7 +33,7 @@ set_target_properties(dolfinx PROPERTIES
 set_source_files_properties(common/defines.cpp PROPERTIES
   COMPILE_DEFINITIONS "UFCX_SIGNATURE=\"${UFCX_SIGNATURE}\";DOLFINX_GIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"")
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Set compiler options and definitions
 
 # Set 'Developer' build type flags
@@ -46,18 +42,18 @@ target_compile_options(dolfinx PRIVATE $<$<CONFIG:Developer>:${DOLFINX_CXX_DEVEL
 # Add version to definitions (public)
 target_compile_definitions(dolfinx PUBLIC DOLFINX_VERSION="${DOLFINX_VERSION}")
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Add include directories and libraries of required packages
 
 # pugixml (see https://pugixml.org/docs/manual.html#v1.11)
-if (TARGET pugixml::pugixml)
+if(TARGET pugixml::pugixml)
   target_link_libraries(dolfinx PUBLIC pugixml::pugixml)
 else()
   target_link_libraries(dolfinx PUBLIC pugixml)
 endif()
 
 # UFCx
-if (TARGET ufcx::ufcx)
+if(TARGET ufcx::ufcx)
   target_link_libraries(dolfinx PUBLIC ufcx::ufcx)
 else()
   target_include_directories(dolfinx SYSTEM PUBLIC ${UFCX_INCLUDE_DIRS})
@@ -65,12 +61,6 @@ endif()
 
 # Basix
 target_link_libraries(dolfinx PUBLIC Basix::basix)
-
-# xtensor
-target_link_libraries(dolfinx PUBLIC xtensor)
-if(XTENSOR_USE_XSIMD)
-  target_compile_definitions(dolfinx PUBLIC XTENSOR_USE_XSIMD)
-endif()
 
 # Boost
 target_link_libraries(dolfinx PUBLIC Boost::headers)
@@ -83,7 +73,7 @@ target_link_libraries(dolfinx PUBLIC MPI::MPI_CXX)
 target_link_libraries(dolfinx PUBLIC PkgConfig::PETSC)
 
 # HDF5
-if (TARGET hdf5::hdf5)
+if(TARGET hdf5::hdf5)
   target_link_libraries(dolfinx PUBLIC hdf5::hdf5)
 else()
   # This is the old-style CMake (3.18 and earlier), remove when no
@@ -93,51 +83,50 @@ else()
   target_include_directories(dolfinx SYSTEM PUBLIC ${HDF5_INCLUDE_DIRS})
 endif()
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Optional packages
 
 # ADIOS2
-if (ADIOS2_FOUND)
+if(ADIOS2_FOUND)
   target_compile_definitions(dolfinx PUBLIC HAS_ADIOS2)
   target_link_libraries(dolfinx PRIVATE adios2::cxx11_mpi)
 endif()
 
 # SLEPC
-if (DOLFINX_ENABLE_SLEPC AND SLEPC_FOUND)
+if(DOLFINX_ENABLE_SLEPC AND SLEPC_FOUND)
   target_link_libraries(dolfinx PUBLIC PkgConfig::SLEPC)
   target_compile_definitions(dolfinx PUBLIC HAS_SLEPC)
 endif()
 
 # SCOTCH
-if (DOLFINX_ENABLE_SCOTCH AND SCOTCH_FOUND)
+if(DOLFINX_ENABLE_SCOTCH AND SCOTCH_FOUND)
   target_compile_definitions(dolfinx PUBLIC HAS_PTSCOTCH)
   target_link_libraries(dolfinx PRIVATE ${SCOTCH_LIBRARIES})
   target_include_directories(dolfinx SYSTEM PRIVATE ${SCOTCH_INCLUDE_DIRS})
 endif()
 
 # ParMETIS
-if (DOLFINX_ENABLE_PARMETIS AND PARMETIS_FOUND)
+if(DOLFINX_ENABLE_PARMETIS AND PARMETIS_FOUND)
   target_compile_definitions(dolfinx PUBLIC HAS_PARMETIS)
   target_link_libraries(dolfinx PRIVATE ${PARMETIS_LIBRARIES})
   target_include_directories(dolfinx SYSTEM PRIVATE ${PARMETIS_INCLUDE_DIRS})
 endif()
 
 # KaHIP
-if (DOLFINX_ENABLE_KAHIP AND KAHIP_FOUND)
+if(DOLFINX_ENABLE_KAHIP AND KAHIP_FOUND)
   target_compile_definitions(dolfinx PUBLIC HAS_KAHIP)
   target_link_libraries(dolfinx PRIVATE ${KAHIP_LIBRARIES})
   target_include_directories(dolfinx SYSTEM PRIVATE ${KAHIP_INCLUDE_DIRS})
 endif()
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Install dolfinx library and header files
-
 install(TARGETS dolfinx
   EXPORT DOLFINXTargets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT RuntimeExecutables
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT RuntimeLibraries
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development
-  )
+)
 
 # Generate DOLFINTargets.cmake
 install(EXPORT DOLFINXTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/dolfinx)
@@ -151,11 +140,10 @@ foreach(DIR ${DOLFINX_DIRS})
 endforeach()
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/common/version.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dolfinx/common
-COMPONENT Development)
+  COMPONENT Development)
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Generate CMake config files (DOLFINXConfig{,Version}.cmake)
-
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(${CMAKE_BINARY_DIR}/dolfinx/DOLFINXConfigVersion.cmake
   VERSION ${DOLFINX_VERSION}
@@ -173,7 +161,7 @@ install(
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/dolfinx
   COMPONENT Development)
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Generate pkg-config file and install it
 
 # Define packages that should be required by pkg-config file
@@ -185,20 +173,21 @@ get_target_property(PKGCONFIG_DOLFINX_INCLUDE_DIRECTORIES dolfinx INTERFACE_SYST
 
 # Add imported targets to lists for creating pkg-config file
 set(PKGCONFIG_DOLFINX_LIBS)
+
 foreach(_target ${PKGCONFIG_DOLFINX_TARGET_LINK_LIBRARIES})
-
-  if ("${_target}" MATCHES "^[^<>]+$")  # Skip "$<foo...>", which we get with static libs
-
-    if ("${_target}" MATCHES "^.*::.*$")
+  if("${_target}" MATCHES "^[^<>]+$") # Skip "$<foo...>", which we get with static libs
+    if("${_target}" MATCHES "^.*::.*$")
       # Get include paths
       get_target_property(_inc_dirs ${_target} INTERFACE_INCLUDE_DIRECTORIES)
-      if (_inc_dirs)
+
+      if(_inc_dirs)
         list(APPEND PKGCONFIG_DOLFINX_INCLUDE_DIRECTORIES ${_inc_dirs})
       endif()
 
       # Get libraries
       get_target_property(_libs ${_target} INTERFACE_LINK_LIBRARIES)
-      if (_libs)
+
+      if(_libs)
         list(APPEND PKGCONFIG_DOLFINX_LIBS ${_libs})
       endif()
 
@@ -208,15 +197,14 @@ foreach(_target ${PKGCONFIG_DOLFINX_TARGET_LINK_LIBRARIES})
     endif()
 
     # Special handling for compiled Boost imported targets
-    if (("${_target}" MATCHES "^.*Boost::.*$") AND NOT "${_target}" STREQUAL "Boost::headers")
+    if(("${_target}" MATCHES "^.*Boost::.*$") AND NOT "${_target}" STREQUAL "Boost::headers")
       get_target_property(_libs ${_target} IMPORTED_LOCATION_RELEASE)
-      if (_libs)
+
+      if(_libs)
         list(APPEND PKGCONFIG_DOLFINX_LIBS ${_libs})
       endif()
     endif()
-
   endif()
-
 endforeach()
 
 # Join include lists and remove duplicates
@@ -231,6 +219,7 @@ endforeach()
 # Get dolfinx definitions
 get_target_property(PKG_DOLFINX_DEFINITIONS dolfinx INTERFACE_COMPILE_DEFINITIONS)
 set(PKG_DEFINITIONS)
+
 foreach(_def ${PKG_DOLFINX_DEFINITIONS})
   set(PKG_DEFINITIONS "${PKG_DEFINITIONS} -D${_def}")
 endforeach()
@@ -239,6 +228,7 @@ endforeach()
 # to the pkg-config file, in the future Basix should create its own
 # basix.pc file, see https://github.com/FEniCS/basix/issues/204)
 get_target_property(PKG_BASIX_DEFINITIONS Basix::basix INTERFACE_COMPILE_DEFINITIONS)
+
 foreach(_def ${PKG_BASIX_DEFINITIONS})
   set(PKG_DEFINITIONS "${PKG_DEFINITIONS} -D${_def}")
 endforeach()
@@ -250,7 +240,7 @@ string(REPLACE ";" " " PKG_LINKFLAGS "${CMAKE_EXE_LINKER_FLAGS}")
 # Convert libraries to -L<libdir> -l<lib> form
 foreach(_lib ${PKGCONFIG_DOLFINX_LIBS})
   # Add -Wl,option directives
-  if ("${_lib}" MATCHES "-Wl,[^ ]*")
+  if("${_lib}" MATCHES "-Wl,[^ ]*")
     set(PKG_LINKFLAGS "${_lib} ${PKG_LINKFLAGS}")
   else()
     get_filename_component(_path ${_lib} DIRECTORY)
@@ -258,7 +248,7 @@ foreach(_lib ${PKGCONFIG_DOLFINX_LIBS})
     string(REPLACE "lib" "" _name "${_name}")
 
     # Add libraries that matches the form -L<libdir> -l<lib>
-    if (NOT "${_path}" STREQUAL "")
+    if(NOT "${_path}" STREQUAL "")
       set(PKG_LINKFLAGS "-L${_path} -l${_name} ${PKG_LINKFLAGS}")
     endif()
   endif()
@@ -282,5 +272,6 @@ configure_file(${DOLFINX_SOURCE_DIR}/cmake/templates/dolfinx.pc.in ${CMAKE_BINAR
 install(FILES ${CMAKE_BINARY_DIR}/dolfinx.pc
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
   COMPONENT Development
-  )
-#------------------------------------------------------------------------------
+)
+
+# ------------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/DirichletBC.cpp
+++ b/cpp/dolfinx/fem/DirichletBC.cpp
@@ -22,6 +22,11 @@
 using namespace dolfinx;
 using namespace dolfinx::fem;
 
+namespace stdex = std::experimental;
+using cmdspan3x_t
+    = stdex::mdspan<const double,
+                    stdex::extents<std::size_t, 3, stdex::dynamic_extent>>;
+
 namespace
 {
 //-----------------------------------------------------------------------------
@@ -472,10 +477,7 @@ std::vector<std::int32_t> fem::locate_dofs_geometrical(
   const std::vector<double> dof_coordinates = V.tabulate_dof_coordinates(true);
 
   // Compute marker for each dof coordinate
-  std::experimental::mdspan<
-      const double, std::experimental::extents<
-                        std::size_t, 3, std::experimental::dynamic_extent>>
-      x(dof_coordinates.data(), 3, dof_coordinates.size() / 3);
+  cmdspan3x_t x(dof_coordinates.data(), 3, dof_coordinates.size() / 3);
   const std::vector<std::int8_t> marked_dofs = marker_fn(x);
 
   std::vector<std::int32_t> dofs;
@@ -523,10 +525,7 @@ std::array<std::vector<std::int32_t>, 2> fem::locate_dofs_geometrical(
   const std::vector<double> dof_coordinates = V1.tabulate_dof_coordinates(true);
 
   // Evaluate marker for each dof coordinate
-  std::experimental::mdspan<
-      const double, std::experimental::extents<
-                        std::size_t, 3, std::experimental::dynamic_extent>>
-      x(dof_coordinates.data(), 3, dof_coordinates.size() / 3);
+  cmdspan3x_t x(dof_coordinates.data(), 3, dof_coordinates.size() / 3);
   const std::vector<std::int8_t> marked_dofs = marker_fn(x);
 
   // Get dofmaps

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -18,7 +18,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <xtensor/xtensor.hpp>
 
 namespace dolfinx::fem
 {

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -89,7 +89,11 @@ std::array<std::vector<std::int32_t>, 2> locate_dofs_topological(
 /// with V.
 std::vector<std::int32_t> locate_dofs_geometrical(
     const FunctionSpace& V,
-    const std::function<xt::xtensor<bool, 1>(const xt::xtensor<double, 2>&)>&
+    const std::function<std::vector<std::int8_t>(
+        std::experimental::mdspan<
+            const double,
+            std::experimental::extents<std::size_t, 3,
+                                       std::experimental::dynamic_extent>>)>&
         marker_fn);
 
 /// Finds degrees of freedom whose geometric coordinate is true for the
@@ -107,7 +111,11 @@ std::vector<std::int32_t> locate_dofs_geometrical(
 /// V[1]. The returned dofs are 'unrolled', i.e. block size = 1.
 std::array<std::vector<std::int32_t>, 2> locate_dofs_geometrical(
     const std::array<std::reference_wrapper<const FunctionSpace>, 2>& V,
-    const std::function<xt::xtensor<bool, 1>(const xt::xtensor<double, 2>&)>&
+    const std::function<std::vector<std::int8_t>(
+        std::experimental::mdspan<
+            const double,
+            std::experimental::extents<std::size_t, 3,
+                                       std::experimental::dynamic_extent>>)>&
         marker_fn);
 
 /// Object for setting (strong) Dirichlet boundary conditions

--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -131,93 +131,12 @@ public:
     return n;
   }
 
-  // /// Evaluate the expression on cells
-  // /// @param[in] cells Cells on which to evaluate the Expression
-  // /// @param[out] values A 2D array to store the result. Caller
-  // /// is responsible for correct sizing which should be (num_cells,
-  // /// num_points * value_size * num_all_argument_dofs columns).
-  // template <typename U>
-  // void eval(const std::span<const std::int32_t>& cells, U& values) const
-  // {
-  //   // Extract data from Expression
-  //   assert(_mesh);
-
-  //   // Prepare coefficients and constants
-  //   const auto [coeffs, cstride] = pack_coefficients(*this, cells);
-  //   const std::vector<T> constant_data = pack_constants(*this);
-  //   const auto& fn = this->get_tabulate_expression();
-
-  //   // Prepare cell geometry
-  //   const graph::AdjacencyList<std::int32_t>& x_dofmap
-  //       = _mesh->geometry().dofmap();
-  //   const std::size_t num_dofs_g = _mesh->geometry().cmap().dim();
-  //   std::span<const double> x_g = _mesh->geometry().x();
-
-  //   // Create data structures used in evaluation
-  //   std::vector<scalar_value_type_t> coordinate_dofs(3 * num_dofs_g);
-
-  //   int num_argument_dofs = 1;
-  //   std::span<const std::uint32_t> cell_info;
-  //   std::function<void(const std::span<T>&,
-  //                      const std::span<const std::uint32_t>&, std::int32_t,
-  //                      int)>
-  //       dof_transform_to_transpose
-  //       = [](const std::span<T>&, const std::span<const std::uint32_t>&,
-  //            std::int32_t, int)
-  //   {
-  //     // Do nothing
-  //   };
-
-  //   if (_argument_function_space)
-  //   {
-  //     num_argument_dofs
-  //         = _argument_function_space->dofmap()->element_dof_layout().num_dofs();
-  //     auto element = _argument_function_space->element();
-
-  //     assert(element);
-  //     if (element->needs_dof_transformations())
-  //     {
-  //       _mesh->topology_mutable().create_entity_permutations();
-  //       cell_info = std::span(_mesh->topology().get_cell_permutation_info());
-  //       dof_transform_to_transpose
-  //           = element
-  //                 ->template get_dof_transformation_to_transpose_function<T>();
-  //     }
-  //   }
-
-  //   const int size0 = _x_ref.second[0] * value_size();
-  //   std::vector<T> values_local(size0 * num_argument_dofs, 0);
-  //   const std::span<T> _values_local(values_local);
-
-  //   // Iterate over cells and 'assemble' into values
-  //   for (std::size_t c = 0; c < cells.size(); ++c)
-  //   {
-  //     const std::int32_t cell = cells[c];
-
-  //     auto x_dofs = x_dofmap.links(cell);
-  //     for (std::size_t i = 0; i < x_dofs.size(); ++i)
-  //     {
-  //       std::copy_n(std::next(x_g.begin(), 3 * x_dofs[i]), 3,
-  //                   std::next(coordinate_dofs.begin(), 3 * i));
-  //     }
-
-  //     const T* coeff_cell = coeffs.data() + c * cstride;
-  //     std::fill(values_local.begin(), values_local.end(), 0.0);
-  //     _fn(values_local.data(), coeff_cell, constant_data.data(),
-  //         coordinate_dofs.data(), nullptr, nullptr);
-
-  //     dof_transform_to_transpose(_values_local, cell_info, c, size0);
-
-  //     for (std::size_t j = 0; j < values_local.size(); ++j)
-  //       values(c, j) = values_local[j];
-  //   }
-  // }
-
-  /// Evaluate the expression on cells
+  /// @brief Evaluate the expression on cells
   /// @param[in] cells Cells on which to evaluate the Expression
   /// @param[out] values A 2D array to store the result. Caller
   /// is responsible for correct sizing which should be (num_cells,
   /// num_points * value_size * num_all_argument_dofs columns).
+  /// @param[in] vshape The shape of `values` (row-major storage).
   void eval(const std::span<const std::int32_t>& cells, std::span<T> values,
             std::array<std::size_t, 2> vshape) const
   {

--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -203,15 +203,13 @@ public:
       }
 
       const T* coeff_cell = coeffs.data() + c * cstride;
-      std::fill(values_local.begin(), values_local.end(), 0.0);
+      std::fill(values_local.begin(), values_local.end(), 0);
       _fn(values_local.data(), coeff_cell, constant_data.data(),
           coordinate_dofs.data(), nullptr, nullptr);
 
       dof_transform_to_transpose(_values_local, cell_info, c, size0);
-
       for (std::size_t j = 0; j < values_local.size(); ++j)
         values[c * vshape[1] + j] = values_local[j];
-      // values(c, j) = values_local[j];
     }
   }
 

--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -7,13 +7,13 @@
 #pragma once
 
 #include "Function.h"
+#include <algorithm>
 #include <array>
 #include <dolfinx/mesh/Mesh.h>
 #include <functional>
 #include <span>
 #include <utility>
 #include <vector>
-#include <algorithm>
 
 namespace dolfinx::fem
 {
@@ -131,13 +131,95 @@ public:
     return n;
   }
 
+  // /// Evaluate the expression on cells
+  // /// @param[in] cells Cells on which to evaluate the Expression
+  // /// @param[out] values A 2D array to store the result. Caller
+  // /// is responsible for correct sizing which should be (num_cells,
+  // /// num_points * value_size * num_all_argument_dofs columns).
+  // template <typename U>
+  // void eval(const std::span<const std::int32_t>& cells, U& values) const
+  // {
+  //   // Extract data from Expression
+  //   assert(_mesh);
+
+  //   // Prepare coefficients and constants
+  //   const auto [coeffs, cstride] = pack_coefficients(*this, cells);
+  //   const std::vector<T> constant_data = pack_constants(*this);
+  //   const auto& fn = this->get_tabulate_expression();
+
+  //   // Prepare cell geometry
+  //   const graph::AdjacencyList<std::int32_t>& x_dofmap
+  //       = _mesh->geometry().dofmap();
+  //   const std::size_t num_dofs_g = _mesh->geometry().cmap().dim();
+  //   std::span<const double> x_g = _mesh->geometry().x();
+
+  //   // Create data structures used in evaluation
+  //   std::vector<scalar_value_type_t> coordinate_dofs(3 * num_dofs_g);
+
+  //   int num_argument_dofs = 1;
+  //   std::span<const std::uint32_t> cell_info;
+  //   std::function<void(const std::span<T>&,
+  //                      const std::span<const std::uint32_t>&, std::int32_t,
+  //                      int)>
+  //       dof_transform_to_transpose
+  //       = [](const std::span<T>&, const std::span<const std::uint32_t>&,
+  //            std::int32_t, int)
+  //   {
+  //     // Do nothing
+  //   };
+
+  //   if (_argument_function_space)
+  //   {
+  //     num_argument_dofs
+  //         = _argument_function_space->dofmap()->element_dof_layout().num_dofs();
+  //     auto element = _argument_function_space->element();
+
+  //     assert(element);
+  //     if (element->needs_dof_transformations())
+  //     {
+  //       _mesh->topology_mutable().create_entity_permutations();
+  //       cell_info = std::span(_mesh->topology().get_cell_permutation_info());
+  //       dof_transform_to_transpose
+  //           = element
+  //                 ->template get_dof_transformation_to_transpose_function<T>();
+  //     }
+  //   }
+
+  //   const int size0 = _x_ref.second[0] * value_size();
+  //   std::vector<T> values_local(size0 * num_argument_dofs, 0);
+  //   const std::span<T> _values_local(values_local);
+
+  //   // Iterate over cells and 'assemble' into values
+  //   for (std::size_t c = 0; c < cells.size(); ++c)
+  //   {
+  //     const std::int32_t cell = cells[c];
+
+  //     auto x_dofs = x_dofmap.links(cell);
+  //     for (std::size_t i = 0; i < x_dofs.size(); ++i)
+  //     {
+  //       std::copy_n(std::next(x_g.begin(), 3 * x_dofs[i]), 3,
+  //                   std::next(coordinate_dofs.begin(), 3 * i));
+  //     }
+
+  //     const T* coeff_cell = coeffs.data() + c * cstride;
+  //     std::fill(values_local.begin(), values_local.end(), 0.0);
+  //     _fn(values_local.data(), coeff_cell, constant_data.data(),
+  //         coordinate_dofs.data(), nullptr, nullptr);
+
+  //     dof_transform_to_transpose(_values_local, cell_info, c, size0);
+
+  //     for (std::size_t j = 0; j < values_local.size(); ++j)
+  //       values(c, j) = values_local[j];
+  //   }
+  // }
+
   /// Evaluate the expression on cells
   /// @param[in] cells Cells on which to evaluate the Expression
   /// @param[out] values A 2D array to store the result. Caller
   /// is responsible for correct sizing which should be (num_cells,
   /// num_points * value_size * num_all_argument_dofs columns).
-  template <typename U>
-  void eval(const std::span<const std::int32_t>& cells, U& values) const
+  void eval(const std::span<const std::int32_t>& cells, std::span<T> values,
+            std::array<std::size_t, 2> vshape) const
   {
     // Extract data from Expression
     assert(_mesh);
@@ -209,7 +291,8 @@ public:
       dof_transform_to_transpose(_values_local, cell_info, c, size0);
 
       for (std::size_t j = 0; j < values_local.size(); ++j)
-        values(c, j) = values_local[j];
+        values[c * vshape[1] + j] = values_local[j];
+      // values(c, j) = values_local[j];
     }
   }
 

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -182,14 +182,13 @@ public:
     assert(_function_space->mesh());
     const std::vector<double> x = fem::interpolation_coords(
         *_function_space->element(), *_function_space->mesh(), cells);
-    std::experimental::mdspan<
-        const double, std::experimental::extents<
-                          std::size_t, 3, std::experimental::dynamic_extent>>
+    namespace stdex = std::experimental;
+    stdex::mdspan<const double,
+                  stdex::extents<std::size_t, 3, stdex::dynamic_extent>>
         _x(x.data(), 3, x.size() / 3);
 
     const auto [fx, fshape] = f(_x);
     assert(fshape.size() <= 2);
-    // assert(fx.dimension() <= 2);
     if (int vs = _function_space->element()->value_size();
         vs == 1 and fshape.size() == 1)
     {
@@ -286,13 +285,14 @@ public:
       }
     }
 
+    namespace stdex = std::experimental;
+
     // Array to hold evaluated Expression
     std::size_t num_cells = cells.size();
     std::size_t num_points = e.X().second[0];
     std::vector<T> fdata(num_cells * num_points * value_size);
-    std::experimental::mdspan<const T,
-                              std::experimental::dextents<std::size_t, 3>>
-        f(fdata.data(), num_cells, num_points, value_size);
+    stdex::mdspan<const T, stdex::dextents<std::size_t, 3>> f(
+        fdata.data(), num_cells, num_points, value_size);
 
     // Evaluate Expression at points
     e.eval(cells, fdata, {num_cells, num_points * value_size});
@@ -304,8 +304,8 @@ public:
     // cell, i.e. (value_size, num_cells*num_points)
 
     std::vector<T> fdata1(num_cells * num_points * value_size);
-    std::experimental::mdspan<T, std::experimental::dextents<std::size_t, 3>>
-        f1(fdata1.data(), value_size, num_cells, num_points);
+    stdex::mdspan<T, stdex::dextents<std::size_t, 3>> f1(
+        fdata1.data(), value_size, num_cells, num_points);
     for (std::size_t i = 0; i < f.extent(0); ++i)
       for (std::size_t j = 0; j < f.extent(1); ++j)
         for (std::size_t k = 0; k < f.extent(2); ++k)

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -32,46 +32,6 @@ namespace
 /// @param[in] mesh The mesh to compute the vertex coordinates for
 /// @return The vertex coordinates. The shape is `(3, num_vertices)` and
 /// the jth column hold the coordinates of vertex j.
-xt::xtensor<double, 2> compute_vertex_coords(const mesh::Mesh& mesh)
-{
-  const mesh::Topology& topology = mesh.topology();
-  const int tdim = topology.dim();
-
-  // Create entities and connectivities
-  mesh.topology_mutable().create_connectivity(tdim, 0);
-
-  // Get all vertex 'node' indices
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
-  const std::int32_t num_vertices = topology.index_map(0)->size_local()
-                                    + topology.index_map(0)->num_ghosts();
-  auto c_to_v = topology.connectivity(tdim, 0);
-  assert(c_to_v);
-  std::vector<std::int32_t> vertex_to_node(num_vertices);
-  for (int c = 0; c < c_to_v->num_nodes(); ++c)
-  {
-    auto x_dofs = x_dofmap.links(c);
-    auto vertices = c_to_v->links(c);
-    for (std::size_t i = 0; i < vertices.size(); ++i)
-      vertex_to_node[vertices[i]] = x_dofs[i];
-  }
-
-  // Pack coordinates of vertices
-  std::span<const double> x_nodes = mesh.geometry().x();
-  xt::xtensor<double, 2> x_vertices({3, vertex_to_node.size()});
-  for (std::size_t i = 0; i < vertex_to_node.size(); ++i)
-  {
-    const int pos = 3 * vertex_to_node[i];
-    for (std::size_t j = 0; j < 3; ++j)
-      x_vertices(j, i) = x_nodes[pos + j];
-  }
-
-  return x_vertices;
-}
-
-/// The coordinates for all 'vertices' in the mesh
-/// @param[in] mesh The mesh to compute the vertex coordinates for
-/// @return The vertex coordinates. The shape is `(3, num_vertices)` and
-/// the jth column hold the coordinates of vertex j.
 std::pair<std::vector<double>, std::array<std::size_t, 2>>
 compute_vertex_coords_new(const mesh::Mesh& mesh)
 {
@@ -424,50 +384,6 @@ mesh::compute_midpoints(const Mesh& mesh, int dim,
   }
 
   return x_mid;
-}
-//-----------------------------------------------------------------------------
-std::vector<std::int32_t> mesh::locate_entities(
-    const Mesh& mesh, int dim,
-    const std::function<xt::xtensor<bool, 1>(const xt::xtensor<double, 2>&)>&
-        marker)
-{
-  // Run marker function on vertex coordinates
-  const xt::xtensor<double, 2> x = compute_vertex_coords(mesh);
-  const xt::xtensor<bool, 1> marked = marker(x);
-  if (marked.shape(0) != x.shape(1))
-    throw std::runtime_error("Length of array of markers is wrong.");
-
-  const mesh::Topology& topology = mesh.topology();
-  const int tdim = topology.dim();
-
-  mesh.topology_mutable().create_entities(dim);
-  mesh.topology_mutable().create_connectivity(tdim, 0);
-  if (dim < tdim)
-    mesh.topology_mutable().create_connectivity(dim, 0);
-
-  // Iterate over entities of dimension 'dim' to build vector of marked
-  // entities
-  auto e_to_v = topology.connectivity(dim, 0);
-  assert(e_to_v);
-  std::vector<std::int32_t> entities;
-  for (int e = 0; e < e_to_v->num_nodes(); ++e)
-  {
-    // Iterate over entity vertices
-    bool all_vertices_marked = true;
-    for (std::int32_t v : e_to_v->links(e))
-    {
-      if (!marked[v])
-      {
-        all_vertices_marked = false;
-        break;
-      }
-    }
-
-    if (all_vertices_marked)
-      entities.push_back(e);
-  }
-
-  return entities;
 }
 //-----------------------------------------------------------------------------
 std::vector<std::int32_t> mesh::locate_entities(

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -154,7 +154,7 @@ compute_vertex_coords_boundary(const mesh::Mesh& mesh, int dim,
     vertex_to_pos[v] = i;
   }
 
-  return {entities, std::move(x_vertices), vertex_to_pos};
+  return {std::move(entities), std::move(x_vertices), std::move(vertex_to_pos)};
 }
 } // namespace
 

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -63,7 +63,6 @@ compute_vertex_coords(const mesh::Mesh& mesh)
     const int pos = 3 * vertex_to_node[i];
     for (std::size_t j = 0; j < 3; ++j)
       x_vertices[j * vertex_to_node.size() + i] = x_nodes[pos + j];
-    // x_vertices(j, i) = x_nodes[pos + j];
   }
 
   return {std::move(x_vertices), {3, vertex_to_node.size()}};
@@ -132,7 +131,7 @@ compute_vertex_coords_boundary(const mesh::Mesh& mesh, int dim,
   assert(v_to_c);
   auto c_to_v = topology.connectivity(tdim, 0);
   assert(c_to_v);
-  std::vector<double> x_vertices(3 * vertices.size(), 0.0);
+  std::vector<double> x_vertices(3 * vertices.size(), -1.0);
   std::vector<std::int32_t> vertex_to_pos(v_to_c->num_nodes(), -1);
   for (std::size_t i = 0; i < vertices.size(); ++i)
   {
@@ -140,13 +139,13 @@ compute_vertex_coords_boundary(const mesh::Mesh& mesh, int dim,
 
     // Get first cell and find position
     const int c = v_to_c->links(v).front();
-    auto vertices = c_to_v->links(c);
-    auto it = std::find(vertices.begin(), vertices.end(), v);
-    assert(it != vertices.end());
-    const int local_pos = std::distance(vertices.begin(), it);
+    auto cell_vertices = c_to_v->links(c);
+    auto it = std::find(cell_vertices.begin(), cell_vertices.end(), v);
+    assert(it != cell_vertices.end());
+    const int local_pos = std::distance(cell_vertices.begin(), it);
 
     auto dofs = x_dofmap.links(c);
-    for (int j = 0; j < 3; ++j)
+    for (std::size_t j = 0; j < 3; ++j)
       x_vertices[j * vertices.size() + i] = x_nodes[3 * dofs[local_pos] + j];
     vertex_to_pos[v] = i;
   }

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -23,6 +23,10 @@
 #include <vector>
 
 using namespace dolfinx;
+namespace stdex = std::experimental;
+using cmdspan3x_t
+    = stdex::mdspan<const double,
+                    stdex::extents<std::size_t, 3, stdex::dynamic_extent>>;
 
 namespace
 {
@@ -393,10 +397,7 @@ std::vector<std::int32_t> mesh::locate_entities(
 {
   // Run marker function on vertex coordinates
   const auto [xdata, xshape] = compute_vertex_coords(mesh);
-  std::experimental::mdspan<
-      const double, std::experimental::extents<
-                        std::size_t, 3, std::experimental::dynamic_extent>>
-      x(xdata.data(), xshape);
+  cmdspan3x_t x(xdata.data(), xshape);
   const std::vector<std::int8_t> marked = marker(x);
   if (marked.size() != x.extent(1))
     throw std::runtime_error("Length of array of markers is wrong.");
@@ -459,10 +460,7 @@ std::vector<std::int32_t> mesh::locate_entities_boundary(
   // Run marker function on the vertex coordinates
   const auto [facet_entities, xdata, vertex_to_pos]
       = compute_vertex_coords_boundary(mesh, dim, boundary_facets);
-  std::experimental::mdspan<
-      const double, std::experimental::extents<
-                        std::size_t, 3, std::experimental::dynamic_extent>>
-      x(xdata.data(), 3, xdata.size() / 3);
+  cmdspan3x_t x(xdata.data(), 3, xdata.size() / 3);
   const std::vector<std::int8_t> marked = marker(x);
   if (marked.size() != x.extent(1))
     throw std::runtime_error("Length of array of markers is wrong.");

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -102,21 +102,6 @@ compute_midpoints(const Mesh& mesh, int dim,
 /// (indices local to the process)
 std::vector<std::int32_t> locate_entities(
     const Mesh& mesh, int dim,
-    const std::function<xt::xtensor<bool, 1>(const xt::xtensor<double, 2>&)>&
-        marker);
-
-/// Compute indices of all mesh entities that evaluate to true for the
-/// provided geometric marking function. An entity is considered marked
-/// if the marker function evaluates true for all of its vertices.
-///
-/// @param[in] mesh The mesh
-/// @param[in] dim The topological dimension of the entities to be
-/// considered
-/// @param[in] marker The marking function
-/// @returns List of marked entity indices, including any ghost indices
-/// (indices local to the process)
-std::vector<std::int32_t> locate_entities(
-    const Mesh& mesh, int dim,
     const std::function<std::vector<std::int8_t>(
         std::experimental::mdspan<
             const double,

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <basix/mdspan.hpp>
 #include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/graph/partition.h>
 #include <functional>
@@ -103,6 +104,24 @@ std::vector<std::int32_t> locate_entities(
     const Mesh& mesh, int dim,
     const std::function<xt::xtensor<bool, 1>(const xt::xtensor<double, 2>&)>&
         marker);
+
+/// Compute indices of all mesh entities that evaluate to true for the
+/// provided geometric marking function. An entity is considered marked
+/// if the marker function evaluates true for all of its vertices.
+///
+/// @param[in] mesh The mesh
+/// @param[in] dim The topological dimension of the entities to be
+/// considered
+/// @param[in] marker The marking function
+/// @returns List of marked entity indices, including any ghost indices
+/// (indices local to the process)
+std::vector<std::int32_t> locate_entities(
+    const Mesh& mesh, int dim,
+    const std::function<std::vector<std::int8_t>(
+        std::experimental::mdspan<
+            const double,
+            std::experimental::extents<
+                std::size_t, 3, std::experimental::dynamic_extent>>)>& marker);
 
 /// Compute indices of all mesh entities that are attached to an owned
 /// boundary facet and evaluate to true for the provided geometric

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -12,7 +12,6 @@
 #include <functional>
 #include <mpi.h>
 #include <span>
-#include <xtensor/xtensor.hpp>
 
 namespace dolfinx::fem
 {
@@ -130,8 +129,11 @@ std::vector<std::int32_t> locate_entities(
 /// process)
 std::vector<std::int32_t> locate_entities_boundary(
     const Mesh& mesh, int dim,
-    const std::function<xt::xtensor<bool, 1>(const xt::xtensor<double, 2>&)>&
-        marker);
+    const std::function<std::vector<std::int8_t>(
+        std::experimental::mdspan<
+            const double,
+            std::experimental::extents<
+                std::size_t, 3, std::experimental::dynamic_extent>>)>& marker);
 
 /// @brief Determine the indices in the geometry data for each vertex of
 /// the given mesh entities.

--- a/cpp/test/matrix.cpp
+++ b/cpp/test/matrix.cpp
@@ -13,6 +13,7 @@
 #include <dolfinx/la/MatrixCSR.h>
 #include <dolfinx/la/SparsityPattern.h>
 #include <dolfinx/la/Vector.h>
+#include <xtensor/xadapt.hpp>
 #include <xtensor/xio.hpp>
 #include <xtensor/xtensor.hpp>
 

--- a/cpp/test/matrix.cpp
+++ b/cpp/test/matrix.cpp
@@ -13,9 +13,6 @@
 #include <dolfinx/la/MatrixCSR.h>
 #include <dolfinx/la/SparsityPattern.h>
 #include <dolfinx/la/Vector.h>
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xio.hpp>
-#include <xtensor/xtensor.hpp>
 
 using namespace dolfinx;
 
@@ -168,16 +165,16 @@ void test_matrix()
   A.add(std::vector<decltype(A)::value_type>{2.3}, std::vector{4},
         std::vector{5});
 
-  const std::vector Adense0 = A.to_dense();
-  auto Adense = xt::adapt(Adense0, {8, 8});
+  // const std::vector Adense0 = A.to_dense();
+  // auto Adense = xt::adapt(Adense0, {8, 8});
 
-  xt::xtensor<float, 2> Aref = xt::zeros<float>({8, 8});
-  Aref(0, 0) = 1;
-  Aref(4, 5) = 2.3;
-  CHECK((Adense == Aref));
+  // xt::xtensor<float, 2> Aref = xt::zeros<float>({8, 8});
+  // Aref(0, 0) = 1;
+  // Aref(4, 5) = 2.3;
+  // CHECK((Adense == Aref));
 
-  Aref(4, 4) = 2.3;
-  CHECK((Adense != Aref));
+  // Aref(4, 4) = 2.3;
+  // CHECK((Adense != Aref));
 }
 
 } // namespace

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,8 +56,6 @@ ARG PYBIND11_VERSION=2.10.0
 ARG PETSC_VERSION=3.17.4
 ARG SLEPC_VERSION=3.17.2
 ARG PYVISTA_VERSION=0.36.1
-ARG XTENSOR_VERSION=0.24.2
-ARG XTL_VERSION=0.7.4
 
 ARG MPICH_VERSION=4.0.2
 ARG OPENMPI_SERIES=4.1
@@ -81,8 +79,6 @@ ARG SLEPC_VERSION
 ARG ADIOS2_VERSION
 ARG KAHIP_VERSION
 ARG NUMPY_VERSION
-ARG XTENSOR_VERSION
-ARG XTL_VERSION
 ARG MPICH_VERSION
 ARG OPENMPI_SERIES
 ARG OPENMPI_PATCH
@@ -182,18 +178,6 @@ RUN if [ "$MPI" = "mpich" ]; then \
 #   documentation or run tests.
 RUN pip3 install --no-binary="numpy" --no-cache-dir cffi mpi4py numba numpy==${NUMPY_VERSION} scipy && \
     pip3 install --no-cache-dir cppimport flake8 isort jupytext matplotlib mypy myst-parser pybind11==${PYBIND11_VERSION} pytest pytest-xdist sphinx sphinx_rtd_theme
-
-# Install xtl, xtensor
-RUN git clone -b ${XTL_VERSION} --single-branch --depth 1 https://github.com/xtensor-stack/xtl.git && \
-    cd xtl && \
-    cmake -G Ninja . && \
-    ninja install && \
-    cd ../ && \
-    git clone -b ${XTENSOR_VERSION} --single-branch --depth 1 https://github.com/xtensor-stack/xtensor.git && \
-    cd xtensor && \
-    cmake -G Ninja . && \
-    ninja install && \
-    rm -rf /tmp/*
 
 # Install KaHIP
 RUN wget -nc --quiet https://github.com/kahip/kahip/archive/v${KAHIP_VERSION}.tar.gz && \

--- a/docker/Dockerfile.redhat
+++ b/docker/Dockerfile.redhat
@@ -15,7 +15,6 @@ ARG PETSC_VERSION=3.17.1
 ARG PYBIND11_VERSION=2.9.2
 ARG NUMPY_VERSION=1.21.6
 ARG MPICH_VERSION=4.0.2
-ARG XTENSOR_VERSION=0.24.2
 ARG XTL_VERSION=0.7.4
 
 WORKDIR /tmp
@@ -102,22 +101,6 @@ RUN curl -L -O https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${HDF5_SERIES
     cd hdf5-${HDF5_SERIES}.${HDF5_PATCH} && \
     ./configure --prefix=/usr/local --enable-parallel --enable-shared --enable-static=no && \
     make -j${BUILD_NP} install && \
-    rm -rf /tmp/*
-
-# Install xtensor libraries
-RUN git clone -b ${XTL_VERSION} --single-branch https://github.com/xtensor-stack/xtl.git && \
-    cd xtl && \
-    mkdir -p build && \
-    cd build && \
-    cmake -G Ninja ../ && \
-    ninja install && \
-    cd ../../ && \
-    git clone -b ${XTENSOR_VERSION} --single-branch https://github.com/xtensor-stack/xtensor.git && \
-    cd xtensor && \
-    mkdir -p build && \
-    cd build && \
-    cmake -G Ninja ../ && \
-    ninja install && \
     rm -rf /tmp/*
 
 # RHEL pkgconfig does not look here by default. Setting this probably better

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -24,22 +24,9 @@ execute_process(
   OUTPUT_VARIABLE BASIX_PY_DIR
   RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
   ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-if (BASIX_PY_DIR)
-  message(STATUS "Adding ${BASIX_PY_DIR} to Basix search hints")
-  set(xtl_ROOT "${BASIX_PY_DIR};${xtl_ROOT}")
-  set(xtensor_ROOT "${BASIX_PY_DIR};${xtensor_ROOT}")
-endif()
 find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
 
-find_package(xtensor REQUIRED)
 find_package(DOLFINX REQUIRED CONFIG)
-
-# Check if the Basix C++ library was compiled with xtensor SIMD
-get_target_property(BASIX_DEFN Basix::basix INTERFACE_COMPILE_DEFINITIONS)
-get_target_property(DOLFINX_DEFN dolfinx INTERFACE_COMPILE_DEFINITIONS)
-if("XTENSOR_USE_XSIMD" IN_LIST BASIX_DEFN OR "XTENSOR_USE_XSIMD" IN_LIST DOLFINX_DEFN)
-  find_package(xsimd REQUIRED)
-endif()
 
 # Create the binding library
 # pybind11 handles its own calls to target_link_libraries
@@ -71,11 +58,6 @@ endif()
 
 # Add DOLFINx libraries.
 target_link_libraries(cpp PRIVATE dolfinx)
-
-# Add xsimd if the Basix C++ interface was compiled with it
-if("XTENSOR_USE_XSIMD" IN_LIST BASIX_DEFN OR "XTENSOR_USE_XSIMD" IN_LIST DOLFINX_DEFN)
-  target_link_libraries(cpp PRIVATE xsimd)
-endif()
 
 # Check for petsc4py
 execute_process(

--- a/python/doc/source/installation.rst
+++ b/python/doc/source/installation.rst
@@ -38,7 +38,6 @@ C++ core
   - timer
 
 - `CMake <https://cmake.org>`_ [build dependency]
-- `xtensor <https://xtensor.readthedocs.io/>`_
 - `pkg-config <https://www.freedesktop.org/wiki/Software/pkg-config/>`_
 - `Basix <http://github.com/FEniCS/basix>`_
 - `pugixml <https://pugixml.org/>`_

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -47,7 +47,6 @@
 #include <string>
 #include <ufcx.h>
 #include <utility>
-#include <xtensor/xadapt.hpp>
 
 namespace py = pybind11;
 
@@ -522,13 +521,9 @@ void declare_objects(py::module& m, const std::string& type)
                                    py::array::c_style>& active_cells,
                  py::array_t<T, py::array::c_style>& values)
               {
-                const int size = values.shape(0) * values.shape(1);
-                auto _values = xt::adapt(
-                    const_cast<T*>(values.data()), size, xt::no_ownership(),
-                    std::array<std::size_t, 2>({(std::size_t)values.shape(0),
-                                                (std::size_t)values.shape(1)}));
                 self.eval(std::span(active_cells.data(), active_cells.size()),
-                          _values);
+                          std::span(values.mutable_data(), values.size()),
+                          {(std::size_t)values.shape(0), (std::size_t)values.shape(1)});
               },
               py::arg("active_cells"), py::arg("values"))
           .def("X",

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -48,7 +48,6 @@
 #include <ufcx.h>
 #include <utility>
 #include <xtensor/xadapt.hpp>
-#include <xtensor/xtensor.hpp>
 
 namespace py = pybind11;
 
@@ -1231,16 +1230,13 @@ void fem(py::module& m)
         if (V.size() != 2)
           throw std::runtime_error("Expected two function spaces.");
 
-        auto _marker
-            = [&marker](const xt::xtensor<double, 2>& x) -> xt::xtensor<bool, 1>
+        auto _marker = [&marker](auto x)
         {
-          auto strides = x.strides();
-          std::transform(strides.begin(), strides.end(), strides.begin(),
-                         [](auto s) { return s * sizeof(double); });
-          py::array_t _x(x.shape(), strides, x.data(), py::none());
-          py::array_t m = marker(_x);
-          std::vector<std::size_t> s(m.shape(), m.shape() + m.ndim());
-          return xt::adapt(m.data(), m.size(), xt::no_ownership(), s);
+          std::array<std::size_t, 2> shape = {x.extent(0), x.extent(1)};
+          py::array_t<double> x_view(shape, x.data_handle(), py::none());
+          py::array_t<bool> marked = marker(x_view);
+          return std::vector<std::int8_t>(marked.data(),
+                                          marked.data() + marked.size());
         };
 
         std::array<std::vector<std::int32_t>, 2> dofs
@@ -1254,17 +1250,15 @@ void fem(py::module& m)
          const std::function<py::array_t<bool>(const py::array_t<double>&)>&
              marker)
       {
-        auto _marker
-            = [&marker](const xt::xtensor<double, 2>& x) -> xt::xtensor<bool, 1>
+        auto _marker = [&marker](auto x)
         {
-          auto strides = x.strides();
-          std::transform(strides.begin(), strides.end(), strides.begin(),
-                         [](auto s) { return s * sizeof(double); });
-          py::array_t _x(x.shape(), strides, x.data(), py::none());
-          py::array_t m = marker(_x);
-          std::vector<std::size_t> s(m.shape(), m.shape() + m.ndim());
-          return xt::adapt(m.data(), m.size(), xt::no_ownership(), s);
+          std::array<std::size_t, 2> shape = {x.extent(0), x.extent(1)};
+          py::array_t<double> x_view(shape, x.data_handle(), py::none());
+          py::array_t<bool> marked = marker(x_view);
+          return std::vector<std::int8_t>(marked.data(),
+                                          marked.data() + marked.size());
         };
+
         return as_pyarray(dolfinx::fem::locate_dofs_geometrical(V, _marker));
       },
       py::arg("V"), py::arg("marker"));

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -392,17 +392,13 @@ void mesh(py::module& m)
          const std::function<py::array_t<bool>(
              const py::array_t<double, py::array::c_style>&)>& marker)
       {
-        auto cpp_marker = [&marker](auto x) -> std::vector<std::int8_t>
+        auto cpp_marker = [&marker](auto x)
         {
           std::array<std::size_t, 2> shape = {x.extent(0), x.extent(1)};
           py::array_t<double> x_view(shape, x.data_handle(), py::none());
           py::array_t<bool> marked = marker(x_view);
-          //   std::array shape = {static_cast<std::size_t>(marked.size())};
           return std::vector<std::int8_t>(marked.data(),
                                           marked.data() + marked.size());
-          //   return xt::adapt(marked.data(), marked.size(),
-          //   xt::no_ownership(),
-          //                    shape);
         };
 
         return as_pyarray(

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -392,15 +392,19 @@ void mesh(py::module& m)
          const std::function<py::array_t<bool>(
              const py::array_t<double, py::array::c_style>&)>& marker)
       {
-        auto cpp_marker
-            = [&marker](const xt::xtensor<double, 2>& x) -> xt::xtensor<bool, 1>
+        auto cpp_marker = [&marker](auto x) -> std::vector<std::int8_t>
         {
-          py::array_t<double> x_view(x.shape(), x.data(), py::none());
+          std::array<std::size_t, 2> shape = {x.extent(0), x.extent(1)};
+          py::array_t<double> x_view(shape, x.data_handle(), py::none());
           py::array_t<bool> marked = marker(x_view);
-          std::array shape = {static_cast<std::size_t>(marked.size())};
-          return xt::adapt(marked.data(), marked.size(), xt::no_ownership(),
-                           shape);
+          //   std::array shape = {static_cast<std::size_t>(marked.size())};
+          return std::vector<std::int8_t>(marked.data(),
+                                          marked.data() + marked.size());
+          //   return xt::adapt(marked.data(), marked.size(),
+          //   xt::no_ownership(),
+          //                    shape);
         };
+
         return as_pyarray(
             dolfinx::mesh::locate_entities(mesh, dim, cpp_marker));
       },

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -29,7 +29,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <span>
-#include <xtensor/xadapt.hpp>
 
 namespace py = pybind11;
 
@@ -412,14 +411,13 @@ void mesh(py::module& m)
          const std::function<py::array_t<bool>(
              const py::array_t<double, py::array::c_style>&)>& marker)
       {
-        auto cpp_marker
-            = [&marker](const xt::xtensor<double, 2>& x) -> xt::xtensor<bool, 1>
+        auto cpp_marker = [&marker](auto x)
         {
-          py::array_t<double> x_view(x.shape(), x.data(), py::none());
+          std::array<std::size_t, 2> shape = {x.extent(0), x.extent(1)};
+          py::array_t<double> x_view(shape, x.data_handle(), py::none());
           py::array_t<bool> marked = marker(x_view);
-          std::array shape = {static_cast<std::size_t>(marked.size())};
-          return xt::adapt(marked.data(), marked.size(), xt::no_ownership(),
-                           shape);
+          return std::vector<std::int8_t>(marked.data(),
+                                          marked.data() + marked.size());
         };
         return as_pyarray(
             dolfinx::mesh::locate_entities_boundary(mesh, dim, cpp_marker));


### PR DESCRIPTION
This change removes xtensor. xtensor was used only in the C++ interface for mesh entity marking and user expressions. Other internal use was removed earlier.

Removing xtensor
- reduces the number of dependencies
- avoids ABI incompatibilities that can sneak in if `xsimd` is installed
- avoids potential C++20 compatibility issues (xtensor does not support C++20)

Closes #2350.