### PR TITLE
Support for `FiniteElement`s with different scalar types

### DIFF
--- a/cpp/demo/interpolation-io/main.cpp
+++ b/cpp/demo/interpolation-io/main.cpp
@@ -160,11 +160,11 @@ void interpolate_nedelec(std::shared_ptr<mesh::Mesh<U>> mesh,
   // space:
   u_l->interpolate(*u);
 
-// Output the discontinuous Lagrange space in VTX format. When
-// plotting the x0 component the field will appear discontinuous at x0
-// = 0.5 (jump in the normal component between cells) and the x1
-// component will appear continuous (continuous tangent component
-// between cells).
+  // Output the discontinuous Lagrange space in VTX format. When
+  // plotting the x0 component the field will appear discontinuous at x0
+  // = 0.5 (jump in the normal component between cells) and the x1
+  // component will appear continuous (continuous tangent component
+  // between cells).
 #ifdef HAS_ADIOS2
   io::VTXWriter<U> outfile(mesh->comm(), filename.replace_extension("bp"),
                            {u_l});

--- a/cpp/demo/interpolation-io/main.cpp
+++ b/cpp/demo/interpolation-io/main.cpp
@@ -55,12 +55,13 @@ void interpolate_scalar(std::shared_ptr<mesh::Mesh<U>> mesh,
         return {f, {f.size()}};
       });
 
-  // #ifdef HAS_ADIOS2
-  //   // Write the function to a VTX file for visualisation, e.g. using
-  //   // ParaView
-  //   io::VTXWriter<U> outfile(mesh->comm(), filename.replace_extension("bp"),
-  //   {u}); outfile.write(0.0); outfile.close();
-  // #endif
+#ifdef HAS_ADIOS2
+  // Write the function to a VTX file for visualisation, e.g. using
+  // ParaView
+  io::VTXWriter<U> outfile(mesh->comm(), filename.replace_extension("bp"), {u});
+  outfile.write(0.0);
+  outfile.close();
+#endif
 }
 
 // This function interpolations a function is a H(curl) finite element
@@ -159,17 +160,17 @@ void interpolate_nedelec(std::shared_ptr<mesh::Mesh<U>> mesh,
   // space:
   u_l->interpolate(*u);
 
-  // Output the discontinuous Lagrange space in VTX format. When
-  // plotting the x0 component the field will appear discontinuous at x0
-  // = 0.5 (jump in the normal component between cells) and the x1
-  // component will appear continuous (continuous tangent component
-  // between cells).
-  // #ifdef HAS_ADIOS2
-  //   io::VTXWriter<U> outfile(mesh->comm(), filename.replace_extension("bp"),
-  //                            {u_l});
-  //   outfile.write(0.0);
-  //   outfile.close();
-  // #endif
+// Output the discontinuous Lagrange space in VTX format. When
+// plotting the x0 component the field will appear discontinuous at x0
+// = 0.5 (jump in the normal component between cells) and the x1
+// component will appear continuous (continuous tangent component
+// between cells).
+#ifdef HAS_ADIOS2
+  io::VTXWriter<U> outfile(mesh->comm(), filename.replace_extension("bp"),
+                           {u_l});
+  outfile.write(0.0);
+  outfile.close();
+#endif
 }
 
 /// This program shows how to create finite element spaces without FFCx
@@ -204,17 +205,17 @@ int main(int argc, char* argv[])
     // Interpolate a function in a scalar Lagrange space and output the
     // result to file for visualisation using different types
     interpolate_scalar<float>(mesh0, "u32");
-    // interpolate_scalar<double>(mesh1, "u64");
-    // interpolate_scalar<std::complex<float>>(mesh0, "u_complex64");
-    // interpolate_scalar<std::complex<double>>(mesh1, "u_complex128");
+    interpolate_scalar<double>(mesh1, "u64");
+    interpolate_scalar<std::complex<float>>(mesh0, "u_complex64");
+    interpolate_scalar<std::complex<double>>(mesh1, "u_complex128");
 
-    // // Interpolate a function in a H(curl) finite element space, and
-    // // then interpolate the H(curl) function in a discontinuous Lagrange
-    // // space for visualisation using different types
-    // interpolate_nedelec<float>(mesh0, "u_nedelec32");
-    // interpolate_nedelec<double>(mesh1, "u_nedelec64");
-    // interpolate_nedelec<std::complex<float>>(mesh0, "u_nedelec_complex64");
-    // interpolate_nedelec<std::complex<double>>(mesh1, "u_nedelec_complex12");
+    // Interpolate a function in a H(curl) finite element space, and
+    // then interpolate the H(curl) function in a discontinuous Lagrange
+    // space for visualisation using different types
+    interpolate_nedelec<float>(mesh0, "u_nedelec32");
+    interpolate_nedelec<double>(mesh1, "u_nedelec64");
+    interpolate_nedelec<std::complex<float>>(mesh0, "u_nedelec_complex64");
+    interpolate_nedelec<std::complex<double>>(mesh1, "u_nedelec_complex12");
   }
 
   MPI_Finalize();

--- a/cpp/demo/mixed_topology/main.cpp
+++ b/cpp/demo/mixed_topology/main.cpp
@@ -102,7 +102,7 @@ int main(int argc, char* argv[])
   std::vector<dolfinx::mesh::CellType> cell_types{
       dolfinx::mesh::CellType::quadrilateral,
       dolfinx::mesh::CellType::triangle};
