### PR TITLE
Adjust API to be more consistent

### DIFF
--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -79,7 +79,7 @@ public:
     // Assertion uses '<=' to deal with sub-functions
     assert(V->dofmap());
     assert(V->dofmap()->index_map->size_global() * V->dofmap()->index_map_bs()
-           <= _x->bs() * _x->map()->size_global());
+           <= _x->bs() * _x->index_map()->size_global());
   }
 
   // Copy constructor

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -547,8 +547,9 @@ std::pair<std::vector<std::int64_t>, std::vector<int>> get_global_indices(
 
       // Number and values to send and receive
       const int num_indices = global[d].size();
-      std::vector<int> size_recv(src.size());
-      size_recv.reserve(1);
+      std::vector<int> size_recv;
+      size_recv.reserve(1); // ensure data is not a nullptr
+      size_recv.resize(src.size());
       MPI_Neighbor_allgather(&num_indices, 1, MPI_INT, size_recv.data(), 1,
                              MPI_INT, comm[d]);
 

--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -43,7 +43,7 @@ Mat create_matrix(const Form<PetscScalar, T>& a,
                   const std::string& type = std::string())
 {
   la::SparsityPattern pattern = fem::create_sparsity_pattern(a);
-  pattern.assemble();
+  pattern.finalize();
   return la::petsc::create_matrix(a.mesh()->comm(), pattern, type);
 }
 
@@ -114,7 +114,7 @@ Mat create_matrix_block(
       p[row].push_back(patterns[row][col].get());
 
   la::SparsityPattern pattern(mesh->comm(), p, maps, bs_dofs);
-  pattern.assemble();
+  pattern.finalize();
 
   // FIXME: Add option to pass customised local-to-global map to PETSc
   // Mat constructor

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -146,7 +146,7 @@ void SparsityPattern::insert(const std::span<const std::int32_t>& rows,
   if (!_offsets.empty())
   {
     throw std::runtime_error(
-        "Cannot insert into sparsity pattern. It has already been assembled");
+        "Cannot insert into sparsity pattern. It has already been finalized");
   }
 
   assert(_index_maps[0]);
@@ -170,7 +170,7 @@ void SparsityPattern::insert_diagonal(std::span<const std::int32_t> rows)
   if (!_offsets.empty())
   {
     throw std::runtime_error(
-        "Cannot insert into sparsity pattern. It has already been assembled");
+        "Cannot insert into sparsity pattern. It has already been finalized");
   }
 
   assert(_index_maps[0]);
@@ -223,12 +223,12 @@ common::IndexMap SparsityPattern::column_index_map() const
 //-----------------------------------------------------------------------------
 int SparsityPattern::block_size(int dim) const { return _bs[dim]; }
 //-----------------------------------------------------------------------------
-void SparsityPattern::assemble()
+void SparsityPattern::finalize()
 {
   if (!_offsets.empty())
     throw std::runtime_error("Sparsity pattern has already been finalised.");
 
-  common::Timer t0("SparsityPattern::assemble");
+  common::Timer t0("SparsityPattern::finalize");
 
   assert(_index_maps[0]);
   const std::int32_t local_size0 = _index_maps[0]->size_local();
@@ -388,21 +388,21 @@ void SparsityPattern::assemble()
 std::int64_t SparsityPattern::num_nonzeros() const
 {
   if (_offsets.empty())
-    throw std::runtime_error("Sparsity pattern has not be assembled.");
+    throw std::runtime_error("Sparsity pattern has not be finalized.");
   return _edges.size();
 }
 //-----------------------------------------------------------------------------
 std::int32_t SparsityPattern::nnz_diag(std::int32_t row) const
 {
   if (_offsets.empty())
-    throw std::runtime_error("Sparsity pattern has not be assembled.");
+    throw std::runtime_error("Sparsity pattern has not be finalized.");
   return _off_diagonal_offsets[row];
 }
 //-----------------------------------------------------------------------------
 std::int32_t SparsityPattern::nnz_off_diag(std::int32_t row) const
 {
   if (_offsets.empty())
-    throw std::runtime_error("Sparsity pattern has not be assembled.");
+    throw std::runtime_error("Sparsity pattern has not be finalized.");
   return (_offsets[row + 1] - _offsets[row]) - _off_diagonal_offsets[row];
 }
 //-----------------------------------------------------------------------------
@@ -410,14 +410,14 @@ std::pair<std::span<const std::int32_t>, std::span<const std::int64_t>>
 SparsityPattern::graph() const
 {
   if (_offsets.empty())
-    throw std::runtime_error("Sparsity pattern has not been assembled.");
+    throw std::runtime_error("Sparsity pattern has not been finalized.");
   return {_edges, _offsets};
 }
 //-----------------------------------------------------------------------------
 std::span<const std::int32_t> SparsityPattern::off_diagonal_offsets() const
 {
   if (_offsets.empty())
-    throw std::runtime_error("Sparsity pattern has not be assembled.");
+    throw std::runtime_error("Sparsity pattern has not be finalized.");
   return _off_diagonal_offsets;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -75,7 +75,7 @@ public:
   void insert_diagonal(std::span<const std::int32_t> rows);
 
   /// @brief Finalize sparsity pattern and communicate off-process entries
-  void assemble();
+  void finalize();
 
   /// @brief Index map for given dimension dimension. Returns the index
   /// map for rows and columns that will be set by the current MPI rank.
@@ -85,7 +85,7 @@ public:
 
   /// @brief Global indices of non-zero columns on owned rows.
   ///
-  /// @note The ghosts are computed only once SparsityPattern::assemble
+  /// @note The ghosts are computed only once SparsityPattern::finalize
   /// has been called.
   /// @return Global index non-zero columns on this process, including
   /// ghosts.

--- a/cpp/dolfinx/la/petsc.h
+++ b/cpp/dolfinx/la/petsc.h
@@ -81,8 +81,8 @@ Vec create_vector_wrap(const common::IndexMap& map, int bs,
 template <class V>
 Vec create_vector_wrap(const la::Vector<V>& x)
 {
-  assert(x.map());
-  return create_vector_wrap(*x.map(), x.bs(), x.array());
+  assert(x.index_map());
+  return create_vector_wrap(*x.index_map(), x.bs(), x.array());
 }
 
 /// @todo This function could take just the local sizes

--- a/cpp/test/matrix.cpp
+++ b/cpp/test/matrix.cpp
@@ -120,7 +120,7 @@ la::MatrixCSR<double> create_operator(MPI_Comm comm)
                                        {{"kappa", kappa}}, {}));
 
   la::SparsityPattern sp = fem::create_sparsity_pattern(*a);
-  sp.assemble();
+  sp.finalize();
   la::MatrixCSR<double> A(sp);
   fem::assemble_matrix(A.mat_add_values(), *a, {});
   A.finalize();
@@ -192,7 +192,7 @@ void test_matrix()
   p.insert(std::vector{0}, std::vector{0});
   p.insert(std::vector{4}, std::vector{5});
   p.insert(std::vector{5}, std::vector{4});
-  p.assemble();
+  p.finalize();
 
   using T = float;
   la::MatrixCSR<T> A(p);

--- a/cpp/test/matrix.cpp
+++ b/cpp/test/matrix.cpp
@@ -123,7 +123,7 @@ la::MatrixCSR<double> create_operator(MPI_Comm comm)
   sp.assemble();
   la::MatrixCSR<double> A(sp);
   fem::assemble_matrix(A.mat_add_values(), *a, {});
-  A.assemble();
+  A.finalize();
 
   return A;
 }
@@ -162,7 +162,7 @@ la::MatrixCSR<double> create_operator(MPI_Comm comm)
   // Assemble matrix
   la::MatrixCSR<double> A(sp);
   fem::assemble_matrix(A.mat_add_values(), *a, {});
-  A.assemble();
+  A.finalize();
   CHECK((V->dofmap()->index_map->size_local() == A.num_owned_rows()));
 
   // Get compatible vectors

--- a/cpp/test/matrix.cpp
+++ b/cpp/test/matrix.cpp
@@ -157,7 +157,7 @@ la::MatrixCSR<double> create_operator(MPI_Comm comm)
 
   // Create sparsity pattern
   la::SparsityPattern sp = fem::create_sparsity_pattern(*a);
-  sp.assemble();
+  sp.finalize();
 
   // Assemble matrix
   la::MatrixCSR<double> A(sp);

--- a/python/demo/demo_types.py
+++ b/python/demo/demo_types.py
@@ -81,7 +81,7 @@ def solve(dtype=np.float32):
 
     # Assemble forms
     A = fem.assemble_matrix(a0, [bc])
-    A.assemble()
+    A.finalize()
     b = fem.assemble_vector(L0)
     fem.apply_lifting(b.array, [a0], bcs=[[bc]])
     b.scatter_reverse(la.InsertMode.add)

--- a/python/demo/demo_types.py
+++ b/python/demo/demo_types.py
@@ -81,7 +81,7 @@ def solve(dtype=np.float32):
 
     # Assemble forms
     A = fem.assemble_matrix(a0, [bc])
-    A.finalize()
+    A.assemble()
     b = fem.assemble_vector(L0)
     fem.apply_lifting(b.array, [a0], bcs=[[bc]])
     b.scatter_reverse(la.ScatterMode.add)

--- a/python/demo/demo_types.py
+++ b/python/demo/demo_types.py
@@ -84,7 +84,7 @@ def solve(dtype=np.float32):
     A.assemble()
     b = fem.assemble_vector(L0)
     fem.apply_lifting(b.array, [a0], bcs=[[bc]])
-    b.scatter_reverse(la.ScatterMode.add)
+    b.scatter_reverse(la.InsertMode.add)
     fem.set_bc(b.array, [bc])
 
     # Create a Scipy sparse matrix that shares data with A

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -93,7 +93,7 @@ def create_vector(L: FormMetaClass) -> la.VectorMetaClass:
 def create_matrix(a: FormMetaClass) -> la.MatrixCSRMetaClass:
     """Create a sparse matrix that is compatible with a given bilinear form"""
     sp = dolfinx.fem.create_sparsity_pattern(a)
-    sp.assemble()
+    sp.finalize()
     return la.matrix_csr(sp, dtype=a.dtype)
 
 

--- a/python/dolfinx/la.py
+++ b/python/dolfinx/la.py
@@ -9,11 +9,11 @@
 import numpy as np
 
 from dolfinx import cpp as _cpp
-from dolfinx.cpp.la import Norm, ScatterMode
+from dolfinx.cpp.la import Norm, InsertMode
 from dolfinx.cpp.la.petsc import create_vector as create_petsc_vector
 
 __all__ = ["orthonormalize", "is_orthonormal", "create_petsc_vector", "matrix_csr", "vector",
-           "MatrixCSRMetaClass", "Norm", "ScatterMode", "VectorMetaClass", ]
+           "MatrixCSRMetaClass", "Norm", "InsertMode", "VectorMetaClass", ]
 
 
 class MatrixCSRMetaClass:

