### PR TITLE
Associate `MeshTags` with `Topology` (and not `Mesh`)

### DIFF
--- a/cpp/demo/biharmonic/main.cpp
+++ b/cpp/demo/biharmonic/main.cpp
@@ -221,7 +221,7 @@ int main(int argc, char* argv[])
           return marker;
         });
     const auto bdofs = fem::locate_dofs_topological(
-        V->mesh()->topology_mutable(), *V->dofmap(), 1, facets);
+        *V->mesh()->topology_mutable(), *V->dofmap(), 1, facets);
     auto bc = std::make_shared<const fem::DirichletBC<T>>(0.0, bdofs, V);
 
     // Now, we have specified the variational forms and can consider the

--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -222,7 +222,7 @@ int main(int argc, char* argv[])
     // Construct appropriate Basix element for stress
     constexpr auto family = basix::element::family::P;
     const auto cell_type
-        = mesh::cell_type_to_basix_type(mesh->topology().cell_type());
+        = mesh::cell_type_to_basix_type(mesh->topology()->cell_type());
     constexpr int k = 0;
     constexpr bool discontinuous = true;
 

--- a/cpp/demo/interpolation-io/main.cpp
+++ b/cpp/demo/interpolation-io/main.cpp
@@ -193,12 +193,10 @@ int main(int argc, char* argv[])
             mesh::CellType::triangle,
             mesh::create_cell_partitioner(mesh::GhostMode::none)));
 
-    // Create mesh using double for geometry coordinates
-    auto mesh1
-        = std::make_shared<mesh::Mesh<double>>(mesh::create_rectangle<double>(
-            MPI_COMM_WORLD, {{{0.0, 0.0}, {1.0, 1.0}}}, {32, 4},
-            mesh::CellType::triangle,
-            mesh::create_cell_partitioner(mesh::GhostMode::none)));
+    // Create mesh using same topology as mesh0, but with different
+    // scalar type for geometry
+    auto mesh1 = std::make_shared<mesh::Mesh<double>>(
+        mesh0->comm(), mesh0->topology(), mesh0->geometry().astype<double>());
 
     // Interpolate a function in a scalar Lagrange space and output the
     // result to file for visualisation using different types

--- a/cpp/demo/interpolation_different_meshes/main.cpp
+++ b/cpp/demo/interpolation_different_meshes/main.cpp
@@ -33,13 +33,13 @@ int main(int argc, char* argv[])
                          mesh::CellType::hexahedron));
 
     basix::FiniteElement element_tet = basix::element::create_lagrange(
-        mesh::cell_type_to_basix_type(mesh_tet->topology().cell_type()), 1,
+        mesh::cell_type_to_basix_type(mesh_tet->topology()->cell_type()), 1,
         basix::element::lagrange_variant::equispaced, false);
     auto V_tet = std::make_shared<fem::FunctionSpace<double>>(
         fem::create_functionspace(mesh_tet, element_tet, 3));
 
     basix::FiniteElement element_hex = basix::element::create_lagrange(
-        mesh::cell_type_to_basix_type(mesh_hex->topology().cell_type()), 2,
+        mesh::cell_type_to_basix_type(mesh_hex->topology()->cell_type()), 2,
         basix::element::lagrange_variant::equispaced, false);
     auto V_hex = std::make_shared<fem::FunctionSpace<double>>(
         fem::create_functionspace(mesh_hex, element_hex, 3));

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -178,7 +178,7 @@ int main(int argc, char* argv[])
           return marker;
         });
     const auto bdofs = fem::locate_dofs_topological(
-        V->mesh()->topology_mutable(), *V->dofmap(), 1, facets);
+        *V->mesh()->topology_mutable(), *V->dofmap(), 1, facets);
     auto bc = std::make_shared<const fem::DirichletBC<T>>(0.0, bdofs, V);
 
     f->interpolate(

--- a/cpp/demo/poisson_matrix_free/main.cpp
+++ b/cpp/demo/poisson_matrix_free/main.cpp
@@ -153,7 +153,7 @@ int main(int argc, char* argv[])
           return {f, {f.size()}};
         });
 
