### PR TITLE
Correctly wrap FidesWriter constructor

### DIFF
--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -541,9 +541,7 @@ public:
   FidesWriter(MPI_Comm comm, const std::filesystem::path& filename,
               const typename adios2_writer::U<T>& u,
               const FidesMeshPolicy mesh_policy = FidesMeshPolicy::update)
-      : ADIOS2Writer(comm, filename, "Fides function writer", "BPFile"),
-        _mesh_reuse_policy(mesh_policy),
-        _mesh(impl_adios2::extract_common_mesh<T>(u)), _u(u)
+      : FidesWriter(comm, filename, u, "BPFile", mesh_policy)
   {
   }
 


### PR DESCRIPTION
Related to the discussion in https://github.com/FEniCS/dolfinx/pull/2679 , I think there still is a problem and that this commit fixes it.