### PR TITLE
Allow extra control for mesh partitioning from python

### DIFF
--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -378,15 +378,14 @@ void mesh(py::module& m)
       [](const std::function<dolfinx::graph::AdjacencyList<std::int32_t>(
              MPICommWrapper comm, int nparts,
              const dolfinx::graph::AdjacencyList<std::int64_t>& local_graph,
-             bool ghosting)>& part) -> PythonCellPartitionFunction
+             bool ghosting)>& part,
+         dolfinx::mesh::GhostMode ghost_mode) -> PythonCellPartitionFunction
       {
         return create_cell_partitioner_py(
             dolfinx::mesh::create_cell_partitioner(
-                dolfinx::mesh::GhostMode::none,
-                create_cell_partitioner_cpp(part)));
+                ghost_mode, create_cell_partitioner_cpp(part)));
       },
-      py::arg("part"));
-
+      py::arg("part"), py::arg("ghost_mode") = dolfinx::mesh::GhostMode::none);
   m.def(
       "locate_entities",
       [](const dolfinx::mesh::Mesh& mesh, int dim,


### PR DESCRIPTION
Resolves #2591.
MWE:
```python

import ipyparallel
from dolfinx.mesh import GhostMode


def create_mesh(ghost_mode):
    from mpi4py import MPI
    import numpy as np
    import ufl
    import dolfinx

    if MPI.COMM_WORLD.rank == 0:
        quadrilaterals = np.array([], dtype=np.int64)
        quad_points = np.array([[0, 0], [0.3, 0]], dtype=np.float64)
    elif MPI.COMM_WORLD.rank == 1:
        quadrilaterals = np.array(
            [[0, 1, 3, 4], [1, 2, 4, 5]], dtype=np.int64)
        quad_points = np.array(
            [[1, 0], [0, 1], [0.5, 1], [1, 1]], dtype=np.float64)
    else:
        quad_points = np.empty((0, 2), dtype=np.float64)
        quadrilaterals = np.empty((0, 4), dtype=np.int64)

    ufl_quad = ufl.Mesh(ufl.VectorElement(
        "Lagrange", ufl.quadrilateral, 1))

    partitioner = dolfinx.mesh.create_cell_partitioner(
        dolfinx.graph.partitioner_scotch(), ghost_mode)
    quad_mesh = dolfinx.mesh.create_mesh(
        MPI.COMM_WORLD, quadrilaterals, quad_points, ufl_quad, partitioner=partitioner)
    output = f"{quad_mesh.comm.rank}: {ghost_mode}, "
    output += f"num cells local {quad_mesh.topology.index_map(2).size_local}, "
    output += f"num ghosts {quad_mesh.topology.index_map(2).num_ghosts}"
    return output


with ipyparallel.Cluster(engines="mpi", n=2) as rc:
    view = rc.broadcast_view()
    for ghost_mode in [GhostMode.none, GhostMode.shared_facet]:
        output = view.apply_sync(create_mesh, ghost_mode=ghost_mode)
        print("\n".join(output))
```
yields:
```bash
0: GhostMode.none, num cells local 1, num ghosts 0
1: GhostMode.none, num cells local 1, num ghosts 0
0: GhostMode.shared_facet, num cells local 1, num ghosts 1
1: GhostMode.shared_facet, num cells local 1, num ghosts 1
```
default behavior is still sending in `GhostMode.none` which means that when using custom-partitioners, we are not sending in the wrong ghost mode.