### PR TITLE
Improve `create_submesh` performance

### DIFF
--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -193,11 +193,9 @@ std::tuple<Mesh, std::vector<std::int32_t>, std::vector<std::int32_t>,
 mesh::create_submesh(const Mesh& mesh, int dim,
                      const std::span<const std::int32_t>& entities)
 {
-  std::cout << "Topology\n";
   // -- Submesh topology
   const Topology& topology = mesh.topology();
 
-  std::cout << "Gat owned submesh entities\n";
   // Get the entities in the submesh that are owned by this process
   auto mesh_entity_index_map = topology.index_map(dim);
   assert(mesh_entity_index_map);
@@ -208,7 +206,6 @@ mesh::create_submesh(const Mesh& mesh, int dim,
                [size = mesh_entity_index_map->size_local()](std::int32_t e)
                { return e < size; });
 
-  std::cout << "Create entity map\n";
   // Create a map from the (local) entities in the submesh to the
   // (local) entities in the mesh, and create the submesh entity index
   // map.
@@ -239,7 +236,6 @@ mesh::create_submesh(const Mesh& mesh, int dim,
                      std::int32_t entity_index)
                  { return size_local + entity_index; });
 
-  std::cout << "Get vertices\n";
   // Get the vertices in the submesh. Use submesh_to_mesh_entity_map
   // (instead of `entities`) to ensure vertices for ghost entities are
   // included
@@ -259,7 +255,6 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   auto submesh_vertex_index_map = std::make_shared<common::IndexMap>(
       std::move(submesh_vertex_index_map_pair.first));
 
