### PR TITLE
Add `basix_cell` method to `Mesh`

### DIFF
--- a/python/demo/demo_axis/demo_axis.py
+++ b/python/demo/demo_axis/demo_axis.py
@@ -369,8 +369,8 @@ if have_pyvista:
 # will use Lagrange elements:
 
 degree = 3
-curl_el = element("N1curl", msh.ufl_cell().cellname(), degree)
-lagr_el = element("Lagrange", msh.ufl_cell().cellname(), degree)
+curl_el = element("N1curl", msh.basix_cell(), degree)
+lagr_el = element("Lagrange", msh.basix_cell(), degree)
 V = fem.FunctionSpace(msh, mixed_element([curl_el, lagr_el]))
 
 # The integration domains of our problem are the following:
@@ -625,7 +625,7 @@ assert err_abs < 0.01
 assert err_ext < 0.01
 
 if has_vtx:
-    v_dg_el = element("DG", msh.ufl_cell().cellname(), degree, shape=(3, ))
+    v_dg_el = element("DG", msh.basix_cell(), degree, shape=(3, ))
     W = fem.FunctionSpace(msh, v_dg_el)
     Es_dg = fem.Function(W)
     Es_expr = fem.Expression(Esh, W.element.interpolation_points())

--- a/python/demo/demo_cahn-hilliard.py
+++ b/python/demo/demo_cahn-hilliard.py
@@ -161,7 +161,7 @@ theta = 0.5  # time stepping family, e.g. theta=1 -> backward Euler, theta=0.5 -
 # using a pair of linear Lagrange elements.
 
 msh = create_unit_square(MPI.COMM_WORLD, 96, 96, CellType.triangle)
-P1 = element("Lagrange", msh.ufl_cell().cellname(), 1)
+P1 = element("Lagrange", msh.basix_cell(), 1)
 ME = FunctionSpace(msh, mixed_element([P1, P1]))
 
 # Trial and test functions of the space `ME` are now defined:

--- a/python/demo/demo_mixed-poisson.py
+++ b/python/demo/demo_mixed-poisson.py
@@ -101,8 +101,8 @@ domain = mesh.create_unit_square(
 )
 
 k = 1
-Q_el = element("BDMCF", domain.ufl_cell().cellname(), k)
-P_el = element("DG", domain.ufl_cell().cellname(), k - 1)
+Q_el = element("BDMCF", domain.basix_cell(), k)
+P_el = element("DG", domain.basix_cell(), k - 1)
 V_el = mixed_element([Q_el, P_el])
 V = fem.FunctionSpace(domain, V_el)
 

--- a/python/demo/demo_pml/demo_pml.py
+++ b/python/demo/demo_pml/demo_pml.py
@@ -229,7 +229,7 @@ theta = 0  # Angle of incidence of the background field
 # element to represent the electric field:
 
 degree = 3
-curl_el = element("N1curl", msh.ufl_cell().cellname(), degree)
+curl_el = element("N1curl", msh.basix_cell(), degree)
 V = fem.FunctionSpace(msh, curl_el)
 
 # Next, we interpolate $\mathbf{E}_b$ into the function space $V$,

--- a/python/demo/demo_scattering_boundary_conditions/demo_scattering_boundary_conditions.py
+++ b/python/demo/demo_scattering_boundary_conditions/demo_scattering_boundary_conditions.py
@@ -271,7 +271,7 @@ theta = np.pi / 4  # Angle of incidence of the background field
 # represent the electric field
 
 degree = 3
-curl_el = element("N1curl", domain.ufl_cell().cellname(), degree)
+curl_el = element("N1curl", domain.basix_cell(), degree)
 V = fem.FunctionSpace(domain, curl_el)
 
 # Next, we can interpolate $\mathbf{E}_b$ into the function space $V$:

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -48,8 +48,8 @@ msh = infile.read_mesh(name="Grid")
 infile.close()
 
 # Stress (Se) and displacement (Ue) elements
-Se = element("DG", msh.ufl_cell().cellname(), 1, rank=2, symmetry=True)
-Ue = element("Lagrange", msh.ufl_cell().cellname(), 2, rank=1)
+Se = element("DG", msh.basix_cell(), 1, rank=2, symmetry=True)
+Ue = element("Lagrange", msh.basix_cell(), 2, rank=1)
 
 S = FunctionSpace(msh, Se)
 U = FunctionSpace(msh, Ue)

