### PR TITLE
Add elasticity to 'types' demo

### DIFF
--- a/python/demo/demo_types.py
+++ b/python/demo/demo_types.py
@@ -40,94 +40,192 @@ comm = MPI.COMM_SELF
 
 msh = mesh.create_rectangle(comm=comm, points=((0.0, 0.0), (2.0, 1.0)), n=(32, 16),
                             cell_type=mesh.CellType.triangle)
-V = fem.FunctionSpace(msh, ("Lagrange", 1))
-
-# Define a variational problem.
-
-u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
-x = ufl.SpatialCoordinate(msh)
-fr = 10 * ufl.exp(-((x[0] - 0.5) ** 2 + (x[1] - 0.5) ** 2) / 0.02)
-fc = ufl.sin(2 * np.pi * x[0]) + 10 * ufl.sin(4 * np.pi * x[1]) * 1j
-gr = ufl.sin(5 * x[0])
-gc = ufl.sin(5 * x[0]) * 1j
-a = ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx
-L = ufl.inner(fr + fc, v) * ufl.dx + ufl.inner(gr + gc, v) * ufl.ds
-
-# In preparation for constructing Dirichlet boundary conditions, locate
-# facets on the constrained boundary and the corresponding
-# degrees-of-freedom.
 
 facets = mesh.locate_entities_boundary(msh, dim=1,
                                        marker=lambda x: np.logical_or(np.isclose(x[0], 0.0),
                                                                       np.isclose(x[0], 2.0)))
-dofs = fem.locate_dofs_topological(V=V, entity_dim=1, entities=facets)
 
 
-# The below function computes the solution of the finite problem using a
-# specified scalar type.
+def poisson():
 
-def solve(dtype=np.float32):
-    """Solve the variational problem"""
+    V = fem.FunctionSpace(msh, ("Lagrange", 1))
 
-    # Process forms. This will compile the forms for the requested type.
-    a0 = fem.form(a, dtype=dtype)
-    if np.issubdtype(dtype, np.complexfloating):
-        L0 = fem.form(L, dtype=dtype)
-    else:
-        L0 = fem.form(ufl.replace(L, {fc: 0, gc: 0}), dtype=dtype)
+    # Define a variational problem.
 
-    # Create a Dirichlet boundary condition
-    bc = fem.dirichletbc(value=dtype(0), dofs=dofs, V=V)
+    u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
+    x = ufl.SpatialCoordinate(msh)
+    fr = 10 * ufl.exp(-((x[0] - 0.5) ** 2 + (x[1] - 0.5) ** 2) / 0.02)
+    fc = ufl.sin(2 * np.pi * x[0]) + 10 * ufl.sin(4 * np.pi * x[1]) * 1j
+    gr = ufl.sin(5 * x[0])
+    gc = ufl.sin(5 * x[0]) * 1j
+    a = ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx
+    L = ufl.inner(fr + fc, v) * ufl.dx + ufl.inner(gr + gc, v) * ufl.ds
 
-    # Assemble forms
-    A = fem.assemble_matrix(a0, [bc])
-    A.finalize()
-    b = fem.assemble_vector(L0)
-    fem.apply_lifting(b.array, [a0], bcs=[[bc]])
-    b.scatter_reverse(la.InsertMode.add)
-    fem.set_bc(b.array, [bc])
+    # In preparation for constructing Dirichlet boundary conditions, locate
+    # facets on the constrained boundary and the corresponding
+    # degrees-of-freedom.
 
-    # Create a Scipy sparse matrix that shares data with A
-    As = scipy.sparse.csr_matrix((A.data, A.indices, A.indptr))
+    dofs = fem.locate_dofs_topological(V=V, entity_dim=1, entities=facets)
 
-    # Solve the variational problem and return the solution
-    uh = fem.Function(V, dtype=dtype)
-    uh.x.array[:] = scipy.sparse.linalg.spsolve(As, b.array)
-    return uh
+    # The below function computes the solution of the finite problem using a
+    # specified scalar type.
 
