### PR TITLE
Attempt to use pyproject.toml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ build-python-interface: &build-python-interface
   name: Build Python/pybind11 interface
   command: |
     cd python
-    pip3 -v install --global-option build --global-option --debug . --user
+    pip3 -v install --no-build-isolation --global-option build --global-option --debug . --user
 
 demos-python: &demos-python
   name: Run demos (Python, serial)

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   build:
     if: "!(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: fenicsproject/test-env:nightly-openmpi
 
     env:
@@ -64,8 +64,6 @@ jobs:
           python3 -m pip install git+https://github.com/FEniCS/basix.git@${{ github.event.inputs.basix_ref }}
           python3 -m pip install git+https://github.com/FEniCS/ffcx.git@${{ github.event.inputs.ffcx_ref }}
 
-      - name: Install matplotlib
-        run: pip3 install matplotlib
       - name: Flake8 checks
         run: |
           cd python/
@@ -79,7 +77,7 @@ jobs:
           python3 -m isort --check .
       - name: mypy checks
         run: |
-          python3 -m pip install types-setuptools
+          python3 -m pip install types-setuptools # TODO: Remove
           cd python/
           mypy dolfinx
           mypy demo
@@ -105,7 +103,7 @@ jobs:
 
       - name: Build C++ interface documentation
         run: |
-          python3 -m pip install breathe
+          python3 -m pip install breathe # TODO: Remove
           export DOLFINX_VERSION=`cmake -L build | grep DOXYGEN_DOLFINX_VERSION | cut -f2 -d "="`
           echo $DOLFINX_VERSION
           cd cpp/doc
@@ -133,10 +131,10 @@ jobs:
           ctest -V -R demo -R mpi_2
 
       - name: Build Python interface
-        run: python3 -m pip -v install --global-option build --global-option --debug python/
+        run: |
+          python3 -m pip -v install --no-build-isolation --global-option build --global-option --debug python/
       - name: Build Python interface documentation
         run: |
-          python3 -m pip install sphinx==5.0.2
           cd python/doc
           make html
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -51,6 +51,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Upgrade setuptools and pip
+        run: |
+          python3 -m pip install --upgrade pip setuptools # TODO: Remove
+
       - name: Install FEniCS Python components (default branches/tags)
         if: github.event_name != 'workflow_dispatch'
         run: |

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Build DOLFINx Python interface
         run: |
           . /opt/intel/oneapi/setvars.sh
-          python3 -m pip -v install python/
+          python3 -m pip -v install --no-build-isolation python/
       - name: Set default DOLFINx JIT options
         run: |
           mkdir -p ~/.config/dolfinx

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -97,7 +97,7 @@ jobs:
           source fenicsx/bin/activate
           cd dolfinx
           PETSC_DIR=$GITHUB_WORKSPACE/petsc PETSC_ARCH=arch-darwin-c-opt \
-          python -m pip -v install python/
+          python -m pip -v install --no-build-isolation python/
 
       - name: Basic test
         run: |

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -17,6 +17,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      
+      - name: Upgrade setuptools and pip
+        run: |
+          python3 -m pip install --upgrade pip setuptools # TODO: Remove
 
       - name: Install FEniCS Python components
         run: |

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -53,7 +53,7 @@ jobs:
           ctest -V -R demo -R mpi_2
 
       - name: Build Python interface
-        run: python3 -m pip -v install --global-option build --global-option --debug python/
+        run: python3 -m pip -v install --no-build-isolation --global-option build --global-option --debug python/
 
       - name: Set default DOLFINx JIT options
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -176,8 +176,9 @@ RUN if [ "$MPI" = "mpich" ]; then \
 # - First set of packages are required to build and run DOLFINx Python.
 # - Second set of packages are recommended and/or required to build
 #   documentation or run tests.
-RUN pip3 install --no-binary="numpy" --no-cache-dir cffi mpi4py numba numpy==${NUMPY_VERSION} scipy && \
-    pip3 install --no-cache-dir cppimport flake8 isort jupytext matplotlib mypy myst-parser pybind11==${PYBIND11_VERSION} pytest pytest-xdist sphinx sphinx_rtd_theme
+RUN pip3 install --upgrade pip setuptools && \
+    pip3 install --no-binary="numpy" --no-cache-dir cffi mpi4py numba numpy==${NUMPY_VERSION} scipy && \
+    pip3 install --no-cache-dir breathe cppimport flake8 isort jupytext matplotlib mypy myst-parser pybind11==${PYBIND11_VERSION} pytest pytest-xdist sphinx sphinx_rtd_theme types-setuptools
 
 # Install KaHIP
 RUN wget -nc --quiet https://github.com/kahip/kahip/archive/v${KAHIP_VERSION}.tar.gz && \
