### PR TITLE
Fix isort checks for some demos

### DIFF
--- a/python/demo/demo_axis/demo_axis.py
+++ b/python/demo/demo_axis/demo_axis.py
@@ -19,12 +19,13 @@ from functools import partial
 
 import numpy as np
 from mesh_sphere_axis import generate_mesh_sphere_axis
-from mpi4py import MPI
-from petsc4py import PETSc
 from scipy.special import jv, jvp
 
 import ufl
 from dolfinx import fem, io, mesh, plot
+
+from mpi4py import MPI
+from petsc4py import PETSc
 
 try:
     from dolfinx.io import VTXWriter

--- a/python/demo/demo_pml/demo_pml.py
+++ b/python/demo/demo_pml/demo_pml.py
@@ -33,14 +33,15 @@ except ModuleNotFoundError:
 from functools import partial
 from typing import Tuple, Union
 
-from dolfinx.io import VTXWriter, gmshio
 from efficiencies_pml_demo import calculate_analytical_efficiencies
 from mesh_wire_pml import generate_mesh_wire
-from mpi4py import MPI
-from petsc4py import PETSc
 
 import ufl
 from dolfinx import fem, mesh, plot
+from dolfinx.io import VTXWriter, gmshio
+
+from mpi4py import MPI
+from petsc4py import PETSc
 
 # -
 

--- a/python/demo/demo_pml/efficiencies_pml_demo.py
+++ b/python/demo/demo_pml/efficiencies_pml_demo.py
@@ -66,10 +66,10 @@
 # \end{align}
 # $$
 
-import numpy as np
-from scipy.special import h2vp, hankel2, jv, jvp
 from typing import Tuple
 
+import numpy as np
+from scipy.special import h2vp, hankel2, jv, jvp
 
 # The functions that we import from `scipy.special` correspond to:
 #

--- a/python/demo/demo_pml/efficiencies_pml_demo.py
+++ b/python/demo/demo_pml/efficiencies_pml_demo.py
@@ -91,6 +91,8 @@ from scipy.special import h2vp, hankel2, jv, jvp
 # orders of the Bessel functions is truncated at $\nu=50$.
 
 # +
+
+
 def compute_a(nu: int, m: complex, alpha: float) -> float:
     J_nu_alpha = jv(nu, alpha)
     J_nu_malpha = jv(nu, m * alpha)

--- a/python/demo/demo_scattering_boundary_conditions/analytical_efficiencies_wire.py
+++ b/python/demo/demo_scattering_boundary_conditions/analytical_efficiencies_wire.py
@@ -66,10 +66,10 @@
 # \end{align}
 # $$
 
-import numpy as np
-from scipy.special import h2vp, hankel2, jv, jvp
 from typing import Tuple
 
+import numpy as np
+from scipy.special import h2vp, hankel2, jv, jvp
 
 # The functions that we import from `scipy.special` correspond to:
 #

--- a/python/demo/demo_scattering_boundary_conditions/analytical_efficiencies_wire.py
+++ b/python/demo/demo_scattering_boundary_conditions/analytical_efficiencies_wire.py
@@ -91,6 +91,8 @@ from scipy.special import h2vp, hankel2, jv, jvp
 # orders of the Bessel functions is truncated at $\nu=50$.
 
 # +
+
+
 def compute_a(nu: int, m: complex, alpha: float) -> float:
     J_nu_alpha = jv(nu, alpha)
     J_nu_malpha = jv(nu, m * alpha)

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -16,8 +16,6 @@ from functools import singledispatch
 
 import numpy as np
 import numpy.typing as npt
-from dolfinx.fem import dofmap
-from petsc4py import PETSc
 
 import basix
 import basix.ufl_wrapper
@@ -26,7 +24,10 @@ import ufl.algorithms
 import ufl.algorithms.analysis
 from dolfinx import cpp as _cpp
 from dolfinx import jit, la
+from dolfinx.fem import dofmap
 from ufl.domain import extract_unique_domain
+
+from petsc4py import PETSc
 
 
 class Constant(ufl.Constant):

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -15,10 +15,8 @@ import basix
 import basix.ufl_wrapper
 import ufl
 from dolfinx import cpp as _cpp
-
-from dolfinx.cpp.io import perm_vtk as cell_perm_vtk  # noqa F401
 from dolfinx.cpp.io import perm_gmsh as cell_perm_gmsh  # noqa F401
-
+from dolfinx.cpp.io import perm_vtk as cell_perm_vtk  # noqa F401
 from dolfinx.fem import Function
 from dolfinx.mesh import GhostMode, Mesh
 

--- a/python/test/unit/fem/test_constant.py
+++ b/python/test/unit/fem/test_constant.py
@@ -7,8 +7,10 @@
 
 import numpy as np
 import pytest
+
 from dolfinx.fem import Constant
 from dolfinx.mesh import create_unit_cube
+
 from mpi4py import MPI
 
 

--- a/python/test/unit/io/test_vtk.py
+++ b/python/test/unit/io/test_vtk.py
@@ -7,15 +7,14 @@
 from pathlib import Path
 
 import numpy as np
-from numpy.testing import assert_array_equal
 import pytest
+from numpy.testing import assert_array_equal
 
 import ufl
 from dolfinx.fem import (Function, FunctionSpace, TensorFunctionSpace,
                          VectorFunctionSpace)
-from dolfinx.io import (VTKFile)
+from dolfinx.io import VTKFile
 from dolfinx.io.utils import cell_perm_vtk  # noqa F401
-
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
                           create_unit_interval, create_unit_square)
 from dolfinx.plot import create_vtk_mesh


### PR DESCRIPTION
Currently, for a few existing demos, the isort checks fail. The pipeline still runs successfully because the isort checks are non-blocking. However, the following annotations appear:

![image](https://user-images.githubusercontent.com/43179176/213440675-7c7d8f10-bdef-4d81-bf80-f2418f258bb3.png)

Log of the isort checks:

![image](https://user-images.githubusercontent.com/43179176/213393080-106cc8e6-6d50-40b4-afb7-16990e7645d0.png)

I changed the order of the imports to fix the isort checks.