### PR TITLE
Const consistency improvements

### DIFF
--- a/cpp/demo/interpolation-io/main.cpp
+++ b/cpp/demo/interpolation-io/main.cpp
@@ -25,7 +25,7 @@ using namespace dolfinx;
 // outputs the finite element function to a VTK file for visualisation.
 // It also shows how to create a finite element using Basix.
 template <typename T>
-void interpolate_scalar(const std::shared_ptr<mesh::Mesh>& mesh,
+void interpolate_scalar(std::shared_ptr<const mesh::Mesh> mesh,
                         std::filesystem::path filename)
 {
   // Create a Basix continuous Lagrange element of degree 1
@@ -62,7 +62,7 @@ void interpolate_scalar(const std::shared_ptr<mesh::Mesh>& mesh,
 // element function in a discontinuous Lagrange space and outputs the
 // Lagrange finite element function to a VTX file for visualisation.
 template <typename T>
-void interpolate_nedelec(const std::shared_ptr<mesh::Mesh>& mesh,
+void interpolate_nedelec(std::shared_ptr<const mesh::Mesh> mesh,
                          [[maybe_unused]] std::filesystem::path filename)
 {
   // Create a Basix Nedelec (first kind) element of degree 2 (dim=6 on triangle)

--- a/cpp/demo/interpolation-io/main.cpp
+++ b/cpp/demo/interpolation-io/main.cpp
@@ -25,7 +25,7 @@ using namespace dolfinx;
 // outputs the finite element function to a VTK file for visualisation.
 // It also shows how to create a finite element using Basix.
 template <typename T>
-void interpolate_scalar(std::shared_ptr<const mesh::Mesh> mesh,
+void interpolate_scalar(std::shared_ptr<mesh::Mesh> mesh,
                         std::filesystem::path filename)
 {
   // Create a Basix continuous Lagrange element of degree 1
@@ -62,7 +62,7 @@ void interpolate_scalar(std::shared_ptr<const mesh::Mesh> mesh,
 // element function in a discontinuous Lagrange space and outputs the
 // Lagrange finite element function to a VTX file for visualisation.
 template <typename T>
-void interpolate_nedelec(std::shared_ptr<const mesh::Mesh> mesh,
+void interpolate_nedelec(std::shared_ptr<mesh::Mesh> mesh,
                          [[maybe_unused]] std::filesystem::path filename)
 {
   // Create a Basix Nedelec (first kind) element of degree 2 (dim=6 on triangle)

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -177,8 +177,7 @@ public:
             typename = std::enable_if_t<
                 std::is_convertible_v<
                     S, T> or std::is_convertible_v<S, std::span<const T>>>>
-  DirichletBC(const S& g, U&& dofs,
-              const std::shared_ptr<const FunctionSpace>& V)
+  DirichletBC(const S& g, U&& dofs, std::shared_ptr<const FunctionSpace> V)
       : DirichletBC(std::make_shared<Constant<T>>(g), dofs, V)
   {
   }
@@ -200,8 +199,8 @@ public:
   /// Use the Function version if this is not the case, e.g. for some
   /// mixed spaces.
   template <typename U>
-  DirichletBC(const std::shared_ptr<const Constant<T>>& g, U&& dofs,
-              const std::shared_ptr<const FunctionSpace>& V)
+  DirichletBC(std::shared_ptr<const Constant<T>> g, U&& dofs,
+              std::shared_ptr<const FunctionSpace> V)
       : _function_space(V), _g(g), _dofs0(std::forward<U>(dofs)),
         _owned_indices0(num_owned(*V, _dofs0))
   {
@@ -249,7 +248,7 @@ public:
   /// corresponds to 3 degrees-of-freedom if the dofmap associated with
   /// `g` has block size 3.
   template <typename U>
-  DirichletBC(const std::shared_ptr<const Function<T>>& g, U&& dofs)
+  DirichletBC(std::shared_ptr<const Function<T>> g, U&& dofs)
       : _function_space(g->function_space()), _g(g),
         _dofs0(std::forward<U>(dofs)),
         _owned_indices0(num_owned(*_function_space, _dofs0))
@@ -286,8 +285,8 @@ public:
   /// condition is applied
   /// @note The indices in `dofs` are unrolled and not for blocks.
   template <typename U>
-  DirichletBC(const std::shared_ptr<const Function<T>>& g, U&& V_g_dofs,
-              const std::shared_ptr<const FunctionSpace>& V)
+  DirichletBC(std::shared_ptr<const Function<T>> g, U&& V_g_dofs,
+              std::shared_ptr<const FunctionSpace> V)
       : _function_space(V), _g(g),
         _dofs0(std::forward<typename U::value_type>(V_g_dofs[0])),
         _dofs1_g(std::forward<typename U::value_type>(V_g_dofs[1])),

--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -67,9 +67,8 @@ public:
                                const uint8_t*)>
           fn,
       const std::vector<int>& value_shape,
-      const std::shared_ptr<const mesh::Mesh>& mesh = nullptr,
-      const std::shared_ptr<const FunctionSpace> argument_function_space
-      = nullptr)
+      std::shared_ptr<const mesh::Mesh> mesh = nullptr,
+      std::shared_ptr<const FunctionSpace> argument_function_space = nullptr)
       : _coefficients(coefficients), _constants(constants), _mesh(mesh),
         _x_ref(std::vector<double>(X.begin(), X.end()), Xshape), _fn(fn),
         _value_shape(value_shape),

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -102,7 +102,7 @@ public:
        const std::vector<std::shared_ptr<const Function<T>>>& coefficients,
        const std::vector<std::shared_ptr<const Constant<T>>>& constants,
        bool needs_facet_permutations,
-       const std::shared_ptr<const mesh::Mesh>& mesh = nullptr)
+       std::shared_ptr<const mesh::Mesh> mesh = nullptr)
       : _function_spaces(function_spaces), _coefficients(coefficients),
         _constants(constants), _mesh(mesh),
         _needs_facet_permutations(needs_facet_permutations)

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -430,8 +430,7 @@ void interpolate(Function<T>& u, std::span<const T> f,
   using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
   using mdspan3_t = stdex::mdspan<double, stdex::dextents<std::size_t, 3>>;
 
-  const std::shared_ptr<const FiniteElement> element
-      = u.function_space()->element();
+  std::shared_ptr<const FiniteElement> element = u.function_space()->element();
   assert(element);
   const int element_bs = element->block_size();
   if (int num_sub = element->num_sub_elements();

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -193,8 +193,7 @@ std::vector<std::string> fem::get_constant_names(const ufcx_form& ufcx_form)
 }
 //-----------------------------------------------------------------------------
 fem::FunctionSpace fem::create_functionspace(
-    const std::shared_ptr<mesh::Mesh>& mesh, const basix::FiniteElement& e,
-    int bs,
+    std::shared_ptr<mesh::Mesh> mesh, const basix::FiniteElement& e, int bs,
     const std::function<std::vector<int>(
         const graph::AdjacencyList<std::int32_t>&)>& reorder_fn)
 {
@@ -221,7 +220,7 @@ fem::FunctionSpace fem::create_functionspace(
   // Create a dofmap
   ElementDofLayout layout(bs, e.entity_dofs(), e.entity_closure_dofs(), {},
                           sub_doflayout);
-  auto dofmap = std::make_shared<DofMap>(
+  auto dofmap = std::make_shared<const DofMap>(
       create_dofmap(mesh->comm(), layout, mesh->topology(), reorder_fn, *_e));
 
   return FunctionSpace(mesh, _e, dofmap);
@@ -229,7 +228,7 @@ fem::FunctionSpace fem::create_functionspace(
 //-----------------------------------------------------------------------------
 fem::FunctionSpace fem::create_functionspace(
     ufcx_function_space* (*fptr)(const char*), const std::string& function_name,
-    const std::shared_ptr<mesh::Mesh>& mesh,
+    std::shared_ptr<mesh::Mesh> mesh,
     const std::function<std::vector<int>(
         const graph::AdjacencyList<std::int32_t>&)>& reorder_fn)
 {

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -231,7 +231,7 @@ Form<T> create_form(
     const std::vector<std::shared_ptr<const Function<T>>>& coefficients,
     const std::vector<std::shared_ptr<const Constant<T>>>& constants,
     const std::map<IntegralType, const mesh::MeshTags<int>*>& subdomains,
-    const std::shared_ptr<const mesh::Mesh>& mesh = nullptr)
+    std::shared_ptr<const mesh::Mesh> mesh = nullptr)
 {
   if (ufcx_form.rank != (int)spaces.size())
     throw std::runtime_error("Wrong number of argument spaces for Form.");
@@ -440,7 +440,7 @@ Form<T> create_form(
         coefficients,
     const std::map<std::string, std::shared_ptr<const Constant<T>>>& constants,
     const std::map<IntegralType, const mesh::MeshTags<int>*>& subdomains,
-    const std::shared_ptr<const mesh::Mesh>& mesh = nullptr)
+    std::shared_ptr<const mesh::Mesh> mesh = nullptr)
 {
   // Place coefficients in appropriate order
   std::vector<std::shared_ptr<const Function<T>>> coeff_map;
@@ -487,7 +487,7 @@ Form<T> create_form(
         coefficients,
     const std::map<std::string, std::shared_ptr<const Constant<T>>>& constants,
     const std::map<IntegralType, const mesh::MeshTags<int>*>& subdomains,
-    const std::shared_ptr<const mesh::Mesh>& mesh = nullptr)
+    std::shared_ptr<const mesh::Mesh> mesh = nullptr)
 {
   ufcx_form* form = fptr();
   Form<T> L = create_form<T>(*form, spaces, coefficients, constants, subdomains,
@@ -504,12 +504,11 @@ Form<T> create_form(
 /// @param[in] reorder_fn The graph reordering function to call on the
 /// dofmap. If `nullptr`, the default re-ordering is used.
 /// @return The created function space
-FunctionSpace
-create_functionspace(const std::shared_ptr<mesh::Mesh>& mesh,
-                     const basix::FiniteElement& e, int bs,
-                     const std::function<std::vector<int>(
-                         const graph::AdjacencyList<std::int32_t>&)>& reorder_fn
-                     = nullptr);
+FunctionSpace create_functionspace(
+    std::shared_ptr<mesh::Mesh> mesh, const basix::FiniteElement& e, int bs,
+    const std::function<
+        std::vector<int>(const graph::AdjacencyList<std::int32_t>&)>& reorder_fn
+    = nullptr);
 
 /// Create a FunctionSpace from UFC data
 ///
@@ -525,7 +524,7 @@ create_functionspace(const std::shared_ptr<mesh::Mesh>& mesh,
 /// @return The created function space
 FunctionSpace create_functionspace(
     ufcx_function_space* (*fptr)(const char*), const std::string& function_name,
-    const std::shared_ptr<mesh::Mesh>& mesh,
+    std::shared_ptr<mesh::Mesh> mesh,
     const std::function<
         std::vector<int>(const graph::AdjacencyList<std::int32_t>&)>& reorder_fn
     = nullptr);
@@ -814,9 +813,8 @@ Expression<T> create_expression(
     const ufcx_expression& expression,
     const std::vector<std::shared_ptr<const Function<T>>>& coefficients,
     const std::vector<std::shared_ptr<const Constant<T>>>& constants,
-    const std::shared_ptr<const mesh::Mesh>& mesh = nullptr,
-    const std::shared_ptr<const FunctionSpace>& argument_function_space
-    = nullptr)
+    std::shared_ptr<const mesh::Mesh> mesh = nullptr,
+    std::shared_ptr<const FunctionSpace> argument_function_space = nullptr)
 {
   if (expression.rank > 0 and !argument_function_space)
   {
@@ -875,9 +873,8 @@ Expression<T> create_expression(
     const std::map<std::string, std::shared_ptr<const Function<T>>>&
         coefficients,
     const std::map<std::string, std::shared_ptr<const Constant<T>>>& constants,
-    const std::shared_ptr<const mesh::Mesh>& mesh = nullptr,
-    const std::shared_ptr<const FunctionSpace>& argument_function_space
-    = nullptr)
+    std::shared_ptr<const mesh::Mesh> mesh = nullptr,
+    std::shared_ptr<const FunctionSpace> argument_function_space = nullptr)
 {
   // Place coefficients in appropriate order
   std::vector<std::shared_ptr<const Function<T>>> coeff_map;

--- a/cpp/dolfinx/io/ADIOS2Writers.cpp
+++ b/cpp/dolfinx/io/ADIOS2Writers.cpp
@@ -644,8 +644,7 @@ void fides_initialize_function_attributes(adios2::IO& io,
 //-----------------------------------------------------------------------------
 ADIOS2Writer::ADIOS2Writer(MPI_Comm comm, const std::filesystem::path& filename,
                            const std::string& tag,
-                           const std::shared_ptr<const mesh::Mesh>& mesh,
-                           const U& u)
+                           std::shared_ptr<const mesh::Mesh> mesh, const U& u)
     : _adios(std::make_unique<adios2::ADIOS>(comm)),
       _io(std::make_unique<adios2::IO>(_adios->DeclareIO(tag))),
       _engine(std::make_unique<adios2::Engine>(

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -58,8 +58,8 @@ private:
   /// @param[in] mesh
   /// @param[in] u
   ADIOS2Writer(MPI_Comm comm, const std::filesystem::path& filename,
-               const std::string& tag,
-               const std::shared_ptr<const mesh::Mesh>& mesh, const U& u);
+               const std::string& tag, std::shared_ptr<const mesh::Mesh> mesh,
+               const U& u);
 
 protected:
   /// @brief Create an ADIOS2-based writer for a mesh

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -87,7 +87,7 @@ void _write_function(dolfinx::MPI::Comm& comm,
 
 //-----------------------------------------------------------------------------
 XDMFFile::XDMFFile(MPI_Comm comm, const std::filesystem::path& filename,
-                   const std::string file_mode, const Encoding encoding)
+                   std::string file_mode, Encoding encoding)
     : _comm(comm), _filename(filename), _file_mode(file_mode),
       _xml_doc(new pugi::xml_document), _encoding(encoding)
 {
@@ -188,7 +188,7 @@ void XDMFFile::close()
   _h5_id = -1;
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write_mesh(const mesh::Mesh& mesh, const std::string xpath)
+void XDMFFile::write_mesh(const mesh::Mesh& mesh, std::string xpath)
 {
   pugi::xml_node node = _xml_doc->select_node(xpath.c_str()).node();
   if (!node)
@@ -202,8 +202,8 @@ void XDMFFile::write_mesh(const mesh::Mesh& mesh, const std::string xpath)
     _xml_doc->save_file(_filename.c_str(), "  ");
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write_geometry(const mesh::Geometry& geometry,
-                              const std::string name, const std::string xpath)
+void XDMFFile::write_geometry(const mesh::Geometry& geometry, std::string name,
+                              std::string xpath)
 {
   pugi::xml_node node = _xml_doc->select_node(xpath.c_str()).node();
   if (!node)
@@ -225,9 +225,8 @@ void XDMFFile::write_geometry(const mesh::Geometry& geometry,
 }
 //-----------------------------------------------------------------------------
 mesh::Mesh XDMFFile::read_mesh(const fem::CoordinateElement& element,
-                               const mesh::GhostMode& mode,
-                               const std::string name,
-                               const std::string xpath) const
+                               mesh::GhostMode mode, std::string name,
+                               std::string xpath) const
 {
   // Read mesh data
   auto [cells, cshape] = XDMFFile::read_topology_data(name, xpath);
@@ -248,8 +247,7 @@ mesh::Mesh XDMFFile::read_mesh(const fem::CoordinateElement& element,
 }
 //-----------------------------------------------------------------------------
 std::pair<std::vector<std::int64_t>, std::array<std::size_t, 2>>
-XDMFFile::read_topology_data(const std::string name,
-                             const std::string xpath) const
+XDMFFile::read_topology_data(std::string name, std::string xpath) const
 {
   pugi::xml_node node = _xml_doc->select_node(xpath.c_str()).node();
   if (!node)
@@ -265,8 +263,7 @@ XDMFFile::read_topology_data(const std::string name,
 }
 //-----------------------------------------------------------------------------
 std::pair<std::vector<double>, std::array<std::size_t, 2>>
-XDMFFile::read_geometry_data(const std::string name,
-                             const std::string xpath) const
+XDMFFile::read_geometry_data(std::string name, std::string xpath) const
 {
   pugi::xml_node node = _xml_doc->select_node(xpath.c_str()).node();
   if (!node)
@@ -282,20 +279,19 @@ XDMFFile::read_geometry_data(const std::string name,
 }
 //-----------------------------------------------------------------------------
 void XDMFFile::write_function(const fem::Function<double>& u, double t,
-                              const std::string& mesh_xpath)
+                              std::string mesh_xpath)
 {
   _write_function(_comm, u, t, mesh_xpath, *_xml_doc, _h5_id, _filename);
 }
 //-----------------------------------------------------------------------------
 void XDMFFile::write_function(const fem::Function<std::complex<double>>& u,
-                              double t, const std::string& mesh_xpath)
+                              double t, std::string mesh_xpath)
 {
   _write_function(_comm, u, t, mesh_xpath, *_xml_doc, _h5_id, _filename);
 }
 //-----------------------------------------------------------------------------
 void XDMFFile::write_meshtags(const mesh::MeshTags<std::int32_t>& meshtags,
-                              const std::string& geometry_xpath,
-                              const std::string& xpath)
+                              std::string geometry_xpath, std::string xpath)
 {
   pugi::xml_node node = _xml_doc->select_node(xpath.c_str()).node();
   if (!node)
@@ -319,8 +315,8 @@ void XDMFFile::write_meshtags(const mesh::MeshTags<std::int32_t>& meshtags,
 }
 //-----------------------------------------------------------------------------
 mesh::MeshTags<std::int32_t>
-XDMFFile::read_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh,
-                        const std::string name, const std::string xpath)
+XDMFFile::read_meshtags(std::shared_ptr<const mesh::Mesh> mesh,
+                        std::string name, std::string xpath)
 {
   LOG(INFO) << "XDMF read meshtags (" << name << ")";
   pugi::xml_node node = _xml_doc->select_node(xpath.c_str()).node();
@@ -366,8 +362,8 @@ XDMFFile::read_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh,
   return meshtags;
 }
 //-----------------------------------------------------------------------------
-std::pair<mesh::CellType, int>
-XDMFFile::read_cell_type(const std::string grid_name, const std::string xpath)
+std::pair<mesh::CellType, int> XDMFFile::read_cell_type(std::string grid_name,
+                                                        std::string xpath)
 {
   pugi::xml_node node = _xml_doc->select_node(xpath.c_str()).node();
   if (!node)
@@ -391,9 +387,8 @@ XDMFFile::read_cell_type(const std::string grid_name, const std::string xpath)
   return {cell_type, cell_type_str.second};
 }
 //-----------------------------------------------------------------------------
-void XDMFFile::write_information(const std::string name,
-                                 const std::string value,
-                                 const std::string xpath)
+void XDMFFile::write_information(std::string name, std::string value,
+                                 std::string xpath)
 {
   pugi::xml_node node = _xml_doc->select_node(xpath.c_str()).node();
   if (!node)
@@ -409,8 +404,7 @@ void XDMFFile::write_information(const std::string name,
     _xml_doc->save_file(_filename.c_str(), "  ");
 }
 //-----------------------------------------------------------------------------
-std::string XDMFFile::read_information(const std::string name,
-                                       const std::string xpath)
+std::string XDMFFile::read_information(std::string name, std::string xpath)
 {
   pugi::xml_node node = _xml_doc->select_node(xpath.c_str()).node();
   if (!node)

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -68,8 +68,7 @@ public:
 
   /// Constructor
   XDMFFile(MPI_Comm comm, const std::filesystem::path& filename,
-           const std::string file_mode,
-           const Encoding encoding = default_encoding);
+           std::string file_mode, Encoding encoding = default_encoding);
 
   /// Destructor
   ~XDMFFile();
@@ -84,15 +83,14 @@ public:
   /// Save Mesh
   /// @param[in] mesh
   /// @param[in] xpath XPath where Mesh Grid will be written
-  void write_mesh(const mesh::Mesh& mesh,
-                  const std::string xpath = "/Xdmf/Domain");
+  void write_mesh(const mesh::Mesh& mesh, std::string xpath = "/Xdmf/Domain");
 
   /// Save Geometry
   /// @param[in] geometry
   /// @param[in] name
   /// @param[in] xpath XPath of a node where Geometry will be inserted
-  void write_geometry(const mesh::Geometry& geometry, const std::string name,
-                      const std::string xpath = "/Xdmf/Domain");
+  void write_geometry(const mesh::Geometry& geometry, std::string name,
+                      std::string xpath = "/Xdmf/Domain");
 
   /// Read in Mesh
   /// @param[in] element Element that describes the geometry of a cell
@@ -103,31 +101,30 @@ public:
   /// @return A Mesh distributed on the same communicator as the
   ///   XDMFFile
   mesh::Mesh read_mesh(const fem::CoordinateElement& element,
-                       const mesh::GhostMode& mode, const std::string name,
-                       const std::string xpath = "/Xdmf/Domain") const;
+                       mesh::GhostMode mode, std::string name,
+                       std::string xpath = "/Xdmf/Domain") const;
 
   /// Read Topology data for Mesh
   /// @param[in] name Name of the mesh (Grid)
   /// @param[in] xpath XPath where Mesh Grid data is located
   /// @return (Cell type, degree), and cells topology (global node indexing)
   std::pair<std::vector<std::int64_t>, std::array<std::size_t, 2>>
-  read_topology_data(const std::string name,
-                     const std::string xpath = "/Xdmf/Domain") const;
+  read_topology_data(std::string name,
+                     std::string xpath = "/Xdmf/Domain") const;
 
   /// Read Geometry data for Mesh
   /// @param[in] name Name of the mesh (Grid)
   /// @param[in] xpath XPath where Mesh Grid data is located
   /// @return points on each process
   std::pair<std::vector<double>, std::array<std::size_t, 2>>
-  read_geometry_data(const std::string name,
-                     const std::string xpath = "/Xdmf/Domain") const;
+  read_geometry_data(std::string name,
+                     std::string xpath = "/Xdmf/Domain") const;
 
   /// Read information about cell type
   /// @param[in] grid_name Name of Grid for which cell type is needed
   /// @param[in] xpath XPath where Grid is stored
-  std::pair<mesh::CellType, int> read_cell_type(const std::string grid_name,
-                                                const std::string xpath
-                                                = "/Xdmf/Domain");
+  std::pair<mesh::CellType, int>
+  read_cell_type(std::string grid_name, std::string xpath = "/Xdmf/Domain");
 
   /// Write Function
   /// @param[in] u The Function to write to file
@@ -135,7 +132,7 @@ public:
   /// @param[in] mesh_xpath XPath for a Grid under which Function will
   /// be inserted
   void write_function(const fem::Function<double>& u, double t,
-                      const std::string& mesh_xpath
+                      std::string mesh_xpath
                       = "/Xdmf/Domain/Grid[@GridType='Uniform'][1]");
 
   /// Write Function
@@ -144,7 +141,7 @@ public:
   /// @param[in] mesh_xpath XPath for a Grid under which Function will
   /// be inserted
   void write_function(const fem::Function<std::complex<double>>& u, double t,
-                      const std::string& mesh_xpath
+                      std::string mesh_xpath
                       = "/Xdmf/Domain/Grid[@GridType='Uniform'][1]");
 
   /// Write MeshTags
@@ -153,30 +150,29 @@ public:
   ///   in file
   /// @param[in] xpath XPath where MeshTags Grid will be inserted
   void write_meshtags(const mesh::MeshTags<std::int32_t>& meshtags,
-                      const std::string& geometry_xpath,
-                      const std::string& xpath = "/Xdmf/Domain");
+                      std::string geometry_xpath,
+                      std::string xpath = "/Xdmf/Domain");
 
   /// Read MeshTags
   /// @param[in] mesh The Mesh that the data is defined on
   /// @param[in] name
   /// @param[in] xpath XPath where MeshTags Grid is stored in file
   mesh::MeshTags<std::int32_t>
-  read_meshtags(const std::shared_ptr<const mesh::Mesh>& mesh,
-                const std::string name,
-                const std::string xpath = "/Xdmf/Domain");
+  read_meshtags(std::shared_ptr<const mesh::Mesh> mesh, std::string name,
+                std::string xpath = "/Xdmf/Domain");
 
   /// Write Information
   /// @param[in] name
   /// @param[in] value String to store into Information tag
   /// @param[in] xpath XPath where Information will be inserted
-  void write_information(const std::string name, const std::string value,
-                         const std::string xpath = "/Xdmf/Domain/");
+  void write_information(std::string name, std::string value,
+                         std::string xpath = "/Xdmf/Domain/");
 
   /// Read Information
   /// @param[in] name
   /// @param[in] xpath XPath where Information is stored in file
-  std::string read_information(const std::string name,
-                               const std::string xpath = "/Xdmf/Domain/");
+  std::string read_information(std::string name,
+                               std::string xpath = "/Xdmf/Domain/");
 
   /// Get the MPI communicator
   /// @return The MPI communicator for the file object

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -32,7 +32,7 @@ public:
   using allocator_type = Allocator;
 
   /// Create a distributed vector
-  Vector(const std::shared_ptr<const common::IndexMap>& map, int bs,
+  Vector(std::shared_ptr<const common::IndexMap> map, int bs,
          const Allocator& alloc = Allocator())
       : _map(map), _scatterer(std::make_shared<common::Scatterer>(*_map, bs)),
         _bs(bs), _buffer_local(_scatterer->local_buffer_size(), alloc),

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -40,7 +40,7 @@ public:
   /// point, commonly from a mesh input file. The type is
   /// `std:vector<std::int64_t>`.
   template <typename AdjacencyList32, typename Array, typename Vector64>
-  Geometry(const std::shared_ptr<const common::IndexMap>& index_map,
+  Geometry(std::shared_ptr<const common::IndexMap> index_map,
            AdjacencyList32&& dofmap, const fem::CoordinateElement& element,
            Array&& x, int dim, Vector64&& input_global_indices)
       : _dim(dim), _dofmap(std::forward<AdjacencyList32>(dofmap)),

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -327,10 +327,10 @@ mesh::create_submesh(const Mesh& mesh, int dim,
     // Fetch connectivities required to get entity dofs
     const std::vector<std::vector<std::vector<int>>>& closure_dofs
         = layout.entity_closure_dofs_all();
-    const std::shared_ptr<const graph::AdjacencyList<int>> e_to_c
+    std::shared_ptr<const graph::AdjacencyList<int>> e_to_c
         = topology.connectivity(dim, tdim);
     assert(e_to_c);
-    const std::shared_ptr<const graph::AdjacencyList<int>> c_to_e
+    std::shared_ptr<const graph::AdjacencyList<int>> c_to_e
         = topology.connectivity(tdim, dim);
     assert(c_to_e);
     for (std::size_t i = 0; i < submesh_to_mesh_entity_map.size(); ++i)

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -44,8 +44,7 @@ public:
   /// @param[in] values std::vector<T> of values for each index in
   /// indices. The size must be equal to the size of @p indices.
   template <typename U, typename V>
-  MeshTags(const std::shared_ptr<const Mesh>& mesh, int dim, U&& indices,
-           V&& values)
+  MeshTags(std::shared_ptr<const Mesh> mesh, int dim, U&& indices, V&& values)
       : _mesh(mesh), _dim(dim), _indices(std::forward<U>(indices)),
         _values(std::forward<V>(values))
   {
@@ -133,7 +132,7 @@ private:
 /// @note Entities that do not exist on this rank are ignored.
 /// @warning `entities` must not contain duplicate entities.
 template <typename T>
-MeshTags<T> create_meshtags(const std::shared_ptr<const Mesh>& mesh, int dim,
+MeshTags<T> create_meshtags(std::shared_ptr<const Mesh> mesh, int dim,
                             const graph::AdjacencyList<std::int32_t>& entities,
                             const std::span<const T>& values)
 {

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -733,7 +733,7 @@ Topology::Topology(MPI_Comm comm, CellType type)
 int Topology::dim() const noexcept { return _connectivity.size() - 1; }
 //-----------------------------------------------------------------------------
 void Topology::set_index_map(int dim,
-                             const std::shared_ptr<const common::IndexMap>& map)
+                             std::shared_ptr<const common::IndexMap> map)
 {
   assert(dim < (int)_index_map.size());
   _index_map[dim] = map;

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -67,8 +67,7 @@ public:
   ///
   /// Set the IndexMap for dimension dim
   /// @warning This is experimental and likely to change
-  void set_index_map(int dim,
-                     const std::shared_ptr<const common::IndexMap>& map);
+  void set_index_map(int dim, std::shared_ptr<const common::IndexMap> map);
 
   /// @brief Get the IndexMap that described the parallel distribution
   /// of the mesh entities.

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -624,7 +624,7 @@ plaza::refine(const mesh::Mesh& mesh, bool redistribute,
             std::move(parent_cell), std::move(parent_facet)};
   }
 
-  const std::shared_ptr<const common::IndexMap> map_c
+  std::shared_ptr<const common::IndexMap> map_c
       = mesh.topology().index_map(mesh.topology().dim());
   const int num_ghost_cells = map_c->num_ghosts();
   // Check if mesh has ghost cells on any rank
@@ -659,7 +659,7 @@ plaza::refine(const mesh::Mesh& mesh,
             std::move(parent_cell), std::move(parent_facet)};
   }
 
-  const std::shared_ptr<const common::IndexMap> map_c
+  std::shared_ptr<const common::IndexMap> map_c
       = mesh.topology().index_map(mesh.topology().dim());
   const int num_ghost_cells = map_c->num_ghosts();
   // Check if mesh has ghost cells on any rank

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -289,32 +289,28 @@ void declare_objects(py::module& m, const std::string& type)
           py::init(
               [](const py::array_t<T, py::array::c_style>& g,
                  const py::array_t<std::int32_t, py::array::c_style>& dofs,
-                 const std::shared_ptr<const dolfinx::fem::FunctionSpace>& V)
+                 std::shared_ptr<const dolfinx::fem::FunctionSpace> V)
               {
                 if (dofs.ndim() != 1)
                   throw std::runtime_error("Wrong number of dims");
                 std::vector<std::size_t> shape(g.shape(), g.shape() + g.ndim());
-                auto _g  = std::make_shared<dolfinx::fem::Constant<T>>(std::span(g.data(), g.size()), shape);
+                auto _g = std::make_shared<dolfinx::fem::Constant<T>>(
+                    std::span(g.data(), g.size()), shape);
                 return dolfinx::fem::DirichletBC<T>(
-                   _g, std::vector(dofs.data(), dofs.data() + dofs.size()),
-                    V);
+                    _g, std::vector(dofs.data(), dofs.data() + dofs.size()), V);
               }),
-          py::arg("g").noconvert(), py::arg("dofs").noconvert(),
-          py::arg("V"))
+          py::arg("g").noconvert(), py::arg("dofs").noconvert(), py::arg("V"))
       .def(py::init(
-               [](const std::shared_ptr<const dolfinx::fem::Constant<T>>& g,
+               [](std::shared_ptr<const dolfinx::fem::Constant<T>> g,
                   const py::array_t<std::int32_t, py::array::c_style>& dofs,
-                  const std::shared_ptr<const dolfinx::fem::FunctionSpace>&
-                  V)
+                  std::shared_ptr<const dolfinx::fem::FunctionSpace> V)
                {
                  return dolfinx::fem::DirichletBC<T>(
-                     g, std::vector(dofs.data(), dofs.data() + dofs.size()),
-                     V);
+                     g, std::vector(dofs.data(), dofs.data() + dofs.size()), V);
                }),
-           py::arg("g").noconvert(), py::arg("dofs").noconvert(),
-           py::arg("V"))
+           py::arg("g").noconvert(), py::arg("dofs").noconvert(), py::arg("V"))
       .def(py::init(
-               [](const std::shared_ptr<const dolfinx::fem::Function<T>>& g,
+               [](std::shared_ptr<const dolfinx::fem::Function<T>> g,
                   const py::array_t<std::int32_t, py::array::c_style>& dofs)
                {
                  return dolfinx::fem::DirichletBC<T>(
@@ -323,15 +319,15 @@ void declare_objects(py::module& m, const std::string& type)
            py::arg("g").noconvert(), py::arg("dofs"))
       .def(
           py::init(
-              [](const std::shared_ptr<const dolfinx::fem::Function<T>>& g,
-                 const std::array<py::array_t<std::int32_t,
-                 py::array::c_style>,
+              [](std::shared_ptr<const dolfinx::fem::Function<T>> g,
+                 const std::array<py::array_t<std::int32_t, py::array::c_style>,
                                   2>& V_g_dofs,
-                 const std::shared_ptr<const dolfinx::fem::FunctionSpace>& V)
+                 std::shared_ptr<const dolfinx::fem::FunctionSpace> V)
               {
-                std::array dofs = {std::vector(V_g_dofs[0].data(),
-                V_g_dofs[0].data() + V_g_dofs[0].size()),
-                                   std::vector(V_g_dofs[1].data(),
+                std::array dofs
+                    = {std::vector(V_g_dofs[0].data(),
+                                   V_g_dofs[0].data() + V_g_dofs[0].size()),
+                       std::vector(V_g_dofs[1].data(),
                                    V_g_dofs[1].data() + V_g_dofs[1].size())};
                 return dolfinx::fem::DirichletBC(g, std::move(dofs), V);
               }),
@@ -496,8 +492,8 @@ void declare_objects(py::module& m, const std::string& type)
                       const py::array_t<double, py::array::c_style>& X,
                       std::uintptr_t fn_addr,
                       const std::vector<int>& value_shape,
-                      const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh,
-                      const std::shared_ptr<const dolfinx::fem::FunctionSpace>&
+                      std::shared_ptr<const dolfinx::mesh::Mesh> mesh,
+                      std::shared_ptr<const dolfinx::fem::FunctionSpace>
                           argument_function_space)
                    {
                      auto tabulate_expression_ptr
@@ -550,8 +546,8 @@ void declare_objects(py::module& m, const std::string& type)
              coefficients,
          const std::vector<std::shared_ptr<const dolfinx::fem::Constant<T>>>&
              constants,
-         const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh,
-         const std::shared_ptr<const dolfinx::fem::FunctionSpace>&
+         std::shared_ptr<const dolfinx::mesh::Mesh> mesh,
+         std::shared_ptr<const dolfinx::fem::FunctionSpace>
              argument_function_space)
       {
         const ufcx_expression* p
@@ -759,7 +755,7 @@ void declare_form(py::module& m, const std::string& type)
                  const std::vector<std::shared_ptr<
                      const dolfinx::fem::Constant<T>>>& constants,
                  bool needs_permutation_data,
-                 const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh)
+                 std::shared_ptr<const dolfinx::mesh::Mesh> mesh)
               {
                 using kern = std::function<void(
                     T*, const T*, const T*,
@@ -807,7 +803,7 @@ void declare_form(py::module& m, const std::string& type)
                   const std::map<dolfinx::fem::IntegralType,
                                  const dolfinx::mesh::MeshTags<int>*>&
                       subdomains,
-                  const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh)
+                  std::shared_ptr<const dolfinx::mesh::Mesh> mesh)
                {
                  ufcx_form* p = reinterpret_cast<ufcx_form*>(form);
                  return dolfinx::fem::create_form<T>(
@@ -879,7 +875,7 @@ void declare_form(py::module& m, const std::string& type)
              constants,
          const std::map<dolfinx::fem::IntegralType,
                         const dolfinx::mesh::MeshTags<int>*>& subdomains,
-         const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh)
+         std::shared_ptr<const dolfinx::mesh::Mesh> mesh)
       {
         ufcx_form* p = reinterpret_cast<ufcx_form*>(form);
         return dolfinx::fem::create_form<T>(*p, spaces, coefficients, constants,

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -95,9 +95,8 @@ void io(py::module& m)
 
   xdmf_file
       .def(py::init(
-               [](const MPICommWrapper comm,
-                  const std::filesystem::path& filename,
-                  const std::string& file_mode,
+               [](const MPICommWrapper comm, std::filesystem::path filename,
+                  std::string file_mode,
                   dolfinx::io::XDMFFile::Encoding encoding)
                {
                  return std::make_unique<dolfinx::io::XDMFFile>(
@@ -113,8 +112,7 @@ void io(py::module& m)
            py::arg("xpath") = "/Xdmf/Domain")
       .def(
           "read_topology_data",
-          [](dolfinx::io::XDMFFile& self, const std::string& name,
-             const std::string& xpath)
+          [](dolfinx::io::XDMFFile& self, std::string name, std::string xpath)
           {
             auto [cells, shape] = self.read_topology_data(name, xpath);
             return as_pyarray(std::move(cells), shape);
@@ -122,8 +120,7 @@ void io(py::module& m)
           py::arg("name") = "mesh", py::arg("xpath") = "/Xdmf/Domain")
       .def(
           "read_geometry_data",
-          [](dolfinx::io::XDMFFile& self, const std::string& name,
-             const std::string& xpath)
+          [](dolfinx::io::XDMFFile& self, std::string name, std::string xpath)
           {
             auto [x, shape] = self.read_geometry_data(name, xpath);
             return as_pyarray(std::move(x), shape);
@@ -135,13 +132,13 @@ void io(py::module& m)
            py::arg("name") = "mesh", py::arg("xpath") = "/Xdmf/Domain")
       .def("write_function",
            py::overload_cast<const dolfinx::fem::Function<double>&, double,
-                             const std::string&>(
+                             std::string>(
                &dolfinx::io::XDMFFile::write_function),
            py::arg("function"), py::arg("t"), py::arg("mesh_xpath"))
       .def(
           "write_function",
           py::overload_cast<const dolfinx::fem::Function<std::complex<double>>&,
-                            double, const std::string&>(
+                            double, std::string>(
               &dolfinx::io::XDMFFile::write_function),
           py::arg("function"), py::arg("t"), py::arg("mesh_xpath"))
       .def("write_meshtags", &dolfinx::io::XDMFFile::write_meshtags,
@@ -161,9 +158,8 @@ void io(py::module& m)
   py::class_<dolfinx::io::VTKFile, std::shared_ptr<dolfinx::io::VTKFile>>(
       m, "VTKFile")
       .def(py::init(
-               [](const MPICommWrapper comm,
-                  const std::filesystem::path& filename,
-                  const std::string& mode) {
+               [](MPICommWrapper comm, std::filesystem::path filename,
+                  std::string mode) {
                  return std::make_unique<dolfinx::io::VTKFile>(comm.get(),
                                                                filename, mode);
                }),

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -42,7 +42,7 @@ void declare_objects(py::module& m, const std::string& type)
   py::class_<dolfinx::la::Vector<T>, std::shared_ptr<dolfinx::la::Vector<T>>>(
       m, pyclass_vector_name.c_str())
       .def(py::init(
-               [](const std::shared_ptr<const dolfinx::common::IndexMap>& map,
+               [](std::shared_ptr<const dolfinx::common::IndexMap> map,
                   int bs) { return dolfinx::la::Vector<T>(map, bs); }),
            py::arg("map"), py::arg("bs"))
       .def(py::init([](const dolfinx::la::Vector<T>& vec)

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -89,7 +89,7 @@ void declare_meshtags(py::module& m, std::string type)
              std::shared_ptr<dolfinx::mesh::MeshTags<T>>>(
       m, pyclass_name.c_str(), "MeshTags object")
       .def(py::init(
-          [](const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh, int dim,
+          [](std::shared_ptr<const dolfinx::mesh::Mesh> mesh, int dim,
              const py::array_t<std::int32_t, py::array::c_style>& indices,
              const py::array_t<T, py::array::c_style>& values)
           {
@@ -123,7 +123,7 @@ void declare_meshtags(py::module& m, std::string type)
            { return as_pyarray(self.find(value)); });
 
   m.def("create_meshtags",
-        [](const std::shared_ptr<const dolfinx::mesh::Mesh>& mesh, int dim,
+        [](std::shared_ptr<const dolfinx::mesh::Mesh> mesh, int dim,
            const dolfinx::graph::AdjacencyList<std::int32_t>& entities,
            const py::array_t<T, py::array::c_style>& values)
         {


### PR DESCRIPTION
In general, pass `std:span` by value rather than const reference.

Similarly for `std::shared_ptr`.