-# This function visualises the solution.
+    def solve(dtype=np.float32):
+        """Solve the variational problem"""
 
-
-def display(u, filter=np.real):
-    """Plot the solution using pyvista"""
-    try:
-        import pyvista
-        cells, types, x = plot.create_vtk_mesh(V)
-        grid = pyvista.UnstructuredGrid(cells, types, x)
-        grid.point_data["u"] = filter(u.x.array)
-        grid.set_active_scalars("u")
-
-        plotter = pyvista.Plotter()
-        plotter.add_mesh(grid, show_edges=True)
-        plotter.add_mesh(grid.warp_by_scalar())
-        plotter.add_title("real" if filter is np.real else "imag")
-        if pyvista.OFF_SCREEN:
-            pyvista.start_xvfb(wait=0.1)
-            plotter.screenshot(f"u_{'real' if filter is np.real else 'imag'}.png")
+        # Process forms. This will compile the forms for the requested type.
+        a0 = fem.form(a, dtype=dtype)
+        if np.issubdtype(dtype, np.complexfloating):
+            L0 = fem.form(L, dtype=dtype)
         else:
-            plotter.show()
-    except ModuleNotFoundError:
-        print("'pyvista' is required to visualise the solution")
+            L0 = fem.form(ufl.replace(L, {fc: 0, gc: 0}), dtype=dtype)
+
+        # Create a Dirichlet boundary condition
+        bc = fem.dirichletbc(value=dtype(0), dofs=dofs, V=V)
+
+        # Assemble forms
+        A = fem.assemble_matrix(a0, [bc])
+        A.finalize()
+        b = fem.assemble_vector(L0)
+        fem.apply_lifting(b.array, [a0], bcs=[[bc]])
+        b.scatter_reverse(la.InsertMode.add)
+        fem.set_bc(b.array, [bc])
+
+        # Create a Scipy sparse matrix that shares data with A
+        As = scipy.sparse.csr_matrix((A.data, A.indices, A.indptr))
+
+        # Solve the variational problem and return the solution
+        uh = fem.Function(V, dtype=dtype)
+        uh.x.array[:] = scipy.sparse.linalg.spsolve(As, b.array)
+        return uh
+
+    # This function visualises the solution.
+
+    def display(u, filter=np.real):
+        """Plot the solution using pyvista"""
+        try:
+            import pyvista
+            cells, types, x = plot.create_vtk_mesh(V)
+            grid = pyvista.UnstructuredGrid(cells, types, x)
+            grid.point_data["u"] = filter(u.x.array)
+            grid.set_active_scalars("u")
+
+            plotter = pyvista.Plotter()
+            plotter.add_mesh(grid, show_edges=True)
+            plotter.add_mesh(grid.warp_by_scalar())
+            plotter.add_title("real" if filter is np.real else "imag")
+            if pyvista.OFF_SCREEN:
+                pyvista.start_xvfb(wait=0.1)
+                plotter.screenshot(f"u_{'real' if filter is np.real else 'imag'}.png")
+            else:
+                plotter.show()
+        except ModuleNotFoundError:
+            print("'pyvista' is required to visualise the solution")
+
+    # Solve the variational problem using different scalar types
+
+    uh = solve(dtype=np.float32)
+    uh = solve(dtype=np.float64)
+    uh = solve(dtype=np.complex64)
+    uh = solve(dtype=np.complex128)
+
+    # Display the last computed solution
+
+    display(uh, np.real)
+    display(uh, np.imag)
 
 
-# Solve the variational problem using different scalar types
+def elasticity():
+    print("EEEEEE")
 
-uh = solve(dtype=np.float32)
-uh = solve(dtype=np.float64)
-uh = solve(dtype=np.complex64)
-uh = solve(dtype=np.complex128)
+    V = fem.VectorFunctionSpace(msh, ("Lagrange", 1))
 
-# Display the last computed solution
+    # Define a variational problem.
 
