### PR TITLE
Fix `set_exterior_facet_domains` for arbitrary ghosting

### DIFF
--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -487,12 +487,12 @@ private:
         {
           // Ge the facet as a pair of (cell, local facet) pairs, one for each
           // cell
-          std::array<std::array<std::int32_t, 2>, 2> facets
+          auto [facet_0, facet_1]
               = get_cell_local_facet_pairs<2>(f, f_to_c->links(f), *c_to_f);
-          it->second.second.insert(it->second.second.end(), facets[0].cbegin(),
-                                   facets[0].cend());
-          it->second.second.insert(it->second.second.end(), facets[1].cbegin(),
-                                   facets[1].cend());
+          it->second.second.insert(it->second.second.end(), facet_0.cbegin(),
+                                   facet_0.cend());
+          it->second.second.insert(it->second.second.end(), facet_1.cbegin(),
+                                   facet_1.cend());
         }
       }
     }

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -454,11 +454,12 @@ private:
       const int index = std::distance(tagged_facets_begin, index_it);
       if (auto it = integrals.find(tags[index]); it != integrals.end())
       {
-        // There will only be one pair for an exterior facet integral
-        const std::array<std::int32_t, 2> pair
+        // Get the facet as a (cell, local_facet) pair. There will only be one
+        // pair for an exterior facet integral
+        const std::array<std::int32_t, 2> facet
             = get_cell_local_facet_pairs<1>(f, f_to_c->links(f), *c_to_f).front();
-        it->second.second.insert(it->second.second.end(), pair.cbegin(),
-                                 pair.cend());
+        it->second.second.insert(it->second.second.end(), facet.cbegin(),
+                                 facet.cend());
       }
     }
   }

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -415,6 +415,12 @@ private:
   }
 
   // Set exterior facet domains
