### PR TITLE
Rename public API test to be more meaningful

### DIFF
--- a/python/test/unit/common/test_public_api.py
+++ b/python/test/unit/common/test_public_api.py
@@ -21,6 +21,11 @@ def collect_pkg_modules_recursive(name):
 
 
 def test_all_implemented():
+    """
+    flake8 does not catch its warning code F822: whether the public API
+    offered by the members of __all__ are implemented. We therefore manually
+    check.
+    """
     module_names = collect_pkg_modules_recursive("dolfinx")
     for module_name in module_names:
         module = importlib.import_module(module_name)


### PR DESCRIPTION
Rename an ambiguously named test which checks for implementation of the public API via `__all__`.

Also add a comment stub explaining the test.