### PR TITLE
Wrap C++ `Mesh` from Python (fixes support for Python 3.11)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
 
   build-complex:
     docker:
-      - image: ghcr.io/fenics/test-env:latest-mpich
+      - image: ghcr.io/fenics/test-env:nightly-mpich
     environment:
       DEBIAN_FRONTEND: "noninteractive"
       PETSC_ARCH: "linux-gnu-complex-32"

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -74,13 +74,13 @@ jobs:
         run: |
           cd python/
           python3 -m isort --check .
-      # - name: mypy checks
-      #   run: |
-      #     python3 -m pip install types-setuptools
-      #     cd python/
-      #     mypy dolfinx
-      #     mypy demo
-      #     mypy test
+      - name: mypy checks
+        run: |
+          python3 -m pip install types-setuptools
+          cd python/
+          mypy dolfinx
+          mypy demo
+          mypy test
       - name: clang-format C++ checks (non-blocking)
         continue-on-error: true
         run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -74,13 +74,13 @@ jobs:
         run: |
           cd python/
           python3 -m isort --check .
-      - name: mypy checks
-        run: |
-          python3 -m pip install types-setuptools
-          cd python/
-          mypy dolfinx
-          mypy demo
-          mypy test
+      # - name: mypy checks
+      #   run: |
+      #     python3 -m pip install types-setuptools
+      #     cd python/
+      #     mypy dolfinx
+      #     mypy demo
+      #     mypy test
       - name: clang-format C++ checks (non-blocking)
         continue-on-error: true
         run: |

--- a/python/demo/demo_lagrange_variants.py
+++ b/python/demo/demo_lagrange_variants.py
@@ -165,7 +165,7 @@ u_exact = saw_tooth(x[0])
 for variant in [basix.LagrangeVariant.equispaced, basix.LagrangeVariant.gll_warped]:
     element = basix.create_element(basix.ElementFamily.P, basix.CellType.interval, 10, variant)
     ufl_element = basix.ufl_wrapper.BasixElement(element)
-    V = fem.FunctionSpace(mesh, ufl_element)
+    V = fem.FunctionSpace(msh, ufl_element)
     uh = fem.Function(V)
     uh.interpolate(lambda x: saw_tooth(x[0]))
     if MPI.COMM_WORLD.size == 1:  # Skip this plotting in parallel