--- a/python/dolfinx/wrappers/assemble.cpp
+++ b/python/dolfinx/wrappers/assemble.cpp
@@ -385,7 +385,7 @@ void petsc_module(py::module& m)
         std::vector<std::int32_t> c(map->size_local(), 0);
         std::iota(c.begin(), c.end(), 0);
         dolfinx::fem::sparsitybuild::cells(sp, c, {*dofmap1, *dofmap0});
-        sp.assemble();
+        sp.finalize();
 
         // Build operator
         Mat A = dolfinx::la::petsc::create_matrix(comm, sp);
@@ -426,7 +426,7 @@ void petsc_module(py::module& m)
         std::vector<std::int32_t> c(map->size_local(), 0);
         std::iota(c.begin(), c.end(), 0);
         dolfinx::fem::sparsitybuild::cells(sp, c, {*dofmap1, *dofmap0});
-        sp.assemble();
+        sp.finalize();
 
         // Build operator
         Mat A = dolfinx::la::petsc::create_matrix(comm, sp);

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -100,7 +100,7 @@ void declare_objects(py::module& m, const std::string& type)
            static_cast<void (dolfinx::la::MatrixCSR<T>::*)(T)>(
                &dolfinx::la::MatrixCSR<T>::set),
            py::arg("x"))
