### PR TITLE
Remove macos-11 from CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ jobs:
     name: macOS Homebrew install and test
     strategy:
       matrix:
-        os: [macos-12, macos-11]
+        os: [macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Lacks adequate support for C++20.