### PR TITLE
Fix bugs picked up by static analysis

### DIFF
--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -743,7 +743,7 @@ class NonlinearProblem:
         A.assemble()
 
 
-def load_petsc_lib(loader: typing.Callable[[str, 'os.PathLike[typing.Any]'], typing.Any]) -> typing.Any:
+def load_petsc_lib(loader: typing.Callable[[typing.Union[str, 'os.PathLike[typing.Any]']], typing.Any]) -> typing.Any:
     """
     Load PETSc shared library using loader callable, e.g. ctypes.CDLL.
 
@@ -767,19 +767,20 @@ def load_petsc_lib(loader: typing.Callable[[str, 'os.PathLike[typing.Any]'], typ
     else:
         candidate_paths = [os.path.join(petsc_dir, petsc_arch, "lib", "libpetsc.so"),
                            os.path.join(petsc_dir, petsc_arch, "lib", "libpetsc.dylib")]
-
+   
+        exists_paths = []
         for candidate_path in candidate_paths:
-            if not os.path.exists(candidate_path):
-                candidate_paths.remove(candidate_path)
+            if os.path.exists(candidate_path):
+                exists_paths.append(candidate_path)
 
-        if len(candidate_paths) == 0:
+        if len(exists_paths) == 0:
             raise RuntimeError("Could not find a PETSc shared library.")
 
-        for candidate_path in candidate_paths:
+        for exist_path in exists_paths:
             try:
-                petsc_lib = loader(candidate_path)
+                petsc_lib = loader(exist_path)
             except OSError:
-                print(f"Failed to load shared library found at {candidate_path}.")
+                print(f"Failed to load shared library found at {exist_path}.")
                 continue
 
     if petsc_lib is None:

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -748,7 +748,7 @@ def load_petsc_lib(loader: typing.Callable[[str, 'os.PathLike[typing.Any]'], typ
     Load PETSc shared library using loader callable, e.g. ctypes.CDLL.
 
     Args:
-        A callable that accepts a path and returns a wrapped library.
+        loader: A callable that accepts a library path and returns a wrapped library.
 
     Returns:
         A wrapped library of the type returned by the callable.

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 import contextlib
 import functools
 import typing
-import ctypes
-import ctypes.util
 import os
 
 import ufl

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -767,7 +767,7 @@ def load_petsc_lib(loader: typing.Callable[[typing.Union[str, 'os.PathLike[typin
     else:
         candidate_paths = [os.path.join(petsc_dir, petsc_arch, "lib", "libpetsc.so"),
                            os.path.join(petsc_dir, petsc_arch, "lib", "libpetsc.dylib")]
-   
+
         exists_paths = []
         for candidate_path in candidate_paths:
             if os.path.exists(candidate_path):

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -34,9 +34,9 @@ from dolfinx.fem.forms import form as _create_form
 from dolfinx.fem.forms import form_types
 from dolfinx.fem.function import Function as _Function
 
+import petsc4py
 from petsc4py import PETSc
 import petsc4py.lib
-from petsc4py import get_config as PETSc_get_config
 
 
 def _extract_function_spaces(a: typing.List[typing.List[FormMetaClass]]):
@@ -750,7 +750,7 @@ def load_petsc_lib(loader: Callable):
     """
     petsc_lib = None
 
-    petsc_dir = PETSc_get_config()['PETSC_DIR']
+    petsc_dir = petsc4py.get_config()['PETSC_DIR']
     petsc_arch = petsc4py.lib.getPathArchPETSc()[1]
 
     petsc_lib_path = ctypes.util.find_library("petsc")
@@ -773,8 +773,9 @@ def load_petsc_lib(loader: Callable):
         for candidate_path in candidate_paths:
             try:
                 petsc_lib = loader(candidate_path)
-            except OSError as exc:
-                raise RuntimeWarning(f"Failed to load shared library found at {candidate_path}.") from exc
+            except OSError:
+                print(f"Failed to load shared library found at {candidate_path}.")
+                continue
 
     if petsc_lib is None:
         raise RuntimeError("Failed to load a PETSc shared library.")

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -17,7 +17,6 @@ import functools
 import typing
 import ctypes
 import ctypes.util