--- a/python/demo/demo_stokes.py
+++ b/python/demo/demo_stokes.py
@@ -130,8 +130,8 @@ def lid_velocity_expression(x):
 # linear basis (scalar).
 
 
-P2 = element("Lagrange", msh.ufl_cell().cellname(), 2, rank=1)
-P1 = element("Lagrange", msh.ufl_cell().cellname(), 1)
+P2 = element("Lagrange", msh.basix_cell(), 2, rank=1)
+P1 = element("Lagrange", msh.basix_cell(), 1)
 V, Q = FunctionSpace(msh, P2), FunctionSpace(msh, P1)
 
 # Boundary conditions for the velocity field are defined:

--- a/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
+++ b/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
@@ -191,8 +191,8 @@ eps.x.array[cells_v] = np.full_like(cells_v, eps_v, dtype=ScalarType)
 # `mixed_element`:
 
 degree = 1
-RTCE = element("RTCE", msh.ufl_cell().cellname(), degree)
-Q = element("Lagrange", msh.ufl_cell().cellname(), degree)
+RTCE = element("RTCE", msh.basix_cell(), degree)
+Q = element("Lagrange", msh.basix_cell(), degree)
 V = fem.FunctionSpace(msh, mixed_element([RTCE, Q]))
 
 # Now we can define our weak form:

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -472,7 +472,7 @@ class FunctionSpace(ufl.FunctionSpace):
                 assert len(element) == 2, "Expected sequence of (element_type, degree)"
                 e = ElementMetaData(*element)
                 ufl_e = basix.ufl.element(
-                    e.family, mesh.ufl_cell().cellname(), e.degree, gdim=mesh.ufl_cell().geometric_dimension())
+                    e.family, mesh.basix_cell(), e.degree, gdim=mesh.ufl_cell().geometric_dimension())
                 super().__init__(mesh.ufl_domain(), ufl_e)
 
             # Compile dofmap and element and create DOLFIN objects
@@ -616,7 +616,7 @@ def _is_scalar(mesh, element):
                               gdim=mesh.geometry.dim)
     except AttributeError:
         ed = ElementMetaData(*element)
