### PR TITLE
Flatten dofmap storage

### DIFF
--- a/cpp/dolfinx/fem/DirichletBC.cpp
+++ b/cpp/dolfinx/fem/DirichletBC.cpp
@@ -11,7 +11,6 @@
 #include <array>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/sort.h>
-#include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/Topology.h>
 #include <dolfinx/mesh/cell_types.h>

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -107,8 +107,6 @@ fem::DofMap build_collapsed_dofmap(const DofMap& dofmap_view,
   }
 
   // Map dofs to new collapsed indices for new dofmap
-  // const std::vector<std::int32_t>& dof_array_view =
-  // dofmap_view.list().array();
   auto dof_array_view = dofmap_view.list();
   std::vector<std::int32_t> dofmap;
   dofmap.reserve(dof_array_view.size());
@@ -253,10 +251,8 @@ std::pair<DofMap, std::vector<std::int32_t>> DofMap::collapse(
     }
   };
 
-  // std::cout << "*** Create new dofmap" << std::endl;
   DofMap dofmap_new = create_subdofmap(
       comm, index_map_bs(), _element_dof_layout, topology, reorder_fn, *this);
-  // std::cout << "*** End create new dofmap" << std::endl;
 
   // Build map from collapsed dof index to original dof index
   auto index_map_new = dofmap_new.index_map;
@@ -283,7 +279,6 @@ std::pair<DofMap, std::vector<std::int32_t>> DofMap::collapse(
       }
     }
   }