@@ -396,7 +397,7 @@ ONBUILD RUN cd dolfinx && \
     PETSC_ARCH=linux-gnu-real-32 cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-real -DCMAKE_BUILD_TYPE=${DOLFINX_CMAKE_BUILD_TYPE} -DCMAKE_CXX_FLAGS=${DOLFINX_CMAKE_CXX_FLAGS} ../cpp && \
     ninja install && \
     cd ../python && \
-    CXXFLAGS=${DOLFINX_CMAKE_CXX_FLAGS} PETSC_ARCH=linux-gnu-real-32 pip3 install -v --target /usr/local/dolfinx-real/lib/python${PYTHON_VERSION}/dist-packages --no-dependencies --no-cache-dir . && \
+    CXXFLAGS=${DOLFINX_CMAKE_CXX_FLAGS} PETSC_ARCH=linux-gnu-real-32 pip3 install -v --target /usr/local/dolfinx-real/lib/python${PYTHON_VERSION}/dist-packages --no-dependencies --no-cache-dir --no-build-isolation . && \
     git clean -fdx && \
     cd ../ && \
     mkdir -p build-complex && \
@@ -405,7 +406,7 @@ ONBUILD RUN cd dolfinx && \
     ninja install && \
     . /usr/local/dolfinx-complex/lib/dolfinx/dolfinx.conf && \
     cd ../python && \
-    CXXFLAGS=${DOLFINX_CMAKE_CXX_FLAGS} PETSC_ARCH=linux-gnu-complex-32 pip3 install -v --target /usr/local/dolfinx-complex/lib/python${PYTHON_VERSION}/dist-packages --no-dependencies --no-cache-dir .
+    CXXFLAGS=${DOLFINX_CMAKE_CXX_FLAGS} PETSC_ARCH=linux-gnu-complex-32 pip3 install -v --target /usr/local/dolfinx-complex/lib/python${PYTHON_VERSION}/dist-packages --no-dependencies --no-cache-dir --no-build-isolation .
 
 # Real by default.
 ONBUILD ENV PKG_CONFIG_PATH=/usr/local/dolfinx-real/lib/pkgconfig:$PKG_CONFIG_PATH \

--- a/docker/Dockerfile.redhat
+++ b/docker/Dockerfile.redhat
@@ -55,7 +55,8 @@ RUN curl -L -O http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MP
 
 # First set of dependencies for building and running Python DOLFINx
 # Second set of dependencies for running DOLFINx tests
-RUN python3 -m pip install --no-binary="numpy" --no-cache-dir cffi numba numpy==${NUMPY_VERSION} mpi4py pybind11==${PYBIND11_VERSION} wheel && \
+RUN python3 -m pip install --upgrade pip setuptools
+    python3 -m pip install --no-binary="numpy" --no-cache-dir cffi numba numpy==${NUMPY_VERSION} mpi4py pybind11==${PYBIND11_VERSION} wheel && \
     python3 -m pip install --no-cache-dir cppimport pytest pytest-xdist scipy matplotlib
 
 # Build PETSc

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -19,13 +19,6 @@ endif()
 find_package(pybind11 2.7.0 REQUIRED CONFIG HINTS ${PYBIND11_DIR} ${PYBIND11_ROOT}
   $ENV{PYBIND11_DIR} $ENV{PYBIND11_ROOT})
 
