### PR TITLE
Use more expressive Actions labels

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -48,6 +48,8 @@ jobs:
         petsc_arch: [real, complex]
         petsc_int_type: [32, 64]
 
+    name: Build and test (scalar type ${{ matrix.petsc_arch }}, int${{ matrix.petsc_int_type }})
+
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Easy to wonder if '32' in a label means `int32` or `float32`. Fix this ambiguity.