-        e = basix.ufl.element(ed.family, mesh.ufl_cell().cellname(), ed.degree,
+        e = basix.ufl.element(ed.family, mesh.basix_cell(), ed.degree,
                               gdim=mesh.geometry.dim)
     return len(e.value_shape()) == 0
 
@@ -636,7 +636,7 @@ def VectorFunctionSpace(mesh: Mesh,
                                   shape=None if dim is None else (dim, ), gdim=mesh.geometry.dim, rank=1)
     except AttributeError:
         ed = ElementMetaData(*element)
-        ufl_e = basix.ufl.element(ed.family, mesh.ufl_cell().cellname(), ed.degree,
+        ufl_e = basix.ufl.element(ed.family, mesh.basix_cell(), ed.degree,
                                   shape=None if dim is None else (dim, ), gdim=mesh.geometry.dim, rank=1)
     return FunctionSpace(mesh, ufl_e)
 
@@ -648,7 +648,7 @@ def TensorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typin
         raise ValueError("Cannot create tensor element containing a non-scalar.")
 
     e = ElementMetaData(*element)
-    ufl_element = basix.ufl.element(e.family, mesh.ufl_cell().cellname(),
+    ufl_element = basix.ufl.element(e.family, mesh.basix_cell(),
                                     e.degree, shape=shape, symmetry=symmetry,
                                     gdim=mesh.geometry.dim, rank=2)
     return FunctionSpace(mesh, ufl_element)

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -76,6 +76,10 @@ class Mesh:
         """Return the ufl domain corresponding to the mesh."""
         return self._ufl_domain
 
+    def basix_cell(self) -> ufl.Cell:
+        """Return the Basix cell type."""
+        return getattr(basix.CellType, self.topology.cell_name())
+
     def h(self, dim: int, entities: npt.NDArray[np.int32]) -> npt.NDArray[np.float64]:
         """Size measure for each cell."""
         return _cpp.mesh.h(self._cpp_object, dim, entities)

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -246,9 +246,9 @@ def test_matrix_assembly_block(mode):
     structures"""
     mesh = create_unit_square(MPI.COMM_WORLD, 4, 8, ghost_mode=mode)
     p0, p1 = 1, 2
-    P0 = element("Lagrange", mesh.ufl_cell().cellname(), p0)
-    P1 = element("Lagrange", mesh.ufl_cell().cellname(), p1)
-    P2 = element("Lagrange", mesh.ufl_cell().cellname(), p0)
+    P0 = element("Lagrange", mesh.basix_cell(), p0)
+    P1 = element("Lagrange", mesh.basix_cell(), p1)
+    P2 = element("Lagrange", mesh.basix_cell(), p0)
     V0 = FunctionSpace(mesh, P0)
     V1 = FunctionSpace(mesh, P1)
     V2 = FunctionSpace(mesh, P2)
@@ -362,7 +362,7 @@ def test_assembly_solve_block(mode):
     """Solve a two-field mass-matrix like problem with block matrix approaches
     and test that solution is the same"""
     mesh = create_unit_square(MPI.COMM_WORLD, 32, 31, ghost_mode=mode)
-    P = element("Lagrange", mesh.ufl_cell().cellname(), 1)
+    P = element("Lagrange", mesh.basix_cell(), 1)
     V0 = FunctionSpace(mesh, P)
     V1 = V0.clone()
 
@@ -609,8 +609,8 @@ def test_assembly_solve_taylor_hood(mesh):
 
     def monolithic_solve():
         """Monolithic (interleaved) solver"""
-        P2_el = element("Lagrange", mesh.ufl_cell().cellname(), 2, rank=1)
-        P1_el = element("Lagrange", mesh.ufl_cell().cellname(), 1)
+        P2_el = element("Lagrange", mesh.basix_cell(), 2, rank=1)
+        P1_el = element("Lagrange", mesh.basix_cell(), 1)
         TH = mixed_element([P2_el, P1_el])
         W = FunctionSpace(mesh, TH)
         (u, p) = ufl.TrialFunctions(W)

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -28,8 +28,8 @@ def test_locate_dofs_geometrical():
     spaces, returns the correct degrees of freedom in each space"""
     mesh = create_unit_square(MPI.COMM_WORLD, 4, 8)
     p0, p1 = 1, 2
-    P0 = element("Lagrange", mesh.ufl_cell().cellname(), p0)
-    P1 = element("Lagrange", mesh.ufl_cell().cellname(), p1)
+    P0 = element("Lagrange", mesh.basix_cell(), p0)
+    P1 = element("Lagrange", mesh.basix_cell(), p1)
 
     W = FunctionSpace(mesh, mixed_element([P0, P1]))
     V = W.sub(0).collapse()[0]
@@ -247,8 +247,8 @@ def test_mixed_constant_bc(mesh_factory):
     tdim = mesh.topology.dim
     boundary_facets = locate_entities_boundary(mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool))
     TH = mixed_element([
-        element("Lagrange", mesh.ufl_cell().cellname(), 1),
-        element("Lagrange", mesh.ufl_cell().cellname(), 2)])
+        element("Lagrange", mesh.basix_cell(), 1),
+        element("Lagrange", mesh.basix_cell(), 2)])
     W = FunctionSpace(mesh, TH)
     u = Function(W)
 
@@ -283,8 +283,8 @@ def test_mixed_blocked_constant():
     boundary_facets = locate_entities_boundary(mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool))
 
     TH = mixed_element([
-        element("Lagrange", mesh.ufl_cell().cellname(), 1),
-        element("Lagrange", mesh.ufl_cell().cellname(), 2, rank=1)])
+        element("Lagrange", mesh.basix_cell(), 1),
+        element("Lagrange", mesh.basix_cell(), 2, rank=1)])
     W = FunctionSpace(mesh, TH)
     u = Function(W)
     c0 = PETSc.ScalarType(3)

--- a/python/test/unit/fem/test_complex_assembler.py
+++ b/python/test/unit/fem/test_complex_assembler.py
@@ -26,7 +26,7 @@ def test_complex_assembly():
     """Test assembly of complex matrices and vectors"""
 
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10)
-    P2 = element("Lagrange", mesh.ufl_cell().cellname(), 2)
+    P2 = element("Lagrange", mesh.basix_cell(), 2)
     V = FunctionSpace(mesh, P2)
     u = ufl.TrialFunction(V)
     v = ufl.TestFunction(V)
@@ -79,7 +79,7 @@ def test_complex_assembly_solve():
 
     degree = 3
     mesh = create_unit_square(MPI.COMM_WORLD, 20, 20)
-    P = element("Lagrange", mesh.ufl_cell().cellname(), degree)
+    P = element("Lagrange", mesh.basix_cell(), degree)
     V = FunctionSpace(mesh, P)
 
     x = ufl.SpatialCoordinate(mesh)