-from typing import Callable
 import os
 
 import ufl
@@ -744,9 +743,15 @@ class NonlinearProblem:
         A.assemble()
 
 
-def load_petsc_lib(loader: Callable):
+def load_petsc_lib(loader: typing.Callable[[str, 'os.PathLike[typing.Any]'], typing.Any]) -> typing.Any:
     """
-    Load PETSc shared library using loader callable, e.g. ctypes.CDLL. 
+    Load PETSc shared library using loader callable, e.g. ctypes.CDLL.
+
+    Args:
+        A callable that accepts a path and returns a wrapped library.
+
+    Returns:
+        A wrapped library of the type returned by the callable.
     """
     petsc_lib = None
 

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -776,11 +776,11 @@ def load_petsc_lib(loader: typing.Callable[[typing.Union[str, 'os.PathLike[typin
         if len(exists_paths) == 0:
             raise RuntimeError("Could not find a PETSc shared library.")
 
-        for exist_path in exists_paths:
+        for exists_path in exists_paths:
             try:
-                petsc_lib = loader(exist_path)
+                petsc_lib = loader(exists_path)
             except OSError:
-                print(f"Failed to load shared library found at {exist_path}.")
+                print(f"Failed to load shared library found at {exists_path}.")
                 continue
 
     if petsc_lib is None:

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -743,7 +743,7 @@ class NonlinearProblem:
         A.assemble()
 
 
-def load_petsc_lib(loader: typing.Callable[[typing.Union[str, 'os.PathLike[typing.Any]']], typing.Any]) -> typing.Any:
+def load_petsc_lib(loader: typing.Callable[[str], typing.Any]) -> typing.Any:
     """
     Load PETSc shared library using loader callable, e.g. ctypes.CDLL.
 

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -72,7 +72,6 @@ else:
         f"Cannot translate PETSc scalar type to a C type, complex: {complex} size: {scalar_size}.")
 
 
-
 petsc_lib_ctypes = load_petsc_lib(ctypes.CDLL)
 # Get the PETSc MatSetValuesLocal function via ctypes
 # ctypes does not support static types well, ignore type check errors

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -24,7 +24,7 @@ import dolfinx
 import dolfinx.pkgconfig
 import ufl
 from dolfinx.fem import Function, FunctionSpace, form, transpose_dofmap
-from dolfinx.fem.petsc import assemble_matrix
+from dolfinx.fem.petsc import assemble_matrix, load_petsc_lib
 from dolfinx.mesh import create_unit_square
 from ufl import dx, inner
 
@@ -72,33 +72,8 @@ else:
         f"Cannot translate PETSc scalar type to a C type, complex: {complex} size: {scalar_size}.")
 
 
-# Load PETSc library via ctypes
-petsc_lib_path = ctypes.util.find_library("petsc")
-if petsc_lib_path is not None:
-    try:
-        petsc_lib_ctypes = ctypes.CDLL(petsc_lib_path)
-    except OSError as exc:
-        raise RuntimeError(f"Could not load shared library at {petsc_lib_path} using ctypes.") from exc
 
-else:
-    candidate_paths = [os.path.join(petsc_dir, petsc_arch, "lib", "libpetsc.so"),
-                       os.path.join(petsc_dir, petsc_arch, "lib", "libpetsc.dylib")]
-
-    for candidate_path in candidate_paths:
-        if not os.path.exists(candidate_path):
-            candidate_paths.remove(candidate_path)
-
-    if len(candidate_paths) == 0:
-        raise RuntimeError("Could not find a PETSc shared library.")
-
-    for candidate_path in candidate_paths:
-        if os.path.exists(candidate_path):
-            try:
-                petsc_lib_ctypes = ctypes.CDLL(candidate_path)
-            except OSError as exc:
-                raise RuntimeError(f"Could not load shared library at {candidate_path} using ctypes.") from exc
-
-
+petsc_lib_ctypes = load_petsc_lib(ctypes.CDLL)
 # Get the PETSc MatSetValuesLocal function via ctypes
 # ctypes does not support static types well, ignore type check errors
 MatSetValues_ctypes = petsc_lib_ctypes.MatSetValuesLocal
@@ -118,31 +93,7 @@ ffi.cdef("""int MatSetValuesLocal(void* mat, {0} nrow, const {0}* irow,
 """.format(c_int_t, c_scalar_t))
 
 
-petsc_lib_path = ctypes.util.find_library("petsc")
-if petsc_lib_path is not None:
-    try:
-        petsc_lib_cffi = ffi.dlopen(petsc_lib_path)
-    except OSError as exc:
-        raise RuntimeError(f"Could not load PETSc shared object located at {petsc_lib_path} in CFFI ABI mode.") from exc
-
-else:
-    candidate_paths = [os.path.join(petsc_dir, petsc_arch, "lib", "libpetsc.so"),
-                       os.path.join(petsc_dir, petsc_arch, "lib", "libpetsc.dylib")]
-    for candidate_path in candidate_paths:
-        if not os.path.exists(candidate_path):
-            candidate_paths.remove(candidate_path)
-
-    if len(candidate_paths) == 0:
-        raise RuntimeError("Could not find PETSc shared library.")
-
-    for candidate_path in candidate_paths:
-        if os.path.exists(candidate_path):
-            try:
-                petsc_lib_cffi = ffi.dlopen(candidate_path)
-            except OSError as exc:
-                raise RuntimeError(
-                    f"Could not load PETSc shared object located at {candidate_path} in CFFI ABI mode.") from exc
-
+petsc_lib_cffi = load_petsc_lib(ffi.dlopen)
 MatSetValues_abi = petsc_lib_cffi.MatSetValuesLocal
 
 

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -72,7 +72,7 @@ else:
         f"Cannot translate PETSc scalar type to a C type, complex: {complex} size: {scalar_size}.")
 
 
-petsc_lib_ctypes = load_petsc_lib(ctypes.CDLL)
+petsc_lib_ctypes = load_petsc_lib(ctypes.cdll.LoadLibrary)
 # Get the PETSc MatSetValuesLocal function via ctypes
 # ctypes does not support static types well, ignore type check errors
 MatSetValues_ctypes = petsc_lib_ctypes.MatSetValuesLocal

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -143,33 +143,33 @@ def test_entity_closure_dofs(mesh_factory):
         assert set(V.dofmap.entity_closure_dofs(mesh, d, all_cells)) == set(range(V.dim))
 
 
-@pytest.mark.skip
 def test_block_size(mesh):
     meshes = [
-        create_unit_square(8, 8),
-        create_unit_cube(4, 4, 4),
-        create_unit_square(8, 8, CellType.quadrilateral),
-        create_unit_cube(4, 4, 4, CellType.hexahedron)
+        create_unit_square(MPI.COMM_WORLD, 8, 8),
+        create_unit_cube(MPI.COMM_WORLD, 4, 4, 4),
+        create_unit_square(MPI.COMM_WORLD, 8, 8, CellType.quadrilateral),
+        create_unit_cube(MPI.COMM_WORLD, 4, 4, 4, CellType.hexahedron)
     ]
     for mesh in meshes:
         P2 = FiniteElement("Lagrange", mesh.ufl_cell(), 2)
 
         V = FunctionSpace(mesh, P2)
         assert V.dofmap.bs == 1
-
-        V = FunctionSpace(mesh, P2 * P2)
-        assert V.dofmap.index_map_bs == 2
+        
+        # Only VectorElements have index_map_bs > 1
+        V = FunctionSpace(mesh, MixedElement([P2, P2]))
+        assert V.dofmap.index_map_bs == 1
 
         for i in range(1, 6):
             W = FunctionSpace(mesh, MixedElement(i * [P2]))
-            assert W.dofmap.index_map_bs == i
+            assert W.dofmap.index_map_bs == 1
 
         V = VectorFunctionSpace(mesh, ("Lagrange", 2))
         assert V.dofmap.index_map_bs == mesh.geometry.dim
 
 
 @pytest.mark.skip
-def test_block_size_real(mesh):
+def test_block_size_real():
     mesh = create_unit_interval(MPI.COMM_WORLD, 12)
     V = FiniteElement('DG', mesh.ufl_cell(), 0)
     R = FiniteElement('R', mesh.ufl_cell(), 0)

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -155,7 +155,7 @@ def test_block_size(mesh):
 
         V = FunctionSpace(mesh, P2)
         assert V.dofmap.bs == 1
-        
+
         # Only VectorElements have index_map_bs > 1
         V = FunctionSpace(mesh, MixedElement([P2, P2]))
         assert V.dofmap.index_map_bs == 1

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -6,7 +6,6 @@
 
 import ctypes
 import ctypes.util
-import os
 
 import cffi
 import numba
@@ -17,6 +16,7 @@ import basix
 import dolfinx.cpp
 import ufl
 from dolfinx.cpp.la.petsc import create_matrix
+from dolfinx.fem.petsc import load_petsc_lib
 from dolfinx.fem import (Constant, Expression, Function, FunctionSpace,
                          VectorFunctionSpace, create_sparsity_pattern, form)
 from dolfinx.mesh import create_unit_square
@@ -76,16 +76,7 @@ int MatAssemblyBegin(void* mat, int mode);
 int MatAssemblyEnd(void* mat, int mode);
 """.format(c_int_t, c_scalar_t))
 
-if petsc_lib_name is not None:
-    petsc_lib_cffi = ffi.dlopen(petsc_lib_name)
-else:
-    try:
-        petsc_lib_cffi = ffi.dlopen(os.path.join(petsc_dir, petsc_arch, "lib", "libpetsc.so"))
-    except OSError:
-        petsc_lib_cffi = ffi.dlopen(os.path.join(petsc_dir, petsc_arch, "lib", "libpetsc.dylib"))
-    except OSError:
-        print("Could not load PETSc library for CFFI (ABI mode).")
-        raise
+petsc_lib_cffi = load_petsc_lib(ffi.dlopen)
 MatSetValues = petsc_lib_cffi.MatSetValuesLocal
 
 

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -21,16 +21,10 @@ from dolfinx.fem import (Constant, Expression, Function, FunctionSpace,
                          VectorFunctionSpace, create_sparsity_pattern, form)
 from dolfinx.mesh import create_unit_square
 
-import petsc4py.lib
 from mpi4py import MPI
 from petsc4py import PETSc
-from petsc4py import get_config as PETSc_get_config
 
 dolfinx.cpp.common.init_logging(["-v"])
-# Get details of PETSc install
-petsc_dir = PETSc_get_config()['PETSC_DIR']
-petsc_arch = petsc4py.lib.getPathArchPETSc()[1]
-petsc_lib_name = ctypes.util.find_library("petsc")
 
 # Get PETSc int and scalar types
 if np.dtype(PETSc.ScalarType).kind == 'c':

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -85,7 +85,7 @@ def test_component(V, W, Q):
 
 
 def test_equality(V, V2, W, W2):
-    assert V == V # /NOSONAR
+    assert V == V  # /NOSONAR
     assert V == V2
     assert W == W
     assert W == W2

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -85,7 +85,7 @@ def test_component(V, W, Q):
 
 
 def test_equality(V, V2, W, W2):
-    assert V == V
+    assert V == V # /NOSONAR
     assert V == V2
     assert W == W
     assert W == W2


### PR DESCRIPTION
This PR fixes a few bugs picked up by SonarCloud.

Because the code with the two `except OSError` was incorrect (an exception block can only pickup a single exception type at a time) and used in three places

I decided to refactor the PETSc shared library loader into its own function. I removed the call to find the PETSc library using ctypes, this is likely to create a conflict with the version that petsc4py was compiled against. It still works if the library is in e.g. `/usr/local/lib` as shown by the successful RockyLinux CI run.