-      .def("assemble", &dolfinx::la::MatrixCSR<T>::assemble)
+      .def("finalize", &dolfinx::la::MatrixCSR<T>::finalize)
       .def("to_dense",
            [](const dolfinx::la::MatrixCSR<T>& self)
            {
@@ -131,8 +131,8 @@ void declare_objects(py::module& m, const std::string& type)
                                return py::array_t(array.size(), array.data(),
                                                   py::cast(self));
                              })
-      .def("assemble_begin", &dolfinx::la::MatrixCSR<T>::assemble_begin)
-      .def("assemble_end", &dolfinx::la::MatrixCSR<T>::assemble_end);
+      .def("finalize_begin", &dolfinx::la::MatrixCSR<T>::finalize_begin)
+      .def("finalize_end", &dolfinx::la::MatrixCSR<T>::finalize_end);
 }
 
 void petsc_module(py::module& m)
@@ -246,7 +246,7 @@ void la(py::module& m)
       .def("index_map", &dolfinx::la::SparsityPattern::index_map,
            py::arg("dim"))
       .def("column_index_map", &dolfinx::la::SparsityPattern::column_index_map)
-      .def("assemble",   &dolfinx::la::SparsityPattern::assemble)
+      .def("finalize", &dolfinx::la::SparsityPattern::finalize)
       .def_property_readonly("num_nonzeros",
                              &dolfinx::la::SparsityPattern::num_nonzeros)
       .def(

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -158,12 +158,12 @@ def test_basic_assembly_petsc_matrixcsr(mode):
     a = form(a)
 
     A0 = fem.assemble_matrix(a)
-    A0.finalize()
+    A0.assemble()
     assert isinstance(A0, la.MatrixCSRMetaClass)
     A1 = fem.petsc.assemble_matrix(a)
     A1.assemble()
     assert isinstance(A1, PETSc.Mat)
-    assert np.sqrt(A0.norm_squared()) == pytest.approx(A1.norm())
+    assert np.sqrt(A0.squared_norm()) == pytest.approx(A1.norm())
     A1.destroy()
 
     V = VectorFunctionSpace(mesh, ("Lagrange", 1))
@@ -892,7 +892,7 @@ def test_vector_types():
     c0 = _cpp.fem.pack_constants(L)
     c1 = _cpp.fem.pack_coefficients(L)
     _cpp.fem.assemble_vector(x0.array, L, c0, c1)
-    x0.scatter_reverse(la.ScatterMode.add)
+    x0.scatter_reverse(la.InsertMode.add)
 
     c = Constant(mesh, np.complex128(1))
     L = inner(c, v) * ufl.dx
@@ -901,7 +901,7 @@ def test_vector_types():
     c0 = _cpp.fem.pack_constants(L)
     c1 = _cpp.fem.pack_coefficients(L)
     _cpp.fem.assemble_vector(x1.array, L, c0, c1)
-    x1.scatter_reverse(la.ScatterMode.add)
+    x1.scatter_reverse(la.InsertMode.add)
 
     c = Constant(mesh, np.float32(1))
     L = inner(c, v) * ufl.dx
@@ -910,7 +910,7 @@ def test_vector_types():
     c0 = _cpp.fem.pack_constants(L)
     c1 = _cpp.fem.pack_coefficients(L)
     _cpp.fem.assemble_vector(x2.array, L, c0, c1)
-    x2.scatter_reverse(la.ScatterMode.add)
+    x2.scatter_reverse(la.InsertMode.add)
 
     assert np.linalg.norm(x0.array - x1.array) == pytest.approx(0.0)
     assert np.linalg.norm(x0.array - x2.array) == pytest.approx(0.0, abs=1e-7)

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -158,7 +158,7 @@ def test_basic_assembly_petsc_matrixcsr(mode):
     a = form(a)
 
     A0 = fem.assemble_matrix(a)
-    A0.assemble()
+    A0.finalize()
     assert isinstance(A0, la.MatrixCSRMetaClass)
     A1 = fem.petsc.assemble_matrix(a)
     A1.assemble()

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -240,9 +240,9 @@ def test_cffi_assembly():
     L = _cpp.fem.Form_float64([V._cpp_object], integrals, [], [], False)
 
     A = fem.assemble_matrix(a)
-    A.finalize()
-    assert np.isclose(np.sqrt(A.norm_squared()), 56.124860801609124)
+    A.assemble()
+    assert np.isclose(np.sqrt(A.squared_norm()), 56.124860801609124)
 
     b = fem.assemble_vector(L)
-    b.scatter_reverse(la.ScatterMode.add)
+    b.scatter_reverse(la.InsertMode.add)
     assert np.isclose(b.norm(), 0.0739710713711999)

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -240,7 +240,7 @@ def test_cffi_assembly():
     L = _cpp.fem.Form_float64([V._cpp_object], integrals, [], [], False)
 
     A = fem.assemble_matrix(a)
-    A.assemble()
+    A.finalize()
     assert np.isclose(np.sqrt(A.squared_norm()), 56.124860801609124)
 
     b = fem.assemble_vector(L)

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -156,7 +156,7 @@ def test_rank1_hdiv():
 
     a = form(ufl.inner(f, ufl.TestFunction(vdP1)) * ufl.dx)
     sparsity_pattern = create_sparsity_pattern(a)
-    sparsity_pattern.assemble()
+    sparsity_pattern.finalize()
     A = create_matrix(MPI.COMM_WORLD, sparsity_pattern)
 
     dofmap_col = RT1.dofmap.list.astype(np.dtype(PETSc.IntType))

--- a/python/test/unit/la/test_matrix_vector.py
+++ b/python/test/unit/la/test_matrix_vector.py
@@ -27,7 +27,7 @@ def test_create_matrix_csr():
     rows = range(0, bs * map.size_local)
     cols = range(0, bs * map.size_local)
     pattern.insert(rows, cols)
-    pattern.assemble()
+    pattern.finalize()
 
     A = la.matrix_csr(pattern)
     assert A.data.dtype == np.float64

--- a/python/test/unit/la/test_sparsity_pattern.py
+++ b/python/test/unit/la/test_sparsity_pattern.py
@@ -22,5 +22,5 @@ def test_add_diagonal():
     facets = exterior_facet_indices(mesh.topology)
     blocks = locate_dofs_topological(V, mesh.topology.dim - 1, facets)
     pattern.insert_diagonal(blocks)
-    pattern.assemble()
+    pattern.finalize()
     assert len(blocks) == pattern.num_nonzeros

--- a/python/test/unit/la/test_vector_scatter.py
+++ b/python/test/unit/la/test_vector_scatter.py
@@ -62,7 +62,7 @@ def test_scatter_reverse(e):
 
     # Reverse scatter (insert) should have no effect
     w0 = u.x.array.copy()
-    u.x.scatter_reverse(_cpp.la.ScatterMode.insert)
+    u.x.scatter_reverse(_cpp.la.InsertMode.insert)
     assert np.allclose(w0, u.x.array)
 
     # Fill with MPI rank, and sum all entries in the vector (including
@@ -71,7 +71,7 @@ def test_scatter_reverse(e):
     all_count0 = MPI.COMM_WORLD.allreduce(u.x.array.sum(), op=MPI.SUM)
 
     # Reverse scatter (add)
-    u.x.scatter_reverse(_cpp.la.ScatterMode.add)
+    u.x.scatter_reverse(_cpp.la.InsertMode.add)
     num_ghosts = V.dofmap.index_map.num_ghosts
     ghost_count = MPI.COMM_WORLD.allreduce(num_ghosts * comm.rank, op=MPI.SUM)
 


### PR DESCRIPTION
* use `squared_norm()` for both `Vector` and `MatrixCSR`
* Use `InsertMode` not `ScatterMode`
* Use `finalize` for both `MatrixCSR` and `SparsityPattern`
* `index_map()` not `map()` for `Vector` 

If any others seem obvious, we can add to this branch. 