@@ -205,11 +205,11 @@ for variant in [basix.LagrangeVariant.equispaced, basix.LagrangeVariant.gll_warp
 for variant in [basix.LagrangeVariant.equispaced, basix.LagrangeVariant.gll_warped]:
     element = basix.create_element(basix.ElementFamily.P, basix.CellType.interval, 10, variant)
     ufl_element = basix.ufl_wrapper.BasixElement(element)
-    V = fem.FunctionSpace(mesh, ufl_element)
+    V = fem.FunctionSpace(msh, ufl_element)
     uh = fem.Function(V)
     uh.interpolate(lambda x: saw_tooth(x[0]))
     M = fem.form((u_exact - uh)**2 * dx)
-    error = mesh.comm.allreduce(fem.assemble_scalar(M), op=MPI.SUM)
+    error = msh.comm.allreduce(fem.assemble_scalar(M), op=MPI.SUM)
     print(f"Computed L2 interpolation error ({variant.name}):", error ** 0.5)
 # -
 

--- a/python/demo/demo_lagrange_variants.py
+++ b/python/demo/demo_lagrange_variants.py
@@ -163,15 +163,15 @@ def saw_tooth(x):
 # elements, and plot the finite element interpolation.
 
 # +
-mesh = mesh.create_unit_interval(MPI.COMM_WORLD, 10)
+msh = mesh.create_unit_interval(MPI.COMM_WORLD, 10)
 
-x = ufl.SpatialCoordinate(mesh)
+x = ufl.SpatialCoordinate(msh)
 u_exact = saw_tooth(x[0])
 
 for variant in [basix.LagrangeVariant.equispaced, basix.LagrangeVariant.gll_warped]:
     element = basix.create_element(basix.ElementFamily.P, basix.CellType.interval, 10, variant)
     ufl_element = basix.ufl_wrapper.BasixElement(element)
-    V = fem.FunctionSpace(mesh, ufl_element)
+    V = fem.FunctionSpace(msh, ufl_element)
 
     uh = fem.Function(V)
     uh.interpolate(lambda x: saw_tooth(x[0]))
@@ -216,12 +216,12 @@ for variant in [basix.LagrangeVariant.equispaced, basix.LagrangeVariant.gll_warp
 for variant in [basix.LagrangeVariant.equispaced, basix.LagrangeVariant.gll_warped]:
     element = basix.create_element(basix.ElementFamily.P, basix.CellType.interval, 10, variant)
     ufl_element = basix.ufl_wrapper.BasixElement(element)
-    V = fem.FunctionSpace(mesh, ufl_element)
+    V = fem.FunctionSpace(msh, ufl_element)
 
     uh = fem.Function(V)
     uh.interpolate(lambda x: saw_tooth(x[0]))
     M = fem.form((u_exact - uh)**2 * dx)
-    error = mesh.comm.allreduce(fem.assemble_scalar(M), op=MPI.SUM)
+    error = msh.comm.allreduce(fem.assemble_scalar(M), op=MPI.SUM)
 
     print(f"Computed L2 interpolation error ({variant.name}):", error ** 0.5)
 # -

--- a/python/demo/demo_lagrange_variants.py
+++ b/python/demo/demo_lagrange_variants.py
@@ -165,12 +165,7 @@ u_exact = saw_tooth(x[0])
 for variant in [basix.LagrangeVariant.equispaced, basix.LagrangeVariant.gll_warped]:
     element = basix.create_element(basix.ElementFamily.P, basix.CellType.interval, 10, variant)
     ufl_element = basix.ufl_wrapper.BasixElement(element)
-<<<<<<< HEAD
-    V = fem.FunctionSpace(msh, ufl_element)
-
-=======
     V = fem.FunctionSpace(mesh, ufl_element)
->>>>>>> origin/main
     uh = fem.Function(V)
     uh.interpolate(lambda x: saw_tooth(x[0]))
     if MPI.COMM_WORLD.size == 1:  # Skip this plotting in parallel

--- a/python/demo/demo_types.py
+++ b/python/demo/demo_types.py
@@ -26,7 +26,6 @@ import ufl
 from dolfinx import fem, la, mesh, plot
 
 from mpi4py import MPI
-
 # -
 
 # SciPy solvers do not support MPI, so all computations will be

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -562,7 +562,7 @@ class FunctionSpace(ufl.FunctionSpace):
         return super().__ne__(other) or self._cpp_object != other._cpp_object
 
     def ufl_cell(self):
-        return self._cpp_object.mesh.ufl_cell()
+        return self._mesh.ufl_cell()
 
     def ufl_function_space(self) -> ufl.FunctionSpace:
         """UFL function space"""

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -1,9 +1,9 @@
-# Copyright (C) 2009-2022 Chris N. Richardson, Garth N. Wells and Michal Habera
+# Copyright (C) 2009-2023 Chris N. Richardson, Garth N. Wells and Michal Habera
 #
 # This file is part of DOLFINx (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
-"""Collection of functions and function spaces"""
+"""Finite element function spaces and functions"""
 
 from __future__ import annotations
 
@@ -40,7 +40,6 @@ class Constant(ufl.Constant):
         """
         c = np.asarray(c)
         super().__init__(domain, c.shape)
-
         try:
             if c.dtype == np.complex64:
                 self._cpp_object = _cpp.fem.Constant_complex64(c)
@@ -597,14 +596,15 @@ class FunctionSpace(ufl.FunctionSpace):
                 Coordinates of the degrees-of-freedom.
 
             Notes:
-                The methods should be used only for elements with point
+                This method should be used only for elements with point
                 evaluation degrees-of-freedom.
 
          """
         return self._cpp_object.tabulate_dof_coordinates()
 
 
-def VectorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typing.Tuple[str, int]], dim=None) -> FunctionSpace:
+def VectorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typing.Tuple[str, int]],
+                        dim=None) -> FunctionSpace:
     """Create vector finite element (composition of scalar elements) function space."""
     e = ElementMetaData(*element)
     ufl_element = basix.ufl_wrapper.create_vector_element(e.family, mesh.ufl_cell().cellname(), e.degree,

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -14,19 +14,19 @@ if typing.TYPE_CHECKING:
 
 from functools import singledispatch
 
-import numpy as np
-import numpy.typing as npt
-from dolfinx.fem import dofmap
-from petsc4py import PETSc
-
 import basix
 import basix.ufl_wrapper
+import numpy as np
+import numpy.typing as npt
 import ufl
 import ufl.algorithms
 import ufl.algorithms.analysis
+from dolfinx.fem import dofmap
+from petsc4py import PETSc
+from ufl.domain import extract_unique_domain
+
 from dolfinx import cpp as _cpp
 from dolfinx import jit, la
-from ufl.domain import extract_unique_domain
 
 
 class Constant(ufl.Constant):
@@ -454,7 +454,7 @@ class ElementMetaData(typing.NamedTuple):
 class FunctionSpace(ufl.FunctionSpace):
     """A space on which Functions (fields) can be defined."""
 
-    def __init__(self, mesh: typing.Union[None, Mesh],
+    def __init__(self, mesh: Mesh,
                  element: typing.Union[ufl.FiniteElementBase, ElementMetaData, typing.Tuple[str, int]],
                  cppV: typing.Optional[_cpp.fem.FunctionSpace] = None,
                  form_compiler_options: dict[str, typing.Any] = {}, jit_options: dict[str, typing.Any] = {}):
@@ -463,8 +463,6 @@ class FunctionSpace(ufl.FunctionSpace):
         # Create function space from a UFL element and existing cpp
         # FunctionSpace
         if cppV is not None:
-            # assert mesh is None
-            # ufl_domain = cppV.mesh.ufl_domain()
             ufl_domain = mesh.ufl_domain()
             super().__init__(ufl_domain, element)
             self._cpp_object = cppV

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -515,7 +515,7 @@ class FunctionSpace(ufl.FunctionSpace):
 
         """
         Vcpp = _cpp.fem.FunctionSpace(self._cpp_object.mesh, self._cpp_object.element, self._cpp_object.dofmap)
-        return FunctionSpace(None, self.ufl_element(), Vcpp)
+        return FunctionSpace(self._mesh, self.ufl_element(), Vcpp)
 
     @property
     def num_sub_spaces(self) -> int:

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -372,7 +372,7 @@ class Function(ufl.Coefficient):
         except TypeError:
             # u is callable
             assert callable(u)
-            x = _cpp.fem.interpolation_coords(self._V.element, self._V.mesh._mesh, cells)
+            x = _cpp.fem.interpolation_coords(self._V.element, self._V.mesh._cpp_object, cells)
             self._cpp_object.interpolate(np.asarray(u(x), dtype=self.dtype), cells)
 
     def copy(self) -> Function:
@@ -495,7 +495,7 @@ class FunctionSpace(ufl.FunctionSpace):
             try:
                 self._cpp_object = _cpp.fem.FunctionSpace(mesh, cpp_element, cpp_dofmap)
             except TypeError:
-                self._cpp_object = _cpp.fem.FunctionSpace(mesh._mesh, cpp_element, cpp_dofmap)
+                self._cpp_object = _cpp.fem.FunctionSpace(mesh._cpp_object, cpp_element, cpp_dofmap)
 
             self._mesh = mesh
 
@@ -577,7 +577,7 @@ class FunctionSpace(ufl.FunctionSpace):
         return dofmap.DofMap(self._cpp_object.dofmap)
 
     @property
-    def mesh(self) -> _cpp.mesh.Mesh:
+    def mesh(self) -> Mesh:
         """Return the mesh on which the function space is defined."""
         return self._mesh
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -535,7 +535,6 @@ class FunctionSpace(ufl.FunctionSpace):
         assert self.ufl_element().num_sub_elements() > i
         sub_element = self.ufl_element().sub_elements()[i]
         cppV_sub = self._cpp_object.sub([i])
-        print("A: ******", type(self._mesh))
         return FunctionSpace(self._mesh, sub_element, cppV_sub)
 
     def component(self):

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -14,9 +14,6 @@ if typing.TYPE_CHECKING:
 
 from functools import singledispatch
 
-import numpy as np
-import numpy.typing as npt
-
 import basix
 import basix.ufl_wrapper
 import numpy as np
@@ -30,10 +27,6 @@ from ufl.domain import extract_unique_domain
 
 from dolfinx import cpp as _cpp
 from dolfinx import jit, la
-from dolfinx.fem import dofmap
-from ufl.domain import extract_unique_domain
-
-from petsc4py import PETSc
 
 
 class Constant(ufl.Constant):

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -604,8 +604,7 @@ class FunctionSpace(ufl.FunctionSpace):
         return self._cpp_object.tabulate_dof_coordinates()
 
 
-def VectorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typing.Tuple[str, int]], dim=None,
-                        restriction=None) -> FunctionSpace:
+def VectorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typing.Tuple[str, int]], dim=None) -> FunctionSpace:
     """Create vector finite element (composition of scalar elements) function space."""
     e = ElementMetaData(*element)
     ufl_element = basix.ufl_wrapper.create_vector_element(e.family, mesh.ufl_cell().cellname(), e.degree,
@@ -614,7 +613,7 @@ def VectorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typin
 
 
 def TensorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typing.Tuple[str, int]], shape=None,
-                        symmetry: typing.Optional[bool] = None, restriction=None) -> FunctionSpace:
+                        symmetry: typing.Optional[bool] = None) -> FunctionSpace:
     """Create tensor finite element (composition of scalar elements) function space."""
     e = ElementMetaData(*element)
     ufl_element = basix.ufl_wrapper.create_tensor_element(e.family, mesh.ufl_cell().cellname(),

--- a/python/dolfinx/geometry.py
+++ b/python/dolfinx/geometry.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import typing
 
+import numpy as np
 import numpy.typing as npt
 
 if typing.TYPE_CHECKING:

--- a/python/dolfinx/geometry.py
+++ b/python/dolfinx/geometry.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import typing
 
+import numpy.typing as npt
+
 if typing.TYPE_CHECKING:
     from dolfinx.mesh import Mesh
     from dolfinx.cpp.graph import AdjacencyList_int32
@@ -46,11 +48,26 @@ class BoundingBoxTree(_cpp.geometry.BoundingBoxTree):
         super().__init__(mesh._cpp_object, dim, entities, padding)
 
 
-def compute_closest_entity(tree, midpoint_tree, mesh, points):
+def compute_closest_entity(tree: BoundingBoxTree, midpoint_tree: BoundingBoxTree, mesh: Mesh,
+                           points: numpy.ndarray) -> npt.NDArray[np.int32]:
+    """Compute closest mesh entity to a point.
+
+        Args:
+            tree: bounding box tree for the entities
+            midpoint_tree: A bounding box tree with the midpoints of all
+                the mesh entities. This is used to accelerate the search.
+            mesh: The mesh
+            points: The points to check for collision, shape=(num_points, 3)
+
+        Returns:
+            Mesh entity index for each point in `points`. Returns -1 for
+            a point if the bounding box tree is empty.
+
+    """
     return _cpp.geometry.compute_closest_entity(tree, midpoint_tree, mesh._cpp_object, points)
 
 
-def create_midpoint_tree(mesh, dim, entities):
+def create_midpoint_tree(mesh: Mesh, dim: int, entities: numpy.ndarray):
     return _cpp.geometry.create_midpoint_tree(mesh._cpp_object, dim, entities)
 
 

--- a/python/dolfinx/geometry.py
+++ b/python/dolfinx/geometry.py
@@ -14,8 +14,7 @@ if typing.TYPE_CHECKING:
     from dolfinx.cpp.graph import AdjacencyList_int32
 
 import numpy
-from dolfinx.cpp.geometry import (compute_closest_entity, compute_collisions,
-                                  compute_distance_gjk)
+from dolfinx.cpp.geometry import compute_collisions, compute_distance_gjk
 
 from dolfinx import cpp as _cpp
 

--- a/python/dolfinx/geometry.py
+++ b/python/dolfinx/geometry.py
@@ -43,15 +43,15 @@ class BoundingBoxTree(_cpp.geometry.BoundingBoxTree):
         if entities is None:
             entities = range(0, map.size_local + map.num_ghosts)
 
-        super().__init__(mesh._mesh, dim, entities, padding)
+        super().__init__(mesh._cpp_object, dim, entities, padding)
 
 
 def compute_closest_entity(tree, midpoint_tree, mesh, points):
-    return _cpp.geometry.compute_closest_entity(tree, midpoint_tree, mesh._mesh, points)
+    return _cpp.geometry.compute_closest_entity(tree, midpoint_tree, mesh._cpp_object, points)
 
 
 def create_midpoint_tree(mesh, dim, entities):
-    return _cpp.geometry.create_midpoint_tree(mesh._mesh, dim, entities)
+    return _cpp.geometry.create_midpoint_tree(mesh._cpp_object, dim, entities)
 
 
 def compute_colliding_cells(mesh: Mesh, candidates: AdjacencyList_int32, x: numpy.ndarray):
@@ -67,7 +67,7 @@ def compute_colliding_cells(mesh: Mesh, candidates: AdjacencyList_int32, x: nump
         Adjacency list where the ith node is the list of entities that
         collide with the ith point
     """
-    return _cpp.geometry.compute_colliding_cells(mesh._mesh, candidates, x)
+    return _cpp.geometry.compute_colliding_cells(mesh._cpp_object, candidates, x)
 
 
 def squared_distance(mesh: Mesh, dim: int, entities: typing.List[int], points: numpy.ndarray):
@@ -87,4 +87,4 @@ def squared_distance(mesh: Mesh, dim: int, entities: typing.List[int], points: n
         Squared shortest distance from points[i] to entities[i]
 
     """
-    return _cpp.geometry.squared_distance(mesh._mesh, dim, entities, points)
+    return _cpp.geometry.squared_distance(mesh._cpp_object, dim, entities, points)

--- a/python/dolfinx/geometry.py
+++ b/python/dolfinx/geometry.py
@@ -14,10 +14,10 @@ if typing.TYPE_CHECKING:
     from dolfinx.cpp.graph import AdjacencyList_int32
 
 import numpy
+from dolfinx.cpp.geometry import (compute_closest_entity, compute_collisions,
+                                  compute_distance_gjk)
 
 from dolfinx import cpp as _cpp
-from dolfinx.cpp.geometry import (compute_closest_entity, compute_collisions,
-                                  compute_distance_gjk, create_midpoint_tree)
 
 __all__ = ["compute_colliding_cells", "squared_distance", "compute_closest_entity", "compute_collisions",
            "compute_distance_gjk", "create_midpoint_tree"]
@@ -45,6 +45,14 @@ class BoundingBoxTree(_cpp.geometry.BoundingBoxTree):
             entities = range(0, map.size_local + map.num_ghosts)
 
         super().__init__(mesh._mesh, dim, entities, padding)
+
+
+def compute_closest_entity(tree, midpoint_tree, mesh, points):
+    return _cpp.geometry.compute_closest_entity(tree, midpoint_tree, mesh._mesh, points)
+
+
+def create_midpoint_tree(mesh, dim, entities):
+    return _cpp.geometry.create_midpoint_tree(mesh._mesh, dim, entities)
 
 
 def compute_colliding_cells(mesh: Mesh, candidates: AdjacencyList_int32, x: numpy.ndarray):

--- a/python/dolfinx/geometry.py
+++ b/python/dolfinx/geometry.py
@@ -44,7 +44,7 @@ class BoundingBoxTree(_cpp.geometry.BoundingBoxTree):
         if entities is None:
             entities = range(0, map.size_local + map.num_ghosts)
 
-        super().__init__(mesh, dim, entities, padding)
+        super().__init__(mesh._mesh, dim, entities, padding)
 
 
 def compute_colliding_cells(mesh: Mesh, candidates: AdjacencyList_int32, x: numpy.ndarray):
@@ -60,7 +60,7 @@ def compute_colliding_cells(mesh: Mesh, candidates: AdjacencyList_int32, x: nump
         Adjacency list where the ith node is the list of entities that
         collide with the ith point
     """
-    return _cpp.geometry.compute_colliding_cells(mesh, candidates, x)
+    return _cpp.geometry.compute_colliding_cells(mesh._mesh, candidates, x)
 
 
 def squared_distance(mesh: Mesh, dim: int, entities: typing.List[int], points: numpy.ndarray):
@@ -80,4 +80,4 @@ def squared_distance(mesh: Mesh, dim: int, entities: typing.List[int], points: n
         Squared shortest distance from points[i] to entities[i]
 
     """
-    return _cpp.geometry.squared_distance(mesh, dim, entities, points)
+    return _cpp.geometry.squared_distance(mesh._mesh, dim, entities, points)

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -247,7 +247,8 @@ if _has_gmsh:
         mesh = create_mesh(comm, cells, x[:, :gdim], ufl_domain, partitioner)
 
         # Create MeshTags for cells
-        local_entities, local_values = _cpp.io.distribute_entity_data(mesh._cpp_object, mesh.topology.dim, cells, cell_values)
+        local_entities, local_values = _cpp.io.distribute_entity_data(
+            mesh._cpp_object, mesh.topology.dim, cells, cell_values)
         mesh.topology.create_connectivity(mesh.topology.dim, 0)
         adj = _cpp.graph.AdjacencyList_int32(local_entities)
         ct = meshtags_from_entities(mesh, mesh.topology.dim, adj, local_values.astype(np.int32, copy=False))

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -232,7 +232,6 @@ if _has_gmsh:
 
             cells = np.asarray(topologies[cell_id]["topology"], dtype=np.int64)
             cell_values = np.asarray(topologies[cell_id]["cell_data"], dtype=np.int32)
-
         else:
             cell_id, num_nodes = comm.bcast([None, None], root=rank)
             cells, x = np.empty([0, num_nodes], dtype=np.int32), np.empty([0, gdim])
@@ -259,7 +258,7 @@ if _has_gmsh:
         # Create MeshTags for facets
         topology = mesh.topology
         if has_facet_data:
-            # Permute facets from MSH to Dolfin-X ordering
+            # Permute facets from MSH to DOLFINx ordering
             # FIXME: This does not work for prism meshes
             if topology.cell_type == CellType.prism or topology.cell_type == CellType.pyramid:
                 raise RuntimeError(f"Unsupported cell type {topology.cell_type}")
@@ -305,12 +304,11 @@ if _has_gmsh:
             gmsh.initialize()
             gmsh.model.add("Mesh from file")
             gmsh.merge(filename)
-
-        output = model_to_mesh(gmsh.model, comm, rank, gdim=gdim, partitioner=partitioner)
-
-        if comm.rank == rank:
+            msh = model_to_mesh(gmsh.model, comm, rank, gdim=gdim, partitioner=partitioner)
             gmsh.finalize()
-        return output
+            return msh
+        else:
+            return model_to_mesh(gmsh.model, comm, rank, gdim=gdim, partitioner=partitioner)
 
     # Map from Gmsh cell type identifier (integer) to DOLFINx cell type
     # and degree http://gmsh.info//doc/texinfo/gmsh.html#MSH-file-format

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -250,7 +250,7 @@ if _has_gmsh:
         mesh = create_mesh(comm, cells, x[:, :gdim], ufl_domain, partitioner)
 
         # Create MeshTags for cells
-        local_entities, local_values = _cpp.io.distribute_entity_data(mesh, mesh.topology.dim, cells, cell_values)
+        local_entities, local_values = _cpp.io.distribute_entity_data(mesh._mesh, mesh.topology.dim, cells, cell_values)
         mesh.topology.create_connectivity(mesh.topology.dim, 0)
         adj = _cpp.graph.AdjacencyList_int32(local_entities)
         ct = meshtags_from_entities(mesh, mesh.topology.dim, adj, local_values.astype(np.int32, copy=False))
@@ -269,7 +269,7 @@ if _has_gmsh:
             marked_facets = marked_facets[:, gmsh_facet_perm]
 
             local_entities, local_values = _cpp.io.distribute_entity_data(
-                mesh, mesh.topology.dim - 1, marked_facets, facet_values)
+                mesh._mesh, mesh.topology.dim - 1, marked_facets, facet_values)
             mesh.topology.create_connectivity(topology.dim - 1, topology.dim)
             adj = _cpp.graph.AdjacencyList_int32(local_entities)
             ft = meshtags_from_entities(mesh, topology.dim - 1, adj, local_values.astype(np.int32, copy=False))

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -247,7 +247,7 @@ if _has_gmsh:
         mesh = create_mesh(comm, cells, x[:, :gdim], ufl_domain, partitioner)
 
         # Create MeshTags for cells
-        local_entities, local_values = _cpp.io.distribute_entity_data(mesh._mesh, mesh.topology.dim, cells, cell_values)
+        local_entities, local_values = _cpp.io.distribute_entity_data(mesh._cpp_object, mesh.topology.dim, cells, cell_values)
         mesh.topology.create_connectivity(mesh.topology.dim, 0)
         adj = _cpp.graph.AdjacencyList_int32(local_entities)
         ct = meshtags_from_entities(mesh, mesh.topology.dim, adj, local_values.astype(np.int32, copy=False))
@@ -266,7 +266,7 @@ if _has_gmsh:
             marked_facets = marked_facets[:, gmsh_facet_perm]
 
             local_entities, local_values = _cpp.io.distribute_entity_data(
-                mesh._mesh, mesh.topology.dim - 1, marked_facets, facet_values)
+                mesh._cpp_object, mesh.topology.dim - 1, marked_facets, facet_values)
             mesh.topology.create_connectivity(topology.dim - 1, topology.dim)
             adj = _cpp.graph.AdjacencyList_int32(local_entities)
             ft = meshtags_from_entities(mesh, topology.dim - 1, adj, local_values.astype(np.int32, copy=False))

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -52,7 +52,7 @@ if _cpp.common.has_adios2:
 
         """
 
-        def __init__(self, comm: _MPI.Comm, filename: str, output: typing.Union[Mesh, Function. typing.List[Function]]):
+        def __init__(self, comm: _MPI.Comm, filename: str, output: typing.Union[Mesh, Function, typing.List[Function]]):
             """Initialize a writer for outputting data in the VTX format.
 
             Args:

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -151,7 +151,7 @@ class XDMFFile(_cpp.io.XDMFFile):
 
     def write_mesh(self, mesh: Mesh) -> None:
         """Write mesh to file for a given time (default 0.0)"""
-        super().write_mesh(mesh)
+        super().write_mesh(mesh._mesh)
 
     def write_function(self, u, t: float = 0.0, mesh_xpath="/Xdmf/Domain/Grid[@GridType='Uniform'][1]"):
         super().write_function(getattr(u, "_cpp_object", u), t, mesh_xpath)
@@ -171,7 +171,7 @@ class XDMFFile(_cpp.io.XDMFFile):
         domain = ufl.Mesh(basix.ufl_wrapper.create_vector_element(
             "Lagrange", cell_shape.name, cell_degree, basix.LagrangeVariant.equispaced, dim=x.shape[1],
             gdim=x.shape[1]))
-        return Mesh.from_cpp(mesh, domain)
+        return Mesh(mesh, domain)
 
     def read_meshtags(self, mesh, name, xpath="/Xdmf/Domain"):
         return super().read_meshtags(mesh, name, xpath)

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -52,7 +52,7 @@ if _cpp.common.has_adios2:
 
         """
 
-        def __init__(self, comm: _MPI.Comm, filename: str, output: typing.Union[Mesh, typing.List[Function], Function]):
+        def __init__(self, comm: _MPI.Comm, filename: str, output: typing.Union[Mesh, Function. typing.List[Function]]):
             """Initialize a writer for outputting data in the VTX format.
 
             Args:

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -67,7 +67,7 @@ if _cpp.common.has_adios2:
             """
             try:
                 # Input is a mesh
-                super().__init__(comm, filename, output._mesh)  # type: ignore[union-attr]
+                super().__init__(comm, filename, output._cpp_object)  # type: ignore[union-attr]
             except (NotImplementedError, TypeError, AttributeError):
                 # Input is a single function or a list of functions
                 super().__init__(comm, filename, _extract_cpp_functions(output))   # type: ignore[arg-type]
@@ -105,7 +105,7 @@ if _cpp.common.has_adios2:
 
             """
             try:
-                super().__init__(comm, filename, output._mesh)  # type: ignore[union-attr]
+                super().__init__(comm, filename, output._cpp_object)  # type: ignore[union-attr]
             except (NotImplementedError, TypeError, AttributeError):
                 super().__init__(comm, filename, _extract_cpp_functions(output))  # type: ignore[arg-type]
 
@@ -133,7 +133,7 @@ class VTKFile(_cpp.io.VTKFile):
 
     def write_mesh(self, mesh: Mesh, t: float = 0.0) -> None:
         """Write mesh to file for a given time (default 0.0)"""
-        self.write(mesh._mesh, t)
+        self.write(mesh._cpp_object, t)
 
     def write_function(self, u: typing.Union[typing.List[Function], Function], t: float = 0.0) -> None:
         """Write a single function or a list of functions to file for a given time (default 0.0)"""
@@ -149,7 +149,7 @@ class XDMFFile(_cpp.io.XDMFFile):
 
     def write_mesh(self, mesh: Mesh) -> None:
         """Write mesh to file for a given time (default 0.0)"""
-        super().write_mesh(mesh._mesh)
+        super().write_mesh(mesh._cpp_object)
 
     def write_function(self, u, t: float = 0.0, mesh_xpath="/Xdmf/Domain/Grid[@GridType='Uniform'][1]"):
         super().write_function(getattr(u, "_cpp_object", u), t, mesh_xpath)
@@ -172,9 +172,9 @@ class XDMFFile(_cpp.io.XDMFFile):
         return Mesh(msh, domain)
 
     def read_meshtags(self, mesh, name, xpath="/Xdmf/Domain"):
-        return super().read_meshtags(mesh._mesh, name, xpath)
+        return super().read_meshtags(mesh._cpp_object, name, xpath)
 
 
 def distribute_entity_data(mesh: Mesh, entity_dim: int, entities: npt.NDArray[np.int64],
                            values: npt.NDArray[np.int32]) -> typing.Tuple[npt.NDArray[np.int64], npt.NDArray[np.int32]]:
-    return _cpp.io.distribute_entity_data(mesh._mesh, entity_dim, entities, values)
+    return _cpp.io.distribute_entity_data(mesh._cpp_object, entity_dim, entities, values)

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -69,10 +69,10 @@ if _cpp.common.has_adios2:
             """
             try:
                 # Input is a mesh
-                super().__init__(comm, filename, output._mesh)
+                super().__init__(comm, filename, output._mesh)  # type: ignore[union-attr]
             except (NotImplementedError, TypeError, AttributeError):
                 # Input is a single function or a list of functions
-                super().__init__(comm, filename, _extract_cpp_functions(output))
+                super().__init__(comm, filename, _extract_cpp_functions(output))   # type: ignore[arg-type]
 
         def __enter__(self):
             return self
@@ -107,9 +107,9 @@ if _cpp.common.has_adios2:
 
             """
             try:
-                super().__init__(comm, filename, output._mesh)
+                super().__init__(comm, filename, output._mesh)  # type: ignore[union-attr]
             except (NotImplementedError, TypeError, AttributeError):
-                super().__init__(comm, filename, _extract_cpp_functions(output))
+                super().__init__(comm, filename, _extract_cpp_functions(output))  # type: ignore[arg-type]
 
         def __enter__(self):
             return self

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -74,6 +74,10 @@ class Mesh:
         """Return the ufl domain corresponding to the mesh."""
         return self._ufl_domain
 
+    def h(self, dim: int, entities: npt.NDArray[np.int32]) -> npt.NDArray[np.float64]:
+        """Size measure for each cell."""
+        return _cpp.mesh.h(self._cpp_object, dim, entities)
+
     @property
     def topology(self):
         return self._cpp_object.topology

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -30,41 +30,29 @@ __all__ = ["meshtags_from_entities", "locate_entities", "locate_entities_boundar
            "create_box", "create_unit_cube", "to_type", "to_string"]
 
 
-def compute_incident_entities(mesh, entities, d0: int, d1: int):
+def compute_incident_entities(mesh: Mesh, entities, d0: int, d1: int):
     return _cpp.mesh.compute_incident_entities(mesh._cpp_object, entities, d0, d1)
 
 
-def compute_midpoints(mesh, dim: int, entities):
+def compute_midpoints(mesh: Mesh, dim: int, entities):
     return _cpp.mesh.compute_midpoints(mesh._cpp_object, dim, entities)
 
 
 class Mesh:
-    def __init__(self, mesh, domain: ufl.Mesh):
+    def __init__(self, mesh: _cpp.mesh.Mesh, domain: ufl.Mesh):
         """A class for representing meshes
 
         Args:
-            comm: The MPI communicator
-            topology: The mesh topology
-            geometry: The mesh geometry
-            domain: The MPI communicator
+            mesh: The C++ mesh object
+            domain: The UFL domain
 
         Note:
-            Mesh objects are not generally created using this class directly.
+            Mesh objects should not usually be created using this class directly.
 
         """
-        # super().__init__(comm, topology, geometry)
         self._cpp_object = mesh
         self._ufl_domain = domain
         self._ufl_domain._ufl_cargo = self._cpp_object
-        # domain._ufl_cargo = self
-
-    # @classmethod
-    # def from_cpp(cls, obj: _cpp.mesh.Mesh, domain: ufl.Mesh) -> Mesh:
-    #     """Create Mesh object from a C++ Mesh object"""
-    #     obj._ufl_domain = domain
-    #     obj.__class__ = Mesh
-    #     domain._ufl_cargo = obj
-    #     return obj
 
     @property
     def comm(self):
@@ -93,41 +81,6 @@ class Mesh:
     @property
     def geometry(self):
         return self._cpp_object.geometry
-
-# class Mesh(_cpp.mesh.Mesh):
-#     def __init__(self, comm: _MPI.Comm, topology: _cpp.mesh.Topology,
-#                  geometry: _cpp.mesh.Geometry, domain: ufl.Mesh):
-#         """A class for representing meshes
-
-#         Args:
-#             comm: The MPI communicator
-#             topology: The mesh topology
-#             geometry: The mesh geometry
-#             domain: The MPI communicator
-
-#         Note:
-#             Mesh objects are not generally created using this class directly.
-
-#         """
-#         super().__init__(comm, topology, geometry)
-#         self._ufl_domain = domain
-#         domain._ufl_cargo = self
-
-#     @classmethod
-#     def from_cpp(cls, obj: _cpp.mesh.Mesh, domain: ufl.Mesh) -> Mesh:
-#         """Create Mesh object from a C++ Mesh object"""
-#         obj._ufl_domain = domain
-#         obj.__class__ = Mesh
-#         domain._ufl_cargo = obj
-#         return obj
-
-#     def ufl_cell(self) -> ufl.Cell:
-#         """Return the UFL cell type"""
-#         return ufl.Cell(self.topology.cell_name(), geometric_dimension=self.geometry.dim)
-
-#     def ufl_domain(self) -> ufl.Mesh:
-#         """Return the ufl domain corresponding to the mesh."""
-#         return self._ufl_domain
 
 
 def locate_entities(mesh: Mesh, dim: int, marker: typing.Callable) -> np.ndarray:

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -31,11 +31,11 @@ __all__ = ["meshtags_from_entities", "locate_entities", "locate_entities_boundar
 
 
 def compute_incident_entities(mesh, entities, d0: int, d1: int):
-    return _cpp.mesh.compute_incident_entities(mesh._mesh, entities, d0, d1)
+    return _cpp.mesh.compute_incident_entities(mesh._cpp_object, entities, d0, d1)
 
 
 def compute_midpoints(mesh, dim: int, entities):
-    return _cpp.mesh.compute_midpoints(mesh._mesh, dim, entities)
+    return _cpp.mesh.compute_midpoints(mesh._cpp_object, dim, entities)
 
 
 class Mesh:
@@ -53,9 +53,9 @@ class Mesh:
 
         """
         # super().__init__(comm, topology, geometry)
-        self._mesh = mesh
+        self._cpp_object = mesh
         self._ufl_domain = domain
-        self._ufl_domain._ufl_cargo = self._mesh
+        self._ufl_domain._ufl_cargo = self._cpp_object
         # domain._ufl_cargo = self
 
     # @classmethod
@@ -68,15 +68,15 @@ class Mesh:
 
     @property
     def comm(self):
-        return self._mesh.comm
+        return self._cpp_object.comm
 
     @property
     def name(self):
-        return self._mesh.name
+        return self._cpp_object.name
 
     @name.setter
     def name(self, value):
-        self._mesh.name = value
+        self._cpp_object.name = value
 
     def ufl_cell(self) -> ufl.Cell:
         """Return the UFL cell type"""
@@ -88,11 +88,11 @@ class Mesh:
 
     @property
     def topology(self):
-        return self._mesh.topology
+        return self._cpp_object.topology
 
     @property
     def geometry(self):
-        return self._mesh.geometry
+        return self._cpp_object.geometry
 
 # class Mesh(_cpp.mesh.Mesh):
 #     def __init__(self, comm: _MPI.Comm, topology: _cpp.mesh.Topology,
@@ -144,7 +144,7 @@ def locate_entities(mesh: Mesh, dim: int, marker: typing.Callable) -> np.ndarray
         Indices (local to the process) of marked mesh entities.
 
     """
-    return _cpp.mesh.locate_entities(mesh._mesh, dim, marker)
+    return _cpp.mesh.locate_entities(mesh._cpp_object, dim, marker)
 
 
 def locate_entities_boundary(mesh: Mesh, dim: int, marker: typing.Callable) -> np.ndarray:
@@ -171,7 +171,7 @@ def locate_entities_boundary(mesh: Mesh, dim: int, marker: typing.Callable) -> n
         Indices (local to the process) of marked mesh entities.
 
     """
-    return _cpp.mesh.locate_entities_boundary(mesh._mesh, dim, marker)
+    return _cpp.mesh.locate_entities_boundary(mesh._cpp_object, dim, marker)
 
 
 _uflcell_to_dolfinxcell = {
@@ -202,9 +202,9 @@ def refine(mesh: Mesh, edges: typing.Optional[np.ndarray] = None, redistribute: 
         A refined mesh
     """
     if edges is None:
-        mesh_refined = _cpp.refinement.refine(mesh._mesh, redistribute)
+        mesh_refined = _cpp.refinement.refine(mesh._cpp_object, redistribute)
     else:
-        mesh_refined = _cpp.refinement.refine(mesh._mesh, edges, redistribute)
+        mesh_refined = _cpp.refinement.refine(mesh._cpp_object, edges, redistribute)
 
     coordinate_element = mesh._ufl_domain.ufl_coordinate_element()
     domain = ufl.Mesh(coordinate_element)
@@ -246,7 +246,7 @@ def create_mesh(comm: _MPI.Comm, cells: typing.Union[np.ndarray, _cpp.graph.Adja
 
 
 def create_submesh(msh, dim, entities):
-    submsh, entity_map, vertex_map, geom_map = _cpp.mesh.create_submesh(msh._mesh, dim, entities)
+    submsh, entity_map, vertex_map, geom_map = _cpp.mesh.create_submesh(msh._cpp_object, dim, entities)
     submsh_ufl_cell = ufl.Cell(submsh.topology.cell_name(), geometric_dimension=submsh.geometry.dim)
     submsh_domain = ufl.Mesh(basix.ufl_wrapper.create_vector_element(
         "Lagrange", submsh_ufl_cell.cellname(), submsh.geometry.cmap.degree, submsh.geometry.cmap.variant,
@@ -286,7 +286,7 @@ class MeshTagsMetaClass:
             directly.
 
         """
-        super().__init__(mesh._mesh, dim, np.asarray(entities, dtype=np.int32), values)  # type: ignore
+        super().__init__(mesh._cpp_object, dim, np.asarray(entities, dtype=np.int32), values)  # type: ignore
 
     def ufl_id(self) -> int:
         """Object identifier.
@@ -372,7 +372,7 @@ def meshtags_from_entities(mesh: Mesh, dim: int, entities: _cpp.graph.AdjacencyL
         values = np.full(entities.num_nodes, values, dtype=np.double)
 
     values = np.asarray(values)
-    return _cpp.mesh.create_meshtags(mesh._mesh, dim, entities, values)
+    return _cpp.mesh.create_meshtags(mesh._cpp_object, dim, entities, values)
 
 
 def create_interval(comm: _MPI.Comm, nx: int, points: numpy.typing.ArrayLike,

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -12,7 +12,7 @@ import typing
 import basix
 import basix.ufl_wrapper
 import numpy as np
-import numpy.typing
+import numpy.typing as npt
 import ufl
 from dolfinx.cpp.mesh import (CellType, DiagonalType, GhostMode,
                               build_dual_graph, cell_dim,
@@ -30,11 +30,11 @@ __all__ = ["meshtags_from_entities", "locate_entities", "locate_entities_boundar
            "create_box", "create_unit_cube", "to_type", "to_string"]
 
 
-def compute_incident_entities(mesh: Mesh, entities, d0: int, d1: int):
+def compute_incident_entities(mesh: Mesh, entities: npt.NDArray[np.int32], d0: int, d1: int):
     return _cpp.mesh.compute_incident_entities(mesh._cpp_object, entities, d0, d1)
 
 
-def compute_midpoints(mesh: Mesh, dim: int, entities):
+def compute_midpoints(mesh: Mesh, dim: int, entities: npt.NDArray[np.int32]):
     return _cpp.mesh.compute_midpoints(mesh._cpp_object, dim, entities)
 
 
@@ -221,8 +221,8 @@ del _ufl_id
 
 
 class MeshTagsMetaClass:
-    def __init__(self, mesh: Mesh, dim: int, entities: numpy.typing.NDArray[typing.Any],
-                 values: numpy.typing.NDArray[typing.Any]):
+    def __init__(self, mesh: Mesh, dim: int, entities: npt.NDArray[typing.Any],
+                 values: npt.NDArray[typing.Any]):
         """A distributed sparse matrix that uses compressed sparse row storage.
 
         Args:
@@ -254,7 +254,7 @@ class MeshTagsMetaClass:
         return id(self)
 
 
-def meshtags(mesh: Mesh, dim: int, entities: np.ndarray,
+def meshtags(mesh: Mesh, dim: int, entities: npt.NDArray[np.int64],
              values: typing.Union[np.ndarray, int, float]) -> MeshTagsMetaClass:
     """Create a MeshTags object that associates data with a subset of mesh entities.
 
@@ -298,7 +298,7 @@ def meshtags(mesh: Mesh, dim: int, entities: np.ndarray,
 
 
 def meshtags_from_entities(mesh: Mesh, dim: int, entities: _cpp.graph.AdjacencyList_int32,
-                           values: numpy.typing.NDArray[typing.Any]):
+                           values: npt.NDArray[typing.Any]):
     """Create a MeshTags object that associates data with a subset of
     mesh entities, where the entities are defined by their vertices.
 
@@ -328,7 +328,7 @@ def meshtags_from_entities(mesh: Mesh, dim: int, entities: _cpp.graph.AdjacencyL
     return _cpp.mesh.create_meshtags(mesh._cpp_object, dim, entities, values)
 
 
-def create_interval(comm: _MPI.Comm, nx: int, points: numpy.typing.ArrayLike,
+def create_interval(comm: _MPI.Comm, nx: int, points: npt.ArrayLike,
                     ghost_mode=GhostMode.shared_facet, partitioner=None) -> Mesh:
     """Create an interval mesh
 
@@ -374,7 +374,7 @@ def create_unit_interval(comm: _MPI.Comm, nx: int, ghost_mode=GhostMode.shared_f
     return create_interval(comm, nx, [0.0, 1.0], ghost_mode, partitioner)
 
 
-def create_rectangle(comm: _MPI.Comm, points: numpy.typing.ArrayLike, n: numpy.typing.ArrayLike,
+def create_rectangle(comm: _MPI.Comm, points: npt.ArrayLike, n: npt.ArrayLike,
                      cell_type=CellType.triangle, ghost_mode=GhostMode.shared_facet,
                      partitioner=None,
                      diagonal: DiagonalType = DiagonalType.right) -> Mesh:
@@ -431,7 +431,7 @@ def create_unit_square(comm: _MPI.Comm, nx: int, ny: int, cell_type=CellType.tri
                             partitioner, diagonal)
 
 
-def create_box(comm: _MPI.Comm, points: typing.List[numpy.typing.ArrayLike], n: list,
+def create_box(comm: _MPI.Comm, points: typing.List[npt.ArrayLike], n: list,
                cell_type=CellType.tetrahedron,
                ghost_mode=GhostMode.shared_facet,
                partitioner=None) -> Mesh:

--- a/python/dolfinx/plot.py
+++ b/python/dolfinx/plot.py
@@ -51,7 +51,7 @@ def create_vtk_mesh(msh: mesh.Mesh, dim: typing.Optional[int] = None, entities=N
         entities = range(msh.topology.index_map(dim).size_local)
 
     if dim == tdim:
-        vtk_topology = _cpp.io.extract_vtk_connectivity(msh)[entities]
+        vtk_topology = _cpp.io.extract_vtk_connectivity(msh._mesh)[entities]
         num_nodes_per_cell = vtk_topology.shape[1]
     else:
         # NOTE: This linearizes higher order geometries

--- a/python/dolfinx/plot.py
+++ b/python/dolfinx/plot.py
@@ -51,11 +51,11 @@ def create_vtk_mesh(msh: mesh.Mesh, dim: typing.Optional[int] = None, entities=N
         entities = range(msh.topology.index_map(dim).size_local)
 
     if dim == tdim:
-        vtk_topology = _cpp.io.extract_vtk_connectivity(msh._mesh)[entities]
+        vtk_topology = _cpp.io.extract_vtk_connectivity(msh._cpp_object)[entities]
         num_nodes_per_cell = vtk_topology.shape[1]
     else:
         # NOTE: This linearizes higher order geometries
-        geometry_entities = _cpp.mesh.entities_to_geometry(msh._mesh, dim, entities, False)
+        geometry_entities = _cpp.mesh.entities_to_geometry(msh._cpp_object, dim, entities, False)
         if degree > 1:
             warnings.warn("Linearizing topology for higher order sub entities.")
 

--- a/python/dolfinx/plot.py
+++ b/python/dolfinx/plot.py
@@ -55,7 +55,7 @@ def create_vtk_mesh(msh: mesh.Mesh, dim: typing.Optional[int] = None, entities=N
         num_nodes_per_cell = vtk_topology.shape[1]
     else:
         # NOTE: This linearizes higher order geometries
-        geometry_entities = _cpp.mesh.entities_to_geometry(msh, dim, entities, False)
+        geometry_entities = _cpp.mesh.entities_to_geometry(msh._mesh, dim, entities, False)
         if degree > 1:
             warnings.warn("Linearizing topology for higher order sub entities.")
 

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -13,24 +13,26 @@ import math
 import os
 import pathlib
 import time
+
 import cffi
+import dolfinx.pkgconfig
 import numpy as np
 import numpy.typing
-import dolfinx
-import dolfinx.pkgconfig
+import petsc4py.lib
+import pytest
 import ufl
 from dolfinx.fem import Function, FunctionSpace, form
 from dolfinx.fem.petsc import assemble_matrix, load_petsc_lib
 from dolfinx.mesh import create_unit_square
-from ufl import dx, inner
-import petsc4py.lib
 from mpi4py import MPI
 from petsc4py import PETSc
 from petsc4py import get_config as PETSc_get_config
+from ufl import dx, inner
 
-import pytest
+import dolfinx
+
 numba = pytest.importorskip("numba")
-import numba.core.typing.cffi_utils as cffi_support
+cffi_support = pytest.importorskip("numba.core.typing.cffi_utils")
 
 # Get details of PETSc install
 petsc_dir = PETSc_get_config()['PETSC_DIR']

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Tests for custom Python assemblers"""
 
+# FoodImports
 import ctypes
 import ctypes.util
 import importlib
@@ -12,14 +13,9 @@ import math
 import os
 import pathlib
 import time
-
 import cffi
-import numba
-import numba.core.typing.cffi_utils as cffi_support
 import numpy as np
 import numpy.typing
-import pytest
-
 import dolfinx
 import dolfinx.pkgconfig
 import ufl
@@ -27,11 +23,14 @@ from dolfinx.fem import Function, FunctionSpace, form
 from dolfinx.fem.petsc import assemble_matrix, load_petsc_lib
 from dolfinx.mesh import create_unit_square
 from ufl import dx, inner
-
 import petsc4py.lib
 from mpi4py import MPI
 from petsc4py import PETSc
 from petsc4py import get_config as PETSc_get_config
+
+import pytest
+numba = pytest.importorskip("numba")
+import numba.core.typing.cffi_utils as cffi_support
 
 # Get details of PETSc install
 petsc_dir = PETSc_get_config()['PETSC_DIR']

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -9,19 +9,19 @@
 import os
 import sys
 
-import numba
 import numpy as np
 import pytest
+from dolfinx.fem import Function, FunctionSpace, IntegralType
+from dolfinx.mesh import create_unit_square, meshtags
+from mpi4py import MPI
+from petsc4py import PETSc
 
 import dolfinx
 from dolfinx import TimingType
 from dolfinx import cpp as _cpp
 from dolfinx import fem, la, list_timings
-from dolfinx.fem import Function, FunctionSpace, IntegralType
-from dolfinx.mesh import create_unit_square, meshtags
 
-from mpi4py import MPI
-from petsc4py import PETSc
+numba = pytest.importorskip("numba")
 
 # Add current directory - required for some Python versions to find cffi
 # compiled modules

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -7,24 +7,23 @@
 import ctypes
 import ctypes.util
 
+import basix
 import cffi
 import numpy as np
-
-import basix
-import dolfinx.cpp
+import pytest
 import ufl
 from dolfinx.cpp.la.petsc import create_matrix
 from dolfinx.fem import (Constant, Expression, Function, FunctionSpace,
                          VectorFunctionSpace, create_sparsity_pattern, form)
 from dolfinx.fem.petsc import load_petsc_lib
 from dolfinx.mesh import create_unit_square
-
 from mpi4py import MPI
 from petsc4py import PETSc
 
-import pytest
+import dolfinx.cpp
+
 numba = pytest.importorskip("numba")
-import numba.core.typing.cffi_utils as cffi_support
+cffi_support = pytest.importorskip("numba.core.typing.cffi_utils")
 
 
 dolfinx.cpp.common.init_logging(["-v"])

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -8,8 +8,6 @@ import ctypes
 import ctypes.util
 
 import cffi
-import numba
-import numba.core.typing.cffi_utils as cffi_support
 import numpy as np
 
 import basix
@@ -23,6 +21,11 @@ from dolfinx.mesh import create_unit_square
 
 from mpi4py import MPI
 from petsc4py import PETSc
+
+import pytest
+numba = pytest.importorskip("numba")
+import numba.core.typing.cffi_utils as cffi_support
+
 
 dolfinx.cpp.common.init_logging(["-v"])
 

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -65,8 +65,8 @@ def test_python_interface(V, V2, W, W2, Q):
     assert isinstance(V2, FunctionSpace)
     assert isinstance(W2, FunctionSpace)
 
-    assert V.ufl_cell() == V2.ufl_cell()
-    assert W.ufl_cell() == W2.ufl_cell()
+    assert V.mesh.ufl_cell() == V2.mesh.ufl_cell()
+    assert W.mesh.ufl_cell() == W2.mesh.ufl_cell()
     assert V.element == V2.element
     assert W.element == W2.element
     assert V.ufl_element() == V2.ufl_element()

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -609,6 +609,7 @@ def test_interpolate_callable():
     u0, u1 = Function(V), Function(V)
 
     numba = pytest.importorskip("numba")
+
     @numba.njit
     def f(x):
         return x[0]

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -7,18 +7,15 @@
 
 import random
 
-import numba
-import numpy as np
-import pytest
-
 import basix
 import basix.ufl_wrapper
+import numpy as np
+import pytest
 import ufl
 from dolfinx.fem import (Expression, Function, FunctionSpace,
                          VectorFunctionSpace, assemble_scalar, form)
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
                           create_unit_square, locate_entities, meshtags)
-
 from mpi4py import MPI
 
 parametrize_cell_types = pytest.mark.parametrize(
@@ -611,6 +608,7 @@ def test_interpolate_callable():
     V = FunctionSpace(mesh, ("Lagrange", 2))
     u0, u1 = Function(V), Function(V)
 
+    numba = pytest.importorskip("numba")
     @numba.njit
     def f(x):
         return x[0]

--- a/python/test/unit/geometry/test_bounding_box_tree.py
+++ b/python/test/unit/geometry/test_bounding_box_tree.py
@@ -7,8 +7,6 @@
 
 import numpy as np
 import pytest
-
-from dolfinx import cpp as _cpp
 from dolfinx.geometry import (BoundingBoxTree, compute_closest_entity,
                               compute_colliding_cells, compute_collisions,
                               compute_distance_gjk, create_midpoint_tree)
@@ -16,8 +14,9 @@ from dolfinx.mesh import (CellType, create_box, create_unit_cube,
                           create_unit_interval, create_unit_square,
                           exterior_facet_indices, locate_entities,
                           locate_entities_boundary)
-
 from mpi4py import MPI
+
+from dolfinx import cpp as _cpp
 
 
 def extract_geometricial_data(mesh, dim, entities):

--- a/python/test/unit/geometry/test_bounding_box_tree.py
+++ b/python/test/unit/geometry/test_bounding_box_tree.py
@@ -24,7 +24,7 @@ def extract_geometricial_data(mesh, dim, entities):
     vertices"""
     mesh_nodes = []
     geom = mesh.geometry
-    g_indices = _cpp.mesh.entities_to_geometry(mesh._mesh, dim, np.array(entities, dtype=np.int32), False)
+    g_indices = _cpp.mesh.entities_to_geometry(mesh._cpp_object, dim, np.array(entities, dtype=np.int32), False)
     for cell in g_indices:
         nodes = np.zeros((len(cell), 3), dtype=np.float64)
         for j, entity in enumerate(cell):
@@ -52,7 +52,7 @@ def find_colliding_cells(mesh, bbox):
     # Find actual cells using known bounding box tree
     colliding_cells = []
     num_cells = mesh.topology.index_map(mesh.topology.dim).size_local
-    x_indices = _cpp.mesh.entities_to_geometry(mesh._mesh, mesh.topology.dim,
+    x_indices = _cpp.mesh.entities_to_geometry(mesh._cpp_object, mesh.topology.dim,
                                                np.arange(num_cells, dtype=np.int32), False)
     points = mesh.geometry.x
     bounding_box = expand_bbox(bbox)
@@ -145,7 +145,7 @@ def test_compute_collisions_point_1d():
     assert len(entities.array) == 1
 
     # Get the vertices of the geometry
-    geom_entities = _cpp.mesh.entities_to_geometry(mesh._mesh, tdim, entities.array, False)[0]
+    geom_entities = _cpp.mesh.entities_to_geometry(mesh._cpp_object, tdim, entities.array, False)[0]
     x = mesh.geometry.x
     cell_vertices = x[geom_entities]
     # Check that we get the cell with correct vertices
@@ -161,7 +161,7 @@ def test_compute_collisions_tree_1d(point):
     def locator_A(x):
         return x[0] >= point[0]
     # Locate all vertices of mesh A that should collide
-    vertices_A = _cpp.mesh.locate_entities(mesh_A._mesh, 0, locator_A)
+    vertices_A = _cpp.mesh.locate_entities(mesh_A._cpp_object, 0, locator_A)
     mesh_A.topology.create_connectivity(0, mesh_A.topology.dim)
     v_to_c = mesh_A.topology.connectivity(0, mesh_A.topology.dim)
 
@@ -176,7 +176,7 @@ def test_compute_collisions_tree_1d(point):
         return x[0] <= 1
 
     # Locate all vertices of mesh B that should collide
-    vertices_B = _cpp.mesh.locate_entities(mesh_B._mesh, 0, locator_B)
+    vertices_B = _cpp.mesh.locate_entities(mesh_B._cpp_object, 0, locator_B)
     mesh_B.topology.create_connectivity(0, mesh_B.topology.dim)
     v_to_c = mesh_B.topology.connectivity(0, mesh_B.topology.dim)
 

--- a/python/test/unit/geometry/test_bounding_box_tree.py
+++ b/python/test/unit/geometry/test_bounding_box_tree.py
@@ -25,9 +25,7 @@ def extract_geometricial_data(mesh, dim, entities):
     vertices"""
     mesh_nodes = []
     geom = mesh.geometry
-    g_indices = _cpp.mesh.entities_to_geometry(mesh, dim,
-                                               np.array(entities, dtype=np.int32),
-                                               False)
+    g_indices = _cpp.mesh.entities_to_geometry(mesh._mesh, dim, np.array(entities, dtype=np.int32), False)
     for cell in g_indices:
         nodes = np.zeros((len(cell), 3), dtype=np.float64)
         for j, entity in enumerate(cell):
@@ -55,8 +53,8 @@ def find_colliding_cells(mesh, bbox):
     # Find actual cells using known bounding box tree
     colliding_cells = []
     num_cells = mesh.topology.index_map(mesh.topology.dim).size_local
-    x_indices = _cpp.mesh.entities_to_geometry(
-        mesh, mesh.topology.dim, np.arange(num_cells, dtype=np.int32), False)
+    x_indices = _cpp.mesh.entities_to_geometry(mesh._mesh, mesh.topology.dim,
+                                               np.arange(num_cells, dtype=np.int32), False)
     points = mesh.geometry.x
     bounding_box = expand_bbox(bbox)
     for cell in range(num_cells):
@@ -148,7 +146,7 @@ def test_compute_collisions_point_1d():
     assert len(entities.array) == 1
 
     # Get the vertices of the geometry
-    geom_entities = _cpp.mesh.entities_to_geometry(mesh, tdim, entities.array, False)[0]
+    geom_entities = _cpp.mesh.entities_to_geometry(mesh._mesh, tdim, entities.array, False)[0]
     x = mesh.geometry.x
     cell_vertices = x[geom_entities]
     # Check that we get the cell with correct vertices

--- a/python/test/unit/geometry/test_bounding_box_tree.py
+++ b/python/test/unit/geometry/test_bounding_box_tree.py
@@ -162,7 +162,7 @@ def test_compute_collisions_tree_1d(point):
     def locator_A(x):
         return x[0] >= point[0]
     # Locate all vertices of mesh A that should collide
-    vertices_A = _cpp.mesh.locate_entities(mesh_A, 0, locator_A)
+    vertices_A = _cpp.mesh.locate_entities(mesh_A._mesh, 0, locator_A)
     mesh_A.topology.create_connectivity(0, mesh_A.topology.dim)
     v_to_c = mesh_A.topology.connectivity(0, mesh_A.topology.dim)
 
@@ -177,7 +177,7 @@ def test_compute_collisions_tree_1d(point):
         return x[0] <= 1
 
     # Locate all vertices of mesh B that should collide
-    vertices_B = _cpp.mesh.locate_entities(mesh_B, 0, locator_B)
+    vertices_B = _cpp.mesh.locate_entities(mesh_B._mesh, 0, locator_B)
     mesh_B.topology.create_connectivity(0, mesh_B.topology.dim)
     v_to_c = mesh_B.topology.connectivity(0, mesh_B.topology.dim)
 

--- a/python/test/unit/io/test_xdmf_mesh.py
+++ b/python/test/unit/io/test_xdmf_mesh.py
@@ -64,9 +64,9 @@ def test_save_and_load_2d_mesh(tempdir, encoding, cell_type):
         mesh2 = file.read_mesh(name="square")
 
     assert mesh2.name == mesh.name
-    assert mesh.topology.index_map(0).size_global == mesh2.topology.index_map(0).size_global
-    assert mesh.topology.index_map(mesh.topology.dim).size_global == mesh2.topology.index_map(
-        mesh.topology.dim).size_global
+    topology, topology2 = mesh.topology, mesh2.topology
+    assert topology.index_map(0).size_global == topology2.index_map(0).size_global
+    assert topology.index_map(topology.dim).size_global == topology2.index_map(topology.dim).size_global
 
 
 @pytest.mark.parametrize("cell_type", celltypes_3D)
@@ -80,9 +80,9 @@ def test_save_and_load_3d_mesh(tempdir, encoding, cell_type):
     with XDMFFile(MPI.COMM_WORLD, filename, "r", encoding=encoding) as file:
         mesh2 = file.read_mesh()
 
-    assert mesh.topology.index_map(0).size_global == mesh2.topology.index_map(0).size_global
-    assert mesh.topology.index_map(mesh.topology.dim).size_global == mesh2.topology.index_map(
-        mesh.topology.dim).size_global
+    topology, topology2 = mesh.topology, mesh2.topology
+    assert topology.index_map(0).size_global == topology2.index_map(0).size_global
+    assert topology.index_map(topology.dim).size_global == topology2.index_map(topology.dim).size_global
 
 
 @pytest.mark.parametrize("encoding", encodings)
@@ -131,9 +131,9 @@ def test_read_write_p2_mesh(tempdir, encoding):
     with XDMFFile(mesh.comm, filename, "r", encoding=encoding) as xdmf:
         mesh2 = xdmf.read_mesh()
 
-    assert mesh.topology.index_map(0).size_global == mesh2.topology.index_map(0).size_global
-    assert mesh.topology.index_map(mesh.topology.dim).size_global == mesh2.topology.index_map(
-        mesh.topology.dim).size_global
+    topology, topology2 = mesh.topology, mesh2.topology
+    assert topology.index_map(0).size_global == topology2.index_map(0).size_global
+    assert topology.index_map(topology.dim).size_global == topology2.index_map(topology.dim).size_global
 
 
 @pytest.mark.parametrize("d", [2, 3])

--- a/python/test/unit/mesh/test_face.py
+++ b/python/test/unit/mesh/test_face.py
@@ -49,10 +49,10 @@ def test_normals(cube, square):
         return np.isclose(x[0], 0)
     fdim = cube.topology.dim - 1
     facets = locate_entities_boundary(cube, fdim, left_side)
-    normals = cell_normals(cube._mesh, fdim, facets)
+    normals = cell_normals(cube._cpp_object, fdim, facets)
     assert np.allclose(normals, [-1, 0, 0])
 
     fdim = square.topology.dim - 1
     facets = locate_entities_boundary(square, fdim, left_side)
-    normals = cell_normals(square._mesh, fdim, facets)
+    normals = cell_normals(square._cpp_object, fdim, facets)
     assert np.allclose(normals, [-1, 0, 0])

--- a/python/test/unit/mesh/test_face.py
+++ b/python/test/unit/mesh/test_face.py
@@ -49,10 +49,10 @@ def test_normals(cube, square):
         return np.isclose(x[0], 0)
     fdim = cube.topology.dim - 1
     facets = locate_entities_boundary(cube, fdim, left_side)
-    normals = cell_normals(cube, fdim, facets)
+    normals = cell_normals(cube._mesh, fdim, facets)
     assert np.allclose(normals, [-1, 0, 0])
 
     fdim = square.topology.dim - 1
     facets = locate_entities_boundary(square, fdim, left_side)
-    normals = cell_normals(square, fdim, facets)
+    normals = cell_normals(square._mesh, fdim, facets)
     assert np.allclose(normals, [-1, 0, 0])

--- a/python/test/unit/mesh/test_manifold_point_search.py
+++ b/python/test/unit/mesh/test_manifold_point_search.py
@@ -25,7 +25,7 @@ def test_manifold_point_search():
     colliding_cells = geometry.compute_colliding_cells(mesh, cell_candidates, points)
 
     # Extract vertices of cell
-    indices = _cpp.mesh.entities_to_geometry(mesh._mesh, mesh.topology.dim, [colliding_cells.links(0)[
+    indices = _cpp.mesh.entities_to_geometry(mesh._cpp_object, mesh.topology.dim, [colliding_cells.links(0)[
         0], colliding_cells.links(1)[0]], False)
     cell_vertices = mesh.geometry.x[indices]
 

--- a/python/test/unit/mesh/test_manifold_point_search.py
+++ b/python/test/unit/mesh/test_manifold_point_search.py
@@ -25,7 +25,7 @@ def test_manifold_point_search():
     colliding_cells = geometry.compute_colliding_cells(mesh, cell_candidates, points)
 
     # Extract vertices of cell
-    indices = _cpp.mesh.entities_to_geometry(mesh, mesh.topology.dim, [colliding_cells.links(0)[
+    indices = _cpp.mesh.entities_to_geometry(mesh._mesh, mesh.topology.dim, [colliding_cells.links(0)[
         0], colliding_cells.links(1)[0]], False)
     cell_vertices = mesh.geometry.x[indices]
 

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -65,7 +65,7 @@ def submesh_geometry_test(mesh, submesh, entity_map, geom_map, entity_dim):
     if len(entity_map) > 0:
         assert mesh.geometry.dim == submesh.geometry.dim
 
-        e_to_g = entities_to_geometry(mesh._mesh, entity_dim, entity_map, False)
+        e_to_g = entities_to_geometry(mesh._cpp_object, entity_dim, entity_map, False)
         for submesh_entity in range(len(entity_map)):
             submesh_x_dofs = submesh.geometry.dofmap.links(submesh_entity)
             # e_to_g[i] gets the mesh x_dofs of entities[i], which should
@@ -312,7 +312,7 @@ def test_cell_circumradius(c0, c1, c5):
 @pytest.mark.skip_in_parallel
 def test_cell_h(c0, c1, c5):
     for c in [c0, c1, c5]:
-        assert _cpp.mesh.h(c[0]._mesh, c[1], [c[2]]) == pytest.approx(math.sqrt(2.0))
+        assert _cpp.mesh.h(c[0]._cpp_object, c[1], [c[2]]) == pytest.approx(math.sqrt(2.0))
 
 
 def test_cell_h_prism():
@@ -321,7 +321,7 @@ def test_cell_h_prism():
     tdim = mesh.topology.dim
     num_cells = mesh.topology.index_map(tdim).size_local
     cells = np.arange(num_cells, dtype=np.int32)
-    h = _cpp.mesh.h(mesh._mesh, tdim, cells)
+    h = _cpp.mesh.h(mesh._cpp_object, tdim, cells)
     assert np.allclose(h, np.sqrt(3 / (N**2)))
 
 
@@ -330,7 +330,7 @@ def test_facet_h(ct):
     N = 3
     mesh = create_unit_cube(MPI.COMM_WORLD, N, N, N, ct)
     left_facets = locate_entities_boundary(mesh, mesh.topology.dim - 1, lambda x: np.isclose(x[0], 0))
-    h = _cpp.mesh.h(mesh._mesh, mesh.topology.dim - 1, left_facets)
+    h = _cpp.mesh.h(mesh._cpp_object, mesh.topology.dim - 1, left_facets)
     assert np.allclose(h, np.sqrt(2 / (N**2)))
 
 
@@ -358,7 +358,7 @@ def test_hmin_hmax(_mesh, hmin, hmax):
     mesh = _mesh()
     tdim = mesh.topology.dim
     num_cells = mesh.topology.index_map(tdim).size_local
-    h = _cpp.mesh.h(mesh._mesh, tdim, range(num_cells))
+    h = _cpp.mesh.h(mesh._cpp_object, tdim, range(num_cells))
     assert h.min() == pytest.approx(hmin)
     assert h.max() == pytest.approx(hmax)
 

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -65,7 +65,7 @@ def submesh_geometry_test(mesh, submesh, entity_map, geom_map, entity_dim):
     if len(entity_map) > 0:
         assert mesh.geometry.dim == submesh.geometry.dim
 
-        e_to_g = entities_to_geometry(mesh, entity_dim, entity_map, False)
+        e_to_g = entities_to_geometry(mesh._mesh, entity_dim, entity_map, False)
         for submesh_entity in range(len(entity_map)):
             submesh_x_dofs = submesh.geometry.dofmap.links(submesh_entity)
             # e_to_g[i] gets the mesh x_dofs of entities[i], which should
@@ -312,7 +312,7 @@ def test_cell_circumradius(c0, c1, c5):
 @pytest.mark.skip_in_parallel
 def test_cell_h(c0, c1, c5):
     for c in [c0, c1, c5]:
-        assert _cpp.mesh.h(c[0], c[1], [c[2]]) == pytest.approx(math.sqrt(2.0))
+        assert _cpp.mesh.h(c[0]._mesh, c[1], [c[2]]) == pytest.approx(math.sqrt(2.0))
 
 
 def test_cell_h_prism():
@@ -321,7 +321,7 @@ def test_cell_h_prism():
     tdim = mesh.topology.dim
     num_cells = mesh.topology.index_map(tdim).size_local
     cells = np.arange(num_cells, dtype=np.int32)
-    h = _cpp.mesh.h(mesh, tdim, cells)
+    h = _cpp.mesh.h(mesh._mesh, tdim, cells)
     assert np.allclose(h, np.sqrt(3 / (N**2)))
 
 
@@ -330,7 +330,7 @@ def test_facet_h(ct):
     N = 3
     mesh = create_unit_cube(MPI.COMM_WORLD, N, N, N, ct)
     left_facets = locate_entities_boundary(mesh, mesh.topology.dim - 1, lambda x: np.isclose(x[0], 0))
-    h = _cpp.mesh.h(mesh, mesh.topology.dim - 1, left_facets)
+    h = _cpp.mesh.h(mesh._mesh, mesh.topology.dim - 1, left_facets)
     assert np.allclose(h, np.sqrt(2 / (N**2)))
 
 
@@ -358,7 +358,7 @@ def test_hmin_hmax(_mesh, hmin, hmax):
     mesh = _mesh()
     tdim = mesh.topology.dim
     num_cells = mesh.topology.index_map(tdim).size_local
-    h = _cpp.mesh.h(mesh, tdim, range(num_cells))
+    h = _cpp.mesh.h(mesh._mesh, tdim, range(num_cells))
     assert h.min() == pytest.approx(hmin)
     assert h.max() == pytest.approx(hmax)
 

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -312,7 +312,7 @@ def test_cell_circumradius(c0, c1, c5):
 @pytest.mark.skip_in_parallel
 def test_cell_h(c0, c1, c5):
     for c in [c0, c1, c5]:
-        assert _cpp.mesh.h(c[0]._cpp_object, c[1], [c[2]]) == pytest.approx(math.sqrt(2.0))
+        assert c[0].h(c[1], [c[2]])
 
 
 def test_cell_h_prism():

--- a/python/test/unit/mesh/test_refinement.py
+++ b/python/test/unit/mesh/test_refinement.py
@@ -139,7 +139,7 @@ def test_refine_facet_meshtag(tdim):
                        numpy.arange(len(facet_indices), dtype=numpy.int32))
 
     fine_mesh, parent_cell, parent_facet = _cpp.refinement.plaza_refine_data(
-        mesh, False, _cpp.refinement.RefinementOptions.parent_cell_and_facet)
+        mesh._mesh, False, _cpp.refinement.RefinementOptions.parent_cell_and_facet)
     fine_mesh.topology.create_entities(tdim - 1)
 
     new_meshtag = _cpp.refinement.transfer_facet_meshtag(meshtag, fine_mesh, parent_cell, parent_facet)
@@ -177,7 +177,7 @@ def test_refine_cell_meshtag(tdim):
                        numpy.arange(len(cell_indices), dtype=numpy.int32))
 
     fine_mesh, parent_cell, parent_facet = _cpp.refinement.plaza_refine_data(
-        mesh, False, _cpp.refinement.RefinementOptions.parent_cell_and_facet)
+        mesh._mesh, False, _cpp.refinement.RefinementOptions.parent_cell_and_facet)
 
     new_meshtag = _cpp.refinement.transfer_cell_meshtag(meshtag, fine_mesh, parent_cell)
 

--- a/python/test/unit/mesh/test_refinement.py
+++ b/python/test/unit/mesh/test_refinement.py
@@ -139,7 +139,7 @@ def test_refine_facet_meshtag(tdim):
                        numpy.arange(len(facet_indices), dtype=numpy.int32))
 
     fine_mesh, parent_cell, parent_facet = _cpp.refinement.plaza_refine_data(
-        mesh._mesh, False, _cpp.refinement.RefinementOptions.parent_cell_and_facet)
+        mesh._cpp_object, False, _cpp.refinement.RefinementOptions.parent_cell_and_facet)
     fine_mesh.topology.create_entities(tdim - 1)
 
     new_meshtag = _cpp.refinement.transfer_facet_meshtag(meshtag, fine_mesh, parent_cell, parent_facet)
@@ -177,7 +177,7 @@ def test_refine_cell_meshtag(tdim):
                        numpy.arange(len(cell_indices), dtype=numpy.int32))
 
     fine_mesh, parent_cell, parent_facet = _cpp.refinement.plaza_refine_data(
-        mesh._mesh, False, _cpp.refinement.RefinementOptions.parent_cell_and_facet)
+        mesh._cpp_object, False, _cpp.refinement.RefinementOptions.parent_cell_and_facet)
 
     new_meshtag = _cpp.refinement.transfer_cell_meshtag(meshtag, fine_mesh, parent_cell)
 

--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -120,7 +120,6 @@ def test_linear_pde():
 
 def test_nonlinear_pde():
     """Test Newton solver for a simple nonlinear PDE"""
-    # Create mesh and function space
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 5)
     V = FunctionSpace(mesh, ("Lagrange", 1))
     u = Function(V)
@@ -154,7 +153,6 @@ def test_nonlinear_pde():
 
 def test_nonlinear_pde_snes():
     """Test Newton solver for a simple nonlinear PDE"""
-    # Create mesh and function space
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 15)
     V = FunctionSpace(mesh, ("Lagrange", 1))
     u = Function(V)

--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -159,8 +159,7 @@ def test_nonlinear_pde_snes():
     V = FunctionSpace(mesh, ("Lagrange", 1))
     u = Function(V)
     v = TestFunction(V)
-    F = inner(5.0, v) * dx - ufl.sqrt(u * u) * inner(
-        grad(u), grad(v)) * dx - inner(u, v) * dx
+    F = inner(5.0, v) * dx - ufl.sqrt(u * u) * inner(grad(u), grad(v)) * dx - inner(u, v) * dx
 
     u_bc = Function(V)
     u_bc.x.array[:] = 1.0


### PR DESCRIPTION
The difference between C++ and Python meshes is that Python meshes have `ufl_cell` and `ufl_domain` methods. The 'trick' used to handle mesh construction does not work with Python 3.11 (see https://github.com/FEniCS/dolfinx/issues/2423#issuecomment-1370847185).

This change wraps all `Mesh` instances in Python. This change is simple and fixes #2423, and will allow straightforward future support of different precision mesh geometry storage. It does, however, involve more hand-coding of methods and functions that operate of meshes. The design is similar to how `FunctionSpace` is handled on the Python side. The upside of the extra hand-coding is that docstring are easier to write.