### PR TITLE
Remove deprecated ufl function

### DIFF
--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -25,9 +25,9 @@ import ufl.algorithms.analysis
 from dolfinx import cpp as _cpp
 from dolfinx import jit, la
 from dolfinx.fem import dofmap
+from ufl.domain import extract_unique_domain
 
 from petsc4py import PETSc
-from ufl.domain import extract_unique_domain
 
 
 class Constant(ufl.Constant):

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -27,6 +27,7 @@ from dolfinx import jit, la
 from dolfinx.fem import dofmap
 
 from petsc4py import PETSc
+from ufl.domain import extract_unique_domain
 
 
 class Constant(ufl.Constant):
@@ -104,7 +105,7 @@ class Expression:
         num_points = X.shape[0] if X.ndim == 2 else 1
         _X = np.reshape(X, (num_points, -1))
 
-        mesh = ufl_expression.ufl_domain().ufl_cargo()
+        mesh = extract_unique_domain(ufl_expression).ufl_cargo()
 
         # Compile UFL expression with JIT
         if dtype == np.float32:


### PR DESCRIPTION
`expr.ufl_domain()` was deprecated with https://github.com/FEniCS/ufl/pull/131
This removes some of the deprecation warnings.
It seems ufl itself still uses this internally so not all deprecation warnings will disappear.