-    mesh->topology_mutable().create_connectivity(1, 2);
+    mesh->topology_mutable()->create_connectivity(1, 2);
     const std::vector<std::int32_t> facets
         = mesh::exterior_facet_indices(mesh->topology());
     std::vector<std::int32_t> bdofs = fem::locate_dofs_topological(

--- a/cpp/demo/poisson_matrix_free/main.cpp
+++ b/cpp/demo/poisson_matrix_free/main.cpp
@@ -155,9 +155,9 @@ int main(int argc, char* argv[])
 
     mesh->topology_mutable()->create_connectivity(1, 2);
     const std::vector<std::int32_t> facets
-        = mesh::exterior_facet_indices(mesh->topology());
+        = mesh::exterior_facet_indices(*mesh->topology());
     std::vector<std::int32_t> bdofs = fem::locate_dofs_topological(
-        V->mesh()->topology_mutable(), *V->dofmap(), 1, facets);
+        *V->mesh()->topology_mutable(), *V->dofmap(), 1, facets);
     auto bc = std::make_shared<const fem::DirichletBC<T>>(u_D, bdofs);
 
     // Assemble RHS vector

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -190,9 +190,10 @@ std::array<std::vector<std::int32_t>, 2> locate_dofs_geometrical(
   assert(element_bs == dofmap1->element_dof_layout().block_size());
 
   // Iterate over cells
-  const mesh::Topology& topology = mesh->topology();
+  auto topology = mesh->topology();
+  assert(topology);
   std::vector<std::array<std::int32_t, 2>> bc_dofs;
-  for (int c = 0; c < topology.connectivity(tdim, 0)->num_nodes(); ++c)
+  for (int c = 0; c < topology->connectivity(tdim, 0)->num_nodes(); ++c)
   {
     // Get cell dofmaps
     auto cell_dofs0 = dofmap0->cell_dofs(c);

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -159,7 +159,7 @@ std::array<std::vector<std::int32_t>, 2> locate_dofs_geometrical(
   assert(V1.mesh());
   if (mesh != V1.mesh())
     throw std::runtime_error("Meshes are not the same.");
-  const int tdim = mesh->topology().dim();
+  const int tdim = mesh->topology()->dim();
 
   assert(V0.element());
   assert(V1.element());

--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -169,8 +169,8 @@ public:
       assert(element);
       if (element->needs_dof_transformations())
       {
-        _mesh->topology_mutable().create_entity_permutations();
-        cell_info = std::span(_mesh->topology().get_cell_permutation_info());
+        _mesh->topology_mutable()->create_entity_permutations();
+        cell_info = std::span(_mesh->topology()->get_cell_permutation_info());
         dof_transform_to_transpose
             = element
                   ->template get_dof_transformation_to_transpose_function<T>();

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -171,8 +171,8 @@ public:
   {
     assert(_function_space);
     assert(_function_space->mesh());
-    int tdim = _function_space->mesh()->topology().dim();
-    auto cell_map = _function_space->mesh()->topology().index_map(tdim);
+    int tdim = _function_space->mesh()->topology()->dim();
+    auto cell_map = _function_space->mesh()->topology()->index_map(tdim);
     assert(cell_map);
     std::int32_t num_cells = cell_map->size_local() + cell_map->num_ghosts();
     std::vector<std::int32_t> cells(num_cells, 0);
@@ -251,8 +251,8 @@ public:
   {
     assert(_function_space);
     assert(_function_space->mesh());
-    const int tdim = _function_space->mesh()->topology().dim();
-    auto cell_map = _function_space->mesh()->topology().index_map(tdim);
+    const int tdim = _function_space->mesh()->topology()->dim();
+    auto cell_map = _function_space->mesh()->topology()->index_map(tdim);
     assert(cell_map);
     std::int32_t num_cells = cell_map->size_local() + cell_map->num_ghosts();
     std::vector<std::int32_t> cells(num_cells, 0);
@@ -338,8 +338,8 @@ public:
   {
     assert(_function_space);
     assert(_function_space->mesh());
-    const int tdim = _function_space->mesh()->topology().dim();
-    auto cell_map = _function_space->mesh()->topology().index_map(tdim);
+    const int tdim = _function_space->mesh()->topology()->dim();
+    auto cell_map = _function_space->mesh()->topology()->index_map(tdim);
     assert(cell_map);
     std::int32_t num_cells = cell_map->size_local() + cell_map->num_ghosts();
     std::vector<std::int32_t> cells(num_cells, 0);
@@ -390,8 +390,8 @@ public:
     auto mesh = _function_space->mesh();
     assert(mesh);
     const std::size_t gdim = mesh->geometry().dim();
-    const std::size_t tdim = mesh->topology().dim();
-    auto map = mesh->topology().index_map(tdim);
+    const std::size_t tdim = mesh->topology()->dim();
+    auto map = mesh->topology()->index_map(tdim);
 
     // Get geometry data
     const graph::AdjacencyList<std::int32_t>& x_dofmap
@@ -431,8 +431,8 @@ public:
     std::span<const std::uint32_t> cell_info;
     if (element->needs_dof_transformations())
     {
-      mesh->topology_mutable().create_entity_permutations();
-      cell_info = std::span(mesh->topology().get_cell_permutation_info());
+      mesh->topology_mutable()->create_entity_permutations();
+      cell_info = std::span(mesh->topology()->get_cell_permutation_info());
     }
 
     namespace stdex = std::experimental;

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -191,7 +191,7 @@ public:
     assert(_mesh);
     assert(_element);
     const std::size_t gdim = _mesh->geometry().dim();
-    const int tdim = _mesh->topology().dim();
+    const int tdim = _mesh->topology()->dim();
 
     // Get dofmap local size
     assert(_dofmap);
@@ -240,15 +240,15 @@ public:
     std::vector<T> coordinate_dofs_b(num_dofs_g * gdim);
     mdspan2_t coordinate_dofs(coordinate_dofs_b.data(), num_dofs_g, gdim);
 
-    auto map = _mesh->topology().index_map(tdim);
+    auto map = _mesh->topology()->index_map(tdim);
     assert(map);
     const int num_cells = map->size_local() + map->num_ghosts();
 
     std::span<const std::uint32_t> cell_info;
     if (_element->needs_dof_transformations())
     {
-      _mesh->topology_mutable().create_entity_permutations();
-      cell_info = std::span(_mesh->topology().get_cell_permutation_info());
+      _mesh->topology_mutable()->create_entity_permutations();
+      cell_info = std::span(_mesh->topology()->get_cell_permutation_info());
     }
 
     auto apply_dof_transformation

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -147,7 +147,7 @@ public:
 
     // Create collapsed DofMap
     auto [_collapsed_dofmap, collapsed_dofs]
-        = _dofmap->collapse(_mesh->comm(), _mesh->topology());
+        = _dofmap->collapse(_mesh->comm(), *_mesh->topology());
     auto collapsed_dofmap
         = std::make_shared<DofMap>(std::move(_collapsed_dofmap));
 

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -412,7 +412,7 @@ void assemble_matrix(
 
   for (int i : a.integral_ids(IntegralType::cell))
   {
-    const auto& fn = a.kernel(IntegralType::cell, i);
+    auto fn = a.kernel(IntegralType::cell, i);
     const auto& [coeffs, cstride] = coefficients.at({IntegralType::cell, i});
     const std::vector<std::int32_t>& cells = a.cell_domains(i);
     impl::assemble_cells(mat_set, geometry, cells, dof_transform, dofs0, bs0,
@@ -422,7 +422,7 @@ void assemble_matrix(
 
   for (int i : a.integral_ids(IntegralType::exterior_facet))
   {
-    const auto& fn = a.kernel(IntegralType::exterior_facet, i);
+    auto fn = a.kernel(IntegralType::exterior_facet, i);
     const auto& [coeffs, cstride]
         = coefficients.at({IntegralType::exterior_facet, i});
     const std::vector<std::int32_t>& facets = a.exterior_facet_domains(i);
@@ -454,7 +454,7 @@ void assemble_matrix(
     const std::vector<int> c_offsets = a.coefficient_offsets();
     for (int i : a.integral_ids(IntegralType::interior_facet))
     {
-      const auto& fn = a.kernel(IntegralType::interior_facet, i);
+      auto fn = a.kernel(IntegralType::interior_facet, i);
       const auto& [coeffs, cstride]
           = coefficients.at({IntegralType::interior_facet, i});
       const std::vector<std::int32_t>& facets = a.interior_facet_domains(i);

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -406,8 +406,8 @@ void assemble_matrix(
   std::span<const std::uint32_t> cell_info;
   if (needs_transformation_data)
   {
-    mesh->topology_mutable().create_entity_permutations();
-    cell_info = std::span(mesh->topology().get_cell_permutation_info());
+    mesh->topology_mutable()->create_entity_permutations();
+    cell_info = std::span(mesh->topology()->get_cell_permutation_info());
   }
 
   for (int i : a.integral_ids(IntegralType::cell))
@@ -437,16 +437,16 @@ void assemble_matrix(
     std::function<std::uint8_t(std::size_t)> get_perm;
     if (a.needs_facet_permutations())
     {
-      mesh->topology_mutable().create_entity_permutations();
+      mesh->topology_mutable()->create_entity_permutations();
       const std::vector<std::uint8_t>& perms
-          = mesh->topology().get_facet_permutations();
+          = mesh->topology()->get_facet_permutations();
       get_perm = [&perms](std::size_t i) { return perms[i]; };
     }
     else
       get_perm = [](std::size_t) { return 0; };
 
-    int num_cell_facets = mesh::cell_num_entities(mesh->topology().cell_type(),
-                                                  mesh->topology().dim() - 1);
+    int num_cell_facets = mesh::cell_num_entities(mesh->topology()->cell_type(),
+                                                  mesh->topology()->dim() - 1);
     const std::vector<int> c_offsets = a.coefficient_offsets();
     for (int i : a.integral_ids(IntegralType::interior_facet))
     {

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -175,7 +175,7 @@ T assemble_scalar(
   T value = 0;
   for (int i : M.integral_ids(IntegralType::cell))
   {
-    const auto& fn = M.kernel(IntegralType::cell, i);
+    auto fn = M.kernel(IntegralType::cell, i);
     const auto& [coeffs, cstride] = coefficients.at({IntegralType::cell, i});
     const std::vector<std::int32_t>& cells = M.cell_domains(i);
     value += impl::assemble_cells(geometry, cells, fn, constants, coeffs,
@@ -184,7 +184,7 @@ T assemble_scalar(
 
   for (int i : M.integral_ids(IntegralType::exterior_facet))
   {
-    const auto& fn = M.kernel(IntegralType::exterior_facet, i);
+    auto fn = M.kernel(IntegralType::exterior_facet, i);
     const auto& [coeffs, cstride]
         = coefficients.at({IntegralType::exterior_facet, i});
     const std::vector<std::int32_t>& facets = M.exterior_facet_domains(i);
@@ -201,13 +201,13 @@ T assemble_scalar(
 
     auto cell_types = mesh->topology()->cell_types();
     if (cell_types.size() > 1)
-      throw std::runtime_error("MUltiple cell types in the assembler");
+      throw std::runtime_error("Multiple cell types in the assembler");
     int num_cell_facets = mesh::cell_num_entities(cell_types.back(),
                                                   mesh->topology()->dim() - 1);
     const std::vector<int> c_offsets = M.coefficient_offsets();
     for (int i : M.integral_ids(IntegralType::interior_facet))
     {
-      const auto& fn = M.kernel(IntegralType::interior_facet, i);
+      auto fn = M.kernel(IntegralType::interior_facet, i);
       const auto& [coeffs, cstride]
           = coefficients.at({IntegralType::interior_facet, i});
       const std::vector<std::int32_t>& facets = M.interior_facet_domains(i);

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -194,13 +194,13 @@ T assemble_scalar(
 
   if (M.num_integrals(IntegralType::interior_facet) > 0)
   {
-    mesh->topology_mutable().create_entity_permutations();
+    mesh->topology_mutable()->create_entity_permutations();
 
     const std::vector<std::uint8_t>& perms
-        = mesh->topology().get_facet_permutations();
+        = mesh->topology()->get_facet_permutations();
 
-    int num_cell_facets = mesh::cell_num_entities(mesh->topology().cell_type(),
-                                                  mesh->topology().dim() - 1);
+    int num_cell_facets = mesh::cell_num_entities(mesh->topology()->cell_type(),
+                                                  mesh->topology()->dim() - 1);
     const std::vector<int> c_offsets = M.coefficient_offsets();
     for (int i : M.integral_ids(IntegralType::interior_facet))
     {

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -760,8 +760,8 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
   std::span<const std::uint32_t> cell_info;
   if (needs_transformation_data)
   {
-    mesh->topology_mutable().create_entity_permutations();
-    cell_info = std::span(mesh->topology().get_cell_permutation_info());
+    mesh->topology_mutable()->create_entity_permutations();
+    cell_info = std::span(mesh->topology()->get_cell_permutation_info());
   }
 
   const std::function<void(const std::span<T>&,
@@ -820,16 +820,16 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
     std::function<std::uint8_t(std::size_t)> get_perm;
     if (a.needs_facet_permutations())
     {
-      mesh->topology_mutable().create_entity_permutations();
+      mesh->topology_mutable()->create_entity_permutations();
       const std::vector<std::uint8_t>& perms
-          = mesh->topology().get_facet_permutations();
+          = mesh->topology()->get_facet_permutations();
       get_perm = [&perms](std::size_t i) { return perms[i]; };
     }
     else
       get_perm = [](std::size_t) { return 0; };
 
-    int num_cell_facets = mesh::cell_num_entities(mesh->topology().cell_type(),
-                                                  mesh->topology().dim() - 1);
+    int num_cell_facets = mesh::cell_num_entities(mesh->topology()->cell_type(),
+                                                  mesh->topology()->dim() - 1);
     for (int i : a.integral_ids(IntegralType::interior_facet))
     {
       const auto& kernel = a.kernel(IntegralType::interior_facet, i);
@@ -962,8 +962,8 @@ void assemble_vector(
   std::span<const std::uint32_t> cell_info;
   if (needs_transformation_data)
   {
-    mesh->topology_mutable().create_entity_permutations();
-    cell_info = std::span(mesh->topology().get_cell_permutation_info());
+    mesh->topology_mutable()->create_entity_permutations();
+    cell_info = std::span(mesh->topology()->get_cell_permutation_info());
   }
 
   for (int i : L.integral_ids(IntegralType::cell))
@@ -1019,16 +1019,16 @@ void assemble_vector(
     std::function<std::uint8_t(std::size_t)> get_perm;
     if (L.needs_facet_permutations())
     {
-      mesh->topology_mutable().create_entity_permutations();
+      mesh->topology_mutable()->create_entity_permutations();
       const std::vector<std::uint8_t>& perms
-          = mesh->topology().get_facet_permutations();
+          = mesh->topology()->get_facet_permutations();
       get_perm = [&perms](std::size_t i) { return perms[i]; };
     }
     else
       get_perm = [](std::size_t) { return 0; };
 
-    int num_cell_facets = mesh::cell_num_entities(mesh->topology().cell_type(),
-                                                  mesh->topology().dim() - 1);
+    int num_cell_facets = mesh::cell_num_entities(mesh->topology()->cell_type(),
+                                                  mesh->topology()->dim() - 1);
     for (int i : L.integral_ids(IntegralType::interior_facet))
     {
       const auto& fn = L.kernel(IntegralType::interior_facet, i);

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -776,7 +776,7 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
 
   for (int i : a.integral_ids(IntegralType::cell))
   {
-    const auto& kernel = a.kernel(IntegralType::cell, i);
+    auto kernel = a.kernel(IntegralType::cell, i);
     const auto& [coeffs, cstride] = coefficients.at({IntegralType::cell, i});
     const std::vector<std::int32_t>& cells = a.cell_domains(i);
     if (bs0 == 1 and bs1 == 1)
@@ -804,7 +804,7 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
 
   for (int i : a.integral_ids(IntegralType::exterior_facet))
   {
-    const auto& kernel = a.kernel(IntegralType::exterior_facet, i);
+    auto kernel = a.kernel(IntegralType::exterior_facet, i);
     const auto& [coeffs, cstride]
         = coefficients.at({IntegralType::exterior_facet, i});
     const std::vector<std::int32_t>& facets = a.exterior_facet_domains(i);
@@ -830,12 +830,12 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
 
     auto cell_types = mesh->topology()->cell_types();
     if (cell_types.size() > 1)
-      throw std::runtime_error("MUltiple cell types in the assembler");
+      throw std::runtime_error("Multiple cell types in the assembler");
     int num_cell_facets = mesh::cell_num_entities(cell_types.back(),
                                                   mesh->topology()->dim() - 1);
     for (int i : a.integral_ids(IntegralType::interior_facet))
     {
-      const auto& kernel = a.kernel(IntegralType::interior_facet, i);
+      auto kernel = a.kernel(IntegralType::interior_facet, i);
       const auto& [coeffs, cstride]
           = coefficients.at({IntegralType::interior_facet, i});
       const std::vector<std::int32_t>& facets = a.interior_facet_domains(i);
@@ -971,7 +971,7 @@ void assemble_vector(
 
   for (int i : L.integral_ids(IntegralType::cell))
   {
-    const auto& fn = L.kernel(IntegralType::cell, i);
+    auto fn = L.kernel(IntegralType::cell, i);
     const auto& [coeffs, cstride] = coefficients.at({IntegralType::cell, i});
     const std::vector<std::int32_t>& cells = L.cell_domains(i);
     if (bs == 1)
@@ -993,7 +993,7 @@ void assemble_vector(
 
   for (int i : L.integral_ids(IntegralType::exterior_facet))
   {
-    const auto& fn = L.kernel(IntegralType::exterior_facet, i);
+    auto fn = L.kernel(IntegralType::exterior_facet, i);
     const auto& [coeffs, cstride]
         = coefficients.at({IntegralType::exterior_facet, i});
     const std::vector<std::int32_t>& facets = L.exterior_facet_domains(i);
@@ -1037,7 +1037,7 @@ void assemble_vector(
                                                   mesh->topology()->dim() - 1);
     for (int i : L.integral_ids(IntegralType::interior_facet))
     {
-      const auto& fn = L.kernel(IntegralType::interior_facet, i);
+      auto fn = L.kernel(IntegralType::interior_facet, i);
       const auto& [coeffs, cstride]
           = coefficients.at({IntegralType::interior_facet, i});
       const std::vector<std::int32_t>& facets = L.interior_facet_domains(i);

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -157,7 +157,7 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
   assert(mesh);
 
   // Mesh dims
-  const int tdim = mesh->topology().dim();
+  const int tdim = mesh->topology()->dim();
   const int gdim = mesh->geometry().dim();
 
   // Get elements
@@ -169,8 +169,8 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
   std::span<const std::uint32_t> cell_info;
   if (e1->needs_dof_transformations() or e0->needs_dof_transformations())
   {
-    mesh->topology_mutable().create_entity_permutations();
-    cell_info = std::span(mesh->topology().get_cell_permutation_info());
+    mesh->topology_mutable()->create_entity_permutations();
+    cell_info = std::span(mesh->topology()->get_cell_permutation_info());
   }
 
   // Get dofmaps
@@ -282,7 +282,7 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
   std::vector<T> local1(space_dim1);
 
   // Iterate over mesh and interpolate on each cell
-  auto cell_map = mesh->topology().index_map(tdim);
+  auto cell_map = mesh->topology()->index_map(tdim);
   assert(cell_map);
   std::int32_t num_cells = cell_map->size_local();
   for (std::int32_t c = 0; c < num_cells; ++c)

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -1024,8 +1024,8 @@ create_nonmatching_meshes_interpolation_data(const mesh::Mesh<T>& mesh0,
                                              const FiniteElement& element0,
                                              const mesh::Mesh<T>& mesh1)
 {
-  int tdim = mesh0.topology().dim();
-  auto cell_map = mesh0.topology().index_map(tdim);
+  int tdim = mesh0.topology()->dim();
+  auto cell_map = mesh0.topology()->index_map(tdim);
   assert(cell_map);
   std::int32_t num_cells = cell_map->size_local() + cell_map->num_ghosts();
   std::vector<std::int32_t> cells(num_cells, 0);

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -324,8 +324,8 @@ void interpolate_same_map(Function<T, U>& u1, const Function<T, U>& u0,
   std::shared_ptr<const FiniteElement> element1 = V1->element();
   assert(element1);
 
-  const int tdim = mesh->topology().dim();
-  auto map = mesh->topology().index_map(tdim);
+  const int tdim = mesh->topology()->dim();
+  auto map = mesh->topology()->index_map(tdim);
   assert(map);
   std::span<T> u1_array = u1.x()->mutable_array();
   std::span<const T> u0_array = u0.x()->array();
@@ -334,8 +334,8 @@ void interpolate_same_map(Function<T, U>& u1, const Function<T, U>& u0,
   if (element1->needs_dof_transformations()
       or element0->needs_dof_transformations())
   {
-    mesh->topology_mutable().create_entity_permutations();
-    cell_info = std::span(mesh->topology().get_cell_permutation_info());
+    mesh->topology_mutable()->create_entity_permutations();
+    cell_info = std::span(mesh->topology()->get_cell_permutation_info());
   }
 
   // Get dofmaps
@@ -405,7 +405,7 @@ void interpolate_nonmatching_maps(Function<T, U>& u1, const Function<T, U>& u0,
   assert(mesh);
 
   // Mesh dims
-  const int tdim = mesh->topology().dim();
+  const int tdim = mesh->topology()->dim();
   const int gdim = mesh->geometry().dim();
 
   // Get elements
@@ -420,8 +420,8 @@ void interpolate_nonmatching_maps(Function<T, U>& u1, const Function<T, U>& u0,
   if (element1->needs_dof_transformations()
       or element0->needs_dof_transformations())
   {
-    mesh->topology_mutable().create_entity_permutations();
-    cell_info = std::span(mesh->topology().get_cell_permutation_info());
+    mesh->topology_mutable()->create_entity_permutations();
+    cell_info = std::span(mesh->topology()->get_cell_permutation_info());
   }
 
   // Get dofmaps
@@ -638,8 +638,8 @@ void interpolate_nonmatching_meshes(
                              "supported with the same communicator.");
 
   MPI_Comm comm = mesh->comm();
-  const int tdim = mesh->topology().dim();
-  const auto cell_map = mesh->topology().index_map(tdim);
+  const int tdim = mesh->topology()->dim();
+  const auto cell_map = mesh->topology()->index_map(tdim);
 
   std::shared_ptr<const FiniteElement> element_u
       = u.function_space()->element();
@@ -735,13 +735,13 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
   assert(mesh);
 
   const int gdim = mesh->geometry().dim();
-  const int tdim = mesh->topology().dim();
+  const int tdim = mesh->topology()->dim();
 
   std::span<const std::uint32_t> cell_info;
   if (element->needs_dof_transformations())
   {
-    mesh->topology_mutable().create_entity_permutations();
-    cell_info = std::span(mesh->topology().get_cell_permutation_info());
+    mesh->topology_mutable()->create_entity_permutations();
+    cell_info = std::span(mesh->topology()->get_cell_permutation_info());
   }
 
   const std::size_t f_shape1 = f.size() / element->value_size();
@@ -1055,7 +1055,7 @@ void interpolate(
   auto mesh = u.function_space()->mesh();
   assert(mesh);
 
-  auto cell_map0 = mesh->topology().index_map(mesh->topology().dim());
+  auto cell_map0 = mesh->topology()->index_map(mesh->topology()->dim());
   assert(cell_map0);
   std::size_t num_cells0 = cell_map0->size_local() + cell_map0->num_ghosts();
   if (u.function_space() == v.function_space() and cells.size() == num_cells0)
@@ -1094,8 +1094,8 @@ void interpolate(
       {
         // Same element, different dofmaps (or just a subset of cells)
 
-        const int tdim = mesh->topology().dim();
-        auto cell_map = mesh->topology().index_map(tdim);
+        const int tdim = mesh->topology()->dim();
+        auto cell_map = mesh->topology()->index_map(tdim);
         assert(cell_map);
 
         assert(element1->block_size() == element0->block_size());

--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -72,7 +72,7 @@ Mat create_matrix_block(
 
   std::shared_ptr mesh = V[0][0]->mesh();
   assert(mesh);
-  const int tdim = mesh->topology().dim();
+  const int tdim = mesh->topology()->dim();
 
   // Build sparsity pattern for each block
   std::vector<std::vector<std::unique_ptr<la::SparsityPattern>>> patterns(
@@ -103,12 +103,12 @@ Mat create_matrix_block(
           sparsitybuild::cells(*sp, mesh->topology(), dofmaps);
         if (form->num_integrals(IntegralType::interior_facet) > 0)
         {
-          mesh->topology_mutable().create_entities(tdim - 1);
+          mesh->topology_mutable()->create_entities(tdim - 1);
           sparsitybuild::interior_facets(*sp, mesh->topology(), dofmaps);
         }
         if (form->num_integrals(IntegralType::exterior_facet) > 0)
         {
-          mesh->topology_mutable().create_entities(tdim - 1);
+          mesh->topology_mutable()->create_entities(tdim - 1);
           sparsitybuild::exterior_facets(*sp, mesh->topology(), dofmaps);
         }
       }

--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -100,16 +100,16 @@ Mat create_matrix_block(
         auto& sp = patterns[row].back();
         assert(sp);
         if (form->num_integrals(IntegralType::cell) > 0)
-          sparsitybuild::cells(*sp, mesh->topology(), dofmaps);
+          sparsitybuild::cells(*sp, *mesh->topology(), dofmaps);
         if (form->num_integrals(IntegralType::interior_facet) > 0)
         {
           mesh->topology_mutable()->create_entities(tdim - 1);
-          sparsitybuild::interior_facets(*sp, mesh->topology(), dofmaps);
+          sparsitybuild::interior_facets(*sp, *mesh->topology(), dofmaps);
         }
         if (form->num_integrals(IntegralType::exterior_facet) > 0)
         {
           mesh->topology_mutable()->create_entities(tdim - 1);
-          sparsitybuild::exterior_facets(*sp, mesh->topology(), dofmaps);
+          sparsitybuild::exterior_facets(*sp, *mesh->topology(), dofmaps);
         }
       }
       else

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -227,9 +227,17 @@ fem::compute_integration_domains(fem::IntegralType integral_type,
     // topology.create_connectivity(dim, tdim);
     // topology.create_connectivity(tdim, dim);
     auto f_to_c = topology.connectivity(tdim - 1, tdim);
-    assert(f_to_c);
+    if (!f_to_c)
+    {
+      throw std::runtime_error(
+          "Topology facet-to-cell connectivity has not been computed.");
+    }
     auto c_to_f = topology.connectivity(tdim, tdim - 1);
-    assert(c_to_f);
+    {
+      if (!c_to_f)
+        throw std::runtime_error(
+            "Topology cell-to-facet connectivity has not been computed.");
+    }
     switch (integral_type)
     {
     case IntegralType::exterior_facet:

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -224,8 +224,6 @@ fem::compute_integration_domains(fem::IntegralType integral_type,
     values1.insert(values1.begin(), values.begin(), values.end());
     break;
   default:
-    // topology.create_connectivity(dim, tdim);
-    // topology.create_connectivity(tdim, dim);
     auto f_to_c = topology.connectivity(tdim - 1, tdim);
     if (!f_to_c)
     {

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -195,7 +195,7 @@ std::vector<std::string> fem::get_constant_names(const ufcx_form& ufcx_form)
 //-----------------------------------------------------------------------------
 std::vector<std::pair<int, std::vector<std::int32_t>>>
 fem::compute_integration_domains(fem::IntegralType integral_type,
-                                 mesh::Topology& topology,
+                                 const mesh::Topology& topology,
                                  std::span<const std::int32_t> entities,
                                  int dim, std::span<const int> values)
 {
@@ -224,8 +224,8 @@ fem::compute_integration_domains(fem::IntegralType integral_type,
     values1.insert(values1.begin(), values.begin(), values.end());
     break;
   default:
-    topology.create_connectivity(dim, tdim);
-    topology.create_connectivity(tdim, dim);
+    // topology.create_connectivity(dim, tdim);
+    // topology.create_connectivity(tdim, dim);
     auto f_to_c = topology.connectivity(tdim - 1, tdim);
     assert(f_to_c);
     auto c_to_f = topology.connectivity(tdim, tdim - 1);

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -82,8 +82,8 @@ get_cell_facet_pairs(std::int32_t f, const std::span<const std::int32_t>& cells,
 
 } // namespace impl
 
-/// @brief Given an integral type and MeshTags, compute the entities
-/// that should be integrated over.
+/// @brief Given an integral type and mesh tag data, compute the
+/// entities that should be integrated over.
 ///
 /// This function returns as list `[(id, entities)]`, where `entities`
 /// are the entities in `meshtags` with tag value `id`. For cell
@@ -103,10 +103,10 @@ get_cell_facet_pairs(std::int32_t f, const std::span<const std::int32_t>& cells,
 /// @param[in] values Value associated with each entity
 /// @return A list of (integral id, entities) pairs
 /// @pre The topological dimension of the integral entity type and the
-/// topological dimension of `meshtags` must be equal.
+/// topological dimension of mesh tag data must be equal.
 std::vector<std::pair<int, std::vector<std::int32_t>>>
 compute_integration_domains(IntegralType integral_type,
-                            mesh::Topology& topology,
+                            const mesh::Topology& topology,
                             std::span<const std::int32_t> entities, int dim,
                             std::span<const int> values);
 

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -105,7 +105,7 @@ get_cell_facet_pairs(std::int32_t f, const std::span<const std::int32_t>& cells,
 /// @pre The topological dimension of the integral entity type and the
 /// topological dimension of mesh tag data must be equal.
 /// @pre For facet integrals, the topology facet-to-cell and
-/// cell-to-facet connectivity must be computed before using the
+/// cell-to-facet connectivity must be computed before calling this
 /// function.
 std::vector<std::pair<int, std::vector<std::int32_t>>>
 compute_integration_domains(IntegralType integral_type,
@@ -682,6 +682,7 @@ create_functionspace(std::shared_ptr<mesh::Mesh<T>> mesh,
   ElementDofLayout layout(bs, e.entity_dofs(), e.entity_closure_dofs(), {},
                           sub_doflayout);
   assert(mesh);
+  assert(mesh->topology());
   auto dofmap = std::make_shared<const DofMap>(
       create_dofmap(mesh->comm(), layout, *mesh->topology(), reorder_fn, *_e));
 
@@ -720,6 +721,7 @@ create_functionspace(ufcx_function_space* (*fptr)(const char*),
   ufcx_finite_element* ufcx_element = space->finite_element;
   assert(ufcx_element);
 
+  assert(mesh);
   if (space->geometry_degree != mesh->geometry().cmap().degree()
       or static_cast<basix::cell::type>(space->geometry_basix_cell)
              != mesh::cell_type_to_basix_type(
@@ -735,6 +737,7 @@ create_functionspace(ufcx_function_space* (*fptr)(const char*),
   assert(element);
   ufcx_dofmap* ufcx_map = space->dofmap;
   assert(ufcx_map);
+  assert(mesh->topology());
   ElementDofLayout layout
       = create_element_dof_layout(*ufcx_map, mesh->topology()->cell_type());
   return FunctionSpace(

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -181,9 +181,9 @@ la::SparsityPattern create_sparsity_pattern(const Form<T, U>& a)
       or types.find(IntegralType::exterior_facet) != types.end())
   {
     // FIXME: cleanup these calls? Some of the happen internally again.
-    const int tdim = mesh->topology().dim();
-    mesh->topology_mutable().create_entities(tdim - 1);
-    mesh->topology_mutable().create_connectivity(tdim - 1, tdim);
+    const int tdim = mesh->topology()->dim();
+    mesh->topology_mutable()->create_entities(tdim - 1);
+    mesh->topology_mutable()->create_connectivity(tdim - 1, tdim);
   }
 
   common::Timer t0("Build sparsity");
@@ -332,9 +332,9 @@ Form<T, U> create_form(
   if (ufcx_form.num_integrals(exterior_facet) > 0
       or ufcx_form.num_integrals(interior_facet) > 0)
   {
-    mesh->topology_mutable().create_entities(tdim - 1);
-    mesh->topology_mutable().create_connectivity(tdim - 1, tdim);
-    mesh->topology_mutable().create_connectivity(tdim, tdim - 1);
+    mesh->topology_mutable()->create_entities(tdim - 1);
+    mesh->topology_mutable()->create_connectivity(tdim - 1, tdim);
+    mesh->topology_mutable()->create_connectivity(tdim, tdim - 1);
   }
 
   // Get list of integral IDs, and load tabulate tensor into memory for
@@ -732,7 +732,7 @@ create_functionspace(ufcx_function_space* (*fptr)(const char*),
   ufcx_dofmap* ufcx_map = space->dofmap;
   assert(ufcx_map);
   ElementDofLayout layout
-      = create_element_dof_layout(*ufcx_map, mesh->topology().cell_type());
+      = create_element_dof_layout(*ufcx_map, mesh->topology()->cell_type());
   return FunctionSpace(
       mesh, element,
       std::make_shared<DofMap>(create_dofmap(
@@ -763,8 +763,8 @@ std::span<const std::uint32_t> get_cell_orientation_info(
   if (needs_dof_transformations)
   {
     auto mesh = coefficients.front()->function_space()->mesh();
-    mesh->topology_mutable().create_entity_permutations();
-    cell_info = std::span(mesh->topology().get_cell_permutation_info());
+    mesh->topology_mutable()->create_entity_permutations();
+    cell_info = std::span(mesh->topology()->get_cell_permutation_info());
   }
 
   return cell_info;

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -104,6 +104,9 @@ get_cell_facet_pairs(std::int32_t f, const std::span<const std::int32_t>& cells,
 /// @return A list of (integral id, entities) pairs
 /// @pre The topological dimension of the integral entity type and the
 /// topological dimension of mesh tag data must be equal.
+/// @pre For facet integrals, the topology facet-to-cell and
+/// cell-to-facet connectivity must be computed before using the
+/// function.
 std::vector<std::pair<int, std::vector<std::int32_t>>>
 compute_integration_domains(IntegralType integral_type,
                             const mesh::Topology& topology,

--- a/cpp/dolfinx/geometry/BoundingBoxTree.h
+++ b/cpp/dolfinx/geometry/BoundingBoxTree.h
@@ -236,8 +236,8 @@ public:
     }
 
     // Initialize entities of given dimension if they don't exist
-    mesh.topology_mutable().create_entities(tdim);
-    mesh.topology_mutable().create_connectivity(tdim, mesh.topology()->dim());
+    mesh.topology_mutable()->create_entities(tdim);
+    mesh.topology_mutable()->create_connectivity(tdim, mesh.topology()->dim());
 
     // Create bounding boxes for all mesh entities (leaves)
     std::vector<std::pair<std::array<T, 6>, std::int32_t>> leaf_bboxes;

--- a/cpp/dolfinx/geometry/BoundingBoxTree.h
+++ b/cpp/dolfinx/geometry/BoundingBoxTree.h
@@ -228,7 +228,7 @@ public:
                   std::span<const std::int32_t> entities, double padding = 0)
       : _tdim(tdim)
   {
-    if (tdim < 0 or tdim > mesh.topology().dim())
+    if (tdim < 0 or tdim > mesh.topology()->dim())
     {
       throw std::runtime_error(
           "Dimension must be non-negative and less than or "
@@ -237,7 +237,7 @@ public:
 
     // Initialize entities of given dimension if they don't exist
     mesh.topology_mutable().create_entities(tdim);
-    mesh.topology_mutable().create_connectivity(tdim, mesh.topology().dim());
+    mesh.topology_mutable().create_connectivity(tdim, mesh.topology()->dim());
 
     // Create bounding boxes for all mesh entities (leaves)
     std::vector<std::pair<std::array<T, 6>, std::int32_t>> leaf_bboxes;

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -36,7 +36,7 @@ std::vector<T> shortest_vector(const mesh::Mesh<T>& mesh, int dim,
                                std::span<const std::int32_t> entities,
                                std::span<const T> points)
 {
-  const int tdim = mesh.topology().dim();
+  const int tdim = mesh.topology()->dim();
   const mesh::Geometry<T>& geometry = mesh.geometry();
   std::span<const T> geom_dofs = geometry.x();
   const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
@@ -61,11 +61,11 @@ std::vector<T> shortest_vector(const mesh::Mesh<T>& mesh, int dim,
   }
   else
   {
-    mesh.topology_mutable().create_connectivity(dim, tdim);
-    mesh.topology_mutable().create_connectivity(tdim, dim);
-    auto e_to_c = mesh.topology().connectivity(dim, tdim);
+    mesh.topology_mutable()->create_connectivity(dim, tdim);
+    mesh.topology_mutable()->create_connectivity(tdim, dim);
+    auto e_to_c = mesh.topology()->connectivity(dim, tdim);
     assert(e_to_c);
-    auto c_to_e = mesh.topology_mutable().connectivity(tdim, dim);
+    auto c_to_e = mesh.topology_mutable()->connectivity(tdim, dim);
     assert(c_to_e);
     for (std::size_t e = 0; e < entities.size(); e++)
     {
@@ -604,7 +604,7 @@ graph::AdjacencyList<std::int32_t> compute_colliding_cells(
   offsets.reserve(candidate_cells.num_nodes() + 1);
   std::vector<std::int32_t> colliding_cells;
   constexpr T eps2 = 1e-20;
-  const int tdim = mesh.topology().dim();
+  const int tdim = mesh.topology()->dim();
   for (std::int32_t i = 0; i < candidate_cells.num_nodes(); i++)
   {
     auto cells = candidate_cells.links(i);
@@ -652,8 +652,8 @@ determine_point_ownership(const mesh::Mesh<T>& mesh, std::span<const T> points)
   // Create a global bounding-box tree to find candidate processes with
   // cells that could collide with the points
   constexpr T padding = 1.0e-4;
-  const int tdim = mesh.topology().dim();
-  const auto cell_map = mesh.topology().index_map(tdim);
+  const int tdim = mesh.topology()->dim();
+  const auto cell_map = mesh.topology()->index_map(tdim);
   const std::int32_t num_cells = cell_map->size_local();
   // NOTE: Should we send the cells in as input?
   std::vector<std::int32_t> cells(num_cells, 0);

--- a/cpp/dolfinx/io/ADIOS2Writers.cpp
+++ b/cpp/dolfinx/io/ADIOS2Writers.cpp
@@ -175,6 +175,7 @@ std::vector<T> pack_function_data(const fem::Function<T, U>& u)
   assert(mesh);
   const mesh::Geometry<U>& geometry = mesh->geometry();
   auto topology = mesh->topology();
+  assert(topology);
 
   // The Function and the mesh must have identical element_dof_layouts
   // (up to the block size)

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -374,10 +374,10 @@ void vtx_write_mesh(adios2::IO& io, adios2::Engine& engine,
   engine.Put<std::uint32_t>(vertices, num_vertices);
 
   const auto [vtkcells, shape] = io::extract_vtk_connectivity(
-      mesh.geometry().dofmap(), mesh.topology()->cell_type());
+      mesh.geometry().dofmap(), topology->cell_type());
 
   // Add cell metadata
-  const int tdim = topology.dim();
+  const int tdim = topology->dim();
   adios2::Variable<std::uint32_t> cell_variable
       = define_variable<std::uint32_t>(io, "NumberOfCells",
                                        {adios2::LocalValueDim});
@@ -385,7 +385,7 @@ void vtx_write_mesh(adios2::IO& io, adios2::Engine& engine,
   adios2::Variable<std::uint32_t> celltype_variable
       = define_variable<std::uint32_t>(io, "types");
   engine.Put<std::uint32_t>(
-      celltype_variable, cells::get_vtk_cell_type(topology.cell_type(), tdim));
+      celltype_variable, cells::get_vtk_cell_type(topology->cell_type(), tdim));
 
   // Pack mesh 'nodes'. Output is written as [N0, v0_0,...., v0_N0, N1,
   // v1_0,...., v1_N1,....], where N is the number of cell nodes and v0,

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -358,7 +358,7 @@ void vtx_write_mesh(adios2::IO& io, adios2::Engine& engine,
                     const mesh::Mesh<T>& mesh)
 {
   const mesh::Geometry<T>& geometry = mesh.geometry();
-  const mesh::Topology& topology = mesh.topology();
+  auto topology = mesh.topology();
 
   // "Put" geometry
   std::shared_ptr<const common::IndexMap> x_map = geometry.index_map();
@@ -374,7 +374,7 @@ void vtx_write_mesh(adios2::IO& io, adios2::Engine& engine,
   engine.Put<std::uint32_t>(vertices, num_vertices);
 
   const auto [vtkcells, shape] = io::extract_vtk_connectivity(
-      mesh.geometry().dofmap(), mesh.topology().cell_type());
+      mesh.geometry().dofmap(), mesh.topology()->cell_type());
 
   // Add cell metadata
   const int tdim = topology.dim();
@@ -430,7 +430,7 @@ void vtx_write_mesh_from_space(adios2::IO& io, adios2::Engine& engine,
 {
   auto mesh = V.mesh();
   assert(mesh);
-  const int tdim = mesh->topology().dim();
+  const int tdim = mesh->topology()->dim();
 
   // Get a VTK mesh with points at the 'nodes'
   const auto [x, xshape, x_id, x_ghost, vtk, vtkshape]
@@ -470,7 +470,7 @@ void vtx_write_mesh_from_space(adios2::IO& io, adios2::Engine& engine,
   engine.Put<std::uint32_t>(vertices, num_dofs);
   engine.Put<std::uint32_t>(elements, vtkshape[0]);
   engine.Put<std::uint32_t>(
-      cell_type, cells::get_vtk_cell_type(mesh->topology().cell_type(), tdim));
+      cell_type, cells::get_vtk_cell_type(mesh->topology()->cell_type(), tdim));
   engine.Put<T>(local_geometry, x.data());
   engine.Put<std::int64_t>(local_topology, cells.data());
 

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -351,7 +351,7 @@ XDMFFile::read_meshtags(const mesh::Mesh<double>& mesh, std::string name,
 
   LOG(INFO) << "XDMF create meshtags";
   const std::size_t num_vertices_per_entity = mesh::cell_num_entities(
-      mesh::cell_entity_type(mesh.topology().cell_type(),
+      mesh::cell_entity_type(mesh.topology()->cell_type(),
                              mesh::cell_dim(cell_type), 0),
       0);
   const graph::AdjacencyList<std::int32_t> entities_adj

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -150,6 +150,7 @@ public:
 
   /// Write MeshTags
   /// @param[in] meshtags
+  /// @param[in] x Mesh geometry
   /// @param[in] geometry_xpath XPath where Geometry is already stored
   /// in file
   /// @param[in] xpath XPath where MeshTags Grid will be inserted

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -34,7 +34,7 @@ class Geometry;
 enum class GhostMode : int;
 template <std::floating_point T>
 class Mesh;
-template <typename T, std::floating_point U>
+template <typename T>
 class MeshTags;
 } // namespace dolfinx::mesh
 
@@ -151,9 +151,10 @@ public:
   /// Write MeshTags
   /// @param[in] meshtags
   /// @param[in] geometry_xpath XPath where Geometry is already stored
-  ///   in file
+  /// in file
   /// @param[in] xpath XPath where MeshTags Grid will be inserted
-  void write_meshtags(const mesh::MeshTags<std::int32_t, double>& meshtags,
+  void write_meshtags(const mesh::MeshTags<std::int32_t>& meshtags,
+                      const mesh::Geometry<double>& x,
                       std::string geometry_xpath,
                       std::string xpath = "/Xdmf/Domain");
 
@@ -161,9 +162,9 @@ public:
   /// @param[in] mesh The Mesh that the data is defined on
   /// @param[in] name
   /// @param[in] xpath XPath where MeshTags Grid is stored in file
-  mesh::MeshTags<std::int32_t, double>
-  read_meshtags(std::shared_ptr<const mesh::Mesh<double>> mesh,
-                std::string name, std::string xpath = "/Xdmf/Domain");
+  mesh::MeshTags<std::int32_t>
+  read_meshtags(const mesh::Mesh<double>& mesh, std::string name,
+                std::string xpath = "/Xdmf/Domain");
 
   /// Write Information
   /// @param[in] name

--- a/cpp/dolfinx/io/vtk_utils.h
+++ b/cpp/dolfinx/io/vtk_utils.h
@@ -60,7 +60,7 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace<T>& V)
   auto mesh = V.mesh();
   assert(mesh);
   const std::size_t gdim = mesh->geometry().dim();
-  const int tdim = mesh->topology().dim();
+  const int tdim = mesh->topology()->dim();
 
   // Get dofmap data
   auto dofmap = V.dofmap();
@@ -93,8 +93,8 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace<T>& V)
   std::span<const std::uint32_t> cell_info;
   if (element->needs_dof_transformations())
   {
-    mesh->topology_mutable().create_entity_permutations();
-    cell_info = std::span(mesh->topology().get_cell_permutation_info());
+    mesh->topology_mutable()->create_entity_permutations();
+    cell_info = std::span(mesh->topology()->get_cell_permutation_info());
   }
   const auto apply_dof_transformation
       = element->template get_dof_transformation_function<T>();
@@ -114,7 +114,7 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace<T>& V)
                               stdex::full_extent, 0);
 
   // Loop over cells and tabulate dofs
-  auto map = mesh->topology().index_map(tdim);
+  auto map = mesh->topology()->index_map(tdim);
   assert(map);
   const std::int32_t num_cells = map->size_local() + map->num_ghosts();
   std::vector<T> x_b(scalar_dofs * gdim);
@@ -186,7 +186,7 @@ vtk_mesh_from_space(const fem::FunctionSpace<T>& V)
 {
   auto mesh = V.mesh();
   assert(mesh);
-  const int tdim = mesh->topology().dim();
+  const int tdim = mesh->topology()->dim();
 
   assert(V.element());
   if (V.element()->is_mixed())
@@ -194,7 +194,7 @@ vtk_mesh_from_space(const fem::FunctionSpace<T>& V)
 
   const auto [x, xshape, x_id, x_ghost]
       = impl::tabulate_lagrange_dof_coordinates(V);
-  auto map = mesh->topology().index_map(tdim);
+  auto map = mesh->topology()->index_map(tdim);
   const std::size_t num_cells = map->size_local() + map->num_ghosts();
 
   // Create permutation from DOLFINx dof ordering to VTK
@@ -204,7 +204,7 @@ vtk_mesh_from_space(const fem::FunctionSpace<T>& V)
   const std::uint32_t num_nodes
       = V.element()->space_dimension() / element_block_size;
   const std::vector<std::uint8_t> vtkmap = io::cells::transpose(
-      io::cells::perm_vtk(mesh->topology().cell_type(), num_nodes));
+      io::cells::perm_vtk(mesh->topology()->cell_type(), num_nodes));
 
   // Extract topology for all local cells as
   // [v0_0, ...., v0_N0, v1_0, ...., v1_N1, ....]

--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -50,7 +50,7 @@ bool has_cell_centred_data(const fem::Function<Scalar, double>& u)
   int cell_based_dim = 1;
   const int rank = u.function_space()->element()->value_shape().size();
   for (int i = 0; i < rank; i++)
-    cell_based_dim *= u.function_space()->mesh()->topology().dim();
+    cell_based_dim *= u.function_space()->mesh()->topology()->dim();
 
   assert(u.function_space());
   assert(u.function_space()->dofmap());
@@ -91,7 +91,7 @@ void _add_function(MPI_Comm comm, const fem::Function<Scalar, double>& u,
   else
     data_values = xdmf_utils::get_point_data_values(u);
 
-  auto map_c = mesh->topology().index_map(mesh->topology().dim());
+  auto map_c = mesh->topology()->index_map(mesh->topology()->dim());
   assert(map_c);
 
   auto map_v = mesh->geometry().index_map();

--- a/cpp/dolfinx/io/xdmf_mesh.cpp
+++ b/cpp/dolfinx/io/xdmf_mesh.cpp
@@ -214,17 +214,17 @@ void xdmf_mesh::add_mesh(MPI_Comm comm, pugi::xml_node& xml_node,
 
   // Add topology node and attributes (including writing data)
   const std::string path_prefix = "/Mesh/" + name;
-  const int tdim = mesh.topology().dim();
+  const int tdim = mesh.topology()->dim();
 
   // Prepare an array of active cells
   // Writing whole mesh so each cell is active, excl. ghosts
-  auto map = mesh.topology().index_map(tdim);
+  auto map = mesh.topology()->index_map(tdim);
   assert(map);
   const int num_cells = map->size_local();
   std::vector<std::int32_t> cells(num_cells);
   std::iota(cells.begin(), cells.end(), 0);
 
-  add_topology_data(comm, grid_node, h5_id, path_prefix, mesh.topology(),
+  add_topology_data(comm, grid_node, h5_id, path_prefix, *mesh.topology(),
                     mesh.geometry(), tdim,
                     std::span<std::int32_t>(cells.data(), num_cells));
 

--- a/cpp/dolfinx/io/xdmf_meshtags.h
+++ b/cpp/dolfinx/io/xdmf_meshtags.h
@@ -20,11 +20,8 @@
 
 namespace dolfinx
 {
-namespace io
+namespace io::xdmf_meshtags
 {
-namespace xdmf_meshtags
-{
-
 /// Add mesh tags to XDMF file
 template <typename T, typename U>
 void add_meshtags(MPI_Comm comm, const mesh::MeshTags<T>& meshtags,
@@ -75,6 +72,5 @@ void add_meshtags(MPI_Comm comm, const mesh::MeshTags<T>& meshtags,
       {global_num_values, 1}, "", use_mpi_io);
 }
 
-} // namespace xdmf_meshtags
-} // namespace io
+} // namespace io::xdmf_meshtags
 } // namespace dolfinx

--- a/cpp/dolfinx/io/xdmf_meshtags.h
+++ b/cpp/dolfinx/io/xdmf_meshtags.h
@@ -26,18 +26,16 @@ namespace xdmf_meshtags
 {
 
 /// Add mesh tags to XDMF file
-template <typename T>
-void add_meshtags(MPI_Comm comm, const mesh::MeshTags<T, double>& meshtags,
-                  pugi::xml_node& xml_node, const hid_t h5_id,
-                  const std::string name)
+template <typename T, typename U>
+void add_meshtags(MPI_Comm comm, const mesh::MeshTags<T>& meshtags,
+                  const mesh::Geometry<U>& geometry, pugi::xml_node& xml_node,
+                  const hid_t h5_id, const std::string name)
 {
   LOG(INFO) << "XDMF: add meshtags (" << name << ")";
   // Get mesh
-  assert(meshtags.mesh());
-  auto mesh = meshtags.mesh();
   const int dim = meshtags.dim();
   std::shared_ptr<const common::IndexMap> entity_map
-      = mesh->topology().index_map(dim);
+      = meshtags.topology().index_map(dim);
   if (!entity_map)
   {
     throw std::runtime_error("Missing entities. Did you forget to call "
@@ -52,8 +50,7 @@ void add_meshtags(MPI_Comm comm, const mesh::MeshTags<T, double>& meshtags,
 
   const std::string path_prefix = "/MeshTags/" + name;
   xdmf_mesh::add_topology_data(
-      comm, xml_node, h5_id, path_prefix, mesh->topology(), mesh->geometry(),
-      dim,
+      comm, xml_node, h5_id, path_prefix, meshtags.topology(), geometry, dim,
       std::span<const std::int32_t>(meshtags.indices().data(),
                                     num_active_entities));
 

--- a/cpp/dolfinx/io/xdmf_meshtags.h
+++ b/cpp/dolfinx/io/xdmf_meshtags.h
@@ -32,7 +32,7 @@ void add_meshtags(MPI_Comm comm, const mesh::MeshTags<T>& meshtags,
   // Get mesh
   const int dim = meshtags.dim();
   std::shared_ptr<const common::IndexMap> entity_map
-      = meshtags.topology().index_map(dim);
+      = meshtags.topology()->index_map(dim);
   if (!entity_map)
   {
     throw std::runtime_error("Missing entities. Did you forget to call "
@@ -47,7 +47,7 @@ void add_meshtags(MPI_Comm comm, const mesh::MeshTags<T>& meshtags,
 
   const std::string path_prefix = "/MeshTags/" + name;
   xdmf_mesh::add_topology_data(
-      comm, xml_node, h5_id, path_prefix, meshtags.topology(), geometry, dim,
+      comm, xml_node, h5_id, path_prefix, *meshtags.topology(), geometry, dim,
       std::span<const std::int32_t>(meshtags.indices().data(),
                                     num_active_entities));
 

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -81,7 +81,7 @@ compute_point_values(const fem::Function<T, double>& u)
   assert(V);
   auto mesh = V->mesh();
   assert(mesh);
-  const int tdim = mesh->topology().dim();
+  const int tdim = mesh->topology()->dim();
 
   // Compute in tensor (one for scalar function, . . .)
   const std::size_t value_size_loc = V->element()->value_size();
@@ -98,7 +98,7 @@ compute_point_values(const fem::Function<T, double>& u)
 
   // Interpolate point values on each cell (using last computed value if
   // not continuous, e.g. discontinuous Galerkin methods)
-  auto map = mesh->topology().index_map(tdim);
+  auto map = mesh->topology()->index_map(tdim);
   assert(map);
   const std::int32_t num_cells = map->size_local() + map->num_ghosts();
 
@@ -183,9 +183,9 @@ _get_cell_data_values(const fem::Function<Scalar, double>& u)
   const int value_rank = u.function_space()->element()->value_shape().size();
 
   // Allocate memory for function values at cell centres
-  const int tdim = mesh->topology().dim();
+  const int tdim = mesh->topology()->dim();
   const std::int32_t num_local_cells
-      = mesh->topology().index_map(tdim)->size_local();
+      = mesh->topology()->index_map(tdim)->size_local();
   const std::int32_t local_size = num_local_cells * value_size;
 
   // Build lists of dofs and create map
@@ -459,8 +459,8 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh<double>& mesh,
     // Get layout of dofs on 0th cell entity of dimension entity_dim
     const fem::ElementDofLayout cmap_dof_layout
         = mesh.geometry().cmap().create_dof_layout();
-    for (int i = 0; i < mesh::cell_num_entities(mesh.topology().cell_type(), 0);
-         ++i)
+    for (int i = 0;
+         i < mesh::cell_num_entities(mesh.topology()->cell_type(), 0); ++i)
     {
       const std::vector<int>& local_index = cmap_dof_layout.entity_dofs(0, i);
       assert(local_index.size() == 1);
@@ -527,8 +527,8 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh<double>& mesh,
     const std::int64_t num_nodes_g = mesh.geometry().index_map()->size_global();
 
     const std::size_t num_vert_per_entity = mesh::cell_num_entities(
-        mesh::cell_entity_type(mesh.topology().cell_type(), entity_dim, 0), 0);
-    auto c_to_v = mesh.topology().connectivity(mesh.topology().dim(), 0);
+        mesh::cell_entity_type(mesh.topology()->cell_type(), entity_dim, 0), 0);
+    auto c_to_v = mesh.topology()->connectivity(mesh.topology()->dim(), 0);
     if (!c_to_v)
       throw std::runtime_error("Missing cell-vertex connectivity.");
 
@@ -613,7 +613,7 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh<double>& mesh,
     const int comm_size = dolfinx::MPI::size(comm);
 
     const std::size_t num_vert_per_entity = mesh::cell_num_entities(
-        mesh::cell_entity_type(mesh.topology().cell_type(), entity_dim, 0), 0);
+        mesh::cell_entity_type(mesh.topology()->cell_type(), entity_dim, 0), 0);
 
     // Build map from global node index to ranks that have the node
     std::multimap<std::int64_t, int> node_to_rank;
@@ -687,8 +687,8 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh<double>& mesh,
     LOG(INFO) << "XDMF build map";
 
     const std::size_t num_vert_per_entity = mesh::cell_num_entities(
-        mesh::cell_entity_type(mesh.topology().cell_type(), entity_dim, 0), 0);
-    auto c_to_v = mesh.topology().connectivity(mesh.topology().dim(), 0);
+        mesh::cell_entity_type(mesh.topology()->cell_type(), entity_dim, 0), 0);
+    auto c_to_v = mesh.topology()->connectivity(mesh.topology()->dim(), 0);
     if (!c_to_v)
       throw std::runtime_error("Missing cell-vertex connectivity.");
 

--- a/cpp/dolfinx/mesh/Mesh.h
+++ b/cpp/dolfinx/mesh/Mesh.h
@@ -7,13 +7,13 @@
 #pragma once
 
 #include "Geometry.h"
-#include "Topology.h"
 #include <concepts>
 #include <dolfinx/common/MPI.h>
 #include <string>
 
 namespace dolfinx::mesh
 {
+class Topology;
 
 /// @brief A Mesh consists of a set of connected and numbered mesh topological
 /// entities, and geometry data.
@@ -29,10 +29,9 @@ public:
   /// @param[in] comm MPI Communicator
   /// @param[in] topology Mesh topology
   /// @param[in] geometry Mesh geometry
-  template <std::convertible_to<Topology> U, std::convertible_to<Geometry<T>> V>
-  Mesh(MPI_Comm comm, U&& topology, V&& geometry)
-      : _topology(std::forward<U>(topology)),
-        _geometry(std::forward<V>(geometry)), _comm(comm)
+  template <std::convertible_to<Geometry<T>> V>
+  Mesh(MPI_Comm comm, std::shared_ptr<Topology> topology, V&& geometry)
+      : _topology(topology), _geometry(std::forward<V>(geometry)), _comm(comm)
   {
     // Do nothing
   }
@@ -61,15 +60,15 @@ public:
   // Mesh::topology()) may still rely on it.
   /// @brief Get mesh topology
   /// @return The topology object associated with the mesh.
-  Topology& topology() { return _topology; }
+  std::shared_ptr<Topology> topology() { return _topology; }
 
   /// Get mesh topology (const version)
   /// @return The topology object associated with the mesh.
-  const Topology& topology() const { return _topology; }
+  std::shared_ptr<const Topology> topology() const { return _topology; }
 
   /// Get mesh topology if one really needs the mutable version
   /// @return The topology object associated with the mesh.
-  Topology& topology_mutable() const { return _topology; }
+  std::shared_ptr<Topology> topology_mutable() const { return _topology; }
 
   /// @brief Get mesh geometry
   /// @return The geometry object associated with the mesh
@@ -91,7 +90,7 @@ private:
   // Note: This is mutable because of the current memory management
   // within mesh::Topology. It allows to obtain a non-const Topology
   // from a const mesh (via Mesh::topology_mutable()).
-  mutable Topology _topology;
+  std::shared_ptr<Topology> _topology;
 
   // Mesh geometry
   Geometry<T> _geometry;

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -40,7 +40,7 @@ public:
   /// @brief Create a MeshTag from entities of given dimension on a
   /// mesh.
   ///
-  /// @param[in] mesh The mesh on which the tags are associated.
+  /// @param[in] topology Mesh topology on which the tags are associated.
   /// @param[in] dim Topological dimension of mesh entities to tag.
   /// @param[in] indices List of entity indices (indices local to the
   /// process).
@@ -130,7 +130,7 @@ private:
 };
 
 /// @brief Create MeshTags from arrays
-/// @param[in] mesh The Mesh that the tags are associated with
+/// @param[in] topology Mesh topology that the tags are associated with
 /// @param[in] dim Topological dimension of tagged entities
 /// @param[in] entities Local vertex indices for tagged entities.
 ///

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -6,16 +6,12 @@
 
 #pragma once
 
-#include "Geometry.h"
-#include "Mesh.h"
 #include "Topology.h"
 #include <algorithm>
-#include <concepts>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/log.h>
 #include <dolfinx/common/utils.h>
 #include <dolfinx/graph/AdjacencyList.h>
-#include <dolfinx/graph/partition.h>
 #include <dolfinx/io/cells.h>
 #include <memory>
 #include <span>
@@ -97,29 +93,27 @@ public:
     return indices;
   }
 
-  /// Indices of tagged mesh entities (local-to-process). The indices
-  /// are sorted.
+  /// Indices of tagged topology entities (local-to-process). The
+  /// indices are sorted.
   std::span<const std::int32_t> indices() const { return _indices; }
 
-  /// Values attached to mesh entities
+  /// Values attached to topology entities
   std::span<const T> values() const { return _values; }
 
   /// Return topological dimension of tagged entities
   int dim() const { return _dim; }
 
-  /// Return mesh
-  // std::shared_ptr<const Mesh<X>> mesh() const { return _mesh; }
+  /// Return topology
   std::shared_ptr<const Topology> topology() const { return _topology; }
 
   /// Name
   std::string name = "mesh_tags";
 
 private:
-  // Associated mesh
-  // std::shared_ptr<const Mesh<X>> _mesh;
+  // Associated topology
   std::shared_ptr<const Topology> _topology;
 
-  // Topological dimension of tagged mesh entities
+  // Topological dimension of tagged topology entities
   int _dim;
 
   // Local-to-process indices of tagged entities
@@ -133,16 +127,10 @@ private:
 /// @param[in] topology Mesh topology that the tags are associated with
 /// @param[in] dim Topological dimension of tagged entities
 /// @param[in] entities Local vertex indices for tagged entities.
-///
 /// @param[in] values Tag values for each entity in `entities`. The
 /// length of `values` must be equal to number of rows in `entities`.
 /// @note Entities that do not exist on this rank are ignored.
 /// @warning `entities` must not contain duplicate entities.
-// template <typename T, std::floating_point U>
-// MeshTags<T, U>
-// create_meshtags(std::shared_ptr<const Mesh<U>> mesh, int dim,
-//                 const graph::AdjacencyList<std::int32_t>& entities,
-//                 std::span<const T> values)
 template <typename T>
 MeshTags<T> create_meshtags(std::shared_ptr<const Topology> topology, int dim,
                             const graph::AdjacencyList<std::int32_t>& entities,
@@ -151,10 +139,8 @@ MeshTags<T> create_meshtags(std::shared_ptr<const Topology> topology, int dim,
   LOG(INFO)
       << "Building MeshTags object from tagged entities (defined by vertices).";
 
-  // assert(mesh);
-
-  // Compute the indices of the mesh entities (index is set to -1 if it
-  // can't be found)
+  // Compute the indices of the topology entities (index is set to -1 if
+  // it can't be found)
   assert(topology);
   const std::vector<std::int32_t> indices
       = entities_to_index(*topology, dim, entities);

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -32,7 +32,6 @@ namespace dolfinx::mesh
 /// with an arbitrary subset of mesh entities. An entity can have only
 /// one associated tag.
 /// @tparam Type
-// template <typename T, std::floating_point X>
 template <typename T>
 class MeshTags
 {

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -48,7 +48,8 @@ public:
   /// @pre `indices` must be sorted and unique.
   template <std::convertible_to<std::vector<std::int32_t>> U,
             std::convertible_to<std::vector<T>> V>
-  MeshTags(const Topology& topology, int dim, U&& indices, V&& values)
+  MeshTags(std::shared_ptr<const Topology> topology, int dim, U&& indices,
+           V&& values)
       : _topology(topology), _dim(dim), _indices(std::forward<U>(indices)),
         _values(std::forward<V>(values))
   {
@@ -108,7 +109,7 @@ public:
 
   /// Return mesh
   // std::shared_ptr<const Mesh<X>> mesh() const { return _mesh; }
-  const Topology& topology() const { return _topology; }
+  std::shared_ptr<const Topology> topology() const { return _topology; }
 
   /// Name
   std::string name = "mesh_tags";
@@ -116,7 +117,7 @@ public:
 private:
   // Associated mesh
   // std::shared_ptr<const Mesh<X>> _mesh;
-  const Topology& _topology;
+  std::shared_ptr<const Topology> _topology;
 
   // Topological dimension of tagged mesh entities
   int _dim;
@@ -143,7 +144,7 @@ private:
 //                 const graph::AdjacencyList<std::int32_t>& entities,
 //                 std::span<const T> values)
 template <typename T>
-MeshTags<T> create_meshtags(const Topology& topology, int dim,
+MeshTags<T> create_meshtags(std::shared_ptr<const Topology> topology, int dim,
                             const graph::AdjacencyList<std::int32_t>& entities,
                             std::span<const T> values)
 {
@@ -154,8 +155,9 @@ MeshTags<T> create_meshtags(const Topology& topology, int dim,
 
   // Compute the indices of the mesh entities (index is set to -1 if it
   // can't be found)
+  assert(topology);
   const std::vector<std::int32_t> indices
-      = entities_to_index(topology, dim, entities);
+      = entities_to_index(*topology, dim, entities);
   if (indices.size() != values.size())
   {
     throw std::runtime_error(

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -72,8 +72,8 @@ compute_vertex_coords_boundary(const mesh::Mesh<T>& mesh, int dim,
   }
 
   // Build set of vertices on boundary and set of boundary entities
-  mesh.topology_mutable().create_connectivity(tdim - 1, 0);
-  mesh.topology_mutable().create_connectivity(tdim - 1, dim);
+  mesh.topology_mutable()->create_connectivity(tdim - 1, 0);
+  mesh.topology_mutable()->create_connectivity(tdim - 1, dim);
   std::vector<std::int32_t> vertices, entities;
   {
     auto f_to_v = topology->connectivity(tdim - 1, 0);
@@ -102,11 +102,11 @@ compute_vertex_coords_boundary(const mesh::Mesh<T>& mesh, int dim,
   std::span<const T> x_nodes = mesh.geometry().x();
 
   // Get all vertex 'node' indices
-  mesh.topology_mutable().create_connectivity(0, tdim);
-  mesh.topology_mutable().create_connectivity(tdim, 0);
-  auto v_to_c = topology.connectivity(0, tdim);
+  mesh.topology_mutable()->create_connectivity(0, tdim);
+  mesh.topology_mutable()->create_connectivity(tdim, 0);
+  auto v_to_c = topology->connectivity(0, tdim);
   assert(v_to_c);
-  auto c_to_v = topology.connectivity(tdim, 0);
+  auto c_to_v = topology->connectivity(tdim, 0);
   assert(c_to_v);
   std::vector<T> x_vertices(3 * vertices.size(), -1.0);
   std::vector<std::int32_t> vertex_to_pos(v_to_c->num_nodes(), -1);
@@ -408,7 +408,7 @@ compute_vertex_coords(const mesh::Mesh<T>& mesh)
   const int tdim = topology->dim();
 
   // Create entities and connectivities
-  mesh.topology_mutable().create_connectivity(tdim, 0);
+  mesh.topology_mutable()->create_connectivity(tdim, 0);
 
   // Get all vertex 'node' indices
   const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
@@ -473,7 +473,7 @@ std::vector<std::int32_t> locate_entities(const Mesh<T>& mesh, int dim,
   mesh.topology_mutable()->create_entities(dim);
   mesh.topology_mutable()->create_connectivity(tdim, 0);
   if (dim < tdim)
-    mesh.topology_mutable().create_connectivity(dim, 0);
+    mesh.topology_mutable()->create_connectivity(dim, 0);
 
   // Iterate over entities of dimension 'dim' to build vector of marked
   // entities
@@ -524,8 +524,9 @@ template <std::floating_point T, typename U>
 std::vector<std::int32_t> locate_entities_boundary(const Mesh<T>& mesh, int dim,
                                                    U marker)
 {
-  const Topology& topology = mesh.topology();
-  const int tdim = topology.dim();
+  auto topology = mesh.topology();
+  assert(topology);
+  const int tdim = topology->dim();
   if (dim == tdim)
   {
     throw std::runtime_error(
@@ -533,10 +534,10 @@ std::vector<std::int32_t> locate_entities_boundary(const Mesh<T>& mesh, int dim,
   }
 
   // Compute list of boundary facets
-  mesh.topology_mutable().create_entities(tdim - 1);
-  mesh.topology_mutable().create_connectivity(tdim - 1, tdim);
+  mesh.topology_mutable()->create_entities(tdim - 1);
+  mesh.topology_mutable()->create_connectivity(tdim - 1, tdim);
   const std::vector<std::int32_t> boundary_facets
-      = exterior_facet_indices(topology);
+      = exterior_facet_indices(*topology);
 
   namespace stdex = std::experimental;
   using cmdspan3x_t
@@ -552,8 +553,8 @@ std::vector<std::int32_t> locate_entities_boundary(const Mesh<T>& mesh, int dim,
     throw std::runtime_error("Length of array of markers is wrong.");
 
   // Loop over entities and check vertex markers
-  mesh.topology_mutable().create_entities(dim);
-  auto e_to_v = topology.connectivity(dim, 0);
+  mesh.topology_mutable()->create_entities(dim);
+  auto e_to_v = topology->connectivity(dim, 0);
   assert(e_to_v);
   std::vector<std::int32_t> entities;
   for (auto e : facet_entities)
@@ -610,18 +611,18 @@ entities_to_geometry(const Mesh<T>& mesh, int dim,
 
   auto topology = mesh.topology();
   assert(topology);
-  const int tdim = topology.dim();
-  // mesh.topology_mutable().create_entities(dim);
-  // mesh.topology_mutable().create_connectivity(dim, tdim);
-  // mesh.topology_mutable().create_connectivity(dim, 0);
-  // mesh.topology_mutable().create_connectivity(tdim, 0);
+  const int tdim = topology->dim();
+  // mesh.topology_mutable()->create_entities(dim);
+  // mesh.topology_mutable()->create_connectivity(dim, tdim);
+  // mesh.topology_mutable()->create_connectivity(dim, 0);
+  // mesh.topology_mutable()->create_connectivity(tdim, 0);
 
   const graph::AdjacencyList<std::int32_t>& xdofs = geometry.dofmap();
   const auto e_to_c = topology->connectivity(dim, tdim);
   assert(e_to_c);
   const auto e_to_v = topology->connectivity(dim, 0);
   assert(e_to_v);
-  const auto c_to_v = topologyvconnectivity(tdim, 0);
+  const auto c_to_v = topology->connectivity(tdim, 0);
   assert(c_to_v);
 
   const std::size_t num_vertices
@@ -902,19 +903,20 @@ create_submesh(const Mesh<T>& mesh, int dim,
                std::span<const std::int32_t> entities)
 {
   // Create sub-topology
-  mesh.topology_mutable().create_connectivity(dim, 0);
+  mesh.topology_mutable()->create_connectivity(dim, 0);
   auto [topology, subentity_to_entity, subvertex_to_vertex]
-      = mesh::create_subtopology(mesh.topology(), dim, entities);
+      = mesh::create_subtopology(*mesh.topology(), dim, entities);
 
   // Create sub-geometry
   const int tdim = mesh.topology()->dim();
-  mesh.topology_mutable().create_entities(dim);
-  mesh.topology_mutable().create_connectivity(dim, tdim);
-  mesh.topology_mutable().create_connectivity(tdim, dim);
+  mesh.topology_mutable()->create_entities(dim);
+  mesh.topology_mutable()->create_connectivity(dim, tdim);
+  mesh.topology_mutable()->create_connectivity(tdim, dim);
   auto [geometry, subx_to_x_dofmap] = mesh::create_subgeometry(
-      mesh.topology(), mesh.geometry(), dim, subentity_to_entity);
+      *mesh.topology(), mesh.geometry(), dim, subentity_to_entity);
 
-  return {Mesh<T>(mesh.comm(), std::move(topology), std::move(geometry)),
+  return {Mesh<T>(mesh.comm(), std::make_shared<Topology>(std::move(topology)),
+                  std::move(geometry)),
           std::move(subentity_to_entity), std::move(subvertex_to_vertex),
           std::move(subx_to_x_dofmap)};
 }

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -612,18 +612,32 @@ entities_to_geometry(const Mesh<T>& mesh, int dim,
   auto topology = mesh.topology();
   assert(topology);
   const int tdim = topology->dim();
-  // mesh.topology_mutable()->create_entities(dim);
-  // mesh.topology_mutable()->create_connectivity(dim, tdim);
-  // mesh.topology_mutable()->create_connectivity(dim, 0);
-  // mesh.topology_mutable()->create_connectivity(tdim, 0);
+  mesh.topology_mutable()->create_entities(dim);
+  mesh.topology_mutable()->create_connectivity(dim, tdim);
+  mesh.topology_mutable()->create_connectivity(dim, 0);
+  mesh.topology_mutable()->create_connectivity(tdim, 0);
 
   const graph::AdjacencyList<std::int32_t>& xdofs = geometry.dofmap();
-  const auto e_to_c = topology->connectivity(dim, tdim);
-  assert(e_to_c);
-  const auto e_to_v = topology->connectivity(dim, 0);
-  assert(e_to_v);
+  auto e_to_c = topology->connectivity(dim, tdim);
+  if (!e_to_c)
+  {
+    throw std::runtime_error(
+        "Entity-to-cell connectivity has not been computed.");
+  }
+
+  auto e_to_v = topology->connectivity(dim, 0);
+  if (!e_to_v)
+  {
+    throw std::runtime_error(
+        "Entity-to-vertex connectivity has not been computed.");
+  }
+
   const auto c_to_v = topology->connectivity(tdim, 0);
-  assert(c_to_v);
+  if (!e_to_v)
+  {
+    throw std::runtime_error(
+        "Cell-to-vertex connectivity has not been computed.");
+  }
 
   const std::size_t num_vertices
       = num_cell_vertices(cell_entity_type(cell_type, dim, 0));

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -870,8 +870,6 @@ create_mesh(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
       = create_geometry(comm, topology, element, cell_nodes, x, xshape[1]);
   auto _t = std::make_shared<Topology>(std::move(topology));
   return Mesh<typename U::value_type>(comm, _t, std::move(geometry));
-  // return Mesh<typename U::value_type>(comm, std::move(topology),
-  //                                     std::move(geometry));
 }
 
 /// @brief Create a mesh using the default partitioner.

--- a/cpp/dolfinx/refinement/plaza.h
+++ b/cpp/dolfinx/refinement/plaza.h
@@ -141,7 +141,7 @@ template <typename T>
 std::pair<std::vector<std::int32_t>, std::vector<std::int8_t>>
 face_long_edge(const mesh::Mesh<T>& mesh)
 {
-  const int tdim = mesh.topology().dim();
+  const int tdim = mesh.topology()->dim();
   // FIXME: cleanup these calls? Some of the happen internally again.
   mesh.topology_mutable().create_entities(1);
   mesh.topology_mutable().create_entities(2);
@@ -149,8 +149,8 @@ face_long_edge(const mesh::Mesh<T>& mesh)
   mesh.topology_mutable().create_connectivity(1, tdim);
   mesh.topology_mutable().create_connectivity(tdim, 2);
 
-  std::int64_t num_faces = mesh.topology().index_map(2)->size_local()
-                           + mesh.topology().index_map(2)->num_ghosts();
+  std::int64_t num_faces = mesh.topology()->index_map(2)->size_local()
+                           + mesh.topology()->index_map(2)->num_ghosts();
 
   // Storage for face-local index of longest edge
   std::vector<std::int32_t> long_edge(num_faces);
@@ -164,15 +164,15 @@ face_long_edge(const mesh::Mesh<T>& mesh)
 
   const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
 
-  auto c_to_v = mesh.topology().connectivity(tdim, 0);
+  auto c_to_v = mesh.topology()->connectivity(tdim, 0);
   assert(c_to_v);
-  auto e_to_c = mesh.topology().connectivity(1, tdim);
+  auto e_to_c = mesh.topology()->connectivity(1, tdim);
   assert(e_to_c);
-  auto e_to_v = mesh.topology().connectivity(1, 0);
+  auto e_to_v = mesh.topology()->connectivity(1, 0);
   assert(e_to_v);
 
   // Store all edge lengths in Mesh to save recalculating for each Face
-  auto map_e = mesh.topology().index_map(1);
+  auto map_e = mesh.topology()->index_map(1);
   assert(map_e);
   std::vector<T> edge_length(map_e->size_local() + map_e->num_ghosts());
   for (std::size_t e = 0; e < edge_length.size(); ++e)
@@ -206,12 +206,12 @@ face_long_edge(const mesh::Mesh<T>& mesh)
   }
 
   // Get longest edge of each face
-  auto f_to_v = mesh.topology().connectivity(2, 0);
+  auto f_to_v = mesh.topology()->connectivity(2, 0);
   assert(f_to_v);
-  auto f_to_e = mesh.topology().connectivity(2, 1);
+  auto f_to_e = mesh.topology()->connectivity(2, 1);
   assert(f_to_e);
   const std::vector global_indices
-      = mesh.topology().index_map(0)->global_indices();
+      = mesh.topology()->index_map(0)->global_indices();
   for (int f = 0; f < f_to_v->num_nodes(); ++f)
   {
     auto face_edges = f_to_e->links(f);
@@ -265,7 +265,7 @@ compute_refinement(MPI_Comm neighbor_comm,
                    const std::vector<std::int8_t>& edge_ratio_ok,
                    plaza::Option option)
 {
-  int tdim = mesh.topology().dim();
+  int tdim = mesh.topology()->dim();
   int num_cell_edges = tdim * 3 - 3;
   int num_cell_vertices = tdim + 1;
   bool compute_facets = (option == plaza::Option::parent_facet
@@ -283,21 +283,21 @@ compute_refinement(MPI_Comm neighbor_comm,
   std::vector<std::int64_t> indices(num_cell_vertices + num_cell_edges);
   std::vector<std::int32_t> simplex_set;
 
-  auto map_c = mesh.topology().index_map(tdim);
+  auto map_c = mesh.topology()->index_map(tdim);
   assert(map_c);
-  auto c_to_v = mesh.topology().connectivity(tdim, 0);
+  auto c_to_v = mesh.topology()->connectivity(tdim, 0);
   assert(c_to_v);
-  auto c_to_e = mesh.topology().connectivity(tdim, 1);
+  auto c_to_e = mesh.topology()->connectivity(tdim, 1);
   assert(c_to_e);
-  auto c_to_f = mesh.topology().connectivity(tdim, 2);
+  auto c_to_f = mesh.topology()->connectivity(tdim, 2);
   assert(c_to_f);
 
   std::int32_t num_new_vertices_local = std::count(
       marked_edges.begin(),
-      marked_edges.begin() + mesh.topology().index_map(1)->size_local(), true);
+      marked_edges.begin() + mesh.topology()->index_map(1)->size_local(), true);
 
   std::vector<std::int64_t> global_indices
-      = adjust_indices(*mesh.topology().index_map(0), num_new_vertices_local);
+      = adjust_indices(*mesh.topology()->index_map(0), num_new_vertices_local);
 
   const int num_cells = map_c->size_local();
 
@@ -435,7 +435,7 @@ refine(const mesh::Mesh<T>& mesh, bool redistribute, Option option)
   else
   {
     std::shared_ptr<const common::IndexMap> map_c
-        = mesh.topology().index_map(mesh.topology().dim());
+        = mesh.topology()->index_map(mesh.topology()->dim());
     const int num_ghost_cells = map_c->num_ghosts();
     // Check if mesh has ghost cells on any rank
     // FIXME: this is not a robust test. Should be user option.
@@ -482,7 +482,7 @@ refine(const mesh::Mesh<T>& mesh, std::span<const std::int32_t> edges,
   else
   {
     std::shared_ptr<const common::IndexMap> map_c
-        = mesh.topology().index_map(mesh.topology().dim());
+        = mesh.topology()->index_map(mesh.topology()->dim());
     const int num_ghost_cells = map_c->num_ghosts();
     // Check if mesh has ghost cells on any rank
     // FIXME: this is not a robust test. Should be user option.
@@ -517,13 +517,13 @@ compute_refinement_data(const mesh::Mesh<T>& mesh, Option option)
 {
   common::Timer t0("PLAZA: refine");
 
-  if (mesh.topology().cell_type() != mesh::CellType::triangle
-      and mesh.topology().cell_type() != mesh::CellType::tetrahedron)
+  if (mesh.topology()->cell_type() != mesh::CellType::triangle
+      and mesh.topology()->cell_type() != mesh::CellType::tetrahedron)
   {
     throw std::runtime_error("Cell type not supported");
   }
 
-  auto map_e = mesh.topology().index_map(1);
+  auto map_e = mesh.topology()->index_map(1);
   if (!map_e)
     throw std::runtime_error("Edges must be initialised");
 
@@ -582,13 +582,13 @@ compute_refinement_data(const mesh::Mesh<T>& mesh,
 {
   common::Timer t0("PLAZA: refine");
 
-  if (mesh.topology().cell_type() != mesh::CellType::triangle
-      and mesh.topology().cell_type() != mesh::CellType::tetrahedron)
+  if (mesh.topology()->cell_type() != mesh::CellType::triangle
+      and mesh.topology()->cell_type() != mesh::CellType::tetrahedron)
   {
     throw std::runtime_error("Cell type not supported");
   }
 
-  auto map_e = mesh.topology().index_map(1);
+  auto map_e = mesh.topology()->index_map(1);
   if (!map_e)
     throw std::runtime_error("Edges must be initialised");
 

--- a/cpp/dolfinx/refinement/plaza.h
+++ b/cpp/dolfinx/refinement/plaza.h
@@ -143,11 +143,11 @@ face_long_edge(const mesh::Mesh<T>& mesh)
 {
   const int tdim = mesh.topology()->dim();
   // FIXME: cleanup these calls? Some of the happen internally again.
-  mesh.topology_mutable().create_entities(1);
-  mesh.topology_mutable().create_entities(2);
-  mesh.topology_mutable().create_connectivity(2, 1);
-  mesh.topology_mutable().create_connectivity(1, tdim);
-  mesh.topology_mutable().create_connectivity(tdim, 2);
+  mesh.topology_mutable()->create_entities(1);
+  mesh.topology_mutable()->create_entities(2);
+  mesh.topology_mutable()->create_connectivity(2, 1);
+  mesh.topology_mutable()->create_connectivity(1, tdim);
+  mesh.topology_mutable()->create_connectivity(tdim, 2);
 
   std::int64_t num_faces = mesh.topology()->index_map(2)->size_local()
                            + mesh.topology()->index_map(2)->num_ghosts();
@@ -638,7 +638,7 @@ compute_refinement_data(const mesh::Mesh<T>& mesh,
   // Enforce rules about refinement (i.e. if any edge is marked in a
   // triangle, then the longest edge must also be marked).
   const auto [long_edge, edge_ratio_ok] = impl::face_long_edge(mesh);
-  impl::enforce_rules(comm, edge_ranks, marked_edges, mesh.topology(),
+  impl::enforce_rules(comm, edge_ranks, marked_edges, *mesh.topology(),
                       long_edge);
 
   auto [cell_adj, new_vertex_coords, xshape, parent_cell, parent_facet]

--- a/cpp/dolfinx/refinement/refine.h
+++ b/cpp/dolfinx/refinement/refine.h
@@ -24,8 +24,8 @@ namespace dolfinx::refinement
 template <typename T>
 mesh::Mesh<T> refine(const mesh::Mesh<T>& mesh, bool redistribute = true)
 {
-  if (mesh.topology().cell_type() != mesh::CellType::triangle
-      and mesh.topology().cell_type() != mesh::CellType::tetrahedron)
+  if (mesh.topology()->cell_type() != mesh::CellType::triangle
+      and mesh.topology()->cell_type() != mesh::CellType::tetrahedron)
   {
     throw std::runtime_error("Refinement only defined for simplices");
   }
@@ -34,9 +34,9 @@ mesh::Mesh<T> refine(const mesh::Mesh<T>& mesh, bool redistribute = true)
       = plaza::refine(mesh, redistribute, plaza::Option::none);
 
   // Report the number of refined cells
-  const int D = mesh.topology().dim();
-  const std::int64_t n0 = mesh.topology().index_map(D)->size_global();
-  const std::int64_t n1 = refined_mesh.topology().index_map(D)->size_global();
+  const int D = mesh.topology()->dim();
+  const std::int64_t n0 = mesh.topology()->index_map(D)->size_global();
+  const std::int64_t n1 = refined_mesh.topology()->index_map(D)->size_global();
   LOG(INFO) << "Number of cells increased from " << n0 << " to " << n1 << " ("
             << 100.0 * (static_cast<double>(n1) / static_cast<double>(n0) - 1.0)
             << "%% increase).";
@@ -59,8 +59,8 @@ mesh::Mesh<T> refine(const mesh::Mesh<T>& mesh,
                      std::span<const std::int32_t> edges,
                      bool redistribute = true)
 {
-  if (mesh.topology().cell_type() != mesh::CellType::triangle
-      and mesh.topology().cell_type() != mesh::CellType::tetrahedron)
+  if (mesh.topology()->cell_type() != mesh::CellType::triangle
+      and mesh.topology()->cell_type() != mesh::CellType::tetrahedron)
   {
     throw std::runtime_error("Refinement only defined for simplices");
   }
@@ -69,9 +69,9 @@ mesh::Mesh<T> refine(const mesh::Mesh<T>& mesh,
       = plaza::refine(mesh, edges, redistribute, plaza::Option::none);
 
   // Report the number of refined cells
-  const int D = mesh.topology().dim();
-  const std::int64_t n0 = mesh.topology().index_map(D)->size_global();
-  const std::int64_t n1 = refined_mesh.topology().index_map(D)->size_global();
+  const int D = mesh.topology()->dim();
+  const std::int64_t n0 = mesh.topology()->index_map(D)->size_global();
+  const std::int64_t n1 = refined_mesh.topology()->index_map(D)->size_global();
   LOG(INFO) << "Number of cells increased from " << n0 << " to " << n1 << " ("
             << 100.0 * (static_cast<double>(n1) / static_cast<double>(n0) - 1.0)
             << "%% increase).";

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -153,10 +153,13 @@ refinement::adjust_indices(const common::IndexMap& map, std::int32_t n)
 }
 //-----------------------------------------------------------------------------
 std::array<std::vector<std::int32_t>, 2> refinement::transfer_facet_meshtag(
-    const mesh::Topology& topology, std::span<const std::int32_t> indices,
-    std::span<const std::int32_t> values, const mesh::Topology& topology1,
+    const mesh::MeshTags<std::int32_t>& tags0, const mesh::Topology& topology1,
     std::span<const std::int32_t> cell, std::span<const std::int8_t> facet)
 {
+  const mesh::Topology& topology = tags0.topology();
+  auto values = tags0.values();
+  auto indices = tags0.indices();
+
   int tdim = topology.dim();
   if (topology.index_map(tdim)->num_ghosts() > 0)
     throw std::runtime_error("Ghosted meshes are not supported");
@@ -267,11 +270,15 @@ std::array<std::vector<std::int32_t>, 2> refinement::transfer_facet_meshtag(
   return {std::move(sorted_facet_indices), std::move(sorted_tag_values)};
 }
 //----------------------------------------------------------------------------
-std::array<std::vector<std::int32_t>, 2> refinement::transfer_cell_meshtag(
-    const mesh::Topology& topology0, std::span<const std::int32_t> indices0,
-    std::span<const std::int32_t> values0, const mesh::Topology& topology1,
-    std::span<const std::int32_t> cell)
+std::array<std::vector<std::int32_t>, 2>
+refinement::transfer_cell_meshtag(const mesh::MeshTags<std::int32_t>& tags0,
+                                  const mesh::Topology& topology1,
+                                  std::span<const std::int32_t> cell)
 {
+  const mesh::Topology& topology0 = tags0.topology();
+  auto values0 = tags0.values();
+  auto indices0 = tags0.indices();
+
   const int tdim = topology0.dim();
   // if (meshtag.dim() != tdim)
   //   throw std::runtime_error("Input meshtag is not cell-based");

--- a/cpp/dolfinx/refinement/utils.h
+++ b/cpp/dolfinx/refinement/utils.h
@@ -56,14 +56,14 @@ std::pair<std::vector<T>, std::array<std::size_t, 2>> create_new_geometry(
 {
   // Build map from vertex -> geometry dof
   const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
-  const int tdim = mesh.topology().dim();
-  auto c_to_v = mesh.topology().connectivity(tdim, 0);
+  const int tdim = mesh.topology()->dim();
+  auto c_to_v = mesh.topology()->connectivity(tdim, 0);
   assert(c_to_v);
-  auto map_v = mesh.topology().index_map(0);
+  auto map_v = mesh.topology()->index_map(0);
   assert(map_v);
   std::vector<std::int32_t> vertex_to_x(map_v->size_local()
                                         + map_v->num_ghosts());
-  auto map_c = mesh.topology().index_map(tdim);
+  auto map_c = mesh.topology()->index_map(tdim);
 
   assert(map_c);
   auto dof_layout = mesh.geometry().cmap().create_dof_layout();
@@ -150,7 +150,7 @@ create_new_vertices(MPI_Comm comm,
 {
   // Take marked_edges and use to create new vertices
   std::shared_ptr<const common::IndexMap> edge_index_map
-      = mesh.topology().index_map(1);
+      = mesh.topology()->index_map(1);
 
   // Add new edge midpoints to list of vertices
   int n = 0;
@@ -168,7 +168,7 @@ create_new_vertices(MPI_Comm comm,
   const std::int64_t num_local = n;
   std::int64_t global_offset = 0;
   MPI_Exscan(&num_local, &global_offset, 1, MPI_INT64_T, MPI_SUM, mesh.comm());
-  global_offset += mesh.topology().index_map(0)->local_range()[1];
+  global_offset += mesh.topology()->index_map(0)->local_range()[1];
   std::for_each(local_edge_to_new_vertex.begin(),
                 local_edge_to_new_vertex.end(),
                 [global_offset](auto& e) { e.second += global_offset; });
@@ -245,7 +245,7 @@ create_new_vertices(MPI_Comm comm,
   for (std::size_t i = 0; i < received_values.size() / 2; ++i)
     recv_global_edge.push_back(received_values[i * 2]);
   std::vector<std::int32_t> recv_local_edge(recv_global_edge.size());
-  mesh.topology().index_map(1)->global_to_local(recv_global_edge,
+  mesh.topology()->index_map(1)->global_to_local(recv_global_edge,
                                                 recv_local_edge);
   for (std::size_t i = 0; i < received_values.size() / 2; ++i)
   {

--- a/cpp/dolfinx/refinement/utils.h
+++ b/cpp/dolfinx/refinement/utils.h
@@ -22,6 +22,8 @@
 
 namespace dolfinx::mesh
 {
+template <typename T>
+class MeshTags;
 class Topology;
 enum class GhostMode;
 } // namespace dolfinx::mesh
@@ -319,16 +321,13 @@ std::vector<std::int64_t> adjust_indices(const common::IndexMap& map,
 /// @note The refined mesh must not have been redistributed during
 /// refinement
 /// @note GhostMode must be GhostMode.none
-/// @param[in] topology Topology of the parent mesh
-/// @param[in] indices Tagged facets of the parent mesh
-/// @param[in] values Values for tagged entities
+/// @param[in] tags0 Tags on the parent mesh
 /// @param[in] topology1 Refined mesh topology
 /// @param[in] cell Parent cell of each cell in refined mesh
 /// @param[in] facet Local facets of parent in each cell in refined mesh
 /// @return (0) entities and (1) values on the refined topology
 std::array<std::vector<std::int32_t>, 2> transfer_facet_meshtag(
-    const mesh::Topology& topology, std::span<const std::int32_t> indices,
-    std::span<const std::int32_t> values, const mesh::Topology& topology1,
+    const mesh::MeshTags<std::int32_t>& tags0, const mesh::Topology& topology1,
     std::span<const std::int32_t> cell, std::span<const std::int8_t> facet);
 
 /// @brief Transfer cell MeshTags from coarse mesh to refined mesh.
@@ -337,15 +336,13 @@ std::array<std::vector<std::int32_t>, 2> transfer_facet_meshtag(
 /// refinement.
 /// @note GhostMode must be GhostMode.none
 ///
-/// @param[in] topology0 Topology of the parent mesh
-/// @param[in] indices0 Tagged facets of the parent mesh
-/// @param[in] values0 Values for tagged entities
+/// @param[in] tags0 Tags on the parent mesh
 /// @param[in] topology1 Refined mesh topology
 /// @param[in] parent_cell Parent cell of each cell in refined mesh
 /// @return (0) entities and (1) values on the refined topology
-std::array<std::vector<std::int32_t>, 2> transfer_cell_meshtag(
-    const mesh::Topology& topology0, std::span<const std::int32_t> indices0,
-    std::span<const std::int32_t> values0, const mesh::Topology& topology1,
-    std::span<const std::int32_t> parent_cell);
+std::array<std::vector<std::int32_t>, 2>
+transfer_cell_meshtag(const mesh::MeshTags<std::int32_t>& tags0,
+                      const mesh::Topology& topology1,
+                      std::span<const std::int32_t> parent_cell);
 
 } // namespace dolfinx::refinement

--- a/cpp/dolfinx/refinement/utils.h
+++ b/cpp/dolfinx/refinement/utils.h
@@ -12,7 +12,6 @@
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/mesh/Mesh.h>
-#include <dolfinx/mesh/MeshTags.h>
 #include <dolfinx/mesh/utils.h>
 #include <map>
 #include <memory>
@@ -23,8 +22,6 @@
 
 namespace dolfinx::mesh
 {
-template <typename T, std::floating_point U>
-class MeshTags;
 class Topology;
 enum class GhostMode;
 } // namespace dolfinx::mesh

--- a/cpp/test/mesh/distributed_mesh.cpp
+++ b/cpp/test/mesh/distributed_mesh.cpp
@@ -122,7 +122,8 @@ void test_distributed_mesh(mesh::CellPartitionFunction partitioner)
                                                   cell_nodes, x, xshape[1]);
 
   auto mesh = std::make_shared<mesh::Mesh<double>>(
-      mpi_comm, std::move(topology), std::move(geometry));
+      mpi_comm, std::make_shared<mesh::Topology>(std::move(topology)),
+      std::move(geometry));
 
   CHECK(mesh->topology()->index_map(tdim)->size_global() == 2 * N * N);
   CHECK(mesh->topology()->index_map(tdim)->size_local() > 0);

--- a/cpp/test/mesh/distributed_mesh.cpp
+++ b/cpp/test/mesh/distributed_mesh.cpp
@@ -124,15 +124,15 @@ void test_distributed_mesh(mesh::CellPartitionFunction partitioner)
   auto mesh = std::make_shared<mesh::Mesh<double>>(
       mpi_comm, std::move(topology), std::move(geometry));
 
-  CHECK(mesh->topology().index_map(tdim)->size_global() == 2 * N * N);
-  CHECK(mesh->topology().index_map(tdim)->size_local() > 0);
+  CHECK(mesh->topology()->index_map(tdim)->size_global() == 2 * N * N);
+  CHECK(mesh->topology()->index_map(tdim)->size_local() > 0);
 
-  CHECK(mesh->topology().index_map(0)->size_global() == (N + 1) * (N + 1));
-  CHECK(mesh->topology().index_map(0)->size_local() > 0);
+  CHECK(mesh->topology()->index_map(0)->size_global() == (N + 1) * (N + 1));
+  CHECK(mesh->topology()->index_map(0)->size_local() > 0);
 
   CHECK((int)mesh->geometry().x().size() / 3
-        == mesh->topology().index_map(0)->size_local()
-               + mesh->topology().index_map(0)->num_ghosts());
+        == mesh->topology()->index_map(0)->size_local()
+               + mesh->topology()->index_map(0)->num_ghosts());
 
   MPI_Group_free(&comm_group);
   MPI_Group_free(&new_group);

--- a/python/demo/demo_gmsh.py
+++ b/python/demo/demo_gmsh.py
@@ -65,9 +65,9 @@ facet_markers.name = f"{msh.name}_facets"
 
 with XDMFFile(msh.comm, f"out_gmsh/mesh_rank_{MPI.COMM_WORLD.rank}.xdmf", "w") as file:
     file.write_mesh(msh)
-    file.write_meshtags(cell_markers)
+    file.write_meshtags(cell_markers, msh.geometry)
     msh.topology.create_connectivity(msh.topology.dim - 1, msh.topology.dim)
-    file.write_meshtags(facet_markers)
+    file.write_meshtags(facet_markers, msh.geometry)
 
 # -
 
@@ -111,8 +111,8 @@ ft.name = f"{msh.name}_facets"
 with XDMFFile(msh.comm, "out_gmsh/mesh.xdmf", "w") as file:
     file.write_mesh(msh)
     msh.topology.create_connectivity(2, 3)
-    file.write_meshtags(mt, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
-    file.write_meshtags(ft, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
+    file.write_meshtags(mt, msh.geometry, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
+    file.write_meshtags(ft, msh.geometry, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
 # -
 
 # Create a distributed (parallel) mesh with quadratic geometry. Generate
@@ -139,8 +139,8 @@ ft.name = f"{msh.name}_surface"
 
 with XDMFFile(msh.comm, "out_gmsh/mesh.xdmf", "a") as file:
     file.write_mesh(msh)
-    file.write_meshtags(ct, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
-    file.write_meshtags(ft, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
+    file.write_meshtags(ct, msh.geometry, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
+    file.write_meshtags(ft, msh.geometry, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
 # -
 
 # Create a distributed (parallel) 2nd order hexahedral mesh. Generate
@@ -191,7 +191,7 @@ ft.name = f"{msh.name}_surface"
 
 with XDMFFile(msh.comm, "out_gmsh/mesh.xdmf", "a") as file:
     file.write_mesh(msh)
-    file.write_meshtags(mt, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
-    file.write_meshtags(ft, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
+    file.write_meshtags(mt, msh.geometry, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
+    file.write_meshtags(ft, msh.geometry, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry")
 
 # -

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -151,10 +151,10 @@ class XDMFFile(_cpp.io.XDMFFile):
         """Write mesh to file"""
         super().write_mesh(mesh._cpp_object, xpath)
 
-    def write_meshtags(self, tags: MeshTags, geometry_xpath: str = "/Xdmf/Domain/Grid/Geometry",
+    def write_meshtags(self, tags: MeshTags, x: _cpp.mesh.Geometry, geometry_xpath: str = "/Xdmf/Domain/Grid/Geometry",
                        xpath: str = "/Xdmf/Domain") -> None:
         """Write mesh tags to file"""
-        super().write_meshtags(tags._cpp_object, geometry_xpath, xpath)
+        super().write_meshtags(tags._cpp_object, x, geometry_xpath, xpath)
 
     def write_function(self, u: Function, t: float = 0.0, mesh_xpath="/Xdmf/Domain/Grid[@GridType='Uniform'][1]"):
         """Write function to file for a given time.
@@ -190,7 +190,7 @@ class XDMFFile(_cpp.io.XDMFFile):
 
     def read_meshtags(self, mesh, name, xpath="/Xdmf/Domain"):
         mt = super().read_meshtags(mesh._cpp_object, name, xpath)
-        return MeshTags(mt, mesh)
+        return MeshTags(mt)
 
 
 def distribute_entity_data(mesh: Mesh, entity_dim: int, entities: npt.NDArray[np.int64],

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -163,13 +163,13 @@ def transfer_meshtag(meshtag: MeshTags, mesh1: Mesh, parent_cell: npt.NDArray[np
             Mesh tags on the refined mesh.
 
     """
-    if meshtag.dim == meshtag.mesh.topology.dim:
-        mt = _cpp.refinement.transfer_cell_meshtag(meshtag._cpp_object, mesh1._cpp_object, parent_cell)
-        return MeshTags(mt, mesh1)
-    elif meshtag.dim == meshtag.mesh.topology.dim - 1:
+    if meshtag.dim == meshtag.topology.dim:
+        mt = _cpp.refinement.transfer_cell_meshtag(meshtag._cpp_object, mesh1.topology, parent_cell)
+        return MeshTags(mt)
+    elif meshtag.dim == meshtag.topology.dim - 1:
         assert parent_facet is not None
-        mt = _cpp.refinement.transfer_facet_meshtag(meshtag._cpp_object, mesh1._cpp_object, parent_cell, parent_facet)
-        return MeshTags(mt, mesh1)
+        mt = _cpp.refinement.transfer_facet_meshtag(meshtag._cpp_object, mesh1.topology, parent_cell, parent_facet)
+        return MeshTags(mt)
     else:
         raise RuntimeError("MeshTag transfer is supported on on cells or facets.")
 

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -291,7 +291,7 @@ class MeshTags:
         return id(self)
 
     @property
-    def topology(self) -> Mesh:
+    def topology(self) -> _cpp.mesh.Topology:
         """Mesh topology with which the the tags are associated."""
         return self._cpp_object.topology
 

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -269,12 +269,11 @@ def create_submesh(msh, dim, entities):
 
 
 class MeshTags:
-    def __init__(self, meshtags, mesh: Mesh):
+    def __init__(self, meshtags):
         """Mesh tags associate data (markers) with a subset of mesh entities of a given dimension.
 
         Args:
             meshtags: C++ mesh tags object.
-            mesh: Python mesh that tags are defined on.
 
         Note:
             MeshTags objects should not usually be created using this
@@ -286,18 +285,15 @@ class MeshTags:
             passed, `mesh` and `meshtags` must share the same C++ mesh.
 
         """
-        if mesh is not None:
-            assert meshtags.mesh is mesh._cpp_object
         self._cpp_object = meshtags
-        self._mesh = mesh
 
     def ufl_id(self) -> int:
         return id(self)
 
     @property
-    def mesh(self) -> Mesh:
-        """Mesh with which the the tags are associated."""
-        return self._mesh
+    def topology(self) -> Mesh:
+        """Mesh topology with which the the tags are associated."""
+        return self._cpp_object.topology
 
     @property
     def dim(self) -> int:
@@ -374,7 +370,7 @@ def meshtags(mesh: Mesh, dim: int, entities: npt.NDArray[np.int32],
     else:
         raise NotImplementedError(f"Type {values.dtype} not supported.")
 
-    return MeshTags(ftype(mesh._cpp_object, dim, np.asarray(entities, dtype=np.int32), values), mesh)
+    return MeshTags(ftype(mesh.topology, dim, np.asarray(entities, dtype=np.int32), values))
 
 
 def meshtags_from_entities(mesh: Mesh, dim: int, entities: _cpp.graph.AdjacencyList_int32,
@@ -405,7 +401,7 @@ def meshtags_from_entities(mesh: Mesh, dim: int, entities: _cpp.graph.AdjacencyL
         values = np.full(entities.num_nodes, values, dtype=np.double)
 
     values = np.asarray(values)
-    return MeshTags(_cpp.mesh.create_meshtags(mesh._cpp_object, dim, entities, values), mesh)
+    return MeshTags(_cpp.mesh.create_meshtags(mesh.topology, dim, entities, values))
 
 
 def create_interval(comm: _MPI.Comm, nx: int, points: npt.ArrayLike,

--- a/python/dolfinx/wrappers/assemble.cpp
+++ b/python/dolfinx/wrappers/assemble.cpp
@@ -381,7 +381,7 @@ void petsc_module(py::module& m)
         dolfinx::la::SparsityPattern sp(
             comm, {dofmap1->index_map, dofmap0->index_map},
             {dofmap1->index_map_bs(), dofmap0->index_map_bs()});
-        dolfinx::fem::sparsitybuild::cells(sp, mesh->topology(),
+        dolfinx::fem::sparsitybuild::cells(sp, *mesh->topology(),
                                            {*dofmap1, *dofmap0});
         sp.assemble();
 
@@ -389,7 +389,7 @@ void petsc_module(py::module& m)
         Mat A = dolfinx::la::petsc::create_matrix(comm, sp);
         MatSetOption(A, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE);
         dolfinx::fem::discrete_gradient<PetscScalar>(
-            V0.mesh()->topology_mutable(), {*V0.element(), *V0.dofmap()},
+            *V0.mesh()->topology_mutable(), {*V0.element(), *V0.dofmap()},
             {*V1.element(), *V1.dofmap()},
             dolfinx::la::petsc::Matrix::set_fn(A, INSERT_VALUES));
         return A;
@@ -417,7 +417,7 @@ void petsc_module(py::module& m)
         dolfinx::la::SparsityPattern sp(
             comm, {dofmap1->index_map, dofmap0->index_map},
             {dofmap1->index_map_bs(), dofmap0->index_map_bs()});
-        dolfinx::fem::sparsitybuild::cells(sp, mesh->topology(),
+        dolfinx::fem::sparsitybuild::cells(sp, *mesh->topology(),
                                            {*dofmap1, *dofmap0});
         sp.assemble();
 

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -636,11 +636,11 @@ void fem(py::module& m)
   m.def(
       "compute_integration_domains",
       [](dolfinx::fem::IntegralType type,
-         const dolfinx::mesh::MeshTags<int, double>& meshtags)
+         const dolfinx::mesh::MeshTags<int>& meshtags)
       {
         return dolfinx::fem::compute_integration_domains(
-            type, meshtags.mesh()->topology_mutable(), meshtags.indices(),
-            meshtags.dim(), meshtags.values());
+            type, meshtags.topology(), meshtags.indices(), meshtags.dim(),
+            meshtags.values());
       },
       py::arg("integral_type"), py::arg("meshtags"));
   m.def(

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -639,7 +639,7 @@ void fem(py::module& m)
          const dolfinx::mesh::MeshTags<int>& meshtags)
       {
         return dolfinx::fem::compute_integration_domains(
-            type, meshtags.topology(), meshtags.indices(), meshtags.dim(),
+            type, *meshtags.topology(), meshtags.indices(), meshtags.dim(),
             meshtags.values());
       },
       py::arg("integral_type"), py::arg("meshtags"));
@@ -649,8 +649,8 @@ void fem(py::module& m)
          const dolfinx::fem::FiniteElement& element0,
          const dolfinx::mesh::Mesh<double>& mesh1)
       {
-        int tdim = mesh0.topology().dim();
-        auto cell_map = mesh0.topology().index_map(tdim);
+        int tdim = mesh0.topology()->dim();
+        auto cell_map = mesh0.topology()->index_map(tdim);
         assert(cell_map);
         std::int32_t num_cells
             = cell_map->size_local() + cell_map->num_ghosts();
@@ -917,7 +917,7 @@ void fem(py::module& m)
           throw std::runtime_error("Expected two function spaces.");
         std::array<std::vector<std::int32_t>, 2> dofs
             = dolfinx::fem::locate_dofs_topological(
-                V[0].get().mesh()->topology_mutable(),
+                *V[0].get().mesh()->topology_mutable(),
                 {*V[0].get().dofmap(), *V[1].get().dofmap()}, dim,
                 std::span(entities.data(), entities.size()), remote);
         return {as_pyarray(std::move(dofs[0])), as_pyarray(std::move(dofs[1]))};
@@ -931,7 +931,7 @@ void fem(py::module& m)
          bool remote)
       {
         return as_pyarray(dolfinx::fem::locate_dofs_topological(
-            V.mesh()->topology_mutable(), *V.dofmap(), dim,
+            *V.mesh()->topology_mutable(), *V.dofmap(), dim,
             std::span(entities.data(), entities.size()), remote));
       },
       py::arg("V"), py::arg("dim"), py::arg("entities"),

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -74,7 +74,7 @@ void io(py::module& m)
                 std::span(values.data(), values.size()));
 
         std::size_t num_vert_per_entity = dolfinx::mesh::cell_num_entities(
-            dolfinx::mesh::cell_entity_type(mesh.topology().cell_type(),
+            dolfinx::mesh::cell_entity_type(mesh.topology()->cell_type(),
                                             entity_dim, 0),
             0);
         std::array shape_e

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -143,7 +143,7 @@ void io(py::module& m)
                double, std::string>(&dolfinx::io::XDMFFile::write_function),
            py::arg("function"), py::arg("t"), py::arg("mesh_xpath"))
       .def("write_meshtags", &dolfinx::io::XDMFFile::write_meshtags,
-           py::arg("meshtags"),
+           py::arg("meshtags"), py::arg("x"),
            py::arg("geometry_xpath") = "/Xdmf/Domain/Grid/Geometry",
            py::arg("xpath") = "/Xdmf/Domain")
       .def("read_meshtags", &dolfinx::io::XDMFFile::read_meshtags,

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -85,11 +85,11 @@ template <typename T>
 void declare_meshtags(py::module& m, std::string type)
 {
   std::string pyclass_name = std::string("MeshTags_") + type;
-  py::class_<dolfinx::mesh::MeshTags<T, double>,
-             std::shared_ptr<dolfinx::mesh::MeshTags<T, double>>>(
+  py::class_<dolfinx::mesh::MeshTags<T>,
+             std::shared_ptr<dolfinx::mesh::MeshTags<T>>>(
       m, pyclass_name.c_str(), "MeshTags object")
       .def(py::init(
-          [](std::shared_ptr<const dolfinx::mesh::Mesh<double>> mesh, int dim,
+          [](const dolfinx::mesh::Topology& topology, int dim,
              const py::array_t<std::int32_t, py::array::c_style>& indices,
              const py::array_t<T, py::array::c_style>& values)
           {
@@ -97,39 +97,38 @@ void declare_meshtags(py::module& m, std::string type)
                 indices.data(), indices.data() + indices.size());
             std::vector<T> values_vec(values.data(),
                                       values.data() + values.size());
-            return dolfinx::mesh::MeshTags<T, double>(
-                mesh, dim, std::move(indices_vec), std::move(values_vec));
+            return dolfinx::mesh::MeshTags<T>(
+                topology, dim, std::move(indices_vec), std::move(values_vec));
           }))
-      .def_property_readonly("dtype",
-                             [](const dolfinx::mesh::MeshTags<T, double>& self)
+      .def_property_readonly("dtype", [](const dolfinx::mesh::MeshTags<T>& self)
                              { return py::dtype::of<T>(); })
-      .def_readwrite("name", &dolfinx::mesh::MeshTags<T, double>::name)
-      .def_property_readonly("dim", &dolfinx::mesh::MeshTags<T, double>::dim)
-      .def_property_readonly("mesh", &dolfinx::mesh::MeshTags<T, double>::mesh)
+      .def_readwrite("name", &dolfinx::mesh::MeshTags<T>::name)
+      .def_property_readonly("dim", &dolfinx::mesh::MeshTags<T>::dim)
+      .def_property_readonly("topology", &dolfinx::mesh::MeshTags<T>::topology)
       .def_property_readonly("values",
-                             [](dolfinx::mesh::MeshTags<T, double>& self)
+                             [](dolfinx::mesh::MeshTags<T>& self)
                              {
                                return py::array_t<T>(self.values().size(),
                                                      self.values().data(),
                                                      py::cast(self));
                              })
       .def_property_readonly("indices",
-                             [](dolfinx::mesh::MeshTags<T, double>& self)
+                             [](dolfinx::mesh::MeshTags<T>& self)
                              {
                                return py::array_t<std::int32_t>(
                                    self.indices().size(), self.indices().data(),
                                    py::cast(self));
                              })
-      .def("find", [](dolfinx::mesh::MeshTags<T, double>& self, T value)
+      .def("find", [](dolfinx::mesh::MeshTags<T>& self, T value)
            { return as_pyarray(self.find(value)); });
 
   m.def("create_meshtags",
-        [](std::shared_ptr<const dolfinx::mesh::Mesh<double>> mesh, int dim,
+        [](const dolfinx::mesh::Topology& topology, int dim,
            const dolfinx::graph::AdjacencyList<std::int32_t>& entities,
            const py::array_t<T, py::array::c_style>& values)
         {
           return dolfinx::mesh::create_meshtags(
-              mesh, dim, entities, std::span(values.data(), values.size()));
+              topology, dim, entities, std::span(values.data(), values.size()));
         });
 }
 

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -89,7 +89,7 @@ void declare_meshtags(py::module& m, std::string type)
              std::shared_ptr<dolfinx::mesh::MeshTags<T>>>(
       m, pyclass_name.c_str(), "MeshTags object")
       .def(py::init(
-          [](const dolfinx::mesh::Topology& topology, int dim,
+          [](std::shared_ptr<const dolfinx::mesh::Topology> topology, int dim,
              const py::array_t<std::int32_t, py::array::c_style>& indices,
              const py::array_t<T, py::array::c_style>& values)
           {
@@ -123,7 +123,7 @@ void declare_meshtags(py::module& m, std::string type)
            { return as_pyarray(self.find(value)); });
 
   m.def("create_meshtags",
-        [](const dolfinx::mesh::Topology& topology, int dim,
+        [](std::shared_ptr<const dolfinx::mesh::Topology> topology, int dim,
            const dolfinx::graph::AdjacencyList<std::int32_t>& entities,
            const py::array_t<T, py::array::c_style>& values)
         {
@@ -342,7 +342,7 @@ void mesh(py::module& m)
       m, "Mesh", py::dynamic_attr(), "Mesh object")
       .def(py::init(
                [](const MPICommWrapper comm,
-                  const dolfinx::mesh::Topology& topology,
+                  std::shared_ptr<dolfinx::mesh::Topology> topology,
                   dolfinx::mesh::Geometry<double>& geometry) {
                  return dolfinx::mesh::Mesh<double>(comm.get(), topology,
                                                     geometry);

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -437,7 +437,7 @@ void mesh(py::module& m)
       {
         std::vector<std::int32_t> idx = dolfinx::mesh::entities_to_geometry(
             mesh, dim, std::span(entities.data(), entities.size()), orient);
-        dolfinx::mesh::CellType cell_type = mesh.topology().cell_type();
+        dolfinx::mesh::CellType cell_type = mesh.topology()->cell_type();
         std::size_t num_vertices = dolfinx::mesh::num_cell_vertices(
             cell_entity_type(cell_type, dim, 0));
         std::array<std::size_t, 2> shape

--- a/python/dolfinx/wrappers/refinement.cpp
+++ b/python/dolfinx/wrappers/refinement.cpp
@@ -73,7 +73,7 @@ void refinement(py::module& m)
   m.def(
       "transfer_facet_meshtag",
       [](const dolfinx::mesh::MeshTags<std::int32_t>& parent_meshtag,
-         std::shared_ptr<const dolfinx::mesh::Mesh<double>> refined_mesh,
+         const dolfinx::mesh::Topology& topology1,
          const py::array_t<std::int32_t, py::array::c_style>& parent_cell,
          const py::array_t<std::int8_t, py::array::c_style>& parent_facet)
       {
@@ -81,22 +81,20 @@ void refinement(py::module& m)
         if (parent_meshtag.dim() != tdim - 1)
           throw std::runtime_error("Input meshtag is not facet-based");
         auto [entities, values] = dolfinx::refinement::transfer_facet_meshtag(
-            parent_meshtag.topology(), parent_meshtag.indices(),
-            parent_meshtag.values(), refined_mesh->topology(),
+            parent_meshtag, topology1,
             std::span<const std::int32_t>(parent_cell.data(),
                                           parent_cell.size()),
             std::span<const std::int8_t>(parent_facet.data(),
                                          parent_facet.size()));
         return dolfinx::mesh::MeshTags<std::int32_t>(
-            refined_mesh->topology(), tdim - 1, std::move(entities),
-            std::move(values));
+            topology1, tdim - 1, std::move(entities), std::move(values));
       },
       py::arg("parent_meshtag"), py::arg("refined_mesh"),
       py::arg("parent_cell"), py::arg("parent_facet"));
   m.def(
       "transfer_cell_meshtag",
       [](const dolfinx::mesh::MeshTags<std::int32_t>& parent_meshtag,
-         std::shared_ptr<const dolfinx::mesh::Mesh<double>> refined_mesh,
+         const dolfinx::mesh::Topology& topology1,
          const py::array_t<std::int32_t, py::array::c_style>& parent_cell)
       {
         int tdim = parent_meshtag.topology().dim();
@@ -105,13 +103,11 @@ void refinement(py::module& m)
         if (parent_meshtag.topology().index_map(tdim)->num_ghosts() > 0)
           throw std::runtime_error("Ghosted meshes are not supported");
         auto [entities, values] = dolfinx::refinement::transfer_cell_meshtag(
-            parent_meshtag.topology(), parent_meshtag.indices(),
-            parent_meshtag.values(), refined_mesh->topology(),
+            parent_meshtag, topology1,
             std::span<const std::int32_t>(parent_cell.data(),
                                           parent_cell.size()));
-        return dolfinx::mesh::MeshTags<std::int32_t>(refined_mesh->topology(),
-                                                     tdim, std::move(entities),
-                                                     std::move(values));
+        return dolfinx::mesh::MeshTags<std::int32_t>(
+            topology1, tdim, std::move(entities), std::move(values));
       },
       py::arg("parent_meshtag"), py::arg("refined_mesh"),
       py::arg("parent_cell"));

--- a/python/dolfinx/wrappers/refinement.cpp
+++ b/python/dolfinx/wrappers/refinement.cpp
@@ -73,15 +73,15 @@ void refinement(py::module& m)
   m.def(
       "transfer_facet_meshtag",
       [](const dolfinx::mesh::MeshTags<std::int32_t>& parent_meshtag,
-         const dolfinx::mesh::Topology& topology1,
+         std::shared_ptr<const dolfinx::mesh::Topology> topology1,
          const py::array_t<std::int32_t, py::array::c_style>& parent_cell,
          const py::array_t<std::int8_t, py::array::c_style>& parent_facet)
       {
-        int tdim = parent_meshtag.topology().dim();
+        int tdim = parent_meshtag.topology()->dim();
         if (parent_meshtag.dim() != tdim - 1)
           throw std::runtime_error("Input meshtag is not facet-based");
         auto [entities, values] = dolfinx::refinement::transfer_facet_meshtag(
-            parent_meshtag, topology1,
+            parent_meshtag, *topology1,
             std::span<const std::int32_t>(parent_cell.data(),
                                           parent_cell.size()),
             std::span<const std::int8_t>(parent_facet.data(),
@@ -94,16 +94,16 @@ void refinement(py::module& m)
   m.def(
       "transfer_cell_meshtag",
       [](const dolfinx::mesh::MeshTags<std::int32_t>& parent_meshtag,
-         const dolfinx::mesh::Topology& topology1,
+         std::shared_ptr<const dolfinx::mesh::Topology> topology1,
          const py::array_t<std::int32_t, py::array::c_style>& parent_cell)
       {
-        int tdim = parent_meshtag.topology().dim();
+        int tdim = parent_meshtag.topology()->dim();
         if (parent_meshtag.dim() != tdim)
           throw std::runtime_error("Input meshtag is not cell-based");
-        if (parent_meshtag.topology().index_map(tdim)->num_ghosts() > 0)
+        if (parent_meshtag.topology()->index_map(tdim)->num_ghosts() > 0)
           throw std::runtime_error("Ghosted meshes are not supported");
         auto [entities, values] = dolfinx::refinement::transfer_cell_meshtag(
-            parent_meshtag, topology1,
+            parent_meshtag, *topology1,
             std::span<const std::int32_t>(parent_cell.data(),
                                           parent_cell.size()));
         return dolfinx::mesh::MeshTags<std::int32_t>(

--- a/python/dolfinx/wrappers/refinement.cpp
+++ b/python/dolfinx/wrappers/refinement.cpp
@@ -72,44 +72,46 @@ void refinement(py::module& m)
 
   m.def(
       "transfer_facet_meshtag",
-      [](const dolfinx::mesh::MeshTags<std::int32_t, double>& parent_meshtag,
+      [](const dolfinx::mesh::MeshTags<std::int32_t>& parent_meshtag,
          std::shared_ptr<const dolfinx::mesh::Mesh<double>> refined_mesh,
          const py::array_t<std::int32_t, py::array::c_style>& parent_cell,
          const py::array_t<std::int8_t, py::array::c_style>& parent_facet)
       {
-        int tdim = parent_meshtag.mesh()->topology().dim();
+        int tdim = parent_meshtag.topology().dim();
         if (parent_meshtag.dim() != tdim - 1)
           throw std::runtime_error("Input meshtag is not facet-based");
         auto [entities, values] = dolfinx::refinement::transfer_facet_meshtag(
-            parent_meshtag.mesh()->topology(), parent_meshtag.indices(),
+            parent_meshtag.topology(), parent_meshtag.indices(),
             parent_meshtag.values(), refined_mesh->topology(),
             std::span<const std::int32_t>(parent_cell.data(),
                                           parent_cell.size()),
             std::span<const std::int8_t>(parent_facet.data(),
                                          parent_facet.size()));
-        return dolfinx::mesh::MeshTags<std::int32_t, double>(
-            refined_mesh, tdim - 1, std::move(entities), std::move(values));
+        return dolfinx::mesh::MeshTags<std::int32_t>(
+            refined_mesh->topology(), tdim - 1, std::move(entities),
+            std::move(values));
       },
       py::arg("parent_meshtag"), py::arg("refined_mesh"),
       py::arg("parent_cell"), py::arg("parent_facet"));
   m.def(
       "transfer_cell_meshtag",
-      [](const dolfinx::mesh::MeshTags<std::int32_t, double>& parent_meshtag,
+      [](const dolfinx::mesh::MeshTags<std::int32_t>& parent_meshtag,
          std::shared_ptr<const dolfinx::mesh::Mesh<double>> refined_mesh,
          const py::array_t<std::int32_t, py::array::c_style>& parent_cell)
       {
-        int tdim = parent_meshtag.mesh()->topology().dim();
+        int tdim = parent_meshtag.topology().dim();
         if (parent_meshtag.dim() != tdim)
           throw std::runtime_error("Input meshtag is not cell-based");
-        if (parent_meshtag.mesh()->topology().index_map(tdim)->num_ghosts() > 0)
+        if (parent_meshtag.topology().index_map(tdim)->num_ghosts() > 0)
           throw std::runtime_error("Ghosted meshes are not supported");
         auto [entities, values] = dolfinx::refinement::transfer_cell_meshtag(
-            parent_meshtag.mesh()->topology(), parent_meshtag.indices(),
+            parent_meshtag.topology(), parent_meshtag.indices(),
             parent_meshtag.values(), refined_mesh->topology(),
             std::span<const std::int32_t>(parent_cell.data(),
                                           parent_cell.size()));
-        return dolfinx::mesh::MeshTags<std::int32_t, double>(
-            refined_mesh, tdim, std::move(entities), std::move(values));
+        return dolfinx::mesh::MeshTags<std::int32_t>(refined_mesh->topology(),
+                                                     tdim, std::move(entities),
+                                                     std::move(values));
       },
       py::arg("parent_meshtag"), py::arg("refined_mesh"),
       py::arg("parent_cell"));

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -162,8 +162,10 @@ def test_facet_integral(cell_type):
         elif cell_type == CellType.hexahedron:
             v.interpolate(lambda x: x[0] * (1 - x[0]) + x[1] * (1 - x[1]) + x[2] * (1 - x[2]))
 
-        # assert that the integral of these functions over each face are
+        # Check that integral of these functions over each face are
         # equal
+        mesh.topology.create_connectivity(tdim - 1, tdim)
+        mesh.topology.create_connectivity(tdim, tdim - 1)
         out = []
         for j in range(num_facets):
             a = form(v * ufl.ds(subdomain_data=marker, subdomain_id=j))

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -224,7 +224,7 @@ def test_facet_normals(cell_type):
                 # faces
                 v.interpolate(lambda x: tuple(x[j] - i % 2 if j == i // 3 else 0 * x[j] for j in range(3)))
 
-            # assert that the integrals these functions dotted with the
+            # Check that integrals these functions dotted with the
             # normal over a face is 1 on one face and 0 on the others
             ones = 0
             for j in range(num_facets):

--- a/python/test/unit/io/test_xdmf_meshtags.py
+++ b/python/test/unit/io/test_xdmf_meshtags.py
@@ -55,8 +55,8 @@ def test_3d(tempdir, cell_type, encoding):
 
     with XDMFFile(comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
-        file.write_meshtags(mt)
-        file.write_meshtags(mt_lines)
+        file.write_meshtags(mt, mesh.geometry)
+        file.write_meshtags(mt_lines, mesh.geometry)
         file.write_information("units", "mm")
 
     with XDMFFile(comm, filename, "r", encoding=encoding) as file:
@@ -74,8 +74,8 @@ def test_3d(tempdir, cell_type, encoding):
 
     with XDMFFile(comm, Path(tempdir, "meshtags_3d_out.xdmf"), "w", encoding=encoding) as file:
         file.write_mesh(mesh_in)
-        file.write_meshtags(mt_lines_in)
-        file.write_meshtags(mt_in)
+        file.write_meshtags(mt_lines_in, mesh_in.geometry)
+        file.write_meshtags(mt_in, mesh_in.geometry)
 
     # Check number of owned and marked entities
     lines_local = comm.allreduce((mt_lines.indices < mesh.topology.index_map(1).size_local).sum(), op=MPI.SUM)


### PR DESCRIPTION
MeshTags data is defined on mesh entities (topology), and not a full mesh, i.e. geometry plays no role. The PR makes MeshTags depend on `Topology` and not `Mesh`. This avoids `MeshTags` having to be templated over the geometry scalar type.

To make this work, a `Mesh` now holds a shared pointer to its topology, allowing the topology to be shared with a MeshTags. This has the additional benefit of allowing meshes with different geometry scalar types to share a common topology.

Fixes #2601.