### PR TITLE
Fix geometric dimension of `VectorFunctionSpace` element cell

### DIFF
--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -585,5 +585,6 @@ def TensorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typin
 
     e = ElementMetaData(*element)
     ufl_element = basix.ufl_wrapper.create_tensor_element(
-        e.family, mesh.ufl_cell().cellname(), e.degree, shape=shape, symmetry=symmetry)
+        e.family, mesh.ufl_cell().cellname(), e.degree, shape=shape, symmetry=symmetry,
+        gdim=mesh.geometry.dim)
     return FunctionSpace(mesh, ufl_element)

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -573,7 +573,8 @@ def VectorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typin
 
     e = ElementMetaData(*element)
     ufl_element = basix.ufl_wrapper.create_vector_element(
-        e.family, mesh.ufl_cell().cellname(), e.degree, dim=dim)
+        e.family, mesh.ufl_cell().cellname(), e.degree, dim=dim,
+        gdim=mesh.geometry.dim)
 
     return FunctionSpace(mesh, ufl_element)
 

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -7,12 +7,13 @@
 import pytest
 
 import basix.finite_element
+from dolfinx.graph import create_adjacencylist
 from dolfinx.fem import Function, FunctionSpace, VectorFunctionSpace
-from dolfinx.mesh import create_unit_cube
+from dolfinx.mesh import create_unit_cube, CellType, create_mesh, create_cell_partitioner
 from ufl import (FiniteElement, TestFunction, TrialFunction, VectorElement,
-                 grad, triangle)
+                 grad, triangle, Mesh, Cell, VectorElement)
 from ufl.log import UFLException
-
+import numpy as np
 from mpi4py import MPI
 
 
@@ -232,3 +233,23 @@ def test_basix_element(V, W, Q, V2):
     # Mixed spaces do not yet return a basix element
     with pytest.raises(RuntimeError):
         e = Q.element.basix_element
+
+
+@pytest.mark.skip_in_parallel
+def test_vector_function_space_cell_type():
+    """Test that the UFL element cell of a vector function
+    space is correct on meshes where gdim > tdim"""
+    comm = MPI.COMM_WORLD
+    gdim = 2
+
+    # Create a mesh containing a single interval living in 2D
+    cell = Cell("interval", geometric_dimension=gdim)
+    domain = Mesh(VectorElement("Lagrange", cell, 1))
+    cells = np.array([[0, 1]], dtype=np.int64)
+    x = np.array([[0., 0.], [1., 1.]])
+    mesh = create_mesh(comm, cells, x, domain)
+
+    # Create functions space over mesh, and check element cell
+    # is correct
+    V = VectorFunctionSpace(mesh, ('Lagrange', 1))
+    assert V.ufl_element().cell() == cell

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -7,9 +7,8 @@
 import pytest
 
 import basix.finite_element
-from dolfinx.graph import create_adjacencylist
 from dolfinx.fem import Function, FunctionSpace, VectorFunctionSpace
-from dolfinx.mesh import create_unit_cube, CellType, create_mesh, create_cell_partitioner
+from dolfinx.mesh import create_unit_cube, create_mesh
 from ufl import (FiniteElement, TestFunction, TrialFunction, VectorElement,
                  grad, triangle, Mesh, Cell, VectorElement)
 from ufl.log import UFLException

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -10,7 +10,7 @@ import basix.finite_element
 from dolfinx.fem import Function, FunctionSpace, VectorFunctionSpace
 from dolfinx.mesh import create_unit_cube, create_mesh
 from ufl import (FiniteElement, TestFunction, TrialFunction, VectorElement,
-                 grad, triangle, Mesh, Cell, VectorElement)
+                 grad, triangle, Mesh, Cell)
 from ufl.log import UFLException
 import numpy as np
 from mpi4py import MPI


### PR DESCRIPTION
This PR fixes an issue where the UFL element of a vector function space has the wrong geometric dimension when the geometric dimension is higher than the topological dimension. It also adds a test that fails on main.