### PR TITLE
Add `from dolfinx.io import gmshio` in `io/__init__.py`

### DIFF
--- a/python/dolfinx/io/__init__.py
+++ b/python/dolfinx/io/__init__.py
@@ -7,6 +7,7 @@
 
 from dolfinx import cpp as _cpp
 from dolfinx.cpp.io import distribute_entity_data  # noqa: F401
+from dolfinx.io import gmshio
 from dolfinx.io.utils import VTKFile, XDMFFile  # noqa: F401
 
 __all__ = ["gmshio", "distribute_entity_data", "VTKFile", "XDMFFile"]

--- a/python/dolfinx/io/__init__.py
+++ b/python/dolfinx/io/__init__.py
@@ -15,4 +15,4 @@ __all__ = ["gmshio", "distribute_entity_data", "VTKFile", "XDMFFile"]
 if _cpp.common.has_adios2:
     # FidesWriter and VTXWriter require ADIOS2
     from dolfinx.io.utils import FidesWriter, VTXWriter  # noqa: F401
-    __all__ = __all__ + ["FidesWriter", "VTXWriter", "gmshio"]
+    __all__ = __all__ + ["FidesWriter", "VTXWriter"]

--- a/python/dolfinx/io/__init__.py
+++ b/python/dolfinx/io/__init__.py
@@ -7,7 +7,7 @@
 
 from dolfinx import cpp as _cpp
 from dolfinx.cpp.io import distribute_entity_data  # noqa: F401
-from dolfinx.io import gmshio
+from dolfinx.io import gmshio  # noqa: F401
 from dolfinx.io.utils import VTKFile, XDMFFile  # noqa: F401
 
 __all__ = ["gmshio", "distribute_entity_data", "VTKFile", "XDMFFile"]


### PR DESCRIPTION
This pull request 

- adds `from dolfinx.io import gmshio` in `python/dolfinx/io/__init__.py` so that `gmshio` is considered a module, making calls like the one below possible:

https://github.com/FEniCS/dolfinx/blob/ce832ec12bc6dbfff9e9f94eb06356e84e739f7f/python/demo/demo_scattering_boundary_conditions/demo_scattering_boundary_conditions.py#L244

- removes an unnecessary `gmshio` string in the `has_adios2` conditional block.