--- a/python/test/unit/fem/test_discrete_operators.py
+++ b/python/test/unit/fem/test_discrete_operators.py
@@ -113,8 +113,8 @@ def test_interpolation_matrix(cell_type, p, q, from_lagrange):
         mesh = create_unit_cube(comm, 3, 2, 2, ghost_mode=GhostMode.none, cell_type=cell_type)
         lagrange = "Lagrange" if from_lagrange else "DG"
         nedelec = "Nedelec 1st kind H(curl)"
-    v_el = element(lagrange, mesh.ufl_cell().cellname(), p, rank=1)
-    s_el = element(nedelec, mesh.ufl_cell().cellname(), q)
+    v_el = element(lagrange, mesh.basix_cell(), p, rank=1)
+    s_el = element(nedelec, mesh.basix_cell(), q)
     if from_lagrange:
         el0 = v_el
         el1 = s_el

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -36,8 +36,8 @@ def mesh():
 def test_tabulate_dofs(mesh_factory):
     func, args = mesh_factory
     mesh = func(*args)
-    W0 = element("Lagrange", mesh.ufl_cell().cellname(), 1)
-    W1 = element("Lagrange", mesh.ufl_cell().cellname(), 1, rank=1)
+    W0 = element("Lagrange", mesh.basix_cell(), 1)
+    W1 = element("Lagrange", mesh.basix_cell(), 1, rank=1)
     W = FunctionSpace(mesh, W0 * W1)
 
     L0 = W.sub(0)
@@ -147,7 +147,7 @@ def test_block_size(mesh):
               create_unit_square(MPI.COMM_WORLD, 8, 8, CellType.quadrilateral),
               create_unit_cube(MPI.COMM_WORLD, 4, 4, 4, CellType.hexahedron)]
     for mesh in meshes:
-        P2 = element("Lagrange", mesh.ufl_cell().cellname(), 2)
+        P2 = element("Lagrange", mesh.basix_cell(), 2)
         V = FunctionSpace(mesh, P2)
         assert V.dofmap.bs == 1
 
@@ -166,8 +166,8 @@ def test_block_size(mesh):
 @pytest.mark.skip
 def test_block_size_real():
     mesh = create_unit_interval(MPI.COMM_WORLD, 12)
-    V = element('DG', mesh.ufl_cell().cellname(), 0)
-    R = element('R', mesh.ufl_cell().cellname(), 0)
+    V = element('DG', mesh.basix_cell(), 0)
+    R = element('R', mesh.basix_cell(), 0)
     X = FunctionSpace(mesh, V * R)
     assert X.dofmap.index_map_bs == 1
 
@@ -180,8 +180,8 @@ def test_local_dimension(mesh_factory):
     func, args = mesh_factory
     mesh = func(*args)
 
-    v = element("Lagrange", mesh.ufl_cell().cellname(), 1)
-    q = element("Lagrange", mesh.ufl_cell().cellname(), 1, rank=1)
+    v = element("Lagrange", mesh.basix_cell(), 1)
+    q = element("Lagrange", mesh.basix_cell(), 1, rank=1)
     w = v * q
 
     V = FunctionSpace(mesh, v)

--- a/python/test/unit/fem/test_function.py
+++ b/python/test/unit/fem/test_function.py
@@ -128,7 +128,7 @@ def test_interpolation_mismatch_rank1(W):
 
 def test_mixed_element_interpolation():
     mesh = create_unit_cube(MPI.COMM_WORLD, 3, 3, 3)
-    el = element("Lagrange", mesh.ufl_cell().cellname(), 1)
+    el = element("Lagrange", mesh.basix_cell(), 1)
     V = FunctionSpace(mesh, mixed_element([el, el]))
     u = Function(V)
     with pytest.raises(RuntimeError):
@@ -184,9 +184,9 @@ def test_nonmatching_interpolation(cell_type0, cell_type1):
     def f(x):
         return (7 * x[1], 3 * x[0], x[2] + 0.4)
 
-    el0 = element("Lagrange", mesh0.ufl_cell().cellname(), 1, shape=(3, ))
+    el0 = element("Lagrange", mesh0.basix_cell(), 1, shape=(3, ))
     V0 = FunctionSpace(mesh0, el0)
