### PR TITLE
Remove "needs" from the first step of the end-user Docker images workflow, since now build images are prepared in a standalone workflow

### DIFF
--- a/.github/workflows/docker-end-user.yml
+++ b/.github/workflows/docker-end-user.yml
@@ -17,7 +17,7 @@ on:
         default: "nightly"
         type: string
         required: true
-      
+
       baseimage:
         description: "tag prefix for docker images"
         default: "docker.io/dolfinx/dev-env:current"
@@ -66,8 +66,6 @@ jobs:
           - arch_tag: arm64
             os: buildjet-4vcpu-ubuntu-2204-arm
     runs-on: ${{ matrix.os }}
-    needs:
-      - create_multiarch_build_images
     steps:
       - name: Create tag without image name
         run: |
@@ -90,7 +88,7 @@ jobs:
         run: |
           USER_INPUT=${{ github.event.inputs.dockerfile }}
           echo "DOCKERFILE=${USER_INPUT:-docker/Dockerfile}" >> $GITHUB_ENV
-      
+
       - name: Set baseimage
         run: |
           USER_INPUT=${{ github.event.inputs.baseimage }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![DOLFINx CI](https://github.com/FEniCS/dolfinx/actions/workflows/ccpp.yml/badge.svg)](https://github.com/FEniCS/dolfinx/actions/workflows/ccpp.yml)
 [![CircleCI](https://circleci.com/gh/FEniCS/dolfinx.svg?style=shield)](https://circleci.com/gh/FEniCS/dolfinx)
-[![Actions Docker images](https://github.com/FEniCS/dolfinx/actions/workflows/docker.yml/badge.svg)](https://github.com/FEniCS/dolfinx/actions/workflows/docker.yml)
+[![Actions Docker images](https://github.com/FEniCS/dolfinx/actions/workflows/docker-end-user.yml/badge.svg)](https://github.com/FEniCS/dolfinx/actions/workflows/docker-end-user.yml)
 [![Actions Spack build](https://github.com/FEniCS/dolfinx/actions/workflows/spack.yml/badge.svg)](https://github.com/FEniCS/dolfinx/actions/workflows/spack.yml)
 [![Actions Conda install](https://github.com/FEniCS/dolfinx/actions/workflows/conda.yml/badge.svg)](https://github.com/FEniCS/dolfinx/actions/workflows/conda.yml)
 [![Actions macOS/Homebrew install](https://github.com/FEniCS/dolfinx/actions/workflows/macos.yml/badge.svg)](https://github.com/FEniCS/dolfinx/actions/workflows/macos.yml)


### PR DESCRIPTION
Fixes #2642. Should resume end-user docker workflow, which has been broken for a week.