-  std::cout << "Create vertex map\n";
   // Create a map from the (local) vertices in the submesh to the
   // (local) vertices in the mesh
   std::vector<int32_t> submesh_to_mesh_vertex_map(
@@ -279,8 +274,6 @@ mesh::create_submesh(const Mesh& mesh, int dim,
       submesh_vertex_index_map->size_local()
       + submesh_vertex_index_map->num_ghosts());
 
-  std::cout << "Entity to vertex connectivity\n";
-
   // Submesh entity to vertex connectivity
   const CellType entity_type = cell_entity_type(topology.cell_type(), dim, 0);
   const int num_vertices_per_entity = cell_num_entities(entity_type, 0);
@@ -291,8 +284,6 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   std::vector<std::int32_t> submesh_e_to_v_offsets(1, 0);
   submesh_e_to_v_offsets.reserve(submesh_to_mesh_entity_map.size() + 1);
 
-  std::cout << "Create inverse vertex map\n";
-
   std::vector<int32_t> mesh_to_submesh_vertex_map(
       mesh_vertex_index_map->size_local() + mesh_vertex_index_map->num_ghosts(),
       -1);
@@ -301,7 +292,6 @@ mesh::create_submesh(const Mesh& mesh, int dim,
     mesh_to_submesh_vertex_map[submesh_to_mesh_vertex_map[i]] = i;
   }
 
-  std::cout << "Loop through entities\n";
   for (std::int32_t e : submesh_to_mesh_entity_map)
   {
     std::span<const std::int32_t> vertices = mesh_e_to_v->links(e);
@@ -316,7 +306,6 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   auto submesh_e_to_v = std::make_shared<graph::AdjacencyList<std::int32_t>>(
       std::move(submesh_e_to_v_vec), std::move(submesh_e_to_v_offsets));
 
-  std::cout << "Create topology\n";
   // Create submesh topology
   Topology submesh_topology(mesh.comm(), entity_type);
   submesh_topology.set_index_map(0, submesh_vertex_index_map);
@@ -324,7 +313,6 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   submesh_topology.set_connectivity(submesh_v_to_v, 0, 0);
   submesh_topology.set_connectivity(submesh_e_to_v, dim, 0);
 
-  std::cout << "Geometry\n";
   // -- Submesh geometry
   const Geometry& geometry = mesh.geometry();
 
@@ -425,7 +413,6 @@ mesh::create_submesh(const Mesh& mesh, int dim,
     mesh_to_submesh_x_dof_map[submesh_to_mesh_x_dof_map[i]] = i;
   }
 
-  std::cout << "Geom dofmap\n";
   // Crete submesh geometry dofmap
   std::vector<std::int32_t> entity_x_dofs;
   std::vector<std::int32_t> submesh_x_dofmap_vec;
@@ -449,7 +436,6 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   }
   graph::AdjacencyList<std::int32_t> submesh_x_dofmap(
       std::move(submesh_x_dofmap_vec), std::move(submesh_x_dofmap_offsets));
-  std::cout << "Geom dofmap done\n";
 
   // Create submesh coordinate element
   CellType submesh_coord_cell
@@ -472,8 +458,6 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   Geometry submesh_geometry(
       submesh_x_dof_index_map, std::move(submesh_x_dofmap), submesh_coord_ele,
       std::move(submesh_x), geometry.dim(), std::move(submesh_igi));
-
-  std::cout << "Done\n";
 
   return {Mesh(mesh.comm(), std::move(submesh_topology),
                std::move(submesh_geometry)),

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -288,7 +288,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   // submesh_to_mesh_vertex_map)
   // NOTE: Depending on the submesh, this may be densely or sparsely
   // populated. Is a different data structure more appropriate?
-  std::vector<int32_t> mesh_to_submesh_vertex_map(
+  std::vector<std::int32_t> mesh_to_submesh_vertex_map(
       mesh_vertex_index_map->size_local() + mesh_vertex_index_map->num_ghosts(),
       -1);
   for (std::size_t i = 0; i < submesh_to_mesh_vertex_map.size(); ++i)
@@ -409,7 +409,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   }
 
   // Create mesh to submesh geometry map
-  std::vector<int32_t> mesh_to_submesh_x_dof_map(
+  std::vector<std::int32_t> mesh_to_submesh_x_dof_map(
       mesh_geometry_dof_index_map->size_local()
           + mesh_geometry_dof_index_map->num_ghosts(),
       -1);

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -294,8 +294,8 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   std::cout << "Create inverse vertex map\n";
 
   std::vector<int32_t> mesh_to_submesh_vertex_map(
-      mesh_vertex_index_map->size_local()
-      + mesh_vertex_index_map->num_ghosts(), -1);
+      mesh_vertex_index_map->size_local() + mesh_vertex_index_map->num_ghosts(),
+      -1);
   for (std::size_t i = 0; i < submesh_to_mesh_vertex_map.size(); ++i)
   {
     mesh_to_submesh_vertex_map[submesh_to_mesh_vertex_map[i]] = i;
@@ -416,9 +416,18 @@ mesh::create_submesh(const Mesh& mesh, int dim,
                 std::next(submesh_x.begin(), 3 * i));
   }
 
-  std::vector<std::int32_t> entity_x_dofs;
+  std::vector<int32_t> mesh_to_submesh_x_dof_map(
+      mesh_geometry_dof_index_map->size_local()
+          + mesh_geometry_dof_index_map->num_ghosts(),
+      -1);
+  for (std::size_t i = 0; i < submesh_to_mesh_x_dof_map.size(); ++i)
+  {
+    mesh_to_submesh_x_dof_map[submesh_to_mesh_x_dof_map[i]] = i;
+  }
 
+  std::cout << "Geom dofmap\n";
   // Crete submesh geometry dofmap
+  std::vector<std::int32_t> entity_x_dofs;
   std::vector<std::int32_t> submesh_x_dofmap_vec;
   submesh_x_dofmap_vec.reserve(geometry_indices.size());
   std::vector<std::int32_t> submesh_x_dofmap_offsets(1, 0);
@@ -432,16 +441,15 @@ mesh::create_submesh(const Mesh& mesh, int dim,
     // For each mesh dof of the entity, get the submesh dof
     for (std::int32_t x_dof : entity_x_dofs)
     {
-      auto it = std::find(submesh_to_mesh_x_dof_map.begin(),
-                          submesh_to_mesh_x_dof_map.end(), x_dof);
-      assert(it != submesh_to_mesh_x_dof_map.end());
-      submesh_x_dofmap_vec.push_back(
-          std::distance(submesh_to_mesh_x_dof_map.begin(), it));
+      std::int32_t x_dof_submesh = mesh_to_submesh_x_dof_map[x_dof];
+      assert(x_dof_submesh != -1);
+      submesh_x_dofmap_vec.push_back(x_dof_submesh);
     }
     submesh_x_dofmap_offsets.push_back(submesh_x_dofmap_vec.size());
   }
   graph::AdjacencyList<std::int32_t> submesh_x_dofmap(
       std::move(submesh_x_dofmap_vec), std::move(submesh_x_dofmap_offsets));
+  std::cout << "Geom dofmap done\n";
 
   // Create submesh coordinate element
   CellType submesh_coord_cell

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -284,6 +284,10 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   std::vector<std::int32_t> submesh_e_to_v_offsets(1, 0);
   submesh_e_to_v_offsets.reserve(submesh_to_mesh_entity_map.size() + 1);
 
+  // Create mesh to submesh vertex map (i.e. the inverse of
+  // submesh_to_mesh_vertex_map)
+  // NOTE: Depending on the submesh, this may be densely or sparsely
+  // populated. Is a different data structure more appropriate?
   std::vector<int32_t> mesh_to_submesh_vertex_map(
       mesh_vertex_index_map->size_local() + mesh_vertex_index_map->num_ghosts(),
       -1);
@@ -404,6 +408,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
                 std::next(submesh_x.begin(), 3 * i));
   }
 