-    el1 = element("Lagrange", mesh1.ufl_cell().cellname(), 1, shape=(3, ))
+    el1 = element("Lagrange", mesh1.basix_cell(), 1, shape=(3, ))
     V1 = FunctionSpace(mesh1, el1)
 
     # Interpolate on 3D mesh

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -33,8 +33,8 @@ def W(mesh):
 
 @pytest.fixture
 def Q(mesh):
-    W = element('Lagrange', mesh.ufl_cell().cellname(), 1, rank=1)
-    V = element('Lagrange', mesh.ufl_cell().cellname(), 1)
+    W = element('Lagrange', mesh.basix_cell(), 1, rank=1)
+    V = element('Lagrange', mesh.basix_cell(), 1)
     return FunctionSpace(mesh, mixed_element([W, V]))
 
 

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -265,8 +265,8 @@ def test_mixed_sub_interpolation():
     def f(x):
         return np.vstack((10 + x[0], -10 - x[1], 25 + x[0]))
 
-    P2 = element("Lagrange", mesh.ufl_cell().cellname(), 2, rank=1)
-    P1 = element("Lagrange", mesh.ufl_cell().cellname(), 1)
+    P2 = element("Lagrange", mesh.basix_cell(), 2, rank=1)
+    P1 = element("Lagrange", mesh.basix_cell(), 1)
     for i, P in enumerate((mixed_element([P2, P1]), mixed_element([P1, P2]))):
         W = FunctionSpace(mesh, P)
         U = Function(W)
@@ -314,8 +314,8 @@ def test_mixed_sub_interpolation():
 def test_mixed_interpolation():
     """Test that mixed interpolation raised an exception."""
     mesh = one_cell_mesh(CellType.triangle)
-    A = element("Lagrange", mesh.ufl_cell().cellname(), 1)
-    B = element("Lagrange", mesh.ufl_cell().cellname(), 1, rank=1)
+    A = element("Lagrange", mesh.basix_cell(), 1)
+    B = element("Lagrange", mesh.basix_cell(), 1, rank=1)
     v = Function(FunctionSpace(mesh, mixed_element([A, B])))
     with pytest.raises(RuntimeError):
         v.interpolate(lambda x: (x[1], 2 * x[0], 3 * x[1]))
@@ -695,9 +695,9 @@ def test_mixed_interpolation_permuting(cell_type, order):
     x = ufl.SpatialCoordinate(mesh)
     dgdy = ufl.cos(x[1])
 
-    curl_el = element("N1curl", mesh.ufl_cell().cellname(), 1)
-    vlag_el = element("Lagrange", mesh.ufl_cell().cellname(), 1, rank=1)
-    lagr_el = element("Lagrange", mesh.ufl_cell().cellname(), order)
+    curl_el = element("N1curl", mesh.basix_cell(), 1)
+    vlag_el = element("Lagrange", mesh.basix_cell(), 1, rank=1)
+    lagr_el = element("Lagrange", mesh.basix_cell(), order)
 
     V = FunctionSpace(mesh, mixed_element([curl_el, lagr_el]))
     Eb_m = Function(V)

--- a/python/test/unit/fem/test_mixed_element.py
+++ b/python/test/unit/fem/test_mixed_element.py
@@ -75,8 +75,8 @@ def test_vector_element():
 @pytest.mark.parametrize("d2", range(1, 4))
 def test_element_product(d1, d2):
     mesh = create_unit_square(MPI.COMM_WORLD, 2, 2)
-    P3 = element("Lagrange", mesh.ufl_cell().cellname(), d1, rank=1)
-    P1 = element("Lagrange", mesh.ufl_cell().cellname(), d2)
+    P3 = element("Lagrange", mesh.basix_cell(), d1, rank=1)
+    P1 = element("Lagrange", mesh.basix_cell(), d2)
     TH = mixed_element([P3, P1])
     W = FunctionSpace(mesh, TH)
 

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -52,8 +52,8 @@ def test_matrix_assembly_block_nl():
     in the nonlinear setting."""
     mesh = create_unit_square(MPI.COMM_WORLD, 4, 8)
     p0, p1 = 1, 2
-    P0 = element("Lagrange", mesh.ufl_cell().cellname(), p0)
-    P1 = element("Lagrange", mesh.ufl_cell().cellname(), p1)
+    P0 = element("Lagrange", mesh.basix_cell(), p0)
+    P1 = element("Lagrange", mesh.basix_cell(), p1)
     V0 = FunctionSpace(mesh, P0)
     V1 = FunctionSpace(mesh, P1)
 
@@ -279,7 +279,7 @@ def test_assembly_solve_block_nl():
     matrix approaches and test that solution is the same."""
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 11)
     p = 1
