### PR TITLE
Add `complex` type hint to `dirichletbc`

### DIFF
--- a/python/dolfinx/fem/bcs.py
+++ b/python/dolfinx/fem/bcs.py
@@ -9,7 +9,6 @@ via modification of linear systems."""
 from __future__ import annotations
 
 import collections.abc
-import numbers
 import typing
 
 import numpy.typing

--- a/python/dolfinx/fem/bcs.py
+++ b/python/dolfinx/fem/bcs.py
@@ -139,7 +139,7 @@ class DirichletBCMetaClass:
         return super().function_space  # type: ignore
 
 
-def dirichletbc(value: typing.Union[Function, Constant, np.ndarray],
+def dirichletbc(value: typing.Union[complex, Function, Constant, np.ndarray],
                 dofs: numpy.typing.NDArray[np.int32],
                 V: typing.Optional[dolfinx.fem.FunctionSpace] = None) -> DirichletBCMetaClass:
     """Create a representation of Dirichlet boundary condition which

--- a/python/dolfinx/fem/bcs.py
+++ b/python/dolfinx/fem/bcs.py
@@ -161,7 +161,7 @@ def dirichletbc(value: typing.Union[complex, Function, Constant, np.ndarray],
 
     """
 
-    if isinstance(value, numbers.Number):
+    if isinstance(value, complex):
         value = np.asarray(value)
 
     try:


### PR DESCRIPTION
This change stops `mypy` detecting an error when a call like `fem.dirichletbc(0.0, dofs, V)` is made.

NOTE: I've used `complex` since `numbers.Number` doesn't seem to work with `mypy`