+  // Create mesh to submesh geometry map
   std::vector<int32_t> mesh_to_submesh_x_dof_map(
       mesh_geometry_dof_index_map->size_local()
           + mesh_geometry_dof_index_map->num_ghosts(),
@@ -413,7 +418,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
     mesh_to_submesh_x_dof_map[submesh_to_mesh_x_dof_map[i]] = i;
   }
 
-  // Crete submesh geometry dofmap
+  // Create submesh geometry dofmap
   std::vector<std::int32_t> entity_x_dofs;
   std::vector<std::int32_t> submesh_x_dofmap_vec;
   submesh_x_dofmap_vec.reserve(geometry_indices.size());

--- a/cpp/dolfinx/mesh/Mesh.cpp
+++ b/cpp/dolfinx/mesh/Mesh.cpp
@@ -197,21 +197,20 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   const Topology& topology = mesh.topology();
 
   // Get the entities in the submesh that are owned by this process
-  auto mesh_entity_index_map = topology.index_map(dim);
-  assert(mesh_entity_index_map);
+  auto mesh_map = topology.index_map(dim);
+  assert(mesh_map);
 
-  std::vector<std::int32_t> submesh_owned_entities;
-  std::copy_if(entities.begin(), entities.end(),
-               std::back_inserter(submesh_owned_entities),
-               [size = mesh_entity_index_map->size_local()](std::int32_t e)
-               { return e < size; });
+  std::vector<std::int32_t> submesh_owned;
+  std::copy_if(
+      entities.begin(), entities.end(), std::back_inserter(submesh_owned),
+      [size = mesh_map->size_local()](std::int32_t e) { return e < size; });
 
   // Create a map from the (local) entities in the submesh to the
   // (local) entities in the mesh, and create the submesh entity index
   // map.
-  std::vector<int32_t> submesh_to_mesh_entity_map(
-      submesh_owned_entities.begin(), submesh_owned_entities.end());
-  std::shared_ptr<common::IndexMap> submesh_entity_index_map;
+  std::vector<int32_t> submesh_to_mesh_map(submesh_owned.begin(),
+                                           submesh_owned.end());
+  std::shared_ptr<common::IndexMap> submesh_map;
 
   // Create submesh entity index map
   // TODO Call common::get_owned_indices here? Do we want to
@@ -220,27 +219,26 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   // TODO Should entities still be ghosted in the submesh even if they
   // are not in the `entities` list? If this is not desirable,
   // create_submap needs to be changed
-  std::pair<common::IndexMap, std::vector<int32_t>>
-      submesh_entity_index_map_pair
-      = mesh_entity_index_map->create_submap(submesh_owned_entities);
-  submesh_entity_index_map = std::make_shared<common::IndexMap>(
-      std::move(submesh_entity_index_map_pair.first));
+  std::pair<common::IndexMap, std::vector<int32_t>> submesh_index_map_pair
+      = mesh_map->create_submap(submesh_owned);
+  submesh_map = std::make_shared<common::IndexMap>(
+      std::move(submesh_index_map_pair.first));
 
   // Add ghost entities to the entity map
-  submesh_to_mesh_entity_map.reserve(submesh_entity_index_map->size_local()
-                                     + submesh_entity_index_map->num_ghosts());
-  std::transform(submesh_entity_index_map_pair.second.begin(),
-                 submesh_entity_index_map_pair.second.end(),
-                 std::back_inserter(submesh_to_mesh_entity_map),
-                 [size_local = mesh_entity_index_map->size_local()](
-                     std::int32_t entity_index)
-                 { return size_local + entity_index; });
+  submesh_to_mesh_map.reserve(submesh_map->size_local()
+                              + submesh_map->num_ghosts());
+  std::transform(
+      submesh_index_map_pair.second.begin(),
+      submesh_index_map_pair.second.end(),
+      std::back_inserter(submesh_to_mesh_map),
+      [size_local = mesh_map->size_local()](std::int32_t entity_index)
+      { return size_local + entity_index; });
 
