### PR TITLE
Fix extraction of `fem::Function` names in ADIOS2-based output

### DIFF
--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -124,7 +124,7 @@ int main(int argc, char* argv[])
     auto part = mesh::create_cell_partitioner(mesh::GhostMode::shared_facet);
     auto mesh = std::make_shared<mesh::Mesh<U>>(
         mesh::create_rectangle<U>(MPI_COMM_WORLD, {{{0.0, 0.0}, {2.0, 1.0}}},
-                                  {2, 1}, mesh::CellType::triangle, part));
+                                  {32, 16}, mesh::CellType::triangle, part));
 
     auto V = std::make_shared<fem::FunctionSpace<U>>(
         fem::create_functionspace(functionspace_form_poisson_a, "u", mesh));

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -260,7 +260,7 @@ int main(int argc, char* argv[])
 #ifdef HAS_ADIOS2
     // Save solution in VTX format
     io::VTXWriter<U> vtx(MPI_COMM_WORLD, "u.bp", {u}, "bp4");
-    // vtx.write(0);
+    vtx.write(0);
 #endif
   }
 

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -1,310 +1,270 @@
-#include <basix/e-lagrange.h>
+// Poisson equation (C++)
+// ======================
+//
+// This demo illustrates how to:
+//
+// * Solve a linear partial differential equation
+// * Create and apply Dirichlet boundary conditions
+// * Define Expressions
+// * Define a FunctionSpace
+//
+// The solution for :math:`u` in this demo will look as follows:
+//
+// .. image:: ../poisson_u.png
+//     :scale: 75 %
+//
+//
+// Equation and problem definition
+// -------------------------------
+//
+// The Poisson equation is the canonical elliptic partial differential
+// equation.  For a domain :math:`\Omega \subset \mathbb{R}^n` with
+// boundary :math:`\partial \Omega = \Gamma_{D} \cup \Gamma_{N}`, the
+// Poisson equation with particular boundary conditions reads:
+//
+// .. math::
+//    - \nabla^{2} u &= f \quad {\rm in} \ \Omega, \\
+//      u &= 0 \quad {\rm on} \ \Gamma_{D}, \\
+//      \nabla u \cdot n &= g \quad {\rm on} \ \Gamma_{N}. \\
+//
+// Here, :math:`f` and :math:`g` are input data and :math:`n` denotes the
+// outward directed boundary normal. The most standard variational form
+// of Poisson equation reads: find :math:`u \in V` such that
+//
+// .. math::
+//    a(u, v) = L(v) \quad \forall \ v \in V,
+//
+// where :math:`V` is a suitable function space and
+//
+// .. math::
+//    a(u, v) &= \int_{\Omega} \nabla u \cdot \nabla v \, {\rm d} x, \\
+//    L(v)    &= \int_{\Omega} f v \, {\rm d} x
+//    + \int_{\Gamma_{N}} g v \, {\rm d} s.
+//
+// The expression :math:`a(u, v)` is the bilinear form and :math:`L(v)`
+// is the linear form. It is assumed that all functions in :math:`V`
+// satisfy the Dirichlet boundary conditions (:math:`u = 0 \ {\rm on} \
+// \Gamma_{D}`).
+//
+// In this demo, we shall consider the following definitions of the input
+// functions, the domain, and the boundaries:
+//
+// * :math:`\Omega = [0,1] \times [0,1]` (a unit square)
+// * :math:`\Gamma_{D} = \{(0, y) \cup (1, y) \subset \partial \Omega\}`
+// (Dirichlet boundary)
+// * :math:`\Gamma_{N} = \{(x, 0) \cup (x, 1) \subset \partial \Omega\}`
+// (Neumann boundary)
+// * :math:`g = \sin(5x)` (normal derivative)
+// * :math:`f = 10\exp(-((x - 0.5)^2 + (y - 0.5)^2) / 0.02)` (source term)
+//
+//
+// Implementation
+// --------------
+//
+// The implementation is split in two files: a form file containing the
+// definition of the variational forms expressed in UFL and a C++ file
+// containing the actual solver.
+//
+// Running this demo requires the files: :download:`main.cpp`,
+// :download:`poisson.py` and :download:`CMakeLists.txt`.
+//
+//
+// UFL form file
+// ^^^^^^^^^^^^^
+//
+// The UFL file is implemented in :download:`poisson.py`, and the
+// explanation of the UFL file can be found at :doc:`here <poisson.py>`.
+//
+//
+// C++ program
+// ^^^^^^^^^^^
+//
+// The main solver is implemented in the :download:`main.cpp` file.
+//
+// At the top we include the DOLFINx header file and the generated header
+// file "Poisson.h" containing the variational forms for the Poisson
+// equation.  For convenience we also include the DOLFINx namespace.
+//
+// .. code-block:: cpp
 
+#include "poisson.h"
+#include <cmath>
 #include <dolfinx.h>
-#include <dolfinx/io/ADIOS2Writers.h>
-#include <dolfinx/mesh/generation.h>
+#include <dolfinx/fem/Constant.h>
+#include <dolfinx/fem/petsc.h>
+#include <utility>
+#include <vector>
 
 using namespace dolfinx;
