### PR TITLE
Suggest that users try MUMPS for LU decomposition.

### DIFF
--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -555,8 +555,10 @@ class LinearProblem:
 
         Example::
 
-            problem = LinearProblem(a, L, [bc0, bc1], petsc_options={"ksp_type": "preonly", "pc_type": "lu"})
-
+            problem = LinearProblem(a, L, [bc0, bc1],
+                                    petsc_options={"ksp_type": "preonly",
+                                                   "pc_type": "lu",
+                                                   "pc_factor_mat_solver_type": "mumps"})
         """
         self._a = _create_form(a, form_compiler_options=form_compiler_options, jit_options=jit_options)
         self._A = create_matrix(self._a)


### PR DESCRIPTION
It has been my experience that the default PETSc LU solver can fail for many quite standard problems. This patch keeps the behaviour of using the PETSc defaults for KSP, but proposes in the example that users set `pc_factor_mat_solver_type` to be MUMPS if they switch to LU.