-execute_process(
-  COMMAND ${Python3_EXECUTABLE} -c "import basix, os, sys; sys.stdout.write(os.path.dirname(basix.__file__))"
-  OUTPUT_VARIABLE BASIX_PY_DIR
-  RESULT_VARIABLE BASIX_PY_COMMAND_RESULT
-  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-find_package(Basix REQUIRED CONFIG HINTS ${BASIX_PY_DIR})
-
 find_package(DOLFINX REQUIRED CONFIG)
 
 # Create the binding library

--- a/python/build-and-run-requirements.txt
+++ b/python/build-and-run-requirements.txt
@@ -1,0 +1,4 @@
+setuptools>=61
+petsc4py
+mpi4py
+pybind11

--- a/python/build-and-run-requirements.txt
+++ b/python/build-and-run-requirements.txt
@@ -1,4 +1,6 @@
 setuptools>=61
-petsc4py
+wheel
+#cmake>=3.16
 mpi4py
+petsc4py
 pybind11

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+# DOLFINx Python cannot be built in isolated mode without recompiling mpi4py and petsc4py
+# pip install -r build-and-run-requirements.txt
+# pip install --no-build-isolation .
+requires = ["setuptools>=61", "wheel"]
 
 build-backend = "setuptools.build_meta"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,7 +2,7 @@
 # DOLFINx Python cannot be built in isolated mode without recompiling mpi4py and petsc4py
 # pip install -r build-and-run-requirements.txt
 # pip install --no-build-isolation .
-requires = ["setuptools>=61", "wheel"]
+requires = ["setuptools>=61", "wheel", "petsc4py", "pybind11", "slepc4py"]
 
 build-backend = "setuptools.build_meta"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,7 +2,7 @@
 # DOLFINx Python cannot be built in isolated mode without recompiling mpi4py and petsc4py
 # pip install -r build-and-run-requirements.txt
 # pip install --no-build-isolation .
-requires = ["setuptools>=61", "wheel", "petsc4py", "pybind11", "slepc4py"]
+requires = ["setuptools>=61", "wheel", "cmake>=3.16", "mpi4py", "petsc4py", "pybind11"]
 
 build-backend = "setuptools.build_meta"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fenics-dolfinx"
+version = "0.5.3.dev0"
+authors = [{name="FEniCS Project Contributors"}]
+maintainers = [{name="FEniCS Project Steering Council", email="fenics-dev@googlegroups.com"}]
+description = "DOLFINx Python interface"
+readme = "README.rst"
+requires-python = ">=3.8"
+license = {text = "LGPLv3 or later"}
+dependencies = [
+  "cffi",
+  "numpy>=1.21",
+  "mpi4py",
+  "petsc4py",
+  "fenics-ffcx>=0.5.1.dev0,<0.6.0",
+  "fenics-ufl>=2022.3.0.dev0,<2022.4.0"
+]
+
+[project.urls]
+homepage = "https://fenicsproject.org"
+documentation = "https://docs.fenicsproject.org"
+issues = "https://github.com/FeniCS/ffcx/issues"
+funding = "https://numfocus.org/donate"
+
+[tool.setuptools.packages.find]
+where = ["dolfinx"]
+
+[tools.setuptools.package-data]
+dolfinx.wrappers = ["*.h"]
+"*" = ["py.typed"]
+
+[tools.setuptools]
+packages = ["dolfinx", "dolfinx.fem", "dolfinx.io", "dolfinx.nls", "dolfinx.wrappers"]
+zip-safe = false

--- a/python/setup.py
+++ b/python/setup.py
@@ -59,8 +59,6 @@ class CMakeBuild(build_ext):
 
         import pybind11
         env['pybind11_DIR'] = pybind11.get_cmake_dir()
-        env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
-                                                              self.distribution.get_version())
 
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,16 +3,12 @@ import shlex
 import subprocess
 import sys
 import sysconfig
+from pathlib import Path
 
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-if sys.version_info < (3, 8):
-    print("Python 3.8 or higher required, please upgrade.")
-    sys.exit(1)
-
 VERSION = "0.5.2.dev0"
-
 REQUIREMENTS = [
     "cffi",
     "numpy>=1.21",
@@ -24,9 +20,9 @@ REQUIREMENTS = [
 
 
 class CMakeExtension(Extension):
-    def __init__(self, name, sourcedir=''):
-        Extension.__init__(self, name, sources=[])
-        self.sourcedir = os.path.abspath(sourcedir)
+    def __init__(self, name: str, sourcedir: str = "") -> None:
+        super().__init__(name, sources=[])
+        self.sourcedir = os.fspath(Path(sourcedir).resolve())
 
 
 class CMakeBuild(build_ext):
@@ -36,34 +32,36 @@ class CMakeBuild(build_ext):
         except OSError:
             raise RuntimeError("CMake must be installed to build the following extensions: "
                                + ", ".join(e.name for e in self.extensions))
-
         for ext in self.extensions:
             self.build_extension(ext)
 
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = shlex.split(os.environ.get("CMAKE_ARGS", ""))
-        cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-                       '-DPython3_EXECUTABLE=' + sys.executable,
-                       f'-DPython3_LIBRARIES={sysconfig.get_config_var("LIBDEST")}',
+        cmake_args += [f'-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}',
+                       f'-DPython3_EXECUTABLE={sys.executable}',
                        f'-DPython3_INCLUDE_DIRS={sysconfig.get_config_var("INCLUDEPY")}']
+
+        # if "pybind11_DIR" not in os.environ:
+        import pybind11
+        cmake_args += [f'-DPYBIND11_DIR={pybind11.get_cmake_dir()}']
 
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]
         cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
 
-        env = os.environ.copy()
-        # default to 3 build threads
-        if "CMAKE_BUILD_PARALLEL_LEVEL" not in env:
-            env["CMAKE_BUILD_PARALLEL_LEVEL"] = "3"
+        # Default to 3 build threads
+        if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
+            build_args += ['-j3']
 
-        import pybind11
-        env['pybind11_DIR'] = pybind11.get_cmake_dir()
+        # import pybind11
+        # env = os.environ.copy()
+        # env['pybind11_DIR'] = pybind11.get_cmake_dir()
 
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
-        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
-        subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp, env=env)
+        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp)
+        subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
 
 
 setup(name='fenics-dolfinx',
@@ -81,5 +79,5 @@ setup(name='fenics-dolfinx',
       ext_modules=[CMakeExtension('dolfinx.cpp')],
       cmdclass=dict(build_ext=CMakeBuild),
       install_requires=REQUIREMENTS,
-      setup_requires=["pybind11"],
-      zip_safe=False)
+      zip_safe=False,
+      python_requires=">=3.8",)