+using T = PetscScalar;
+using U = typename dolfinx::scalar_value_type_t<T>;
+
+// Then follows the definition of the coefficient functions (for
+// :math:`f` and :math:`g`), which are derived from the
+// :cpp:class:`Expression` class in DOLFINx
+//
+// .. code-block:: cpp
+
+// Inside the ``main`` function, we begin by defining a mesh of the
+// domain. As the unit square is a very standard domain, we can use a
+// built-in mesh provided by the :cpp:class:`UnitSquareMesh` factory. In
+// order to create a mesh consisting of 32 x 32 squares with each square
+// divided into two triangles, and the finite element space (specified in
+// the form file) defined relative to this mesh, we do as follows
+//
+// .. code-block:: cpp
 
 int main(int argc, char* argv[])
 {
+  dolfinx::init_logging(argc, argv);
   PetscInitialize(&argc, &argv, nullptr, nullptr);
-  init_logging(argc, argv);
+
   {
-    auto part = mesh::create_cell_partitioner(mesh::GhostMode::none);
-    auto meshL = std::make_shared<mesh::Mesh<double>>(
-        mesh::create_box(MPI_COMM_WORLD, {{{0, 0, 0}, {1, 1, 1}}}, {15, 15, 15},
-                         mesh::CellType::tetrahedron, part));
+    // Create mesh and function space
+    auto part = mesh::create_cell_partitioner(mesh::GhostMode::shared_facet);
+    auto mesh = std::make_shared<mesh::Mesh<U>>(
+        mesh::create_rectangle<U>(MPI_COMM_WORLD, {{{0.0, 0.0}, {2.0, 1.0}}},
+                                  {32, 16}, mesh::CellType::triangle, part));
 
-    basix::FiniteElement eL = basix::element::create_lagrange<double>(
-        mesh::cell_type_to_basix_type(meshL->topology()->cell_types()[0]), 1,
-        basix::element::lagrange_variant::equispaced, false);
-    auto VL = std::make_shared<fem::FunctionSpace<double>>(
-        fem::create_functionspace(meshL, eL, 3));
+    auto V = std::make_shared<fem::FunctionSpace<U>>(
+        fem::create_functionspace(functionspace_form_poisson_a, "u", mesh));
 
-    auto uL = std::make_shared<fem::Function<PetscScalar>>(VL);
+    // Next, we define the variational formulation by initializing the
+    // bilinear and linear forms (:math:`a`, :math:`L`) using the previously
+    // defined :cpp:class:`FunctionSpace` ``V``.  Then we can create the
+    // source and boundary flux term (:math:`f`, :math:`g`) and attach these
+    // to the linear form.
+    //
+    // .. code-block:: cpp
 
-    uL->x()->set(1);
+    // Prepare and set Constants for the bilinear form
+    auto kappa = std::make_shared<fem::Constant<T>>(2.0);
+    auto f = std::make_shared<fem::Function<T>>(V);
+    auto g = std::make_shared<fem::Function<T>>(V);
 
-    io::FidesWriter<double> writeruL(meshL->comm(), "uL.bp",
-                                     io::adios2_writer::U<double>{uL}, "bp4",
-                                     io::FidesMeshPolicy::reuse);
-    //    io::VTXWriter<double> writeruL(meshL->comm(), "uL.bp", {uL});    //
-    //    Doesn't work either
-    writeruL.write(0.0);
+    // Define variational forms
+    auto a = std::make_shared<fem::Form<T>>(fem::create_form<T>(
+        *form_poisson_a, {V, V}, {}, {{"kappa", kappa}}, {}));
+    auto L = std::make_shared<fem::Form<T>>(fem::create_form<T>(
+        *form_poisson_L, {V}, {{"f", f}, {"g", g}}, {}, {}));
+
+    // Now, the Dirichlet boundary condition (:math:`u = 0`) can be created
+    // using the class :cpp:class:`DirichletBC`. A :cpp:class:`DirichletBC`
+    // takes two arguments: the value of the boundary condition,
+    // and the part of the boundary on which the condition applies.
+    // In our example, the value of the boundary condition (0.0) can
+    // represented using a :cpp:class:`Function`, and the Dirichlet boundary
+    // is defined by the indices of degrees of freedom to which the boundary
+    // condition applies.
+    // The definition of the Dirichlet boundary condition then looks
+    // as follows:
+    //
+    // .. code-block:: cpp
+
+    // Define boundary condition
+
+    auto facets = mesh::locate_entities_boundary(
+        *mesh, 1,
+        [](auto x)
+        {
+          using U = typename decltype(x)::value_type;
+          constexpr U eps = 1.0e-8;
+          std::vector<std::int8_t> marker(x.extent(1), false);
+          for (std::size_t p = 0; p < x.extent(1); ++p)
+          {
+            auto x0 = x(0, p);
+            if (std::abs(x0) < eps or std::abs(x0 - 2) < eps)
+              marker[p] = true;
+          }
+          return marker;
+        });
+    const auto bdofs = fem::locate_dofs_topological(
+        *V->mesh()->topology_mutable(), *V->dofmap(), 1, facets);
+    auto bc = std::make_shared<const fem::DirichletBC<T>>(0.0, bdofs, V);
+
+    f->interpolate(
+        [](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
+        {
+          std::vector<T> f;
+          for (std::size_t p = 0; p < x.extent(1); ++p)
+          {
+            auto dx = (x(0, p) - 0.5) * (x(0, p) - 0.5);
+            auto dy = (x(1, p) - 0.5) * (x(1, p) - 0.5);
+            f.push_back(10 * std::exp(-(dx + dy) / 0.02));
+          }
+
+          return {f, {f.size()}};
+        });
+
+    g->interpolate(
+        [](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
+        {
+          std::vector<T> f;
+          for (std::size_t p = 0; p < x.extent(1); ++p)
+            f.push_back(std::sin(5 * x(0, p)));
+          return {f, {f.size()}};
+        });
+
+    // Now, we have specified the variational forms and can consider the
+    // solution of the variational problem. First, we need to define a
+    // :cpp:class:`Function` ``u`` to store the solution. (Upon
+    // initialization, it is simply set to the zero function.) Next, we can
+    // call the ``solve`` function with the arguments ``a == L``, ``u`` and
+    // ``bc`` as follows:
+    //
+    // .. code-block:: cpp
+
+    // Compute solution
+    auto u = std::make_shared<fem::Function<T>>(V);
+    auto A = la::petsc::Matrix(fem::petsc::create_matrix(*a), false);
+    la::Vector<T> b(L->function_spaces()[0]->dofmap()->index_map,
+                    L->function_spaces()[0]->dofmap()->index_map_bs());
+
+    MatZeroEntries(A.mat());
+    fem::assemble_matrix(la::petsc::Matrix::set_block_fn(A.mat(), ADD_VALUES),
+                         *a, {bc});
+    MatAssemblyBegin(A.mat(), MAT_FLUSH_ASSEMBLY);
+    MatAssemblyEnd(A.mat(), MAT_FLUSH_ASSEMBLY);
+    fem::set_diagonal<T>(la::petsc::Matrix::set_fn(A.mat(), INSERT_VALUES), *V,
+                         {bc});
+    MatAssemblyBegin(A.mat(), MAT_FINAL_ASSEMBLY);
+    MatAssemblyEnd(A.mat(), MAT_FINAL_ASSEMBLY);
+
+    b.set(0.0);
+    fem::assemble_vector(b.mutable_array(), *L);
+    fem::apply_lifting<T, U>(b.mutable_array(), {a}, {{bc}}, {}, T(1));
+    b.scatter_rev(std::plus<T>());
+    fem::set_bc<T, U>(b.mutable_array(), {bc});
+
+    la::petsc::KrylovSolver lu(MPI_COMM_WORLD);
+    la::petsc::options::set("ksp_type", "preonly");
+    la::petsc::options::set("pc_type", "lu");
+    lu.set_from_options();
+
+    lu.set_operator(A.mat());
+    la::petsc::Vector _u(la::petsc::create_vector_wrap(*u->x()), false);
+    la::petsc::Vector _b(la::petsc::create_vector_wrap(b), false);
+    lu.solve(_u.vec(), _b.vec());
+
+    // The function ``u`` will be modified during the call to solve. A
+    // :cpp:class:`Function` can be saved to a file. Here, we output the
+    // solution to a ``VTK`` file (specified using the suffix ``.pvd``) for
+    // visualisation in an external program such as Paraview.
+    //
+    // .. code-block:: cpp
+
+    // Save solution in VTK format
+    io::VTKFile file(MPI_COMM_WORLD, "u.pvd", "w");
+    file.write<T>({*u}, 0.0);
+
+#ifdef HAS_ADIOS2
+    // Save solution in VTX format
+    io::VTXWriter<U> vtx(MPI_COMM_WORLD, "u.bp", {u}, "bp4");
+    vtx.write(0);
+#endif
   }
+
   PetscFinalize();
+
+  return 0;
 }
-
-// // Poisson equation (C++)
-// // ======================
-// //
-// // This demo illustrates how to:
-// //
-// // * Solve a linear partial differential equation
-// // * Create and apply Dirichlet boundary conditions
-// // * Define Expressions
-// // * Define a FunctionSpace
-// //
-// // The solution for :math:`u` in this demo will look as follows:
-// //
-// // .. image:: ../poisson_u.png
-// //     :scale: 75 %
-// //
-// //
-// // Equation and problem definition
-// // -------------------------------
-// //
-// // The Poisson equation is the canonical elliptic partial differential
-// // equation.  For a domain :math:`\Omega \subset \mathbb{R}^n` with
-// // boundary :math:`\partial \Omega = \Gamma_{D} \cup \Gamma_{N}`, the
-// // Poisson equation with particular boundary conditions reads:
-// //
-// // .. math::
-// //    - \nabla^{2} u &= f \quad {\rm in} \ \Omega, \\
-// //      u &= 0 \quad {\rm on} \ \Gamma_{D}, \\
-// //      \nabla u \cdot n &= g \quad {\rm on} \ \Gamma_{N}. \\
-// //
-// // Here, :math:`f` and :math:`g` are input data and :math:`n` denotes the
-// // outward directed boundary normal. The most standard variational form
-// // of Poisson equation reads: find :math:`u \in V` such that
-// //
-// // .. math::
-// //    a(u, v) = L(v) \quad \forall \ v \in V,
-// //
-// // where :math:`V` is a suitable function space and
-// //
-// // .. math::
-// //    a(u, v) &= \int_{\Omega} \nabla u \cdot \nabla v \, {\rm d} x, \\
-// //    L(v)    &= \int_{\Omega} f v \, {\rm d} x
-// //    + \int_{\Gamma_{N}} g v \, {\rm d} s.
-// //
-// // The expression :math:`a(u, v)` is the bilinear form and :math:`L(v)`
-// // is the linear form. It is assumed that all functions in :math:`V`
-// // satisfy the Dirichlet boundary conditions (:math:`u = 0 \ {\rm on} \
-// // \Gamma_{D}`).
-// //
-// // In this demo, we shall consider the following definitions of the input
-// // functions, the domain, and the boundaries:
-// //
-// // * :math:`\Omega = [0,1] \times [0,1]` (a unit square)
-// // * :math:`\Gamma_{D} = \{(0, y) \cup (1, y) \subset \partial \Omega\}`
-// // (Dirichlet boundary)
-// // * :math:`\Gamma_{N} = \{(x, 0) \cup (x, 1) \subset \partial \Omega\}`
-// // (Neumann boundary)
-// // * :math:`g = \sin(5x)` (normal derivative)
-// // * :math:`f = 10\exp(-((x - 0.5)^2 + (y - 0.5)^2) / 0.02)` (source term)
-// //
-// //
-// // Implementation
-// // --------------
-// //
-// // The implementation is split in two files: a form file containing the
-// // definition of the variational forms expressed in UFL and a C++ file
-// // containing the actual solver.
-// //
-// // Running this demo requires the files: :download:`main.cpp`,
-// // :download:`poisson.py` and :download:`CMakeLists.txt`.
-// //
-// //
-// // UFL form file
-// // ^^^^^^^^^^^^^
-// //
-// // The UFL file is implemented in :download:`poisson.py`, and the
-// // explanation of the UFL file can be found at :doc:`here <poisson.py>`.
-// //
-// //
-// // C++ program
-// // ^^^^^^^^^^^
-// //
-// // The main solver is implemented in the :download:`main.cpp` file.
-// //
-// // At the top we include the DOLFINx header file and the generated header
-// // file "Poisson.h" containing the variational forms for the Poisson
-// // equation.  For convenience we also include the DOLFINx namespace.
-// //
-// // .. code-block:: cpp
-
-// #include "poisson.h"
-// #include <cmath>
-// #include <dolfinx.h>
-// #include <dolfinx/fem/Constant.h>
-// #include <dolfinx/fem/petsc.h>
-// #include <utility>
-// #include <vector>
-
-// using namespace dolfinx;
-// using T = PetscScalar;
-// using U = typename dolfinx::scalar_value_type_t<T>;
-
-// // Then follows the definition of the coefficient functions (for
-// // :math:`f` and :math:`g`), which are derived from the
-// // :cpp:class:`Expression` class in DOLFINx
-// //
-// // .. code-block:: cpp
-
-// // Inside the ``main`` function, we begin by defining a mesh of the
-// // domain. As the unit square is a very standard domain, we can use a
-// // built-in mesh provided by the :cpp:class:`UnitSquareMesh` factory. In
-// // order to create a mesh consisting of 32 x 32 squares with each square
-// // divided into two triangles, and the finite element space (specified in
-// // the form file) defined relative to this mesh, we do as follows
-// //
-// // .. code-block:: cpp
-
-// int main(int argc, char* argv[])
-// {
-//   dolfinx::init_logging(argc, argv);
-//   PetscInitialize(&argc, &argv, nullptr, nullptr);
-
-//   {
-//     // Create mesh and function space
-//     auto part = mesh::create_cell_partitioner(mesh::GhostMode::shared_facet);
-//     auto mesh = std::make_shared<mesh::Mesh<U>>(
-//         mesh::create_rectangle<U>(MPI_COMM_WORLD, {{{0.0, 0.0}, {2.0, 1.0}}},
-//                                   {32, 16}, mesh::CellType::triangle, part));
-
-//     auto V = std::make_shared<fem::FunctionSpace<U>>(
-//         fem::create_functionspace(functionspace_form_poisson_a, "u", mesh));
-
-//     // Next, we define the variational formulation by initializing the
-//     // bilinear and linear forms (:math:`a`, :math:`L`) using the previously
-//     // defined :cpp:class:`FunctionSpace` ``V``.  Then we can create the
-//     // source and boundary flux term (:math:`f`, :math:`g`) and attach these
-//     // to the linear form.
-//     //
-//     // .. code-block:: cpp
-
-//     // Prepare and set Constants for the bilinear form
-//     auto kappa = std::make_shared<fem::Constant<T>>(2.0);
-//     auto f = std::make_shared<fem::Function<T>>(V);
-//     auto g = std::make_shared<fem::Function<T>>(V);
-
-//     // Define variational forms
-//     auto a = std::make_shared<fem::Form<T>>(fem::create_form<T>(
-//         *form_poisson_a, {V, V}, {}, {{"kappa", kappa}}, {}));
-//     auto L = std::make_shared<fem::Form<T>>(fem::create_form<T>(
-//         *form_poisson_L, {V}, {{"f", f}, {"g", g}}, {}, {}));
-
-//     // Now, the Dirichlet boundary condition (:math:`u = 0`) can be created
-//     // using the class :cpp:class:`DirichletBC`. A :cpp:class:`DirichletBC`
-//     // takes two arguments: the value of the boundary condition,
-//     // and the part of the boundary on which the condition applies.
-//     // In our example, the value of the boundary condition (0.0) can
-//     // represented using a :cpp:class:`Function`, and the Dirichlet boundary
-//     // is defined by the indices of degrees of freedom to which the boundary
-//     // condition applies.
-//     // The definition of the Dirichlet boundary condition then looks
-//     // as follows:
-//     //
-//     // .. code-block:: cpp
-
-//     // Define boundary condition
-
-//     auto facets = mesh::locate_entities_boundary(
-//         *mesh, 1,
-//         [](auto x)
-//         {
-//           using U = typename decltype(x)::value_type;
-//           constexpr U eps = 1.0e-8;
-//           std::vector<std::int8_t> marker(x.extent(1), false);
-//           for (std::size_t p = 0; p < x.extent(1); ++p)
-//           {
-//             auto x0 = x(0, p);
-//             if (std::abs(x0) < eps or std::abs(x0 - 2) < eps)
-//               marker[p] = true;
-//           }
-//           return marker;
-//         });
-//     const auto bdofs = fem::locate_dofs_topological(
-//         *V->mesh()->topology_mutable(), *V->dofmap(), 1, facets);
-//     auto bc = std::make_shared<const fem::DirichletBC<T>>(0.0, bdofs, V);
-
-//     f->interpolate(
-//         [](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
-//         {
-//           std::vector<T> f;
-//           for (std::size_t p = 0; p < x.extent(1); ++p)
-//           {
-//             auto dx = (x(0, p) - 0.5) * (x(0, p) - 0.5);
-//             auto dy = (x(1, p) - 0.5) * (x(1, p) - 0.5);
-//             f.push_back(10 * std::exp(-(dx + dy) / 0.02));
-//           }
-
-//           return {f, {f.size()}};
-//         });
-
-//     g->interpolate(
-//         [](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
-//         {
-//           std::vector<T> f;
-//           for (std::size_t p = 0; p < x.extent(1); ++p)
-//             f.push_back(std::sin(5 * x(0, p)));
-//           return {f, {f.size()}};
-//         });
-
-//     // Now, we have specified the variational forms and can consider the
-//     // solution of the variational problem. First, we need to define a
-//     // :cpp:class:`Function` ``u`` to store the solution. (Upon
-//     // initialization, it is simply set to the zero function.) Next, we can
-//     // call the ``solve`` function with the arguments ``a == L``, ``u`` and
-//     // ``bc`` as follows:
-//     //
-//     // .. code-block:: cpp
-
-//     // Compute solution
-//     auto u = std::make_shared<fem::Function<T>>(V);
-//     auto A = la::petsc::Matrix(fem::petsc::create_matrix(*a), false);
-//     la::Vector<T> b(L->function_spaces()[0]->dofmap()->index_map,
-//                     L->function_spaces()[0]->dofmap()->index_map_bs());
-
-//     MatZeroEntries(A.mat());
-//     fem::assemble_matrix(la::petsc::Matrix::set_block_fn(A.mat(),
-//     ADD_VALUES),
-//                          *a, {bc});
-//     MatAssemblyBegin(A.mat(), MAT_FLUSH_ASSEMBLY);
-//     MatAssemblyEnd(A.mat(), MAT_FLUSH_ASSEMBLY);
-//     fem::set_diagonal<T>(la::petsc::Matrix::set_fn(A.mat(), INSERT_VALUES),
-//     *V,
-//                          {bc});
-//     MatAssemblyBegin(A.mat(), MAT_FINAL_ASSEMBLY);
-//     MatAssemblyEnd(A.mat(), MAT_FINAL_ASSEMBLY);
-
-//     b.set(0.0);
-//     fem::assemble_vector(b.mutable_array(), *L);
-//     fem::apply_lifting<T, U>(b.mutable_array(), {a}, {{bc}}, {}, T(1));
-//     b.scatter_rev(std::plus<T>());
-//     fem::set_bc<T, U>(b.mutable_array(), {bc});
-
-//     la::petsc::KrylovSolver lu(MPI_COMM_WORLD);
-//     la::petsc::options::set("ksp_type", "preonly");
-//     la::petsc::options::set("pc_type", "lu");
-//     lu.set_from_options();
-
-//     lu.set_operator(A.mat());
-//     la::petsc::Vector _u(la::petsc::create_vector_wrap(*u->x()), false);
-//     la::petsc::Vector _b(la::petsc::create_vector_wrap(b), false);
-//     lu.solve(_u.vec(), _b.vec());
-
-//     // The function ``u`` will be modified during the call to solve. A
-//     // :cpp:class:`Function` can be saved to a file. Here, we output the
-//     // solution to a ``VTK`` file (specified using the suffix ``.pvd``) for
-//     // visualisation in an external program such as Paraview.
-//     //
-//     // .. code-block:: cpp
-
-//     // Save solution in VTK format
-//     io::VTKFile file(MPI_COMM_WORLD, "u.pvd", "w");
-//     file.write<T>({*u}, 0.0);
-
-// #ifdef HAS_ADIOS2
-//     // Save solution in VTX format
-//     io::VTXWriter<U> vtx(MPI_COMM_WORLD, "u.bp", {u}, "bp4");
-//     vtx.write(0);
-// #endif
-//   }
-
-//   PetscFinalize();
-
-//   return 0;
-// }

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -1,270 +1,310 @@
-// Poisson equation (C++)
-// ======================
-//
-// This demo illustrates how to:
-//
-// * Solve a linear partial differential equation
-// * Create and apply Dirichlet boundary conditions
-// * Define Expressions
-// * Define a FunctionSpace
-//
-// The solution for :math:`u` in this demo will look as follows:
-//
-// .. image:: ../poisson_u.png
-//     :scale: 75 %
-//
-//
-// Equation and problem definition
-// -------------------------------
-//
-// The Poisson equation is the canonical elliptic partial differential
-// equation.  For a domain :math:`\Omega \subset \mathbb{R}^n` with
-// boundary :math:`\partial \Omega = \Gamma_{D} \cup \Gamma_{N}`, the
-// Poisson equation with particular boundary conditions reads:
-//
-// .. math::
-//    - \nabla^{2} u &= f \quad {\rm in} \ \Omega, \\
-//      u &= 0 \quad {\rm on} \ \Gamma_{D}, \\
-//      \nabla u \cdot n &= g \quad {\rm on} \ \Gamma_{N}. \\
-//
-// Here, :math:`f` and :math:`g` are input data and :math:`n` denotes the
-// outward directed boundary normal. The most standard variational form
-// of Poisson equation reads: find :math:`u \in V` such that
-//
-// .. math::
-//    a(u, v) = L(v) \quad \forall \ v \in V,
-//
-// where :math:`V` is a suitable function space and
-//
-// .. math::
-//    a(u, v) &= \int_{\Omega} \nabla u \cdot \nabla v \, {\rm d} x, \\
-//    L(v)    &= \int_{\Omega} f v \, {\rm d} x
-//    + \int_{\Gamma_{N}} g v \, {\rm d} s.
-//
-// The expression :math:`a(u, v)` is the bilinear form and :math:`L(v)`
-// is the linear form. It is assumed that all functions in :math:`V`
-// satisfy the Dirichlet boundary conditions (:math:`u = 0 \ {\rm on} \
-// \Gamma_{D}`).
-//
-// In this demo, we shall consider the following definitions of the input
-// functions, the domain, and the boundaries:
-//
-// * :math:`\Omega = [0,1] \times [0,1]` (a unit square)
-// * :math:`\Gamma_{D} = \{(0, y) \cup (1, y) \subset \partial \Omega\}`
-// (Dirichlet boundary)
-// * :math:`\Gamma_{N} = \{(x, 0) \cup (x, 1) \subset \partial \Omega\}`
-// (Neumann boundary)
-// * :math:`g = \sin(5x)` (normal derivative)
-// * :math:`f = 10\exp(-((x - 0.5)^2 + (y - 0.5)^2) / 0.02)` (source term)
-//
-//
-// Implementation
-// --------------
-//
-// The implementation is split in two files: a form file containing the
-// definition of the variational forms expressed in UFL and a C++ file
-// containing the actual solver.
-//
-// Running this demo requires the files: :download:`main.cpp`,
-// :download:`poisson.py` and :download:`CMakeLists.txt`.
-//
-//
-// UFL form file
-// ^^^^^^^^^^^^^
-//
-// The UFL file is implemented in :download:`poisson.py`, and the
-// explanation of the UFL file can be found at :doc:`here <poisson.py>`.
-//
-//
-// C++ program
-// ^^^^^^^^^^^
-//
-// The main solver is implemented in the :download:`main.cpp` file.
-//
-// At the top we include the DOLFINx header file and the generated header
-// file "Poisson.h" containing the variational forms for the Poisson
-// equation.  For convenience we also include the DOLFINx namespace.
-//
-// .. code-block:: cpp
+#include <basix/e-lagrange.h>
 
-#include "poisson.h"
-#include <cmath>
 #include <dolfinx.h>
-#include <dolfinx/fem/Constant.h>
-#include <dolfinx/fem/petsc.h>
-#include <utility>
-#include <vector>
+#include <dolfinx/io/ADIOS2Writers.h>
+#include <dolfinx/mesh/generation.h>
 
 using namespace dolfinx;
-using T = PetscScalar;
-using U = typename dolfinx::scalar_value_type_t<T>;
-
-// Then follows the definition of the coefficient functions (for
-// :math:`f` and :math:`g`), which are derived from the
-// :cpp:class:`Expression` class in DOLFINx
-//
-// .. code-block:: cpp
-
-// Inside the ``main`` function, we begin by defining a mesh of the
-// domain. As the unit square is a very standard domain, we can use a
-// built-in mesh provided by the :cpp:class:`UnitSquareMesh` factory. In
-// order to create a mesh consisting of 32 x 32 squares with each square
-// divided into two triangles, and the finite element space (specified in
-// the form file) defined relative to this mesh, we do as follows
-//
-// .. code-block:: cpp
 
 int main(int argc, char* argv[])
 {
-  dolfinx::init_logging(argc, argv);
   PetscInitialize(&argc, &argv, nullptr, nullptr);
-
+  init_logging(argc, argv);
   {
-    // Create mesh and function space
-    auto part = mesh::create_cell_partitioner(mesh::GhostMode::shared_facet);
-    auto mesh = std::make_shared<mesh::Mesh<U>>(
-        mesh::create_rectangle<U>(MPI_COMM_WORLD, {{{0.0, 0.0}, {2.0, 1.0}}},
-                                  {32, 16}, mesh::CellType::triangle, part));
+    auto part = mesh::create_cell_partitioner(mesh::GhostMode::none);
+    auto meshL = std::make_shared<mesh::Mesh<double>>(
+        mesh::create_box(MPI_COMM_WORLD, {{{0, 0, 0}, {1, 1, 1}}}, {15, 15, 15},
+                         mesh::CellType::tetrahedron, part));
 
-    auto V = std::make_shared<fem::FunctionSpace<U>>(
-        fem::create_functionspace(functionspace_form_poisson_a, "u", mesh));
+    basix::FiniteElement eL = basix::element::create_lagrange<double>(
+        mesh::cell_type_to_basix_type(meshL->topology()->cell_types()[0]), 1,
+        basix::element::lagrange_variant::equispaced, false);
+    auto VL = std::make_shared<fem::FunctionSpace<double>>(
+        fem::create_functionspace(meshL, eL, 3));
 
-    // Next, we define the variational formulation by initializing the
-    // bilinear and linear forms (:math:`a`, :math:`L`) using the previously
-    // defined :cpp:class:`FunctionSpace` ``V``.  Then we can create the
-    // source and boundary flux term (:math:`f`, :math:`g`) and attach these
-    // to the linear form.
-    //
-    // .. code-block:: cpp
+    auto uL = std::make_shared<fem::Function<PetscScalar>>(VL);
 
-    // Prepare and set Constants for the bilinear form
-    auto kappa = std::make_shared<fem::Constant<T>>(2.0);
-    auto f = std::make_shared<fem::Function<T>>(V);
-    auto g = std::make_shared<fem::Function<T>>(V);
+    uL->x()->set(1);
 
-    // Define variational forms
-    auto a = std::make_shared<fem::Form<T>>(fem::create_form<T>(
-        *form_poisson_a, {V, V}, {}, {{"kappa", kappa}}, {}));
-    auto L = std::make_shared<fem::Form<T>>(fem::create_form<T>(
-        *form_poisson_L, {V}, {{"f", f}, {"g", g}}, {}, {}));
-
-    // Now, the Dirichlet boundary condition (:math:`u = 0`) can be created
-    // using the class :cpp:class:`DirichletBC`. A :cpp:class:`DirichletBC`
-    // takes two arguments: the value of the boundary condition,
-    // and the part of the boundary on which the condition applies.
-    // In our example, the value of the boundary condition (0.0) can
-    // represented using a :cpp:class:`Function`, and the Dirichlet boundary
-    // is defined by the indices of degrees of freedom to which the boundary
-    // condition applies.
-    // The definition of the Dirichlet boundary condition then looks
-    // as follows:
-    //
-    // .. code-block:: cpp
-
-    // Define boundary condition
-
-    auto facets = mesh::locate_entities_boundary(
-        *mesh, 1,
-        [](auto x)
-        {
-          using U = typename decltype(x)::value_type;
-          constexpr U eps = 1.0e-8;
-          std::vector<std::int8_t> marker(x.extent(1), false);
-          for (std::size_t p = 0; p < x.extent(1); ++p)
-          {
-            auto x0 = x(0, p);
-            if (std::abs(x0) < eps or std::abs(x0 - 2) < eps)
-              marker[p] = true;
-          }
-          return marker;
-        });
-    const auto bdofs = fem::locate_dofs_topological(
-        *V->mesh()->topology_mutable(), *V->dofmap(), 1, facets);
-    auto bc = std::make_shared<const fem::DirichletBC<T>>(0.0, bdofs, V);
-
-    f->interpolate(
-        [](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
-        {
-          std::vector<T> f;
-          for (std::size_t p = 0; p < x.extent(1); ++p)
-          {
-            auto dx = (x(0, p) - 0.5) * (x(0, p) - 0.5);
-            auto dy = (x(1, p) - 0.5) * (x(1, p) - 0.5);
-            f.push_back(10 * std::exp(-(dx + dy) / 0.02));
-          }
-
-          return {f, {f.size()}};
-        });
-
-    g->interpolate(
-        [](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
-        {
-          std::vector<T> f;
-          for (std::size_t p = 0; p < x.extent(1); ++p)
-            f.push_back(std::sin(5 * x(0, p)));
-          return {f, {f.size()}};
-        });
-
-    // Now, we have specified the variational forms and can consider the
-    // solution of the variational problem. First, we need to define a
-    // :cpp:class:`Function` ``u`` to store the solution. (Upon
-    // initialization, it is simply set to the zero function.) Next, we can
-    // call the ``solve`` function with the arguments ``a == L``, ``u`` and
-    // ``bc`` as follows:
-    //
-    // .. code-block:: cpp
-
-    // Compute solution
-    auto u = std::make_shared<fem::Function<T>>(V);
-    auto A = la::petsc::Matrix(fem::petsc::create_matrix(*a), false);
-    la::Vector<T> b(L->function_spaces()[0]->dofmap()->index_map,
-                    L->function_spaces()[0]->dofmap()->index_map_bs());
-
-    MatZeroEntries(A.mat());
-    fem::assemble_matrix(la::petsc::Matrix::set_block_fn(A.mat(), ADD_VALUES),
-                         *a, {bc});
-    MatAssemblyBegin(A.mat(), MAT_FLUSH_ASSEMBLY);
-    MatAssemblyEnd(A.mat(), MAT_FLUSH_ASSEMBLY);
-    fem::set_diagonal<T>(la::petsc::Matrix::set_fn(A.mat(), INSERT_VALUES), *V,
-                         {bc});
-    MatAssemblyBegin(A.mat(), MAT_FINAL_ASSEMBLY);
-    MatAssemblyEnd(A.mat(), MAT_FINAL_ASSEMBLY);
-
-    b.set(0.0);
-    fem::assemble_vector(b.mutable_array(), *L);
-    fem::apply_lifting<T, U>(b.mutable_array(), {a}, {{bc}}, {}, T(1));
-    b.scatter_rev(std::plus<T>());
-    fem::set_bc<T, U>(b.mutable_array(), {bc});
-
-    la::petsc::KrylovSolver lu(MPI_COMM_WORLD);
-    la::petsc::options::set("ksp_type", "preonly");
-    la::petsc::options::set("pc_type", "lu");
-    lu.set_from_options();
-
-    lu.set_operator(A.mat());
-    la::petsc::Vector _u(la::petsc::create_vector_wrap(*u->x()), false);
-    la::petsc::Vector _b(la::petsc::create_vector_wrap(b), false);
-    lu.solve(_u.vec(), _b.vec());
-
-    // The function ``u`` will be modified during the call to solve. A
-    // :cpp:class:`Function` can be saved to a file. Here, we output the
-    // solution to a ``VTK`` file (specified using the suffix ``.pvd``) for
-    // visualisation in an external program such as Paraview.
-    //
-    // .. code-block:: cpp
-
-    // Save solution in VTK format
-    io::VTKFile file(MPI_COMM_WORLD, "u.pvd", "w");
-    file.write<T>({*u}, 0.0);
-
-#ifdef HAS_ADIOS2
-    // Save solution in VTX format
-    io::VTXWriter<U> vtx(MPI_COMM_WORLD, "u.bp", {u}, "bp4");
-    vtx.write(0);
-#endif
+    io::FidesWriter<double> writeruL(meshL->comm(), "uL.bp",
+                                     io::adios2_writer::U<double>{uL}, "bp4",
+                                     io::FidesMeshPolicy::reuse);
+    //    io::VTXWriter<double> writeruL(meshL->comm(), "uL.bp", {uL});    //
+    //    Doesn't work either
+    writeruL.write(0.0);
   }
-
   PetscFinalize();
-
-  return 0;
 }
+
+// // Poisson equation (C++)
+// // ======================
+// //
+// // This demo illustrates how to:
+// //
+// // * Solve a linear partial differential equation
+// // * Create and apply Dirichlet boundary conditions
+// // * Define Expressions
+// // * Define a FunctionSpace
+// //
+// // The solution for :math:`u` in this demo will look as follows:
+// //
+// // .. image:: ../poisson_u.png
+// //     :scale: 75 %
+// //
+// //
+// // Equation and problem definition
+// // -------------------------------
+// //
+// // The Poisson equation is the canonical elliptic partial differential
+// // equation.  For a domain :math:`\Omega \subset \mathbb{R}^n` with
+// // boundary :math:`\partial \Omega = \Gamma_{D} \cup \Gamma_{N}`, the
+// // Poisson equation with particular boundary conditions reads:
+// //
+// // .. math::
+// //    - \nabla^{2} u &= f \quad {\rm in} \ \Omega, \\
+// //      u &= 0 \quad {\rm on} \ \Gamma_{D}, \\
+// //      \nabla u \cdot n &= g \quad {\rm on} \ \Gamma_{N}. \\
+// //
+// // Here, :math:`f` and :math:`g` are input data and :math:`n` denotes the
+// // outward directed boundary normal. The most standard variational form
+// // of Poisson equation reads: find :math:`u \in V` such that
+// //
+// // .. math::
+// //    a(u, v) = L(v) \quad \forall \ v \in V,
+// //
+// // where :math:`V` is a suitable function space and
+// //
+// // .. math::
+// //    a(u, v) &= \int_{\Omega} \nabla u \cdot \nabla v \, {\rm d} x, \\
+// //    L(v)    &= \int_{\Omega} f v \, {\rm d} x
+// //    + \int_{\Gamma_{N}} g v \, {\rm d} s.
+// //
+// // The expression :math:`a(u, v)` is the bilinear form and :math:`L(v)`
+// // is the linear form. It is assumed that all functions in :math:`V`
+// // satisfy the Dirichlet boundary conditions (:math:`u = 0 \ {\rm on} \
+// // \Gamma_{D}`).
+// //
+// // In this demo, we shall consider the following definitions of the input
+// // functions, the domain, and the boundaries:
+// //
+// // * :math:`\Omega = [0,1] \times [0,1]` (a unit square)
+// // * :math:`\Gamma_{D} = \{(0, y) \cup (1, y) \subset \partial \Omega\}`
+// // (Dirichlet boundary)
+// // * :math:`\Gamma_{N} = \{(x, 0) \cup (x, 1) \subset \partial \Omega\}`
+// // (Neumann boundary)
+// // * :math:`g = \sin(5x)` (normal derivative)
+// // * :math:`f = 10\exp(-((x - 0.5)^2 + (y - 0.5)^2) / 0.02)` (source term)
+// //
+// //
+// // Implementation
+// // --------------
+// //
+// // The implementation is split in two files: a form file containing the
+// // definition of the variational forms expressed in UFL and a C++ file
+// // containing the actual solver.
+// //
+// // Running this demo requires the files: :download:`main.cpp`,
+// // :download:`poisson.py` and :download:`CMakeLists.txt`.
+// //
+// //
+// // UFL form file
+// // ^^^^^^^^^^^^^
+// //
+// // The UFL file is implemented in :download:`poisson.py`, and the
+// // explanation of the UFL file can be found at :doc:`here <poisson.py>`.
+// //
+// //
+// // C++ program
+// // ^^^^^^^^^^^
+// //
+// // The main solver is implemented in the :download:`main.cpp` file.
+// //
+// // At the top we include the DOLFINx header file and the generated header
+// // file "Poisson.h" containing the variational forms for the Poisson
+// // equation.  For convenience we also include the DOLFINx namespace.
+// //
+// // .. code-block:: cpp
+
+// #include "poisson.h"
+// #include <cmath>
+// #include <dolfinx.h>
+// #include <dolfinx/fem/Constant.h>
+// #include <dolfinx/fem/petsc.h>
+// #include <utility>
+// #include <vector>
+
+// using namespace dolfinx;
+// using T = PetscScalar;
+// using U = typename dolfinx::scalar_value_type_t<T>;
+
+// // Then follows the definition of the coefficient functions (for
+// // :math:`f` and :math:`g`), which are derived from the
+// // :cpp:class:`Expression` class in DOLFINx
+// //
+// // .. code-block:: cpp
+
+// // Inside the ``main`` function, we begin by defining a mesh of the
+// // domain. As the unit square is a very standard domain, we can use a
+// // built-in mesh provided by the :cpp:class:`UnitSquareMesh` factory. In
+// // order to create a mesh consisting of 32 x 32 squares with each square
+// // divided into two triangles, and the finite element space (specified in
+// // the form file) defined relative to this mesh, we do as follows
+// //
+// // .. code-block:: cpp
+
+// int main(int argc, char* argv[])
+// {
+//   dolfinx::init_logging(argc, argv);
+//   PetscInitialize(&argc, &argv, nullptr, nullptr);
+
+//   {
+//     // Create mesh and function space
+//     auto part = mesh::create_cell_partitioner(mesh::GhostMode::shared_facet);
+//     auto mesh = std::make_shared<mesh::Mesh<U>>(
+//         mesh::create_rectangle<U>(MPI_COMM_WORLD, {{{0.0, 0.0}, {2.0, 1.0}}},
+//                                   {32, 16}, mesh::CellType::triangle, part));
+
+//     auto V = std::make_shared<fem::FunctionSpace<U>>(
+//         fem::create_functionspace(functionspace_form_poisson_a, "u", mesh));
+
+//     // Next, we define the variational formulation by initializing the
+//     // bilinear and linear forms (:math:`a`, :math:`L`) using the previously
+//     // defined :cpp:class:`FunctionSpace` ``V``.  Then we can create the
+//     // source and boundary flux term (:math:`f`, :math:`g`) and attach these
+//     // to the linear form.
+//     //
+//     // .. code-block:: cpp
+
+//     // Prepare and set Constants for the bilinear form
+//     auto kappa = std::make_shared<fem::Constant<T>>(2.0);
+//     auto f = std::make_shared<fem::Function<T>>(V);
+//     auto g = std::make_shared<fem::Function<T>>(V);
+
+//     // Define variational forms
+//     auto a = std::make_shared<fem::Form<T>>(fem::create_form<T>(
+//         *form_poisson_a, {V, V}, {}, {{"kappa", kappa}}, {}));
+//     auto L = std::make_shared<fem::Form<T>>(fem::create_form<T>(
+//         *form_poisson_L, {V}, {{"f", f}, {"g", g}}, {}, {}));
+
+//     // Now, the Dirichlet boundary condition (:math:`u = 0`) can be created
+//     // using the class :cpp:class:`DirichletBC`. A :cpp:class:`DirichletBC`
+//     // takes two arguments: the value of the boundary condition,
+//     // and the part of the boundary on which the condition applies.
+//     // In our example, the value of the boundary condition (0.0) can
+//     // represented using a :cpp:class:`Function`, and the Dirichlet boundary
+//     // is defined by the indices of degrees of freedom to which the boundary
+//     // condition applies.
+//     // The definition of the Dirichlet boundary condition then looks
+//     // as follows:
+//     //
+//     // .. code-block:: cpp
+
+//     // Define boundary condition
+
+//     auto facets = mesh::locate_entities_boundary(
+//         *mesh, 1,
+//         [](auto x)
+//         {
+//           using U = typename decltype(x)::value_type;
+//           constexpr U eps = 1.0e-8;
+//           std::vector<std::int8_t> marker(x.extent(1), false);
+//           for (std::size_t p = 0; p < x.extent(1); ++p)
+//           {
+//             auto x0 = x(0, p);
+//             if (std::abs(x0) < eps or std::abs(x0 - 2) < eps)
+//               marker[p] = true;
+//           }
+//           return marker;
+//         });
+//     const auto bdofs = fem::locate_dofs_topological(
+//         *V->mesh()->topology_mutable(), *V->dofmap(), 1, facets);
+//     auto bc = std::make_shared<const fem::DirichletBC<T>>(0.0, bdofs, V);
+
+//     f->interpolate(
+//         [](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
+//         {
+//           std::vector<T> f;
+//           for (std::size_t p = 0; p < x.extent(1); ++p)
+//           {
+//             auto dx = (x(0, p) - 0.5) * (x(0, p) - 0.5);
+//             auto dy = (x(1, p) - 0.5) * (x(1, p) - 0.5);
+//             f.push_back(10 * std::exp(-(dx + dy) / 0.02));
+//           }
+
+//           return {f, {f.size()}};
+//         });
+
+//     g->interpolate(
+//         [](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
+//         {
+//           std::vector<T> f;
+//           for (std::size_t p = 0; p < x.extent(1); ++p)
+//             f.push_back(std::sin(5 * x(0, p)));
+//           return {f, {f.size()}};
+//         });
+
+//     // Now, we have specified the variational forms and can consider the
+//     // solution of the variational problem. First, we need to define a
+//     // :cpp:class:`Function` ``u`` to store the solution. (Upon
+//     // initialization, it is simply set to the zero function.) Next, we can
+//     // call the ``solve`` function with the arguments ``a == L``, ``u`` and
+//     // ``bc`` as follows:
+//     //
+//     // .. code-block:: cpp
+
+//     // Compute solution
+//     auto u = std::make_shared<fem::Function<T>>(V);
+//     auto A = la::petsc::Matrix(fem::petsc::create_matrix(*a), false);
+//     la::Vector<T> b(L->function_spaces()[0]->dofmap()->index_map,
+//                     L->function_spaces()[0]->dofmap()->index_map_bs());
+
+//     MatZeroEntries(A.mat());
+//     fem::assemble_matrix(la::petsc::Matrix::set_block_fn(A.mat(),
+//     ADD_VALUES),
+//                          *a, {bc});
+//     MatAssemblyBegin(A.mat(), MAT_FLUSH_ASSEMBLY);
+//     MatAssemblyEnd(A.mat(), MAT_FLUSH_ASSEMBLY);
+//     fem::set_diagonal<T>(la::petsc::Matrix::set_fn(A.mat(), INSERT_VALUES),
+//     *V,
+//                          {bc});
+//     MatAssemblyBegin(A.mat(), MAT_FINAL_ASSEMBLY);
+//     MatAssemblyEnd(A.mat(), MAT_FINAL_ASSEMBLY);
+
+//     b.set(0.0);
+//     fem::assemble_vector(b.mutable_array(), *L);
+//     fem::apply_lifting<T, U>(b.mutable_array(), {a}, {{bc}}, {}, T(1));
+//     b.scatter_rev(std::plus<T>());
+//     fem::set_bc<T, U>(b.mutable_array(), {bc});
+
+//     la::petsc::KrylovSolver lu(MPI_COMM_WORLD);
+//     la::petsc::options::set("ksp_type", "preonly");
+//     la::petsc::options::set("pc_type", "lu");
+//     lu.set_from_options();
+
+//     lu.set_operator(A.mat());
+//     la::petsc::Vector _u(la::petsc::create_vector_wrap(*u->x()), false);
+//     la::petsc::Vector _b(la::petsc::create_vector_wrap(b), false);
+//     lu.solve(_u.vec(), _b.vec());
+
+//     // The function ``u`` will be modified during the call to solve. A
+//     // :cpp:class:`Function` can be saved to a file. Here, we output the
+//     // solution to a ``VTK`` file (specified using the suffix ``.pvd``) for
+//     // visualisation in an external program such as Paraview.
+//     //
+//     // .. code-block:: cpp
+
+//     // Save solution in VTK format
+//     io::VTKFile file(MPI_COMM_WORLD, "u.pvd", "w");
+//     file.write<T>({*u}, 0.0);
+
+// #ifdef HAS_ADIOS2
+//     // Save solution in VTX format
+//     io::VTXWriter<U> vtx(MPI_COMM_WORLD, "u.bp", {u}, "bp4");
+//     vtx.write(0);
+// #endif
+//   }
+
+//   PetscFinalize();
+
+//   return 0;
+// }

--- a/cpp/dolfinx/io/ADIOS2Writers.cpp
+++ b/cpp/dolfinx/io/ADIOS2Writers.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Jørgen S. Dokken and Garth N. Wells
+// Copyright (C) 2021-2023 Jørgen S. Dokken and Garth N. Wells
 //
 // This file is part of DOLFINX (https://www.fenicsproject.org)
 //

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -179,17 +179,20 @@ void initialize_function_attributes(adios2::IO& io,
   std::vector<std::array<std::string, 2>> u_data;
   for (auto& v : u)
   {
-    [&u_data](auto&& u)
-    {
-      using X = typename decltype(u)::element_type;
-      if (std::is_floating_point_v<typename X::geometry_type>)
-        u_data.push_back({u->name, "points"});
-      else
-      {
-        u_data.push_back({u->name + impl_adios2::field_ext[0], "points"});
-        u_data.push_back({u->name + impl_adios2::field_ext[1], "points"});
-      }
-    };
+    std::visit(
+        [&u_data](auto&& u)
+        {
+          using U = std::decay_t<decltype(u)>;
+          using X = typename U::element_type;
+          if constexpr (std::is_floating_point_v<typename X::geometry_type>)
+            u_data.push_back({u->name, "points"});
+          else
+          {
+            u_data.push_back({u->name + impl_adios2::field_ext[0], "points"});
+            u_data.push_back({u->name + impl_adios2::field_ext[1], "points"});
+          }
+        },
+        v);
   }
 
   // Write field associations to file

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -468,14 +468,14 @@ public:
     if (element0->is_mixed())
     {
       throw std::runtime_error(
-          "Mixed functions are not supported by VTXWriter");
+          "Mixed functions are not supported by FidesWriter");
     }
 
     // Check if function is DG 0
     if (element0->space_dimension() / element0->block_size() == 1)
     {
       throw std::runtime_error(
-          "Piecewise constants are not (yet) supported by VTXWriter");
+          "Piecewise constants are not (yet) supported by FidesWriter");
     }
 
     // FIXME: is the below check adequate for detecting a
@@ -927,6 +927,7 @@ public:
     // Define VTK scheme attribute for set of functions
     std::vector<std::string> names = impl_vtx::extract_function_names<T>(u);
     std::string vtk_scheme = impl_vtx::create_vtk_schema(names, {}).str();
+    std::cout << "Add attr" << vtk_scheme << std::endl;
     impl_adios2::define_attribute<std::string>(*_io, "vtk.xml", vtk_scheme);
   }
 

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Jørgen S. Dokken and Garth N. Wells
+// Copyright (C) 2021-2023 Jørgen S. Dokken and Garth N. Wells
 //
 // This file is part of DOLFINX (https://www.fenicsproject.org)
 //
@@ -609,17 +609,21 @@ extract_function_names(const typename adios2_writer::U<T>& u)
   std::vector<std::string> names;
   for (auto& v : u)
   {
-    [&names](auto&& u)
-    {
-      using X = typename decltype(u)::element_type;
-      if (std::is_floating_point_v<typename X::geometry_type>)
-        names.push_back(u->name);
-      else
-      {
-        names.push_back(u->name + impl_adios2::field_ext[0]);
-        names.push_back(u->name + impl_adios2::field_ext[1]);
-      }
-    };
+    std::visit(
+        [&names](auto&& u)
+        {
+          using U = std::decay_t<decltype(u)>;
+          using X = typename U::element_type;
+
+          if constexpr (std::is_floating_point_v<typename X::geometry_type>)
+            names.push_back(u->name);
+          else
+          {
+            names.push_back(u->name + impl_adios2::field_ext[0]);
+            names.push_back(u->name + impl_adios2::field_ext[1]);
+          }
+        },
+        v);
   }
 
   return names;
@@ -927,7 +931,6 @@ public:
     // Define VTK scheme attribute for set of functions
     std::vector<std::string> names = impl_vtx::extract_function_names<T>(u);
     std::string vtk_scheme = impl_vtx::create_vtk_schema(names, {}).str();
-    std::cout << "Add attr" << vtk_scheme << std::endl;
     impl_adios2::define_attribute<std::string>(*_io, "vtk.xml", vtk_scheme);
   }
 

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -614,7 +614,6 @@ extract_function_names(const typename adios2_writer::U<T>& u)
         {
           using U = std::decay_t<decltype(u)>;
           using X = typename U::element_type;
-
           if constexpr (std::is_floating_point_v<typename X::geometry_type>)
             names.push_back(u->name);
           else

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -77,7 +77,7 @@ if _cpp.common.has_adios2:
                     dtype = output.function_space.mesh.geometry.x.dtype  # type: ignore
                 except AttributeError:
                     # type: ignore
-                    dtype = output[0].function_space.mesh.geometry.x.dtype
+                    dtype = output[0].function_space.mesh.geometry.x.dtype  # type: ignore
 
             if dtype == np.float32:
                 _vtxwriter = _cpp.io.VTXWriter_float32
@@ -141,8 +141,7 @@ if _cpp.common.has_adios2:
                 try:
                     dtype = output.function_space.mesh.geometry.x.dtype  # type: ignore
                 except AttributeError:
-                    # type: ignore
-                    dtype = output[0].function_space.mesh.geometry.x.dtype
+                    dtype = output[0].function_space.mesh.geometry.x.dtype  # type: ignore
 
             if dtype == np.float32:
                 _fides_writer = _cpp.io.FidesWriter_float32

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -86,8 +86,7 @@ if _cpp.common.has_adios2:
 
             try:
                 # Input is a mesh
-                self._cpp_object = _vtxwriter(
-                    comm, filename, output._cpp_object, engine)  # type: ignore[union-attr]
+                self._cpp_object = _vtxwriter(comm, filename, output._cpp_object, engine)  # type: ignore[union-attr]
             except (NotImplementedError, TypeError, AttributeError):
                 # Input is a single function or a list of functions
                 self._cpp_object = _vtxwriter(comm, filename, _extract_cpp_functions(
@@ -151,10 +150,10 @@ if _cpp.common.has_adios2:
                 _fides_writer = _cpp.io.FidesWriter_float64
 
             try:
-                self._cpp_object = _fides_writer(
-                    comm, filename, output._cpp_object, engine)  # type: ignore[union-attr]
+                self._cpp_object = _fides_writer(comm, filename, output._cpp_object, engine)  # type: ignore[union-attr]
             except (NotImplementedError, TypeError, AttributeError):
-                self._cpp_object = _fides_writer(comm, filename, _extract_cpp_functions(output), engine)  # type: ignore[arg-type]
+                self._cpp_object = _fides_writer(comm, filename, _extract_cpp_functions(
+                    output), engine)  # type: ignore[arg-type]
 
         def __enter__(self):
             return self
@@ -237,9 +236,9 @@ class XDMFFile(_cpp.io.XDMFFile):
                                     cmap, x, _cpp.mesh.create_cell_partitioner(ghost_mode))
         msh.name = name
 
-        domain = ufl.Mesh(basix.ufl.element(
-            "Lagrange", cell_shape.name, cell_degree, basix.LagrangeVariant.equispaced, shape=(x.shape[1], ),
-            gdim=x.shape[1]))
+        domain = ufl.Mesh(basix.ufl.element("Lagrange", cell_shape.name, cell_degree,
+                                            basix.LagrangeVariant.equispaced, shape=(x.shape[1], ),
+                                            gdim=x.shape[1]))
         return Mesh(msh, domain)
 
     def read_meshtags(self, mesh, name, xpath="/Xdmf/Domain"):

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -5,6 +5,9 @@ ignore = W503
 [tool:pytest]
 junit_family = xunit2
 
+[pycodestyle]
+max_line_length = 120
+
 [mypy]
 # Suggested at https://blog.wolt.com/engineering/2021/09/30/professional-grade-mypy-configuration/
 # Goal would be to make all of the below True long-term


### PR DESCRIPTION
Fixes visitor pattern for extracting function names.

Fixes #2702 (I think).