### PR TITLE
Use large integer type in SparsityPattern adjacency data structures

### DIFF
--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -179,7 +179,7 @@ public:
       throw std::runtime_error("Block size not yet supported");
 
     // Compute off-diagonal offset for each row
-    std::span<const std::int64_t> num_diag_nnz = p.off_diagonal_offset();
+    std::span<const std::int32_t> num_diag_nnz = p.off_diagonal_offset() s;
     _off_diagonal_offset.reserve(num_diag_nnz.size());
     std::transform(num_diag_nnz.begin(), num_diag_nnz.end(), _row_ptr.begin(),
                    std::back_inserter(_off_diagonal_offset), std::plus{});

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -179,7 +179,7 @@ public:
       throw std::runtime_error("Block size not yet supported");
 
     // Compute off-diagonal offset for each row
-    std::span<const std::int32_t> num_diag_nnz = p.off_diagonal_offset() s;
+    std::span<const std::int32_t> num_diag_nnz = p.off_diagonal_offsets();
     _off_diagonal_offset.reserve(num_diag_nnz.size());
     std::transform(num_diag_nnz.begin(), num_diag_nnz.end(), _row_ptr.begin(),
                    std::back_inserter(_off_diagonal_offset), std::plus{});

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -170,8 +170,8 @@ public:
                      std::make_shared<common::IndexMap>(p.column_index_map())}),
         _bs({p.block_size(0), p.block_size(1)}),
         _data(p.num_nonzeros(), 0, alloc),