-  std::cout << "Post-pack" << std::endl;
 
   return {std::move(dofmap_new), std::move(collapsed_map)};
 }

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -42,10 +42,7 @@ fem::DofMap build_collapsed_dofmap(const DofMap& dofmap_view,
   assert(cells);
 
   // Build set of dofs that are in the new dofmap (un-blocked)
-  auto dofs_view_md = dofmap_view.new_list();
-  std::vector<std::int32_t> dofs_view(dofs_view_md.data_handle(),
-                                      dofs_view_md.data_handle()
-                                          + dofs_view_md.size());
+  std::vector<std::int32_t> dofs_view = dofmap_view.list().array();
   dolfinx::radix_sort(std::span(dofs_view));
   dofs_view.erase(std::unique(dofs_view.begin(), dofs_view.end()),
                   dofs_view.end());
@@ -107,9 +104,7 @@ fem::DofMap build_collapsed_dofmap(const DofMap& dofmap_view,
   }
 
   // Map dofs to new collapsed indices for new dofmap
-  auto dof_array_view_md = dofmap_view.new_list();
-  std::span<const std::int32_t> dof_array_view(dof_array_view_md.data_handle(),
-                                               dof_array_view_md.size());
+  const std::vector<std::int32_t>& dof_array_view = dofmap_view.list().array();
   std::vector<std::int32_t> dofmap;
   dofmap.reserve(dof_array_view.size());
   std::transform(dof_array_view.begin(), dof_array_view.end(),
@@ -251,8 +246,10 @@ std::pair<DofMap, std::vector<std::int32_t>> DofMap::collapse(
     }
   };
 
+  std::cout << "Create new dofmap" << std::endl;
   DofMap dofmap_new = create_subdofmap(
       comm, index_map_bs(), _element_dof_layout, topology, reorder_fn, *this);
+  std::cout << "End create new dofmap" << std::endl;
 
   // Build map from collapsed dof index to original dof index
   auto index_map_new = dofmap_new.index_map;
@@ -267,7 +264,9 @@ std::pair<DofMap, std::vector<std::int32_t>> DofMap::collapse(
   const int bs = dofmap_new.bs();
   for (int c = 0; c < cells->num_nodes(); ++c)
   {
+    std::cout << "View" << std::endl;
     std::span<const std::int32_t> cell_dofs_view = this->cell_dofs(c);
+    std::cout << "New" << std::endl;
     std::span<const std::int32_t> cell_dofs = dofmap_new.cell_dofs(c);
     for (std::size_t i = 0; i < cell_dofs.size(); ++i)
     {

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -126,9 +126,8 @@ fem::DofMap build_collapsed_dofmap(const DofMap& dofmap_view,
   ElementDofLayout element_dof_layout = dofmap_view.element_dof_layout().copy();
 
   // Create new dofmap and return
-  return DofMap(
-      std::move(element_dof_layout), index_map, 1,
-      graph::regular_adjacency_list(std::move(dofmap), cell_dimension), 1);
+  return DofMap(std::move(element_dof_layout), index_map, 1, std::move(dofmap),
+                1);
 }
 
 } // namespace
@@ -216,9 +215,8 @@ DofMap DofMap::extract_sub_dofmap(std::span<const int> component) const
 
   // Set element dof layout and cell dimension
   ElementDofLayout sub_dof_layout = _element_dof_layout.sub_layout(component);
-  return DofMap(
-      std::move(sub_dof_layout), this->index_map, this->index_map_bs(),
-      graph::regular_adjacency_list(std::move(dofmap), dofs_per_cell), 1);
+  return DofMap(std::move(sub_dof_layout), this->index_map,
+                this->index_map_bs(), std::move(dofmap), 1);
 }
 //-----------------------------------------------------------------------------
 std::pair<DofMap, std::vector<std::int32_t>> DofMap::collapse(

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -19,6 +19,7 @@
 
 using namespace dolfinx;
 using namespace dolfinx::fem;
+namespace stdex = std::experimental;
 
 namespace
 {
@@ -147,8 +148,9 @@ graph::AdjacencyList<std::int32_t> fem::transpose_dofmap(
   std::vector<int> num_local_contributions(max_index + 1, 0);
   for (std::int32_t c = 0; c < num_cells; ++c)
   {
+    auto dofs = stdex::submdspan(dofmap, c, stdex::full_extent);
     for (std::size_t d = 0; d < dofmap.extent(1); ++d)
-      num_local_contributions[dofmap(c, d)]++;
+      num_local_contributions[dofs[d]]++;
   }
 
   // Compute offset for each global index
@@ -161,8 +163,9 @@ graph::AdjacencyList<std::int32_t> fem::transpose_dofmap(
   int cell_offset = 0;
   for (std::int32_t c = 0; c < num_cells; ++c)
   {
+    auto dofs = stdex::submdspan(dofmap, c, stdex::full_extent);
     for (std::size_t d = 0; d < dofmap.extent(1); ++d)
-      data[pos[dofmap(c, d)]++] = cell_offset++;
+      data[pos[dofs[d]]++] = cell_offset++;
   }
 
   // Sort the source indices for each global index

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -200,7 +200,7 @@ DofMap DofMap::extract_sub_dofmap(std::span<const int> component) const
     auto cell_dmap_parent = this->_dofmap.links(c);
     for (std::int32_t i = 0; i < dofs_per_cell; ++i)
     {
-      const std::div_t pos = std::div(sub_element_map_view[i], bs_parent);
+      std::div_t pos = std::div(sub_element_map_view[i], bs_parent);
       dofmap[c * dofs_per_cell + i]
           = bs_parent * cell_dmap_parent[pos.quot] + pos.rem;
     }
@@ -209,10 +209,9 @@ DofMap DofMap::extract_sub_dofmap(std::span<const int> component) const
   // FIXME X
 
   // Set element dof layout and cell dimension
-  ElementDofLayout sub_element_dof_layout
-      = _element_dof_layout.sub_layout(component);
+  ElementDofLayout sub_dof_layout = _element_dof_layout.sub_layout(component);
   return DofMap(
-      std::move(sub_element_dof_layout), this->index_map, this->index_map_bs(),
+      std::move(sub_dof_layout), this->index_map, this->index_map_bs(),
       graph::regular_adjacency_list(std::move(dofmap), dofs_per_cell), 1);
 }
 //-----------------------------------------------------------------------------
@@ -246,10 +245,10 @@ std::pair<DofMap, std::vector<std::int32_t>> DofMap::collapse(
     }
   };
 
-  std::cout << "Create new dofmap" << std::endl;
+  // std::cout << "*** Create new dofmap" << std::endl;
   DofMap dofmap_new = create_subdofmap(
       comm, index_map_bs(), _element_dof_layout, topology, reorder_fn, *this);
-  std::cout << "End create new dofmap" << std::endl;
+  // std::cout << "*** End create new dofmap" << std::endl;
 
   // Build map from collapsed dof index to original dof index
   auto index_map_new = dofmap_new.index_map;
@@ -264,9 +263,9 @@ std::pair<DofMap, std::vector<std::int32_t>> DofMap::collapse(
   const int bs = dofmap_new.bs();
   for (int c = 0; c < cells->num_nodes(); ++c)
   {
-    std::cout << "View" << std::endl;
+    // std::cout << "-View" << std::endl;
     std::span<const std::int32_t> cell_dofs_view = this->cell_dofs(c);
-    std::cout << "New" << std::endl;
+    // std::cout << "-New" << std::endl;
     std::span<const std::int32_t> cell_dofs = dofmap_new.cell_dofs(c);
     for (std::size_t i = 0; i < cell_dofs.size(); ++i)
     {
@@ -278,6 +277,7 @@ std::pair<DofMap, std::vector<std::int32_t>> DofMap::collapse(
       }
     }
   }
+  std::cout << "Post-pack" << std::endl;
 
   return {std::move(dofmap_new), std::move(collapsed_map)};
 }

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -43,7 +43,7 @@ fem::DofMap build_collapsed_dofmap(const DofMap& dofmap_view,
   assert(cells);
 
   // Build set of dofs that are in the new dofmap (un-blocked)
-  auto dofs_view_md = dofmap_view.list();
+  auto dofs_view_md = dofmap_view.map();
   std::vector<std::int32_t> dofs_view(dofs_view_md.data_handle(),
                                       dofs_view_md.data_handle()
                                           + dofs_view_md.size());
@@ -108,7 +108,7 @@ fem::DofMap build_collapsed_dofmap(const DofMap& dofmap_view,
   }
 
   // Map dofs to new collapsed indices for new dofmap
-  auto dof_array_view = dofmap_view.list();
+  auto dof_array_view = dofmap_view.map();
   std::vector<std::int32_t> dofmap;
   dofmap.reserve(dof_array_view.size());
   std::transform(dof_array_view.data_handle(),
@@ -286,7 +286,7 @@ std::pair<DofMap, std::vector<std::int32_t>> DofMap::collapse(
 //-----------------------------------------------------------------------------
 std::experimental::mdspan<const std::int32_t,
                           std::experimental::dextents<std::size_t, 2>>
-DofMap::list() const
+DofMap::map() const
 {
   return std::experimental::mdspan<const std::int32_t,
                                    std::experimental::dextents<std::size_t, 2>>(

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -288,8 +288,7 @@ std::experimental::mdspan<const std::int32_t,
                           std::experimental::dextents<std::size_t, 2>>
 DofMap::map() const
 {
-  return std::experimental::mdspan<const std::int32_t,
-                                   std::experimental::dextents<std::size_t, 2>>(
+  return stdex::mdspan<const std::int32_t, stdex::dextents<std::size_t, 2>>(
       _dofmap.data(), _dofmap.size() / _shape1, _shape1);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/DofMap.h
+++ b/cpp/dolfinx/fem/DofMap.h
@@ -153,7 +153,7 @@ public:
   /// @return The adjacency list with dof indices for each cell
   std::experimental::mdspan<const std::int32_t,
                             std::experimental::dextents<std::size_t, 2>>
-  list() const;
+  map() const;
 
   /// Layout of dofs on an element
   const ElementDofLayout& element_dof_layout() const
@@ -175,7 +175,7 @@ private:
   // Layout of dofs on a cell
   ElementDofLayout _element_dof_layout;
 
-  // Cell-local-to-dof map (dofs for cell dofmap[cell])
+  // Cell local-to-dof map
   std::vector<std::int32_t> _dofmap;
 
   // Block size for the dofmap

--- a/cpp/dolfinx/fem/DofMap.h
+++ b/cpp/dolfinx/fem/DofMap.h
@@ -23,6 +23,8 @@
 #include <utility>
 #include <vector>
 
+#include <iostream>
+
 namespace dolfinx::common
 {
 class IndexMap;
@@ -119,11 +121,16 @@ public:
   /// @param[in] cell The cell index
   /// @return Local-global dof map for the cell (using process-local
   /// indices)
-  std::span<const std::int32_t> cell_dofs(std::int32_t cell) const
+  std::span<const std::int32_t> cell_dofs(std::int32_t c) const
   {
-    int ndofs = _element_dof_layout.num_dofs();
-    return std::span<const std::int32_t>(_dofmap.array().data() + ndofs * cell,
+    int ndofs = _element_dof_layout.num_dofs() / _bs;
+    std::cout << "Testing (new, old): " << ndofs << ", "
+              << _dofmap.links(c).size() << std::endl;
+    std::cout << "bs, subel_bs: " << _bs << ", "
+              << _element_dof_layout.block_size() << std::endl;
+    return std::span<const std::int32_t>(_dofmap.array().data() + ndofs * c,
                                          ndofs);
+    // return _dofmap.links(c);
   }
 
   /// @brief Return the block size for the dofmap

--- a/cpp/dolfinx/fem/DofMap.h
+++ b/cpp/dolfinx/fem/DofMap.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "ElementDofLayout.h"
+#include <basix/mdspan.hpp>
 #include <concepts>
 #include <cstdlib>
 #include <dolfinx/common/MPI.h>
@@ -118,9 +119,11 @@ public:
   /// @param[in] cell The cell index
   /// @return Local-global dof map for the cell (using process-local
   /// indices)
-  std::span<const std::int32_t> cell_dofs(int cell) const
+  std::span<const std::int32_t> cell_dofs(std::int32_t cell) const
   {
-    return _dofmap.links(cell);
+    int ndofs = _element_dof_layout.num_dofs();
+    return std::span<const std::int32_t>(_dofmap.array().data() + ndofs * cell,
+                                         ndofs);
   }
 
   /// @brief Return the block size for the dofmap
@@ -148,6 +151,12 @@ public:
   /// @brief Get dofmap data
   /// @return The adjacency list with dof indices for each cell
   const graph::AdjacencyList<std::int32_t>& list() const;
+
+  /// @brief Get dofmap data
+  /// @return The adjacency list with dof indices for each cell
+  std::experimental::mdspan<const std::int32_t,
+                            std::experimental::dextents<std::size_t, 2>>
+  new_list() const;
 
   /// Layout of dofs on an element
   const ElementDofLayout& element_dof_layout() const

--- a/cpp/dolfinx/fem/DofMap.h
+++ b/cpp/dolfinx/fem/DofMap.h
@@ -93,7 +93,9 @@ public:
          int index_map_bs, U&& dofmap, int bs)
       : index_map(index_map), _index_map_bs(index_map_bs),
         _element_dof_layout(std::forward<E>(element)),
-        _dofmap(std::forward<U>(dofmap)), _bs(bs)
+        _dofmap(std::forward<U>(dofmap)), _bs(bs),
+        _shape1(_element_dof_layout.num_dofs()
+                * _element_dof_layout.block_size() / _bs)
   {
     // Do nothing
   }
@@ -123,14 +125,8 @@ public:
   /// indices)
   std::span<const std::int32_t> cell_dofs(std::int32_t c) const
   {
-    int ndofs = _element_dof_layout.num_dofs() / _bs;
-    std::cout << "Testing (new, old): " << ndofs << ", "
-              << _dofmap.links(c).size() << std::endl;
-    std::cout << "bs, subel_bs: " << _bs << ", "
-              << _element_dof_layout.block_size() << std::endl;
-    return std::span<const std::int32_t>(_dofmap.array().data() + ndofs * c,
-                                         ndofs);
-    // return _dofmap.links(c);
+    return std::span<const std::int32_t>(_dofmap.array().data() + _shape1 * c,
+                                         _shape1);
   }
 
   /// @brief Return the block size for the dofmap
@@ -190,5 +186,7 @@ private:
 
   // Block size for the dofmap
   int _bs = -1;
+
+  int _shape1 = -1;
 };
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/DofMap.h
+++ b/cpp/dolfinx/fem/DofMap.h
@@ -88,14 +88,14 @@ public:
   /// each cell.
   /// @param[in] bs The block size of the `dofmap`.
   template <std::convertible_to<fem::ElementDofLayout> E,
-            std::convertible_to<graph::AdjacencyList<std::int32_t>> U>
+            std::convertible_to<std::vector<std::int32_t>> U>
   DofMap(E&& element, std::shared_ptr<const common::IndexMap> index_map,
          int index_map_bs, U&& dofmap, int bs)
       : index_map(index_map), _index_map_bs(index_map_bs),
-        _element_dof_layout(std::forward<E>(element)), _dofmap(dofmap.array()),
-        // _dofmap(std::forward<U>(dofmap)),
-        _bs(bs), _shape1(_element_dof_layout.num_dofs()
-                         * _element_dof_layout.block_size() / _bs)
+        _element_dof_layout(std::forward<E>(element)),
+        _dofmap(std::forward<U>(dofmap)), _bs(bs),
+        _shape1(_element_dof_layout.num_dofs()
+                * _element_dof_layout.block_size() / _bs)
   {
     // Do nothing
   }

--- a/cpp/dolfinx/fem/DofMap.h
+++ b/cpp/dolfinx/fem/DofMap.h
@@ -122,7 +122,7 @@ public:
   bool operator==(const DofMap& map) const;
 
   /// @brief Local-to-global mapping of dofs on a cell
-  /// @param[in] cell The cell index
+  /// @param[in] c The cell index
   /// @return Local-global dof map for the cell (using process-local
   /// indices)
   std::span<const std::int32_t> cell_dofs(std::int32_t c) const

--- a/cpp/dolfinx/fem/DofMap.h
+++ b/cpp/dolfinx/fem/DofMap.h
@@ -23,8 +23,6 @@
 #include <utility>
 #include <vector>
 
-#include <iostream>
-
 namespace dolfinx::common
 {
 class IndexMap;
@@ -183,6 +181,7 @@ private:
   // Block size for the dofmap
   int _bs = -1;
 
+  // Number of columns in _dofmap
   int _shape1 = -1;
 };
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -143,7 +143,7 @@ public:
 
     // Prepare cell geometry
     assert(_mesh);
-    auto x_dofmap = _mesh->geometry().new_dofmap();
+    auto x_dofmap = _mesh->geometry().dofmap();
 
     // Get geometry data
     auto cmaps = _mesh->geometry().cmaps();

--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -134,6 +134,8 @@ public:
   void eval(std::span<const std::int32_t> cells, std::span<T> values,
             std::array<std::size_t, 2> vshape) const
   {
+    namespace stdex = std::experimental;
+
     // Prepare coefficients and constants
     const auto [coeffs, cstride] = pack_coefficients(*this, cells);
     const std::vector<T> constant_data = pack_constants(*this);
@@ -141,8 +143,7 @@ public:
 
     // Prepare cell geometry
     assert(_mesh);
-    const graph::AdjacencyList<std::int32_t>& x_dofmap
-        = _mesh->geometry().dofmap();
+    auto x_dofmap = _mesh->geometry().new_dofmap();
 
     // Get geometry data
     auto cmaps = _mesh->geometry().cmaps();
@@ -189,7 +190,7 @@ public:
     for (std::size_t c = 0; c < cells.size(); ++c)
     {
       const std::int32_t cell = cells[c];
-      auto x_dofs = x_dofmap.links(cell);
+      auto x_dofs = stdex::submdspan(x_dofmap, cell, stdex::full_extent);
       for (std::size_t i = 0; i < x_dofs.size(); ++i)
       {
         std::copy_n(std::next(x_g.begin(), 3 * x_dofs[i]), 3,

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -407,8 +407,7 @@ public:
     const CoordinateElement& cmap = mesh->geometry().cmaps()[0];
 
     // Get geometry data
-    const graph::AdjacencyList<std::int32_t>& x_dofmap
-        = mesh->geometry().dofmap();
+    auto x_dofmap = mesh->geometry().new_dofmap();
     const std::size_t num_dofs_g = cmap.dim();
     std::span<const U> x_g = mesh->geometry().x();
 
@@ -501,7 +500,8 @@ public:
         continue;
 
       // Get cell geometry (coordinate dofs)
-      auto x_dofs = x_dofmap.links(cell_index);
+      // auto x_dofs = x_dofmap.links(cell_index);
+      auto x_dofs = stdex::submdspan(x_dofmap, cell_index, stdex::full_extent);
       assert(x_dofs.size() == num_dofs_g);
       for (std::size_t i = 0; i < num_dofs_g; ++i)
       {

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -407,7 +407,7 @@ public:
     const CoordinateElement& cmap = mesh->geometry().cmaps()[0];
 
     // Get geometry data
-    auto x_dofmap = mesh->geometry().new_dofmap();
+    auto x_dofmap = mesh->geometry().dofmap();
     const std::size_t num_dofs_g = cmap.dim();
     std::span<const U> x_g = mesh->geometry().x();
 

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -500,7 +500,6 @@ public:
         continue;
 
       // Get cell geometry (coordinate dofs)
-      // auto x_dofs = x_dofmap.links(cell_index);
       auto x_dofs = stdex::submdspan(x_dofmap, cell_index, stdex::full_extent);
       assert(x_dofs.size() == num_dofs_g);
       for (std::size_t i = 0; i < num_dofs_g; ++i)

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -223,7 +223,7 @@ public:
     const CoordinateElement& cmap = _mesh->geometry().cmaps()[0];
 
     // Prepare cell geometry
-    auto x_dofmap = _mesh->geometry().new_dofmap();
+    auto x_dofmap = _mesh->geometry().dofmap();
     const std::size_t num_dofs_g = cmap.dim();
     std::span<const T> x_g = _mesh->geometry().x();
 

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -15,7 +15,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <dolfinx/common/IndexMap.h>
-#include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/mesh/Geometry.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/Topology.h>

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -223,8 +223,7 @@ public:
     const CoordinateElement& cmap = _mesh->geometry().cmaps()[0];
 
     // Prepare cell geometry
-    const graph::AdjacencyList<std::int32_t>& x_dofmap
-        = _mesh->geometry().dofmap();
+    auto x_dofmap = _mesh->geometry().new_dofmap();
     const std::size_t num_dofs_g = cmap.dim();
     std::span<const T> x_g = _mesh->geometry().x();
 
@@ -270,7 +269,7 @@ public:
     for (int c = 0; c < num_cells; ++c)
     {
       // Extract cell geometry
-      auto x_dofs = x_dofmap.links(c);
+      auto x_dofs = stdex::submdspan(x_dofmap, c, stdex::full_extent);
       for (std::size_t i = 0; i < x_dofs.size(); ++i)
         for (std::size_t j = 0; j < gdim; ++j)
           coordinate_dofs(i, j) = x_g[3 * x_dofs[i] + j];

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -216,9 +216,7 @@ public:
 
     // Get coordinate map
     if (_mesh->geometry().cmaps().size() > 1)
-    {
       throw std::runtime_error("Mixed topology not supported");
-    }
     const CoordinateElement& cmap = _mesh->geometry().cmaps()[0];
 
     // Prepare cell geometry

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -51,7 +51,7 @@ void assemble_cells(
     return;
 
   // Prepare cell geometry
-  auto x_dofmap = geometry.new_dofmap();
+  auto x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -148,7 +148,7 @@ void assemble_exterior_facets(
     return;
 
   // Prepare cell geometry
-  auto x_dofmap = geometry.new_dofmap();
+  auto x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -244,7 +244,7 @@ void assemble_interior_facets(
     return;
 
   // Prepare cell geometry
-  auto x_dofmap = geometry.new_dofmap();
+  auto x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -58,7 +58,6 @@ void assemble_cells(
   // Iterate over active cells
   const int num_dofs0 = dofmap0.extent(1);
   const int num_dofs1 = dofmap1.extent(1);
-  std::cout << "Num dofs: " << num_dofs0 << ", " << num_dofs1 << std::endl;
   const int ndim0 = bs0 * num_dofs0;
   const int ndim1 = bs1 * num_dofs1;
   std::vector<T> Ae(ndim0 * ndim1);
@@ -66,12 +65,9 @@ void assemble_cells(
   std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
 
   // Iterate over active cells
-  std::cout << "Loop over cells: " << std::endl;
   for (std::size_t index = 0; index < cells.size(); ++index)
   {
     std::int32_t c = cells[index];
-
-    std::cout << "Cell : " << c << std::endl;
 
     // Get cell coordinates/geometry
     auto x_dofs = x_dofmap.links(c);
@@ -82,20 +78,16 @@ void assemble_cells(
     }
 
     // Tabulate tensor
-    std::cout << "Tab : " << c << std::endl;
     std::fill(Ae.begin(), Ae.end(), 0);
     kernel(Ae.data(), coeffs.data() + index * cstride, constants.data(),
            coordinate_dofs.data(), nullptr, nullptr);
-    std::cout << "Post tab : " << c << std::endl;
 
     dof_transform(_Ae, cell_info, c, ndim1);
     dof_transform_to_transpose(_Ae, cell_info, c, ndim0);
 
     // Zero rows/columns for essential bcs
-    std::cout << "Pre view: " << num_dofs0 << ", " << num_dofs1 << std::endl;
     auto dofs0 = std::span(dofmap0.data_handle() + c * num_dofs0, num_dofs0);
     auto dofs1 = std::span(dofmap1.data_handle() + c * num_dofs1, num_dofs1);
-    std::cout << "Post view: " << num_dofs0 << ", " << num_dofs1 << std::endl;
 
     if (!bc0.empty())
     {
@@ -425,7 +417,6 @@ void assemble_matrix(
 
   for (int i : a.integral_ids(IntegralType::cell))
   {
-    std::cout << "Asseemble over cells" << std::endl;
     auto fn = a.kernel(IntegralType::cell, i);
     assert(fn);
     auto& [coeffs, cstride] = coefficients.at({IntegralType::cell, i});

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -58,6 +58,7 @@ void assemble_cells(
   // Iterate over active cells
   const int num_dofs0 = dofmap0.extent(1);
   const int num_dofs1 = dofmap1.extent(1);
+  std::cout << "Num dofs: " << num_dofs0 << ", " << num_dofs1 << std::endl;
   const int ndim0 = bs0 * num_dofs0;
   const int ndim1 = bs1 * num_dofs1;
   std::vector<T> Ae(ndim0 * ndim1);
@@ -65,9 +66,12 @@ void assemble_cells(
   std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
 
   // Iterate over active cells
+  std::cout << "Loop over cells: " << std::endl;
   for (std::size_t index = 0; index < cells.size(); ++index)
   {
     std::int32_t c = cells[index];
+
+    std::cout << "Cell : " << c << std::endl;
 
     // Get cell coordinates/geometry
     auto x_dofs = x_dofmap.links(c);
@@ -78,16 +82,21 @@ void assemble_cells(
     }
 
     // Tabulate tensor
+    std::cout << "Tab : " << c << std::endl;
     std::fill(Ae.begin(), Ae.end(), 0);
     kernel(Ae.data(), coeffs.data() + index * cstride, constants.data(),
            coordinate_dofs.data(), nullptr, nullptr);
+    std::cout << "Post tab : " << c << std::endl;
 
     dof_transform(_Ae, cell_info, c, ndim1);
     dof_transform_to_transpose(_Ae, cell_info, c, ndim0);
 
     // Zero rows/columns for essential bcs
+    std::cout << "Pre view: " << num_dofs0 << ", " << num_dofs1 << std::endl;
     auto dofs0 = std::span(dofmap0.data_handle() + c * num_dofs0, num_dofs0);
     auto dofs1 = std::span(dofmap1.data_handle() + c * num_dofs1, num_dofs1);
+    std::cout << "Post view: " << num_dofs0 << ", " << num_dofs1 << std::endl;
+
     if (!bc0.empty())
     {
       for (int i = 0; i < num_dofs0; ++i)
@@ -416,6 +425,7 @@ void assemble_matrix(
 
   for (int i : a.integral_ids(IntegralType::cell))
   {
+    std::cout << "Asseemble over cells" << std::endl;
     auto fn = a.kernel(IntegralType::cell, i);
     assert(fn);
     auto& [coeffs, cstride] = coefficients.at({IntegralType::cell, i});

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -385,9 +385,9 @@ void assemble_matrix(
       = a.function_spaces().at(1)->dofmap();
   assert(dofmap0);
   assert(dofmap1);
-  auto dofs0 = dofmap0->list();
+  auto dofs0 = dofmap0->map();
   const int bs0 = dofmap0->bs();
-  auto dofs1 = dofmap1->list();
+  auto dofs1 = dofmap1->map();
   const int bs1 = dofmap1->bs();
 
   std::shared_ptr<const fem::FiniteElement> element0

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -52,7 +52,7 @@ void assemble_cells(
 
   // Prepare cell geometry
   auto x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  const std::size_t num_dofs_g = x_dofmap.extent(1);
   auto x = geometry.x();
 
   // Iterate over active cells
@@ -149,7 +149,7 @@ void assemble_exterior_facets(
 
   // Prepare cell geometry
   auto x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  const std::size_t num_dofs_g = x_dofmap.extent(1);
   auto x = geometry.x();
 
   // Data structures used in assembly
@@ -245,7 +245,7 @@ void assemble_interior_facets(
 
   // Prepare cell geometry
   auto x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  const std::size_t num_dofs_g = x_dofmap.extent(1);
   auto x = geometry.x();
 
   // Data structures used in assembly

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -12,7 +12,6 @@
 #include "utils.h"
 #include <algorithm>
 #include <concepts>
-#include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/la/utils.h>
 #include <dolfinx/mesh/Geometry.h>
 #include <dolfinx/mesh/Mesh.h>

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -51,7 +51,7 @@ void assemble_cells(
     return;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.new_dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -70,7 +70,7 @@ void assemble_cells(
     std::int32_t c = cells[index];
 
     // Get cell coordinates/geometry
-    auto x_dofs = x_dofmap.links(c);
+    auto x_dofs = stdex::submdspan(x_dofmap, c, stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs[i]), 3,
@@ -148,7 +148,7 @@ void assemble_exterior_facets(
     return;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.new_dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -167,7 +167,7 @@ void assemble_exterior_facets(
     std::int32_t local_facet = facets[index + 1];
 
     // Get cell coordinates/geometry
-    auto x_dofs = x_dofmap.links(cell);
+    auto x_dofs = stdex::submdspan(x_dofmap, cell, stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs[i]), 3,
@@ -244,7 +244,7 @@ void assemble_interior_facets(
     return;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.new_dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -268,13 +268,13 @@ void assemble_interior_facets(
         = {facets[index + 1], facets[index + 3]};
 
     // Get cell geometry
-    auto x_dofs0 = x_dofmap.links(cells[0]);
+    auto x_dofs0 = stdex::submdspan(x_dofmap, cells[0], stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs0.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs0[i]), 3,
                   std::next(cdofs0.begin(), 3 * i));
     }
-    auto x_dofs1 = x_dofmap.links(cells[1]);
+    auto x_dofs1 = stdex::submdspan(x_dofmap, cells[1], stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs1.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs1[i]), 3,

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -386,9 +386,9 @@ void assemble_matrix(
       = a.function_spaces().at(1)->dofmap();
   assert(dofmap0);
   assert(dofmap1);
-  auto dofs0 = dofmap0->new_list();
+  auto dofs0 = dofmap0->list();
   const int bs0 = dofmap0->bs();
-  auto dofs1 = dofmap1->new_list();
+  auto dofs1 = dofmap1->list();
   const int bs1 = dofmap1->bs();
 
   std::shared_ptr<const fem::FiniteElement> element0

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -34,7 +34,7 @@ T assemble_cells(const mesh::Geometry<scalar_value_type_t<T>>& geometry,
 
   // Prepare cell geometry
   auto x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  const std::size_t num_dofs_g = x_dofmap.extent(1);
   auto x = geometry.x();
 
   // Create data structures used in assembly
@@ -74,7 +74,7 @@ T assemble_exterior_facets(
 
   // Prepare cell geometry
   auto x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  const std::size_t num_dofs_g = x_dofmap.extent(1);
   auto x = geometry.x();
 
   // Create data structures used in assembly
@@ -117,7 +117,7 @@ T assemble_interior_facets(
 
   // Prepare cell geometry
   auto x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  const std::size_t num_dofs_g = x_dofmap.extent(1);
   auto x = geometry.x();
 
   // Create data structures used in assembly

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -33,7 +33,7 @@ T assemble_cells(const mesh::Geometry<scalar_value_type_t<T>>& geometry,
     return value;
 
   // Prepare cell geometry
-  auto x_dofmap = geometry.new_dofmap();
+  auto x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -73,7 +73,7 @@ T assemble_exterior_facets(
     return value;
 
   // Prepare cell geometry
-  auto x_dofmap = geometry.new_dofmap();
+  auto x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -116,7 +116,7 @@ T assemble_interior_facets(
     return value;
 
   // Prepare cell geometry
-  auto x_dofmap = geometry.new_dofmap();
+  auto x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -33,7 +33,7 @@ T assemble_cells(const mesh::Geometry<scalar_value_type_t<T>>& geometry,
     return value;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.new_dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -46,7 +46,7 @@ T assemble_cells(const mesh::Geometry<scalar_value_type_t<T>>& geometry,
     std::int32_t c = cells[index];
 
     // Get cell coordinates/geometry
-    auto x_dofs = x_dofmap.links(c);
+    auto x_dofs = stdex::submdspan(x_dofmap, c, stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs[i]), 3,
@@ -73,7 +73,7 @@ T assemble_exterior_facets(
     return value;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.new_dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -88,7 +88,7 @@ T assemble_exterior_facets(
     std::int32_t local_facet = facets[index + 1];
 
     // Get cell coordinates/geometry
-    auto x_dofs = x_dofmap.links(cell);
+    auto x_dofs = stdex::submdspan(x_dofmap, cell, stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs[i]), 3,
@@ -116,7 +116,7 @@ T assemble_interior_facets(
     return value;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.new_dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -138,13 +138,13 @@ T assemble_interior_facets(
         = {facets[index + 1], facets[index + 3]};
 
     // Get cell geometry
-    auto x_dofs0 = x_dofmap.links(cells[0]);
+    auto x_dofs0 = stdex::submdspan(x_dofmap, cells[0], stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs0.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs0[i]), 3,
                   std::next(cdofs0.begin(), 3 * i));
     }
-    auto x_dofs1 = x_dofmap.links(cells[1]);
+    auto x_dofs1 = stdex::submdspan(x_dofmap, cells[1], stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs1.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs1[i]), 3,

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -750,11 +750,11 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
   // Get dofmap for columns and rows of a
   assert(a.function_spaces().at(0));
   assert(a.function_spaces().at(1));
-  auto dofmap0 = a.function_spaces()[0]->dofmap()->list();
+  auto dofmap0 = a.function_spaces()[0]->dofmap()->map();
   const int bs0 = a.function_spaces()[0]->dofmap()->bs();
   std::shared_ptr<const fem::FiniteElement> element0
       = a.function_spaces()[0]->element();
-  auto dofmap1 = a.function_spaces()[1]->dofmap()->list();
+  auto dofmap1 = a.function_spaces()[1]->dofmap()->map();
   const int bs1 = a.function_spaces()[1]->dofmap()->bs();
   std::shared_ptr<const fem::FiniteElement> element1
       = a.function_spaces()[1]->element();
@@ -961,7 +961,7 @@ void assemble_vector(
   std::shared_ptr<const fem::DofMap> dofmap
       = L.function_spaces().at(0)->dofmap();
   assert(dofmap);
-  auto dofs = dofmap->list();
+  auto dofs = dofmap->map();
   const int bs = dofmap->bs();
 
   const std::function<void(const std::span<T>&,

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -64,7 +64,7 @@ void _lift_bc_cells(
 
   // Prepare cell geometry
   auto x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  const std::size_t num_dofs_g = x_dofmap.extent(1);
   auto x = geometry.x();
 
   // Data structures used in bc application
@@ -218,7 +218,7 @@ void _lift_bc_exterior_facets(
 
   // Prepare cell geometry
   auto x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  const std::size_t num_dofs_g = x_dofmap.extent(1);
   auto x = geometry.x();
 
   // Data structures used in bc application
@@ -328,7 +328,7 @@ void _lift_bc_interior_facets(
 
   // Prepare cell geometry
   auto x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  const std::size_t num_dofs_g = x_dofmap.extent(1);
   auto x = geometry.x();
 
   // Data structures used in assembly
@@ -514,7 +514,7 @@ void assemble_cells(
 
   // Prepare cell geometry
   auto x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  const std::size_t num_dofs_g = x_dofmap.extent(1);
   auto x = geometry.x();
 
   // FIXME: Add proper interface for num_dofs
@@ -544,7 +544,6 @@ void assemble_cells(
     dof_transform(_be, cell_info, c, 1);
 
     // Scatter cell vector to 'global' vector array
-    // auto dofs = dofmap.links(c);
     auto dofs = std::span(dofmap.data_handle() + c * num_dofs, num_dofs);
     if constexpr (_bs > 0)
     {
@@ -585,7 +584,7 @@ void assemble_exterior_facets(
 
   // Prepare cell geometry
   auto x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  const std::size_t num_dofs_g = x_dofmap.extent(1);
   auto x = geometry.x();
 
   // FIXME: Add proper interface for num_dofs
@@ -652,7 +651,7 @@ void assemble_interior_facets(
 {
   // Prepare cell geometry
   auto x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  const std::size_t num_dofs_g = x_dofmap.extent(1);
   auto x = geometry.x();
 
   // Create data structures used in assembly

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -63,7 +63,7 @@ void _lift_bc_cells(
     return;
 
   // Prepare cell geometry
-  auto x_dofmap = geometry.new_dofmap();
+  auto x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -217,7 +217,7 @@ void _lift_bc_exterior_facets(
     return;
 
   // Prepare cell geometry
-  auto x_dofmap = geometry.new_dofmap();
+  auto x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -327,7 +327,7 @@ void _lift_bc_interior_facets(
     return;
 
   // Prepare cell geometry
-  auto x_dofmap = geometry.new_dofmap();
+  auto x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -513,7 +513,7 @@ void assemble_cells(
     return;
 
   // Prepare cell geometry
-  auto x_dofmap = geometry.new_dofmap();
+  auto x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -584,7 +584,7 @@ void assemble_exterior_facets(
     return;
 
   // Prepare cell geometry
-  auto x_dofmap = geometry.new_dofmap();
+  auto x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -651,7 +651,7 @@ void assemble_interior_facets(
     const std::function<std::uint8_t(std::size_t)>& get_perm)
 {
   // Prepare cell geometry
-  auto x_dofmap = geometry.new_dofmap();
+  auto x_dofmap = geometry.dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -15,7 +15,6 @@
 #include <algorithm>
 #include <concepts>
 #include <dolfinx/common/IndexMap.h>
-#include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/mesh/Geometry.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/Topology.h>

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -63,7 +63,7 @@ void _lift_bc_cells(
     return;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.new_dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -114,7 +114,7 @@ void _lift_bc_cells(
       continue;
 
     // Get cell coordinates/geometry
-    auto x_dofs = x_dofmap.links(c);
+    auto x_dofs = stdex::submdspan(x_dofmap, c, stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs[i]), 3,
@@ -218,7 +218,7 @@ void _lift_bc_exterior_facets(
     return;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.new_dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -255,7 +255,7 @@ void _lift_bc_exterior_facets(
       continue;
 
     // Get cell coordinates/geometry
-    auto x_dofs = x_dofmap.links(cell);
+    auto x_dofs = stdex::submdspan(x_dofmap, cell, stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs[i]), 3,
@@ -330,7 +330,7 @@ void _lift_bc_interior_facets(
     return;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.new_dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -354,13 +354,13 @@ void _lift_bc_interior_facets(
         = {facets[index + 1], facets[index + 3]};
 
     // Get cell geometry
-    auto x_dofs0 = x_dofmap.links(cells[0]);
+    auto x_dofs0 = stdex::submdspan(x_dofmap, cells[0], stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs0.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs0[i]), 3,
                   std::next(cdofs0.begin(), 3 * i));
     }
-    auto x_dofs1 = x_dofmap.links(cells[1]);
+    auto x_dofs1 = stdex::submdspan(x_dofmap, cells[1], stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs1.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs1[i]), 3,
@@ -520,7 +520,7 @@ void assemble_cells(
     return;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.new_dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -537,7 +537,7 @@ void assemble_cells(
     std::int32_t c = cells[index];
 
     // Get cell coordinates/geometry
-    auto x_dofs = x_dofmap.links(c);
+    auto x_dofs = stdex::submdspan(x_dofmap, c, stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs[i]), 3,
@@ -591,7 +591,7 @@ void assemble_exterior_facets(
     return;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.new_dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -608,7 +608,7 @@ void assemble_exterior_facets(
     std::int32_t local_facet = facets[index + 1];
 
     // Get cell coordinates/geometry
-    auto x_dofs = x_dofmap.links(cell);
+    auto x_dofs = stdex::submdspan(x_dofmap, cell, stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs[i]), 3,
@@ -659,7 +659,7 @@ void assemble_interior_facets(
     const std::function<std::uint8_t(std::size_t)>& get_perm)
 {
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.new_dofmap();
   const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
   auto x = geometry.x();
 
@@ -680,13 +680,13 @@ void assemble_interior_facets(
         = {facets[index + 1], facets[index + 3]};
 
     // Get cell geometry
-    auto x_dofs0 = x_dofmap.links(cells[0]);
+    auto x_dofs0 = stdex::submdspan(x_dofmap, cells[0], stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs0.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs0[i]), 3,
                   std::next(cdofs0.begin(), 3 * i));
     }
-    auto x_dofs1 = x_dofmap.links(cells[1]);
+    auto x_dofs1 = stdex::submdspan(x_dofmap, cells[1], stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs1.size(); ++i)
     {
       std::copy_n(std::next(x.begin(), 3 * x_dofs1[i]), 3,

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -69,14 +69,12 @@ void _lift_bc_cells(
   // Data structures used in bc application
   std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
   std::vector<T> Ae, be;
-  const int num_dofs0 = dofmap0.extent(1);
-  const int num_dofs1 = dofmap1.extent(1);
   for (std::size_t index = 0; index < cells.size(); ++index)
   {
     std::int32_t c = cells[index];
 
     // Get dof maps for cell
-    auto dmap1 = std::span(dofmap1.data_handle() + c * num_dofs1, num_dofs1);
+    auto dmap1 = stdex::submdspan(dofmap1, c, stdex::full_extent);
 
     // Check if bc is applied to cell
     bool has_bc = false;
@@ -120,8 +118,7 @@ void _lift_bc_cells(
     }
 
     // Size data structure for assembly
-    // auto dmap0 = dofmap0.links(c);
-    auto dmap0 = std::span(dofmap0.data_handle() + c * num_dofs0, num_dofs0);
+    auto dmap0 = stdex::submdspan(dofmap0, c, stdex::full_extent);
 
     const int num_rows = bs0 * dmap0.size();
     const int num_cols = bs1 * dmap1.size();
@@ -224,15 +221,13 @@ void _lift_bc_exterior_facets(
   std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
   std::vector<T> Ae, be;
   assert(facets.size() % 2 == 0);
-  const int num_dofs0 = dofmap0.extent(1);
-  const int num_dofs1 = dofmap1.extent(1);
   for (std::size_t index = 0; index < facets.size(); index += 2)
   {
     std::int32_t cell = facets[index];
     std::int32_t local_facet = facets[index + 1];
 
     // Get dof maps for cell
-    auto dmap1 = std::span(dofmap1.data_handle() + cell * num_dofs1, num_dofs1);
+    auto dmap1 = stdex::submdspan(dofmap1, cell, stdex::full_extent);
 
     // Check if bc is applied to cell
     bool has_bc = false;
@@ -260,7 +255,8 @@ void _lift_bc_exterior_facets(
     }
 
     // Size data structure for assembly
-    auto dmap0 = std::span(dofmap0.data_handle() + cell * num_dofs0, num_dofs0);
+    auto dmap0 = stdex::submdspan(dofmap0, cell, stdex::full_extent);
+
     const int num_rows = bs0 * dmap0.size();
     const int num_cols = bs1 * dmap1.size();
 

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -77,7 +77,6 @@ void _lift_bc_cells(
     std::int32_t c = cells[index];
 
     // Get dof maps for cell
-    // auto dmap1 = dofmap1.links(c);
     auto dmap1 = std::span(dofmap1.data_handle() + c * num_dofs1, num_dofs1);
 
     // Check if bc is applied to cell
@@ -234,7 +233,6 @@ void _lift_bc_exterior_facets(
     std::int32_t local_facet = facets[index + 1];
 
     // Get dof maps for cell
-    // auto dmap1 = dofmap1.links(cell);
     auto dmap1 = std::span(dofmap1.data_handle() + cell * num_dofs1, num_dofs1);
 
     // Check if bc is applied to cell
@@ -263,7 +261,6 @@ void _lift_bc_exterior_facets(
     }
 
     // Size data structure for assembly
-    // auto dmap0 = dofmap0.links(cell);
     auto dmap0 = std::span(dofmap0.data_handle() + cell * num_dofs0, num_dofs0);
     const int num_rows = bs0 * dmap0.size();
     const int num_cols = bs1 * dmap1.size();
@@ -368,8 +365,6 @@ void _lift_bc_interior_facets(
     }
 
     // Get dof maps for cells and pack
-    // std::span<const std::int32_t> dmap0_cell0 = dofmap0.links(cells[0]);
-    // std::span<const std::int32_t> dmap0_cell1 = dofmap0.links(cells[1]);
     auto dmap0_cell0
         = std::span(dofmap0.data_handle() + cells[0] * num_dofs0, num_dofs0);
     auto dmap0_cell1
@@ -380,8 +375,6 @@ void _lift_bc_interior_facets(
     std::copy(dmap0_cell1.begin(), dmap0_cell1.end(),
               std::next(dmapjoint0.begin(), dmap0_cell0.size()));
 
-    // std::span<const std::int32_t> dmap1_cell0 = dofmap1.links(cells[0]);
-    // std::span<const std::int32_t> dmap1_cell1 = dofmap1.links(cells[1]);
     auto dmap1_cell0
         = std::span(dofmap1.data_handle() + cells[0] * num_dofs1, num_dofs1);
     auto dmap1_cell1
@@ -623,7 +616,6 @@ void assemble_exterior_facets(
     dof_transform(_be, cell_info, cell, 1);
 
     // Add element vector to global vector
-    // auto dofs = dofmap.links(cell);
     auto dofs = std::span(dofmap.data_handle() + cell * num_dofs, num_dofs);
     if constexpr (_bs > 0)
     {

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -514,9 +514,8 @@ void assemble_cells(
 
   // FIXME: Add proper interface for num_dofs
   // Create data structures used in assembly
-  const int num_dofs = dofmap.extent(1);
   std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
-  std::vector<T> be(bs * num_dofs);
+  std::vector<T> be(bs * dofmap.extent(1));
   std::span<T> _be(be);
 
   // Iterate over active cells
@@ -539,16 +538,16 @@ void assemble_cells(
     dof_transform(_be, cell_info, c, 1);
 
     // Scatter cell vector to 'global' vector array
-    auto dofs = std::span(dofmap.data_handle() + c * num_dofs, num_dofs);
+    auto dofs = stdex::submdspan(dofmap, c, stdex::full_extent);
     if constexpr (_bs > 0)
     {
-      for (int i = 0; i < num_dofs; ++i)
+      for (std::size_t i = 0; i < dofs.size(); ++i)
         for (int k = 0; k < _bs; ++k)
           b[_bs * dofs[i] + k] += be[_bs * i + k];
     }
     else
     {
-      for (int i = 0; i < num_dofs; ++i)
+      for (std::size_t i = 0; i < dofs.size(); ++i)
         for (int k = 0; k < bs; ++k)
           b[bs * dofs[i] + k] += be[bs * i + k];
     }
@@ -610,16 +609,16 @@ void assemble_exterior_facets(
     dof_transform(_be, cell_info, cell, 1);
 
     // Add element vector to global vector
-    auto dofs = std::span(dofmap.data_handle() + cell * num_dofs, num_dofs);
+    auto dofs = stdex::submdspan(dofmap, cell, stdex::full_extent);
     if constexpr (_bs > 0)
     {
-      for (int i = 0; i < num_dofs; ++i)
+      for (std::size_t i = 0; i < dofs.size(); ++i)
         for (int k = 0; k < _bs; ++k)
           b[_bs * dofs[i] + k] += be[_bs * i + k];
     }
     else
     {
-      for (int i = 0; i < num_dofs; ++i)
+      for (std::size_t i = 0; i < dofs.size(); ++i)
         for (int k = 0; k < bs; ++k)
           b[bs * dofs[i] + k] += be[bs * i + k];
     }

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -741,13 +741,11 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
   // Get dofmap for columns and rows of a
   assert(a.function_spaces().at(0));
   assert(a.function_spaces().at(1));
-  const graph::AdjacencyList<std::int32_t>& dofmap0
-      = a.function_spaces()[0]->dofmap()->list();
+  auto dofmap0 = a.function_spaces()[0]->dofmap()->list();
   const int bs0 = a.function_spaces()[0]->dofmap()->bs();
   std::shared_ptr<const fem::FiniteElement> element0
       = a.function_spaces()[0]->element();
-  const graph::AdjacencyList<std::int32_t>& dofmap1
-      = a.function_spaces()[1]->dofmap()->list();
+  auto dofmap1 = a.function_spaces()[1]->dofmap()->list();
   const int bs1 = a.function_spaces()[1]->dofmap()->bs();
   std::shared_ptr<const fem::FiniteElement> element1
       = a.function_spaces()[1]->element();
@@ -954,7 +952,7 @@ void assemble_vector(
   std::shared_ptr<const fem::DofMap> dofmap
       = L.function_spaces().at(0)->dofmap();
   assert(dofmap);
-  const graph::AdjacencyList<std::int32_t>& dofs = dofmap->list();
+  auto dofs = dofmap->list();
   const int bs = dofmap->bs();
 
   const std::function<void(const std::span<T>&,

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -765,11 +765,11 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
   // Get dofmap for columns and rows of a
   assert(a.function_spaces().at(0));
   assert(a.function_spaces().at(1));
-  auto dofmap0 = a.function_spaces()[0]->dofmap()->new_list();
+  auto dofmap0 = a.function_spaces()[0]->dofmap()->list();
   const int bs0 = a.function_spaces()[0]->dofmap()->bs();
   std::shared_ptr<const fem::FiniteElement> element0
       = a.function_spaces()[0]->element();
-  auto dofmap1 = a.function_spaces()[1]->dofmap()->new_list();
+  auto dofmap1 = a.function_spaces()[1]->dofmap()->list();
   const int bs1 = a.function_spaces()[1]->dofmap()->bs();
   std::shared_ptr<const fem::FiniteElement> element1
       = a.function_spaces()[1]->element();
@@ -976,7 +976,7 @@ void assemble_vector(
   std::shared_ptr<const fem::DofMap> dofmap
       = L.function_spaces().at(0)->dofmap();
   assert(dofmap);
-  auto dofs = dofmap->new_list();
+  auto dofs = dofmap->list();
   const int bs = dofmap->bs();
 
   const std::function<void(const std::span<T>&,

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -200,7 +200,7 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
   assert(cmaps.size() == 1);
 
   const CoordinateElement& cmap = cmaps.back();
-  auto x_dofmap = mesh->geometry().new_dofmap();
+  auto x_dofmap = mesh->geometry().dofmap();
   const std::size_t num_dofs_g = cmap.dim();
   std::span<const U> x_g = mesh->geometry().x();
 

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -200,8 +200,7 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
   assert(cmaps.size() == 1);
 
   const CoordinateElement& cmap = cmaps.back();
-  const graph::AdjacencyList<std::int32_t>& x_dofmap
-      = mesh->geometry().dofmap();
+  auto x_dofmap = mesh->geometry().new_dofmap();
   const std::size_t num_dofs_g = cmap.dim();
   std::span<const U> x_g = mesh->geometry().x();
 
@@ -291,7 +290,7 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
   for (std::int32_t c = 0; c < num_cells; ++c)
   {
     // Get cell geometry (coordinate dofs)
-    auto x_dofs = x_dofmap.links(c);
+    auto x_dofs = stdex::submdspan(x_dofmap, c, stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
     {
       for (std::size_t j = 0; j < gdim; ++j)

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -7,6 +7,7 @@
 #include "dofmapbuilder.h"
 #include "ElementDofLayout.h"
 #include <algorithm>
+#include <basix/mdspan.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <dolfinx/common/IndexMap.h>
@@ -27,6 +28,10 @@ using namespace dolfinx;
 namespace
 {
 
+namespace stdex = std::experimental;
+using mdspan2_t
+    = stdex::mdspan<const std::int32_t, stdex::dextents<std::size_t, 2>>;
+
 //-----------------------------------------------------------------------------
 
 /// Build a graph for owned dofs and apply graph reordering function
@@ -39,8 +44,7 @@ namespace
 /// @return Map from original_to_contiguous[i] to new index after
 /// reordering
 std::vector<int>
-reorder_owned(const graph::AdjacencyList<std::int32_t>& dofmap,
-              std::int32_t owned_size,
+reorder_owned(mdspan2_t dofmap, std::int32_t owned_size,
               const std::vector<int>& original_to_contiguous,
               const std::function<std::vector<int>(
                   const graph::AdjacencyList<std::int32_t>&)>& reorder_fn)
@@ -49,9 +53,11 @@ reorder_owned(const graph::AdjacencyList<std::int32_t>& dofmap,
 
   // Compute maximum number of graph out edges edges per dof
   std::vector<int> num_edges(owned_size);
-  for (std::int32_t cell = 0; cell < dofmap.num_nodes(); ++cell)
+  for (std::size_t cell = 0; cell < dofmap.extent(0); ++cell)
   {
-    auto nodes = dofmap.links(cell);
+    // auto nodes = dofmap.links(cell);
+    std::span<const std::int32_t> nodes(
+        dofmap.data_handle() + cell * dofmap.extent(1), dofmap.extent(1));
     for (auto n0 : nodes)
     {
       const std::int32_t node_0 = original_to_contiguous[n0];
@@ -72,9 +78,11 @@ reorder_owned(const graph::AdjacencyList<std::int32_t>& dofmap,
   std::partial_sum(num_edges.begin(), num_edges.end(),
                    std::next(offsets.begin(), 1));
   std::vector<std::int32_t> edges(offsets.back());
-  for (std::int32_t cell = 0; cell < dofmap.num_nodes(); ++cell)
+  for (std::size_t cell = 0; cell < dofmap.extent(0); ++cell)
   {
-    auto nodes = dofmap.links(cell);
+    // auto nodes = dofmap.links(cell);
+    std::span<const std::int32_t> nodes(
+        dofmap.data_handle() + cell * dofmap.extent(1), dofmap.extent(1));
     for (auto n0 : nodes)
     {
       const std::int32_t node_0 = original_to_contiguous[n0];
@@ -126,7 +134,7 @@ reorder_owned(const graph::AdjacencyList<std::int32_t>& dofmap,
 /// @return Returns {dofmap (local to the process), local-to-global map
 /// to get the global index of local dof i, dof indices, vector of
 /// {dimension, mesh entity index} for each local dof i}
-std::tuple<graph::AdjacencyList<std::int32_t>, std::vector<std::int64_t>,
+std::tuple<std::vector<std::int32_t>, std::vector<std::int64_t>,
            std::vector<std::pair<std::int8_t, std::int32_t>>>
 build_basic_dofmap(
     const mesh::Topology& topology,
@@ -234,20 +242,21 @@ build_basic_dofmap(
   const int num_cells = topology.connectivity(D, 0)->num_nodes();
   const std::vector<int>& group_offsets = topology.entity_group_offsets(D);
 
-  std::vector<std::int32_t> cell_ptr;
-  cell_ptr.reserve(num_cells + 1);
-  cell_ptr.push_back(0);
+  // std::vector<std::int32_t> cell_ptr;
+  // cell_ptr.reserve(num_cells + 1);
+  // cell_ptr.push_back(0);
 
   const std::size_t nelem = element_dof_layouts.size();
-  // Go through elements twice: regular cells followed by ghost cells.
-  for (std::size_t i = 0; i < 2 * nelem; ++i)
-  {
-    // Number of dofs per cell for this element layout
-    const int local_dim = element_dof_layouts[i % nelem].num_dofs();
-    for (int j = group_offsets[i]; j < group_offsets[i + 1]; ++j)
-      cell_ptr.push_back(cell_ptr.back() + local_dim);
-  }
-  std::vector<std::int32_t> dofs(cell_ptr.back());
+  // // Go through elements twice: regular cells followed by ghost cells.
+  // for (std::size_t i = 0; i < 2 * nelem; ++i)
+  // {
+  //   // Number of dofs per cell for this element layout
+  //   const int local_dim = element_dof_layouts[i % nelem].num_dofs();
+  //   for (int j = group_offsets[i]; j < group_offsets[i + 1]; ++j)
+  //     cell_ptr.push_back(cell_ptr.back() + local_dim);
+  // }
+  // std::vector<std::int32_t> dofs(cell_ptr.back());
+  std::vector<std::int32_t> dofs(num_cells * element_dof_layouts[0].num_dofs());
 
   // Allocate entity indices array
   std::vector<std::vector<int32_t>> entity_indices_local(D + 1);
@@ -278,6 +287,7 @@ build_basic_dofmap(
 
   // Loop over cells, group by group, and build dofmaps from respective
   // ElementDofmap
+  const int num_dofs_cell = element_dof_layouts[0].num_dofs();
   for (std::size_t i = 0; i < 2 * nelem; ++i)
   {
     for (int c = group_offsets[i]; c < group_offsets[i + 1]; ++c)
@@ -334,7 +344,7 @@ build_basic_dofmap(
                 = std::distance(e_dofs->begin(), dof_local);
             const std::int32_t dof
                 = offset_local + num_entity_dofs * e_index_local + count;
-            dofs[cell_ptr[c] + *dof_local] = dof;
+            dofs[c * num_dofs_cell + *dof_local] = dof;
           }
         }
         offset_local
@@ -374,8 +384,7 @@ build_basic_dofmap(
     }
   }
 
-  return {graph::AdjacencyList(std::move(dofs), std::move(cell_ptr)),
-          std::move(local_to_global), std::move(dof_entity)};
+  return {std::move(dofs), std::move(local_to_global), std::move(dof_entity)};
 }
 //-----------------------------------------------------------------------------
 
@@ -394,7 +403,7 @@ build_basic_dofmap(
 /// @return The pair (old-to-new local index map, M), where M is the
 /// number of dofs owned by this process
 std::pair<std::vector<std::int32_t>, std::int32_t> compute_reordering_map(
-    const graph::AdjacencyList<std::int32_t>& dofmap,
+    mdspan2_t dofmap,
     const std::vector<std::pair<std::int8_t, std::int32_t>>& dof_entity,
     const mesh::Topology& topology,
     const std::function<std::vector<int>(
@@ -424,9 +433,9 @@ std::pair<std::vector<std::int32_t>, std::int32_t> compute_reordering_map(
   // owned dofs. Set to -1 for unowned dofs.
   std::vector<int> original_to_contiguous(dof_entity.size(), -1);
   std::int32_t counter_owned(0), counter_unowned(owned_size);
-  for (std::int32_t cell = 0; cell < dofmap.num_nodes(); ++cell)
+  for (std::size_t cell = 0; cell < dofmap.extent(0); ++cell)
   {
-    auto dofs = dofmap.links(cell);
+    auto dofs = stdex::submdspan(dofmap, cell, stdex::full_extent);
     for (std::size_t i = 0; i < dofs.size(); ++i)
     {
       if (original_to_contiguous[dofs[i]] == -1)
@@ -672,8 +681,11 @@ fem::build_dofmap_data(
 
   // Build re-ordering map for data locality and get number of owned
   // nodes
+  mdspan2_t _node_graph0(node_graph0.data(),
+                         node_graph0.size() / element_dof_layouts[0].num_dofs(),
+                         element_dof_layouts[0].num_dofs());
   const auto [old_to_new, num_owned]
-      = compute_reordering_map(node_graph0, dof_entity0, topology, reorder_fn);
+      = compute_reordering_map(_node_graph0, dof_entity0, topology, reorder_fn);
 
   // Get global indices for unowned dofs
   const auto [local_to_global_unowned, local_to_global_owner]
@@ -686,11 +698,12 @@ fem::build_dofmap_data(
                              local_to_global_owner);
 
   // Build re-ordered dofmap
-  std::vector<std::int32_t> dofmap(node_graph0.array().size());
-  for (std::int32_t cell = 0; cell < node_graph0.num_nodes(); ++cell)
+  std::vector<std::int32_t> dofmap(node_graph0.size());
+  for (std::size_t cell = 0; cell < _node_graph0.extent(0); ++cell)
   {
     // Get dof order on this cell
-    auto old_nodes = node_graph0.links(cell);
+    // auto old_nodes = node_graph0.links(cell);
+    auto old_nodes = stdex::submdspan(_node_graph0, cell, stdex::full_extent);
     const std::int32_t local_dim0 = old_nodes.size();
     for (std::int32_t j = 0; j < local_dim0; ++j)
     {

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -640,7 +640,7 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
 } // namespace
 
 //-----------------------------------------------------------------------------
-std::tuple<common::IndexMap, int, graph::AdjacencyList<std::int32_t>>
+std::tuple<common::IndexMap, int, std::vector<std::int32_t>>
 fem::build_dofmap_data(
     MPI_Comm comm, const mesh::Topology& topology,
     const std::vector<ElementDofLayout>& element_dof_layouts,
@@ -699,9 +699,8 @@ fem::build_dofmap_data(
       dofmap[local_dim0 * cell + j] = new_node;
     }
   }
-  graph::AdjacencyList<std::int32_t> dmap(dofmap, node_graph0.offsets());
 
   return {std::move(index_map), element_dof_layouts[0].block_size(),
-          std::move(dmap)};
+          std::move(dofmap)};
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -149,15 +149,14 @@ build_basic_dofmap(
     throw std::runtime_error("Mixed topology mismatch: groups");
   }
 
-  // Mixed topology can only manage one dof (e.g. on vertex, or on edge, i.e. P1
-  // or P2) for now.
+  // Mixed topology can only manage one dof (e.g. on vertex, or on edge,
+  // i.e. P1 or P2) for now.
   if (element_dof_layouts.size() > 1)
   {
     for (auto e : element_dof_layouts)
     {
       for (int d = 0; d <= D; ++d)
       {
-
         if (e.num_entity_dofs(d) > 1)
           throw std::runtime_error("Mixed topology: dofmapbuilder does not yet "
                                    "support elements with more than "
@@ -169,13 +168,17 @@ build_basic_dofmap(
     for (int d = 0; d < D; ++d)
       nd[d] = element_dof_layouts[0].num_entity_dofs(d);
     for (int d = 0; d < D; ++d)
+    {
       for (std::size_t i = 1; i < element_dof_layouts.size(); ++i)
       {
         if (element_dof_layouts[i].num_entity_dofs(d) != nd[d])
+        {
           throw std::runtime_error(
               "Mixed topology: dofmapbuilder - incompatible elements "
               "(different number of dofs on shared entity)");
+        }
       }
+    }
   }
 
   // Generate and number required mesh entities

--- a/cpp/dolfinx/fem/dofmapbuilder.h
+++ b/cpp/dolfinx/fem/dofmapbuilder.h
@@ -39,7 +39,7 @@ class ElementDofLayout;
 /// @param[in] reorder_fn Graph reordering function that is applied to
 /// the dofmap
 /// @return The index map and local to global DOF data for the DOF map
-std::tuple<common::IndexMap, int, graph::AdjacencyList<std::int32_t>>
+std::tuple<common::IndexMap, int, std::vector<std::int32_t>>
 build_dofmap_data(MPI_Comm comm, const mesh::Topology& topology,
                   const std::vector<ElementDofLayout>& element_dof_layouts,
                   const std::function<std::vector<int>(

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -44,7 +44,7 @@ std::vector<T> interpolation_coords(const fem::FiniteElement& element,
 {
   // Get geometry data and the element coordinate map
   const std::size_t gdim = geometry.dim();
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.new_dofmap();
   std::span<const T> x_g = geometry.x();
 
   if (geometry.cmaps().size() > 1)
@@ -77,7 +77,7 @@ std::vector<T> interpolation_coords(const fem::FiniteElement& element,
   for (std::size_t c = 0; c < cells.size(); ++c)
   {
     // Get geometry data for current cell
-    auto x_dofs = x_dofmap.links(cells[c]);
+    auto x_dofs = stdex::submdspan(x_dofmap, c, stdex::full_extent);
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
     {
       std::copy_n(std::next(x_g.begin(), 3 * x_dofs[i]), gdim,
@@ -454,8 +454,7 @@ void interpolate_nonmatching_maps(Function<T, U>& u1, const Function<T, U>& u0,
     throw std::runtime_error("Multiple cmaps");
 
   const CoordinateElement& cmap = mesh->geometry().cmaps()[0];
-  const graph::AdjacencyList<std::int32_t>& x_dofmap
-      = mesh->geometry().dofmap();
+  auto x_dofmap = mesh->geometry().new_dofmap();
   const std::size_t num_dofs_g = cmap.dim();
   std::span<const U> x_g = mesh->geometry().x();
 
@@ -531,7 +530,7 @@ void interpolate_nonmatching_maps(Function<T, U>& u1, const Function<T, U>& u0,
   for (auto c : cells)
   {
     // Get cell geometry (coordinate dofs)
-    auto x_dofs = x_dofmap.links(c);
+    auto x_dofs = stdex::submdspan(x_dofmap, c, stdex::full_extent);
     for (std::size_t i = 0; i < num_dofs_g; ++i)
     {
       const int pos = 3 * x_dofs[i];
@@ -870,8 +869,7 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
     const CoordinateElement& cmap = mesh->geometry().cmaps()[0];
 
     // Get geometry data
-    const graph::AdjacencyList<std::int32_t>& x_dofmap
-        = mesh->geometry().dofmap();
+    auto x_dofmap = mesh->geometry().new_dofmap();
     const int num_dofs_g = cmap.dim();
     std::span<const U> x_g = mesh->geometry().x();
 
@@ -924,7 +922,7 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
     for (std::size_t c = 0; c < cells.size(); ++c)
     {
       const std::int32_t cell = cells[c];
-      auto x_dofs = x_dofmap.links(cell);
+      auto x_dofs = stdex::submdspan(x_dofmap, cell, stdex::full_extent);
       for (int i = 0; i < num_dofs_g; ++i)
       {
         const int pos = 3 * x_dofs[i];

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -44,7 +44,7 @@ std::vector<T> interpolation_coords(const fem::FiniteElement& element,
 {
   // Get geometry data and the element coordinate map
   const std::size_t gdim = geometry.dim();
-  auto x_dofmap = geometry.new_dofmap();
+  auto x_dofmap = geometry.dofmap();
   std::span<const T> x_g = geometry.x();
 
   if (geometry.cmaps().size() > 1)
@@ -454,7 +454,7 @@ void interpolate_nonmatching_maps(Function<T, U>& u1, const Function<T, U>& u0,
     throw std::runtime_error("Multiple cmaps");
 
   const CoordinateElement& cmap = mesh->geometry().cmaps()[0];
-  auto x_dofmap = mesh->geometry().new_dofmap();
+  auto x_dofmap = mesh->geometry().dofmap();
   const std::size_t num_dofs_g = cmap.dim();
   std::span<const U> x_g = mesh->geometry().x();
 
@@ -869,7 +869,7 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
     const CoordinateElement& cmap = mesh->geometry().cmaps()[0];
 
     // Get geometry data
-    auto x_dofmap = mesh->geometry().new_dofmap();
+    auto x_dofmap = mesh->geometry().dofmap();
     const int num_dofs_g = cmap.dim();
     std::span<const U> x_g = mesh->geometry().x();
 

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -126,8 +126,13 @@ fem::create_dofmap(MPI_Comm comm, const ElementDofLayout& layout,
 
     const std::function<void(const std::span<std::int32_t>&, std::uint32_t)>
         unpermute_dofs = element.get_dof_permutation_function(true, true);
+
+    int dim = layout.num_dofs();
     for (std::int32_t cell = 0; cell < num_cells; ++cell)
-      unpermute_dofs(dofmap.links(cell), cell_info[cell]);
+    {
+      std::span<std::int32_t> dofs(dofmap.data() + cell * dim, dim);
+      unpermute_dofs(dofs, cell_info[cell]);
+    }
   }
 
   return DofMap(layout, index_map, bs, std::move(dofmap), bs);

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -47,7 +47,7 @@ std::vector<T> shortest_vector(const mesh::Mesh<T>& mesh, int dim,
   }
 
   std::span<const T> geom_dofs = geometry.x();
-  auto x_dofmap = geometry.new_dofmap();
+  auto x_dofmap = geometry.dofmap();
   std::vector<T> shortest_vectors(3 * entities.size());
   if (dim == tdim)
   {
@@ -514,7 +514,7 @@ std::int32_t compute_first_colliding_cell(const mesh::Mesh<T>& mesh,
     constexpr T eps2 = 1e-20;
     const mesh::Geometry<T>& geometry = mesh.geometry();
     std::span<const T> geom_dofs = geometry.x();
-    auto x_dofmap = geometry.new_dofmap();
+    auto x_dofmap = geometry.dofmap();
     const std::size_t num_nodes = geometry.cmaps()[0].dim();
     std::vector<T> coordinate_dofs(num_nodes * 3);
     for (auto cell : cell_candidates)

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -515,7 +515,7 @@ std::int32_t compute_first_colliding_cell(const mesh::Mesh<T>& mesh,
     const mesh::Geometry<T>& geometry = mesh.geometry();
     std::span<const T> geom_dofs = geometry.x();
     auto x_dofmap = geometry.dofmap();
-    const std::size_t num_nodes = geometry.cmaps()[0].dim();
+    const std::size_t num_nodes = x_dofmap.extent(1);
     std::vector<T> coordinate_dofs(num_nodes * 3);
     for (auto cell : cell_candidates)
     {

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -36,6 +36,8 @@ std::vector<T> shortest_vector(const mesh::Mesh<T>& mesh, int dim,
                                std::span<const std::int32_t> entities,
                                std::span<const T> points)
 {
+  namespace stdex = std::experimental;
+
   const int tdim = mesh.topology()->dim();
   const mesh::Geometry<T>& geometry = mesh.geometry();
 
@@ -45,13 +47,13 @@ std::vector<T> shortest_vector(const mesh::Mesh<T>& mesh, int dim,
   }
 
   std::span<const T> geom_dofs = geometry.x();
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.new_dofmap();
   std::vector<T> shortest_vectors(3 * entities.size());
   if (dim == tdim)
   {
     for (std::size_t e = 0; e < entities.size(); e++)
     {
-      auto dofs = x_dofmap.links(entities[e]);
+      auto dofs = stdex::submdspan(x_dofmap, entities[e], stdex::full_extent);
       std::vector<T> nodes(3 * dofs.size());
       for (std::size_t i = 0; i < dofs.size(); ++i)
       {
@@ -88,7 +90,7 @@ std::vector<T> shortest_vector(const mesh::Mesh<T>& mesh, int dim,
       const int local_cell_entity = std::distance(cell_entities.begin(), it0);
 
       // Tabulate geometry dofs for the entity
-      auto dofs = x_dofmap.links(c);
+      auto dofs = stdex::submdspan(x_dofmap, c, stdex::full_extent);
       const std::vector<int> entity_dofs
           = geometry.cmaps()[0].create_dof_layout().entity_closure_dofs(
               dim, local_cell_entity);
@@ -494,6 +496,8 @@ std::int32_t compute_first_colliding_cell(const mesh::Mesh<T>& mesh,
                                           const BoundingBoxTree<T>& tree,
                                           const std::array<T, 3>& point)
 {
+  namespace stdex = std::experimental;
+
   // Compute colliding bounding boxes(cell candidates)
   std::vector<std::int32_t> cell_candidates;
   impl::_compute_collisions_point<T>(tree, point, cell_candidates);
@@ -510,12 +514,12 @@ std::int32_t compute_first_colliding_cell(const mesh::Mesh<T>& mesh,
     constexpr T eps2 = 1e-20;
     const mesh::Geometry<T>& geometry = mesh.geometry();
     std::span<const T> geom_dofs = geometry.x();
-    const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+    auto x_dofmap = geometry.new_dofmap();
     const std::size_t num_nodes = geometry.cmaps()[0].dim();
     std::vector<T> coordinate_dofs(num_nodes * 3);
     for (auto cell : cell_candidates)
     {
-      auto dofs = x_dofmap.links(cell);
+      auto dofs = stdex::submdspan(x_dofmap, cell, stdex::full_extent);
       for (std::size_t i = 0; i < num_nodes; ++i)
       {
         std::copy(std::next(geom_dofs.begin(), 3 * dofs[i]),

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -380,6 +380,8 @@ graph::build::compute_local_to_global(std::span<const std::int64_t> global,
 {
   common::Timer timer(
       "Compute-local-to-global links for global/local adjacency list");
+  if (global.empty() and local.empty())
+    return std::vector<std::int64_t>();
 
   if (global.size() != local.size())
     throw std::runtime_error("Data size mismatch.");

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -374,39 +374,23 @@ graph::build::compute_ghost_indices(MPI_Comm comm,
   return ghost_global_indices;
 }
 //-----------------------------------------------------------------------------
-std::vector<std::int64_t> graph::build::compute_local_to_global_links(
-    const graph::AdjacencyList<std::int64_t>& global,
-    const graph::AdjacencyList<std::int32_t>& local)
+std::vector<std::int64_t>
+graph::build::compute_local_to_global(std::span<const std::int64_t> global,
+                                      std::span<const std::int32_t> local)
 {
   common::Timer timer(
       "Compute-local-to-global links for global/local adjacency list");
 
-  // Return if global and local are empty
-  if (global.num_nodes() == 0 and local.num_nodes() == 0)
-    return std::vector<std::int64_t>();
-
-  // Build local-to-global for adjacency lists
-  if (global.num_nodes() != local.num_nodes())
-  {
-    throw std::runtime_error("Mismatch in number of nodes between local and "
-                             "global adjacency lists.");
-  }
-
-  const std::vector<std::int64_t>& _global = global.array();
-  const std::vector<std::int32_t>& _local = local.array();
-  if (_global.size() != _local.size())
-  {
-    throw std::runtime_error("Data size mismatch between local and "
-                             "global adjacency lists.");
-  }
+  if (global.size() != local.size())
+    throw std::runtime_error("Data size mismatch.");
 
   const std::int32_t max_local_idx
-      = *std::max_element(_local.begin(), _local.end());
+      = *std::max_element(local.begin(), local.end());
   std::vector<std::int64_t> local_to_global_list(max_local_idx + 1, -1);
-  for (std::size_t i = 0; i < _local.size(); ++i)
+  for (std::size_t i = 0; i < local.size(); ++i)
   {
-    if (local_to_global_list[_local[i]] == -1)
-      local_to_global_list[_local[i]] = _global[i];
+    if (local_to_global_list[local[i]] == -1)
+      local_to_global_list[local[i]] = global[i];
   }
 
   return local_to_global_list;

--- a/cpp/dolfinx/graph/partition.h
+++ b/cpp/dolfinx/graph/partition.h
@@ -112,8 +112,8 @@ compute_ghost_indices(MPI_Comm comm,
 /// the local adjacency list indices would yield the global adjacency
 /// list
 std::vector<std::int64_t>
-compute_local_to_global_links(const graph::AdjacencyList<std::int64_t>& global,
-                              const graph::AdjacencyList<std::int32_t>& local);
+compute_local_to_global(std::span<const std::int64_t> global,
+                        std::span<const std::int32_t> local);
 
 /// @brief Compute a local0-to-local1 map from two local-to-global maps
 /// with common global indices.

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -395,7 +395,7 @@ void write_data(adios2::IO& io, adios2::Engine& engine,
                           y.data_handle());
   };
 
-  if (!need_padding and eq_check(mesh->geometry().dofmap(), dofmap->list()))
+  if (!need_padding and eq_check(mesh->geometry().dofmap(), dofmap->map()))
     data = u.x()->array();
   else
   {

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -386,7 +386,6 @@ void write_data(adios2::IO& io, adios2::Engine& engine,
   // can work directly with the dof array.
   std::span<const T> data;
   std::vector<T> _data;
-  // if (mesh->geometry().new_dofmap() == dofmap->new_list() and !need_padding)
   auto equality_check = [](auto x, auto y) -> bool
   {
     return x.extents() == y.extents()
@@ -394,7 +393,7 @@ void write_data(adios2::IO& io, adios2::Engine& engine,
                           y.data_handle());
   };
   if (!need_padding
-      and equality_check(mesh->geometry().new_dofmap(), dofmap->new_list()))
+      and equality_check(mesh->geometry().new_dofmap(), dofmap->list()))
   {
     data = u.x()->array();
   }

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -394,6 +394,7 @@ void write_data(adios2::IO& io, adios2::Engine& engine,
            and std::equal(x.data_handle(), x.data_handle() + x.size(),
                           y.data_handle());
   };
+
   if (!need_padding
       and equality_check(mesh->geometry().new_dofmap(), dofmap->list()))
   {

--- a/cpp/dolfinx/io/VTKFile.cpp
+++ b/cpp/dolfinx/io/VTKFile.cpp
@@ -425,7 +425,7 @@ void write_function(
   {
     std::vector<std::int64_t> tmp;
     std::tie(tmp, cshape) = io::extract_vtk_connectivity(
-        mesh0->geometry().dofmap(), topology0->cell_types()[0]);
+        mesh0->geometry().new_dofmap(), topology0->cell_types()[0]);
     cells.assign(tmp.begin(), tmp.end());
     const mesh::Geometry<double>& geometry = mesh0->geometry();
     x.assign(geometry.x().begin(), geometry.x().end());
@@ -788,7 +788,7 @@ void io::VTKFile::write(const mesh::Mesh<double>& mesh, double time)
 
   // Add mesh data to "Piece" node
   const auto [cells, cshape]
-      = extract_vtk_connectivity(mesh.geometry().dofmap(), cell_types[0]);
+      = extract_vtk_connectivity(mesh.geometry().new_dofmap(), cell_types[0]);
   std::array<std::size_t, 2> xshape = {geometry.x().size() / 3, 3};
   std::vector<std::uint8_t> x_ghost(xshape[0], 0);
   std::fill(std::next(x_ghost.begin(), xmap->size_local()), x_ghost.end(), 1);

--- a/cpp/dolfinx/io/VTKFile.cpp
+++ b/cpp/dolfinx/io/VTKFile.cpp
@@ -425,7 +425,7 @@ void write_function(
   {
     std::vector<std::int64_t> tmp;
     std::tie(tmp, cshape) = io::extract_vtk_connectivity(
-        mesh0->geometry().new_dofmap(), topology0->cell_types()[0]);
+        mesh0->geometry().dofmap(), topology0->cell_types()[0]);
     cells.assign(tmp.begin(), tmp.end());
     const mesh::Geometry<double>& geometry = mesh0->geometry();
     x.assign(geometry.x().begin(), geometry.x().end());
@@ -788,7 +788,7 @@ void io::VTKFile::write(const mesh::Mesh<double>& mesh, double time)
 
   // Add mesh data to "Piece" node
   const auto [cells, cshape]
-      = extract_vtk_connectivity(mesh.geometry().new_dofmap(), cell_types[0]);
+      = extract_vtk_connectivity(mesh.geometry().dofmap(), cell_types[0]);
   std::array<std::size_t, 2> xshape = {geometry.x().size() / 3, 3};
   std::vector<std::uint8_t> x_ghost(xshape[0], 0);
   std::fill(std::next(x_ghost.begin(), xmap->size_local()), x_ghost.end(), 1);

--- a/cpp/dolfinx/io/vtk_utils.cpp
+++ b/cpp/dolfinx/io/vtk_utils.cpp
@@ -27,8 +27,6 @@ io::extract_vtk_connectivity(
     mesh::CellType cell_type)
 {
   // Get DOLFINx to VTK permutation
-  // FIXME: Use better way to get number of nodes
-  // const std::size_t num_nodes = geometry.cmap().dim();
   const std::size_t num_nodes = dofmap_x.extent(1);
   std::vector vtkmap
       = io::cells::transpose(io::cells::perm_vtk(cell_type, num_nodes));

--- a/cpp/dolfinx/io/vtk_utils.cpp
+++ b/cpp/dolfinx/io/vtk_utils.cpp
@@ -20,18 +20,21 @@ using namespace dolfinx;
 
 //-----------------------------------------------------------------------------
 std::pair<std::vector<std::int64_t>, std::array<std::size_t, 2>>
-io::extract_vtk_connectivity(const graph::AdjacencyList<std::int32_t>& dofmap_x,
-                             mesh::CellType cell_type)
+io::extract_vtk_connectivity(
+    std::experimental::mdspan<const std::int32_t,
+                              std::experimental::dextents<std::size_t, 2>>
+        dofmap_x,
+    mesh::CellType cell_type)
 {
   // Get DOLFINx to VTK permutation
   // FIXME: Use better way to get number of nodes
   // const std::size_t num_nodes = geometry.cmap().dim();
-  const std::size_t num_nodes = dofmap_x.links(0).size();
+  const std::size_t num_nodes = dofmap_x.extent(1);
   std::vector vtkmap
       = io::cells::transpose(io::cells::perm_vtk(cell_type, num_nodes));
 
   // Extract mesh 'nodes'
-  const std::size_t num_cells = dofmap_x.num_nodes();
+  const std::size_t num_cells = dofmap_x.extent(0);
 
   // Build mesh connectivity
 
@@ -41,9 +44,8 @@ io::extract_vtk_connectivity(const graph::AdjacencyList<std::int32_t>& dofmap_x,
   for (std::size_t c = 0; c < num_cells; ++c)
   {
     // For each cell, get the 'nodes' and place in VTK order
-    auto dofs_x = dofmap_x.links(c);
-    for (std::size_t i = 0; i < dofs_x.size(); ++i)
-      topology[c * shape[1] + i] = dofs_x[vtkmap[i]];
+    for (std::size_t i = 0; i < num_nodes; ++i)
+      topology[c * shape[1] + i] = dofmap_x(c, vtkmap[i]);
   }
 
   return {std::move(topology), shape};

--- a/cpp/dolfinx/io/vtk_utils.h
+++ b/cpp/dolfinx/io/vtk_utils.h
@@ -88,7 +88,7 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace<T>& V)
   const fem::CoordinateElement& cmap = mesh->geometry().cmaps()[0];
 
   // Prepare cell geometry
-  auto dofmap_x = mesh->geometry().new_dofmap();
+  auto dofmap_x = mesh->geometry().dofmap();
   std::span<const T> x_g = mesh->geometry().x();
   const std::size_t num_dofs_g = cmap.dim();
 

--- a/cpp/dolfinx/io/vtk_utils.h
+++ b/cpp/dolfinx/io/vtk_utils.h
@@ -9,6 +9,7 @@
 #include "cells.h"
 #include "vtk_utils.h"
 #include <array>
+#include <basix/mdspan.hpp>
 #include <concepts>
 #include <cstdint>
 #include <dolfinx/common/IndexMap.h>
@@ -87,8 +88,7 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace<T>& V)
   const fem::CoordinateElement& cmap = mesh->geometry().cmaps()[0];
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& dofmap_x
-      = mesh->geometry().dofmap();
+  auto dofmap_x = mesh->geometry().new_dofmap();
   std::span<const T> x_g = mesh->geometry().x();
   const std::size_t num_dofs_g = cmap.dim();
 
@@ -129,10 +129,9 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace<T>& V)
   for (std::int32_t c = 0; c < num_cells; ++c)
   {
     // Extract cell geometry
-    auto dofs_x = dofmap_x.links(c);
-    for (std::size_t i = 0; i < dofs_x.size(); ++i)
+    for (std::size_t i = 0; i < dofmap_x.extent(1); ++i)
       for (std::size_t j = 0; j < gdim; ++j)
-        coordinate_dofs(i, j) = x_g[3 * dofs_x[i] + j];
+        coordinate_dofs(i, j) = x_g[3 * dofmap_x(c, i) + j];
 
     // Tabulate dof coordinates on cell
     cmap.push_forward(x, coordinate_dofs, phi);
@@ -244,7 +243,10 @@ vtk_mesh_from_space(const fem::FunctionSpace<T>& V)
 /// @note Even if the indices are local (int32), both Fides and VTX
 /// require int64 as local input
 std::pair<std::vector<std::int64_t>, std::array<std::size_t, 2>>
-extract_vtk_connectivity(const graph::AdjacencyList<std::int32_t>& dofmap_x,
-                         mesh::CellType cell_type);
+extract_vtk_connectivity(
+    std::experimental::mdspan<const std::int32_t,
+                              std::experimental::dextents<std::size_t, 2>>
+        dofmap_x,
+    mesh::CellType cell_type);
 } // namespace io
 } // namespace dolfinx

--- a/cpp/dolfinx/io/xdmf_mesh.cpp
+++ b/cpp/dolfinx/io/xdmf_mesh.cpp
@@ -62,7 +62,7 @@ void xdmf_mesh::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
   // Pack topology data
   std::vector<std::int64_t> topology_data;
 
-  const graph::AdjacencyList<std::int32_t>& cells_g = geometry.dofmap();
+  auto cells_g = geometry.new_dofmap();
   auto map_g = geometry.index_map();
   assert(map_g);
   const std::int64_t offset_g = map_g->local_range()[0];
@@ -76,11 +76,10 @@ void xdmf_mesh::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
   {
     for (std::int32_t c : entities)
     {
-      assert(c < cells_g.num_nodes());
-      auto nodes = cells_g.links(c);
-      for (std::size_t i = 0; i < nodes.size(); ++i)
+      assert(c < (std::int32_t)cells_g.extent(0));
+      for (std::size_t i = 0; i < cells_g.extent(1); ++i)
       {
-        std::int64_t global_index = nodes[vtk_map[i]];
+        std::int64_t global_index = cells_g(c, vtk_map[i]);
         if (global_index < map_g->size_local())
           global_index += offset_g;
         else
@@ -121,10 +120,9 @@ void xdmf_mesh::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
       // Get geometry dofs for the entity
       const std::vector<int>& entity_dofs_e = entity_dofs[local_cell_entity];
 
-      auto nodes = cells_g.links(c);
       for (std::size_t i = 0; i < entity_dofs_e.size(); ++i)
       {
-        std::int64_t global_index = nodes[entity_dofs_e[vtk_map[i]]];
+        std::int64_t global_index = cells_g(c, entity_dofs_e[vtk_map[i]]);
         if (global_index < map_g->size_local())
           global_index += offset_g;
         else

--- a/cpp/dolfinx/io/xdmf_mesh.cpp
+++ b/cpp/dolfinx/io/xdmf_mesh.cpp
@@ -15,6 +15,7 @@
 
 using namespace dolfinx;
 using namespace dolfinx::io;
+namespace stdex = std::experimental;
 
 //-----------------------------------------------------------------------------
 void xdmf_mesh::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
@@ -62,7 +63,7 @@ void xdmf_mesh::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
   // Pack topology data
   std::vector<std::int64_t> topology_data;
 
-  auto cells_g = geometry.dofmap();
+  auto x_dofmap = geometry.dofmap();
   auto map_g = geometry.index_map();
   assert(map_g);
   const std::int64_t offset_g = map_g->local_range()[0];
@@ -76,10 +77,11 @@ void xdmf_mesh::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
   {
     for (std::int32_t c : entities)
     {
-      assert(c < (std::int32_t)cells_g.extent(0));
-      for (std::size_t i = 0; i < cells_g.extent(1); ++i)
+      assert(c < (std::int32_t)x_dofmap.extent(0));
+      auto xdofs = stdex::submdspan(x_dofmap, c, stdex::full_extent);
+      for (std::size_t i = 0; i < x_dofmap.extent(1); ++i)
       {
-        std::int64_t global_index = cells_g(c, vtk_map[i]);
+        std::int64_t global_index = xdofs[vtk_map[i]];
         if (global_index < map_g->size_local())
           global_index += offset_g;
         else
@@ -120,9 +122,10 @@ void xdmf_mesh::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
       // Get geometry dofs for the entity
       const std::vector<int>& entity_dofs_e = entity_dofs[local_cell_entity];
 
+      auto xdofs = stdex::submdspan(x_dofmap, c, stdex::full_extent);
       for (std::size_t i = 0; i < entity_dofs_e.size(); ++i)
       {
-        std::int64_t global_index = cells_g(c, entity_dofs_e[vtk_map[i]]);
+        std::int64_t global_index = xdofs[entity_dofs_e[vtk_map[i]]];
         if (global_index < map_g->size_local())
           global_index += offset_g;
         else

--- a/cpp/dolfinx/io/xdmf_mesh.cpp
+++ b/cpp/dolfinx/io/xdmf_mesh.cpp
@@ -62,7 +62,7 @@ void xdmf_mesh::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
   // Pack topology data
   std::vector<std::int64_t> topology_data;
 
-  auto cells_g = geometry.new_dofmap();
+  auto cells_g = geometry.dofmap();
   auto map_g = geometry.index_map();
   assert(map_g);
   const std::int64_t offset_g = map_g->local_range()[0];

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -92,8 +92,7 @@ compute_point_values(const fem::Function<T, double>& u)
   std::vector<T> point_values(num_points * value_size_loc);
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap
-      = mesh->geometry().dofmap();
+  auto x_dofmap = mesh->geometry().new_dofmap();
 
   if (mesh->geometry().cmaps().size() > 1)
   {
@@ -112,9 +111,8 @@ compute_point_values(const fem::Function<T, double>& u)
   for (std::int32_t c = 0; c < num_cells; ++c)
   {
     // Get coordinates for all points in cell
-    std::span<const std::int32_t> dofs = x_dofmap.links(c);
     for (int i = 0; i < num_dofs_g; ++i)
-      cells[dofs[i]] = c;
+      cells[x_dofmap(c, i)] = c;
   }
 
   u.eval(mesh->geometry().x(), {num_points, 3}, cells, point_values,
@@ -724,15 +722,13 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh<double>& mesh,
     const std::vector<std::int64_t>& nodes_g
         = mesh.geometry().input_global_indices();
 
-    const graph::AdjacencyList<std::int32_t>& x_dofmap
-        = mesh.geometry().dofmap();
+    auto x_dofmap = mesh.geometry().new_dofmap();
     std::map<std::int64_t, std::int32_t> igi_to_vertex;
     for (int c = 0; c < c_to_v->num_nodes(); ++c)
     {
       auto vertices = c_to_v->links(c);
-      auto x_dofs = x_dofmap.links(c);
       for (std::size_t v = 0; v < vertices.size(); ++v)
-        igi_to_vertex[nodes_g[x_dofs[cell_vertex_dofs[v]]]] = vertices[v];
+        igi_to_vertex[nodes_g[x_dofmap(c, cell_vertex_dofs[v])]] = vertices[v];
     }
 
     std::vector<std::int32_t> entities_new;

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -92,7 +92,7 @@ compute_point_values(const fem::Function<T, double>& u)
   std::vector<T> point_values(num_points * value_size_loc);
 
   // Prepare cell geometry
-  auto x_dofmap = mesh->geometry().new_dofmap();
+  auto x_dofmap = mesh->geometry().dofmap();
 
   if (mesh->geometry().cmaps().size() > 1)
   {
@@ -722,7 +722,7 @@ xdmf_utils::distribute_entity_data(const mesh::Mesh<double>& mesh,
     const std::vector<std::int64_t>& nodes_g
         = mesh.geometry().input_global_indices();
 
-    auto x_dofmap = mesh.geometry().new_dofmap();
+    auto x_dofmap = mesh.geometry().dofmap();
     std::map<std::int64_t, std::int32_t> igi_to_vertex;
     for (int c = 0; c < c_to_v->num_nodes(); ++c)
     {

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "Topology.h"
+#include <basix/mdspan.hpp>
 #include <concepts>
 #include <cstdint>
 #include <dolfinx/common/IndexMap.h>
@@ -87,6 +88,17 @@ public:
 
   /// Return Euclidean dimension of coordinate system
   int dim() const { return _dim; }
+
+  /// DOF map
+  std::experimental::mdspan<const std::int32_t,
+                            std::experimental::dextents<std::size_t, 2>>
+  new_dofmap() const
+  {
+    int ndofs = _dofmap.num_links(0);
+    return std::experimental::mdspan<
+        const std::int32_t, std::experimental::dextents<std::size_t, 2>>(
+        _dofmap.array().data(), _dofmap.array().size() / ndofs, ndofs);
+  }
 
   /// DOF map
   const graph::AdjacencyList<std::int32_t>& dofmap() const { return _dofmap; }

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -92,17 +92,13 @@ public:
   /// DOF map
   std::experimental::mdspan<const std::int32_t,
                             std::experimental::dextents<std::size_t, 2>>
-  new_dofmap() const
+  dofmap() const
   {
     int ndofs = _cmaps[0].dim();
     return std::experimental::mdspan<
         const std::int32_t, std::experimental::dextents<std::size_t, 2>>(
         _dofmap.array().data(), _dofmap.array().size() / ndofs, ndofs);
   }
-
-  /// DOF map
-  // const graph::AdjacencyList<std::int32_t>& dofmap() const { return _dofmap;
-  // }
 
   /// Index map
   std::shared_ptr<const common::IndexMap> index_map() const
@@ -295,7 +291,7 @@ create_subgeometry(const Topology& topology, const Geometry<T>& geometry,
   sub_x_dofmap_offsets.reserve(subentity_to_entity.size() + 1);
   sub_x_dofmap_offsets.push_back(0);
   {
-    auto xdofs = geometry.new_dofmap();
+    auto xdofs = geometry.dofmap();
     const int tdim = topology.dim();
 
     // Fetch connectivities required to get entity dofs

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -714,7 +714,6 @@ entities_to_geometry(const Mesh<T>& mesh, int dim,
     auto ev = e_to_v->links(idx);
     assert(ev.size() == num_vertices);
     auto cv = c_to_v->links(cell);
-    // auto xc = stdex::submdspan(xdofs, cell, stdex::full_extent);
     std::span<const std::int32_t> xc(
         xdofs.data_handle() + xdofs.extent(1) * cell, xdofs.extent(1));
     for (std::size_t j = 0; j < num_vertices; ++j)

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -135,7 +135,7 @@ compute_vertex_coords_boundary(const mesh::Mesh<T>& mesh, int dim,
   }
 
   // Get geometry data
-  auto x_dofmap = mesh.geometry().new_dofmap();
+  auto x_dofmap = mesh.geometry().dofmap();
   std::span<const T> x_nodes = mesh.geometry().x();
 
   // Get all vertex 'node' indices
@@ -455,7 +455,7 @@ compute_vertex_coords(const mesh::Mesh<T>& mesh)
   mesh.topology_mutable()->create_connectivity(tdim, 0);
 
   // Get all vertex 'node' indices
-  auto x_dofmap = mesh.geometry().new_dofmap();
+  auto x_dofmap = mesh.geometry().dofmap();
   const std::int32_t num_vertices = topology->index_map(0)->size_local()
                                     + topology->index_map(0)->num_ghosts();
   auto c_to_v = topology->connectivity(tdim, 0);
@@ -681,7 +681,7 @@ entities_to_geometry(const Mesh<T>& mesh, int dim,
   mesh.topology_mutable()->create_connectivity(dim, 0);
   mesh.topology_mutable()->create_connectivity(tdim, 0);
 
-  auto xdofs = geometry.new_dofmap();
+  auto xdofs = geometry.dofmap();
   auto e_to_c = topology->connectivity(dim, tdim);
   if (!e_to_c)
   {

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -907,7 +907,6 @@ create_mesh(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
 
   Geometry geometry
       = create_geometry(comm, topology, elements, cell_nodes, x, xshape[1]);
-
   return Mesh<typename U::value_type>(
       comm, std::make_shared<Topology>(std::move(topology)),
       std::move(geometry));

--- a/cpp/dolfinx/refinement/plaza.h
+++ b/cpp/dolfinx/refinement/plaza.h
@@ -164,7 +164,7 @@ face_long_edge(const mesh::Mesh<T>& mesh)
   if (tdim == 2)
     edge_ratio_ok.resize(num_faces);
 
-  auto x_dofmap = mesh.geometry().new_dofmap();
+  auto x_dofmap = mesh.geometry().dofmap();
 
   auto c_to_v = mesh.topology()->connectivity(tdim, 0);
   assert(c_to_v);

--- a/cpp/dolfinx/refinement/plaza.h
+++ b/cpp/dolfinx/refinement/plaza.h
@@ -141,6 +141,8 @@ template <typename T>
 std::pair<std::vector<std::int32_t>, std::vector<std::int8_t>>
 face_long_edge(const mesh::Mesh<T>& mesh)
 {
+  namespace stdex = std::experimental;
+
   const int tdim = mesh.topology()->dim();
   // FIXME: cleanup these calls? Some of the happen internally again.
   mesh.topology_mutable()->create_entities(1);
@@ -162,7 +164,7 @@ face_long_edge(const mesh::Mesh<T>& mesh)
   if (tdim == 2)
     edge_ratio_ok.resize(num_faces);
 
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = mesh.geometry().dofmap();
+  auto x_dofmap = mesh.geometry().new_dofmap();
 
   auto c_to_v = mesh.topology()->connectivity(tdim, 0);
   assert(c_to_v);
@@ -193,7 +195,8 @@ face_long_edge(const mesh::Mesh<T>& mesh)
     assert(it1 != cell_vertices.end());
     const std::size_t local1 = std::distance(cell_vertices.begin(), it1);
 
-    auto x_dofs = x_dofmap.links(cells.front());
+    // auto x_dofs = x_dofmap.links(cells.front());
+    auto x_dofs = stdex::submdspan(x_dofmap, cells.front(), stdex::full_extent);
     std::span<const T, 3> x0(mesh.geometry().x().data() + 3 * x_dofs[local0],
                              3);
     std::span<const T, 3> x1(mesh.geometry().x().data() + 3 * x_dofs[local1],

--- a/cpp/dolfinx/refinement/plaza.h
+++ b/cpp/dolfinx/refinement/plaza.h
@@ -195,7 +195,6 @@ face_long_edge(const mesh::Mesh<T>& mesh)
     assert(it1 != cell_vertices.end());
     const std::size_t local1 = std::distance(cell_vertices.begin(), it1);
 
-    // auto x_dofs = x_dofmap.links(cells.front());
     auto x_dofs = stdex::submdspan(x_dofmap, cells.front(), stdex::full_extent);
     std::span<const T, 3> x0(mesh.geometry().x().data() + 3 * x_dofs[local0],
                              3);

--- a/cpp/dolfinx/refinement/utils.h
+++ b/cpp/dolfinx/refinement/utils.h
@@ -73,7 +73,6 @@ std::pair<std::vector<T>, std::array<std::size_t, 2>> create_new_geometry(
   for (int c = 0; c < map_c->size_local() + map_c->num_ghosts(); ++c)
   {
     auto vertices = c_to_v->links(c);
-    // auto dofs = x_dofmap.links(c);
     auto dofs = stdex::submdspan(x_dofmap, c, stdex::full_extent);
     for (std::size_t i = 0; i < vertices.size(); ++i)
     {

--- a/cpp/dolfinx/refinement/utils.h
+++ b/cpp/dolfinx/refinement/utils.h
@@ -57,7 +57,7 @@ std::pair<std::vector<T>, std::array<std::size_t, 2>> create_new_geometry(
   namespace stdex = std::experimental;
 
   // Build map from vertex -> geometry dof
-  auto x_dofmap = mesh.geometry().new_dofmap();
+  auto x_dofmap = mesh.geometry().dofmap();
   const int tdim = mesh.topology()->dim();
   auto c_to_v = mesh.topology()->connectivity(tdim, 0);
   assert(c_to_v);

--- a/python/demo/demo_elasticity.py
+++ b/python/demo/demo_elasticity.py
@@ -62,7 +62,7 @@ def build_nullspace(V):
     basis = [np.zeros(bs * length1, dtype=dtype) for i in range(6)]
 
     # Get dof indices for each subspace (x, y and z dofs)
-    dofs = [V.sub(i).dofmap.list.array for i in range(3)]
+    dofs = [V.sub(i).dofmap.list.flatten() for i in range(3)]
 
     # Set the three translational rigid body modes
     for i in range(3):
@@ -70,7 +70,7 @@ def build_nullspace(V):
 
     # Set the three rotational rigid body modes
     x = V.tabulate_dof_coordinates()
-    dofs_block = V.dofmap.list.array
+    dofs_block = V.dofmap.list.flatten()
     x0, x1, x2 = x[dofs_block, 0], x[dofs_block, 1], x[dofs_block, 2]
     basis[3][dofs[0]] = -x1
     basis[3][dofs[1]] = x0

--- a/python/dolfinx/fem/dofmap.py
+++ b/python/dolfinx/fem/dofmap.py
@@ -51,4 +51,4 @@ class DofMap:
     @property
     def list(self):
         """Adjacency list with dof indices for each cell"""
-        return self._cpp_object.list()
+        return self._cpp_object.map()

--- a/python/dolfinx/plot.py
+++ b/python/dolfinx/plot.py
@@ -113,7 +113,7 @@ def _(V: fem.FunctionSpace, entities=None):
 
     topology = np.zeros((len(entities), num_dofs_per_cell + 1), dtype=np.int32)
     topology[:, 0] = num_dofs_per_cell
-    dofmap_ = dofmap.list.array.reshape(dofmap.list.num_nodes, num_dofs_per_cell)
+    dofmap_ = dofmap.list
 
     topology[:, 1:] = dofmap_[:len(entities), perm]
     return topology.reshape(1, -1)[0], cell_types, V.tabulate_dof_coordinates()

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -779,7 +779,7 @@ void fem(py::module& m)
           "list",
           [](const dolfinx::fem::DofMap& self)
           {
-            auto dofs = self.new_list();
+            auto dofs = self.list();
             std::array<py::ssize_t, 2> shape
                 = {py::ssize_t(dofs.extent(0)), py::ssize_t(dofs.extent(1))};
             return py::array_t<std::int32_t>(shape, dofs.data_handle(),

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -770,7 +770,8 @@ void fem(py::module& m)
                [](const dolfinx::fem::ElementDofLayout& element,
                   std::shared_ptr<const dolfinx::common::IndexMap> index_map,
                   int index_map_bs,
-                  dolfinx::graph::AdjacencyList<std::int32_t>& dofmap, int bs)
+                  const dolfinx::graph::AdjacencyList<std::int32_t>& dofmap,
+                  int bs)
                {
                  return dolfinx::fem::DofMap(element, index_map, index_map_bs,
                                              dofmap.array(), bs);

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -766,9 +766,15 @@ void fem(py::module& m)
   // dolfinx::fem::DofMap
   py::class_<dolfinx::fem::DofMap, std::shared_ptr<dolfinx::fem::DofMap>>(
       m, "DofMap", "DofMap object")
-      .def(py::init<const dolfinx::fem::ElementDofLayout&,
-                    std::shared_ptr<const dolfinx::common::IndexMap>, int,
-                    dolfinx::graph::AdjacencyList<std::int32_t>&, int>(),
+      .def(py::init(
+               [](const dolfinx::fem::ElementDofLayout& element,
+                  std::shared_ptr<const dolfinx::common::IndexMap> index_map,
+                  int index_map_bs,
+                  dolfinx::graph::AdjacencyList<std::int32_t>& dofmap, int bs)
+               {
+                 return dolfinx::fem::DofMap(element, index_map, index_map_bs,
+                                             dofmap.array(), bs);
+               }),
            py::arg("element_dof_layout"), py::arg("index_map"),
            py::arg("index_map_bs"), py::arg("dofmap"), py::arg("bs"))
       .def_readonly("index_map", &dolfinx::fem::DofMap::index_map)

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -775,8 +775,19 @@ void fem(py::module& m)
           },
           py::arg("cell"))
       .def_property_readonly("bs", &dolfinx::fem::DofMap::bs)
-      .def("list", &dolfinx::fem::DofMap::list,
-           py::return_value_policy::reference_internal);
+      .def(
+          "list",
+          [](const dolfinx::fem::DofMap& self)
+          {
+            auto dofs = self.new_list();
+            std::array<py::ssize_t, 2> shape
+                = {py::ssize_t(dofs.extent(0)), py::ssize_t(dofs.extent(1))};
+            return py::array_t<std::int32_t>(shape, dofs.data_handle(),
+                                             py::cast(self));
+          },
+          py::return_value_policy::reference_internal);
+  //  .def("list", &dolfinx::fem::DofMap::list,
+  //        py::return_value_policy::reference_internal);
 
   // dolfinx::fem::CoordinateElement
   py::class_<dolfinx::fem::CoordinateElement,

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -619,14 +619,13 @@ void fem(py::module& m)
         if (dofmap.ndim() != 2)
           throw std::runtime_error("Dofmap data has wrong rank");
         namespace stdex = std::experimental;
-        using mdspan2_t = stdex::mdspan<const std::int32_t,
-                                        stdex::dextents<std::size_t, 2>>;
-
-        mdspan2_t _dofmap(dofmap.data(), dofmap.shape(0), dofmap.shape(1));
+        stdex::mdspan<const std::int32_t, stdex::dextents<std::size_t, 2>>
+            _dofmap(dofmap.data(), dofmap.shape(0), dofmap.shape(1));
         return dolfinx::fem::transpose_dofmap(_dofmap, num_cells);
       },
+      py::return_value_policy::reference_internal,
       "Build the index to (cell, local index) map from a dofmap ((cell, local "
-      "index ) -> index).");
+      "index) -> index).");
   m.def(
       "compute_integration_domains",
       [](dolfinx::fem::IntegralType type,
@@ -798,8 +797,6 @@ void fem(py::module& m)
                                              py::cast(self));
           },
           py::return_value_policy::reference_internal);
-  //  .def("list", &dolfinx::fem::DofMap::list,
-  //        py::return_value_policy::reference_internal);
 
   // dolfinx::fem::CoordinateElement
   py::class_<dolfinx::fem::CoordinateElement,

--- a/python/dolfinx/wrappers/geometry.cpp
+++ b/python/dolfinx/wrappers/geometry.cpp
@@ -120,7 +120,7 @@ void geometry(py::module& m)
       {
         std::vector coll
             = dolfinx::geometry::compute_collisions<double>(treeA, treeB);
-        std::array<py::ssize_t, 2> shape = {py::ssize_t(coll.size() / 2), 2};
+        std::array<py::ssize_t, 2> shape{py::ssize_t(coll.size() / 2), 2};
         return as_pyarray(std::move(coll), shape);
       },
       py::arg("tree0"), py::arg("tree1"));
@@ -264,7 +264,7 @@ void geometry(py::module& m)
              const std::size_t i)
           {
             std::array<double, 6> bbox = self.get_bbox(i);
-            std::array<std::size_t, 2> shape = {2, 3};
+            std::array<std::size_t, 2> shape{2, 3};
             return py::array_t<double>(shape, bbox.data());
           },
           py::arg("i"))

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -43,7 +43,7 @@ void io(py::module& m)
       [](const dolfinx::mesh::Geometry<double>& x, dolfinx::mesh::CellType cell)
       {
         auto [cells, shape]
-            = dolfinx::io::extract_vtk_connectivity(x.new_dofmap(), cell);
+            = dolfinx::io::extract_vtk_connectivity(x.dofmap(), cell);
         return as_pyarray(std::move(cells), shape);
       },
       py::arg("x"), py::arg("celltype"),

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -77,9 +77,8 @@ void io(py::module& m)
             dolfinx::mesh::cell_entity_type(
                 mesh.topology()->cell_types().back(), entity_dim, 0),
             0);
-        std::array shape_e
-            = {entities_values.first.size() / num_vert_per_entity,
-               num_vert_per_entity};
+        std::array shape_e{entities_values.first.size() / num_vert_per_entity,
+                           num_vert_per_entity};
         return std::pair(as_pyarray(std::move(entities_values.first), shape_e),
                          as_pyarray(std::move(entities_values.second)));
       },

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -43,7 +43,7 @@ void io(py::module& m)
       [](const dolfinx::mesh::Geometry<double>& x, dolfinx::mesh::CellType cell)
       {
         auto [cells, shape]
-            = dolfinx::io::extract_vtk_connectivity(x.dofmap(), cell);
+            = dolfinx::io::extract_vtk_connectivity(x.new_dofmap(), cell);
         return as_pyarray(std::move(cells), shape);
       },
       py::arg("x"), py::arg("celltype"),

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -144,7 +144,6 @@ void declare_mesh(py::module& m, std::string type)
       m, pyclass_geometry_name.c_str(), "Geometry object")
       .def_property_readonly("dim", &dolfinx::mesh::Geometry<T>::dim,
                              "Geometric dimension")
-      // .def_property_readonly("dofmap", &dolfinx::mesh::Geometry<T>::dofmap)
       .def_property_readonly(
           "dofmap",
           [](dolfinx::mesh::Geometry<T>& self)

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -144,7 +144,16 @@ void declare_mesh(py::module& m, std::string type)
       m, pyclass_geometry_name.c_str(), "Geometry object")
       .def_property_readonly("dim", &dolfinx::mesh::Geometry<T>::dim,
                              "Geometric dimension")
-      .def_property_readonly("dofmap", &dolfinx::mesh::Geometry<T>::dofmap)
+      // .def_property_readonly("dofmap", &dolfinx::mesh::Geometry<T>::dofmap)
+      .def_property_readonly(
+          "dofmap",
+          [](dolfinx::mesh::Geometry<T>& self)
+          {
+            auto dofs = self.new_dofmap();
+            std::array<std::size_t, 2> shape = {dofs.extent(0), dofs.extent(1)};
+            return py::array_t<std::int32_t>(shape, dofs.data_handle(),
+                                             py::cast(self));
+          })
       .def("index_map", &dolfinx::mesh::Geometry<T>::index_map)
       .def_property_readonly(
           "x",

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -148,7 +148,7 @@ void declare_mesh(py::module& m, std::string type)
           "dofmap",
           [](dolfinx::mesh::Geometry<T>& self)
           {
-            auto dofs = self.new_dofmap();
+            auto dofs = self.dofmap();
             std::array<std::size_t, 2> shape = {dofs.extent(0), dofs.extent(1)};
             return py::array_t<std::int32_t>(shape, dofs.data_handle(),
                                              py::cast(self));

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -144,21 +144,20 @@ void declare_mesh(py::module& m, std::string type)
       m, pyclass_geometry_name.c_str(), "Geometry object")
       .def_property_readonly("dim", &dolfinx::mesh::Geometry<T>::dim,
                              "Geometric dimension")
-      .def_property_readonly(
-          "dofmap",
-          [](dolfinx::mesh::Geometry<T>& self)
-          {
-            auto dofs = self.dofmap();
-            std::array<std::size_t, 2> shape = {dofs.extent(0), dofs.extent(1)};
-            return py::array_t<std::int32_t>(shape, dofs.data_handle(),
-                                             py::cast(self));
-          })
+      .def_property_readonly("dofmap",
+                             [](dolfinx::mesh::Geometry<T>& self)
+                             {
+                               auto dofs = self.dofmap();
+                               std::array shape{dofs.extent(0), dofs.extent(1)};
+                               return py::array_t<std::int32_t>(
+                                   shape, dofs.data_handle(), py::cast(self));
+                             })
       .def("index_map", &dolfinx::mesh::Geometry<T>::index_map)
       .def_property_readonly(
           "x",
           [](const dolfinx::mesh::Geometry<T>& self)
           {
-            std::array<std::size_t, 2> shape = {self.x().size() / 3, 3};
+            std::array<std::size_t, 2> shape{self.x().size() / 3, 3};
             return py::array_t<T>(shape, self.x().data(), py::cast(self));
           },
           "Return coordinates of all geometry points. Each row is the "
@@ -288,7 +287,7 @@ void declare_mesh(py::module& m, std::string type)
       {
         std::vector<T> x = dolfinx::mesh::compute_midpoints(
             mesh, dim, std::span(entities.data(), entities.size()));
-        std::array<std::size_t, 2> shape = {(std::size_t)entities.size(), 3};
+        std::array<std::size_t, 2> shape{(std::size_t)entities.size(), 3};
         return as_pyarray(std::move(x), shape);
       },
       py::arg("mesh"), py::arg("dim"), py::arg("entities"));
@@ -301,7 +300,7 @@ void declare_mesh(py::module& m, std::string type)
       {
         auto cpp_marker = [&marker](auto x)
         {
-          std::array<std::size_t, 2> shape = {x.extent(0), x.extent(1)};
+          std::array shape{x.extent(0), x.extent(1)};
           py::array_t<T> x_view(shape, x.data_handle(), py::none());
           py::array_t<bool> marked = marker(x_view);
           return std::vector<std::int8_t>(marked.data(),
@@ -321,7 +320,7 @@ void declare_mesh(py::module& m, std::string type)
       {
         auto cpp_marker = [&marker](auto x)
         {
-          std::array<std::size_t, 2> shape = {x.extent(0), x.extent(1)};
+          std::array shape{x.extent(0), x.extent(1)};
           py::array_t<T> x_view(shape, x.data_handle(), py::none());
           py::array_t<bool> marked = marker(x_view);
           return std::vector<std::int8_t>(marked.data(),
@@ -347,8 +346,8 @@ void declare_mesh(py::module& m, std::string type)
         dolfinx::mesh::CellType cell_type = topology->cell_types()[0];
         std::size_t num_vertices = dolfinx::mesh::num_cell_vertices(
             cell_entity_type(cell_type, dim, 0));
-        std::array<std::size_t, 2> shape
-            = {(std::size_t)entities.size(), num_vertices};
+        std::array<std::size_t, 2> shape{(std::size_t)entities.size(),
+                                         num_vertices};
         return as_pyarray(std::move(idx), shape);
       },
       py::arg("mesh"), py::arg("dim"), py::arg("entities"), py::arg("orient"));

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -499,7 +499,7 @@ def test_assembly_solve_block(mode):
     create_unit_square(MPI.COMM_WORLD, 12, 11, ghost_mode=GhostMode.shared_facet),
     create_unit_cube(MPI.COMM_WORLD, 3, 7, 3, ghost_mode=GhostMode.none),
     create_unit_cube(MPI.COMM_WORLD, 3, 7, 3, ghost_mode=GhostMode.shared_facet)])
-def xtest_assembly_solve_taylor_hood(mesh):
+def test_assembly_solve_taylor_hood(mesh):
     """Assemble Stokes problem with Taylor-Hood elements and solve."""
     P2 = VectorFunctionSpace(mesh, ("Lagrange", 2))
     P1 = FunctionSpace(mesh, ("Lagrange", 1))

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -499,7 +499,7 @@ def test_assembly_solve_block(mode):
     create_unit_square(MPI.COMM_WORLD, 12, 11, ghost_mode=GhostMode.shared_facet),
     create_unit_cube(MPI.COMM_WORLD, 3, 7, 3, ghost_mode=GhostMode.none),
     create_unit_cube(MPI.COMM_WORLD, 3, 7, 3, ghost_mode=GhostMode.shared_facet)])
-def test_assembly_solve_taylor_hood(mesh):
+def xtest_assembly_solve_taylor_hood(mesh):
     """Assemble Stokes problem with Taylor-Hood elements and solve."""
     P2 = VectorFunctionSpace(mesh, ("Lagrange", 2))
     P1 = FunctionSpace(mesh, ("Lagrange", 1))

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -282,7 +282,7 @@ def test_custom_mesh_loop_rank1():
     num_cells = num_owned_cells + mesh.topology.index_map(mesh.topology.dim).num_ghosts
     x_dofs = mesh.geometry.dofmap.array.reshape(num_cells, 3)
     x = mesh.geometry.x
-    dofmap = V.dofmap.list.array.reshape(num_cells, 3)
+    dofmap = V.dofmap.list
 
     # Assemble with pure Numba function (two passes, first will include
     # JIT overhead)
@@ -364,7 +364,7 @@ def test_custom_mesh_loop_ctypes_rank2():
     num_cells = num_owned_cells + mesh.topology.index_map(mesh.topology.dim).num_ghosts
     x_dofs = mesh.geometry.dofmap.array.reshape(num_cells, 3)
     x = mesh.geometry.x
-    dofmap = V.dofmap.list.array.reshape(num_cells, 3).astype(np.dtype(PETSc.IntType))
+    dofmap = V.dofmap.list.astype(np.dtype(PETSc.IntType))
 
     # Generated case with general assembler
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
@@ -422,7 +422,7 @@ def test_custom_mesh_loop_cffi_rank2(set_vals):
     num_cells = num_owned_cells + mesh.topology.index_map(mesh.topology.dim).num_ghosts
     x_dofs = mesh.geometry.dofmap.array.reshape(num_cells, 3)
     x = mesh.geometry.x
-    dofmap = V.dofmap.list.array.reshape(num_cells, 3).astype(np.dtype(PETSc.IntType))
+    dofmap = V.dofmap.list.astype(np.dtype(PETSc.IntType))
 
     A1 = A0.copy()
     for i in range(2):

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -280,7 +280,7 @@ def test_custom_mesh_loop_rank1():
     # Unpack mesh and dofmap data
     num_owned_cells = mesh.topology.index_map(mesh.topology.dim).size_local
     num_cells = num_owned_cells + mesh.topology.index_map(mesh.topology.dim).num_ghosts
-    x_dofs = mesh.geometry.dofmap.array.reshape(num_cells, 3)
+    x_dofs = mesh.geometry.dofmap
     x = mesh.geometry.x
     dofmap = V.dofmap.list
 
@@ -362,7 +362,7 @@ def test_custom_mesh_loop_ctypes_rank2():
     # Extract mesh and dofmap data
     num_owned_cells = mesh.topology.index_map(mesh.topology.dim).size_local
     num_cells = num_owned_cells + mesh.topology.index_map(mesh.topology.dim).num_ghosts
-    x_dofs = mesh.geometry.dofmap.array.reshape(num_cells, 3)
+    x_dofs = mesh.geometry.dofmap
     x = mesh.geometry.x
     dofmap = V.dofmap.list.astype(np.dtype(PETSc.IntType))
 

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -279,7 +279,6 @@ def test_custom_mesh_loop_rank1():
 
     # Unpack mesh and dofmap data
     num_owned_cells = mesh.topology.index_map(mesh.topology.dim).size_local
-    num_cells = num_owned_cells + mesh.topology.index_map(mesh.topology.dim).num_ghosts
     x_dofs = mesh.geometry.dofmap
     x = mesh.geometry.x
     dofmap = V.dofmap.list
@@ -361,7 +360,6 @@ def test_custom_mesh_loop_ctypes_rank2():
 
     # Extract mesh and dofmap data
     num_owned_cells = mesh.topology.index_map(mesh.topology.dim).size_local
-    num_cells = num_owned_cells + mesh.topology.index_map(mesh.topology.dim).num_ghosts
     x_dofs = mesh.geometry.dofmap
     x = mesh.geometry.x
     dofmap = V.dofmap.list.astype(np.dtype(PETSc.IntType))
@@ -419,8 +417,7 @@ def test_custom_mesh_loop_cffi_rank2(set_vals):
 
     # Unpack mesh and dofmap data
     num_owned_cells = mesh.topology.index_map(mesh.topology.dim).size_local
-    num_cells = num_owned_cells + mesh.topology.index_map(mesh.topology.dim).num_ghosts
-    x_dofs = mesh.geometry.dofmap.array.reshape(num_cells, 3)
+    x_dofs = mesh.geometry.dofmap
     x = mesh.geometry.x
     dofmap = V.dofmap.list.astype(np.dtype(PETSc.IntType))
 

--- a/python/test/unit/fem/test_dof_permuting.py
+++ b/python/test/unit/fem/test_dof_permuting.py
@@ -126,10 +126,10 @@ def test_dof_positions(cell_type, space_type):
 
     V = FunctionSpace(mesh, space_type)
     entities = {i: {} for i in range(1, tdim)}
-    for cell in range(coord_dofs.num_nodes):
+    for cell in range(coord_dofs.shape[0]):
         # Push coordinates forward
         X = V.element.interpolation_points()
-        xg = x_g[coord_dofs.links(cell), :tdim]
+        xg = x_g[coord_dofs[cell], :tdim]
         x = cmap.push_forward(X, xg)
 
         dofs = V.dofmap.cell_dofs(cell)

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -12,7 +12,6 @@ import pytest
 import ufl
 from basix.ufl import element, mixed_element
 from dolfinx.fem import FunctionSpace, VectorFunctionSpace
-from dolfinx.graph import create_adjacencylist
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
                           create_unit_interval, create_unit_square)
 from mpi4py import MPI

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -259,7 +259,7 @@ def test_higher_order_coordinate_map(points, celltype, order):
 
     i = 0
     for node in range(len(points)):
-        x_coord_new[i] = x_g[coord_dofs.links(0)[node], :mesh.geometry.dim]
+        x_coord_new[i] = x_g[coord_dofs[0, node], :mesh.geometry.dim]
         i += 1
     x = cmap.push_forward(X, x_coord_new)
 
@@ -306,7 +306,7 @@ def test_higher_order_tetra_coordinate_map(order):
 
     i = 0
     for node in range(len(points)):
-        x_coord_new[i] = x_g[coord_dofs.links(0)[node], :mesh.geometry.dim]
+        x_coord_new[i] = x_g[coord_dofs[0, node], :mesh.geometry.dim]
         i += 1
 
     x = cmap.push_forward(X, x_coord_new)
@@ -317,6 +317,6 @@ def test_higher_order_tetra_coordinate_map(order):
 
 @pytest.mark.skip_in_parallel
 def test_transpose_dofmap():
-    dofmap = create_adjacencylist(np.array([[0, 2, 1], [3, 2, 1], [4, 3, 1]], dtype=np.int32))
+    dofmap = np.array([[0, 2, 1], [3, 2, 1], [4, 3, 1]], dtype=np.int32)
     transpose = dolfinx.fem.transpose_dofmap(dofmap, 3)
     assert np.array_equal(transpose.array, [0, 2, 5, 8, 1, 4, 3, 7, 6])

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -294,9 +294,9 @@ def test_plus_minus_simple_vector(cell_type, pm):
         # For each cell
         for cell in range(2):
             # For each point in cell 0 in the first mesh
-            for dof0, point0 in zip(spaces[0].dofmap.cell_dofs(cell), dofmap0.links(cell)):
+            for dof0, point0 in zip(spaces[0].dofmap.cell_dofs(cell), dofmap0[cell]):
                 # Find the point in the cell 0 in the second mesh
-                for dof1, point1 in zip(space.dofmap.cell_dofs(cell), dofmap1.links(cell)):
+                for dof1, point1 in zip(space.dofmap.cell_dofs(cell), dofmap1[cell]):
                     if np.allclose(spaces[0].mesh.geometry.x[point0], space.mesh.geometry.x[point1]):
                         break
                 else:
@@ -349,9 +349,9 @@ def test_plus_minus_vector(cell_type, pm1, pm2):
         # For each cell
         for cell in range(2):
             # For each point in cell 0 in the first mesh
-            for dof0, point0 in zip(spaces[0].dofmap.cell_dofs(cell), dofmap0.links(cell)):
+            for dof0, point0 in zip(spaces[0].dofmap.cell_dofs(cell), dofmap0[cell]):
                 # Find the point in the cell 0 in the second mesh
-                for dof1, point1 in zip(space.dofmap.cell_dofs(cell), dofmap1.links(cell)):
+                for dof1, point1 in zip(space.dofmap.cell_dofs(cell), dofmap1[cell]):
                     if np.allclose(spaces[0].mesh.geometry.x[point0], space.mesh.geometry.x[point1]):
                         break
                 else:
@@ -401,9 +401,9 @@ def test_plus_minus_matrix(cell_type, pm1, pm2):
         # For each cell
         for cell in range(2):
             # For each point in cell 0 in the first mesh
-            for dof0, point0 in zip(spaces[0].dofmap.cell_dofs(cell), dofmap0.links(cell)):
+            for dof0, point0 in zip(spaces[0].dofmap.cell_dofs(cell), dofmap0[cell]):
                 # Find the point in the cell 0 in the second mesh
-                for dof1, point1 in zip(space.dofmap.cell_dofs(cell), dofmap1.links(cell)):
+                for dof1, point1 in zip(space.dofmap.cell_dofs(cell), dofmap1[cell]):
                     if np.allclose(spaces[0].mesh.geometry.x[point0], space.mesh.geometry.x[point1]):
                         break
                 else:

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -345,7 +345,7 @@ def test_assembly_into_quadrature_function():
     with e_Q.vector.localForm() as local:
         e_exact_eval = np.zeros_like(local.array)
         for cell in range(num_cells):
-            xg = x_g[coord_dofs.links(cell), :tdim]
+            xg = x_g[coord_dofs[cell], :tdim]
             x = mesh.geometry.cmaps[0].push_forward(quadrature_points, xg)
             e_exact_eval[Q_dofs_unrolled[cell]] = e_exact(x.T).T.flatten()
         assert np.allclose(local.array, e_exact_eval)

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -116,7 +116,7 @@ def test_rank0():
     # Data structure for the result
     b = Function(vdP1)
 
-    dofmap = vdP1.dofmap.list.array
+    dofmap = vdP1.dofmap.list.flatten()
     scatter(b.x.array, array_evaluated, dofmap)
     b.x.scatter_forward()
 
@@ -159,8 +159,8 @@ def test_rank1_hdiv():
     sparsity_pattern.assemble()
     A = create_matrix(MPI.COMM_WORLD, sparsity_pattern)
 
-    dofmap_col = RT1.dofmap.list.array.reshape(-1, 8).astype(np.dtype(PETSc.IntType))
-    dofmap_row = vdP1.dofmap.list.array
+    dofmap_col = RT1.dofmap.list.astype(np.dtype(PETSc.IntType))
+    dofmap_row = vdP1.dofmap.list.flatten()
 
     dofmap_row_unrolled = (2 * np.repeat(dofmap_row, 2).reshape(-1, 2) + np.arange(2)).flatten()
     dofmap_row = dofmap_row_unrolled.reshape(-1, 12).astype(np.dtype(PETSc.IntType))
@@ -314,7 +314,7 @@ def test_assembly_into_quadrature_function():
     e_Q = Function(Q)
     with e_Q.vector.localForm() as e_Q_local:
         e_Q_local.setBlockSize(e_Q.function_space.dofmap.bs)
-        e_Q_local.setValuesBlocked(Q.dofmap.list.array, e_eval, addv=PETSc.InsertMode.INSERT)
+        e_Q_local.setValuesBlocked(Q.dofmap.list.flatten(), e_eval, addv=PETSc.InsertMode.INSERT)
 
     def e_exact(x):
         T = x[0] + 2.0 * x[1]
@@ -334,7 +334,8 @@ def test_assembly_into_quadrature_function():
     coord_dofs = mesh.geometry.dofmap
     x_g = mesh.geometry.x
     tdim = mesh.topology.dim
-    Q_dofs = Q.dofmap.list.array.reshape(num_cells, quadrature_points.shape[0])
+    Q_dofs = Q.dofmap.list
+
     bs = Q.dofmap.bs
 
     Q_dofs_unrolled = bs * np.repeat(Q_dofs, bs).reshape(-1, bs) + np.arange(bs)

--- a/python/test/unit/la/test_nullspace.py
+++ b/python/test/unit/la/test_nullspace.py
@@ -39,7 +39,7 @@ def build_elastic_nullspace(V):
         vec_local = [stack.enter_context(x.localForm()) for x in ns]
         basis = [np.asarray(x) for x in vec_local]
 
-        dofs = [V.sub(i).dofmap.list.array for i in range(gdim)]
+        dofs = [V.sub(i).dofmap.list.flatten() for i in range(gdim)]
 
         # Build translational null space basis
         for i in range(gdim):
@@ -47,7 +47,7 @@ def build_elastic_nullspace(V):
 
         # Build rotational null space basis
         x = V.tabulate_dof_coordinates()
-        dofs_block = V.dofmap.list.array
+        dofs_block = V.dofmap.list.flatten()
         x0, x1, x2 = x[dofs_block, 0], x[dofs_block, 1], x[dofs_block, 2]
         if gdim == 2:
             basis[2][dofs[0]] = -x1
@@ -73,13 +73,13 @@ def build_broken_elastic_nullspace(V):
         vec_local = [stack.enter_context(x.localForm()) for x in ns]
         basis = [np.asarray(x) for x in vec_local]
 
-        dofs = [V.sub(i).dofmap.list.array for i in range(2)]
+        dofs = [V.sub(i).dofmap.list.flatten() for i in range(2)]
         basis[0][dofs[0]] = 1.0
         basis[1][dofs[1]] = 1.0
 
         # Build rotational null space basis
         x = V.tabulate_dof_coordinates()
-        dofs_block = V.dofmap.list.array
+        dofs_block = V.dofmap.list.flatten()
         x0, x1 = x[dofs_block, 0], x[dofs_block, 1]
         basis[2][dofs[0]] = -x1
         basis[2][dofs[1]] = x0

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -68,7 +68,7 @@ def submesh_geometry_test(mesh, submesh, entity_map, geom_map, entity_dim):
 
         e_to_g = entities_to_geometry(mesh._cpp_object, entity_dim, entity_map, False)
         for submesh_entity in range(len(entity_map)):
-            submesh_x_dofs = submesh.geometry.dofmap.links(submesh_entity)
+            submesh_x_dofs = submesh.geometry.dofmap[submesh_entity]
             # e_to_g[i] gets the mesh x_dofs of entities[i], which should
             # correspond to the x_dofs of cell i in the submesh
             mesh_x_dofs = e_to_g[submesh_entity]


### PR DESCRIPTION
This change stores dofmap data as flat vectors rather than AdjacencyLists, and uses `mdspan` for convenient access. This uses less memory that AdjacencyLists and data access is more performance friendly.

Assumption is that all elements in a DofMap have the same number io dofs. This is presently that case, and for more complex cases in the future, e.g. mixed cell types, each element type will have its own DofMap. This follows the design that has been started for mixed topology, where cells are stored by type, and operations like assembly will be per cell type/kernel.

It's useful to make this change now as unpicking the code will be a lot harder once mixed topology support is further developed. Moreover, removing necessary use of `AdjacencyList` makes considerations dealing with  #2624 simpler as the impact of any change is reduced. 