-display(uh, np.real)
-display(uh, np.imag)
+    ω, ρ = 300.0, 10.0
+    x = ufl.SpatialCoordinate(msh)
+    f = ufl.as_vector((ρ * ω**2 * x[0], ρ * ω**2 * x[1]))
+
+    E = 1.0e9
+    ν = 0.3
+    μ = E / (2.0 * (1.0 + ν))
+    λ = E * ν / ((1.0 + ν) * (1.0 - 2.0 * ν))
+
+    def σ(v):
+        """Return an expression for the stress σ given a displacement field"""
+        return 2.0 * μ * ufl.sym(ufl.grad(v)) + λ * ufl.tr(ufl.sym(ufl.grad(v))) * ufl.Identity(len(v))
+
+    u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
+    a = ufl.inner(σ(u), ufl.grad(v)) * ufl.dx
+    L = ufl.inner(f, v) * ufl.dx
+
+    dofs = fem.locate_dofs_topological(V=V, entity_dim=1, entities=facets)
+
+    def solve(dtype=np.float32):
+        """Solve the variational problem"""
+
+        # Process forms. This will compile the forms for the requested type.
+        a0 = fem.form(a, dtype=dtype)
+        L0 = fem.form(L, dtype=dtype)
+
+        # Create a Dirichlet boundary condition
+        bc = fem.dirichletbc(np.zeros(2, dtype=dtype),
+                             fem.locate_dofs_topological(V, entity_dim=1, entities=facets), V=V)
+
+        # Assemble forms
+        A = fem.assemble_matrix(a0, [bc])
+        A.finalize()
+        b = fem.assemble_vector(L0)
+        fem.apply_lifting(b.array, [a0], bcs=[[bc]])
+        b.scatter_reverse(la.InsertMode.add)
+        fem.set_bc(b.array, [bc])
+
+        # Create a Scipy sparse matrix that shares data with A
+        As = scipy.sparse.csr_matrix((A.data, A.indices, A.indptr))
+        # As = scipy.sparse.bsr_matrix((A.data, A.indices, A.indptr))
+
+        # print(As)
+
+        # # Solve the variational problem and return the solution
+        # uh = fem.Function(V, dtype=dtype)
+        # uh.x.array[:] = scipy.sparse.linalg.spsolve(As, b.array)
+        # return uh
+
+    # This function visualises the solution.
+
+    # def display(u, filter=np.real):
+    #     """Plot the solution using pyvista"""
+    #     try:
+    #         import pyvista
+    #         cells, types, x = plot.create_vtk_mesh(V)
+    #         grid = pyvista.UnstructuredGrid(cells, types, x)
+    #         grid.point_data["u"] = filter(u.x.array)
+    #         grid.set_active_scalars("u")
+
+    #         plotter = pyvista.Plotter()
+    #         plotter.add_mesh(grid, show_edges=True)
+    #         plotter.add_mesh(grid.warp_by_scalar())
+    #         plotter.add_title("real" if filter is np.real else "imag")
+    #         if pyvista.OFF_SCREEN:
+    #             pyvista.start_xvfb(wait=0.1)
+    #             plotter.screenshot(f"u_{'real' if filter is np.real else 'imag'}.png")
+    #         else:
+    #             plotter.show()
+    #     except ModuleNotFoundError:
+    #         print("'pyvista' is required to visualise the solution")
+
+    # Solve the variational problem using different scalar types
+
+    # uh = solve(dtype=np.float32)
+    uh = solve(dtype=np.float64)
+    # uh = solve(dtype=np.complex64)
+    # uh = solve(dtype=np.complex128)
+
+    # Display the last computed solution
+
+    # display(uh, np.real)
+    # display(uh, np.imag)
+
+
+# poisson()
+elasticity()

--- a/python/demo/demo_types.py
+++ b/python/demo/demo_types.py
@@ -72,7 +72,7 @@ def poisson():
 
     # The below function computes the solution of the finite problem using a
     # specified scalar type.