-        _cols(p.graph().array().begin(), p.graph().array().end()),
-        _row_ptr(p.graph().offsets().begin(), p.graph().offsets().end()),
+        _cols(p.graph_new().first.begin(), p.graph_new().first.end()),
+        _row_ptr(p.graph_new().second.begin(), p.graph_new().second.end()),
         _comm(MPI_COMM_NULL)
   {
     // TODO: handle block sizes

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -530,7 +530,7 @@ public:
   /// from operations on the unowned parts.
   /// @note Includes ghost rows, which should be truncated manually if
   /// not required.
-  const std::vector<std::int32_t>& off_diag_offset() const
+  const std::vector<std::int64_t>& off_diag_offset() const
   {
     return _off_diagonal_offset;
   }

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -33,8 +33,8 @@ namespace impl
 /// @param[in] local_size The maximum row index that can be set. Used
 /// when debugging is own to check that rows beyond a permitted range
 /// are not being set.
-template <typename U, typename V, typename W, typename X>
-void set_csr(U&& data, const V& cols, const V& row_ptr, const W& x,
+template <typename U, typename V0, typename V1, typename W, typename X>
+void set_csr(U&& data, const V0& cols, const V1& row_ptr, const W& x,
              const X& xrows, const X& xcols,
              [[maybe_unused]] typename X::value_type local_size)
 {
@@ -75,8 +75,8 @@ void set_csr(U&& data, const V& cols, const V& row_ptr, const W& x,
 /// to the matrix
 /// @param[in] xrows The row indices of `x`
 /// @param[in] xcols The column indices of `x`
-template <typename U, typename V, typename W, typename X>
-void add_csr(U&& data, const V& cols, const V& row_ptr, const W& x,
+template <typename U, typename V0, typename V1, typename W, typename X>
+void add_csr(U&& data, const V0& cols, const V1& row_ptr, const W& x,
              const X& xrows, const X& xcols)
 {
   assert(x.size() == xrows.size() * xcols.size());
@@ -517,7 +517,7 @@ public:
 
   /// Get local row pointers
   /// @note Includes pointers to ghost rows
-  const std::vector<std::int32_t>& row_ptr() const { return _row_ptr; }
+  const std::vector<std::int64_t>& row_ptr() const { return _row_ptr; }
 
   /// Get local column indices
   /// @note Includes columns in ghost rows
@@ -544,10 +544,11 @@ private:
 
   // Matrix data
   std::vector<T, Allocator> _data;
-  std::vector<std::int32_t> _cols, _row_ptr;
+  std::vector<std::int32_t> _cols;
+  std::vector<std::int64_t> _row_ptr;
 
   // Start of off-diagonal (unowned columns) on each row
-  std::vector<std::int32_t> _off_diagonal_offset;
+  std::vector<std::int64_t> _off_diagonal_offset;
 
   // Neighborhood communicator (ghost->owner communicator for rows)
   dolfinx::MPI::Comm _comm;

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -179,7 +179,7 @@ public:
       throw std::runtime_error("Block size not yet supported");
 
     // Compute off-diagonal offset for each row
-    std::span<const std::int32_t> num_diag_nnz = p.off_diagonal_offset();
+    std::span<const std::int64_t> num_diag_nnz = p.off_diagonal_offset();
     _off_diagonal_offset.reserve(num_diag_nnz.size());
     std::transform(num_diag_nnz.begin(), num_diag_nnz.end(), _row_ptr.begin(),
                    std::back_inserter(_off_diagonal_offset), std::plus{});

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -10,7 +10,6 @@
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/common/log.h>
-#include <dolfinx/graph/AdjacencyList.h>
 #include <map>
 
 using namespace dolfinx;

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -358,7 +358,7 @@ void SparsityPattern::assemble()
 
   // Sort and remove duplicate column indices in each row
   std::vector<std::int32_t> adj_counts(local_size0 + owners0.size(), 0);
-  _off_diagonal_offset.resize(local_size0 + owners0.size());
+  _off_diagonal_offsets.resize(local_size0 + owners0.size());
   for (std::size_t i = 0; i < local_size0 + owners0.size(); ++i)
   {
     std::vector<std::int32_t>& row = _row_cache[i];
@@ -366,7 +366,7 @@ void SparsityPattern::assemble()
     auto it_end = std::unique(row.begin(), row.end());
 
     // Find position of first "off-diagonal" column
-    _off_diagonal_offset[i] = std::distance(
+    _off_diagonal_offsets[i] = std::distance(
         row.begin(), std::lower_bound(row.begin(), it_end, local_size1));
 
     _edges.insert(_edges.end(), row.begin(), it_end);
@@ -397,14 +397,14 @@ std::int32_t SparsityPattern::nnz_diag(std::int32_t row) const
 {
   if (_offsets.empty())
     throw std::runtime_error("Sparsity pattern has not be assembled.");
-  return _off_diagonal_offset[row];
+  return _off_diagonal_offsets[row];
 }
 //-----------------------------------------------------------------------------
 std::int32_t SparsityPattern::nnz_off_diag(std::int32_t row) const
 {
   if (_offsets.empty())
     throw std::runtime_error("Sparsity pattern has not be assembled.");
-  return (_offsets[row + 1] - _offsets[row]) - _off_diagonal_offset[row];
+  return (_offsets[row + 1] - _offsets[row]) - _off_diagonal_offsets[row];
 }
 //-----------------------------------------------------------------------------
 std::pair<std::span<const std::int32_t>, std::span<const std::int32_t>>
@@ -415,11 +415,11 @@ SparsityPattern::graph_new() const
   return {_edges, _offsets};
 }
 //-----------------------------------------------------------------------------
-std::span<const std::int64_t> SparsityPattern::off_diagonal_offset() const
+std::span<const std::int32_t> SparsityPattern::off_diagonal_offsets() const
 {
   if (_offsets.empty())
     throw std::runtime_error("Sparsity pattern has not be assembled.");
-  return _off_diagonal_offset;
+  return _off_diagonal_offsets;
 }
 //-----------------------------------------------------------------------------
 MPI_Comm SparsityPattern::comm() const { return _comm.comm(); }

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -415,7 +415,7 @@ SparsityPattern::graph_new() const
   return {_edges, _offsets};
 }
 //-----------------------------------------------------------------------------
-std::span<const int> SparsityPattern::off_diagonal_offset() const
+std::span<const std::int64_t> SparsityPattern::off_diagonal_offset() const
 {
   if (_offsets.empty())
     throw std::runtime_error("Sparsity pattern has not be assembled.");

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -12,12 +12,6 @@
 #include <utility>
 #include <vector>
 
-namespace dolfinx::graph
-{
-template <typename T>
-class AdjacencyList;
-}
-
 namespace dolfinx::common
 {
 class IndexMap;

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -127,7 +127,12 @@ public:
   /// @note Column global indices can be obtained from
   /// SparsityPattern::column_index_map()
   /// @note Includes ghost rows
-  const graph::AdjacencyList<std::int32_t>& graph() const;
+  // const graph::AdjacencyList<std::int32_t>& graph() const;
+
+  /// @brief  Adj list
+  /// @return data
+  std::pair<std::span<const std::int32_t>, std::span<const std::int32_t>>
+  graph_new() const;
 
   /// @brief Row-wise start of off-diagonal (unowned columns) on each
   /// row.
@@ -158,6 +163,9 @@ private:
 
   // Sparsity pattern data (computed once pattern is finalised)
   std::shared_ptr<graph::AdjacencyList<std::int32_t>> _graph;
+
+  std::vector<std::int32_t> _edges;
+  std::vector<std::int32_t> _offsets;
 
   // Start of off-diagonal (unowned columns) on each row
   std::vector<int> _off_diagonal_offset;

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -162,8 +162,6 @@ private:
   std::vector<std::vector<std::int32_t>> _row_cache;
 
   // Sparsity pattern data (computed once pattern is finalised)
-  std::shared_ptr<graph::AdjacencyList<std::int32_t>> _graph;
-
   std::vector<std::int32_t> _edges;
   std::vector<std::int32_t> _offsets;
 

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -137,7 +137,7 @@ public:
   /// @brief Row-wise start of off-diagonal (unowned columns) on each
   /// row.
   /// @note Includes ghost rows
-  std::span<const int> off_diagonal_offset() const;
+  std::span<const std::int64_t> off_diagonal_offset() const;
 
   /// Return MPI communicator
   MPI_Comm comm() const;
@@ -161,11 +161,13 @@ private:
   // Cache for unassembled entries on owned and unowned (ghost) rows
   std::vector<std::vector<std::int32_t>> _row_cache;
 
-  // Sparsity pattern data (computed once pattern is finalised)
+  // Sparsity pattern adjacency data (computed once pattern is
+  // finalised). _edges holds the edges (connected dofs). The edges for
+  // node i are in the range [_edges[i], _edges[i + 1]).
   std::vector<std::int32_t> _edges;
   std::vector<std::int32_t> _offsets;
 
   // Start of off-diagonal (unowned columns) on each row
-  std::vector<int> _off_diagonal_offset;
+  std::vector<std::int64_t> _off_diagonal_offset;
 };
 } // namespace dolfinx::la

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -134,10 +134,10 @@ public:
   std::pair<std::span<const std::int32_t>, std::span<const std::int32_t>>
   graph_new() const;
 
-  /// @brief Row-wise start of off-diagonal (unowned columns) on each
+  /// @brief Row-wise start of off-diagonals (unowned columns) for each
   /// row.
   /// @note Includes ghost rows
-  std::span<const std::int64_t> off_diagonal_offset() const;
+  std::span<const std::int32_t> off_diagonal_offsets() const;
 
   /// Return MPI communicator
   MPI_Comm comm() const;
@@ -167,7 +167,7 @@ private:
   std::vector<std::int32_t> _edges;
   std::vector<std::int32_t> _offsets;
 
-  // Start of off-diagonal (unowned columns) on each row
-  std::vector<std::int64_t> _off_diagonal_offset;
+  // Start of off-diagonal (unowned columns) on each row (row-wise)
+  std::vector<std::int32_t> _off_diagonal_offsets;
 };
 } // namespace dolfinx::la

--- a/cpp/test/matrix.cpp
+++ b/cpp/test/matrix.cpp
@@ -29,8 +29,8 @@ namespace
 /// @param[in, out] x Output vector
 template <typename T>
 void spmv_impl(std::span<const T> values,
-               std::span<const std::int32_t> row_begin,
-               std::span<const std::int32_t> row_end,
+               std::span<const std::int64_t> row_begin,
+               std::span<const std::int64_t> row_end,
                std::span<const std::int32_t> indices, std::span<const T> x,
                std::span<T> y)
 {
@@ -78,17 +78,17 @@ void spmv(la::MatrixCSR<T>& A, la::Vector<T>& x, la::Vector<T>& y)
   x.scatter_fwd_begin();
 
   const std::int32_t nrowslocal = A.num_owned_rows();
-  std::span<const std::int32_t> row_ptr(A.row_ptr().data(), nrowslocal + 1);
+  std::span<const std::int64_t> row_ptr(A.row_ptr().data(), nrowslocal + 1);
   std::span<const std::int32_t> cols(A.cols().data(), row_ptr[nrowslocal]);
-  std::span<const std::int32_t> off_diag_offset(A.off_diag_offset().data(),
+  std::span<const std::int64_t> off_diag_offset(A.off_diag_offset().data(),
                                                 nrowslocal);
   std::span<const T> values(A.values().data(), row_ptr[nrowslocal]);
 
   std::span<const T> _x = x.array();
   std::span<T> _y = y.mutable_array();
 
-  std::span<const std::int32_t> row_begin(row_ptr.data(), nrowslocal);
-  std::span<const std::int32_t> row_end(row_ptr.data() + 1, nrowslocal);
+  std::span<const std::int64_t> row_begin(row_ptr.data(), nrowslocal);
+  std::span<const std::int64_t> row_end(row_ptr.data() + 1, nrowslocal);
 
   // First stage:  spmv - diagonal
   // yi[0] += Ai[0] * xi[0]

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -266,9 +266,9 @@ void la(py::module& m)
           [](dolfinx::la::SparsityPattern& self,
              const py::array_t<std::int32_t, py::array::c_style>& rows)
           { self.insert_diagonal(std::span(rows.data(), rows.size())); },
-          py::arg("rows"))
-      .def_property_readonly("graph", &dolfinx::la::SparsityPattern::graph,
-                             py::return_value_policy::reference_internal);
+          py::arg("rows"));
+      // .def_property_readonly("graph", &dolfinx::la::SparsityPattern::graph,
+      //                        py::return_value_policy::reference_internal);
 
   // Declare objects that are templated over type
   declare_objects<float>(m, "float32");

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -128,9 +128,9 @@ void declare_objects(py::module& m, const std::string& type)
       .def_property_readonly("indptr",
                              [](dolfinx::la::MatrixCSR<T>& self)
                              {
-                               std::span<const std::int32_t> array
+                               std::span<const std::int64_t> array
                                    = self.row_ptr();
-                               return py::array_t<const std::int32_t>(
+                               return py::array_t<const std::int64_t>(
                                    array.size(), array.data(), py::cast(self));
                              })
       .def("finalize_begin", &dolfinx::la::MatrixCSR<T>::finalize_begin)
@@ -267,8 +267,8 @@ void la(py::module& m)
              const py::array_t<std::int32_t, py::array::c_style>& rows)
           { self.insert_diagonal(std::span(rows.data(), rows.size())); },
           py::arg("rows"));
-      // .def_property_readonly("graph", &dolfinx::la::SparsityPattern::graph,
-      //                        py::return_value_policy::reference_internal);
+  // .def_property_readonly("graph", &dolfinx::la::SparsityPattern::graph,
+  //                        py::return_value_policy::reference_internal);
 
   // Declare objects that are templated over type
   declare_objects<float>(m, "float32");


### PR DESCRIPTION
Fixes #2624 for matrix sparsity patterns.