### PR TITLE
Reorder `Scatterer` initialiser list

### DIFF
--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -47,8 +47,8 @@ public:
   /// `map` that will be scattered/gathered.
   /// @param[in] alloc The memory allocator for indices.
   Scatterer(const IndexMap& map, int bs, const Allocator& alloc = Allocator())
-      : _bs(bs), _src(map.src()), _dest(map.dest()), _remote_inds(0, alloc),
-        _local_inds(0, alloc)
+      : _bs(bs), _remote_inds(0, alloc), _local_inds(0, alloc), _src(map.src()),
+        _dest(map.dest())
   {
     if (map.overlapped())
     {


### PR DESCRIPTION
This PR prevents the following warning: `field '_dest' will be initialized after field '_remote_inds' [-Werror,-Wreorder-ctor]`