--- a/python/setup.py
+++ b/python/setup.py
@@ -8,16 +8,6 @@ from pathlib import Path
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-VERSION = "0.5.2.dev0"
-REQUIREMENTS = [
-    "cffi",
-    "numpy>=1.21",
-    "mpi4py",
-    "petsc4py",
-    "fenics-ffcx>=0.5.1.dev0,<0.6.0",
-    "fenics-ufl>=2022.3.0.dev0,<2022.4.0"
-]
-
 
 class CMakeExtension(Extension):
     def __init__(self, name: str, sourcedir: str = "") -> None:
@@ -42,9 +32,14 @@ class CMakeBuild(build_ext):
                        f'-DPython3_EXECUTABLE={sys.executable}',
                        f'-DPython3_INCLUDE_DIRS={sysconfig.get_config_var("INCLUDEPY")}']
 
-        # if "pybind11_DIR" not in os.environ:
-        import pybind11
-        cmake_args += [f'-DPYBIND11_DIR={pybind11.get_cmake_dir()}']
+        # TODO: Not sure about the logic of this. cmake needs to be able to
+        # just find C++ pybind11 if its a non-Python install.
+        if "pybind11_DIR" not in os.environ:
+            try:
+                import pybind11
+                cmake_args += [f'-DPYBIND11_DIR={pybind11.get_cmake_dir()}']
+            except ImportError:
+                pass
 
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]
@@ -54,30 +49,11 @@ class CMakeBuild(build_ext):
         if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
             build_args += ['-j3']
 
-        # import pybind11
-        # env = os.environ.copy()
-        # env['pybind11_DIR'] = pybind11.get_cmake_dir()
-
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
         subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp)
         subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
 
 
-setup(name='fenics-dolfinx',
-      version=VERSION,
-      author='FEniCS Project',
-      description='DOLFINx Python interface',
-      long_description='',
-      packages=["dolfinx",
-                "dolfinx.fem",
-                "dolfinx.io",
-                "dolfinx.nls",
-                "dolfinx.wrappers"],
-      package_data={'dolfinx.wrappers': ['*.h'], 'dolfinx': ['py.typed'],
-                    'dolfinx.fem': ['py.typed'], 'dolfinx.nls': ['py.typed']},
-      ext_modules=[CMakeExtension('dolfinx.cpp')],
-      cmdclass=dict(build_ext=CMakeBuild),
-      install_requires=REQUIREMENTS,
-      zip_safe=False,
-      python_requires=">=3.8",)
+setup(ext_modules=[CMakeExtension('dolfinx.cpp')],
+      cmdclass=dict(build_ext=CMakeBuild))


### PR DESCRIPTION
This is work in progress and probably not ready for merge today for a few reasons.

1. pip has moved to a model of isolated builds. pip sets up a totally clean Python environment, installs the build dependencies, and then builds the wheel before installing it. Our cmake build asks this clean python environment for the location of the petsc4py and slepc4py headers, which then fails in this isolated environment. Adding e.g. petsc4py to the build environment specification works, but can lead to the runtime environment having a different ABI to the build time. pip/setuptools seems to have no concept of a build and run dependency.

3. pip and setuptools in the distributions have to be upgraded beyond any packaged version (setuptools>=61, pip 'newish' version).

4. `pip install --no-build-isolation .` works, but then it is (by design) entirely the users responsibility to make sure the build environment is prepared. This can be done using a `requirements.txt` file but it's not very pretty.