### PR TITLE
Fix Spack CI order

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -49,19 +49,19 @@ jobs:
           apt-get install -y bzip2 curl file git gzip make patch python3-minimal tar xz-utils
           apt-get install -y g++ gfortran  # compilers
 
-      - name: Build DOLFINx (C++) development version via Spack
-        run: |
-          . ./spack/share/spack/setup-env.sh
-          spack env create cpp-main
-          spack env activate cpp-main
-          spack add fenics-dolfinx@main+adios2
-          spack install
       - name: Build DOLFINx (C++) release version via Spack
         run: |
           . ./spack/share/spack/setup-env.sh
           spack env create cpp-release
           spack env activate cpp-release
           spack add fenics-dolfinx+adios2
+          spack install
+      - name: Build DOLFINx (C++) development version via Spack
+        run: |
+          . ./spack/share/spack/setup-env.sh
+          spack env create cpp-main
+          spack env activate cpp-main
+          spack add fenics-dolfinx@main+adios2
           spack install
 
       - name: Get DOLFINx code (to access test files)

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -99,7 +99,6 @@ jobs:
           make -j2
           mpirun -np 2 ./demo_poisson
 
-
       - name: Build DOLFINx (Python, release version)
         run: |
           . ./spack/share/spack/setup-env.sh
@@ -120,7 +119,7 @@ jobs:
           . ./spack/share/spack/setup-env.sh
           spack env activate py-release
           mpirun -np 2 python3 ./dolfinx-release/python/demo/demo_elasticity.py
-     - name: Run DOLFINx (Python, development) test
+      - name: Run DOLFINx (Python, development) test
         run: |
           . ./spack/share/spack/setup-env.sh
           spack env activate py-main

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -69,6 +69,24 @@ jobs:
         with:
           path: ./dolfinx-main
 
+      - name: Get DOLFINx release code (to access test files)
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          # ref: v${{ github.event.inputs.spack_branch }}
+          path: ./dolfinx-release
+
+      - name: Run a C++ test (release version)
+        run: |
+          . ./spack/share/spack/setup-env.sh
+          spack env activate cpp-release
+          spack install cmake py-fenics-ffcx
+          cd dolfinx-release/cpp/
+          cd demo/poisson
+          cmake .
+          export VERBOSE=1
+          make -j2
+          mpirun -np 2 ./demo_poisson
       - name: Run a C++ test (development version)
         run: |
           . ./spack/share/spack/setup-env.sh
@@ -81,31 +99,7 @@ jobs:
           make -j2
           mpirun -np 2 ./demo_poisson
 
-      - name: Get DOLFINx release code (to access test files)
-        uses: actions/checkout@v3
-        with:
-          ref: main
-          # ref: v${{ github.event.inputs.spack_branch }}
-          path: ./dolfinx-release
-      - name: Run a C++ test (release version)
-        run: |
-          . ./spack/share/spack/setup-env.sh
-          spack env activate cpp-release
-          spack install cmake py-fenics-ffcx
-          cd dolfinx-release/cpp/
-          cd demo/poisson
-          cmake .
-          export VERBOSE=1
-          make -j2
-          mpirun -np 2 ./demo_poisson
 
-      - name: Build DOLFINx (Python, development)
-        run: |
-          . ./spack/share/spack/setup-env.sh
-          spack env create py-main
-          spack env activate py-main
-          spack add py-fenics-dolfinx@main
-          spack install
       - name: Build DOLFINx (Python, release version)
         run: |
           . ./spack/share/spack/setup-env.sh
@@ -113,14 +107,21 @@ jobs:
           spack env activate py-release
           spack add py-fenics-dolfinx
           spack install
-
-      - name: Run DOLFINx (Python, development) test
+      - name: Build DOLFINx (Python, development)
         run: |
           . ./spack/share/spack/setup-env.sh
+          spack env create py-main
           spack env activate py-main
-          mpirun -np 2 python3 ./dolfinx-main/python/demo/demo_elasticity.py
+          spack add py-fenics-dolfinx@main
+          spack install
+
       - name: Run DOLFINx (Python, release) test
         run: |
           . ./spack/share/spack/setup-env.sh
           spack env activate py-release
           mpirun -np 2 python3 ./dolfinx-release/python/demo/demo_elasticity.py
+     - name: Run DOLFINx (Python, development) test
+        run: |
+          . ./spack/share/spack/setup-env.sh
+          spack env activate py-main
+          mpirun -np 2 python3 ./dolfinx-main/python/demo/demo_elasticity.py

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -64,18 +64,12 @@ jobs:
           spack add fenics-dolfinx@main+adios2
           spack install
 
-      - name: Get DOLFINx code (to access test files)
-        uses: actions/checkout@v3
-        with:
-          path: ./dolfinx-main
-
       - name: Get DOLFINx release code (to access test files)
         uses: actions/checkout@v3
         with:
-          ref: main
+          ref: v0.5.1
           # ref: v${{ github.event.inputs.spack_branch }}
           path: ./dolfinx-release
-
       - name: Run a C++ test (release version)
         run: |
           . ./spack/share/spack/setup-env.sh
@@ -87,6 +81,11 @@ jobs:
           export VERBOSE=1
           make -j2
           mpirun -np 2 ./demo_poisson
+
+      - name: Get DOLFINx code (to access test files)
+        uses: actions/checkout@v3
+        with:
+          path: ./dolfinx-main
       - name: Run a C++ test (development version)
         run: |
           . ./spack/share/spack/setup-env.sh


### PR DESCRIPTION
When installing a Spack package without specifying the version,

1. If any package is already installed, then no new version is installed
2. If a version is specified, then the specified version is installed unless the specified version has already been installed

The CI was not working as expected because it first installed the `@main` version (to test development version), and then installed without a specified version (with the intention of testing the default, latest release version). However, since after install the `@main` version, Spack detected and existing build and did not install the release version.

This change reverse the order of install in the CI, first installing the 'default' release version and then installing `@main`.