### PR TITLE
Run Spack CI in a bare container

### DIFF
--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -7,9 +7,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
-    container: fenicsproject/test-env:latest-redhat
-
+    runs-on: ubuntu-latest
+    container: ubuntu:latest
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -7,8 +7,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    container: ubuntu:latest
+    runs-on: ubuntu-20.04
+    container: fenicsproject/test-env:latest-redhat
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           apt-get -y update
           apt-get install -y bzip2 curl file git gzip make patch python3-minimal tar xz-utils
-          apt-get install -y g++  # compilers
+          apt-get install -y g++ gfortan  # compilers
 
       - name: Build DOLFINx (C++) development version via Spack
         run: |

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           apt-get -y update
           apt-get install -y bzip2 curl file git gzip make patch python3-minimal tar xz-utils
-          apt-get install -y g++ gfortan  # compilers
+          apt-get install -y g++ gfortran  # compilers
 
       - name: Build DOLFINx (C++) development version via Spack
         run: |

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -24,6 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     container: ubuntu:latest
 
+    env:
+      OMPI_ALLOW_RUN_AS_ROOT: 1
+      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+
     steps:
       - name: Get Spack
         if: github.event_name != 'workflow_dispatch'

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -21,17 +21,8 @@ on:
 
 jobs:
   build:
-    # strategy:
-    #   matrix:
-    #     # os: [ubuntu-20.04, macos-10.15]
-    #     os: [ubuntu-20.04]
-    #   fail-fast: false
-    # runs-on: ${{ matrix.os }}
     runs-on: ubuntu-latest
     container: ubuntu:latest
-    # env:
-    #   CC: gcc-10
-    #   CXX: g++-10
 
     steps:
       - name: Get Spack
@@ -47,6 +38,11 @@ jobs:
           path: ./spack
           repository: ${{ github.event.inputs.spack_repo }}
           ref: ${{ github.event.inputs.spack_ref }}
+
+      - name: Install Spack requirements
+        run: |
+          apt-get -y update
+          apt-get install -y python3-minimal
 
       - name: Build DOLFINx (C++) development version via Spack
         run: |

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           . ./spack/share/spack/setup-env.sh
           spack env activate cpp-main
-          spack install py-fenics-ffcx@main
+          spack install cmake py-fenics-ffcx@main
           cd dolfinx-main/cpp/
           cd demo/poisson
           cmake .
@@ -87,7 +87,7 @@ jobs:
         run: |
           . ./spack/share/spack/setup-env.sh
           spack env activate cpp-release
-          spack install py-fenics-ffcx
+          spack install cmake py-fenics-ffcx
           cd dolfinx-release/cpp/
           cd demo/poisson
           cmake .

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -21,15 +21,17 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        # os: [ubuntu-20.04, macos-10.15]
-        os: [ubuntu-20.04]
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
-    env:
-      CC: gcc-10
-      CXX: g++-10
+    # strategy:
+    #   matrix:
+    #     # os: [ubuntu-20.04, macos-10.15]
+    #     os: [ubuntu-20.04]
+    #   fail-fast: false
+    # runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    container: ubuntu:latest
+    # env:
+    #   CC: gcc-10
+    #   CXX: g++-10
 
     steps:
       - name: Get Spack

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Install Spack requirements
         run: |
           apt-get -y update
-          apt-get install -y python3-minimal
+          apt-get install -y bzip2 curl file git gzip make patch python3-minimal tar xz-utils
+          apt-get install -y g++  # compilers
 
       - name: Build DOLFINx (C++) development version via Spack
         run: |


### PR DESCRIPTION
Run the Spack tests in a container (`ubuntu:latest`) rather than the Github actions VM image. The makes clear the minimum dependencies to build DOLFINx using Spack. The Github VM image comes with a range of libraries/tools, which obscures the minimum requirements.