-    def solve(dtype: typing.Union[np.float32, np.float64, np.complex64, np.complex128]) -> fem.Function:
+    def solve(dtype) -> fem.Function:
         """Solve the variational problem.
 
         Args:
@@ -164,7 +164,7 @@ def elasticity():
 
     dofs = fem.locate_dofs_topological(V=V, entity_dim=1, entities=facets)
 
-    def solve(dtype: typing.Union[np.float32, np.float64, np.complex64, np.complex128]) -> fem.Function:
+    def solve(dtype) -> fem.Function:
         """Solve the variational problem.
 
         Args:

--- a/python/demo/demo_types.py
+++ b/python/demo/demo_types.py
@@ -18,7 +18,6 @@
 #   functionality
 
 # +
-import typing
 import numpy as np
 import scipy.sparse
 import scipy.sparse.linalg

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -11,12 +11,13 @@ import collections.abc
 import typing
 
 import numpy as np
-
+import numpy.typing as npt
 import ufl
-from dolfinx import cpp as _cpp
-from dolfinx import default_scalar_type, jit
 from dolfinx.fem import IntegralType
 from dolfinx.fem.function import FunctionSpace
+
+from dolfinx import cpp as _cpp
+from dolfinx import default_scalar_type, jit
 
 if typing.TYPE_CHECKING:
     from dolfinx.fem import function
@@ -91,7 +92,8 @@ _ufl_to_dolfinx_domain = {"cell": IntegralType.cell,
                           "vertex": IntegralType.vertex}
 
 
-def form(form: typing.Union[ufl.Form, typing.Iterable[ufl.Form]], dtype: np.dtype = default_scalar_type,
+def form(form: typing.Union[ufl.Form, typing.Iterable[ufl.Form]],
+         dtype: typing.Optional[npt.DTypeLike] = default_scalar_type,
          form_compiler_options: dict = {}, jit_options: dict = {}):
     """Create a Form or an array of Forms.
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -239,7 +239,7 @@ class Function(ufl.Coefficient):
     """
 
     def __init__(self, V: FunctionSpace, x: typing.Optional[la.VectorMetaClass] = None,
-                 name: typing.Optional[str] = None, dtype: np.dtype = default_scalar_type):
+                 name: typing.Optional[str] = None, dtype: typing.Optional[npt.DTypeLike] = default_scalar_type):
         """Initialize a finite element Function.
 
         Args:

--- a/python/dolfinx/la.py
+++ b/python/dolfinx/la.py
@@ -42,7 +42,7 @@ def matrix_csr(sp, block_mode=BlockMode.compact, dtype=np.float64) -> MatrixCSRM
 
     Args:
         sp: The sparsity pattern that defines the nonzero structure of
-        the matrix the parallel distribution of the matrix.
+            the matrix the parallel distribution of the matrix.
         dtype: The scalar type.
 
     Returns:

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -92,8 +92,7 @@ void declare_objects(py::module& m, const std::string& type)
       .def(py::init([](const dolfinx::la::SparsityPattern& p,
                        dolfinx::la::BlockMode bm)
                     { return dolfinx::la::MatrixCSR<T>(p, bm); }),
-           py::arg("p"),
-           py::arg("block_mode") = dolfinx::la::BlockMode::compact)
+           py::arg("p"), py::arg("block_mode"))
       .def_property_readonly("dtype", [](const dolfinx::la::MatrixCSR<T>& self)
                              { return py::dtype::of<T>(); })
       .def_property_readonly("block_size",

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -49,7 +49,7 @@ index_size = np.dtype(PETSc.IntType).itemsize
 
 if index_size == 8:
     c_int_t = "int64_t"
-    ctypes_index: numpy.typing.DTypeLike = ctypes.c_int64
+    ctypes_index: np.typing.DTypeLike = ctypes.c_int64
 elif index_size == 4:
     c_int_t = "int32_t"
     ctypes_index = ctypes.c_int32


### PR DESCRIPTION
Demonstrates use of `MatrixCSR` for systems with a block size.

Also adds a matrix type (block size) option to the matrix assembly function.