### PR TITLE
Fix import of `distribute_entity_data`

### DIFF
--- a/python/dolfinx/io/__init__.py
+++ b/python/dolfinx/io/__init__.py
@@ -6,9 +6,8 @@
 """Tools for input/output (IO)."""
 
 from dolfinx import cpp as _cpp
-from dolfinx.cpp.io import distribute_entity_data  # noqa: F401
 from dolfinx.io import gmshio  # noqa: F401
-from dolfinx.io.utils import VTKFile, XDMFFile  # noqa: F401
+from dolfinx.io.utils import VTKFile, XDMFFile, distribute_entity_data  # noqa: F401
 
 __all__ = ["gmshio", "distribute_entity_data", "VTKFile", "XDMFFile"]
 


### PR DESCRIPTION
`distribute_entity_data` now has its own Python-wrapper, and should be imported (and not the C++ function)