### PR TITLE
Fix extraction of mesh from array of forms in lifting

### DIFF
--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -154,7 +154,7 @@ void apply_lifting(
     if (a_i and !mesh)
       mesh = a_i->mesh();
     if (a_i and mesh and a_i->mesh() != mesh)
-      throw std::runtime_error("Mis-mismatch between meshes.");
+      throw std::runtime_error("Mismatch between meshes.");
   }
 
   if (!mesh)

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -157,7 +157,9 @@ void apply_lifting(
       throw std::runtime_error("Mis-mismatch between meshes.");
   }
 
-  assert(mesh);
+  if (!mesh)
+    throw std::runtime_error("Unable to extract a mesh.");
+
   if constexpr (std::is_same_v<double, impl::scalar_value_type_t<T>>)
   {
     impl::apply_lifting<T>(b, a, mesh->geometry(), constants, coeffs, bcs1, x0,

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -148,7 +148,15 @@ void apply_lifting(
     const std::vector<std::vector<std::shared_ptr<const DirichletBC<T>>>>& bcs1,
     const std::vector<std::span<const T>>& x0, T scale)
 {
-  std::shared_ptr<const mesh::Mesh> mesh = a[0]->mesh();
+  std::shared_ptr<const mesh::Mesh> mesh;
+  for (auto& a_i : a)
+  {
+    if (a_i and !mesh)
+      mesh = a_i->mesh();
+    if (a_i and mesh and a_i->mesh() != mesh)
+      throw std::runtime_error("Mis-mismatch between meshes.");
+  }
+
   assert(mesh);
   if constexpr (std::is_same_v<double, impl::scalar_value_type_t<T>>)
   {

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -48,8 +48,7 @@ def nest_matrix_norm(A):
 def test_matrix_assembly_block_nl():
     """Test assembly of block matrices and vectors into (a) monolithic
     blocked structures, PETSc Nest structures, and monolithic structures
-    in the nonlinear setting
-    """
+    in the nonlinear setting."""
     mesh = create_unit_square(MPI.COMM_WORLD, 4, 8)
     p0, p1 = 1, 2
     P0 = ufl.FiniteElement("Lagrange", mesh.ufl_cell(), p0)
@@ -93,79 +92,93 @@ def test_matrix_assembly_block_nl():
                     [derivative(F1, u, du), derivative(F1, p, dp)]])
     L_block = form([F0, F1])
 
-    # Monolithic blocked
-    x0 = create_vector_block(L_block)
-    scatter_local_vectors(x0, [u.vector.array_r, p.vector.array_r],
-                          [(u.function_space.dofmap.index_map, u.function_space.dofmap.index_map_bs),
-                           (p.function_space.dofmap.index_map, p.function_space.dofmap.index_map_bs)])
-    x0.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+    def blocked():
+        """Monolithic blocked"""
+        x = create_vector_block(L_block)
+        scatter_local_vectors(x, [u.vector.array_r, p.vector.array_r],
+                              [(u.function_space.dofmap.index_map, u.function_space.dofmap.index_map_bs),
+                               (p.function_space.dofmap.index_map, p.function_space.dofmap.index_map_bs)])
+        x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
-    # Ghosts are updated inside assemble_vector_block
-    A0 = assemble_matrix_block(a_block, bcs=[bc])
-    b0 = assemble_vector_block(L_block, a_block, bcs=[bc], x0=x0, scale=-1.0)
-    A0.assemble()
-    assert A0.getType() != "nest"
-    Anorm0 = A0.norm()
-    bnorm0 = b0.norm()
+        # Ghosts are updated inside assemble_vector_block
+        A = assemble_matrix_block(a_block, bcs=[bc])
+        b = assemble_vector_block(L_block, a_block, bcs=[bc], x0=x, scale=-1.0)
+        A.assemble()
+        assert A.getType() != "nest"
+        Anorm = A.norm()
+        bnorm = b.norm()
+        A.destroy()
+        b.destroy()
+        x.destroy()
+        return Anorm, bnorm
 
     # Nested (MatNest)
-    x1 = create_vector_nest(L_block)
-    for x1_soln_pair in zip(x1.getNestSubVecs(), (u, p)):
-        x1_sub, soln_sub = x1_soln_pair
-        soln_sub.vector.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
-        soln_sub.vector.copy(result=x1_sub)
-        x1_sub.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+    def nested():
+        """Nested (MatNest)"""
+        x = create_vector_nest(L_block)
+        for x1_soln_pair in zip(x.getNestSubVecs(), (u, p)):
+            x1_sub, soln_sub = x1_soln_pair
+            soln_sub.vector.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+            soln_sub.vector.copy(result=x1_sub)
+            x1_sub.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
-    A1 = assemble_matrix_nest(a_block, bcs=[bc])
-    b1 = assemble_vector_nest(L_block)
-    apply_lifting_nest(b1, a_block, bcs=[bc], x0=x1, scale=-1.0)
-    for b_sub in b1.getNestSubVecs():
-        b_sub.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
-    bcs0 = bcs_by_block([L.function_spaces[0] for L in L_block], [bc])
+        A = assemble_matrix_nest(a_block, bcs=[bc])
+        b = assemble_vector_nest(L_block)
+        apply_lifting_nest(b, a_block, bcs=[bc], x0=x, scale=-1.0)
+        for b_sub in b.getNestSubVecs():
+            b_sub.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
+        bcs0 = bcs_by_block([L.function_spaces[0] for L in L_block], [bc])
 
-    set_bc_nest(b1, bcs0, x1, scale=-1.0)
-    A1.assemble()
+        set_bc_nest(b, bcs0, x, scale=-1.0)
+        A.assemble()
+        assert A.getType() == "nest"
+        Anorm = nest_matrix_norm(A)
+        bnorm = b.norm()
+        A.destroy()
+        b.destroy()
+        x.destroy()
+        return Anorm, bnorm
 
-    assert A1.getType() == "nest"
-    assert nest_matrix_norm(A1) == pytest.approx(Anorm0, 1.0e-12)
-    assert b1.norm() == pytest.approx(bnorm0, 1.0e-12)
+    def monolithic():
+        """Monolithic version"""
+        E = P0 * P1
+        W = FunctionSpace(mesh, E)
+        dU = ufl.TrialFunction(W)
+        U = Function(W)
+        u0, u1 = ufl.split(U)
+        v0, v1 = ufl.TestFunctions(W)
 
-    # Monolithic version
-    E = P0 * P1
-    W = FunctionSpace(mesh, E)
-    dU = ufl.TrialFunction(W)
-    U = Function(W)
-    u0, u1 = ufl.split(U)
-    v0, v1 = ufl.TestFunctions(W)
+        U.sub(0).interpolate(initial_guess_u)
+        U.sub(1).interpolate(initial_guess_p)
 
-    U.sub(0).interpolate(initial_guess_u)
-    U.sub(1).interpolate(initial_guess_p)
+        F = inner(u0, v0) * dx + inner(u1, v0) * dx + inner(u0, v1) * dx + inner(u1, v1) * dx \
+            - inner(f, v0) * ufl.dx - inner(g, v1) * dx
+        J = derivative(F, U, dU)
+        F, J = form(F), form(J)
 
-    F = inner(u0, v0) * dx + inner(u1, v0) * dx + inner(u0, v1) * dx + inner(u1, v1) * dx \
-        - inner(f, v0) * ufl.dx - inner(g, v1) * dx
-    J = derivative(F, U, dU)
-    F, J = form(F), form(J)
+        bdofsW_V1 = locate_dofs_topological((W.sub(1), V1), facetdim, bndry_facets)
+        bc = dirichletbc(u_bc, bdofsW_V1, W.sub(1))
+        A = assemble_matrix(J, bcs=[bc])
+        A.assemble()
+        b = assemble_vector(F)
+        apply_lifting(b, [J], bcs=[[bc]], x0=[U.vector], scale=-1.0)
+        b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
+        set_bc(b, [bc], x0=U.vector, scale=-1.0)
+        assert A.getType() != "nest"
+        Anorm = A.norm()
+        bnorm = b.norm()
+        A.destroy()
+        b.destroy()
+        return Anorm, bnorm
 
-    bdofsW_V1 = locate_dofs_topological((W.sub(1), V1), facetdim, bndry_facets)
+    Anorm0, bnorm0 = blocked()
+    Anorm1, bnorm1 = nested()
+    assert Anorm1 == pytest.approx(Anorm0, 1.0e-12)
+    assert bnorm1 == pytest.approx(bnorm0, 1.0e-12)
 
-    bc = dirichletbc(u_bc, bdofsW_V1, W.sub(1))
-    A2 = assemble_matrix(J, bcs=[bc])
-    A2.assemble()
-    b2 = assemble_vector(F)
-    apply_lifting(b2, [J], bcs=[[bc]], x0=[U.vector], scale=-1.0)
-    b2.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
-    set_bc(b2, [bc], x0=U.vector, scale=-1.0)
-    assert A2.getType() != "nest"
-    assert A2.norm() == pytest.approx(Anorm0, 1.0e-12)
-    assert b2.norm() == pytest.approx(bnorm0, 1.0e-12)
-
-    A0.destroy()
-    A1.destroy()
-    A2.destroy()
-    b0.destroy()
-    b1.destroy()
-    b2.destroy()
-    x1.destroy()
+    Anorm2, bnorm2 = monolithic()
+    assert Anorm2 == pytest.approx(Anorm0, 1.0e-12)
+    assert bnorm2 == pytest.approx(bnorm0, 1.0e-12)
 
 
 class NonlinearPDE_SNESProblem():
@@ -261,9 +274,8 @@ class NonlinearPDE_SNESProblem():
 
 
 def test_assembly_solve_block_nl():
-    """Solve a two-field nonlinear diffusion like problem with block matrix
-    approaches and test that solution is the same.
-    """
+    """Solve a two-field nonlinear diffusion like problem with block
+    matrix approaches and test that solution is the same."""
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 11)
     p = 1
     P = ufl.FiniteElement("Lagrange", mesh.ufl_cell(), p)
@@ -299,24 +311,19 @@ def test_assembly_solve_block_nl():
     du, dp = ufl.TrialFunction(V0), ufl.TrialFunction(V1)
     v, q = ufl.TestFunction(V0), ufl.TestFunction(V1)
 
-    f = 1.0
-    g = -3.0
-
+    f, g = 1.0, -3.0
     F = [inner((u**2 + 1) * ufl.grad(u), ufl.grad(v)) * dx - inner(f, v) * dx,
          inner((p**2 + 1) * ufl.grad(p), ufl.grad(q)) * dx - inner(g, q) * dx]
     J = [[derivative(F[0], u, du), derivative(F[0], p, dp)],
          [derivative(F[1], u, du), derivative(F[1], p, dp)]]
-
     F, J = form(F), form(J)
 
     def blocked_solve():
         """Blocked version"""
         Jmat = create_matrix_block(J)
         Fvec = create_vector_block(F)
-
         snes = PETSc.SNES().create(MPI.COMM_WORLD)
         snes.setTolerances(rtol=1.0e-15, max_it=10)
-
         problem = NonlinearPDE_SNESProblem(F, J, [u, p], bcs)
         snes.setFunction(problem.F_block, Fvec)
         snes.setJacobian(problem.J_block, J=Jmat, P=None)
@@ -329,18 +336,14 @@ def test_assembly_solve_block_nl():
                               [(u.function_space.dofmap.index_map, u.function_space.dofmap.index_map_bs),
                                (p.function_space.dofmap.index_map, p.function_space.dofmap.index_map_bs)])
         x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
-
         snes.solve(None, x)
         assert snes.getKSP().getConvergedReason() > 0
         assert snes.getConvergedReason() > 0
-
         xnorm = x.norm()
-
         snes.destroy()
         Jmat.destroy()
         Fvec.destroy()
         x.destroy()
-
         return xnorm
 
     def nested_solve():
@@ -352,9 +355,7 @@ def test_assembly_solve_block_nl():
 
         snes = PETSc.SNES().create(MPI.COMM_WORLD)
         snes.setTolerances(rtol=1.0e-15, max_it=10)
-
         nested_IS = Jmat.getNestISs()
-
         snes.getKSP().setType("gmres")
         snes.getKSP().setTolerances(rtol=1e-12)
         snes.getKSP().getPC().setType("fieldsplit")
@@ -366,7 +367,6 @@ def test_assembly_solve_block_nl():
 
         u.interpolate(initial_guess_u)
         p.interpolate(initial_guess_p)
-
         x = create_vector_nest(F)
         assert x.getType() == "nest"
         for x_soln_pair in zip(x.getNestSubVecs(), (u, p)):
@@ -378,14 +378,11 @@ def test_assembly_solve_block_nl():
         snes.solve(None, x)
         assert snes.getKSP().getConvergedReason() > 0
         assert snes.getConvergedReason() > 0
-
         xnorm = x.norm()
-
         snes.destroy()
         Jmat.destroy()
         Fvec.destroy()
         x.destroy()
-
         return xnorm
 
     def monolithic_solve():
@@ -401,7 +398,6 @@ def test_assembly_solve_block_nl():
             + inner((u1**2 + 1) * ufl.grad(u1), ufl.grad(v1)) * dx \
             - inner(f, v0) * ufl.dx - inner(g, v1) * dx
         J = derivative(F, U, dU)
-
         F, J = form(F), form(J)
 
         u0_bc = Function(V0)
@@ -431,14 +427,11 @@ def test_assembly_solve_block_nl():
         snes.solve(None, x)
         assert snes.getKSP().getConvergedReason() > 0
         assert snes.getConvergedReason() > 0
-
         xnorm = x.norm()
-
         snes.destroy()
         Jmat.destroy()
         Fvec.destroy()
         x.destroy()
-
         return xnorm
 
     norm0 = blocked_solve()
@@ -503,140 +496,138 @@ def test_assembly_solve_taylor_hood_nl(mesh):
          [derivative(F[1], u, du), derivative(F[1], p, dp)]]
     P = [[J[0][0], None],
          [None, inner(dp, q) * dx]]
-
     F, J, P = form(F), form(J), form(P)
 
-    # -- Blocked and monolithic
+    def blocked():
+        """Blocked and monolithic"""
+        Jmat = create_matrix_block(J)
+        Pmat = create_matrix_block(P)
+        Fvec = create_vector_block(F)
 
-    Jmat0 = create_matrix_block(J)
-    Pmat0 = create_matrix_block(P)
-    Fvec0 = create_vector_block(F)
+        snes = PETSc.SNES().create(MPI.COMM_WORLD)
+        snes.setTolerances(rtol=1.0e-15, max_it=10)
+        snes.getKSP().setType("minres")
 
-    snes = PETSc.SNES().create(MPI.COMM_WORLD)
-    snes.setTolerances(rtol=1.0e-15, max_it=10)
-    snes.getKSP().setType("minres")
+        problem = NonlinearPDE_SNESProblem(F, J, [u, p], bcs, P=P)
+        snes.setFunction(problem.F_block, Fvec)
+        snes.setJacobian(problem.J_block, J=Jmat, P=Pmat)
 
-    problem = NonlinearPDE_SNESProblem(F, J, [u, p], bcs, P=P)
-    snes.setFunction(problem.F_block, Fvec0)
-    snes.setJacobian(problem.J_block, J=Jmat0, P=Pmat0)
+        u.interpolate(initial_guess_u)
+        p.interpolate(initial_guess_p)
+        x = create_vector_block(F)
+        with u.vector.localForm() as _u, p.vector.localForm() as _p:
+            scatter_local_vectors(x, [_u.array_r, _p.array_r],
+                                  [(u.function_space.dofmap.index_map, u.function_space.dofmap.index_map_bs),
+                                   (p.function_space.dofmap.index_map, p.function_space.dofmap.index_map_bs)])
+        x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
-    u.interpolate(initial_guess_u)
-    p.interpolate(initial_guess_p)
+        snes.solve(None, x)
+        assert snes.getConvergedReason() > 0
+        snes.destroy()
+        Jnorm = Jmat.norm()
+        Fnorm = Fvec.norm()
+        xnorm = x.norm()
+        Jmat.destroy()
+        Fvec.destroy()
+        x.destroy()
+        return Jnorm, Fnorm, xnorm
 
-    x0 = create_vector_block(F)
-    with u.vector.localForm() as _u, p.vector.localForm() as _p:
-        scatter_local_vectors(x0, [_u.array_r, _p.array_r],
-                              [(u.function_space.dofmap.index_map, u.function_space.dofmap.index_map_bs),
-                               (p.function_space.dofmap.index_map, p.function_space.dofmap.index_map_bs)])
-    x0.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+    def nested():
+        """Blocked and nested"""
+        Jmat = create_matrix_nest(J)
+        Pmat = create_matrix_nest(P)
+        Fvec = create_vector_nest(F)
 
-    snes.solve(None, x0)
+        snes = PETSc.SNES().create(MPI.COMM_WORLD)
+        snes.setTolerances(rtol=1.0e-15, max_it=10)
+        nested_IS = Jmat.getNestISs()
+        snes.getKSP().setType("minres")
+        snes.getKSP().setTolerances(rtol=1e-12)
+        snes.getKSP().getPC().setType("fieldsplit")
+        snes.getKSP().getPC().setFieldSplitIS(["u", nested_IS[0][0]], ["p", nested_IS[1][1]])
 
-    assert snes.getConvergedReason() > 0
-    snes.destroy()
+        problem = NonlinearPDE_SNESProblem(F, J, [u, p], bcs, P=P)
+        snes.setFunction(problem.F_nest, Fvec)
+        snes.setJacobian(problem.J_nest, J=Jmat, P=Pmat)
 
-    # -- Blocked and nested
+        u.interpolate(initial_guess_u)
+        p.interpolate(initial_guess_p)
+        x = create_vector_nest(F)
+        for x1_soln_pair in zip(x.getNestSubVecs(), (u, p)):
+            x1_sub, soln_sub = x1_soln_pair
+            soln_sub.vector.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+            soln_sub.vector.copy(result=x1_sub)
+            x1_sub.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
-    Jmat1 = create_matrix_nest(J)
-    Pmat1 = create_matrix_nest(P)
-    Fvec1 = create_vector_nest(F)
+        x.set(0.0)
+        snes.solve(None, x)
+        assert snes.getConvergedReason() > 0
+        snes.destroy()
+        Jnorm = nest_matrix_norm(Jmat)
+        Fnorm = Fvec.norm()
+        xnorm = x.norm()
+        Jmat.destroy()
+        Fvec.destroy()
+        x.destroy()
+        return Jnorm, Fnorm, xnorm
 
-    snes = PETSc.SNES().create(MPI.COMM_WORLD)
-    snes.setTolerances(rtol=1.0e-15, max_it=10)
+    def monolithic():
+        """Monolithic"""
+        P2_el = ufl.VectorElement("Lagrange", mesh.ufl_cell(), 2)
+        P1_el = ufl.FiniteElement("Lagrange", mesh.ufl_cell(), 1)
+        TH = P2_el * P1_el
+        W = FunctionSpace(mesh, TH)
+        U = Function(W)
+        dU = ufl.TrialFunction(W)
+        u, p = ufl.split(U)
+        du, dp = ufl.split(dU)
+        v, q = ufl.TestFunctions(W)
 
-    nested_IS = Jmat1.getNestISs()
+        F = inner(ufl.grad(u), ufl.grad(v)) * dx + inner(p, ufl.div(v)) * dx + inner(ufl.div(u), q) * dx
+        J = derivative(F, U, dU)
+        P = inner(ufl.grad(du), ufl.grad(v)) * dx + inner(dp, q) * dx
+        F, J, P = form(F), form(J), form(P)
 
-    snes.getKSP().setType("minres")
-    snes.getKSP().setTolerances(rtol=1e-12)
-    snes.getKSP().getPC().setType("fieldsplit")
-    snes.getKSP().getPC().setFieldSplitIS(["u", nested_IS[0][0]], ["p", nested_IS[1][1]])
+        bdofsW0_P2_0 = locate_dofs_topological((W.sub(0), P2), facetdim, bndry_facets0)
+        bdofsW0_P2_1 = locate_dofs_topological((W.sub(0), P2), facetdim, bndry_facets1)
+        bcs = [dirichletbc(u_bc_0, bdofsW0_P2_0, W.sub(0)), dirichletbc(u_bc_1, bdofsW0_P2_1, W.sub(0))]
 
-    problem = NonlinearPDE_SNESProblem(F, J, [u, p], bcs, P=P)
-    snes.setFunction(problem.F_nest, Fvec1)
-    snes.setJacobian(problem.J_nest, J=Jmat1, P=Pmat1)
+        Jmat = create_matrix(J)
+        Pmat = create_matrix(P)
+        Fvec = create_vector(F)
 
-    u.interpolate(initial_guess_u)
-    p.interpolate(initial_guess_p)
+        snes = PETSc.SNES().create(MPI.COMM_WORLD)
+        snes.setTolerances(rtol=1.0e-15, max_it=10)
+        snes.getKSP().setType("minres")
 
-    x1 = create_vector_nest(F)
-    for x1_soln_pair in zip(x1.getNestSubVecs(), (u, p)):
-        x1_sub, soln_sub = x1_soln_pair
-        soln_sub.vector.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
-        soln_sub.vector.copy(result=x1_sub)
-        x1_sub.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+        problem = NonlinearPDE_SNESProblem(F, J, U, bcs, P=P)
+        snes.setFunction(problem.F_mono, Fvec)
+        snes.setJacobian(problem.J_mono, J=Jmat, P=Pmat)
 
-    x1.set(0.0)
-    snes.solve(None, x1)
+        U.sub(0).interpolate(initial_guess_u)
+        U.sub(1).interpolate(initial_guess_p)
 
-    assert snes.getConvergedReason() > 0
-    assert nest_matrix_norm(Jmat1) == pytest.approx(Jmat0.norm(), 1.0e-12)
-    assert Fvec1.norm() == pytest.approx(Fvec0.norm(), 1.0e-12)
-    assert x1.norm() == pytest.approx(x0.norm(), 1.0e-12)
+        x = create_vector(F)
+        x.array = U.vector.array_r
 
-    snes.destroy()
+        snes.solve(None, x)
+        assert snes.getConvergedReason() > 0
+        snes.destroy()
+        Jnorm = Jmat.norm()
+        Fnorm = Fvec.norm()
+        xnorm = x.norm()
+        Jmat.destroy()
+        Fvec.destroy()
+        x.destroy()
+        return Jnorm, Fnorm, xnorm
 
-    # -- Monolithic
+    Jnorm0, Fnorm0, xnorm0 = blocked()
+    Jnorm1, Fnorm1, xnorm1 = nested()
+    assert Jnorm1 == pytest.approx(Jnorm0, 1.0e-12)
+    assert Fnorm1 == pytest.approx(Fnorm0, 1.0e-12)
+    assert xnorm1 == pytest.approx(xnorm0, 1.0e-12)
 
-    P2_el = ufl.VectorElement("Lagrange", mesh.ufl_cell(), 2)
-    P1_el = ufl.FiniteElement("Lagrange", mesh.ufl_cell(), 1)
-    TH = P2_el * P1_el
-    W = FunctionSpace(mesh, TH)
-    U = Function(W)
-    dU = ufl.TrialFunction(W)
-    u, p = ufl.split(U)
-    du, dp = ufl.split(dU)
-    v, q = ufl.TestFunctions(W)
-
-    F = inner(ufl.grad(u), ufl.grad(v)) * dx + inner(p, ufl.div(v)) * dx \
-        + inner(ufl.div(u), q) * dx
-    J = derivative(F, U, dU)
-    P = inner(ufl.grad(du), ufl.grad(v)) * dx + inner(dp, q) * dx
-
-    F, J, P = form(F), form(J), form(P)
-
-    bdofsW0_P2_0 = locate_dofs_topological((W.sub(0), P2), facetdim, bndry_facets0)
-    bdofsW0_P2_1 = locate_dofs_topological((W.sub(0), P2), facetdim, bndry_facets1)
-
-    bcs = [dirichletbc(u_bc_0, bdofsW0_P2_0, W.sub(0)), dirichletbc(u_bc_1, bdofsW0_P2_1, W.sub(0))]
-
-    Jmat2 = create_matrix(J)
-    Pmat2 = create_matrix(P)
-    Fvec2 = create_vector(F)
-
-    snes = PETSc.SNES().create(MPI.COMM_WORLD)
-    snes.setTolerances(rtol=1.0e-15, max_it=10)
-    snes.getKSP().setType("minres")
-
-    problem = NonlinearPDE_SNESProblem(F, J, U, bcs, P=P)
-    snes.setFunction(problem.F_mono, Fvec2)
-    snes.setJacobian(problem.J_mono, J=Jmat2, P=Pmat2)
-
-    U.sub(0).interpolate(initial_guess_u)
-    U.sub(1).interpolate(initial_guess_p)
-
-    x2 = create_vector(F)
-    x2.array = U.vector.array_r
-
-    snes.solve(None, x2)
-
-    assert snes.getConvergedReason() > 0
-    assert Jmat2.norm() == pytest.approx(Jmat0.norm(), 1.0e-12)
-    assert Fvec2.norm() == pytest.approx(Fvec0.norm(), 1.0e-12)
-    assert x2.norm() == pytest.approx(x0.norm(), 1.0e-12)
-
-    snes.destroy()
-
-    Jmat0.destroy()
-    Pmat0.destroy()
-    Fvec0.destroy()
-    x0.destroy()
-
-    Jmat1.destroy()
-    Pmat1.destroy()
-    Fvec1.destroy()
-    x1.destroy()
-
-    Jmat2.destroy()
-    Pmat2.destroy()
-    Fvec2.destroy()
-    x2.destroy()
+    Jnorm2, Fnorm2, xnorm2 = monolithic()
+    assert Jnorm2 == pytest.approx(Jnorm0, 1.0e-12)
+    assert Fnorm2 == pytest.approx(Fnorm0, 1.0e-12)
+    assert xnorm2 == pytest.approx(xnorm0, 1.0e-12)


### PR DESCRIPTION
Fixes #2558.

Also refactors block assembly tests to use more scoping.