+  // @param[in] topology The mesh topology
+  // @param[in] integrals The integrals to set exterior facet domains for
+  // @param[in] tagged_facets_begin The start of the list of facets
+  // NOTE: The list of tagged facets must be sorted
+  // @param[in] tagged_facets_end The end of the list of facets
+  // @param[in] tags A list of tags
   template <typename iterator>
   void set_exterior_facet_domains(
       const mesh::Topology& topology,

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -457,7 +457,7 @@ private:
       {
         // Get the facet as a (cell, local_facet) pair. There will only be one
         // pair for an exterior facet integral
-        const std::array<std::int32_t, 2> facet
+        std::array<std::int32_t, 2> facet
             = get_cell_local_facet_pairs<1>(f, f_to_c->links(f), *c_to_f)
                   .front();
         it->second.second.insert(it->second.second.end(), facet.cbegin(),
@@ -487,7 +487,7 @@ private:
         {
           // Ge the facet as a pair of (cell, local facet) pairs, one for each
           // cell
-          const std::array<std::array<std::int32_t, 2>, 2> facets
+          std::array<std::array<std::int32_t, 2>, 2> facets
               = get_cell_local_facet_pairs<2>(f, f_to_c->links(f), *c_to_f);
           it->second.second.insert(it->second.second.end(), facets[0].cbegin(),
                                    facets[0].cend());

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -401,15 +401,15 @@ private:
   // Set cell domains
   void set_cell_domains(
       std::map<int, std::pair<kern, std::vector<std::int32_t>>>& integrals,
-      const std::span<const std::int32_t>& owned_tagged_cells,
+      const std::span<const std::int32_t>& tagged_cells,
       const std::vector<int>& tags)
   {
-    // For cell integrals use all markers (but not on ghost entities)
-    for (std::int32_t i = 0; i < owned_tagged_cells.size(); ++i)
+    // For cell integrals use all markers
+    for (std::int32_t i = 0; i < tagged_cells.size(); ++i)
     {
       if (auto it = integrals.find(tags[i]); it != integrals.end())
       {
-        it->second.second.push_back(owned_tagged_cells[i]);
+        it->second.second.push_back(tagged_cells[i]);
       }
     }
   }
@@ -417,14 +417,13 @@ private:
   // Set exterior facet domains
   // @param[in] topology The mesh topology
   // @param[in] integrals The integrals to set exterior facet domains for
-  // @param[in] tagged_facets_begin The start of the list of facets
-  // @param[in] tagged_facets_end The end of the list of facets
+  // @param[in] tagged_facets A list of facets
   // @param[in] tags A list of tags
   // @pre The list of tagged facets must be sorted
   void set_exterior_facet_domains(
       const mesh::Topology& topology,
       std::map<int, std::pair<kern, std::vector<std::int32_t>>>& integrals,
-      const std::span<const std::int32_t>& owned_tagged_facets,
+      const std::span<const std::int32_t>& tagged_facets,
       const std::vector<int>& tags)
   {
     const std::vector<std::int32_t> boundary_facets
@@ -432,9 +431,8 @@ private:
 
     // Create list of tagged boundary facets
     std::vector<std::int32_t> tagged_ext_facets;
-    std::set_intersection(owned_tagged_facets.begin(),
-                          owned_tagged_facets.end(), boundary_facets.begin(),
-                          boundary_facets.end(),
+    std::set_intersection(tagged_facets.begin(), tagged_facets.end(),
+                          boundary_facets.begin(), boundary_facets.end(),
                           std::back_inserter(tagged_ext_facets));
 
     const int tdim = topology.dim();
@@ -449,10 +447,10 @@ private:
       // Find index of f in tagged facets so that we can access the associated
       // tag
       // FIXME Would be better to avoid calling std::lower_bound in a loop
-      auto index_it = std::lower_bound(owned_tagged_facets.begin(),
-                                       owned_tagged_facets.end(), f);
-      assert(index_it != owned_tagged_facets.end() and *index_it == f);
-      const int index = std::distance(owned_tagged_facets.begin(), index_it);
+      auto index_it
+          = std::lower_bound(tagged_facets.begin(), tagged_facets.end(), f);
+      assert(index_it != tagged_facets.end() and *index_it == f);
+      const int index = std::distance(tagged_facets.begin(), index_it);
       if (auto it = integrals.find(tags[index]); it != integrals.end())
       {
         // Get the facet as a (cell, local_facet) pair. There will only be one
@@ -470,7 +468,7 @@ private:
   static void set_interior_facet_domains(
       const mesh::Topology& topology,
       std::map<int, std::pair<kern, std::vector<std::int32_t>>>& integrals,
-      const std::span<const std::int32_t>& owned_tagged_facets,
+      const std::span<const std::int32_t>& tagged_facets,
       const std::vector<int>& tags)
   {
     int tdim = topology.dim();
@@ -478,9 +476,9 @@ private:
     assert(f_to_c);
     auto c_to_f = topology.connectivity(tdim, tdim - 1);
     assert(c_to_f);
-    for (int i = 0; i < owned_tagged_facets.size(); ++i)
+    for (int i = 0; i < tagged_facets.size(); ++i)
     {
-      const std::int32_t f = owned_tagged_facets[i];
+      const std::int32_t f = tagged_facets[i];
       if (f_to_c->num_links(f) == 2)
       {
         if (auto it = integrals.find(tags[i]); it != integrals.end())
@@ -523,6 +521,7 @@ private:
     const auto entity_end
         = std::lower_bound(tagged_entities.begin(), tagged_entities.end(),
                            topology.index_map(dim)->size_local());
+    // Only include owned entities in integration domains
     const std::span<const std::int32_t> owned_tagged_entities(
         tagged_entities.begin(), entity_end);
     switch (type)

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -409,7 +409,8 @@ private:
     {
       if (auto it = integrals.find(tags[i]); it != integrals.end())
       {
-        it->second.second.push_back(tagged_cells[i]);
+        std::vector<std::int32_t>& integration_entities = it->second.second;
+        integration_entities.push_back(tagged_cells[i]);
       }
     }
   }
@@ -458,8 +459,9 @@ private:
         std::array<std::int32_t, 2> facet
             = get_cell_local_facet_pairs<1>(f, f_to_c->links(f), *c_to_f)
                   .front();
-        it->second.second.insert(it->second.second.end(), facet.cbegin(),
-                                 facet.cend());
+        std::vector<std::int32_t>& integration_entities = it->second.second;
+        integration_entities.insert(integration_entities.end(), facet.cbegin(),
+                                    facet.cend());
       }
     }
   }
@@ -487,10 +489,11 @@ private:
           // cell
           auto [facet_0, facet_1]
               = get_cell_local_facet_pairs<2>(f, f_to_c->links(f), *c_to_f);
-          it->second.second.insert(it->second.second.end(), facet_0.cbegin(),
-                                   facet_0.cend());
-          it->second.second.insert(it->second.second.end(), facet_1.cbegin(),
-                                   facet_1.cend());
+          std::vector<std::int32_t>& integration_entities = it->second.second;
+          integration_entities.insert(integration_entities.end(),
+                                      facet_0.cbegin(), facet_0.cend());
+          integration_entities.insert(integration_entities.end(),
+                                      facet_1.cbegin(), facet_1.cend());
         }
       }
     }

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -456,7 +456,7 @@ private:
       {
         // There will only be one pair for an exterior facet integral
         const std::array<std::int32_t, 2> pair
-            = get_cell_local_facet_pairs<1>(f, f_to_c->links(f), *c_to_f)[0];
+            = get_cell_local_facet_pairs<1>(f, f_to_c->links(f), *c_to_f).front();
         it->second.second.insert(it->second.second.end(), pair.cbegin(),
                                  pair.cend());
       }

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -418,9 +418,9 @@ private:
   // @param[in] topology The mesh topology
   // @param[in] integrals The integrals to set exterior facet domains for
   // @param[in] tagged_facets_begin The start of the list of facets
-  // NOTE: The list of tagged facets must be sorted
   // @param[in] tagged_facets_end The end of the list of facets
   // @param[in] tags A list of tags
+  // @pre The list of tagged facets must be sorted
   template <typename iterator>
   void set_exterior_facet_domains(
       const mesh::Topology& topology,

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -399,18 +399,18 @@ private:
   }
 
   // Set cell domains
-  template <typename iterator>
   void set_cell_domains(
       std::map<int, std::pair<kern, std::vector<std::int32_t>>>& integrals,
-      const iterator& tagged_cells_begin, const iterator& tagged_cells_end,
+      const std::span<const std::int32_t>& owned_tagged_cells,
       const std::vector<int>& tags)
   {
     // For cell integrals use all markers (but not on ghost entities)
-    for (auto c = tagged_cells_begin; c != tagged_cells_end; ++c)
+    for (std::int32_t i = 0; i < owned_tagged_cells.size(); ++i)
     {
-      const std::size_t pos = std::distance(tagged_cells_begin, c);
-      if (auto it = integrals.find(tags[pos]); it != integrals.end())
-        it->second.second.push_back(*c);
+      if (auto it = integrals.find(tags[i]); it != integrals.end())
+      {
+        it->second.second.push_back(owned_tagged_cells[i]);
+      }
     }
   }
 
@@ -527,8 +527,7 @@ private:
     switch (type)
     {
     case IntegralType::cell:
-      set_cell_domains(_cell_integrals, tagged_entities.cbegin(), entity_end,
-                       tags);
+      set_cell_domains(_cell_integrals, owned_tagged_entities, tags);
       break;
     default:
       mesh->topology_mutable().create_connectivity(dim, tdim);


### PR DESCRIPTION
Currently, `set_exterior_facet_domains` makes assumptions about the ghosting of the mesh. Looks like it was missed when https://github.com/FEniCS/dolfinx/pull/2337 was merged. This PR removes these assumptions. Unfortunately, it relies on an `std::lower_bound` in a loop, which is not ideal. However, I plan to replace this in https://github.com/FEniCS/dolfinx/pull/2269