-    P = element("Lagrange", mesh.ufl_cell().cellname(), p)
+    P = element("Lagrange", mesh.basix_cell(), p)
     V0 = FunctionSpace(mesh, P)
     V1 = V0.clone()
 
@@ -574,8 +574,8 @@ def test_assembly_solve_taylor_hood_nl(mesh):
 
     def monolithic():
         """Monolithic"""
-        P2_el = element("Lagrange", mesh.ufl_cell().cellname(), 2, rank=1)
-        P1_el = element("Lagrange", mesh.ufl_cell().cellname(), 1)
+        P2_el = element("Lagrange", mesh.basix_cell(), 2, rank=1)
+        P1_el = element("Lagrange", mesh.basix_cell(), 1)
         TH = mixed_element([P2_el, P1_el])
         W = FunctionSpace(mesh, TH)
         U = Function(W)

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -236,7 +236,7 @@ def test_vtx_functions(tempdir, dtype, dim, simplex):
 def test_save_vtkx_cell_point(tempdir):
     """Test writing point-wise data"""
     mesh = create_unit_square(MPI.COMM_WORLD, 8, 5)
-    P = element("Discontinuous Lagrange", mesh.ufl_cell().cellname(), 0)
+    P = element("Discontinuous Lagrange", mesh.basix_cell(), 0)
 
     V = FunctionSpace(mesh, P)
     u = Function(V)

--- a/python/test/unit/io/test_vtk.py
+++ b/python/test/unit/io/test_vtk.py
@@ -94,7 +94,7 @@ def test_save_1d_vector(tempdir):
         vals[1] = 2 * x[0] * x[0]
         return vals
 
-    e = element("Lagrange", mesh.ufl_cell().cellname(), 2, shape=(2, ))
+    e = element("Lagrange", mesh.basix_cell(), 2, shape=(2, ))
     u = Function(FunctionSpace(mesh, e))
     u.interpolate(f)
     filename = Path(tempdir, "u.pvd")
@@ -140,8 +140,8 @@ def test_save_2d_vector_CG2(tempdir):
 
 def test_save_vtk_mixed(tempdir):
     mesh = create_unit_cube(MPI.COMM_WORLD, 3, 3, 3)
-    P2 = element("Lagrange", mesh.ufl_cell().cellname(), 1, rank=1)
-    P1 = element("Lagrange", mesh.ufl_cell().cellname(), 1)
+    P2 = element("Lagrange", mesh.basix_cell(), 1, rank=1)
+    P1 = element("Lagrange", mesh.basix_cell(), 1)
     W = FunctionSpace(mesh, mixed_element([P2, P1]))
     V1 = FunctionSpace(mesh, P1)
     V2 = FunctionSpace(mesh, P2)
@@ -175,8 +175,8 @@ def test_save_vtk_mixed(tempdir):
 def test_save_vtk_cell_point(tempdir):
     """Test writing cell-wise and point-wise data"""
     mesh = create_unit_cube(MPI.COMM_WORLD, 3, 3, 3)
-    P2 = element("Lagrange", mesh.ufl_cell().cellname(), 1, rank=1)
-    P1 = element("Discontinuous Lagrange", mesh.ufl_cell().cellname(), 0)
+    P2 = element("Lagrange", mesh.basix_cell(), 1, rank=1)
+    P1 = element("Discontinuous Lagrange", mesh.basix_cell(), 0)
 
     V2, V1 = FunctionSpace(mesh, P2), FunctionSpace(mesh, P1)
     U2, U1 = Function(V2), Function(V1)
@@ -195,7 +195,7 @@ def test_save_vtk_cell_point(tempdir):
 def test_save_1d_tensor(tempdir):
     mesh = create_unit_interval(MPI.COMM_WORLD, 32)
     e = element(
-        "Lagrange", mesh.ufl_cell().cellname(), 2, shape=(2, 2))
+        "Lagrange", mesh.basix_cell(), 2, shape=(2, 2))
     u = Function(FunctionSpace(mesh, e))
     u.x.array[:] = 1.0
     filename = Path(tempdir, "u.pvd")


### PR DESCRIPTION
This allows us to use `msh.basix_cell()` when creating an element instead of having to pass in `msh.ufl_cell().cellname()`.

This removes the need for https://github.com/FEniCS/basix/issues/648 (and so is an alternative to https://github.com/FEniCS/basix/pull/649).