### PR TITLE
Fix for isort configuration

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -76,9 +76,7 @@ jobs:
         continue-on-error: true
         run: |
           cd python/
-          python3 -m isort --check dolfinx
-          python3 -m isort --check demo
-          python3 -m isort --check test
+          python3 -m isort --check .
       - name: mypy checks
         run: |
           python3 -m pip install types-setuptools

--- a/python/.isort.cfg
+++ b/python/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-src_paths = ["demo", "dolfinx", "test"]
+src_paths = demo,dolfinx,test
 known_first_party = basix,dolfinx,ffcx,ufl
 known_third_party = gmsh,numpy,pytest
 known_mpi = mpi4py,petsc4py

--- a/python/demo/demo_gmsh.py
+++ b/python/demo/demo_gmsh.py
@@ -25,6 +25,7 @@ except ImportError:
 
 
 from dolfinx.io import XDMFFile, gmshio
+
 from mpi4py import MPI
 
 # -

--- a/python/demo/demo_poisson.py
+++ b/python/demo/demo_poisson.py
@@ -75,6 +75,7 @@ from ufl import ds, dx, grad, inner
 
 from mpi4py import MPI
 from petsc4py.PETSc import ScalarType
+
 # -
 
 # We begin by using {py:func}`create_rectangle

--- a/python/demo/demo_stokes.py
+++ b/python/demo/demo_stokes.py
@@ -92,6 +92,7 @@ from ufl import div, dx, grad, inner
 
 from mpi4py import MPI
 from petsc4py import PETSc
+
 # -
 
 # We create a {py:class}`Mesh <dolfinx.mesh.Mesh>`, define functions to

--- a/python/doc/source/conf.py
+++ b/python/doc/source/conf.py
@@ -3,15 +3,15 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import dolfinx
 import datetime
 import os
 import sys
 
+import dolfinx
+
 sys.path.insert(0, os.path.abspath('.'))
 
-import jupytext_process # noqa
-
+import jupytext_process  # noqa
 
 jupytext_process.process()
 

--- a/python/doc/source/jupytext_process.py
+++ b/python/doc/source/jupytext_process.py
@@ -4,9 +4,9 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
-import shutil
-import pathlib
 import os
+import pathlib
+import shutil
 
 import jupytext
 

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -11,8 +11,8 @@ import numpy.typing as npt
 
 import ufl
 from dolfinx import cpp as _cpp
-from dolfinx.mesh import (CellType, Mesh, create_mesh, meshtags,
-                          meshtags_from_entities, create_cell_partitioner, GhostMode)
+from dolfinx.mesh import (CellType, GhostMode, Mesh, create_cell_partitioner,
+                          create_mesh, meshtags, meshtags_from_entities)
 
 from mpi4py import MPI as _MPI
 

--- a/python/test/unit/fem/test_assemble_domains.py
+++ b/python/test/unit/fem/test_assemble_domains.py
@@ -14,8 +14,9 @@ from dolfinx.fem import (Constant, Function, FunctionSpace, assemble_scalar,
                          dirichletbc, form)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                set_bc)
-from dolfinx.mesh import (GhostMode, Mesh, create_unit_square, meshtags, meshtags_from_entities,
-                          locate_entities_boundary)
+from dolfinx.mesh import (GhostMode, Mesh, create_unit_square,
+                          locate_entities_boundary, meshtags,
+                          meshtags_from_entities)
 
 from mpi4py import MPI
 from petsc4py import PETSc

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -16,7 +16,7 @@ import ufl
 from dolfinx.fem import (Constant, Function, FunctionSpace,
                          VectorFunctionSpace, assemble_scalar, form)
 from dolfinx.fem.petsc import assemble_matrix, assemble_vector
-from dolfinx.mesh import CellType, meshtags, create_mesh
+from dolfinx.mesh import CellType, create_mesh, meshtags
 
 from mpi4py import MPI
 from petsc4py import PETSc

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -14,6 +14,7 @@ import numpy as np
 import numpy.typing
 
 import basix
+import dolfinx.cpp
 import ufl
 from dolfinx.cpp.la.petsc import create_matrix
 from dolfinx.fem import (Constant, Expression, Function, FunctionSpace,
@@ -24,7 +25,7 @@ import petsc4py.lib
 from mpi4py import MPI
 from petsc4py import PETSc
 from petsc4py import get_config as PETSc_get_config
-import dolfinx.cpp
+
 dolfinx.cpp.common.init_logging(["-v"])
 # Get details of PETSc install
 petsc_dir = PETSc_get_config()['PETSC_DIR']

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -21,7 +21,6 @@ from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
 
 from mpi4py import MPI
 
-
 parametrize_cell_types = pytest.mark.parametrize(
     "cell_type", [
         CellType.interval,

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -12,9 +12,9 @@ import pytest
 import ufl
 from dolfinx.common import has_adios2
 from dolfinx.fem import Function, FunctionSpace, VectorFunctionSpace
+from dolfinx.graph import create_adjacencylist
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
                           create_unit_square)
-from dolfinx.graph import create_adjacencylist
 
 from mpi4py import MPI
 

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -19,10 +19,10 @@ from dolfinx.cpp.mesh import (create_cell_partitioner, entities_to_geometry,
                               is_simplex)
 from dolfinx.fem import assemble_scalar, form
 from dolfinx.mesh import (CellType, DiagonalType, GhostMode, create_box,
-                          create_interval, create_rectangle, create_submesh, create_unit_cube,
-                          create_unit_interval, create_unit_square,
-                          exterior_facet_indices, locate_entities,
-                          locate_entities_boundary)
+                          create_interval, create_rectangle, create_submesh,
+                          create_unit_cube, create_unit_interval,
+                          create_unit_square, exterior_facet_indices,
+                          locate_entities, locate_entities_boundary)
 
 from mpi4py import MPI
 


### PR DESCRIPTION
This corrects an error in `python/.isort.cfg` which allows the CI and user call to `isort` to be simplified.