-  std::vector<dolfinx::fem::CoordinateElement> elements;
+  std::vector<dolfinx::fem::CoordinateElement<double>> elements;
   for (auto ct : cell_types)
     elements.push_back(dolfinx::fem::CoordinateElement(ct, 1));
 

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -67,8 +67,9 @@ ElementDofLayout CoordinateElement<T>::create_dof_layout() const
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
-void CoordinateElement<T>::pull_back_nonaffine(mdspan2_t X, cmdspan2_t x,
-                                               cmdspan2_t cell_geometry,
+void CoordinateElement<T>::pull_back_nonaffine(mdspan2_t<T> X,
+                                               mdspan2_t<const T> x,
+                                               mdspan2_t<const T> cell_geometry,
                                                double tol, int maxit) const
 {
   // Number of points
@@ -84,20 +85,17 @@ void CoordinateElement<T>::pull_back_nonaffine(mdspan2_t X, cmdspan2_t x,
   assert(X.extent(1) == tdim);
 
   std::vector<T> dphi_b(tdim * num_xnodes);
-  mdspan2_t dphi(dphi_b.data(), tdim, num_xnodes);
+  mdspan2_t<T> dphi(dphi_b.data(), tdim, num_xnodes);
 
   std::vector<T> Xk_b(tdim);
-  mdspan2_t Xk(Xk_b.data(), 1, tdim);
+  mdspan2_t<T> Xk(Xk_b.data(), 1, tdim);
 
   std::array<T, 3> xk = {0, 0, 0};
-
   std::vector<T> dX(tdim);
-
   std::vector<T> J_b(gdim * tdim);
-  mdspan2_t J(J_b.data(), gdim, tdim);
-
+  mdspan2_t<T> J(J_b.data(), gdim, tdim);
   std::vector<T> K_b(tdim * gdim);
-  mdspan2_t K(K_b.data(), tdim, gdim);
+  mdspan2_t<T> K(K_b.data(), tdim, gdim);
 
   namespace stdex = std::experimental;
   using mdspan4_t = stdex::mdspan<T, stdex::dextents<std::size_t, 4>>;
@@ -107,7 +105,6 @@ void CoordinateElement<T>::pull_back_nonaffine(mdspan2_t X, cmdspan2_t x,
       std::reduce(bsize.begin(), bsize.end(), 1, std::multiplies{}));
   mdspan4_t basis(basis_b.data(), bsize);
   std::vector<T> phi(basis.extent(2));
-
   for (std::size_t p = 0; p < num_points; ++p)
   {
     std::fill(Xk_b.begin(), Xk_b.end(), 0.0);

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -14,8 +14,9 @@ using namespace dolfinx;
 using namespace dolfinx::fem;
 
 //-----------------------------------------------------------------------------
-CoordinateElement::CoordinateElement(
-    std::shared_ptr<const basix::FiniteElement<double>> element)
+template <std::floating_point T>
+CoordinateElement<T>::CoordinateElement(
+    std::shared_ptr<const basix::FiniteElement<T>> element)
     : _element(element)
 {
   int degree = _element->degree();
@@ -23,45 +24,52 @@ CoordinateElement::CoordinateElement(
   _is_affine = mesh::is_simplex(cell) and degree == 1;
 }
 //-----------------------------------------------------------------------------
-CoordinateElement::CoordinateElement(mesh::CellType celltype, int degree,
-                                     basix::element::lagrange_variant type)
-    : CoordinateElement(std::make_shared<basix::FiniteElement<double>>(
-        basix::create_element<double>(
+template <std::floating_point T>
+CoordinateElement<T>::CoordinateElement(mesh::CellType celltype, int degree,
+                                        basix::element::lagrange_variant type)
+    : CoordinateElement(
+        std::make_shared<basix::FiniteElement<T>>(basix::create_element<T>(
             basix::element::family::P, mesh::cell_type_to_basix_type(celltype),
             degree, type, basix::element::dpc_variant::unset, false)))
 {
   // Do nothing
 }
 //-----------------------------------------------------------------------------
-mesh::CellType CoordinateElement::cell_shape() const
+template <std::floating_point T>
+mesh::CellType CoordinateElement<T>::cell_shape() const
 {
   return mesh::cell_type_from_basix_type(_element->cell_type());
 }
 //-----------------------------------------------------------------------------
+template <std::floating_point T>
 std::array<std::size_t, 4>
-CoordinateElement::tabulate_shape(std::size_t nd, std::size_t num_points) const
+CoordinateElement<T>::tabulate_shape(std::size_t nd,
+                                     std::size_t num_points) const
 {
   return _element->tabulate_shape(nd, num_points);
 }
 //-----------------------------------------------------------------------------
-void CoordinateElement::tabulate(int nd, std::span<const double> X,
-                                 std::array<std::size_t, 2> shape,
-                                 std::span<double> basis) const
+template <std::floating_point T>
+void CoordinateElement<T>::tabulate(int nd, std::span<const T> X,
+                                    std::array<std::size_t, 2> shape,
+                                    std::span<T> basis) const
 {
   assert(_element);
   _element->tabulate(nd, X, shape, basis);
 }
 //--------------------------------------------------------------------------------
-ElementDofLayout CoordinateElement::create_dof_layout() const
+template <std::floating_point T>
+ElementDofLayout CoordinateElement<T>::create_dof_layout() const
 {
   assert(_element);
   return ElementDofLayout(1, _element->entity_dofs(),
                           _element->entity_closure_dofs(), {}, {});
 }
 //-----------------------------------------------------------------------------
-void CoordinateElement::pull_back_nonaffine(mdspan2_t X, cmdspan2_t x,
-                                            cmdspan2_t cell_geometry,
-                                            double tol, int maxit) const
+template <std::floating_point T>
+void CoordinateElement<T>::pull_back_nonaffine(mdspan2_t X, cmdspan2_t x,
+                                               cmdspan2_t cell_geometry,
+                                               double tol, int maxit) const
 {
   // Number of points
   std::size_t num_points = x.extent(0);
@@ -75,30 +83,30 @@ void CoordinateElement::pull_back_nonaffine(mdspan2_t X, cmdspan2_t x,
   assert(X.extent(0) == num_points);
   assert(X.extent(1) == tdim);
 
-  std::vector<double> dphi_b(tdim * num_xnodes);
+  std::vector<T> dphi_b(tdim * num_xnodes);
   mdspan2_t dphi(dphi_b.data(), tdim, num_xnodes);
 
-  std::vector<double> Xk_b(tdim);
+  std::vector<T> Xk_b(tdim);
   mdspan2_t Xk(Xk_b.data(), 1, tdim);
 
-  std::array<double, 3> xk = {0, 0, 0};
+  std::array<T, 3> xk = {0, 0, 0};
 
-  std::vector<double> dX(tdim);
+  std::vector<T> dX(tdim);
 
-  std::vector<double> J_b(gdim * tdim);
+  std::vector<T> J_b(gdim * tdim);
   mdspan2_t J(J_b.data(), gdim, tdim);
 
-  std::vector<double> K_b(tdim * gdim);
+  std::vector<T> K_b(tdim * gdim);
   mdspan2_t K(K_b.data(), tdim, gdim);
 
   namespace stdex = std::experimental;
-  using mdspan4_t = stdex::mdspan<double, stdex::dextents<std::size_t, 4>>;
+  using mdspan4_t = stdex::mdspan<T, stdex::dextents<std::size_t, 4>>;
 
   const std::array<std::size_t, 4> bsize = _element->tabulate_shape(1, 1);
-  std::vector<double> basis_b(
+  std::vector<T> basis_b(
       std::reduce(bsize.begin(), bsize.end(), 1, std::multiplies{}));
   mdspan4_t basis(basis_b.data(), bsize);
-  std::vector<double> phi(basis.extent(2));
+  std::vector<T> phi(basis.extent(2));
 
   for (std::size_t p = 0; p < num_points; ++p)
   {
@@ -131,7 +139,7 @@ void CoordinateElement::pull_back_nonaffine(mdspan2_t X, cmdspan2_t x,
 
       // Compute Xk += dX
       std::transform(dX.begin(), dX.end(), Xk_b.begin(), Xk_b.begin(),
-                     [](double a, double b) { return a + b; });
+                     [](auto a, auto b) { return a + b; });
 
       // Compute norm(dX)
       if (auto dX_squared
@@ -153,42 +161,51 @@ void CoordinateElement::pull_back_nonaffine(mdspan2_t X, cmdspan2_t x,
   }
 }
 //-----------------------------------------------------------------------------
-void CoordinateElement::permute_dofs(const std::span<std::int32_t>& dofs,
-                                     std::uint32_t cell_perm) const
+template <std::floating_point T>
+void CoordinateElement<T>::permute_dofs(const std::span<std::int32_t>& dofs,
+                                        std::uint32_t cell_perm) const
 {
   assert(_element);
   _element->permute_dofs(dofs, cell_perm);
 }
 //-----------------------------------------------------------------------------
-void CoordinateElement::unpermute_dofs(const std::span<std::int32_t>& dofs,
-                                       std::uint32_t cell_perm) const
+template <std::floating_point T>
+void CoordinateElement<T>::unpermute_dofs(const std::span<std::int32_t>& dofs,
+                                          std::uint32_t cell_perm) const
 {
   assert(_element);
   _element->unpermute_dofs(dofs, cell_perm);
 }
 //-----------------------------------------------------------------------------
-bool CoordinateElement::needs_dof_permutations() const
+template <std::floating_point T>
+bool CoordinateElement<T>::needs_dof_permutations() const
 {
   assert(_element);
   assert(_element->dof_transformations_are_permutations());
   return !_element->dof_transformations_are_identity();
 }
 //-----------------------------------------------------------------------------
-int CoordinateElement::degree() const
+template <std::floating_point T>
+int CoordinateElement<T>::degree() const
 {
   assert(_element);
   return _element->degree();
 }
 //-----------------------------------------------------------------------------
-int CoordinateElement::dim() const
+template <std::floating_point T>
+int CoordinateElement<T>::dim() const
 {
   assert(_element);
   return _element->dim();
 }
 //-----------------------------------------------------------------------------
-basix::element::lagrange_variant CoordinateElement::variant() const
+template <std::floating_point T>
+basix::element::lagrange_variant CoordinateElement<T>::variant() const
 {
   assert(_element);
   return _element->lagrange_variant();
 }
+//-----------------------------------------------------------------------------
+template class fem::CoordinateElement<float>;
+template class fem::CoordinateElement<double>;
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -110,8 +110,8 @@ public:
   template <typename U, typename V>
   static void compute_jacobian_inverse(const U& J, V&& K)
   {
-    const int gdim = J.extent(0);
-    const int tdim = K.extent(0);
+    int gdim = J.extent(0);
+    int tdim = K.extent(0);
     if (gdim == tdim)
       math::inv(J, K);
     else
@@ -201,12 +201,9 @@ public:
   }
 
   /// mdspan typedef
+  template <typename X>
   using mdspan2_t
-      = std::experimental::mdspan<T,
-                                  std::experimental::dextents<std::size_t, 2>>;
-  /// mdspan typedef
-  using cmdspan2_t
-      = std::experimental::mdspan<const T,
+      = std::experimental::mdspan<X,
                                   std::experimental::dextents<std::size_t, 2>>;
 
   /// Compute reference coordinates X for physical coordinates x for a
@@ -220,7 +217,8 @@ public:
   /// @param [in] maxit Maximum number of Newton iterations
   /// @note If convergence is not achieved within maxit, the function
   /// throws a runtime error.
-  void pull_back_nonaffine(mdspan2_t X, cmdspan2_t x, cmdspan2_t cell_geometry,
+  void pull_back_nonaffine(mdspan2_t<T> X, mdspan2_t<const T> x,
+                           mdspan2_t<const T> cell_geometry,
                            double tol = 1.0e-8, int maxit = 10) const;
 
   /// Permutes a list of DOF numbers on a cell

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -20,7 +20,7 @@
 
 namespace basix
 {
-template <std::floating_point F>
+template <std::floating_point T>
 class FiniteElement;
 }
 
@@ -30,13 +30,14 @@ namespace dolfinx::fem
 /// A CoordinateElement manages coordinate mappings for isoparametric
 /// cells.
 /// @todo A dof layout on a reference cell needs to be defined.
+template <std::floating_point T>
 class CoordinateElement
 {
 public:
   /// Create a coordinate element from a Basix element
   /// @param[in] element Element from Basix
   explicit CoordinateElement(
-      std::shared_ptr<const basix::FiniteElement<double>> element);
+      std::shared_ptr<const basix::FiniteElement<T>> element);
 
   /// Create a Lagrange coordinate element
   /// @param[in] celltype The cell shape
@@ -86,9 +87,8 @@ public:
   /// @param[out] basis The array to fill with the basis function
   /// values. The shape can be computed using
   /// `FiniteElement::tabulate_shape`
-  void tabulate(int nd, std::span<const double> X,
-                std::array<std::size_t, 2> shape,
-                std::span<double> basis) const;
+  void tabulate(int nd, std::span<const T> X, std::array<std::size_t, 2> shape,
+                std::span<T> basis) const;
 
   /// Compute Jacobian for a cell with given geometry using the
   /// basis functions and first order derivatives.
@@ -134,9 +134,9 @@ public:
     {
       assert(w.size() >= 2 * J.extent(0) * J.extent(1));
 
-      using T = typename U::element_type;
+      using X = typename U::element_type;
       namespace stdex = std::experimental;
-      using mdspan2_t = stdex::mdspan<T, stdex::dextents<std::size_t, 2>>;
+      using mdspan2_t = stdex::mdspan<X, stdex::dextents<std::size_t, 2>>;
       mdspan2_t B(w.data(), J.extent(1), J.extent(0));
       mdspan2_t BA(w.data() + J.extent(0) * J.extent(1), B.extent(0),
                    J.extent(1));
@@ -183,8 +183,8 @@ public:
   /// 0).
   /// @param[in] x The physical coordinates (shape=(num_points, gdim))
   template <typename U, typename V, typename W>
-  static void pull_back_affine(U&& X, const V& K,
-                               const std::array<double, 3>& x0, const W& x)
+  static void pull_back_affine(U&& X, const V& K, const std::array<T, 3>& x0,
+                               const W& x)
   {
     assert(X.extent(0) == x.extent(0));
     assert(X.extent(1) == K.extent(0));
@@ -202,11 +202,11 @@ public:
 
   /// mdspan typedef
   using mdspan2_t
-      = std::experimental::mdspan<double,
+      = std::experimental::mdspan<T,
                                   std::experimental::dextents<std::size_t, 2>>;
   /// mdspan typedef
   using cmdspan2_t
-      = std::experimental::mdspan<const double,
+      = std::experimental::mdspan<const T,
                                   std::experimental::dextents<std::size_t, 2>>;
 
   /// Compute reference coordinates X for physical coordinates x for a
@@ -247,6 +247,6 @@ private:
   bool _is_affine;
 
   // Basix Element
-  std::shared_ptr<const basix::FiniteElement<double>> _element;
+  std::shared_ptr<const basix::FiniteElement<T>> _element;
 };
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -139,7 +139,7 @@ public:
     // Prepare coefficients and constants
     const auto [coeffs, cstride] = pack_coefficients(*this, cells);
     const std::vector<T> constant_data = pack_constants(*this);
-    const auto& fn = this->get_tabulate_expression();
+    auto fn = this->get_tabulate_expression();
 
     // Prepare cell geometry
     assert(_mesh);

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -87,8 +87,7 @@ _extract_sub_element(const FiniteElement<T>& finite_element,
   }
 
   // Get sub system
-  std::shared_ptr<const FiniteElement<T>> sub_element
-      = finite_element.sub_elements()[component[0]];
+  auto sub_element = finite_element.sub_elements()[component[0]];
   assert(sub_element);
 
   // Return sub system if sub sub system should not be extracted
@@ -413,8 +412,7 @@ std::shared_ptr<const FiniteElement<T>>
 FiniteElement<T>::extract_sub_element(const std::vector<int>& component) const
 {
   // Recursively extract sub element
-  std::shared_ptr<const FiniteElement<T>> sub_finite_element
-      = _extract_sub_element(*this, component);
+  auto sub_finite_element = _extract_sub_element(*this, component);
   DLOG(INFO) << "Extracted finite element for sub-system: "
              << sub_finite_element->signature().c_str();
   return sub_finite_element;

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -200,8 +200,7 @@ FiniteElement<T>::FiniteElement(const ufcx_finite_element& e)
           std::array mshape = {ndofs, value_size, npts, nderivs_dim};
           std::size_t msize
               = std::reduce(mshape.begin(), mshape.end(), 1, std::multiplies{});
-          auto& mat
-              = M[d].emplace_back(std::vector<double>(msize), mshape).first;
+          auto& mat = M[d].emplace_back(std::vector<T>(msize), mshape).first;
           std::copy_n(ce->M + m_e, mat.size(), mat.begin());
           m_e += mat.size();
         }
@@ -374,7 +373,7 @@ std::string FiniteElement<T>::family() const noexcept
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
-void FiniteElement<T>::tabulate(std::span<T> values, std::span<const double> X,
+void FiniteElement<T>::tabulate(std::span<T> values, std::span<const T> X,
                                 std::array<std::size_t, 2> shape,
                                 int order) const
 {
@@ -384,7 +383,7 @@ void FiniteElement<T>::tabulate(std::span<T> values, std::span<const double> X,
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
 std::pair<std::vector<T>, std::array<std::size_t, 4>>
-FiniteElement<T>::tabulate(std::span<const double> X,
+FiniteElement<T>::tabulate(std::span<const T> X,
                            std::array<std::size_t, 2> shape, int order) const
 {
   assert(_element);
@@ -512,7 +511,7 @@ FiniteElement<T>::create_interpolation_operator(const FiniteElement& from) const
     const auto [data, dshape]
         = basix::compute_interpolation_operator<T>(*from._element, *_element);
     std::array<std::size_t, 2> shape = {dshape[0] * _bs, dshape[1] * _bs};
-    std::vector<double> out(shape[0] * shape[1]);
+    std::vector<T> out(shape[0] * shape[1]);
 
     // NOTE: Alternatively this operation could be implemented during
     // matvec with the original matrix
@@ -633,6 +632,6 @@ FiniteElement<T>::get_dof_permutation_function(bool inverse,
   }
 }
 //-----------------------------------------------------------------------------
-// template class fem::FiniteElement<float>;
+template class fem::FiniteElement<float>;
 template class fem::FiniteElement<double>;
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -56,8 +56,9 @@ bool is_basix_custom_element(const ufcx_finite_element& element)
 }
 //-----------------------------------------------------------------------------
 // Recursively extract sub finite element
-std::shared_ptr<const FiniteElement>
-_extract_sub_element(const FiniteElement& finite_element,
+template <std::floating_point T>
+std::shared_ptr<const FiniteElement<T>>
+_extract_sub_element(const FiniteElement<T>& finite_element,
                      const std::vector<int>& component)
 {
   // Check that a sub system has been specified
@@ -83,7 +84,7 @@ _extract_sub_element(const FiniteElement& finite_element,
   }
 
   // Get sub system
-  std::shared_ptr<const FiniteElement> sub_element
+  std::shared_ptr<const FiniteElement<T>> sub_element
       = finite_element.sub_elements()[component[0]];
   assert(sub_element);
 
@@ -101,7 +102,8 @@ _extract_sub_element(const FiniteElement& finite_element,
 } // namespace
 
 //-----------------------------------------------------------------------------
-FiniteElement::FiniteElement(const ufcx_finite_element& e)
+template <std::floating_point T>
+FiniteElement<T>::FiniteElement(const ufcx_finite_element& e)
     : _signature(e.signature), _family(e.family), _space_dim(e.space_dimension),
       _value_shape(e.value_shape, e.value_shape + e.value_rank),
       _bs(e.block_size)
@@ -146,15 +148,12 @@ FiniteElement::FiniteElement(const ufcx_finite_element& e)
   for (int i = 0; i < e.num_sub_elements; ++i)
   {
     ufcx_finite_element* ufcx_sub_element = e.sub_elements[i];
-    _sub_elements.push_back(std::make_shared<FiniteElement>(*ufcx_sub_element));
+    _sub_elements.push_back(
+        std::make_shared<FiniteElement<T>>(*ufcx_sub_element));
     if (_sub_elements[i]->needs_dof_permutations())
-    {
       _needs_dof_permutations = true;
-    }
     if (_sub_elements[i]->needs_dof_transformations())
-    {
       _needs_dof_transformations = true;
-    }
   }
 
   if (is_basix_custom_element(e))
@@ -173,8 +172,8 @@ FiniteElement::FiniteElement(const ufcx_finite_element& e)
     const int nderivs = ce->interpolation_nderivs;
     const std::size_t nderivs_dim = basix::polyset::nderivs(cell_type, nderivs);
 
-    using array2_t = std::pair<std::vector<double>, std::array<std::size_t, 2>>;
-    using array4_t = std::pair<std::vector<double>, std::array<std::size_t, 4>>;
+    using array2_t = std::pair<std::vector<T>, std::array<std::size_t, 2>>;
+    using array4_t = std::pair<std::vector<T>, std::array<std::size_t, 4>>;
     std::array<std::vector<array2_t>, 4> x;
     std::array<std::vector<array4_t>, 4> M;
     { // scope
@@ -193,8 +192,7 @@ FiniteElement::FiniteElement(const ufcx_finite_element& e)
 
           std::array pshape = {npts, dim};
           auto& pts
-              = x[d].emplace_back(std::vector<double>(pshape[0] * pshape[1]),
-                                  pshape)
+              = x[d].emplace_back(std::vector<T>(pshape[0] * pshape[1]), pshape)
                     .first;
           std::copy_n(ce->x + p_e, pts.size(), pts.begin());
           p_e += pts.size();
@@ -213,10 +211,8 @@ FiniteElement::FiniteElement(const ufcx_finite_element& e)
     }
 
     namespace stdex = std::experimental;
-    using cmdspan2_t
-        = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
-    using cmdspan4_t
-        = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
+    using cmdspan2_t = stdex::mdspan<const T, stdex::dextents<std::size_t, 2>>;
+    using cmdspan4_t = stdex::mdspan<const T, stdex::dextents<std::size_t, 4>>;
 
     std::array<std::vector<cmdspan2_t>, 4> _x;
     for (std::size_t i = 0; i < x.size(); ++i)
@@ -228,11 +224,11 @@ FiniteElement::FiniteElement(const ufcx_finite_element& e)
       for (auto& [buffer, shape] : M[i])
         _M[i].push_back(cmdspan4_t(buffer.data(), shape));
 
-    std::vector<double> wcoeffs_b(ce->wcoeffs_rows * ce->wcoeffs_cols);
+    std::vector<T> wcoeffs_b(ce->wcoeffs_rows * ce->wcoeffs_cols);
     cmdspan2_t wcoeffs(wcoeffs_b.data(), ce->wcoeffs_rows, ce->wcoeffs_cols);
     std::copy_n(ce->wcoeffs, wcoeffs_b.size(), wcoeffs_b.begin());
 
-    _element = std::make_unique<basix::FiniteElement<double>>(
+    _element = std::make_unique<basix::FiniteElement<T>>(
         basix::create_custom_element(
             cell_type, value_shape, wcoeffs, _x, _M, nderivs,
             static_cast<basix::maps::type>(ce->map_type),
@@ -249,8 +245,8 @@ FiniteElement::FiniteElement(const ufcx_finite_element& e)
   }
   else if (is_basix_element(e))
   {
-    _element = std::make_unique<basix::FiniteElement<double>>(
-        basix::create_element<double>(
+    _element
+        = std::make_unique<basix::FiniteElement<T>>(basix::create_element<T>(
             static_cast<basix::element::family>(e.basix_family),
             static_cast<basix::cell::type>(e.basix_cell), e.degree,
             static_cast<basix::element::lagrange_variant>(e.lagrange_variant),
@@ -267,8 +263,8 @@ FiniteElement::FiniteElement(const ufcx_finite_element& e)
   }
 }
 //-----------------------------------------------------------------------------
-FiniteElement::FiniteElement(const basix::FiniteElement<double>& element,
-                             int bs)
+template <std::floating_point T>
+FiniteElement<T>::FiniteElement(const basix::FiniteElement<T>& element, int bs)
     : _space_dim(bs * element.dim()), _value_shape(element.value_shape()),
       _bs(bs)
 {
@@ -281,10 +277,10 @@ FiniteElement::FiniteElement(const basix::FiniteElement<double>& element,
   {
     // Create all sub-elements
     for (int i = 0; i < bs; ++i)
-      _sub_elements.push_back(std::make_shared<FiniteElement>(element, 1));
+      _sub_elements.push_back(std::make_shared<FiniteElement<T>>(element, 1));
   }
 
-  _element = std::make_unique<basix::FiniteElement<double>>(element);
+  _element = std::make_unique<basix::FiniteElement<T>>(element);
   assert(_element);
   _needs_dof_transformations
       = !_element->dof_transformations_are_identity()
@@ -310,7 +306,8 @@ FiniteElement::FiniteElement(const basix::FiniteElement<double>& element,
   _signature = "Basix element " + _family + " " + std::to_string(bs);
 }
 //-----------------------------------------------------------------------------
-bool FiniteElement::operator==(const FiniteElement& e) const
+template <std::floating_point T>
+bool FiniteElement<T>::operator==(const FiniteElement& e) const
 {
   if (!_element or !e._element)
   {
@@ -320,85 +317,113 @@ bool FiniteElement::operator==(const FiniteElement& e) const
   return *_element == *e._element;
 }
 //-----------------------------------------------------------------------------
-bool FiniteElement::operator!=(const FiniteElement& e) const
+template <std::floating_point T>
+bool FiniteElement<T>::operator!=(const FiniteElement& e) const
 {
   return !(*this == e);
 }
 //-----------------------------------------------------------------------------
-std::string FiniteElement::signature() const noexcept { return _signature; }
+template <std::floating_point T>
+std::string FiniteElement<T>::signature() const noexcept
+{
+  return _signature;
+}
 //-----------------------------------------------------------------------------
-mesh::CellType FiniteElement::cell_shape() const noexcept
+template <std::floating_point T>
+mesh::CellType FiniteElement<T>::cell_shape() const noexcept
 {
   return _cell_shape;
 }
 //-----------------------------------------------------------------------------
-int FiniteElement::space_dimension() const noexcept { return _space_dim; }
+template <std::floating_point T>
+int FiniteElement<T>::space_dimension() const noexcept
+{
+  return _space_dim;
+}
 //-----------------------------------------------------------------------------
-int FiniteElement::value_size() const
+template <std::floating_point T>
+int FiniteElement<T>::value_size() const
 {
   return std::accumulate(_value_shape.begin(), _value_shape.end(), 1,
                          std::multiplies{});
 }
 //-----------------------------------------------------------------------------
-int FiniteElement::reference_value_size() const
+template <std::floating_point T>
+int FiniteElement<T>::reference_value_size() const
 {
   return std::accumulate(_value_shape.begin(), _value_shape.end(), 1,
                          std::multiplies{});
 }
 //-----------------------------------------------------------------------------
-int FiniteElement::block_size() const noexcept { return _bs; }
+template <std::floating_point T>
+int FiniteElement<T>::block_size() const noexcept
+{
+  return _bs;
+}
 //-----------------------------------------------------------------------------
-std::span<const std::size_t> FiniteElement::value_shape() const noexcept
+template <std::floating_point T>
+std::span<const std::size_t> FiniteElement<T>::value_shape() const noexcept
 {
   return _value_shape;
 }
 //-----------------------------------------------------------------------------
-std::string FiniteElement::family() const noexcept { return _family; }
+template <std::floating_point T>
+std::string FiniteElement<T>::family() const noexcept
+{
+  return _family;
+}
 //-----------------------------------------------------------------------------
-void FiniteElement::tabulate(std::span<double> values,
-                             std::span<const double> X,
-                             std::array<std::size_t, 2> shape, int order) const
+template <std::floating_point T>
+void FiniteElement<T>::tabulate(std::span<T> values, std::span<const double> X,
+                                std::array<std::size_t, 2> shape,
+                                int order) const
 {
   assert(_element);
   _element->tabulate(order, X, shape, values);
 }
 //-----------------------------------------------------------------------------
-std::pair<std::vector<double>, std::array<std::size_t, 4>>
-FiniteElement::tabulate(std::span<const double> X,
-                        std::array<std::size_t, 2> shape, int order) const
+template <std::floating_point T>
+std::pair<std::vector<T>, std::array<std::size_t, 4>>
+FiniteElement<T>::tabulate(std::span<const double> X,
+                           std::array<std::size_t, 2> shape, int order) const
 {
   assert(_element);
   return _element->tabulate(order, X, shape);
 }
 //-----------------------------------------------------------------------------
-int FiniteElement::num_sub_elements() const noexcept
+template <std::floating_point T>
+int FiniteElement<T>::num_sub_elements() const noexcept
 {
   return _sub_elements.size();
 }
 //-----------------------------------------------------------------------------
-bool FiniteElement::is_mixed() const noexcept
+template <std::floating_point T>
+bool FiniteElement<T>::is_mixed() const noexcept
 {
   return !_sub_elements.empty() and _bs == 1;
 }
 //-----------------------------------------------------------------------------
-const std::vector<std::shared_ptr<const FiniteElement>>&
-FiniteElement::sub_elements() const noexcept
+template <std::floating_point T>
+const std::vector<std::shared_ptr<const FiniteElement<T>>>&
+FiniteElement<T>::sub_elements() const noexcept
 {
   return _sub_elements;
 }
 //-----------------------------------------------------------------------------
-std::shared_ptr<const FiniteElement>
-FiniteElement::extract_sub_element(const std::vector<int>& component) const
+template <std::floating_point T>
+std::shared_ptr<const FiniteElement<T>>
+FiniteElement<T>::extract_sub_element(const std::vector<int>& component) const
 {
   // Recursively extract sub element
-  std::shared_ptr<const FiniteElement> sub_finite_element
+  std::shared_ptr<const FiniteElement<T>> sub_finite_element
       = _extract_sub_element(*this, component);
   DLOG(INFO) << "Extracted finite element for sub-system: "
              << sub_finite_element->signature().c_str();
   return sub_finite_element;
 }
 //-----------------------------------------------------------------------------
-const basix::FiniteElement<double>& FiniteElement::basix_element() const
+template <std::floating_point T>
+const basix::FiniteElement<T>& FiniteElement<T>::basix_element() const
 {
   if (!_element)
   {
@@ -409,7 +434,8 @@ const basix::FiniteElement<double>& FiniteElement::basix_element() const
   return *_element;
 }
 //-----------------------------------------------------------------------------
-basix::maps::type FiniteElement::map_type() const
+template <std::floating_point T>
+basix::maps::type FiniteElement<T>::map_type() const
 {
   if (!_element)
   {
@@ -420,20 +446,23 @@ basix::maps::type FiniteElement::map_type() const
   return _element->map_type();
 }
 //-----------------------------------------------------------------------------
-bool FiniteElement::map_ident() const noexcept
+template <std::floating_point T>
+bool FiniteElement<T>::map_ident() const noexcept
 {
   assert(_element);
   return _element->map_type() == basix::maps::type::identity;
 }
 //-----------------------------------------------------------------------------
-bool FiniteElement::interpolation_ident() const noexcept
+template <std::floating_point T>
+bool FiniteElement<T>::interpolation_ident() const noexcept
 {
   assert(_element);
   return _element->interpolation_is_identity();
 }
 //-----------------------------------------------------------------------------
-std::pair<std::vector<double>, std::array<std::size_t, 2>>
-FiniteElement::interpolation_points() const
+template <std::floating_point T>
+std::pair<std::vector<T>, std::array<std::size_t, 2>>
+FiniteElement<T>::interpolation_points() const
 {
   if (!_element)
   {
@@ -445,8 +474,9 @@ FiniteElement::interpolation_points() const
   return _element->points();
 }
 //-----------------------------------------------------------------------------
-std::pair<std::vector<double>, std::array<std::size_t, 2>>
-FiniteElement::interpolation_operator() const
+template <std::floating_point T>
+std::pair<std::vector<T>, std::array<std::size_t, 2>>
+FiniteElement<T>::interpolation_operator() const
 {
   if (!_element)
   {
@@ -457,8 +487,9 @@ FiniteElement::interpolation_operator() const
   return _element->interpolation_matrix();
 }
 //-----------------------------------------------------------------------------
-std::pair<std::vector<double>, std::array<std::size_t, 2>>
-FiniteElement::create_interpolation_operator(const FiniteElement& from) const
+template <std::floating_point T>
+std::pair<std::vector<T>, std::array<std::size_t, 2>>
+FiniteElement<T>::create_interpolation_operator(const FiniteElement& from) const
 {
   assert(_element);
   assert(from._element);
@@ -472,15 +503,14 @@ FiniteElement::create_interpolation_operator(const FiniteElement& from) const
   {
     // If one of the elements has bs=1, Basix can figure out the size
     // of the matrix
-    return basix::compute_interpolation_operator<double>(*from._element,
-                                                         *_element);
+    return basix::compute_interpolation_operator<T>(*from._element, *_element);
   }
   else if (_bs > 1 and from._bs == _bs)
   {
     // If bs != 1 for at least one element, then bs0 == bs1 for this
     // case
-    const auto [data, dshape] = basix::compute_interpolation_operator<double>(
-        *from._element, *_element);
+    const auto [data, dshape]
+        = basix::compute_interpolation_operator<T>(*from._element, *_element);
     std::array<std::size_t, 2> shape = {dshape[0] * _bs, dshape[1] * _bs};
     std::vector<double> out(shape[0] * shape[1]);
 
@@ -501,36 +531,39 @@ FiniteElement::create_interpolation_operator(const FiniteElement& from) const
   }
 }
 //-----------------------------------------------------------------------------
-bool FiniteElement::needs_dof_transformations() const noexcept
+template <std::floating_point T>
+bool FiniteElement<T>::needs_dof_transformations() const noexcept
 {
   return _needs_dof_transformations;
 }
 //-----------------------------------------------------------------------------
-bool FiniteElement::needs_dof_permutations() const noexcept
+template <std::floating_point T>
+bool FiniteElement<T>::needs_dof_permutations() const noexcept
 {
   return _needs_dof_permutations;
 }
 //-----------------------------------------------------------------------------
-void FiniteElement::permute_dofs(const std::span<std::int32_t>& doflist,
-                                 std::uint32_t cell_permutation) const
+template <std::floating_point T>
+void FiniteElement<T>::permute_dofs(const std::span<std::int32_t>& doflist,
+                                    std::uint32_t cell_permutation) const
 {
   _element->permute_dofs(doflist, cell_permutation);
 }
 //-----------------------------------------------------------------------------
-void FiniteElement::unpermute_dofs(const std::span<std::int32_t>& doflist,
-                                   std::uint32_t cell_permutation) const
+template <std::floating_point T>
+void FiniteElement<T>::unpermute_dofs(const std::span<std::int32_t>& doflist,
+                                      std::uint32_t cell_permutation) const
 {
   _element->unpermute_dofs(doflist, cell_permutation);
 }
 //-----------------------------------------------------------------------------
+template <std::floating_point T>
 std::function<void(const std::span<std::int32_t>&, std::uint32_t)>
-FiniteElement::get_dof_permutation_function(bool inverse,
-                                            bool scalar_element) const
+FiniteElement<T>::get_dof_permutation_function(bool inverse,
+                                               bool scalar_element) const
 {
   if (!needs_dof_permutations())
-  {
     return [](const std::span<std::int32_t>&, std::uint32_t) {};
-  }
 
   if (!_sub_elements.empty())
   {
@@ -599,4 +632,7 @@ FiniteElement::get_dof_permutation_function(bool inverse,
     { permute_dofs(doflist, cell_permutation); };
   }
 }
+//-----------------------------------------------------------------------------
+// template class fem::FiniteElement<float>;
+template class fem::FiniteElement<double>;
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -23,8 +23,9 @@ using namespace dolfinx::fem;
 namespace
 {
 //-----------------------------------------------------------------------------
-// Check if an element is a Basix element (or a blocked element
-// containing a Basix element)
+
+/// Check if an element is a Basix element (or a blocked element
+/// containing a Basix element)
 bool is_basix_element(const ufcx_finite_element& element)
 {
   if (element.element_type == ufcx_basix_element)
@@ -39,8 +40,9 @@ bool is_basix_element(const ufcx_finite_element& element)
     return false;
 }
 //-----------------------------------------------------------------------------
-// Check if an element is a custom Basix element (or a blocked element
-// containing a custom Basix element)
+
+/// Check if an element is a custom Basix element (or a blocked element
+/// containing a custom Basix element)
 bool is_basix_custom_element(const ufcx_finite_element& element)
 {
   if (element.element_type == ufcx_basix_custom_element)
@@ -55,7 +57,8 @@ bool is_basix_custom_element(const ufcx_finite_element& element)
     return false;
 }
 //-----------------------------------------------------------------------------
-// Recursively extract sub finite element
+
+/// Recursively extract sub finite element
 template <std::floating_point T>
 std::shared_ptr<const FiniteElement<T>>
 _extract_sub_element(const FiniteElement<T>& finite_element,
@@ -251,11 +254,9 @@ FiniteElement<T>::FiniteElement(const ufcx_finite_element& e)
             static_cast<basix::element::lagrange_variant>(e.lagrange_variant),
             static_cast<basix::element::dpc_variant>(e.dpc_variant),
             e.discontinuous));
-
     _needs_dof_transformations
         = !_element->dof_transformations_are_identity()
           and !_element->dof_transformations_are_permutations();
-
     _needs_dof_permutations
         = !_element->dof_transformations_are_identity()
           and _element->dof_transformations_are_permutations();
@@ -271,7 +272,6 @@ FiniteElement<T>::FiniteElement(const basix::FiniteElement<T>& element, int bs)
     _value_shape = {1};
   std::transform(_value_shape.cbegin(), _value_shape.cend(),
                  _value_shape.begin(), [bs](auto s) { return bs * s; });
-
   if (bs > 1)
   {
     // Create all sub-elements
@@ -284,11 +284,9 @@ FiniteElement<T>::FiniteElement(const basix::FiniteElement<T>& element, int bs)
   _needs_dof_transformations
       = !_element->dof_transformations_are_identity()
         and !_element->dof_transformations_are_permutations();
-
   _needs_dof_permutations
       = !_element->dof_transformations_are_identity()
         and _element->dof_transformations_are_permutations();
-
   switch (_element->family())
   {
   case basix::element::family::P:
@@ -313,6 +311,7 @@ bool FiniteElement<T>::operator==(const FiniteElement& e) const
     throw std::runtime_error(
         "Missing a Basix element. Cannot check for equivalence");
   }
+
   return *_element == *e._element;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <basix/finite-element.h>
+#include <concepts>
 #include <dolfinx/mesh/cell_types.h>
 #include <functional>
 #include <memory>
@@ -21,6 +22,7 @@ namespace dolfinx::fem
 {
 /// Finite Element, containing the dof layout on a reference element,
 /// and various methods for evaluating and transforming the basis.
+template <std::floating_point T = double>
 class FiniteElement
 {
 public:
@@ -31,7 +33,7 @@ public:
   /// Create finite element from a Basix finite element
   /// @param[in] element Basix finite element
   /// @param[in] bs The block size
-  FiniteElement(const basix::FiniteElement<double>& element, int bs);
+  FiniteElement(const basix::FiniteElement<T>& element, int bs);
 
   /// Copy constructor
   FiniteElement(const FiniteElement& element) = delete;
@@ -115,7 +117,7 @@ public:
   /// @param[in] shape The shape of `X`
   /// @param[in] order The number of derivatives (up to and including
   /// this order) to tabulate for
-  void tabulate(std::span<double> values, std::span<const double> X,
+  void tabulate(std::span<T> values, std::span<const double> X,
                 std::array<std::size_t, 2> shape, int order) const;
 
   /// Evaluate all derivatives of the basis functions up to given order
@@ -127,7 +129,7 @@ public:
   /// @param[in] order The number of derivatives (up to and including
   /// this order) to tabulate for
   /// @return Basis function values and array shape (row-major storage)
-  std::pair<std::vector<double>, std::array<std::size_t, 4>>
+  std::pair<std::vector<T>, std::array<std::size_t, 4>>
   tabulate(std::span<const double> X, std::array<std::size_t, 2> shape,
            int order) const;
 
@@ -142,15 +144,15 @@ public:
   bool is_mixed() const noexcept;
 
   /// Subelements (if any)
-  const std::vector<std::shared_ptr<const FiniteElement>>&
+  const std::vector<std::shared_ptr<const FiniteElement<T>>>&
   sub_elements() const noexcept;
 
   /// Extract sub finite element for component
-  std::shared_ptr<const FiniteElement>
+  std::shared_ptr<const FiniteElement<T>>
   extract_sub_element(const std::vector<int>& component) const;
 
   /// Return underlying basix element (if it exists)
-  const basix::FiniteElement<double>& basix_element() const;
+  const basix::FiniteElement<T>& basix_element() const;
 
   /// Get the map type used by the element
   basix::maps::type map_type() const;
@@ -178,7 +180,7 @@ public:
   /// @return Interpolation point coordinates on the reference cell,
   /// returning the (0) coordinates data (row-major) storage and (1) the
   /// shape `(num_points, tdim)`.
-  std::pair<std::vector<double>, std::array<std::size_t, 2>>
+  std::pair<std::vector<T>, std::array<std::size_t, 2>>
   interpolation_points() const;
 
   /// Interpolation operator (matrix) `Pi` that maps a function
@@ -190,7 +192,7 @@ public:
   /// @return The interpolation operator `Pi`, returning the data for
   /// `Pi` (row-major storage) and the shape `(num_dofs, num_points *
   /// value_size)`
-  std::pair<std::vector<double>, std::array<std::size_t, 2>>
+  std::pair<std::vector<T>, std::array<std::size_t, 2>>
   interpolation_operator() const;
 
   /// @brief Create a matrix that maps degrees of freedom from one
@@ -205,7 +207,7 @@ public:
   /// @pre The two elements must use the same mapping between the
   /// reference and physical cells
   /// @note Does not support mixed elements
-  std::pair<std::vector<double>, std::array<std::size_t, 2>>
+  std::pair<std::vector<T>, std::array<std::size_t, 2>>
   create_interpolation_operator(const FiniteElement& from) const;
 
   /// @brief Check if DOF transformations are needed for this element.
@@ -256,8 +258,8 @@ public:
   /// transformations should be returned
   /// @param[in] scalar_element Indicates whether the scalar
   /// transformations should be returned for a vector element
-  template <typename T>
-  std::function<void(const std::span<T>&, const std::span<const std::uint32_t>&,
+  template <typename U>
+  std::function<void(const std::span<U>&, const std::span<const std::uint32_t>&,
                      std::int32_t, int)>
   get_dof_transformation_function(bool inverse = false, bool transpose = false,
                                   bool scalar_element = false) const
@@ -265,7 +267,7 @@ public:
     if (!needs_dof_transformations())
     {
       // If no permutation needed, return function that does nothing
-      return [](const std::span<T>&, const std::span<const std::uint32_t>&,
+      return [](const std::span<U>&, const std::span<const std::uint32_t>&,
                 std::int32_t, int)
       {
         // Do nothing
@@ -277,7 +279,7 @@ public:
       if (_bs == 1)
       {
         // Mixed element
-        std::vector<std::function<void(const std::span<T>&,
+        std::vector<std::function<void(const std::span<U>&,
                                        const std::span<const std::uint32_t>&,
                                        std::int32_t, int)>>
             sub_element_functions;
@@ -285,13 +287,13 @@ public:
         for (std::size_t i = 0; i < _sub_elements.size(); ++i)
         {
           sub_element_functions.push_back(
-              _sub_elements[i]->get_dof_transformation_function<T>(inverse,
-                                                                   transpose));
+              _sub_elements[i]->template get_dof_transformation_function<U>(
+                  inverse, transpose));
           dims.push_back(_sub_elements[i]->space_dimension());
         }
 
         return [dims, sub_element_functions](
-                   const std::span<T>& data,
+                   const std::span<U>& data,
                    const std::span<const std::uint32_t>& cell_info,
                    std::int32_t cell, int block_size)
         {
@@ -308,14 +310,15 @@ public:
       else if (!scalar_element)
       {
         // Vector element
-        const std::function<void(const std::span<T>&,
+        const std::function<void(const std::span<U>&,
                                  const std::span<const std::uint32_t>&,
                                  std::int32_t, int)>
-            sub_function = _sub_elements[0]->get_dof_transformation_function<T>(
+            sub_function
+            = _sub_elements[0]->template get_dof_transformation_function<U>(
                 inverse, transpose);
         const int ebs = _bs;
         return
-            [ebs, sub_function](const std::span<T>& data,
+            [ebs, sub_function](const std::span<U>& data,
                                 const std::span<const std::uint32_t>& cell_info,
                                 std::int32_t cell, int data_block_size)
         { sub_function(data, cell_info, cell, ebs * data_block_size); };
@@ -325,7 +328,7 @@ public:
     {
       if (inverse)
       {
-        return [this](const std::span<T>& data,
+        return [this](const std::span<U>& data,
                       const std::span<const std::uint32_t>& cell_info,
                       std::int32_t cell, int block_size)
         {
@@ -335,7 +338,7 @@ public:
       }
       else
       {
-        return [this](const std::span<T>& data,
+        return [this](const std::span<U>& data,
                       const std::span<const std::uint32_t>& cell_info,
                       std::int32_t cell, int block_size) {
           apply_transpose_dof_transformation(data, cell_info[cell], block_size);
@@ -346,7 +349,7 @@ public:
     {
       if (inverse)
       {
-        return [this](const std::span<T>& data,
+        return [this](const std::span<U>& data,
                       const std::span<const std::uint32_t>& cell_info,
                       std::int32_t cell, int block_size) {
           apply_inverse_dof_transformation(data, cell_info[cell], block_size);
@@ -354,7 +357,7 @@ public:
       }
       else
       {
-        return [this](const std::span<T>& data,
+        return [this](const std::span<U>& data,
                       const std::span<const std::uint32_t>& cell_info,
                       std::int32_t cell, int block_size)
         { apply_dof_transformation(data, cell_info[cell], block_size); };
@@ -380,8 +383,8 @@ public:
   /// transformations should be returned
   /// @param[in] scalar_element Indicated whether the scalar
   /// transformations should be returned for a vector element
-  template <typename T>
-  std::function<void(const std::span<T>&, const std::span<const std::uint32_t>&,
+  template <typename U>
+  std::function<void(const std::span<U>&, const std::span<const std::uint32_t>&,
                      std::int32_t, int)>
   get_dof_transformation_to_transpose_function(bool inverse = false,
                                                bool transpose = false,
@@ -391,7 +394,7 @@ public:
     if (!needs_dof_transformations())
     {
       // If no permutation needed, return function that does nothing
-      return [](const std::span<T>&, const std::span<const std::uint32_t>&,
+      return [](const std::span<U>&, const std::span<const std::uint32_t>&,
                 std::int32_t, int)
       {
         // Do nothing
@@ -402,19 +405,20 @@ public:
       if (_bs == 1)
       {
         // Mixed element
-        std::vector<std::function<void(const std::span<T>&,
+        std::vector<std::function<void(const std::span<U>&,
                                        const std::span<const std::uint32_t>&,
                                        std::int32_t, int)>>
             sub_element_functions;
         for (std::size_t i = 0; i < _sub_elements.size(); ++i)
         {
           sub_element_functions.push_back(
-              _sub_elements[i]->get_dof_transformation_to_transpose_function<T>(
-                  inverse, transpose));
+              _sub_elements[i]
+                  ->template get_dof_transformation_to_transpose_function<U>(
+                      inverse, transpose));
         }
 
         return [this, sub_element_functions](
-                   const std::span<T>& data,
+                   const std::span<U>& data,
                    const std::span<const std::uint32_t>& cell_info,
                    std::int32_t cell, int block_size)
         {
@@ -430,13 +434,14 @@ public:
       else if (!scalar_element)
       {
         // Vector element
-        const std::function<void(const std::span<T>&,
+        const std::function<void(const std::span<U>&,
                                  const std::span<const std::uint32_t>&,
                                  std::int32_t, int)>
-            sub_function = _sub_elements[0]->get_dof_transformation_function<T>(
+            sub_function
+            = _sub_elements[0]->template get_dof_transformation_function<U>(
                 inverse, transpose);
         return [this,
-                sub_function](const std::span<T>& data,
+                sub_function](const std::span<U>& data,
                               const std::span<const std::uint32_t>& cell_info,
                               std::int32_t cell, int data_block_size)
         {
@@ -455,7 +460,7 @@ public:
     {
       if (inverse)
       {
-        return [this](const std::span<T>& data,
+        return [this](const std::span<U>& data,
                       const std::span<const std::uint32_t>& cell_info,
                       std::int32_t cell, int block_size)
         {
@@ -465,7 +470,7 @@ public:
       }
       else
       {
-        return [this](const std::span<T>& data,
+        return [this](const std::span<U>& data,
                       const std::span<const std::uint32_t>& cell_info,
                       std::int32_t cell, int block_size)
         {
@@ -478,7 +483,7 @@ public:
     {
       if (inverse)
       {
-        return [this](const std::span<T>& data,
+        return [this](const std::span<U>& data,
                       const std::span<const std::uint32_t>& cell_info,
                       std::int32_t cell, int block_size)
         {
@@ -488,7 +493,7 @@ public:
       }
       else
       {
-        return [this](const std::span<T>& data,
+        return [this](const std::span<U>& data,
                       const std::span<const std::uint32_t>& cell_info,
                       std::int32_t cell, int block_size) {
           apply_dof_transformation_to_transpose(data, cell_info[cell],
@@ -504,8 +509,8 @@ public:
   /// with row-major layout, shape=(num_dofs, block_size)
   /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input data
-  template <typename T>
-  void apply_dof_transformation(const std::span<T>& data,
+  template <typename U>
+  void apply_dof_transformation(const std::span<U>& data,
                                 std::uint32_t cell_permutation,
                                 int block_size) const
   {
@@ -521,9 +526,9 @@ public:
   /// with row-major layout, shape=(num_dofs, block_size)
   /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input data
-  template <typename T>
+  template <typename U>
   void
-  apply_inverse_transpose_dof_transformation(const std::span<T>& data,
+  apply_inverse_transpose_dof_transformation(const std::span<U>& data,
                                              std::uint32_t cell_permutation,
                                              int block_size) const
   {
@@ -539,8 +544,8 @@ public:
   /// with row-major layout, shape=(num_dofs, block_size)
   /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input data
-  template <typename T>
-  void apply_transpose_dof_transformation(const std::span<T>& data,
+  template <typename U>
+  void apply_transpose_dof_transformation(const std::span<U>& data,
                                           std::uint32_t cell_permutation,
                                           int block_size) const
   {
@@ -556,8 +561,8 @@ public:
   /// with row-major layout, shape=(num_dofs, block_size)
   /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input data
-  template <typename T>
-  void apply_inverse_dof_transformation(const std::span<T>& data,
+  template <typename U>
+  void apply_inverse_dof_transformation(const std::span<U>& data,
                                         std::uint32_t cell_permutation,
                                         int block_size) const
   {
@@ -572,8 +577,8 @@ public:
   /// with row-major layout, shape=(num_dofs, block_size)
   /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input data
-  template <typename T>
-  void apply_dof_transformation_to_transpose(const std::span<T>& data,
+  template <typename U>
+  void apply_dof_transformation_to_transpose(const std::span<U>& data,
                                              std::uint32_t cell_permutation,
                                              int block_size) const
   {
@@ -588,9 +593,9 @@ public:
   /// with row-major layout, shape=(num_dofs, block_size)
   /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input data
-  template <typename T>
+  template <typename U>
   void
-  apply_inverse_dof_transformation_to_transpose(const std::span<T>& data,
+  apply_inverse_dof_transformation_to_transpose(const std::span<U>& data,
                                                 std::uint32_t cell_permutation,
                                                 int block_size) const
   {
@@ -605,9 +610,9 @@ public:
   /// with row-major layout, shape=(num_dofs, block_size)
   /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input data
-  template <typename T>
+  template <typename U>
   void apply_transpose_dof_transformation_to_transpose(
-      const std::span<T>& data, std::uint32_t cell_permutation,
+      const std::span<U>& data, std::uint32_t cell_permutation,
       int block_size) const
   {
     assert(_element);
@@ -621,9 +626,9 @@ public:
   /// with row-major layout, shape=(num_dofs, block_size)
   /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input data
-  template <typename T>
+  template <typename U>
   void apply_inverse_transpose_dof_transformation_to_transpose(
-      const std::span<T>& data, std::uint32_t cell_permutation,
+      const std::span<U>& data, std::uint32_t cell_permutation,
       int block_size) const
   {
     assert(_element);
@@ -668,7 +673,7 @@ private:
   int _space_dim;
 
   // List of sub-elements (if any)
-  std::vector<std::shared_ptr<const FiniteElement>> _sub_elements;
+  std::vector<std::shared_ptr<const FiniteElement<T>>> _sub_elements;
 
   // Dimension of each value space
   std::vector<std::size_t> _value_shape;
@@ -682,6 +687,6 @@ private:
   bool _needs_dof_transformations;
 
   // Basix Element (nullptr for mixed elements)
-  std::unique_ptr<basix::FiniteElement<double>> _element;
+  std::unique_ptr<basix::FiniteElement<T>> _element;
 };
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -22,7 +22,7 @@ namespace dolfinx::fem
 {
 /// Finite Element, containing the dof layout on a reference element,
 /// and various methods for evaluating and transforming the basis.
-template <std::floating_point T = double>
+template <std::floating_point T>
 class FiniteElement
 {
 public:
@@ -117,7 +117,7 @@ public:
   /// @param[in] shape The shape of `X`
   /// @param[in] order The number of derivatives (up to and including
   /// this order) to tabulate for
-  void tabulate(std::span<T> values, std::span<const double> X,
+  void tabulate(std::span<T> values, std::span<const T> X,
                 std::array<std::size_t, 2> shape, int order) const;
 
   /// Evaluate all derivatives of the basis functions up to given order
@@ -130,7 +130,7 @@ public:
   /// this order) to tabulate for
   /// @return Basis function values and array shape (row-major storage)
   std::pair<std::vector<T>, std::array<std::size_t, 4>>
-  tabulate(std::span<const double> X, std::array<std::size_t, 2> shape,
+  tabulate(std::span<const T> X, std::array<std::size_t, 2> shape,
            int order) const;
 
   /// @brief Number of sub elements (for a mixed or blocked element)

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -101,7 +101,7 @@ public:
     // Extract _mesh from FunctionSpace, and check they are the same
     if (!_mesh and !V.empty())
       _mesh = V[0]->mesh();
-    for (const auto& space : V)
+    for (auto& space : V)
     {
       if (_mesh != space->mesh())
         throw std::runtime_error("Incompatible mesh");
@@ -240,7 +240,7 @@ public:
   std::vector<int> coefficient_offsets() const
   {
     std::vector<int> n = {0};
-    for (const auto& c : _coefficients)
+    for (auto& c : _coefficients)
     {
       if (!c)
         throw std::runtime_error("Not all form coefficients have been set.");

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -198,9 +198,9 @@ public:
     assert(_function_space);
     assert(_function_space->element());
     assert(_function_space->mesh());
-    const std::vector<U> x
-        = fem::interpolation_coords(*_function_space->element(),
-                                    _function_space->mesh()->geometry(), cells);
+    const std::vector<U> x = fem::interpolation_coords<U>(
+        *_function_space->element(), _function_space->mesh()->geometry(),
+        cells);
     namespace stdex = std::experimental;
     stdex::mdspan<const U,
                   stdex::extents<std::size_t, 3, stdex::dynamic_extent>>

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -404,7 +404,7 @@ public:
       throw std::runtime_error(
           "Function with multiple geometry maps not implemented.");
     }
-    const CoordinateElement& cmap = mesh->geometry().cmaps()[0];
+    const CoordinateElement<double>& cmap = mesh->geometry().cmaps()[0];
 
     // Get geometry data
     const graph::AdjacencyList<std::int32_t>& x_dofmap
@@ -524,14 +524,14 @@ public:
       // Compute reference coordinates X, and J, detJ and K
       if (cmap.is_affine())
       {
-        CoordinateElement::compute_jacobian(dphi0, coord_dofs, _J);
-        CoordinateElement::compute_jacobian_inverse(_J, _K);
+        CoordinateElement<double>::compute_jacobian(dphi0, coord_dofs, _J);
+        CoordinateElement<double>::compute_jacobian_inverse(_J, _K);
         std::array<double, 3> x0 = {0, 0, 0};
         for (std::size_t i = 0; i < coord_dofs.extent(1); ++i)
           x0[i] += coord_dofs(0, i);
-        CoordinateElement::pull_back_affine(Xp, _K, x0, xp);
+        CoordinateElement<double>::pull_back_affine(Xp, _K, x0, xp);
         detJ[p]
-            = CoordinateElement::compute_jacobian_determinant(_J, det_scratch);
+            = CoordinateElement<double>::compute_jacobian_determinant(_J, det_scratch);
       }
       else
       {
@@ -539,10 +539,10 @@ public:
         cmap.pull_back_nonaffine(Xp, xp, coord_dofs);
 
         cmap.tabulate(1, std::span(Xpb.data(), tdim), {1, tdim}, phi_b);
-        CoordinateElement::compute_jacobian(dphi, coord_dofs, _J);
-        CoordinateElement::compute_jacobian_inverse(_J, _K);
+        CoordinateElement<double>::compute_jacobian(dphi, coord_dofs, _J);
+        CoordinateElement<double>::compute_jacobian_inverse(_J, _K);
         detJ[p]
-            = CoordinateElement::compute_jacobian_determinant(_J, det_scratch);
+            = CoordinateElement<double>::compute_jacobian_determinant(_J, det_scratch);
       }
 
       for (std::size_t j = 0; j < X.extent(1); ++j)

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -411,8 +411,7 @@ public:
     std::span<const U> x_g = mesh->geometry().x();
 
     // Get element
-    std::shared_ptr<const FiniteElement<U>> element
-        = _function_space->element();
+    auto element = _function_space->element();
     assert(element);
     const int bs_element = element->block_size();
     const std::size_t reference_value_size

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -413,7 +413,7 @@ public:
     std::span<const U> x_g = mesh->geometry().x();
 
     // Get element
-    std::shared_ptr<const FiniteElement> element = _function_space->element();
+    std::shared_ptr<const FiniteElement<double>> element = _function_space->element();
     assert(element);
     const int bs_element = element->block_size();
     const std::size_t reference_value_size

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -41,7 +41,7 @@ public:
   /// @param[in] element The element
   /// @param[in] dofmap The dofmap
   FunctionSpace(std::shared_ptr<const mesh::Mesh<T>> mesh,
-                std::shared_ptr<const FiniteElement<double>> element,
+                std::shared_ptr<const FiniteElement<T>> element,
                 std::shared_ptr<const DofMap> dofmap)
       : _mesh(mesh), _element(element), _dofmap(dofmap),
         _id(boost::uuids::random_generator()()), _root_space_id(_id)
@@ -81,7 +81,7 @@ public:
     }
 
     // Extract sub-element
-    std::shared_ptr<const FiniteElement<double>> element
+    std::shared_ptr<const FiniteElement<T>> element
         = this->_element->extract_sub_element(component);
 
     // Extract sub dofmap
@@ -221,7 +221,7 @@ public:
     {
       throw std::runtime_error("Mixed topology not supported");
     }
-    const CoordinateElement<double>& cmap = _mesh->geometry().cmaps()[0];
+    const CoordinateElement<T>& cmap = _mesh->geometry().cmaps()[0];
 
     // Prepare cell geometry
     const graph::AdjacencyList<std::int32_t>& x_dofmap
@@ -257,11 +257,11 @@ public:
     }
 
     auto apply_dof_transformation
-        = _element->get_dof_transformation_function<double>();
+        = _element->template get_dof_transformation_function<T>();
 
     const std::array<std::size_t, 4> phi_shape
         = cmap.tabulate_shape(0, Xshape[0]);
-    std::vector<double> phi_b(
+    std::vector<T> phi_b(
         std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
     cmdspan4_t phi_full(phi_b.data(), phi_shape);
     cmap.tabulate(0, X, Xshape, phi_b);
@@ -306,10 +306,7 @@ public:
   std::shared_ptr<const mesh::Mesh<T>> mesh() const { return _mesh; }
 
   /// The finite element
-  std::shared_ptr<const FiniteElement<double>> element() const
-  {
-    return _element;
-  }
+  std::shared_ptr<const FiniteElement<T>> element() const { return _element; }
 
   /// The dofmap
   std::shared_ptr<const DofMap> dofmap() const { return _dofmap; }
@@ -319,7 +316,7 @@ private:
   std::shared_ptr<const mesh::Mesh<T>> _mesh;
 
   // The finite element
-  std::shared_ptr<const FiniteElement<double>> _element;
+  std::shared_ptr<const FiniteElement<T>> _element;
 
   // The dofmap
   std::shared_ptr<const DofMap> _dofmap;

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -77,8 +77,7 @@ public:
     }
 
     // Extract sub-element
-    std::shared_ptr<const FiniteElement<T>> element
-        = this->_element->extract_sub_element(component);
+    auto element = this->_element->extract_sub_element(component);
 
     // Extract sub dofmap
     auto dofmap

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -221,7 +221,7 @@ public:
     {
       throw std::runtime_error("Mixed topology not supported");
     }
-    const CoordinateElement& cmap = _mesh->geometry().cmaps()[0];
+    const CoordinateElement<double>& cmap = _mesh->geometry().cmaps()[0];
 
     // Prepare cell geometry
     const graph::AdjacencyList<std::int32_t>& x_dofmap

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -26,6 +26,7 @@
 namespace dolfinx::fem
 {
 class DofMap;
+template <std::floating_point F>
 class FiniteElement;
 
 /// @brief This class represents a finite element function space defined
@@ -40,7 +41,7 @@ public:
   /// @param[in] element The element
   /// @param[in] dofmap The dofmap
   FunctionSpace(std::shared_ptr<const mesh::Mesh<T>> mesh,
-                std::shared_ptr<const FiniteElement> element,
+                std::shared_ptr<const FiniteElement<double>> element,
                 std::shared_ptr<const DofMap> dofmap)
       : _mesh(mesh), _element(element), _dofmap(dofmap),
         _id(boost::uuids::random_generator()()), _root_space_id(_id)
@@ -80,7 +81,7 @@ public:
     }
 
     // Extract sub-element
-    std::shared_ptr<const FiniteElement> element
+    std::shared_ptr<const FiniteElement<double>> element
         = this->_element->extract_sub_element(component);
 
     // Extract sub dofmap
@@ -305,7 +306,10 @@ public:
   std::shared_ptr<const mesh::Mesh<T>> mesh() const { return _mesh; }
 
   /// The finite element
-  std::shared_ptr<const FiniteElement> element() const { return _element; }
+  std::shared_ptr<const FiniteElement<double>> element() const
+  {
+    return _element;
+  }
 
   /// The dofmap
   std::shared_ptr<const DofMap> dofmap() const { return _dofmap; }
@@ -315,7 +319,7 @@ private:
   std::shared_ptr<const mesh::Mesh<T>> _mesh;
 
   // The finite element
-  std::shared_ptr<const FiniteElement> _element;
+  std::shared_ptr<const FiniteElement<double>> _element;
 
   // The dofmap
   std::shared_ptr<const DofMap> _dofmap;

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -26,8 +26,6 @@
 namespace dolfinx::fem
 {
 class DofMap;
-template <std::floating_point F>
-class FiniteElement;
 
 /// @brief This class represents a finite element function space defined
 /// by a mesh, a finite element, and a local-to-global map of the
@@ -198,8 +196,8 @@ public:
     assert(_dofmap);
     std::shared_ptr<const common::IndexMap> index_map = _dofmap->index_map;
     assert(index_map);
-    const int index_map_bs = _dofmap->index_map_bs();
-    const int dofmap_bs = _dofmap->bs();
+    int index_map_bs = _dofmap->index_map_bs();
+    int dofmap_bs = _dofmap->bs();
 
     const int element_block_size = _element->block_size();
     const std::size_t scalar_dofs

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -380,18 +380,18 @@ void assemble_matrix(
   const graph::AdjacencyList<std::int32_t>& dofs1 = dofmap1->list();
   const int bs1 = dofmap1->bs();
 
-  std::shared_ptr<const fem::FiniteElement<double>> element0
-      = a.function_spaces().at(0)->element();
-  std::shared_ptr<const fem::FiniteElement<double>> element1
-      = a.function_spaces().at(1)->element();
+  auto element0 = a.function_spaces().at(0)->element();
+  assert(element0);
+  auto element1 = a.function_spaces().at(1)->element();
+  assert(element1);
   const std::function<void(const std::span<T>&,
                            const std::span<const std::uint32_t>&, std::int32_t,
                            int)>& dof_transform
-      = element0->get_dof_transformation_function<T>();
+      = element0->template get_dof_transformation_function<T>();
   const std::function<void(const std::span<T>&,
                            const std::span<const std::uint32_t>&, std::int32_t,
                            int)>& dof_transform_to_transpose
-      = element1->get_dof_transformation_to_transpose_function<T>();
+      = element1->template get_dof_transformation_to_transpose_function<T>();
 
   const bool needs_transformation_data
       = element0->needs_dof_transformations()

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -47,10 +47,6 @@ void assemble_cells(
   if (cells.empty())
     return;
 
-  // Prepare cell geometry
-  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  // auto x = geometry.x();
   const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // Iterate over active cells
@@ -145,10 +141,6 @@ void assemble_exterior_facets(
   if (facets.empty())
     return;
 
-  // Prepare cell geometry
-  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  // auto x = geometry.x();
   const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // Data structures used in assembly
@@ -243,10 +235,6 @@ void assemble_interior_facets(
   if (facets.empty())
     return;
 
-  // Prepare cell geometry
-  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  // auto x = geometry.x();
   const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // Data structures used in assembly

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -49,9 +49,6 @@ void assemble_cells(
   if (cells.empty())
     return;
 
-  // Prepare cell geometry
-  const std::size_t num_dofs_g = x_dofmap.extent(1);
-
   // Iterate over active cells
   const int num_dofs0 = dofmap0.extent(1);
   const int num_dofs1 = dofmap1.extent(1);
@@ -59,7 +56,7 @@ void assemble_cells(
   const int ndim1 = bs1 * num_dofs1;
   std::vector<T> Ae(ndim0 * ndim1);
   std::span<T> _Ae(Ae);
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
+  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
 
   // Iterate over active cells
   for (std::size_t index = 0; index < cells.size(); ++index)
@@ -144,11 +141,8 @@ void assemble_exterior_facets(
   if (facets.empty())
     return;
 
-  // Prepare cell geometry
-  const std::size_t num_dofs_g = x_dofmap.extent(1);
-
   // Data structures used in assembly
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
+  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
   const int num_dofs0 = dofmap0.extent(1);
   const int num_dofs1 = dofmap1.extent(1);
   const int ndim0 = bs0 * num_dofs0;
@@ -238,14 +232,12 @@ void assemble_interior_facets(
   if (facets.empty())
     return;
 
-  // Prepare cell geometry
-  const std::size_t num_dofs_g = x_dofmap.extent(1);
-
   // Data structures used in assembly
   using X = scalar_value_type_t<T>;
-  std::vector<X> coordinate_dofs(2 * num_dofs_g * 3);
-  std::span<X> cdofs0(coordinate_dofs.data(), num_dofs_g * 3);
-  std::span<X> cdofs1(coordinate_dofs.data() + num_dofs_g * 3, num_dofs_g * 3);
+  std::vector<X> coordinate_dofs(2 * x_dofmap.extent(1) * 3);
+  std::span<X> cdofs0(coordinate_dofs.data(), x_dofmap.extent(1) * 3);
+  std::span<X> cdofs1(coordinate_dofs.data() + x_dofmap.extent(1) * 3,
+                      x_dofmap.extent(1) * 3);
 
   std::vector<T> Ae, be;
   std::vector<T> coeff_array(2 * offsets.back());

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -386,9 +386,9 @@ void assemble_matrix(
   const graph::AdjacencyList<std::int32_t>& dofs1 = dofmap1->list();
   const int bs1 = dofmap1->bs();
 
-  std::shared_ptr<const fem::FiniteElement> element0
+  std::shared_ptr<const fem::FiniteElement<double>> element0
       = a.function_spaces().at(0)->element();
-  std::shared_ptr<const fem::FiniteElement> element1
+  std::shared_ptr<const fem::FiniteElement<double>> element1
       = a.function_spaces().at(1)->element();
   const std::function<void(const std::span<T>&,
                            const std::span<const std::uint32_t>&, std::int32_t,

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -32,11 +32,8 @@ T assemble_cells(mdspan2_t x_dofmap, std::span<const scalar_value_type_t<T>> x,
   if (cells.empty())
     return value;
 
-  // Prepare cell geometry
-  const std::size_t num_dofs_g = x_dofmap.extent(1);
-
   // Create data structures used in assembly
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
+  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
 
   // Iterate over all cells
   for (std::size_t index = 0; index < cells.size(); ++index)
@@ -71,11 +68,8 @@ T assemble_exterior_facets(mdspan2_t x_dofmap,
   if (facets.empty())
     return value;
 
-  // Prepare cell geometry
-  const std::size_t num_dofs_g = x_dofmap.extent(1);
-
   // Create data structures used in assembly
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
+  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
 
   // Iterate over all facets
   assert(facets.size() % 2 == 0);
@@ -115,14 +109,12 @@ T assemble_interior_facets(mdspan2_t x_dofmap,
   if (facets.empty())
     return value;
 
-  // Prepare cell geometry
-  const std::size_t num_dofs_g = x_dofmap.extent(1);
-
   // Create data structures used in assembly
   using X = scalar_value_type_t<T>;
-  std::vector<X> coordinate_dofs(2 * num_dofs_g * 3);
-  std::span<X> cdofs0(coordinate_dofs.data(), num_dofs_g * 3);
-  std::span<X> cdofs1(coordinate_dofs.data() + num_dofs_g * 3, num_dofs_g * 3);
+  std::vector<X> coordinate_dofs(2 * x_dofmap.extent(1) * 3);
+  std::span<X> cdofs0(coordinate_dofs.data(), x_dofmap.extent(1) * 3);
+  std::span<X> cdofs1(coordinate_dofs.data() + x_dofmap.extent(1) * 3,
+                      x_dofmap.extent(1) * 3);
 
   std::vector<T> coeff_array(2 * offsets.back());
   assert(offsets.back() == cstride);

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -33,10 +33,6 @@ T assemble_cells(const graph::AdjacencyList<std::int32_t>& x_dofmap,
   if (cells.empty())
     return value;
 
-  // Prepare cell geometry
-  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  // auto x = geometry.x();
   const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // Create data structures used in assembly
@@ -75,10 +71,6 @@ T assemble_exterior_facets(const graph::AdjacencyList<std::int32_t>& x_dofmap,
   if (facets.empty())
     return value;
 
-  // Prepare cell geometry
-  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  // auto x = geometry.x();
   const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // Create data structures used in assembly
@@ -122,10 +114,6 @@ T assemble_interior_facets(const graph::AdjacencyList<std::int32_t>& x_dofmap,
   if (facets.empty())
     return value;
 
-  // Prepare cell geometry
-  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  // auto x = geometry.x();
   const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // Create data structures used in assembly

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -59,10 +59,6 @@ void _lift_bc_cells(
   if (cells.empty())
     return;
 
-  // Prepare cell geometry
-  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  // auto x = geometry.x();
   const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // Data structures used in bc application
@@ -212,10 +208,6 @@ void _lift_bc_exterior_facets(
   if (facets.empty())
     return;
 
-  // Prepare cell geometry
-  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  // auto x = geometry.x();
   const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // Data structures used in bc application
@@ -321,10 +313,6 @@ void _lift_bc_interior_facets(
   if (facets.empty())
     return;
 
-  // Prepare cell geometry
-  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  // auto x = geometry.x();
   const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // Data structures used in assembly
@@ -502,10 +490,6 @@ void assemble_cells(
   if (cells.empty())
     return;
 
-  // Prepare cell geometry
-  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  // auto x = geometry.x();
   const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // FIXME: Add proper interface for num_dofs
@@ -575,10 +559,6 @@ void assemble_exterior_facets(
   if (facets.empty())
     return;
 
-  // Prepare cell geometry
-  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  // auto x = geometry.x();
   const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // FIXME: Add proper interface for num_dofs
@@ -644,10 +624,6 @@ void assemble_interior_facets(
     std::span<const std::uint32_t> cell_info,
     const std::function<std::uint8_t(std::size_t)>& get_perm)
 {
-  // Prepare cell geometry
-  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  // auto x = geometry.x();
   const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // Create data structures used in assembly

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -62,11 +62,8 @@ void _lift_bc_cells(
   if (cells.empty())
     return;
 
-  // Prepare cell geometry
-  const std::size_t num_dofs_g = x_dofmap.extent(1);
-
   // Data structures used in bc application
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
+  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
   std::vector<T> Ae, be;
   for (std::size_t index = 0; index < cells.size(); ++index)
   {
@@ -212,11 +209,8 @@ void _lift_bc_exterior_facets(
   if (facets.empty())
     return;
 
-  // Prepare cell geometry
-  const std::size_t num_dofs_g = x_dofmap.extent(1);
-
   // Data structures used in bc application
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
+  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
   std::vector<T> Ae, be;
   assert(facets.size() % 2 == 0);
   for (std::size_t index = 0; index < facets.size(); index += 2)
@@ -319,14 +313,12 @@ void _lift_bc_interior_facets(
   if (facets.empty())
     return;
 
-  // Prepare cell geometry
-  const std::size_t num_dofs_g = x_dofmap.extent(1);
-
   // Data structures used in assembly
   using X = scalar_value_type_t<T>;
-  std::vector<X> coordinate_dofs(2 * num_dofs_g * 3);
-  std::span<X> cdofs0(coordinate_dofs.data(), num_dofs_g * 3);
-  std::span<X> cdofs1(coordinate_dofs.data() + num_dofs_g * 3, num_dofs_g * 3);
+  std::vector<X> coordinate_dofs(2 * x_dofmap.extent(1) * 3);
+  std::span<X> cdofs0(coordinate_dofs.data(), x_dofmap.extent(1) * 3);
+  std::span<X> cdofs1(coordinate_dofs.data() + x_dofmap.extent(1) * 3,
+                      x_dofmap.extent(1) * 3);
   std::vector<T> Ae, be;
 
   // Temporaries for joint dofmaps
@@ -504,12 +496,9 @@ void assemble_cells(
   if (cells.empty())
     return;
 
-  // Prepare cell geometry
-  const std::size_t num_dofs_g = x_dofmap.extent(1);
-
   // FIXME: Add proper interface for num_dofs
   // Create data structures used in assembly
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
+  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
   std::vector<T> be(bs * dofmap.extent(1));
   std::span<T> _be(be);
 
@@ -572,13 +561,10 @@ void assemble_exterior_facets(
   if (facets.empty())
     return;
 
-  // Prepare cell geometry
-  const std::size_t num_dofs_g = x_dofmap.extent(1);
-
   // FIXME: Add proper interface for num_dofs
   // Create data structures used in assembly
   const int num_dofs = dofmap.extent(1);
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
+  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
   std::vector<T> be(bs * num_dofs);
   std::span<T> _be(be);
   assert(facets.size() % 2 == 0);
@@ -638,14 +624,12 @@ void assemble_interior_facets(
     std::span<const std::uint32_t> cell_info,
     const std::function<std::uint8_t(std::size_t)>& get_perm)
 {
-  // Prepare cell geometry
-  const std::size_t num_dofs_g = x_dofmap.extent(1);
-
   // Create data structures used in assembly
   using X = scalar_value_type_t<T>;
-  std::vector<X> coordinate_dofs(2 * num_dofs_g * 3);
-  std::span<X> cdofs0(coordinate_dofs.data(), num_dofs_g * 3);
-  std::span<X> cdofs1(coordinate_dofs.data() + num_dofs_g * 3, num_dofs_g * 3);
+  std::vector<X> coordinate_dofs(2 * x_dofmap.extent(1) * 3);
+  std::span<X> cdofs0(coordinate_dofs.data(), x_dofmap.extent(1) * 3);
+  std::span<X> cdofs1(coordinate_dofs.data() + x_dofmap.extent(1) * 3,
+                      x_dofmap.extent(1) * 3);
   std::vector<T> be;
 
   const int bs = dofmap.bs();

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -38,8 +38,9 @@ namespace dolfinx::fem::impl
 /// @tparam _bs1 The block size of the trial function dof map.
 template <typename T, int _bs0 = -1, int _bs1 = -1>
 void _lift_bc_cells(
-    std::span<T> b, const mesh::Geometry<scalar_value_type_t<T>>& geometry,
-    FEkernel<T> auto kernel, std::span<const std::int32_t> cells,
+    std::span<T> b, const graph::AdjacencyList<std::int32_t>& x_dofmap,
+    std::span<const scalar_value_type_t<T>> x, FEkernel<T> auto kernel,
+    std::span<const std::int32_t> cells,
     const std::function<void(const std::span<T>&,
                              const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform,
@@ -59,9 +60,10 @@ void _lift_bc_cells(
     return;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  auto x = geometry.x();
+  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  // auto x = geometry.x();
+  const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // Data structures used in bc application
   std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
@@ -192,8 +194,9 @@ void _lift_bc_cells(
 /// @tparam _bs1 The block size of the trial function dof map.
 template <typename T, int _bs = -1>
 void _lift_bc_exterior_facets(
-    std::span<T> b, const mesh::Geometry<scalar_value_type_t<T>>& geometry,
-    FEkernel<T> auto kernel, std::span<const std::int32_t> facets,
+    std::span<T> b, const graph::AdjacencyList<std::int32_t>& x_dofmap,
+    std::span<const scalar_value_type_t<T>> x, FEkernel<T> auto kernel,
+    std::span<const std::int32_t> facets,
     const std::function<void(const std::span<T>&,
                              const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform,
@@ -210,9 +213,10 @@ void _lift_bc_exterior_facets(
     return;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  auto x = geometry.x();
+  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  // auto x = geometry.x();
+  const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // Data structures used in bc application
   std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * num_dofs_g);
@@ -297,9 +301,9 @@ void _lift_bc_exterior_facets(
 /// @tparam _bs1 The block size of the trial function dof map.
 template <typename T, int _bs = -1>
 void _lift_bc_interior_facets(
-    std::span<T> b, const mesh::Geometry<scalar_value_type_t<T>>& geometry,
-    int num_cell_facets, FEkernel<T> auto kernel,
-    std::span<const std::int32_t> facets,
+    std::span<T> b, const graph::AdjacencyList<std::int32_t>& x_dofmap,
+    std::span<const scalar_value_type_t<T>> x, int num_cell_facets,
+    FEkernel<T> auto kernel, std::span<const std::int32_t> facets,
     const std::function<void(const std::span<T>&,
                              const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform,
@@ -318,9 +322,10 @@ void _lift_bc_interior_facets(
     return;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  auto x = geometry.x();
+  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  // auto x = geometry.x();
+  const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // Data structures used in assembly
   using X = scalar_value_type_t<T>;
@@ -484,7 +489,8 @@ void assemble_cells(
     const std::function<void(const std::span<T>&,
                              const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform,
-    std::span<T> b, const mesh::Geometry<scalar_value_type_t<T>>& geometry,
+    std::span<T> b, const graph::AdjacencyList<std::int32_t>& x_dofmap,
+    std::span<const scalar_value_type_t<T>> x,
     std::span<const std::int32_t> cells,
     const graph::AdjacencyList<std::int32_t>& dofmap, int bs,
     FEkernel<T> auto kernel, std::span<const T> constants,
@@ -497,9 +503,10 @@ void assemble_cells(
     return;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  auto x = geometry.x();
+  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  // auto x = geometry.x();
+  const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // FIXME: Add proper interface for num_dofs
   // Create data structures used in assembly
@@ -555,7 +562,8 @@ void assemble_exterior_facets(
     const std::function<void(const std::span<T>&,
                              const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform,
-    std::span<T> b, const mesh::Geometry<scalar_value_type_t<T>>& geometry,
+    std::span<T> b, const graph::AdjacencyList<std::int32_t>& x_dofmap,
+    std::span<const scalar_value_type_t<T>> x,
     std::span<const std::int32_t> facets,
     const graph::AdjacencyList<std::int32_t>& dofmap, int bs,
     FEkernel<T> auto fn, std::span<const T> constants,
@@ -568,9 +576,10 @@ void assemble_exterior_facets(
     return;
 
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  auto x = geometry.x();
+  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  // auto x = geometry.x();
+  const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // FIXME: Add proper interface for num_dofs
   // Create data structures used in assembly
@@ -627,17 +636,19 @@ void assemble_interior_facets(
     const std::function<void(const std::span<T>&,
                              const std::span<const std::uint32_t>&,
                              std::int32_t, int)>& dof_transform,
-    std::span<T> b, const mesh::Geometry<scalar_value_type_t<T>>& geometry,
-    int num_cell_facets, std::span<const std::int32_t> facets,
-    const fem::DofMap& dofmap, FEkernel<T> auto fn,
-    std::span<const T> constants, std::span<const T> coeffs, int cstride,
+    std::span<T> b, const graph::AdjacencyList<std::int32_t>& x_dofmap,
+    std::span<const scalar_value_type_t<T>> x, int num_cell_facets,
+    std::span<const std::int32_t> facets, const fem::DofMap& dofmap,
+    FEkernel<T> auto fn, std::span<const T> constants,
+    std::span<const T> coeffs, int cstride,
     std::span<const std::uint32_t> cell_info,
     const std::function<std::uint8_t(std::size_t)>& get_perm)
 {
   // Prepare cell geometry
-  const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
-  const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
-  auto x = geometry.x();
+  // const graph::AdjacencyList<std::int32_t>& x_dofmap = geometry.dofmap();
+  // const std::size_t num_dofs_g = geometry.cmaps()[0].dim();
+  // auto x = geometry.x();
+  const std::size_t num_dofs_g = x_dofmap.num_links(0);
 
   // Create data structures used in assembly
   using X = scalar_value_type_t<T>;
@@ -727,7 +738,8 @@ void assemble_interior_facets(
 /// @param[in] scale Scaling to apply
 template <typename T, std::floating_point U>
 void lift_bc(std::span<T> b, const Form<T, U>& a,
-             const mesh::Geometry<scalar_value_type_t<T>>& geometry,
+             const graph::AdjacencyList<std::int32_t>& x_dofmap,
+             std::span<const scalar_value_type_t<T>> x,
              std::span<const T> constants,
              const std::map<std::pair<IntegralType, int>,
                             std::pair<std::span<const T>, int>>& coefficients,
@@ -782,21 +794,21 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
     std::span<const std::int32_t> cells = a.domain(IntegralType::cell, i);
     if (bs0 == 1 and bs1 == 1)
     {
-      _lift_bc_cells<T, 1, 1>(b, geometry, kernel, cells, dof_transform,
+      _lift_bc_cells<T, 1, 1>(b, x_dofmap, x, kernel, cells, dof_transform,
                               dofmap0, bs0, dof_transform_to_transpose, dofmap1,
                               bs1, constants, coeffs, cstride, cell_info,
                               bc_values1, bc_markers1, x0, scale);
     }
     else if (bs0 == 3 and bs1 == 3)
     {
-      _lift_bc_cells<T, 3, 3>(b, geometry, kernel, cells, dof_transform,
+      _lift_bc_cells<T, 3, 3>(b, x_dofmap, x, kernel, cells, dof_transform,
                               dofmap0, bs0, dof_transform_to_transpose, dofmap1,
                               bs1, constants, coeffs, cstride, cell_info,
                               bc_values1, bc_markers1, x0, scale);
     }
     else
     {
-      _lift_bc_cells(b, geometry, kernel, cells, dof_transform, dofmap0, bs0,
+      _lift_bc_cells(b, x_dofmap, x, kernel, cells, dof_transform, dofmap0, bs0,
                      dof_transform_to_transpose, dofmap1, bs1, constants,
                      coeffs, cstride, cell_info, bc_values1, bc_markers1, x0,
                      scale);
@@ -810,7 +822,7 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
     auto& [coeffs, cstride]
         = coefficients.at({IntegralType::exterior_facet, i});
     _lift_bc_exterior_facets(
-        b, geometry, kernel, a.domain(IntegralType::exterior_facet, i),
+        b, x_dofmap, x, kernel, a.domain(IntegralType::exterior_facet, i),
         dof_transform, dofmap0, bs0, dof_transform_to_transpose, dofmap1, bs1,
         constants, coeffs, cstride, cell_info, bc_values1, bc_markers1, x0,
         scale);
@@ -841,7 +853,7 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
       auto& [coeffs, cstride]
           = coefficients.at({IntegralType::interior_facet, i});
       _lift_bc_interior_facets(
-          b, geometry, num_cell_facets, kernel,
+          b, x_dofmap, x, num_cell_facets, kernel,
           a.domain(IntegralType::interior_facet, i), dof_transform, dofmap0,
           bs0, dof_transform_to_transpose, dofmap1, bs1, constants, coeffs,
           cstride, cell_info, get_perm, bc_values1, bc_markers1, x0, scale);
@@ -872,7 +884,8 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
 template <typename T, std::floating_point U>
 void apply_lifting(
     std::span<T> b, const std::vector<std::shared_ptr<const Form<T, U>>> a,
-    const mesh::Geometry<scalar_value_type_t<T>>& geometry,
+    const graph::AdjacencyList<std::int32_t>& x_dofmap,
+    std::span<const scalar_value_type_t<T>> x,
     const std::vector<std::span<const T>>& constants,
     const std::vector<std::map<std::pair<IntegralType, int>,
                                std::pair<std::span<const T>, int>>>& coeffs,
@@ -917,12 +930,12 @@ void apply_lifting(
 
       if (!x0.empty())
       {
-        lift_bc<T>(b, *a[j], geometry, constants[j], coeffs[j], bc_values1,
+        lift_bc<T>(b, *a[j], x_dofmap, x, constants[j], coeffs[j], bc_values1,
                    bc_markers1, x0[j], scale);
       }
       else
       {
-        lift_bc<T>(b, *a[j], geometry, constants[j], coeffs[j], bc_values1,
+        lift_bc<T>(b, *a[j], x_dofmap, x, constants[j], coeffs[j], bc_values1,
                    bc_markers1, std::span<const T>(), scale);
       }
     }
@@ -939,8 +952,8 @@ void apply_lifting(
 template <typename T, std::floating_point U>
 void assemble_vector(
     std::span<T> b, const Form<T, U>& L,
-    const mesh::Geometry<scalar_value_type_t<T>>& geometry,
-    std::span<const T> constants,
+    const graph::AdjacencyList<std::int32_t>& x_dofmap,
+    std::span<const scalar_value_type_t<T>> x, std::span<const T> constants,
     const std::map<std::pair<IntegralType, int>,
                    std::pair<std::span<const T>, int>>& coefficients)
 {
@@ -979,17 +992,17 @@ void assemble_vector(
     std::span<const std::int32_t> cells = L.domain(IntegralType::cell, i);
     if (bs == 1)
     {
-      impl::assemble_cells<T, 1>(dof_transform, b, geometry, cells, dofs, bs,
+      impl::assemble_cells<T, 1>(dof_transform, b, x_dofmap, x, cells, dofs, bs,
                                  fn, constants, coeffs, cstride, cell_info);
     }
     else if (bs == 3)
     {
-      impl::assemble_cells<T, 3>(dof_transform, b, geometry, cells, dofs, bs,
+      impl::assemble_cells<T, 3>(dof_transform, b, x_dofmap, x, cells, dofs, bs,
                                  fn, constants, coeffs, cstride, cell_info);
     }
     else
     {
-      impl::assemble_cells(dof_transform, b, geometry, cells, dofs, bs, fn,
+      impl::assemble_cells(dof_transform, b, x_dofmap, x, cells, dofs, bs, fn,
                            constants, coeffs, cstride, cell_info);
     }
   }
@@ -1004,20 +1017,20 @@ void assemble_vector(
         = L.domain(IntegralType::exterior_facet, i);
     if (bs == 1)
     {
-      impl::assemble_exterior_facets<T, 1>(dof_transform, b, geometry, facets,
-                                           dofs, bs, fn, constants, coeffs,
-                                           cstride, cell_info);
+      impl::assemble_exterior_facets<T, 1>(dof_transform, b, x_dofmap, x,
+                                           facets, dofs, bs, fn, constants,
+                                           coeffs, cstride, cell_info);
     }
     else if (bs == 3)
     {
-      impl::assemble_exterior_facets<T, 3>(dof_transform, b, geometry, facets,
-                                           dofs, bs, fn, constants, coeffs,
-                                           cstride, cell_info);
+      impl::assemble_exterior_facets<T, 3>(dof_transform, b, x_dofmap, x,
+                                           facets, dofs, bs, fn, constants,
+                                           coeffs, cstride, cell_info);
     }
     else
     {
-      impl::assemble_exterior_facets(dof_transform, b, geometry, facets, dofs,
-                                     bs, fn, constants, coeffs, cstride,
+      impl::assemble_exterior_facets(dof_transform, b, x_dofmap, x, facets,
+                                     dofs, bs, fn, constants, coeffs, cstride,
                                      cell_info);
     }
   }
@@ -1051,19 +1064,19 @@ void assemble_vector(
       if (bs == 1)
       {
         impl::assemble_interior_facets<T, 1>(
-            dof_transform, b, geometry, num_cell_facets, facets, *dofmap, fn,
+            dof_transform, b, x_dofmap, x, num_cell_facets, facets, *dofmap, fn,
             constants, coeffs, cstride, cell_info, get_perm);
       }
       else if (bs == 3)
       {
         impl::assemble_interior_facets<T, 3>(
-            dof_transform, b, geometry, num_cell_facets, facets, *dofmap, fn,
+            dof_transform, b, x_dofmap, x, num_cell_facets, facets, *dofmap, fn,
             constants, coeffs, cstride, cell_info, get_perm);
       }
       else
       {
         impl::assemble_interior_facets(
-            dof_transform, b, geometry, num_cell_facets, facets, *dofmap, fn,
+            dof_transform, b, x_dofmap, x, num_cell_facets, facets, *dofmap, fn,
             constants, coeffs, cstride, cell_info, get_perm);
       }
     }
@@ -1085,12 +1098,14 @@ void assemble_vector(
   std::shared_ptr<const mesh::Mesh<U>> mesh = L.mesh();
   assert(mesh);
   if constexpr (std::is_same_v<U, scalar_value_type_t<T>>)
-    assemble_vector(b, L, mesh->geometry(), constants, coefficients);
+    assemble_vector(b, L, mesh->geometry().dofmap(), mesh->geometry().x(),
+                    constants, coefficients);
   else
   {
-    assemble_vector(b, L,
-                    mesh->geometry().template astype<scalar_value_type_t<T>>(),
-                    constants, coefficients);
+    auto x = mesh->geometry().x();
+    std::vector<scalar_value_type_t<T>> _x(x.begin(), x.end());
+    assemble_vector(b, L, mesh->geometry().dofmap(), _x, constants,
+                    coefficients);
   }
 }
 } // namespace dolfinx::fem::impl

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -733,13 +733,13 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
   const graph::AdjacencyList<std::int32_t>& dofmap0
       = a.function_spaces()[0]->dofmap()->list();
   const int bs0 = a.function_spaces()[0]->dofmap()->bs();
-  std::shared_ptr<const fem::FiniteElement<double>> element0
-      = a.function_spaces()[0]->element();
+  auto element0 = a.function_spaces()[0]->element();
+  assert(element0);
   const graph::AdjacencyList<std::int32_t>& dofmap1
       = a.function_spaces()[1]->dofmap()->list();
   const int bs1 = a.function_spaces()[1]->dofmap()->bs();
-  std::shared_ptr<const fem::FiniteElement<double>> element1
-      = a.function_spaces()[1]->element();
+  auto element1 = a.function_spaces()[1]->element();
+  assert(element0);
 
   const bool needs_transformation_data
       = element0->needs_dof_transformations()
@@ -756,12 +756,12 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
   const std::function<void(const std::span<T>&,
                            const std::span<const std::uint32_t>&, std::int32_t,
                            int)>
-      dof_transform = element0->get_dof_transformation_function<T>();
+      dof_transform = element0->template get_dof_transformation_function<T>();
   const std::function<void(const std::span<T>&,
                            const std::span<const std::uint32_t>&, std::int32_t,
                            int)>
       dof_transform_to_transpose
-      = element1->get_dof_transformation_to_transpose_function<T>();
+      = element1->template get_dof_transformation_to_transpose_function<T>();
 
   for (int i : a.integral_ids(IntegralType::cell))
   {
@@ -941,8 +941,8 @@ void assemble_vector(
 
   // Get dofmap data
   assert(L.function_spaces().at(0));
-  std::shared_ptr<const fem::FiniteElement<double>> element
-      = L.function_spaces().at(0)->element();
+  auto element = L.function_spaces().at(0)->element();
+  assert(element);
   std::shared_ptr<const fem::DofMap> dofmap
       = L.function_spaces().at(0)->dofmap();
   assert(dofmap);
@@ -952,7 +952,7 @@ void assemble_vector(
   const std::function<void(const std::span<T>&,
                            const std::span<const std::uint32_t>&, std::int32_t,
                            int)>
-      dof_transform = element->get_dof_transformation_function<T>();
+      dof_transform = element->template get_dof_transformation_function<T>();
 
   const bool needs_transformation_data
       = element->needs_dof_transformations() or L.needs_facet_permutations();

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -744,12 +744,12 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
   const graph::AdjacencyList<std::int32_t>& dofmap0
       = a.function_spaces()[0]->dofmap()->list();
   const int bs0 = a.function_spaces()[0]->dofmap()->bs();
-  std::shared_ptr<const fem::FiniteElement> element0
+  std::shared_ptr<const fem::FiniteElement<double>> element0
       = a.function_spaces()[0]->element();
   const graph::AdjacencyList<std::int32_t>& dofmap1
       = a.function_spaces()[1]->dofmap()->list();
   const int bs1 = a.function_spaces()[1]->dofmap()->bs();
-  std::shared_ptr<const fem::FiniteElement> element1
+  std::shared_ptr<const fem::FiniteElement<double>> element1
       = a.function_spaces()[1]->element();
 
   const bool needs_transformation_data
@@ -949,7 +949,7 @@ void assemble_vector(
 
   // Get dofmap data
   assert(L.function_spaces().at(0));
-  std::shared_ptr<const fem::FiniteElement> element
+  std::shared_ptr<const fem::FiniteElement<double>> element
       = L.function_spaces().at(0)->element();
   std::shared_ptr<const fem::DofMap> dofmap
       = L.function_spaces().at(0)->dofmap();

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -727,7 +727,8 @@ void assemble_interior_facets(
 ///
 /// @param[in,out] b The vector to be modified
 /// @param[in] a The bilinear form that generates A
-/// @param[in] geometry The mesh geometry
+/// @param[in] x_dofmap Mesh geometry dofmap
+/// @param[in] x Mesh coordinates
 /// @param[in] constants Constants that appear in `a`
 /// @param[in] coefficients Coefficients that appear in `a`
 /// @param[in] bc_values1 The boundary condition 'values'
@@ -873,7 +874,8 @@ void lift_bc(std::span<T> b, const Form<T, U>& a,
 /// @param[in,out] b The vector to be modified
 /// @param[in] a The bilinear forms, where a[j] is the form that
 /// generates A_j
-/// @param[in] geometry The mesh geometry
+/// @param[in] x_dofmap Mesh geometry dofmap
+/// @param[in] x Mesh coordinates
 /// @param[in] constants Constants that appear in `a`
 /// @param[in] coeffs Coefficients that appear in `a`
 /// @param[in] bcs1 List of boundary conditions for each block, i.e.
@@ -946,7 +948,8 @@ void apply_lifting(
 /// @param[in,out] b The vector to be assembled. It will not be zeroed
 /// before assembly.
 /// @param[in] L The linear forms to assemble into b
-/// @param[in] geometry The mesh geometry
+/// @param[in] x_dofmap Mesh geometry dofmap
+/// @param[in] x Mesh coordinates
 /// @param[in] constants Packed constants that appear in `L`
 /// @param[in] coefficients Packed coefficients that appear in `L`
 template <typename T, std::floating_point U>

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -65,12 +65,16 @@ T assemble_scalar(
   std::shared_ptr<const mesh::Mesh<U>> mesh = M.mesh();
   assert(mesh);
   if constexpr (std::is_same_v<U, scalar_value_type_t<T>>)
-    return impl::assemble_scalar(M, mesh->geometry(), constants, coefficients);
+  {
+    return impl::assemble_scalar(M, mesh->geometry().dofmap(),
+                                 mesh->geometry().x(), constants, coefficients);
+  }
   else
   {
-    return impl::assemble_scalar(
-        M, mesh->geometry().template astype<scalar_value_type_t<T>>(),
-        constants, coefficients);
+    auto x = mesh->geometry().x();
+    std::vector<scalar_value_type_t<T>> _x(x.begin(), x.end());
+    return impl::assemble_scalar(M, mesh->geometry().dofmap(), _x, constants,
+                                 coefficients);
   }
 }
 
@@ -166,14 +170,16 @@ void apply_lifting(
 
   if constexpr (std::is_same_v<U, scalar_value_type_t<T>>)
   {
-    impl::apply_lifting<T>(b, a, mesh->geometry(), constants, coeffs, bcs1, x0,
+    impl::apply_lifting<T>(b, a, mesh->geometry().dofmap(),
+                           mesh->geometry().x(), constants, coeffs, bcs1, x0,
                            scale);
   }
   else
   {
-    impl::apply_lifting<T>(
-        b, a, mesh->geometry().template astype<scalar_value_type_t<T>>(),
-        constants, coeffs, bcs1, x0, scale);
+    auto x = mesh->geometry().x();
+    std::vector<scalar_value_type_t<T>> _x(x.begin(), x.end());
+    impl::apply_lifting<T>(b, a, mesh->geometry().dofmap(), _x, constants,
+                           coeffs, bcs1, x0, scale);
   }
 }
 
@@ -255,14 +261,16 @@ void assemble_matrix(
   assert(mesh);
   if constexpr (std::is_same_v<U, scalar_value_type_t<T>>)
   {
-    impl::assemble_matrix(mat_add, a, mesh->geometry(), constants, coefficients,
+    impl::assemble_matrix(mat_add, a, mesh->geometry().dofmap(),
+                          mesh->geometry().x(), constants, coefficients,
                           dof_marker0, dof_marker1);
   }
   else
   {
-    impl::assemble_matrix(
-        mat_add, a, mesh->geometry().template astype<scalar_value_type_t<T>>(),
-        constants, coefficients, dof_marker0, dof_marker1);
+    auto x = mesh->geometry().x();
+    std::vector<scalar_value_type_t<T>> _x(x.begin(), x.end());
+    impl::assemble_matrix(mat_add, a, mesh->geometry().dofmap(), _x, constants,
+                          coefficients, dof_marker0, dof_marker1);
   }
 }
 

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -413,7 +413,7 @@ void set_diagonal(
     const std::vector<std::shared_ptr<const DirichletBC<T, U>>>& bcs,
     T diagonal = 1.0)
 {
-  for (const auto& bc : bcs)
+  for (auto& bc : bcs)
   {
     assert(bc);
     if (V.contains(*bc->function_space()))
@@ -441,7 +441,7 @@ void set_bc(std::span<T> b,
 {
   if (b.size() > x0.size())
     throw std::runtime_error("Size mismatch between b and x0 vectors.");
-  for (const auto& bc : bcs)
+  for (auto& bc : bcs)
   {
     assert(bc);
     bc->set(b, x0, scale);
@@ -456,7 +456,7 @@ void set_bc(std::span<T> b,
             const std::vector<std::shared_ptr<const DirichletBC<T, U>>>& bcs,
             T scale = 1)
 {
-  for (const auto& bc : bcs)
+  for (auto& bc : bcs)
   {
     assert(bc);
     bc->set(b, scale);

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -47,28 +47,25 @@ namespace dolfinx::fem
 /// @param[in] V1 Nédélec (first kind) element and and dofmap for
 /// corresponding space to interpolate into
 /// @param[in] mat_set A functor that sets values in a matrix
-template <typename T>
-void discrete_gradient(
-    mesh::Topology& topology,
-    std::pair<std::reference_wrapper<const FiniteElement<double>>,
-              std::reference_wrapper<const DofMap>>
-        V0,
-    std::pair<std::reference_wrapper<const FiniteElement<double>>,
-              std::reference_wrapper<const DofMap>>
-        V1,
-    auto&& mat_set)
+template <typename T, std::floating_point U = dolfinx::scalar_value_type_t<T>>
+void discrete_gradient(mesh::Topology& topology,
+                       std::pair<std::reference_wrapper<const FiniteElement<U>>,
+                                 std::reference_wrapper<const DofMap>>
+                           V0,
+                       std::pair<std::reference_wrapper<const FiniteElement<U>>,
+                                 std::reference_wrapper<const DofMap>>
+                           V1,
+                       auto&& mat_set)
 {
-  const FiniteElement<double>& e0 = V0.first.get();
+  const FiniteElement<U>& e0 = V0.first.get();
   const DofMap& dofmap0 = V0.second.get();
-  const FiniteElement<double>& e1 = V1.first.get();
+  const FiniteElement<U>& e1 = V1.first.get();
   const DofMap& dofmap1 = V1.second.get();
 
   namespace stdex = std::experimental;
-  using cmdspan2_t
-      = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
-  using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
-  using cmdspan4_t
-      = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
+  using cmdspan2_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 2>>;
+  using mdspan2_t = stdex::mdspan<U, stdex::dextents<std::size_t, 2>>;
+  using cmdspan4_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 4>>;
 
   // Check elements
   if (e0.map_type() != basix::maps::type::identity)
@@ -90,7 +87,7 @@ void discrete_gradient(
   // interpolation points
   const int ndofs0 = e0.space_dimension();
   const int tdim = topology.dim();
-  std::vector<double> phi0_b((tdim + 1) * Xshape[0] * ndofs0 * 1);
+  std::vector<U> phi0_b((tdim + 1) * Xshape[0] * ndofs0 * 1);
   cmdspan4_t phi0(phi0_b.data(), tdim + 1, Xshape[0], ndofs0, 1);
   e0.tabulate(phi0_b, X, Xshape, 1);
 
@@ -102,7 +99,7 @@ void discrete_gradient(
 
   // Get inverse DOF transform function
   auto apply_inverse_dof_transform
-      = e1.get_dof_transformation_function<T>(true, true, false);
+      = e1.template get_dof_transformation_function<T>(true, true, false);
 
   // Generate cell permutations
   topology.create_entity_permutations();
@@ -162,9 +159,9 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
   const int gdim = mesh->geometry().dim();
 
   // Get elements
-  std::shared_ptr<const FiniteElement<double>> e0 = V0.element();
+  std::shared_ptr<const FiniteElement<U>> e0 = V0.element();
   assert(e0);
-  std::shared_ptr<const FiniteElement<double>> e1 = V1.element();
+  std::shared_ptr<const FiniteElement<U>> e1 = V1.element();
   assert(e1);
 
   std::span<const std::uint32_t> cell_info;
@@ -184,9 +181,9 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
   const int bs0 = e0->block_size();
   const int bs1 = e1->block_size();
   const auto apply_dof_transformation0
-      = e0->get_dof_transformation_function<double>(false, false, false);
+      = e0->template get_dof_transformation_function<U>(false, false, false);
   const auto apply_inverse_dof_transform1
-      = e1->get_dof_transformation_function<T>(true, true, false);
+      = e1->template get_dof_transformation_function<T>(true, true, false);
 
   // Get sizes of elements
   const std::size_t space_dim0 = e0->space_dimension();
@@ -216,14 +213,14 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
   // Evaluate coordinate map basis at reference interpolation points
   const auto [X, Xshape] = e1->interpolation_points();
   std::array<std::size_t, 4> phi_shape = cmap.tabulate_shape(1, Xshape[0]);
-  std::vector<double> phi_b(
+  std::vector<U> phi_b(
       std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
   cmdspan4_t phi(phi_b.data(), phi_shape);
   cmap.tabulate(1, X, Xshape, phi_b);
 
   // Evaluate V0 basis functions at reference interpolation points for V1
-  std::vector<double> basis_derivatives_reference0_b(Xshape[0] * dim0
-                                                     * value_size_ref0);
+  std::vector<U> basis_derivatives_reference0_b(Xshape[0] * dim0
+                                                * value_size_ref0);
   cmdspan4_t basis_derivatives_reference0(basis_derivatives_reference0_b.data(),
                                           1, Xshape[0], dim0, value_size_ref0);
   e0->tabulate(basis_derivatives_reference0_b, X, Xshape, 0);
@@ -236,15 +233,15 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
                  { return std::abs(x) < atol ? 0.0 : x; });
 
   // Create working arrays
-  std::vector<double> basis_reference0_b(Xshape[0] * dim0 * value_size_ref0);
+  std::vector<U> basis_reference0_b(Xshape[0] * dim0 * value_size_ref0);
   mdspan3_t basis_reference0(basis_reference0_b.data(), Xshape[0], dim0,
                              value_size_ref0);
-  std::vector<double> J_b(Xshape[0] * gdim * tdim);
+  std::vector<U> J_b(Xshape[0] * gdim * tdim);
   mdspan3_t J(J_b.data(), Xshape[0], gdim, tdim);
-  std::vector<double> K_b(Xshape[0] * tdim * gdim);
+  std::vector<U> K_b(Xshape[0] * tdim * gdim);
   mdspan3_t K(K_b.data(), Xshape[0], tdim, gdim);
-  std::vector<double> detJ(Xshape[0]);
-  std::vector<double> det_scratch(2 * tdim * gdim);
+  std::vector<U> detJ(Xshape[0]);
+  std::vector<U> det_scratch(2 * tdim * gdim);
 
   // Get the interpolation operator (matrix) `Pi` that maps a function
   // evaluated at the interpolation points to the element degrees of
@@ -255,27 +252,28 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
   bool interpolation_ident = e1->interpolation_ident();
 
   namespace stdex = std::experimental;
-  using u_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
-  using U_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
-  using J_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
-  using K_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
-  auto push_forward_fn0 = e0->basix_element().map_fn<u_t, U_t, J_t, K_t>();
+  using u_t = stdex::mdspan<U, stdex::dextents<std::size_t, 2>>;
+  using U_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 2>>;
+  using J_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 2>>;
+  using K_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 2>>;
+  auto push_forward_fn0
+      = e0->basix_element().template map_fn<u_t, U_t, J_t, K_t>();
 
   // Basis values of Lagrange space unrolled for block size
   // (num_quadrature_points, Lagrange dof, value_size)
-  std::vector<double> basis_values_b(Xshape[0] * bs0 * dim0 * e1->value_size());
+  std::vector<U> basis_values_b(Xshape[0] * bs0 * dim0 * e1->value_size());
   mdspan3_t basis_values(basis_values_b.data(), Xshape[0], bs0 * dim0,
                          e1->value_size());
-  std::vector<double> mapped_values_b(Xshape[0] * bs0 * dim0
-                                      * e1->value_size());
+  std::vector<U> mapped_values_b(Xshape[0] * bs0 * dim0 * e1->value_size());
   mdspan3_t mapped_values(mapped_values_b.data(), Xshape[0], bs0 * dim0,
                           e1->value_size());
 
-  auto pull_back_fn1 = e1->basix_element().map_fn<u_t, U_t, K_t, J_t>();
+  auto pull_back_fn1
+      = e1->basix_element().template map_fn<u_t, U_t, K_t, J_t>();
 
-  std::vector<double> coord_dofs_b(num_dofs_g * gdim);
+  std::vector<U> coord_dofs_b(num_dofs_g * gdim);
   mdspan2_t coord_dofs(coord_dofs_b.data(), num_dofs_g, gdim);
-  std::vector<double> basis0_b(Xshape[0] * dim0 * value_size0);
+  std::vector<U> basis0_b(Xshape[0] * dim0 * value_size0);
   mdspan3_t basis0(basis0_b.data(), Xshape[0], dim0, value_size0);
 
   // Buffers

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -199,7 +199,7 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
   auto cmaps = mesh->geometry().cmaps();
   assert(cmaps.size() == 1);
 
-  const CoordinateElement& cmap = cmaps.back();
+  const CoordinateElement<double>& cmap = cmaps.back();
   const graph::AdjacencyList<std::int32_t>& x_dofmap
       = mesh->geometry().dofmap();
   const std::size_t num_dofs_g = cmap.dim();

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -57,9 +57,9 @@ void discrete_gradient(mesh::Topology& topology,
                            V1,
                        auto&& mat_set)
 {
-  const auto& e0 = V0.first.get();
+  auto& e0 = V0.first.get();
   const DofMap& dofmap0 = V0.second.get();
-  const auto& e1 = V1.first.get();
+  auto& e1 = V1.first.get();
   const DofMap& dofmap1 = V1.second.get();
 
   namespace stdex = std::experimental;
@@ -180,9 +180,9 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
   // Get block sizes and dof transformation operators
   const int bs0 = e0->block_size();
   const int bs1 = e1->block_size();
-  const auto apply_dof_transformation0
+  auto apply_dof_transformation0
       = e0->template get_dof_transformation_function<U>(false, false, false);
-  const auto apply_inverse_dof_transform1
+  auto apply_inverse_dof_transform1
       = e1->template get_dof_transformation_function<T>(true, true, false);
 
   // Get sizes of elements

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -49,17 +49,17 @@ namespace dolfinx::fem
 /// @param[in] mat_set A functor that sets values in a matrix
 template <typename T>
 void discrete_gradient(mesh::Topology& topology,
-                       std::pair<std::reference_wrapper<const FiniteElement>,
+                       std::pair<std::reference_wrapper<const FiniteElement<double>>,
                                  std::reference_wrapper<const DofMap>>
                            V0,
-                       std::pair<std::reference_wrapper<const FiniteElement>,
+                       std::pair<std::reference_wrapper<const FiniteElement<double>>,
                                  std::reference_wrapper<const DofMap>>
                            V1,
                        auto&& mat_set)
 {
-  const FiniteElement& e0 = V0.first.get();
+  const FiniteElement<double>& e0 = V0.first.get();
   const DofMap& dofmap0 = V0.second.get();
-  const FiniteElement& e1 = V1.first.get();
+  const FiniteElement<double>& e1 = V1.first.get();
   const DofMap& dofmap1 = V1.second.get();
 
   namespace stdex = std::experimental;
@@ -161,9 +161,9 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
   const int gdim = mesh->geometry().dim();
 
   // Get elements
-  std::shared_ptr<const FiniteElement> e0 = V0.element();
+  std::shared_ptr<const FiniteElement<double>> e0 = V0.element();
   assert(e0);
-  std::shared_ptr<const FiniteElement> e1 = V1.element();
+  std::shared_ptr<const FiniteElement<double>> e1 = V1.element();
   assert(e1);
 
   std::span<const std::uint32_t> cell_info;

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -57,9 +57,9 @@ void discrete_gradient(mesh::Topology& topology,
                            V1,
                        auto&& mat_set)
 {
-  const FiniteElement<U>& e0 = V0.first.get();
+  const auto& e0 = V0.first.get();
   const DofMap& dofmap0 = V0.second.get();
-  const FiniteElement<U>& e1 = V1.first.get();
+  const auto& e1 = V1.first.get();
   const DofMap& dofmap1 = V1.second.get();
 
   namespace stdex = std::experimental;

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -48,14 +48,15 @@ namespace dolfinx::fem
 /// corresponding space to interpolate into
 /// @param[in] mat_set A functor that sets values in a matrix
 template <typename T>
-void discrete_gradient(mesh::Topology& topology,
-                       std::pair<std::reference_wrapper<const FiniteElement<double>>,
-                                 std::reference_wrapper<const DofMap>>
-                           V0,
-                       std::pair<std::reference_wrapper<const FiniteElement<double>>,
-                                 std::reference_wrapper<const DofMap>>
-                           V1,
-                       auto&& mat_set)
+void discrete_gradient(
+    mesh::Topology& topology,
+    std::pair<std::reference_wrapper<const FiniteElement<double>>,
+              std::reference_wrapper<const DofMap>>
+        V0,
+    std::pair<std::reference_wrapper<const FiniteElement<double>>,
+              std::reference_wrapper<const DofMap>>
+        V1,
+    auto&& mat_set)
 {
   const FiniteElement<double>& e0 = V0.first.get();
   const DofMap& dofmap0 = V0.second.get();
@@ -199,21 +200,18 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
   auto cmaps = mesh->geometry().cmaps();
   assert(cmaps.size() == 1);
 
-  const CoordinateElement<double>& cmap = cmaps.back();
+  const CoordinateElement<U>& cmap = cmaps.back();
   const graph::AdjacencyList<std::int32_t>& x_dofmap
       = mesh->geometry().dofmap();
   const std::size_t num_dofs_g = cmap.dim();
   std::span<const U> x_g = mesh->geometry().x();
 
   namespace stdex = std::experimental;
-  using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
-  using cmdspan2_t
-      = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
-  using cmdspan3_t
-      = stdex::mdspan<const double, stdex::dextents<std::size_t, 3>>;
-  using cmdspan4_t
-      = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
-  using mdspan3_t = stdex::mdspan<double, stdex::dextents<std::size_t, 3>>;
+  using mdspan2_t = stdex::mdspan<U, stdex::dextents<std::size_t, 2>>;
+  using cmdspan2_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 2>>;
+  using cmdspan3_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 3>>;
+  using cmdspan4_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 4>>;
+  using mdspan3_t = stdex::mdspan<U, stdex::dextents<std::size_t, 3>>;
 
   // Evaluate coordinate map basis at reference interpolation points
   const auto [X, Xshape] = e1->interpolation_points();

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -324,9 +324,9 @@ void interpolate_same_map(Function<T, U>& u1, const Function<T, U>& u0,
   auto mesh = V0->mesh();
   assert(mesh);
 
-  std::shared_ptr<const FiniteElement<U>> element0 = V0->element();
+  auto element0 = V0->element();
   assert(element0);
-  std::shared_ptr<const FiniteElement<U>> element1 = V1->element();
+  auto element1 = V1->element();
   assert(element1);
 
   const int tdim = mesh->topology()->dim();
@@ -418,9 +418,9 @@ void interpolate_nonmatching_maps(Function<T, U>& u1, const Function<T, U>& u0,
   // Get elements
   auto V1 = u1.function_space();
   assert(V1);
-  std::shared_ptr<const FiniteElement<U>> element0 = V0->element();
+  auto element0 = V0->element();
   assert(element0);
-  std::shared_ptr<const FiniteElement<U>> element1 = V1->element();
+  auto element1 = V1->element();
   assert(element1);
 
   std::span<const std::uint32_t> cell_info;
@@ -651,8 +651,8 @@ void interpolate_nonmatching_meshes(
   const int tdim = mesh->topology()->dim();
   const auto cell_map = mesh->topology()->index_map(tdim);
 
-  std::shared_ptr<const FiniteElement<U>> element_u
-      = u.function_space()->element();
+  auto element_u = u.function_space()->element();
+  assert(element_u);
   const std::size_t value_size = element_u->value_size();
 
   if (std::get<0>(nmm_interpolation_data).empty())
@@ -723,8 +723,7 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
   using cmdspan4_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 4>>;
   using mdspan2_t = stdex::mdspan<U, stdex::dextents<std::size_t, 2>>;
   using mdspan3_t = stdex::mdspan<U, stdex::dextents<std::size_t, 3>>;
-  std::shared_ptr<const FiniteElement<U>> element
-      = u.function_space()->element();
+  auto element = u.function_space()->element();
   assert(element);
   const int element_bs = element->block_size();
   if (int num_sub = element->num_sub_elements();

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -52,7 +52,7 @@ std::vector<T> interpolation_coords(const fem::FiniteElement<double>& element,
     throw std::runtime_error("Mixed topology not supported");
   }
 
-  const CoordinateElement& cmap = geometry.cmaps()[0];
+  const CoordinateElement<double>& cmap = geometry.cmaps()[0];
   const std::size_t num_dofs_g = cmap.dim();
 
   // Get the interpolation points on the reference cells
@@ -453,7 +453,7 @@ void interpolate_nonmatching_maps(Function<T, U>& u1, const Function<T, U>& u0,
   if (mesh->geometry().cmaps().size() > 1)
     throw std::runtime_error("Multiple cmaps");
 
-  const CoordinateElement& cmap = mesh->geometry().cmaps()[0];
+  const CoordinateElement<double>& cmap = mesh->geometry().cmaps()[0];
   const graph::AdjacencyList<std::int32_t>& x_dofmap
       = mesh->geometry().dofmap();
   const std::size_t num_dofs_g = cmap.dim();
@@ -867,7 +867,7 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
     // Get coordinate map
     if (mesh->geometry().cmaps().size() > 1)
       throw std::runtime_error("Multiple cmaps");
-    const CoordinateElement& cmap = mesh->geometry().cmaps()[0];
+    const CoordinateElement<double>& cmap = mesh->geometry().cmaps()[0];
 
     // Get geometry data
     const graph::AdjacencyList<std::int32_t>& x_dofmap

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -38,7 +38,7 @@ class Function;
 /// @return The coordinates in the physical space at which to evaluate
 /// an expression. The shape is (3, num_points) and storage is row-major.
 template <std::floating_point T>
-std::vector<T> interpolation_coords(const fem::FiniteElement<double>& element,
+std::vector<T> interpolation_coords(const fem::FiniteElement<T>& element,
                                     const mesh::Geometry<T>& geometry,
                                     std::span<const std::int32_t> cells)
 {
@@ -52,7 +52,7 @@ std::vector<T> interpolation_coords(const fem::FiniteElement<double>& element,
     throw std::runtime_error("Mixed topology not supported");
   }
 
-  const CoordinateElement<double>& cmap = geometry.cmaps()[0];
+  const CoordinateElement<T>& cmap = geometry.cmaps()[0];
   const std::size_t num_dofs_g = cmap.dim();
 
   // Get the interpolation points on the reference cells
@@ -60,10 +60,9 @@ std::vector<T> interpolation_coords(const fem::FiniteElement<double>& element,
 
   // Evaluate coordinate element basis at reference points
   namespace stdex = std::experimental;
-  using cmdspan4_t
-      = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
+  using cmdspan4_t = stdex::mdspan<const T, stdex::dextents<std::size_t, 4>>;
   std::array<std::size_t, 4> phi_shape = cmap.tabulate_shape(0, Xshape[0]);
-  std::vector<double> phi_b(
+  std::vector<T> phi_b(
       std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
   cmdspan4_t phi_full(phi_b.data(), phi_shape);
   cmap.tabulate(0, X, Xshape, phi_b);
@@ -325,9 +324,9 @@ void interpolate_same_map(Function<T, U>& u1, const Function<T, U>& u0,
   auto mesh = V0->mesh();
   assert(mesh);
 
-  std::shared_ptr<const FiniteElement<double>> element0 = V0->element();
+  std::shared_ptr<const FiniteElement<U>> element0 = V0->element();
   assert(element0);
-  std::shared_ptr<const FiniteElement<double>> element1 = V1->element();
+  std::shared_ptr<const FiniteElement<U>> element1 = V1->element();
   assert(element1);
 
   const int tdim = mesh->topology()->dim();
@@ -352,9 +351,11 @@ void interpolate_same_map(Function<T, U>& u1, const Function<T, U>& u0,
   const int bs1 = dofmap1->bs();
   const int bs0 = dofmap0->bs();
   auto apply_dof_transformation
-      = element0->get_dof_transformation_function<T>(false, true, false);
+      = element0->template get_dof_transformation_function<T>(false, true,
+                                                              false);
   auto apply_inverse_dof_transform
-      = element1->get_dof_transformation_function<T>(true, true, false);
+      = element1->template get_dof_transformation_function<T>(true, true,
+                                                              false);
 
   // Create working array
   std::vector<T> local0(element0->space_dimension());
@@ -417,9 +418,9 @@ void interpolate_nonmatching_maps(Function<T, U>& u1, const Function<T, U>& u0,
   // Get elements
   auto V1 = u1.function_space();
   assert(V1);
-  std::shared_ptr<const FiniteElement<double>> element0 = V0->element();
+  std::shared_ptr<const FiniteElement<U>> element0 = V0->element();
   assert(element0);
-  std::shared_ptr<const FiniteElement<double>> element1 = V1->element();
+  std::shared_ptr<const FiniteElement<U>> element1 = V1->element();
   assert(element1);
 
   std::span<const std::uint32_t> cell_info;
@@ -440,9 +441,11 @@ void interpolate_nonmatching_maps(Function<T, U>& u1, const Function<T, U>& u0,
   const int bs0 = element0->block_size();
   const int bs1 = element1->block_size();
   const auto apply_dof_transformation0
-      = element0->get_dof_transformation_function<double>(false, false, false);
+      = element0->template get_dof_transformation_function<U>(false, false,
+                                                              false);
   const auto apply_inverse_dof_transform1
-      = element1->get_dof_transformation_function<T>(true, true, false);
+      = element1->template get_dof_transformation_function<T>(true, true,
+                                                              false);
 
   // Get sizes of elements
   const std::size_t dim0 = element0->space_dimension() / bs0;
@@ -453,25 +456,23 @@ void interpolate_nonmatching_maps(Function<T, U>& u1, const Function<T, U>& u0,
   if (mesh->geometry().cmaps().size() > 1)
     throw std::runtime_error("Multiple cmaps");
 
-  const CoordinateElement<double>& cmap = mesh->geometry().cmaps()[0];
+  const CoordinateElement<U>& cmap = mesh->geometry().cmaps()[0];
   const graph::AdjacencyList<std::int32_t>& x_dofmap
       = mesh->geometry().dofmap();
   const std::size_t num_dofs_g = cmap.dim();
   std::span<const U> x_g = mesh->geometry().x();
 
   namespace stdex = std::experimental;
-  using cmdspan2_t
-      = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
-  using cmdspan4_t
-      = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
-  using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
-  using mdspan3_t = stdex::mdspan<double, stdex::dextents<std::size_t, 3>>;
+  using cmdspan2_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 2>>;
+  using cmdspan4_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 4>>;
+  using mdspan2_t = stdex::mdspan<U, stdex::dextents<std::size_t, 2>>;
+  using mdspan3_t = stdex::mdspan<U, stdex::dextents<std::size_t, 3>>;
   using mdspan3T_t = stdex::mdspan<T, stdex::dextents<std::size_t, 3>>;
 
   // Evaluate coordinate map basis at reference interpolation points
   const std::array<std::size_t, 4> phi_shape
       = cmap.tabulate_shape(1, Xshape[0]);
-  std::vector<double> phi_b(
+  std::vector<U> phi_b(
       std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
   cmdspan4_t phi(phi_b.data(), phi_shape);
   cmap.tabulate(1, X, Xshape, phi_b);
@@ -486,10 +487,10 @@ void interpolate_nonmatching_maps(Function<T, U>& u1, const Function<T, U>& u0,
   std::vector<T> local1(element1->space_dimension());
   std::vector<T> coeffs0(element0->space_dimension());
 
-  std::vector<double> basis0_b(Xshape[0] * dim0 * value_size0);
+  std::vector<U> basis0_b(Xshape[0] * dim0 * value_size0);
   mdspan3_t basis0(basis0_b.data(), Xshape[0], dim0, value_size0);
 
-  std::vector<double> basis_reference0_b(Xshape[0] * dim0 * value_size_ref0);
+  std::vector<U> basis_reference0_b(Xshape[0] * dim0 * value_size_ref0);
   mdspan3_t basis_reference0(basis_reference0_b.data(), Xshape[0], dim0,
                              value_size_ref0);
 
@@ -500,30 +501,31 @@ void interpolate_nonmatching_maps(Function<T, U>& u1, const Function<T, U>& u0,
   mdspan3T_t mapped_values0(mapped_values_b.data(), Xshape[0], 1,
                             element1->value_size());
 
-  std::vector<double> coord_dofs_b(num_dofs_g * gdim);
+  std::vector<U> coord_dofs_b(num_dofs_g * gdim);
   mdspan2_t coord_dofs(coord_dofs_b.data(), num_dofs_g, gdim);
 
-  std::vector<double> J_b(Xshape[0] * gdim * tdim);
+  std::vector<U> J_b(Xshape[0] * gdim * tdim);
   mdspan3_t J(J_b.data(), Xshape[0], gdim, tdim);
-  std::vector<double> K_b(Xshape[0] * tdim * gdim);
+  std::vector<U> K_b(Xshape[0] * tdim * gdim);
   mdspan3_t K(K_b.data(), Xshape[0], tdim, gdim);
-  std::vector<double> detJ(Xshape[0]);
-  std::vector<double> det_scratch(2 * gdim * tdim);
+  std::vector<U> detJ(Xshape[0]);
+  std::vector<U> det_scratch(2 * gdim * tdim);
 
   // Get interpolation operator
   const auto [_Pi_1, pi_shape] = element1->interpolation_operator();
   cmdspan2_t Pi_1(_Pi_1.data(), pi_shape);
 
-  using u_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
-  using U_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
-  using J_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
-  using K_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
+  using u_t = stdex::mdspan<U, stdex::dextents<std::size_t, 2>>;
+  using U_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 2>>;
+  using J_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 2>>;
+  using K_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 2>>;
   auto push_forward_fn0
-      = element0->basix_element().map_fn<u_t, U_t, J_t, K_t>();
+      = element0->basix_element().template map_fn<u_t, U_t, J_t, K_t>();
 
   using v_t = stdex::mdspan<const T, stdex::dextents<std::size_t, 2>>;
   using V_t = stdex::mdspan<T, stdex::dextents<std::size_t, 2>>;
-  auto pull_back_fn1 = element1->basix_element().map_fn<V_t, v_t, K_t, J_t>();
+  auto pull_back_fn1
+      = element1->basix_element().template map_fn<V_t, v_t, K_t, J_t>();
 
   // Iterate over mesh and interpolate on each cell
   std::span<const T> array0 = u0.x()->array();
@@ -650,7 +652,7 @@ void interpolate_nonmatching_meshes(
   const int tdim = mesh->topology()->dim();
   const auto cell_map = mesh->topology()->index_map(tdim);
 
-  std::shared_ptr<const FiniteElement<double>> element_u
+  std::shared_ptr<const FiniteElement<U>> element_u
       = u.function_space()->element();
   const std::size_t value_size = element_u->value_size();
 
@@ -718,14 +720,12 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
                  std::span<const std::int32_t> cells)
 {
   namespace stdex = std::experimental;
-  using cmdspan2_t
-      = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
-  using cmdspan4_t
-      = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
-  using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
-  using mdspan3_t = stdex::mdspan<double, stdex::dextents<std::size_t, 3>>;
-
-  std::shared_ptr<const FiniteElement<double>> element = u.function_space()->element();
+  using cmdspan2_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 2>>;
+  using cmdspan4_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 4>>;
+  using mdspan2_t = stdex::mdspan<U, stdex::dextents<std::size_t, 2>>;
+  using mdspan3_t = stdex::mdspan<U, stdex::dextents<std::size_t, 3>>;
+  std::shared_ptr<const FiniteElement<U>> element
+      = u.function_space()->element();
   assert(element);
   const int element_bs = element->block_size();
   if (int num_sub = element->num_sub_elements();
@@ -776,7 +776,8 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
     // e.g. not Piola mapped
 
     auto apply_inv_transpose_dof_transformation
-        = element->get_dof_transformation_function<T>(true, true, true);
+        = element->template get_dof_transformation_function<T>(true, true,
+                                                               true);
 
     // Loop over cells
     for (std::size_t c = 0; c < cells.size(); ++c)
@@ -819,7 +820,8 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
     assert(Pi.extent(0) == num_scalar_dofs);
 
     auto apply_inv_transpose_dof_transformation
-        = element->get_dof_transformation_function<T>(true, true, true);
+        = element->template get_dof_transformation_function<T>(true, true,
+                                                               true);
 
     // Loop over cells
     std::vector<T> ref_data_b(num_interp_points);
@@ -867,7 +869,7 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
     // Get coordinate map
     if (mesh->geometry().cmaps().size() > 1)
       throw std::runtime_error("Multiple cmaps");
-    const CoordinateElement<double>& cmap = mesh->geometry().cmaps()[0];
+    const CoordinateElement<U>& cmap = mesh->geometry().cmaps()[0];
 
     // Get geometry data
     const graph::AdjacencyList<std::int32_t>& x_dofmap
@@ -876,14 +878,14 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
     std::span<const U> x_g = mesh->geometry().x();
 
     // Create data structures for Jacobian info
-    std::vector<double> J_b(Xshape[0] * gdim * tdim);
+    std::vector<U> J_b(Xshape[0] * gdim * tdim);
     mdspan3_t J(J_b.data(), Xshape[0], gdim, tdim);
-    std::vector<double> K_b(Xshape[0] * tdim * gdim);
+    std::vector<U> K_b(Xshape[0] * tdim * gdim);
     mdspan3_t K(K_b.data(), Xshape[0], tdim, gdim);
-    std::vector<double> detJ(Xshape[0]);
-    std::vector<double> det_scratch(2 * gdim * tdim);
+    std::vector<U> detJ(Xshape[0]);
+    std::vector<U> det_scratch(2 * gdim * tdim);
 
-    std::vector<double> coord_dofs_b(num_dofs_g * gdim);
+    std::vector<U> coord_dofs_b(num_dofs_g * gdim);
     mdspan2_t coord_dofs(coord_dofs_b.data(), num_dofs_g, gdim);
 
     std::vector<T> ref_data_b(Xshape[0] * 1 * value_size);
@@ -897,7 +899,7 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
     // Tabulate 1st derivative of shape functions at interpolation
     // coords
     std::array<std::size_t, 4> phi_shape = cmap.tabulate_shape(1, Xshape[0]);
-    std::vector<double> phi_b(
+    std::vector<U> phi_b(
         std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
     cmdspan4_t phi(phi_b.data(), phi_shape);
     cmap.tabulate(1, X, Xshape, phi_b);
@@ -908,7 +910,7 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
                              const std::span<const std::uint32_t>&,
                              std::int32_t, int)>
         apply_inverse_transpose_dof_transformation
-        = element->get_dof_transformation_function<T>(true, true);
+        = element->template get_dof_transformation_function<T>(true, true);
 
     // Get interpolation operator
     const auto [_Pi, pi_shape] = element->interpolation_operator();
@@ -917,9 +919,10 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
     namespace stdex = std::experimental;
     using u_t = stdex::mdspan<const T, stdex::dextents<std::size_t, 2>>;
     using U_t = stdex::mdspan<T, stdex::dextents<std::size_t, 2>>;
-    using J_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
-    using K_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
-    auto pull_back_fn = element->basix_element().map_fn<U_t, u_t, J_t, K_t>();
+    using J_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 2>>;
+    using K_t = stdex::mdspan<const U, stdex::dextents<std::size_t, 2>>;
+    auto pull_back_fn
+        = element->basix_element().template map_fn<U_t, u_t, J_t, K_t>();
 
     for (std::size_t c = 0; c < cells.size(); ++c)
     {
@@ -1004,7 +1007,7 @@ template <std::floating_point T>
 std::tuple<std::vector<std::int32_t>, std::vector<std::int32_t>, std::vector<T>,
            std::vector<std::int32_t>>
 create_nonmatching_meshes_interpolation_data(
-    const mesh::Geometry<T>& geometry0, const FiniteElement<double>& element0,
+    const mesh::Geometry<T>& geometry0, const FiniteElement<T>& element0,
     const mesh::Mesh<T>& mesh1, std::span<const std::int32_t> cells)
 {
   // Collect all the points at which values are needed to define the
@@ -1013,7 +1016,7 @@ create_nonmatching_meshes_interpolation_data(
       = interpolation_coords(element0, geometry0, cells);
 
   // Transpose interpolation coords
-  std::vector<double> x(coords.size());
+  std::vector<T> x(coords.size());
   std::size_t num_points = coords.size() / 3;
   for (std::size_t i = 0; i < num_points; ++i)
     for (std::size_t j = 0; j < 3; ++j)
@@ -1032,7 +1035,7 @@ template <std::floating_point T>
 std::tuple<std::vector<std::int32_t>, std::vector<std::int32_t>, std::vector<T>,
            std::vector<std::int32_t>>
 create_nonmatching_meshes_interpolation_data(const mesh::Mesh<T>& mesh0,
-                                             const FiniteElement<double>& element0,
+                                             const FiniteElement<T>& element0,
                                              const mesh::Mesh<T>& mesh1)
 {
   int tdim = mesh0.topology()->dim();

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -38,7 +38,7 @@ class Function;
 /// @return The coordinates in the physical space at which to evaluate
 /// an expression. The shape is (3, num_points) and storage is row-major.
 template <std::floating_point T>
-std::vector<T> interpolation_coords(const fem::FiniteElement& element,
+std::vector<T> interpolation_coords(const fem::FiniteElement<double>& element,
                                     const mesh::Geometry<T>& geometry,
                                     std::span<const std::int32_t> cells)
 {
@@ -325,9 +325,9 @@ void interpolate_same_map(Function<T, U>& u1, const Function<T, U>& u0,
   auto mesh = V0->mesh();
   assert(mesh);
 
-  std::shared_ptr<const FiniteElement> element0 = V0->element();
+  std::shared_ptr<const FiniteElement<double>> element0 = V0->element();
   assert(element0);
-  std::shared_ptr<const FiniteElement> element1 = V1->element();
+  std::shared_ptr<const FiniteElement<double>> element1 = V1->element();
   assert(element1);
 
   const int tdim = mesh->topology()->dim();
@@ -417,9 +417,9 @@ void interpolate_nonmatching_maps(Function<T, U>& u1, const Function<T, U>& u0,
   // Get elements
   auto V1 = u1.function_space();
   assert(V1);
-  std::shared_ptr<const FiniteElement> element0 = V0->element();
+  std::shared_ptr<const FiniteElement<double>> element0 = V0->element();
   assert(element0);
-  std::shared_ptr<const FiniteElement> element1 = V1->element();
+  std::shared_ptr<const FiniteElement<double>> element1 = V1->element();
   assert(element1);
 
   std::span<const std::uint32_t> cell_info;
@@ -650,7 +650,7 @@ void interpolate_nonmatching_meshes(
   const int tdim = mesh->topology()->dim();
   const auto cell_map = mesh->topology()->index_map(tdim);
 
-  std::shared_ptr<const FiniteElement> element_u
+  std::shared_ptr<const FiniteElement<double>> element_u
       = u.function_space()->element();
   const std::size_t value_size = element_u->value_size();
 
@@ -725,7 +725,7 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
   using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
   using mdspan3_t = stdex::mdspan<double, stdex::dextents<std::size_t, 3>>;
 
-  std::shared_ptr<const FiniteElement> element = u.function_space()->element();
+  std::shared_ptr<const FiniteElement<double>> element = u.function_space()->element();
   assert(element);
   const int element_bs = element->block_size();
   if (int num_sub = element->num_sub_elements();
@@ -1004,7 +1004,7 @@ template <std::floating_point T>
 std::tuple<std::vector<std::int32_t>, std::vector<std::int32_t>, std::vector<T>,
            std::vector<std::int32_t>>
 create_nonmatching_meshes_interpolation_data(
-    const mesh::Geometry<T>& geometry0, const FiniteElement& element0,
+    const mesh::Geometry<T>& geometry0, const FiniteElement<double>& element0,
     const mesh::Mesh<T>& mesh1, std::span<const std::int32_t> cells)
 {
   // Collect all the points at which values are needed to define the
@@ -1032,7 +1032,7 @@ template <std::floating_point T>
 std::tuple<std::vector<std::int32_t>, std::vector<std::int32_t>, std::vector<T>,
            std::vector<std::int32_t>>
 create_nonmatching_meshes_interpolation_data(const mesh::Mesh<T>& mesh0,
-                                             const FiniteElement& element0,
+                                             const FiniteElement<double>& element0,
                                              const mesh::Mesh<T>& mesh1)
 {
   int tdim = mesh0.topology()->dim();

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -440,10 +440,10 @@ void interpolate_nonmatching_maps(Function<T, U>& u1, const Function<T, U>& u0,
   // Get block sizes and dof transformation operators
   const int bs0 = element0->block_size();
   const int bs1 = element1->block_size();
-  const auto apply_dof_transformation0
+  auto apply_dof_transformation0
       = element0->template get_dof_transformation_function<U>(false, false,
                                                               false);
-  const auto apply_inverse_dof_transform1
+  auto apply_inverse_dof_transform1
       = element1->template get_dof_transformation_function<T>(true, true,
                                                               false);
 
@@ -649,7 +649,7 @@ void interpolate_nonmatching_meshes(
 
   MPI_Comm comm = mesh->comm();
   const int tdim = mesh->topology()->dim();
-  const auto cell_map = mesh->topology()->index_map(tdim);
+  auto cell_map = mesh->topology()->index_map(tdim);
 
   auto element_u = u.function_space()->element();
   assert(element_u);

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -100,7 +100,7 @@ fem::create_dofmap(MPI_Comm comm, const ElementDofLayout& layout,
                    mesh::Topology& topology,
                    const std::function<std::vector<int>(
                        const graph::AdjacencyList<std::int32_t>&)>& reorder_fn,
-                   const FiniteElement& element)
+                   const FiniteElement<double>& element)
 {
   // Create required mesh entities
   const int D = topology.dim();

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -95,12 +95,12 @@ fem::create_element_dof_layout(const ufcx_dofmap& dofmap,
                           parent_map, sub_doflayout);
 }
 //-----------------------------------------------------------------------------
-fem::DofMap
-fem::create_dofmap(MPI_Comm comm, const ElementDofLayout& layout,
-                   mesh::Topology& topology,
-                   const std::function<std::vector<int>(
-                       const graph::AdjacencyList<std::int32_t>&)>& reorder_fn,
-                   const FiniteElement<double>& element)
+fem::DofMap fem::create_dofmap(
+    MPI_Comm comm, const ElementDofLayout& layout, mesh::Topology& topology,
+    std::function<void(const std::span<std::int32_t>&, std::uint32_t)>
+        unpermute_dofs,
+    std::function<std::vector<int>(const graph::AdjacencyList<std::int32_t>&)>
+        reorder_fn)
 {
   // Create required mesh entities
   const int D = topology.dim();
@@ -116,16 +116,13 @@ fem::create_dofmap(MPI_Comm comm, const ElementDofLayout& layout,
 
   // If the element's DOF transformations are permutations, permute the
   // DOF numbering on each cell
-  if (element.needs_dof_permutations())
+  if (unpermute_dofs)
   {
     const int D = topology.dim();
     const int num_cells = topology.connectivity(D, 0)->num_nodes();
     topology.create_entity_permutations();
     const std::vector<std::uint32_t>& cell_info
         = topology.get_cell_permutation_info();
-
-    const std::function<void(const std::span<std::int32_t>&, std::uint32_t)>
-        unpermute_dofs = element.get_dof_permutation_function(true, true);
     for (std::int32_t cell = 0; cell < num_cells; ++cell)
       unpermute_dofs(dofmap.links(cell), cell_info[cell]);
   }

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -255,7 +255,7 @@ create_dofmap(MPI_Comm comm, const ElementDofLayout& layout,
               mesh::Topology& topology,
               const std::function<std::vector<int>(
                   const graph::AdjacencyList<std::int32_t>&)>& reorder_fn,
-              const FiniteElement& element);
+              const FiniteElement<double>& element);
 
 /// Get the name of each coefficient in a UFC form
 /// @param[in] ufcx_form The UFC form
@@ -660,7 +660,7 @@ create_functionspace(std::shared_ptr<mesh::Mesh<T>> mesh,
                      = nullptr)
 {
   // Create a DOLFINx element
-  auto _e = std::make_shared<FiniteElement>(e, bs);
+  auto _e = std::make_shared<FiniteElement<double>>(e, bs);
 
   // Create UFC subdofmaps and compute offset
   assert(_e);
@@ -732,7 +732,7 @@ create_functionspace(ufcx_function_space* (*fptr)(const char*),
     throw std::runtime_error("UFL mesh and CoordinateElement do not match.");
   }
 
-  auto element = std::make_shared<FiniteElement>(*ufcx_element);
+  auto element = std::make_shared<FiniteElement<double>>(*ufcx_element);
   assert(element);
   ufcx_dofmap* ufcx_map = space->dofmap;
   assert(ufcx_map);
@@ -756,7 +756,7 @@ std::span<const std::uint32_t> get_cell_orientation_info(
   bool needs_dof_transformations = false;
   for (auto coeff : coefficients)
   {
-    std::shared_ptr<const FiniteElement> element
+    std::shared_ptr<const FiniteElement<double>> element
         = coeff->function_space()->element();
     if (element->needs_dof_transformations())
     {
@@ -838,7 +838,7 @@ void pack_coefficient_entity(std::span<T> c, int cstride,
   // Read data from coefficient Function u
   std::span<const T> v = u.x()->array();
   const DofMap& dofmap = *u.function_space()->dofmap();
-  std::shared_ptr<const FiniteElement> element = u.function_space()->element();
+  std::shared_ptr<const FiniteElement<double>> element = u.function_space()->element();
   assert(element);
   int space_dim = element->space_dimension();
   const auto transformation

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -742,10 +742,15 @@ create_functionspace(ufcx_function_space* (*fptr)(const char*),
   assert(mesh->topology());
   ElementDofLayout layout
       = create_element_dof_layout(*ufcx_map, mesh->topology()->cell_types()[0]);
-  return FunctionSpace(
-      mesh, element,
-      std::make_shared<DofMap>(create_dofmap(
-          mesh->comm(), layout, *mesh->topology(), reorder_fn, *element)));
+
+  std::function<void(const std::span<std::int32_t>&, std::uint32_t)>
+      unpermute_dofs = nullptr;
+  if (element->needs_dof_permutations())
+    unpermute_dofs = element->get_dof_permutation_function(true, true);
+  return FunctionSpace(mesh, element,
+                       std::make_shared<DofMap>(create_dofmap(
+                           mesh->comm(), layout, *mesh->topology(),
+                           unpermute_dofs, reorder_fn)));
 }
 
 /// @private

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -661,9 +661,9 @@ create_functionspace(std::shared_ptr<mesh::Mesh<T>> mesh,
 {
   // Create a DOLFINx element
   auto _e = std::make_shared<FiniteElement<T>>(e, bs);
+  assert(_e);
 
   // Create UFC subdofmaps and compute offset
-  assert(_e);
   const int num_sub_elements = _e->num_sub_elements();
   std::vector<ElementDofLayout> sub_doflayout;
   sub_doflayout.reserve(num_sub_elements);
@@ -845,8 +845,7 @@ void pack_coefficient_entity(std::span<T> c, int cstride,
   // Read data from coefficient Function u
   std::span<const T> v = u.x()->array();
   const DofMap& dofmap = *u.function_space()->dofmap();
-  std::shared_ptr<const FiniteElement<U>> element
-      = u.function_space()->element();
+  auto element = u.function_space()->element();
   assert(element);
   int space_dim = element->space_dimension();
   const auto transformation

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -848,7 +848,7 @@ void pack_coefficient_entity(std::span<T> c, int cstride,
   auto element = u.function_space()->element();
   assert(element);
   int space_dim = element->space_dimension();
-  const auto transformation
+  auto transformation
       = element->template get_dof_transformation_function<T>(false, true);
   const int bs = dofmap.bs();
   switch (bs)

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -654,13 +654,13 @@ Form<T, U> create_form(
 template <std::floating_point T>
 FunctionSpace<T>
 create_functionspace(std::shared_ptr<mesh::Mesh<T>> mesh,
-                     const basix::FiniteElement<double>& e, int bs,
+                     const basix::FiniteElement<T>& e, int bs,
                      const std::function<std::vector<int>(
                          const graph::AdjacencyList<std::int32_t>&)>& reorder_fn
                      = nullptr)
 {
   // Create a DOLFINx element
-  auto _e = std::make_shared<FiniteElement<double>>(e, bs);
+  auto _e = std::make_shared<FiniteElement<T>>(e, bs);
 
   // Create UFC subdofmaps and compute offset
   assert(_e);
@@ -735,7 +735,7 @@ create_functionspace(ufcx_function_space* (*fptr)(const char*),
     throw std::runtime_error("UFL mesh and CoordinateElement do not match.");
   }
 
-  auto element = std::make_shared<FiniteElement<double>>(*ufcx_element);
+  auto element = std::make_shared<FiniteElement<T>>(*ufcx_element);
   assert(element);
   ufcx_dofmap* ufcx_map = space->dofmap;
   assert(ufcx_map);
@@ -764,8 +764,7 @@ std::span<const std::uint32_t> get_cell_orientation_info(
   bool needs_dof_transformations = false;
   for (auto coeff : coefficients)
   {
-    std::shared_ptr<const FiniteElement<double>> element
-        = coeff->function_space()->element();
+    auto element = coeff->function_space()->element();
     if (element->needs_dof_transformations())
     {
       needs_dof_transformations = true;
@@ -846,12 +845,12 @@ void pack_coefficient_entity(std::span<T> c, int cstride,
   // Read data from coefficient Function u
   std::span<const T> v = u.x()->array();
   const DofMap& dofmap = *u.function_space()->dofmap();
-  std::shared_ptr<const FiniteElement<double>> element
+  std::shared_ptr<const FiniteElement<U>> element
       = u.function_space()->element();
   assert(element);
   int space_dim = element->space_dimension();
   const auto transformation
-      = element->get_dof_transformation_function<T>(false, true);
+      = element->template get_dof_transformation_function<T>(false, true);
   const int bs = dofmap.bs();
   switch (bs)
   {
@@ -1047,7 +1046,7 @@ Expression<T, U> create_expression(
                              "function space was provided.");
   }
 
-  std::span<const double> X(e.points, e.num_points * e.topological_dimension);
+  std::span<const U> X(e.points, e.num_points * e.topological_dimension);
   std::array<std::size_t, 2> Xshape
       = {static_cast<std::size_t>(e.num_points),
          static_cast<std::size_t>(e.topological_dimension)};

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -668,7 +668,7 @@ determine_point_ownership(const mesh::Mesh<T>& mesh, std::span<const T> points)
   // cells that could collide with the points
   constexpr T padding = 1.0e-4;
   const int tdim = mesh.topology()->dim();
-  const auto cell_map = mesh.topology()->index_map(tdim);
+  auto cell_map = mesh.topology()->index_map(tdim);
   const std::int32_t num_cells = cell_map->size_local();
   // NOTE: Should we send the cells in as input?
   std::vector<std::int32_t> cells(num_cells, 0);
@@ -705,7 +705,7 @@ determine_point_ownership(const mesh::Mesh<T>& mesh, std::span<const T> points)
   // Count the number of points to send per neighbor process
   std::vector<std::int32_t> send_sizes(out_ranks.size());
   for (std::size_t i = 0; i < points.size() / 3; ++i)
-    for (const auto& p : collisions.links(i))
+    for (auto p : collisions.links(i))
       send_sizes[rank_to_neighbor[p]] += 3;
 
   // Compute receive sizes
@@ -728,7 +728,7 @@ determine_point_ownership(const mesh::Mesh<T>& mesh, std::span<const T> points)
   std::vector<std::int32_t> unpack_map(send_offsets.back() / 3);
   for (std::size_t i = 0; i < points.size(); i += 3)
   {
-    for (const auto& p : collisions.links(i / 3))
+    for (auto p : collisions.links(i / 3))
     {
       int neighbor = rank_to_neighbor[p];
       int pos = send_offsets[neighbor] + counter[neighbor];
@@ -816,7 +816,7 @@ determine_point_ownership(const mesh::Mesh<T>& mesh, std::span<const T> points)
   std::fill(counter.begin(), counter.end(), 0);
   for (std::size_t i = 0; i < points.size() / 3; ++i)
   {
-    for (const auto& p : collisions.links(i))
+    for (auto p : collisions.links(i))
     {
       int neighbor = rank_to_neighbor[p];
       send_owners[send_offsets[neighbor] + counter[neighbor]++]

--- a/cpp/dolfinx/graph/AdjacencyList.h
+++ b/cpp/dolfinx/graph/AdjacencyList.h
@@ -59,11 +59,11 @@ public:
     // Initialize offsets and compute total size
     _offsets.reserve(data.size() + 1);
     _offsets.push_back(0);
-    for (const auto& row : data)
+    for (auto& row : data)
       _offsets.push_back(_offsets.back() + row.size());
 
     _array.reserve(_offsets.back());
-    for (const auto& e : data)
+    for (auto& e : data)
       _array.insert(_array.end(), e.begin(), e.end());
   }
 
@@ -172,10 +172,10 @@ AdjacencyList(T, U) -> AdjacencyList<typename T::value_type>;
 /// @return An adjacency list
 template <typename U>
   requires requires {
-             typename std::decay_t<U>::value_type;
-             requires std::convertible_to<
-                 U, std::vector<typename std::decay_t<U>::value_type>>;
-           }
+    typename std::decay_t<U>::value_type;
+    requires std::convertible_to<
+        U, std::vector<typename std::decay_t<U>::value_type>>;
+  }
 AdjacencyList<typename std::decay_t<U>::value_type>
 regular_adjacency_list(U&& data, int degree)
 {

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -532,7 +532,7 @@ public:
     assert(mesh);
 
     // Extract element from first function
-    const fem::FiniteElement<double>* element0 = std::visit(
+    const fem::FiniteElement<T>* element0 = std::visit(
         [](const auto& e) { return e->function_space()->element().get(); },
         u.front());
     assert(element0);
@@ -944,7 +944,7 @@ public:
       throw std::runtime_error("VTXWriter fem::Function list is empty");
 
     // Extract element from first function
-    const fem::FiniteElement<double>* element0 = std::visit(
+    const fem::FiniteElement<T>* element0 = std::visit(
         [](const auto& u) { return u->function_space()->element().get(); },
         u.front());
     assert(element0);

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -148,15 +148,15 @@ extract_common_mesh(const typename adios2_writer::U<T>& u)
 {
   // Extract mesh from first function
   assert(!u.empty());
-  auto mesh = std::visit(
-      [](const auto& u) { return u->function_space()->mesh(); }, u.front());
+  auto mesh = std::visit([](auto& u) { return u->function_space()->mesh(); },
+                         u.front());
   assert(mesh);
 
   // Check that all functions share the same mesh
   for (auto& v : u)
   {
     std::visit(
-        [&mesh](const auto& u)
+        [&mesh](auto& u)
         {
           if (mesh != u->function_space()->mesh())
           {
@@ -483,14 +483,14 @@ public:
       throw std::runtime_error("FidesWriter fem::Function list is empty");
 
     // Extract Mesh from first function
-    auto mesh = std::visit(
-        [](const auto& u) { return u->function_space()->mesh(); }, u.front());
+    auto mesh = std::visit([](auto& u) { return u->function_space()->mesh(); },
+                           u.front());
     assert(mesh);
 
     // Extract element from first function
-    const fem::FiniteElement<T>* element0 = std::visit(
-        [](const auto& e) { return e->function_space()->element().get(); },
-        u.front());
+    auto element0 = std::visit([](auto& e)
+                               { return e->function_space()->element().get(); },
+                               u.front());
     assert(element0);
 
     // Check if function is mixed
@@ -523,7 +523,7 @@ public:
     for (auto& v : _u)
     {
       std::visit(
-          [&](const auto& u)
+          [&](auto& u)
           {
             auto element = u->function_space()->element();
             assert(element);
@@ -607,8 +607,7 @@ public:
 
     for (auto& v : _u)
     {
-      std::visit([&](const auto& u)
-                 { impl_fides::write_data(*_io, *_engine, *u); },
+      std::visit([&](auto& u) { impl_fides::write_data(*_io, *_engine, *u); },
                  v);
     }
 
@@ -919,9 +918,9 @@ public:
       throw std::runtime_error("VTXWriter fem::Function list is empty");
 
     // Extract element from first function
-    const fem::FiniteElement<T>* element0 = std::visit(
-        [](const auto& u) { return u->function_space()->element().get(); },
-        u.front());
+    auto element0 = std::visit([](auto& u)
+                               { return u->function_space()->element().get(); },
+                               u.front());
     assert(element0);
 
     // Check if function is mixed
@@ -951,7 +950,7 @@ public:
     for (auto& v : _u)
     {
       std::visit(
-          [element0](const auto& u)
+          [element0](auto& u)
           {
             auto element = u->function_space()->element();
             assert(element);
@@ -1004,7 +1003,7 @@ public:
     {
       // Write a single mesh for functions as they share finite element
       std::visit(
-          [&](const auto& u) {
+          [&](auto& u) {
             impl_vtx::vtx_write_mesh_from_space(*_io, *_engine,
                                                 *u->function_space());
           },
@@ -1012,9 +1011,8 @@ public:
 
       // Write function data for each function to file
       for (auto& v : _u)
-        std::visit([&](const auto& u)
-                   { impl_vtx::vtx_write_data(*_io, *_engine, *u); },
-                   v);
+        std::visit(
+            [&](auto& u) { impl_vtx::vtx_write_data(*_io, *_engine, *u); }, v);
     }
 
     _engine->EndStep();

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -284,7 +284,7 @@ std::vector<T> pack_function_data(const fem::Function<T, U>& u)
   // Get dof array and pack into array (padded where appropriate)
   auto dofmap_x = geometry.dofmap();
   const int bs = dofmap->bs();
-  const auto& u_data = u.x()->array();
+  auto& u_data = u.x()->array();
   std::vector<T> data(num_vertices * num_components, 0);
   for (std::int32_t c = 0; c < num_cells; ++c)
   {

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -284,7 +284,7 @@ std::vector<T> pack_function_data(const fem::Function<T, U>& u)
   // Get dof array and pack into array (padded where appropriate)
   auto dofmap_x = geometry.dofmap();
   const int bs = dofmap->bs();
-  auto& u_data = u.x()->array();
+  std::span<const T> u_data = u.x()->array();
   std::vector<T> data(num_vertices * num_components, 0);
   for (std::int32_t c = 0; c < num_cells; ++c)
   {

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -370,14 +370,14 @@ void write_data(adios2::IO& io, adios2::Engine& engine,
         io, u.name + impl_adios2::field_ext[0], {}, {},
         {num_vertices, num_components});
     std::transform(data.begin(), data.end(), data_real.begin(),
-                   [](auto& x) -> X { return std::real(x); });
+                   [](auto x) -> X { return std::real(x); });
     engine.Put(local_output_r, data_real.data());
 
     adios2::Variable local_output_c = impl_adios2::define_variable<X>(
         io, u.name + impl_adios2::field_ext[1], {}, {},
         {num_vertices, num_components});
     std::transform(data.begin(), data.end(), data_imag.begin(),
-                   [](auto& x) -> X { return std::imag(x); });
+                   [](auto x) -> X { return std::imag(x); });
     engine.Put(local_output_c, data_imag.data());
     engine.PerformPuts();
   }

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -532,7 +532,7 @@ public:
     assert(mesh);
 
     // Extract element from first function
-    const fem::FiniteElement* element0 = std::visit(
+    const fem::FiniteElement<double>* element0 = std::visit(
         [](const auto& e) { return e->function_space()->element().get(); },
         u.front());
     assert(element0);
@@ -944,7 +944,7 @@ public:
       throw std::runtime_error("VTXWriter fem::Function list is empty");
 
     // Extract element from first function
-    const fem::FiniteElement* element0 = std::visit(
+    const fem::FiniteElement<double>* element0 = std::visit(
         [](const auto& u) { return u->function_space()->element().get(); },
         u.front());
     assert(element0);

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -225,9 +225,10 @@ void XDMFFile::write_geometry(const mesh::Geometry<double>& geometry,
     _xml_doc->save_file(_filename.c_str(), "  ");
 }
 //-----------------------------------------------------------------------------
-mesh::Mesh<double> XDMFFile::read_mesh(const fem::CoordinateElement<double>& element,
-                                       mesh::GhostMode mode, std::string name,
-                                       std::string xpath) const
+mesh::Mesh<double>
+XDMFFile::read_mesh(const fem::CoordinateElement<double>& element,
+                    mesh::GhostMode mode, std::string name,
+                    std::string xpath) const
 {
   // Read mesh data
   auto [cells, cshape] = XDMFFile::read_topology_data(name, xpath);

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -225,7 +225,7 @@ void XDMFFile::write_geometry(const mesh::Geometry<double>& geometry,
     _xml_doc->save_file(_filename.c_str(), "  ");
 }
 //-----------------------------------------------------------------------------
-mesh::Mesh<double> XDMFFile::read_mesh(const fem::CoordinateElement& element,
+mesh::Mesh<double> XDMFFile::read_mesh(const fem::CoordinateElement<double>& element,
                                        mesh::GhostMode mode, std::string name,
                                        std::string xpath) const
 {

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -22,6 +22,7 @@ class xml_document;
 
 namespace dolfinx::fem
 {
+template <std::floating_point T>
 class CoordinateElement;
 template <typename T, std::floating_point U>
 class Function;
@@ -103,7 +104,7 @@ public:
   /// @param[in] xpath XPath where Mesh Grid is located
   /// @return A Mesh distributed on the same communicator as the
   ///   XDMFFile
-  mesh::Mesh<double> read_mesh(const fem::CoordinateElement& element,
+  mesh::Mesh<double> read_mesh(const fem::CoordinateElement<double>& element,
                                mesh::GhostMode mode, std::string name,
                                std::string xpath = "/Xdmf/Domain") const;
 

--- a/cpp/dolfinx/io/vtk_utils.h
+++ b/cpp/dolfinx/io/vtk_utils.h
@@ -84,7 +84,7 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace<T>& V)
   // Get the dof coordinates on the reference element and the  mesh
   // coordinate map
   const auto [X, Xshape] = element->interpolation_points();
-  const fem::CoordinateElement<double>& cmap = mesh->geometry().cmaps()[0];
+  const fem::CoordinateElement<T>& cmap = mesh->geometry().cmaps()[0];
 
   // Prepare cell geometry
   const graph::AdjacencyList<std::int32_t>& dofmap_x
@@ -103,12 +103,12 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace<T>& V)
 
   namespace stdex = std::experimental;
   using mdspan2_t = stdex::mdspan<T, stdex::dextents<std::size_t, 2>>;
-  using cmdspan4_t = stdex::mdspan<double, stdex::dextents<std::size_t, 4>>;
+  using cmdspan4_t = stdex::mdspan<T, stdex::dextents<std::size_t, 4>>;
 
   // Tabulate basis functions at node reference coordinates
   const std::array<std::size_t, 4> phi_shape
       = cmap.tabulate_shape(0, Xshape[0]);
-  std::vector<double> phi_b(
+  std::vector<T> phi_b(
       std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
   cmdspan4_t phi_full(phi_b.data(), phi_shape);
   cmap.tabulate(0, X, Xshape, phi_b);

--- a/cpp/dolfinx/io/vtk_utils.h
+++ b/cpp/dolfinx/io/vtk_utils.h
@@ -84,7 +84,7 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace<T>& V)
   // Get the dof coordinates on the reference element and the  mesh
   // coordinate map
   const auto [X, Xshape] = element->interpolation_points();
-  const fem::CoordinateElement& cmap = mesh->geometry().cmaps()[0];
+  const fem::CoordinateElement<double>& cmap = mesh->geometry().cmaps()[0];
 
   // Prepare cell geometry
   const graph::AdjacencyList<std::int32_t>& dofmap_x

--- a/cpp/dolfinx/io/vtk_utils.h
+++ b/cpp/dolfinx/io/vtk_utils.h
@@ -98,7 +98,7 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace<T>& V)
     mesh->topology_mutable()->create_entity_permutations();
     cell_info = std::span(mesh->topology()->get_cell_permutation_info());
   }
-  const auto apply_dof_transformation
+  auto apply_dof_transformation
       = element->template get_dof_transformation_function<T>();
 
   namespace stdex = std::experimental;

--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -62,7 +62,7 @@ bool has_cell_centred_data(const fem::Function<Scalar, double>& u)
 
 // Get data width - normally the same as u.value_size(), but expand for
 // 2D vector/tensor because XDMF presents everything as 3D
-int get_padded_width(const fem::FiniteElement& e)
+int get_padded_width(const fem::FiniteElement<double>& e)
 {
   const int width = e.value_size();
   const int rank = e.value_shape().size();

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -183,7 +183,7 @@ std::vector<Scalar>
 _get_cell_data_values(const fem::Function<Scalar, double>& u)
 {
   assert(u.function_space()->dofmap());
-  const auto mesh = u.function_space()->mesh();
+  auto mesh = u.function_space()->mesh();
   const int value_size = u.function_space()->element()->value_size();
   const int value_rank = u.function_space()->element()->value_shape().size();
 
@@ -196,7 +196,7 @@ _get_cell_data_values(const fem::Function<Scalar, double>& u)
   // Build lists of dofs and create map
   std::vector<std::int32_t> dof_set;
   dof_set.reserve(local_size);
-  const auto dofmap = u.function_space()->dofmap();
+  auto dofmap = u.function_space()->dofmap();
   const int ndofs = dofmap->element_dof_layout().num_dofs();
   const int bs = dofmap->bs();
   assert(ndofs * bs == value_size);

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -126,7 +126,7 @@ compute_point_values(const fem::Function<T, double>& u)
 //-----------------------------------------------------------------------------
 // Get data width - normally the same as u.value_size(), but expand for
 // 2D vector/tensor because XDMF presents everything as 3D
-std::int64_t get_padded_width(const fem::FiniteElement& e)
+std::int64_t get_padded_width(const fem::FiniteElement<double>& e)
 {
   const int width = e.value_size();
   const int rank = e.value_shape().size();

--- a/cpp/dolfinx/io/xdmf_utils.h
+++ b/cpp/dolfinx/io/xdmf_utils.h
@@ -35,6 +35,7 @@ class Function;
 
 namespace fem
 {
+template <std::floating_point T>
 class CoordinateElement;
 }
 

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -309,7 +309,7 @@ public:
       std::int32_t local_col = ghost_index_array[i + 1] - local_range[1][0];
       if (local_col < 0 or local_col >= local_size[1])
       {
-        const auto it = std::lower_bound(
+        auto it = std::lower_bound(
             global_to_local.begin(), global_to_local.end(),
             std::pair(ghost_index_array[i + 1], -1),
             [](auto& a, auto& b) { return a.first < b.first; });

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -79,15 +79,6 @@ public:
   /// Move Assignment
   Geometry& operator=(Geometry&&) = default;
 
-  /// Copy constructor
-  template <std::floating_point U>
-  Geometry<U> astype() const
-  {
-    return Geometry<U>(_index_map, _dofmap, _cmaps,
-                       std::vector<U>(_x.begin(), _x.end()), _dim,
-                       _input_global_indices);
-  }
-
   /// Return Euclidean dimension of coordinate system
   int dim() const { return _dim; }
 

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -80,7 +80,7 @@ public:
   Geometry& operator=(Geometry&&) = default;
 
   /// Copy constructor
-  template <typename U>
+  template <std::floating_point U>
   Geometry<U> astype() const
   {
     return Geometry<U>(_index_map, _dofmap, _cmaps,
@@ -170,10 +170,10 @@ mesh::Geometry<typename std::remove_reference_t<typename U::value_type>>
 create_geometry(
     MPI_Comm comm, const Topology& topology,
     const std::vector<fem::CoordinateElement<
-        typename std::remove_reference_t<typename U::value_type>>>& elements,
+        std::remove_reference_t<typename U::value_type>>>& elements,
     const graph::AdjacencyList<std::int64_t>& cell_nodes, const U& x, int dim,
-    const std::function<
-        std::vector<int>(const graph::AdjacencyList<std::int32_t>&)>& reorder_fn
+    std::function<std::vector<int>(const graph::AdjacencyList<std::int32_t>&)>
+        reorder_fn
     = nullptr)
 {
   // TODO: make sure required entities are initialised, or extend

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -50,8 +50,11 @@ public:
             std::convertible_to<std::vector<T>> V,
             std::convertible_to<std::vector<std::int64_t>> W>
   Geometry(std::shared_ptr<const common::IndexMap> index_map, U&& dofmap,
-           const std::vector<fem::CoordinateElement<double>>& elements, V&& x,
-           int dim, W&& input_global_indices)
+           const std::vector<fem::CoordinateElement<
+               typename
+
+               std::remove_reference_t<typename V::value_type>>>& elements,
+           V&& x, int dim, W&& input_global_indices)
       : _dim(dim), _dofmap(std::forward<U>(dofmap)), _index_map(index_map),
         _cmaps(elements), _x(std::forward<V>(x)),
         _input_global_indices(std::forward<W>(input_global_indices))
@@ -113,10 +116,7 @@ public:
   /// @brief The elements that describes the geometry maps.
   ///
   /// @return The coordinate/geometry elements
-  const std::vector<fem::CoordinateElement<double>>& cmaps() const
-  {
-    return _cmaps;
-  }
+  const std::vector<fem::CoordinateElement<T>>& cmaps() const { return _cmaps; }
 
   /// Global user indices
   const std::vector<std::int64_t>& input_global_indices() const
@@ -135,7 +135,7 @@ private:
   std::shared_ptr<const common::IndexMap> _index_map;
 
   // The coordinate elements
-  std::vector<fem::CoordinateElement<double>> _cmaps;
+  std::vector<fem::CoordinateElement<T>> _cmaps;
 
   // Coordinates for all points stored as a contiguous array (row-major,
   // column size = 3)
@@ -167,13 +167,14 @@ private:
 /// map associated with the geometry data
 template <typename U>
 mesh::Geometry<typename std::remove_reference_t<typename U::value_type>>
-create_geometry(MPI_Comm comm, const Topology& topology,
-                const std::vector<fem::CoordinateElement<double>>& elements,
-                const graph::AdjacencyList<std::int64_t>& cell_nodes,
-                const U& x, int dim,
-                const std::function<std::vector<int>(
-                    const graph::AdjacencyList<std::int32_t>&)>& reorder_fn
-                = nullptr)
+create_geometry(
+    MPI_Comm comm, const Topology& topology,
+    const std::vector<fem::CoordinateElement<
+        typename std::remove_reference_t<typename U::value_type>>>& elements,
+    const graph::AdjacencyList<std::int64_t>& cell_nodes, const U& x, int dim,
+    const std::function<
+        std::vector<int>(const graph::AdjacencyList<std::int32_t>&)>& reorder_fn
+    = nullptr)
 {
   // TODO: make sure required entities are initialised, or extend
   // fem::build_dofmap_data
@@ -370,9 +371,9 @@ create_subgeometry(const Topology& topology, const Geometry<T>& geometry,
   // Create sub-geometry coordinate element
   CellType sub_coord_cell
       = cell_entity_type(geometry.cmaps()[0].cell_shape(), dim, 0);
-  fem::CoordinateElement<double> sub_coord_ele(sub_coord_cell,
-                                               geometry.cmaps()[0].degree(),
-                                               geometry.cmaps()[0].variant());
+  fem::CoordinateElement<T> sub_coord_ele(sub_coord_cell,
+                                          geometry.cmaps()[0].degree(),
+                                          geometry.cmaps()[0].variant());
 
   // Sub-geometry input_global_indices
   // TODO: Check this

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -50,8 +50,8 @@ public:
             std::convertible_to<std::vector<T>> V,
             std::convertible_to<std::vector<std::int64_t>> W>
   Geometry(std::shared_ptr<const common::IndexMap> index_map, U&& dofmap,
-           const std::vector<fem::CoordinateElement>& elements, V&& x, int dim,
-           W&& input_global_indices)
+           const std::vector<fem::CoordinateElement<double>>& elements, V&& x,
+           int dim, W&& input_global_indices)
       : _dim(dim), _dofmap(std::forward<U>(dofmap)), _index_map(index_map),
         _cmaps(elements), _x(std::forward<V>(x)),
         _input_global_indices(std::forward<W>(input_global_indices))
@@ -113,7 +113,10 @@ public:
   /// @brief The elements that describes the geometry maps.
   ///
   /// @return The coordinate/geometry elements
-  const std::vector<fem::CoordinateElement>& cmaps() const { return _cmaps; }
+  const std::vector<fem::CoordinateElement<double>>& cmaps() const
+  {
+    return _cmaps;
+  }
 
   /// Global user indices
   const std::vector<std::int64_t>& input_global_indices() const
@@ -132,7 +135,7 @@ private:
   std::shared_ptr<const common::IndexMap> _index_map;
 
   // The coordinate elements
-  std::vector<fem::CoordinateElement> _cmaps;
+  std::vector<fem::CoordinateElement<double>> _cmaps;
 
   // Coordinates for all points stored as a contiguous array (row-major,
   // column size = 3)
@@ -165,7 +168,7 @@ private:
 template <typename U>
 mesh::Geometry<typename std::remove_reference_t<typename U::value_type>>
 create_geometry(MPI_Comm comm, const Topology& topology,
-                const std::vector<fem::CoordinateElement>& elements,
+                const std::vector<fem::CoordinateElement<double>>& elements,
                 const graph::AdjacencyList<std::int64_t>& cell_nodes,
                 const U& x, int dim,
                 const std::function<std::vector<int>(
@@ -367,9 +370,9 @@ create_subgeometry(const Topology& topology, const Geometry<T>& geometry,
   // Create sub-geometry coordinate element
   CellType sub_coord_cell
       = cell_entity_type(geometry.cmaps()[0].cell_shape(), dim, 0);
-  fem::CoordinateElement sub_coord_ele(sub_coord_cell,
-                                       geometry.cmaps()[0].degree(),
-                                       geometry.cmaps()[0].variant());
+  fem::CoordinateElement<double> sub_coord_ele(sub_coord_cell,
+                                               geometry.cmaps()[0].degree(),
+                                               geometry.cmaps()[0].variant());
 
   // Sub-geometry input_global_indices
   // TODO: Check this

--- a/cpp/dolfinx/mesh/Mesh.h
+++ b/cpp/dolfinx/mesh/Mesh.h
@@ -15,8 +15,8 @@ namespace dolfinx::mesh
 {
 class Topology;
 
-/// @brief A Mesh consists of a set of connected and numbered mesh topological
-/// entities, and geometry data.
+/// @brief A Mesh consists of a set of connected and numbered mesh
+/// topological entities, and geometry data.
 /// @tparam The float type for representing the geometry,
 template <std::floating_point T>
 class Mesh

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -113,7 +113,7 @@ Mesh<T> create_interval(MPI_Comm comm, std::size_t nx, std::array<double, 2> x,
                         const CellPartitionFunction& partitioner
                         = create_cell_partitioner())
 {
-  fem::CoordinateElement<double> element(CellType::interval, 1);
+  fem::CoordinateElement<T> element(CellType::interval, 1);
 
   // Receive mesh according to parallel policy
   if (dolfinx::MPI::rank(comm) != 0)
@@ -326,7 +326,7 @@ Mesh<T> build_tet(MPI_Comm comm, const std::array<std::array<double, 3>, 2>& p,
     std::copy(c.begin(), c.end(), std::next(cells.begin(), 4 * offset));
   }
 
-  fem::CoordinateElement<double> element(CellType::tetrahedron, 1);
+  fem::CoordinateElement<T> element(CellType::tetrahedron, 1);
   return create_mesh(comm, graph::regular_adjacency_list(std::move(cells), 4),
                      {element}, geom, {geom.size() / 3, 3}, partitioner);
 }
@@ -370,7 +370,7 @@ mesh::Mesh<T> build_hex(MPI_Comm comm,
               std::next(cells.begin(), (i - range_c[0]) * 8));
   }
 
-  fem::CoordinateElement<double> element(CellType::hexahedron, 1);
+  fem::CoordinateElement<T> element(CellType::hexahedron, 1);
   return create_mesh(comm, graph::regular_adjacency_list(std::move(cells), 8),
                      {element}, geom, {geom.size() / 3, 3}, partitioner);
 }
@@ -418,7 +418,7 @@ Mesh<T> build_prism(MPI_Comm comm,
               std::next(cells.begin(), 6 * ((i - range_c[0]) * 2 + 1)));
   }
 
-  fem::CoordinateElement<double> element(CellType::prism, 1);
+  fem::CoordinateElement<T> element(CellType::prism, 1);
   return create_mesh(comm, graph::regular_adjacency_list(std::move(cells), 6),
                      {element}, geom, {geom.size() / 3, 3}, partitioner);
 }
@@ -429,7 +429,7 @@ Mesh<T> build_tri(MPI_Comm comm, const std::array<std::array<double, 2>, 2>& p,
                   const CellPartitionFunction& partitioner,
                   DiagonalType diagonal)
 {
-  fem::CoordinateElement<double> element(CellType::triangle, 1);
+  fem::CoordinateElement<T> element(CellType::triangle, 1);
 
   // Receive mesh if not rank 0
   if (dolfinx::MPI::rank(comm) != 0)
@@ -614,7 +614,7 @@ Mesh<T> build_quad(MPI_Comm comm, const std::array<std::array<double, 2>, 2> p,
                    std::array<std::size_t, 2> n,
                    const CellPartitionFunction& partitioner)
 {
-  fem::CoordinateElement<double> element(CellType::quadrilateral, 1);
+  fem::CoordinateElement<T> element(CellType::quadrilateral, 1);
 
   // Receive mesh if not rank 0
   if (dolfinx::MPI::rank(comm) != 0)

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -113,7 +113,7 @@ Mesh<T> create_interval(MPI_Comm comm, std::size_t nx, std::array<double, 2> x,
                         const CellPartitionFunction& partitioner
                         = create_cell_partitioner())
 {
-  fem::CoordinateElement element(CellType::interval, 1);
+  fem::CoordinateElement<double> element(CellType::interval, 1);
 
   // Receive mesh according to parallel policy
   if (dolfinx::MPI::rank(comm) != 0)
@@ -326,7 +326,7 @@ Mesh<T> build_tet(MPI_Comm comm, const std::array<std::array<double, 3>, 2>& p,
     std::copy(c.begin(), c.end(), std::next(cells.begin(), 4 * offset));
   }
 
-  fem::CoordinateElement element(CellType::tetrahedron, 1);
+  fem::CoordinateElement<double> element(CellType::tetrahedron, 1);
   return create_mesh(comm, graph::regular_adjacency_list(std::move(cells), 4),
                      {element}, geom, {geom.size() / 3, 3}, partitioner);
 }
@@ -370,7 +370,7 @@ mesh::Mesh<T> build_hex(MPI_Comm comm,
               std::next(cells.begin(), (i - range_c[0]) * 8));
   }
 
-  fem::CoordinateElement element(CellType::hexahedron, 1);
+  fem::CoordinateElement<double> element(CellType::hexahedron, 1);
   return create_mesh(comm, graph::regular_adjacency_list(std::move(cells), 8),
                      {element}, geom, {geom.size() / 3, 3}, partitioner);
 }
@@ -418,7 +418,7 @@ Mesh<T> build_prism(MPI_Comm comm,
               std::next(cells.begin(), 6 * ((i - range_c[0]) * 2 + 1)));
   }
 
-  fem::CoordinateElement element(CellType::prism, 1);
+  fem::CoordinateElement<double> element(CellType::prism, 1);
   return create_mesh(comm, graph::regular_adjacency_list(std::move(cells), 6),
                      {element}, geom, {geom.size() / 3, 3}, partitioner);
 }
@@ -429,7 +429,7 @@ Mesh<T> build_tri(MPI_Comm comm, const std::array<std::array<double, 2>, 2>& p,
                   const CellPartitionFunction& partitioner,
                   DiagonalType diagonal)
 {
-  fem::CoordinateElement element(CellType::triangle, 1);
+  fem::CoordinateElement<double> element(CellType::triangle, 1);
 
   // Receive mesh if not rank 0
   if (dolfinx::MPI::rank(comm) != 0)
@@ -614,7 +614,7 @@ Mesh<T> build_quad(MPI_Comm comm, const std::array<std::array<double, 2>, 2> p,
                    std::array<std::size_t, 2> n,
                    const CellPartitionFunction& partitioner)
 {
-  fem::CoordinateElement element(CellType::quadrilateral, 1);
+  fem::CoordinateElement<double> element(CellType::quadrilateral, 1);
 
   // Receive mesh if not rank 0
   if (dolfinx::MPI::rank(comm) != 0)

--- a/cpp/dolfinx/mesh/permutationcomputation.cpp
+++ b/cpp/dolfinx/mesh/permutationcomputation.cpp
@@ -267,9 +267,9 @@ compute_edge_reflections(const mesh::Topology& topology)
       // from the lowest numbered vertex to the highest numbered vertex.
 
       // Find iterators pointing to cell vertex given a vertex on facet
-      const auto it0
+      auto it0
           = std::find(cell_vertices.begin(), cell_vertices.end(), vertices[0]);
-      const auto it1
+      auto it1
           = std::find(cell_vertices.begin(), cell_vertices.end(), vertices[1]);
 
       // The number of reflections. Comparing iterators directly instead

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -699,22 +699,21 @@ compute_from_map(const graph::AdjacencyList<std::int32_t>& c_d0_0,
   std::vector<std::int32_t> offsets(c_d0_0.offsets());
 
   // Search for edges of facet in map, and recover index
-  const auto tri_vertices_ref
+  const graph::AdjacencyList<int> tri_vertices_ref
       = get_entity_vertices(mesh::CellType::triangle, 1);
-  const auto quad_vertices_ref
+  const graph::AdjacencyList<int> quad_vertices_ref
       = get_entity_vertices(mesh::CellType::quadrilateral, 1);
-
   for (int e = 0; e < c_d0_0.num_nodes(); ++e)
   {
     auto e0 = c_d0_0.links(e);
     auto vref = (e0.size() == 3) ? &tri_vertices_ref : &quad_vertices_ref;
     for (std::size_t i = 0; i < e0.size(); ++i)
     {
-      const auto& v = vref->links(i);
+      auto v = vref->links(i);
       for (int j = 0; j < 2; ++j)
         key[j] = e0[v[j]];
       std::sort(key.begin(), key.end());
-      const auto it = edge_to_index.find(key);
+      auto it = edge_to_index.find(key);
       assert(it != edge_to_index.end());
       connections.push_back(it->second);
     }

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -929,14 +929,16 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
 template <typename U>
 Mesh<typename std::remove_reference_t<typename U::value_type>>
 create_mesh(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
-            const std::vector<fem::CoordinateElement<double>>& elements,
+            const std::vector<fem::CoordinateElement<
+                std::remove_reference_t<typename U::value_type>>>& elements,
             const U& x, std::array<std::size_t, 2> xshape, GhostMode ghost_mode)
 {
   return create_mesh(comm, cells, elements, x, xshape,
                      create_cell_partitioner(ghost_mode));
 }
 
-/// Create a new mesh consisting of a subset of entities in a mesh.
+/// @brief Create a new mesh consisting of a subset of entities in a
+/// mesh.
 /// @param[in] mesh The mesh
 /// @param[in] dim Entity dimension
 /// @param[in] entities List of entity indices in `mesh` to include in

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -779,11 +779,12 @@ compute_incident_entities(const Topology& topology,
 
 /// Create a mesh using a provided mesh partitioning function
 template <typename U>
-Mesh<typename std::remove_reference_t<typename U::value_type>>
-create_mesh(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
-            const std::vector<fem::CoordinateElement<double>>& elements, const U& x,
-            std::array<std::size_t, 2> xshape,
-            const CellPartitionFunction& cell_partitioner)
+Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
+    MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
+    const std::vector<fem::CoordinateElement<
+        typename std::remove_reference_t<typename U::value_type>>>& elements,
+    const U& x, std::array<std::size_t, 2> xshape,
+    const CellPartitionFunction& cell_partitioner)
 {
   const fem::ElementDofLayout dof_layout = elements[0].create_dof_layout();
 
@@ -928,8 +929,8 @@ create_mesh(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
 template <typename U>
 Mesh<typename std::remove_reference_t<typename U::value_type>>
 create_mesh(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
-            const std::vector<fem::CoordinateElement<double>>& elements, const U& x,
-            std::array<std::size_t, 2> xshape, GhostMode ghost_mode)
+            const std::vector<fem::CoordinateElement<double>>& elements,
+            const U& x, std::array<std::size_t, 2> xshape, GhostMode ghost_mode)
 {
   return create_mesh(comm, cells, elements, x, xshape,
                      create_cell_partitioner(ghost_mode));

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -696,7 +696,7 @@ entities_to_geometry(const Mesh<T>& mesh, int dim,
         "Entity-to-vertex connectivity has not been computed.");
   }
 
-  const auto c_to_v = topology->connectivity(tdim, 0);
+  auto c_to_v = topology->connectivity(tdim, 0);
   if (!e_to_v)
   {
     throw std::runtime_error(

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -781,7 +781,7 @@ compute_incident_entities(const Topology& topology,
 template <typename U>
 Mesh<typename std::remove_reference_t<typename U::value_type>>
 create_mesh(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
-            const std::vector<fem::CoordinateElement>& elements, const U& x,
+            const std::vector<fem::CoordinateElement<double>>& elements, const U& x,
             std::array<std::size_t, 2> xshape,
             const CellPartitionFunction& cell_partitioner)
 {
@@ -928,7 +928,7 @@ create_mesh(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
 template <typename U>
 Mesh<typename std::remove_reference_t<typename U::value_type>>
 create_mesh(MPI_Comm comm, const graph::AdjacencyList<std::int64_t>& cells,
-            const std::vector<fem::CoordinateElement>& elements, const U& x,
+            const std::vector<fem::CoordinateElement<double>>& elements, const U& x,
             std::array<std::size_t, 2> xshape, GhostMode ghost_mode)
 {
   return create_mesh(comm, cells, elements, x, xshape,

--- a/cpp/test/io.cpp
+++ b/cpp/test/io.cpp
@@ -54,7 +54,7 @@ void test_fides_function()
                                 {22, 12}, mesh::CellType::triangle));
 
   // Create a Basix continuous Lagrange element of degree 1
-  basix::FiniteElement e = basix::create_element<double>(
+  basix::FiniteElement e = basix::create_element<T>(
       basix::element::family::P,
       mesh::cell_type_to_basix_type(mesh::CellType::triangle), 1,
       basix::element::lagrange_variant::unset,

--- a/cpp/test/mesh/distributed_mesh.cpp
+++ b/cpp/test/mesh/distributed_mesh.cpp
@@ -35,6 +35,7 @@ void create_mesh_file()
   file.write_mesh(*mesh);
 }
 
+template <std::floating_point T>
 void test_distributed_mesh(mesh::CellPartitionFunction partitioner)
 {
   MPI_Comm mpi_comm = MPI_COMM_WORLD;

--- a/cpp/test/mesh/distributed_mesh.cpp
+++ b/cpp/test/mesh/distributed_mesh.cpp
@@ -35,9 +35,10 @@ void create_mesh_file()
   file.write_mesh(*mesh);
 }
 
-template <std::floating_point T>
 void test_distributed_mesh(mesh::CellPartitionFunction partitioner)
 {
+  using T = double;
+
   MPI_Comm mpi_comm = MPI_COMM_WORLD;
   const int mpi_size = dolfinx::MPI::size(mpi_comm);
 
@@ -56,15 +57,14 @@ void test_distributed_mesh(mesh::CellPartitionFunction partitioner)
   MPI_Comm_create_group(MPI_COMM_WORLD, new_group, 0, &subset_comm);
 
   // Create coordinate map
-  auto e = std::make_shared<basix::FiniteElement<double>>(
-      basix::create_element<double>(basix::element::family::P,
-                                    basix::cell::type::triangle, 1,
-                                    basix::element::lagrange_variant::unset,
-                                    basix::element::dpc_variant::unset, false));
-  fem::CoordinateElement<double> cmap(e);
+  auto e = std::make_shared<basix::FiniteElement<T>>(basix::create_element<T>(
+      basix::element::family::P, basix::cell::type::triangle, 1,
+      basix::element::lagrange_variant::unset,
+      basix::element::dpc_variant::unset, false));
+  fem::CoordinateElement<T> cmap(e);
 
   // read mesh data
-  std::vector<double> x;
+  std::vector<T> x;
   std::array<std::size_t, 2> xshape = {0, 2};
   std::vector<std::int64_t> cells;
   std::array<std::size_t, 2> cshape = {0, 3};
@@ -128,7 +128,7 @@ void test_distributed_mesh(mesh::CellPartitionFunction partitioner)
   mesh::Geometry geometry = mesh::create_geometry(mpi_comm, topology, {cmap},
                                                   cell_nodes, x, xshape[1]);
 
-  auto mesh = std::make_shared<mesh::Mesh<double>>(
+  auto mesh = std::make_shared<mesh::Mesh<T>>(
       mpi_comm, std::make_shared<mesh::Topology>(std::move(topology)),
       std::move(geometry));
 

--- a/cpp/test/mesh/distributed_mesh.cpp
+++ b/cpp/test/mesh/distributed_mesh.cpp
@@ -60,7 +60,7 @@ void test_distributed_mesh(mesh::CellPartitionFunction partitioner)
                                     basix::cell::type::triangle, 1,
                                     basix::element::lagrange_variant::unset,
                                     basix::element::dpc_variant::unset, false));
-  fem::CoordinateElement cmap(e);
+  fem::CoordinateElement<double> cmap(e);
 
   // read mesh data
   std::vector<double> x;

--- a/cpp/test/vector.cpp
+++ b/cpp/test/vector.cpp
@@ -33,18 +33,18 @@ void test_vector()
                                             (mpi_rank + 1) % mpi_size);
 
   // Create an IndexMap
-  const auto index_map = std::make_shared<common::IndexMap>(
+  auto index_map = std::make_shared<common::IndexMap>(
       MPI_COMM_WORLD, size_local, ghosts, global_ghost_owner);
 
   la::Vector<T> v(index_map, 1);
   std::fill(v.mutable_array().begin(), v.mutable_array().end(), 1.0);
 
-  const double norm2 = la::squared_norm(v);
+  double norm2 = la::squared_norm(v);
   CHECK(norm2 == mpi_size * size_local);
 
   std::fill(v.mutable_array().begin(), v.mutable_array().end(), mpi_rank);
 
-  const double sumn2
+  double sumn2
       = size_local * (mpi_size - 1) * mpi_size * (2 * mpi_size - 1) / 6;
   CHECK(la::squared_norm(v) == sumn2);
   CHECK(la::norm(v, la::Norm::l2) == std::sqrt(sumn2));

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -179,7 +179,7 @@ class XDMFFile(_cpp.io.XDMFFile):
         x = super().read_geometry_data(name, xpath)
 
         # Build the mesh
-        cmap = _cpp.fem.CoordinateElement(cell_shape, cell_degree)
+        cmap = _cpp.fem.CoordinateElement_float64(cell_shape, cell_degree)
         msh = _cpp.mesh.create_mesh(self.comm(), _cpp.graph.AdjacencyList_int64(cells),
                                     cmap, x, _cpp.mesh.create_cell_partitioner(ghost_mode))
         msh.name = name

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -254,9 +254,14 @@ def create_mesh(comm: _MPI.Comm, cells: typing.Union[np.ndarray, _cpp.graph.Adja
         variant = ufl_element.lagrange_variant
     except AttributeError:
         variant = basix.LagrangeVariant.unset
-    cmap = _cpp.fem.CoordinateElement(_uflcell_to_dolfinxcell[cell_shape], cell_degree, variant)
+    # cmap = _cpp.fem.CoordinateElement(_uflcell_to_dolfinxcell[cell_shape], cell_degree, variant)
 
     x = np.asarray(x, order='C')
+    if x.dtype == np.float32:
+        cmap = _cpp.fem.CoordinateElement_float32(_uflcell_to_dolfinxcell[cell_shape], cell_degree, variant)
+    elif x.dtype == np.float64:
+        cmap = _cpp.fem.CoordinateElement_float64(_uflcell_to_dolfinxcell[cell_shape], cell_degree, variant)
+
     try:
         mesh = _cpp.mesh.create_mesh(comm, cells, cmap, x, partitioner)
     except TypeError:

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -254,7 +254,6 @@ def create_mesh(comm: _MPI.Comm, cells: typing.Union[np.ndarray, _cpp.graph.Adja
         variant = ufl_element.lagrange_variant
     except AttributeError:
         variant = basix.LagrangeVariant.unset
-    # cmap = _cpp.fem.CoordinateElement(_uflcell_to_dolfinxcell[cell_shape], cell_degree, variant)
 
     x = np.asarray(x, order='C')
     if x.dtype == np.float32:

--- a/python/dolfinx/wrappers/assemble.cpp
+++ b/python/dolfinx/wrappers/assemble.cpp
@@ -205,7 +205,7 @@ void declare_assembly_functions(py::module& m)
          const std::vector<py::array_t<T, py::array::c_style>>& x0, T scale)
       {
         std::vector<std::span<const T>> _x0;
-        for (const auto& x : x0)
+        for (auto x : x0)
           _x0.emplace_back(x.data(), x.size());
 
         std::vector<std::span<const T>> _constants;

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -787,8 +787,8 @@ void fem(py::module& m)
            py::return_value_policy::reference_internal);
 
   // dolfinx::fem::CoordinateElement
-  py::class_<dolfinx::fem::CoordinateElement,
-             std::shared_ptr<dolfinx::fem::CoordinateElement>>(
+  py::class_<dolfinx::fem::CoordinateElement<double>,
+             std::shared_ptr<dolfinx::fem::CoordinateElement<double>>>(
       m, "CoordinateElement", "Coordinate map element")
       .def(py::init<dolfinx::mesh::CellType, int>(), py::arg("celltype"),
            py::arg("degree"))
@@ -796,13 +796,13 @@ void fem(py::module& m)
                     basix::element::lagrange_variant>(),
            py::arg("celltype"), py::arg("degree"), py::arg("variant"))
       .def("create_dof_layout",
-           &dolfinx::fem::CoordinateElement::create_dof_layout)
-      .def_property_readonly("degree", &dolfinx::fem::CoordinateElement::degree)
+           &dolfinx::fem::CoordinateElement<double>::create_dof_layout)
+      .def_property_readonly("degree", &dolfinx::fem::CoordinateElement<double>::degree)
       .def_property_readonly("variant",
-                             &dolfinx::fem::CoordinateElement::variant)
+                             &dolfinx::fem::CoordinateElement<double>::variant)
       .def(
           "push_forward",
-          [](const dolfinx::fem::CoordinateElement& self,
+          [](const dolfinx::fem::CoordinateElement<double>& self,
              const py::array_t<double, py::array::c_style>& X,
              const py::array_t<double, py::array::c_style>& cell)
           {
@@ -838,7 +838,7 @@ void fem(py::module& m)
           py::arg("X"), py::arg("cell_geometry"))
       .def(
           "pull_back",
-          [](const dolfinx::fem::CoordinateElement& self,
+          [](const dolfinx::fem::CoordinateElement<double>& self,
              const py::array_t<double, py::array::c_style>& x,
              const py::array_t<double, py::array::c_style>& cell_geometry)
           {

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -665,25 +665,28 @@ void fem(py::module& m)
                {
                  ufcx_finite_element* p
                      = reinterpret_cast<ufcx_finite_element*>(ufcx_element);
-                 return dolfinx::fem::FiniteElement(*p);
+                 return dolfinx::fem::FiniteElement<double>(*p);
                }),
            py::arg("ufcx_element"))
       .def("__eq__", &dolfinx::fem::FiniteElement<double>::operator==)
-      .def_property_readonly("basix_element",
-                             &dolfinx::fem::FiniteElement<double>::basix_element,
-                             py::return_value_policy::reference_internal)
-      .def_property_readonly("num_sub_elements",
-                             &dolfinx::fem::FiniteElement<double>::num_sub_elements)
+      .def_property_readonly(
+          "basix_element", &dolfinx::fem::FiniteElement<double>::basix_element,
+          py::return_value_policy::reference_internal)
+      .def_property_readonly(
+          "num_sub_elements",
+          &dolfinx::fem::FiniteElement<double>::num_sub_elements)
       .def("interpolation_points",
            [](const dolfinx::fem::FiniteElement<double>& self)
            {
              auto [X, shape] = self.interpolation_points();
              return as_pyarray(std::move(X), shape);
            })
-      .def_property_readonly("interpolation_ident",
-                             &dolfinx::fem::FiniteElement<double>::interpolation_ident)
-      .def_property_readonly("space_dimension",
-                             &dolfinx::fem::FiniteElement<double>::space_dimension)
+      .def_property_readonly(
+          "interpolation_ident",
+          &dolfinx::fem::FiniteElement<double>::interpolation_ident)
+      .def_property_readonly(
+          "space_dimension",
+          &dolfinx::fem::FiniteElement<double>::space_dimension)
       .def_property_readonly(
           "value_shape",
           [](const dolfinx::fem::FiniteElement<double>& self)

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -797,7 +797,8 @@ void fem(py::module& m)
            py::arg("celltype"), py::arg("degree"), py::arg("variant"))
       .def("create_dof_layout",
            &dolfinx::fem::CoordinateElement<double>::create_dof_layout)
-      .def_property_readonly("degree", &dolfinx::fem::CoordinateElement<double>::degree)
+      .def_property_readonly("degree",
+                             &dolfinx::fem::CoordinateElement<double>::degree)
       .def_property_readonly("variant",
                              &dolfinx::fem::CoordinateElement<double>::variant)
       .def(

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -593,8 +593,13 @@ void fem(py::module& m)
         dolfinx::fem::ElementDofLayout layout
             = dolfinx::fem::create_element_dof_layout(
                 *p, topology.cell_types().back());
+
+        std::function<void(const std::span<std::int32_t>&, std::uint32_t)>
+            unpermute_dofs = nullptr;
+        if (element.needs_dof_permutations())
+          unpermute_dofs = element.get_dof_permutation_function(true, true);
         return dolfinx::fem::create_dofmap(comm.get(), layout, topology,
-                                           nullptr, element);
+                                           unpermute_dofs, nullptr);
       },
       py::arg("comm"), py::arg("dofmap"), py::arg("topology"),
       py::arg("element"),

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -586,7 +586,7 @@ void fem(py::module& m)
       "create_dofmap",
       [](const MPICommWrapper comm, std::uintptr_t dofmap,
          dolfinx::mesh::Topology& topology,
-         const dolfinx::fem::FiniteElement& element)
+         const dolfinx::fem::FiniteElement<double>& element)
       {
         ufcx_dofmap* p = reinterpret_cast<ufcx_dofmap*>(dofmap);
         assert(p);
@@ -628,7 +628,7 @@ void fem(py::module& m)
   m.def(
       "create_nonmatching_meshes_interpolation_data",
       [](const dolfinx::mesh::Mesh<double>& mesh0,
-         const dolfinx::fem::FiniteElement& element0,
+         const dolfinx::fem::FiniteElement<double>& element0,
          const dolfinx::mesh::Mesh<double>& mesh1)
       {
         int tdim = mesh0.topology()->dim();
@@ -646,7 +646,7 @@ void fem(py::module& m)
   m.def(
       "create_nonmatching_meshes_interpolation_data",
       [](const dolfinx::mesh::Geometry<double>& geometry0,
-         const dolfinx::fem::FiniteElement& element0,
+         const dolfinx::fem::FiniteElement<double>& element0,
          const dolfinx::mesh::Mesh<double>& mesh1,
          const py::array_t<std::int32_t, py::array::c_style>& cells)
       {
@@ -657,8 +657,8 @@ void fem(py::module& m)
       py::arg("cells"));
 
   // dolfinx::fem::FiniteElement
-  py::class_<dolfinx::fem::FiniteElement,
-             std::shared_ptr<dolfinx::fem::FiniteElement>>(
+  py::class_<dolfinx::fem::FiniteElement<double>,
+             std::shared_ptr<dolfinx::fem::FiniteElement<double>>>(
       m, "FiniteElement", "Finite element object")
       .def(py::init(
                [](std::uintptr_t ufcx_element)
@@ -668,32 +668,32 @@ void fem(py::module& m)
                  return dolfinx::fem::FiniteElement(*p);
                }),
            py::arg("ufcx_element"))
-      .def("__eq__", &dolfinx::fem::FiniteElement::operator==)
+      .def("__eq__", &dolfinx::fem::FiniteElement<double>::operator==)
       .def_property_readonly("basix_element",
-                             &dolfinx::fem::FiniteElement::basix_element,
+                             &dolfinx::fem::FiniteElement<double>::basix_element,
                              py::return_value_policy::reference_internal)
       .def_property_readonly("num_sub_elements",
-                             &dolfinx::fem::FiniteElement::num_sub_elements)
+                             &dolfinx::fem::FiniteElement<double>::num_sub_elements)
       .def("interpolation_points",
-           [](const dolfinx::fem::FiniteElement& self)
+           [](const dolfinx::fem::FiniteElement<double>& self)
            {
              auto [X, shape] = self.interpolation_points();
              return as_pyarray(std::move(X), shape);
            })
       .def_property_readonly("interpolation_ident",
-                             &dolfinx::fem::FiniteElement::interpolation_ident)
+                             &dolfinx::fem::FiniteElement<double>::interpolation_ident)
       .def_property_readonly("space_dimension",
-                             &dolfinx::fem::FiniteElement::space_dimension)
+                             &dolfinx::fem::FiniteElement<double>::space_dimension)
       .def_property_readonly(
           "value_shape",
-          [](const dolfinx::fem::FiniteElement& self)
+          [](const dolfinx::fem::FiniteElement<double>& self)
           {
             std::span<const std::size_t> shape = self.value_shape();
             return py::array_t(shape.size(), shape.data(), py::none());
           })
       .def(
           "apply_dof_transformation",
-          [](const dolfinx::fem::FiniteElement& self,
+          [](const dolfinx::fem::FiniteElement<double>& self,
              py::array_t<double, py::array::c_style> x,
              std::uint32_t cell_permutation, int dim)
           {
@@ -703,7 +703,7 @@ void fem(py::module& m)
           py::arg("x"), py::arg("cell_permutation"), py::arg("dim"))
       .def(
           "apply_transpose_dof_transformation",
-          [](const dolfinx::fem::FiniteElement& self,
+          [](const dolfinx::fem::FiniteElement<double>& self,
              py::array_t<double, py::array::c_style> x,
              std::uint32_t cell_permutation, int dim)
           {
@@ -713,7 +713,7 @@ void fem(py::module& m)
           py::arg("x"), py::arg("cell_permutation"), py::arg("dim"))
       .def(
           "apply_inverse_transpose_dof_transformation",
-          [](const dolfinx::fem::FiniteElement& self,
+          [](const dolfinx::fem::FiniteElement<double>& self,
              py::array_t<double, py::array::c_style> x,
              std::uint32_t cell_permutation, int dim)
           {
@@ -723,8 +723,8 @@ void fem(py::module& m)
           py::arg("x"), py::arg("cell_permutation"), py::arg("dim"))
       .def_property_readonly(
           "needs_dof_transformations",
-          &dolfinx::fem::FiniteElement::needs_dof_transformations)
-      .def("signature", &dolfinx::fem::FiniteElement::signature);
+          &dolfinx::fem::FiniteElement<double>::needs_dof_transformations)
+      .def("signature", &dolfinx::fem::FiniteElement<double>::signature);
 
   // dolfinx::fem::ElementDofLayout
   py::class_<dolfinx::fem::ElementDofLayout,
@@ -964,7 +964,7 @@ void fem(py::module& m)
 
   m.def(
       "interpolation_coords",
-      [](const dolfinx::fem::FiniteElement& e,
+      [](const dolfinx::fem::FiniteElement<double>& e,
          const dolfinx::mesh::Geometry<double>& geometry,
          py::array_t<std::int32_t, py::array::c_style> cells)
       {
@@ -980,7 +980,7 @@ void fem(py::module& m)
              std::shared_ptr<dolfinx::fem::FunctionSpace<double>>>(
       m, "FunctionSpace")
       .def(py::init<std::shared_ptr<dolfinx::mesh::Mesh<double>>,
-                    std::shared_ptr<dolfinx::fem::FiniteElement>,
+                    std::shared_ptr<dolfinx::fem::FiniteElement<double>>,
                     std::shared_ptr<dolfinx::fem::DofMap>>(),
            py::arg("mesh"), py::arg("element"), py::arg("dofmap"))
       .def("collapse", &dolfinx::fem::FunctionSpace<double>::collapse)

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -74,8 +74,7 @@ void declare_objects(py::module& m, const std::string& type)
           py::init(
               [](const py::array_t<T, py::array::c_style>& g,
                  const py::array_t<std::int32_t, py::array::c_style>& dofs,
-                 std::shared_ptr<const dolfinx::fem::FunctionSpace<double>>
-V)
+                 std::shared_ptr<const dolfinx::fem::FunctionSpace<double>> V)
               {
                 if (dofs.ndim() != 1)
                   throw std::runtime_error("Wrong number of dims");
@@ -285,8 +284,7 @@ V)
           m, pyclass_name_expr.c_str(), "An Expression")
           .def(py::init(
                    [](const std::vector<std::shared_ptr<
-                          const dolfinx::fem::Function<T, double>
->>& coefficients,
+                          const dolfinx::fem::Function<T, double>>>& coefficients,
                       const std::vector<std::shared_ptr<
                           const dolfinx::fem::Constant<T>>>& constants,
                       const py::array_t<double, py::array::c_style>& X,
@@ -551,6 +549,115 @@ void declare_form(py::module& m, const std::string& type)
         &dolfinx::fem ::create_sparsity_pattern<T, double>, py::arg("a"),
         "Create a sparsity pattern.");
 }
+
+template <typename T>
+void declare_cmap(py::module& m, const std::string& type)
+{
+  std::string pyclass_name = std::string("CoordinateElement_") + type;
+  py::class_<dolfinx::fem::CoordinateElement<T>,
+             std::shared_ptr<dolfinx::fem::CoordinateElement<T>>>(
+      m, pyclass_name.c_str(), "Coordinate map element")
+      .def(py::init<dolfinx::mesh::CellType, int>(), py::arg("celltype"),
+           py::arg("degree"))
+      .def(py::init<dolfinx::mesh::CellType, int,
+                    basix::element::lagrange_variant>(),
+           py::arg("celltype"), py::arg("degree"), py::arg("variant"))
+      .def("create_dof_layout",
+           &dolfinx::fem::CoordinateElement<T>::create_dof_layout)
+      .def_property_readonly("degree",
+                             &dolfinx::fem::CoordinateElement<T>::degree)
+      .def_property_readonly("variant",
+                             &dolfinx::fem::CoordinateElement<T>::variant)
+      .def(
+          "push_forward",
+          [](const dolfinx::fem::CoordinateElement<T>& self,
+             const py::array_t<T, py::array::c_style>& X,
+             const py::array_t<T, py::array::c_style>& cell)
+          {
+            namespace stdex = std::experimental;
+            using mdspan2_t = stdex::mdspan<T, stdex::dextents<std::size_t, 2>>;
+            using cmdspan2_t
+                = stdex::mdspan<const T, stdex::dextents<std::size_t, 2>>;
+            using cmdspan4_t
+                = stdex::mdspan<const T, stdex::dextents<std::size_t, 4>>;
+
+            std::array<std::size_t, 2> Xshape
+                = {(std::size_t)X.shape(0), (std::size_t)X.shape(1)};
+
+            std::array<std::size_t, 4> phi_shape
+                = self.tabulate_shape(0, X.shape(0));
+            std::vector<T> phi_b(std::reduce(phi_shape.begin(), phi_shape.end(),
+                                             1, std::multiplies{}));
+            cmdspan4_t phi_full(phi_b.data(), phi_shape);
+            self.tabulate(0, std::span(X.data(), X.size()), Xshape, phi_b);
+            auto phi = stdex::submdspan(phi_full, 0, stdex::full_extent,
+                                        stdex::full_extent, 0);
+
+            std::array<std::size_t, 2> shape
+                = {(std::size_t)X.shape(0), (std::size_t)cell.shape(1)};
+            std::vector<T> xb(shape[0] * shape[1]);
+            self.push_forward(
+                mdspan2_t(xb.data(), shape),
+                cmdspan2_t(cell.data(), cell.shape(0), cell.shape(1)), phi);
+
+            return dolfinx_wrappers::as_pyarray(std::move(xb), shape);
+          },
+          py::arg("X"), py::arg("cell_geometry"))
+      .def(
+          "pull_back",
+          [](const dolfinx::fem::CoordinateElement<T>& self,
+             const py::array_t<T, py::array::c_style>& x,
+             const py::array_t<T, py::array::c_style>& cell_geometry)
+          {
+            const std::size_t num_points = x.shape(0);
+            const std::size_t gdim = x.shape(1);
+            const std::size_t tdim = dolfinx::mesh::cell_dim(self.cell_shape());
+
+            namespace stdex = std::experimental;
+            using mdspan2_t = stdex::mdspan<T, stdex::dextents<std::size_t, 2>>;
+            using cmdspan2_t
+                = stdex::mdspan<const T, stdex::dextents<std::size_t, 2>>;
+            using cmdspan4_t
+                = stdex::mdspan<const T, stdex::dextents<std::size_t, 4>>;
+
+            std::vector<T> Xb(num_points * tdim);
+            mdspan2_t X(Xb.data(), num_points, tdim);
+            cmdspan2_t _x(x.data(), x.shape(0), x.shape(1));
+            cmdspan2_t g(cell_geometry.data(), cell_geometry.shape(0),
+                         cell_geometry.shape(1));
+
+            if (self.is_affine())
+            {
+              std::vector<T> J_b(gdim * tdim);
+              mdspan2_t J(J_b.data(), gdim, tdim);
+              std::vector<T> K_b(tdim * gdim);
+              mdspan2_t K(K_b.data(), tdim, gdim);
+
+              std::array<std::size_t, 4> phi_shape = self.tabulate_shape(1, 1);
+              std::vector<T> phi_b(std::reduce(
+                  phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
+              cmdspan4_t phi(phi_b.data(), phi_shape);
+
+              self.tabulate(1, std::vector<T>(tdim), {1, tdim}, phi_b);
+              auto dphi = stdex::submdspan(phi, std::pair(1, tdim + 1), 0,
+                                           stdex::full_extent, 0);
+
+              self.compute_jacobian(dphi, g, J);
+              self.compute_jacobian_inverse(J, K);
+              std::array<T, 3> x0 = {0, 0, 0};
+              for (std::size_t i = 0; i < g.extent(1); ++i)
+                x0[i] += g(0, i);
+              self.pull_back_affine(X, K, x0, _x);
+            }
+            else
+              self.pull_back_nonaffine(X, _x, g);
+
+            return dolfinx_wrappers::as_pyarray(std::move(Xb),
+                                                std::array{num_points, tdim});
+          },
+          py::arg("x"), py::arg("cell_geometry"));
+}
+
 } // namespace
 
 namespace dolfinx_wrappers
@@ -570,6 +677,10 @@ void fem(py::module& m)
   declare_form<double>(m, "float64");
   declare_form<std::complex<float>>(m, "complex64");
   declare_form<std::complex<double>>(m, "complex128");
+
+  // fem::CoordinateElement
+  declare_cmap<float>(m, "float32");
+  declare_cmap<double>(m, "float64");
 
   m.def(
       "create_element_dof_layout",
@@ -786,111 +897,6 @@ void fem(py::module& m)
       .def("list", &dolfinx::fem::DofMap::list,
            py::return_value_policy::reference_internal);
 
-  // dolfinx::fem::CoordinateElement
-  py::class_<dolfinx::fem::CoordinateElement<double>,
-             std::shared_ptr<dolfinx::fem::CoordinateElement<double>>>(
-      m, "CoordinateElement", "Coordinate map element")
-      .def(py::init<dolfinx::mesh::CellType, int>(), py::arg("celltype"),
-           py::arg("degree"))
-      .def(py::init<dolfinx::mesh::CellType, int,
-                    basix::element::lagrange_variant>(),
-           py::arg("celltype"), py::arg("degree"), py::arg("variant"))
-      .def("create_dof_layout",
-           &dolfinx::fem::CoordinateElement<double>::create_dof_layout)
-      .def_property_readonly("degree",
-                             &dolfinx::fem::CoordinateElement<double>::degree)
-      .def_property_readonly("variant",
-                             &dolfinx::fem::CoordinateElement<double>::variant)
-      .def(
-          "push_forward",
-          [](const dolfinx::fem::CoordinateElement<double>& self,
-             const py::array_t<double, py::array::c_style>& X,
-             const py::array_t<double, py::array::c_style>& cell)
-          {
-            namespace stdex = std::experimental;
-            using mdspan2_t
-                = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
-            using cmdspan2_t
-                = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
-            using cmdspan4_t
-                = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
-
-            std::array<std::size_t, 2> Xshape
-                = {(std::size_t)X.shape(0), (std::size_t)X.shape(1)};
-
-            std::array<std::size_t, 4> phi_shape
-                = self.tabulate_shape(0, X.shape(0));
-            std::vector<double> phi_b(std::reduce(
-                phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
-            cmdspan4_t phi_full(phi_b.data(), phi_shape);
-            self.tabulate(0, std::span(X.data(), X.size()), Xshape, phi_b);
-            auto phi = stdex::submdspan(phi_full, 0, stdex::full_extent,
-                                        stdex::full_extent, 0);
-
-            std::array<std::size_t, 2> shape
-                = {(std::size_t)X.shape(0), (std::size_t)cell.shape(1)};
-            std::vector<double> xb(shape[0] * shape[1]);
-            self.push_forward(
-                mdspan2_t(xb.data(), shape),
-                cmdspan2_t(cell.data(), cell.shape(0), cell.shape(1)), phi);
-
-            return as_pyarray(std::move(xb), shape);
-          },
-          py::arg("X"), py::arg("cell_geometry"))
-      .def(
-          "pull_back",
-          [](const dolfinx::fem::CoordinateElement<double>& self,
-             const py::array_t<double, py::array::c_style>& x,
-             const py::array_t<double, py::array::c_style>& cell_geometry)
-          {
-            const std::size_t num_points = x.shape(0);
-            const std::size_t gdim = x.shape(1);
-            const std::size_t tdim = dolfinx::mesh::cell_dim(self.cell_shape());
-
-            namespace stdex = std::experimental;
-            using mdspan2_t
-                = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
-            using cmdspan2_t
-                = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
-            using cmdspan4_t
-                = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
-
-            std::vector<double> Xb(num_points * tdim);
-            mdspan2_t X(Xb.data(), num_points, tdim);
-            cmdspan2_t _x(x.data(), x.shape(0), x.shape(1));
-            cmdspan2_t g(cell_geometry.data(), cell_geometry.shape(0),
-                         cell_geometry.shape(1));
-
-            if (self.is_affine())
-            {
-              std::vector<double> J_b(gdim * tdim);
-              mdspan2_t J(J_b.data(), gdim, tdim);
-              std::vector<double> K_b(tdim * gdim);
-              mdspan2_t K(K_b.data(), tdim, gdim);
-
-              std::array<std::size_t, 4> phi_shape = self.tabulate_shape(1, 1);
-              std::vector<double> phi_b(std::reduce(
-                  phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
-              cmdspan4_t phi(phi_b.data(), phi_shape);
-
-              self.tabulate(1, std::vector<double>(tdim), {1, tdim}, phi_b);
-              auto dphi = stdex::submdspan(phi, std::pair(1, tdim + 1), 0,
-                                           stdex::full_extent, 0);
-
-              self.compute_jacobian(dphi, g, J);
-              self.compute_jacobian_inverse(J, K);
-              std::array<double, 3> x0 = {0, 0, 0};
-              for (std::size_t i = 0; i < g.extent(1); ++i)
-                x0[i] += g(0, i);
-              self.pull_back_affine(X, K, x0, _x);
-            }
-            else
-              self.pull_back_nonaffine(X, _x, g);
-
-            return as_pyarray(std::move(Xb), std::array{num_points, tdim});
-          },
-          py::arg("x"), py::arg("cell_geometry"));
-
   py::enum_<dolfinx::fem::IntegralType>(m, "IntegralType")
       .value("cell", dolfinx::fem::IntegralType::cell)
       .value("exterior_facet", dolfinx::fem::IntegralType::exterior_facet)
@@ -949,7 +955,8 @@ void fem(py::module& m)
         std::array<std::vector<std::int32_t>, 2> dofs
             = dolfinx::fem::locate_dofs_geometrical<double>({V[0], V[1]},
                                                             _marker);
-        return {as_pyarray(std::move(dofs[0])), as_pyarray(std::move(dofs[1]))};
+        return {dolfinx_wrappers::as_pyarray(std::move(dofs[0])),
+                dolfinx_wrappers::as_pyarray(std::move(dofs[1]))};
       },
       py::arg("V"), py::arg("marker"));
   m.def(
@@ -967,7 +974,8 @@ void fem(py::module& m)
                                           marked.data() + marked.size());
         };
 
-        return as_pyarray(dolfinx::fem::locate_dofs_geometrical(V, _marker));
+        return dolfinx_wrappers::as_pyarray(
+            dolfinx::fem::locate_dofs_geometrical(V, _marker));
       },
       py::arg("V"), py::arg("marker"));
 

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -222,7 +222,7 @@ void declare_mesh(py::module& m, std::string type)
       "create_mesh",
       [](const MPICommWrapper comm,
          const dolfinx::graph::AdjacencyList<std::int64_t>& cells,
-         const dolfinx::fem::CoordinateElement<double>& element,
+         const dolfinx::fem::CoordinateElement<T>& element,
          const py::array_t<T, py::array::c_style>& x,
          const PythonPartitioningFunction& p)
       {

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -222,7 +222,7 @@ void declare_mesh(py::module& m, std::string type)
       "create_mesh",
       [](const MPICommWrapper comm,
          const dolfinx::graph::AdjacencyList<std::int64_t>& cells,
-         const dolfinx::fem::CoordinateElement& element,
+         const dolfinx::fem::CoordinateElement<double>& element,
          const py::array_t<T, py::array::c_style>& x,
          const PythonPartitioningFunction& p)
       {

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -537,7 +537,10 @@ def test_submesh_boundary(d, n, boundary, ghost_mode):
     submesh_geometry_test(mesh, submesh, entity_map, geom_map, edim)
 
 
-@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("dtype", [
+    np.float32,
+    np.float64
+])
 def test_empty_rank_mesh(dtype):
     """Construction of mesh where some ranks are empty"""
     comm = MPI.COMM_WORLD
@@ -559,39 +562,39 @@ def test_empty_rank_mesh(dtype):
         x = np.empty((0, 2), dtype=dtype)
 
     mesh = _mesh.create_mesh(comm, cells, x, domain, partitioner)
-    assert mesh.geometry.x.dtype == dtype
-    topology = mesh.topology
+    # assert mesh.geometry.x.dtype == dtype
+    # topology = mesh.topology
 
-    # Check number of vertices
-    vmap = topology.index_map(0)
-    assert vmap.size_local == x.shape[0]
-    assert vmap.num_ghosts == 0
+    # # Check number of vertices
+    # vmap = topology.index_map(0)
+    # assert vmap.size_local == x.shape[0]
+    # assert vmap.num_ghosts == 0
 
-    # Check number of cells
-    cmap = topology.index_map(tdim)
-    assert cmap.size_local == cells.num_nodes
-    assert cmap.num_ghosts == 0
+    # # Check number of cells
+    # cmap = topology.index_map(tdim)
+    # assert cmap.size_local == cells.num_nodes
+    # assert cmap.num_ghosts == 0
 
-    # Check number of edges
-    topology.create_entities(1)
-    emap = topology.index_map(1)
+    # # Check number of edges
+    # topology.create_entities(1)
+    # emap = topology.index_map(1)
 
-    e_to_v = topology.connectivity(1, 0)
+    # e_to_v = topology.connectivity(1, 0)
 
-    assert emap.num_ghosts == 0
-    if comm.rank == 0:
-        assert emap.size_local == 5
-        assert e_to_v.num_nodes == 5
-        assert len(e_to_v.array) == 10
-    else:
-        assert emap.size_local == 0
-        assert len(e_to_v.array) == 0
-        assert e_to_v.num_nodes == 0
+    # assert emap.num_ghosts == 0
+    # if comm.rank == 0:
+    #     assert emap.size_local == 5
+    #     assert e_to_v.num_nodes == 5
+    #     assert len(e_to_v.array) == 10
+    # else:
+    #     assert emap.size_local == 0
+    #     assert len(e_to_v.array) == 0
+    #     assert e_to_v.num_nodes == 0
 
-    # Test creating and getting permutations doesn't throw an error
-    mesh.topology.create_entity_permutations()
-    mesh.topology.get_cell_permutation_info()
-    mesh.topology.get_facet_permutations()
+    # # Test creating and getting permutations doesn't throw an error
+    # mesh.topology.create_entity_permutations()
+    # mesh.topology.get_cell_permutation_info()
+    # mesh.topology.get_facet_permutations()
 
 
 def test_original_index():

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -562,39 +562,39 @@ def test_empty_rank_mesh(dtype):
         x = np.empty((0, 2), dtype=dtype)
 
     mesh = _mesh.create_mesh(comm, cells, x, domain, partitioner)
-    # assert mesh.geometry.x.dtype == dtype
-    # topology = mesh.topology
+    assert mesh.geometry.x.dtype == dtype
+    topology = mesh.topology
 
-    # # Check number of vertices
-    # vmap = topology.index_map(0)
-    # assert vmap.size_local == x.shape[0]
-    # assert vmap.num_ghosts == 0
+    # Check number of vertices
+    vmap = topology.index_map(0)
+    assert vmap.size_local == x.shape[0]
+    assert vmap.num_ghosts == 0
 
-    # # Check number of cells
-    # cmap = topology.index_map(tdim)
-    # assert cmap.size_local == cells.num_nodes
-    # assert cmap.num_ghosts == 0
+    # Check number of cells
+    cmap = topology.index_map(tdim)
+    assert cmap.size_local == cells.num_nodes
+    assert cmap.num_ghosts == 0
 
-    # # Check number of edges
-    # topology.create_entities(1)
-    # emap = topology.index_map(1)
+    # Check number of edges
+    topology.create_entities(1)
+    emap = topology.index_map(1)
 
-    # e_to_v = topology.connectivity(1, 0)
+    e_to_v = topology.connectivity(1, 0)
 
-    # assert emap.num_ghosts == 0
-    # if comm.rank == 0:
-    #     assert emap.size_local == 5
-    #     assert e_to_v.num_nodes == 5
-    #     assert len(e_to_v.array) == 10
-    # else:
-    #     assert emap.size_local == 0
-    #     assert len(e_to_v.array) == 0
-    #     assert e_to_v.num_nodes == 0
+    assert emap.num_ghosts == 0
+    if comm.rank == 0:
+        assert emap.size_local == 5
+        assert e_to_v.num_nodes == 5
+        assert len(e_to_v.array) == 10
+    else:
+        assert emap.size_local == 0
+        assert len(e_to_v.array) == 0
+        assert e_to_v.num_nodes == 0
 
-    # # Test creating and getting permutations doesn't throw an error
-    # mesh.topology.create_entity_permutations()
-    # mesh.topology.get_cell_permutation_info()
-    # mesh.topology.get_facet_permutations()
+    # Test creating and getting permutations doesn't throw an error
+    mesh.topology.create_entity_permutations()
+    mesh.topology.get_cell_permutation_info()
+    mesh.topology.get_facet_permutations()
 
 
 def test_original_index():


### PR DESCRIPTION
Allows the scalar type behind a FiniteElement to match the FE form or mesh geometry.

No changes at Python level yet.