-  // Get the vertices in the submesh. Use submesh_to_mesh_entity_map
+  // Get the vertices in the submesh. Use submesh_to_mesh_map
   // (instead of `entities`) to ensure vertices for ghost entities are
   // included
   std::vector<std::int32_t> submesh_vertices
-      = compute_incident_entities(mesh, submesh_to_mesh_entity_map, dim, 0);
+      = compute_incident_entities(mesh, submesh_to_mesh_map, dim, 0);
 
   // Get the vertices in the submesh owned by this process
   auto mesh_vertex_index_map = topology.index_map(0);
@@ -249,25 +247,29 @@ mesh::create_submesh(const Mesh& mesh, int dim,
       = common::compute_owned_indices(submesh_vertices, *mesh_vertex_index_map);
 
   // Create submesh vertex index map
-  std::pair<common::IndexMap, std::vector<int32_t>>
-      submesh_vertex_index_map_pair
-      = mesh_vertex_index_map->create_submap(submesh_owned_vertices);
-  auto submesh_vertex_index_map = std::make_shared<common::IndexMap>(
-      std::move(submesh_vertex_index_map_pair.first));
+  std::shared_ptr<common::IndexMap> submesh_vertex_index_map;
+  std::vector<int32_t> submesh_to_mesh_vertex_map;
+  {
+    std::pair<common::IndexMap, std::vector<int32_t>> index_map_data
+        = mesh_vertex_index_map->create_submap(submesh_owned_vertices);
+    submesh_vertex_index_map
+        = std::make_shared<common::IndexMap>(std::move(index_map_data.first));
 
-  // Create a map from the (local) vertices in the submesh to the
-  // (local) vertices in the mesh
-  std::vector<int32_t> submesh_to_mesh_vertex_map(
-      submesh_owned_vertices.begin(), submesh_owned_vertices.end());
-  submesh_to_mesh_vertex_map.reserve(submesh_vertex_index_map->size_local()
-                                     + submesh_vertex_index_map->num_ghosts());
-  // Add ghost vertices to the map
-  std::transform(submesh_vertex_index_map_pair.second.begin(),
-                 submesh_vertex_index_map_pair.second.end(),
-                 std::back_inserter(submesh_to_mesh_vertex_map),
-                 [size_local = mesh_vertex_index_map->size_local()](
-                     std::int32_t vertex_index)
-                 { return size_local + vertex_index; });
+    // Create a map from the (local) vertices in the submesh to the
+    // (local) vertices in the mesh
+    submesh_to_mesh_vertex_map.assign(submesh_owned_vertices.begin(),
+                                      submesh_owned_vertices.end());
+    submesh_to_mesh_vertex_map.reserve(
+        submesh_vertex_index_map->size_local()
+        + submesh_vertex_index_map->num_ghosts());
+
+    // Add ghost vertices to the map
+    std::transform(index_map_data.second.begin(), index_map_data.second.end(),
+                   std::back_inserter(submesh_to_mesh_vertex_map),
+                   [size_local = mesh_vertex_index_map->size_local()](
+                       std::int32_t vertex_index)
+                   { return size_local + vertex_index; });
+  }
 
   // Submesh vertex to vertex connectivity (identity)
   auto submesh_v_to_v = std::make_shared<graph::AdjacencyList<std::int32_t>>(
@@ -279,10 +281,10 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   const int num_vertices_per_entity = cell_num_entities(entity_type, 0);
   auto mesh_e_to_v = topology.connectivity(dim, 0);
   std::vector<std::int32_t> submesh_e_to_v_vec;
-  submesh_e_to_v_vec.reserve(submesh_to_mesh_entity_map.size()
+  submesh_e_to_v_vec.reserve(submesh_to_mesh_map.size()
                              * num_vertices_per_entity);
   std::vector<std::int32_t> submesh_e_to_v_offsets(1, 0);
-  submesh_e_to_v_offsets.reserve(submesh_to_mesh_entity_map.size() + 1);
+  submesh_e_to_v_offsets.reserve(submesh_to_mesh_map.size() + 1);
 
   // Create mesh to submesh vertex map (i.e. the inverse of
   // submesh_to_mesh_vertex_map)
@@ -296,7 +298,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
     mesh_to_submesh_vertex_map[submesh_to_mesh_vertex_map[i]] = i;
   }
 
-  for (std::int32_t e : submesh_to_mesh_entity_map)
+  for (std::int32_t e : submesh_to_mesh_map)
   {
     std::span<const std::int32_t> vertices = mesh_e_to_v->links(e);
     for (std::int32_t v : vertices)
@@ -313,7 +315,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   // Create submesh topology
   Topology submesh_topology(mesh.comm(), entity_type);
   submesh_topology.set_index_map(0, submesh_vertex_index_map);
-  submesh_topology.set_index_map(dim, submesh_entity_index_map);
+  submesh_topology.set_index_map(dim, submesh_map);
   submesh_topology.set_connectivity(submesh_v_to_v, 0, 0);
   submesh_topology.set_connectivity(submesh_e_to_v, dim, 0);
 
@@ -326,8 +328,8 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   // NOTE: Unclear what this return for prisms
   const std::size_t num_entity_dofs = layout.num_entity_closure_dofs(dim);
 
-  std::vector<std::int32_t> geometry_indices(
-      num_entity_dofs * submesh_to_mesh_entity_map.size());
+  std::vector<std::int32_t> geometry_indices(num_entity_dofs
+                                             * submesh_to_mesh_map.size());
   {
     const graph::AdjacencyList<std::int32_t>& xdofs = geometry.dofmap();
     const int tdim = topology.dim();
@@ -344,9 +346,9 @@ mesh::create_submesh(const Mesh& mesh, int dim,
     std::shared_ptr<const graph::AdjacencyList<int>> c_to_e
         = topology.connectivity(tdim, dim);
     assert(c_to_e);
-    for (std::size_t i = 0; i < submesh_to_mesh_entity_map.size(); ++i)
+    for (std::size_t i = 0; i < submesh_to_mesh_map.size(); ++i)
     {
-      const std::int32_t idx = submesh_to_mesh_entity_map[i];
+      const std::int32_t idx = submesh_to_mesh_map[i];
       assert(!e_to_c->links(idx).empty());
       // Always pick the last cell to be consistent with the e_to_v connectivity
       const std::int32_t cell = e_to_c->links(idx).back();
@@ -423,8 +425,8 @@ mesh::create_submesh(const Mesh& mesh, int dim,
   std::vector<std::int32_t> submesh_x_dofmap_vec;
   submesh_x_dofmap_vec.reserve(geometry_indices.size());
   std::vector<std::int32_t> submesh_x_dofmap_offsets(1, 0);
-  submesh_x_dofmap_offsets.reserve(submesh_to_mesh_entity_map.size() + 1);
-  for (std::size_t i = 0; i < submesh_to_mesh_entity_map.size(); ++i)
+  submesh_x_dofmap_offsets.reserve(submesh_to_mesh_map.size() + 1);
+  for (std::size_t i = 0; i < submesh_to_mesh_map.size(); ++i)
   {
     // Get the mesh geometry dofs for ith entity in entities
     auto it = std::next(geometry_indices.begin(), i * num_entity_dofs);
@@ -466,8 +468,7 @@ mesh::create_submesh(const Mesh& mesh, int dim,
 
   return {Mesh(mesh.comm(), std::move(submesh_topology),
                std::move(submesh_geometry)),
-          std::move(submesh_to_mesh_entity_map),
-          std::move(submesh_to_mesh_vertex_map),
+          std::move(submesh_to_mesh_map), std::move(submesh_to_mesh_vertex_map),
           std::move(submesh_to_mesh_x_dof_map)};
 }
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
The current implementation of `create_submesh` does not scale due to an `std::find` on a potentially large array in a tight loop. This PR precomputes the map to avoid this issue.

Performance results:

I ran the following code for different values of `n`:
```
msh = mesh.create_unit_cube(
        MPI.COMM_WORLD, n, n, n, ghost_mode=mesh.GhostMode.none)
tdim = msh.topology.dim
entities = mesh.locate_entities(msh, tdim, lambda x: x[0] <= 0.5)
mesh.create_submesh(msh, tdim, entities)
```
The timings are as follows:

|  | `n = 8` | `n = 16` | `n = 32` |
| ------------- | ------------- | ------------- | ------------- |
| Main  | 0.0365 s  | 0.861 s  | 46.6 s |
| This branch  | 0.00904 s  | 0.0459 s  | 0.38 s  |

The difference in performance gets larger as the mesh size increases.