### PR TITLE
Avoid introducing HDF5-HL library

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -232,7 +232,7 @@ set_package_properties(
 # Check for HDF5
 set(HDF5_PREFER_PARALLEL TRUE)
 set(HDF5_FIND_DEBUG TRUE)
-find_package(HDF5 REQUIRED COMPONENTS C HL)
+find_package(HDF5 REQUIRED COMPONENTS C)
 if(NOT HDF5_IS_PARALLEL)
   message(
     FATAL_ERROR

--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -96,16 +96,7 @@ target_link_libraries(dolfinx PUBLIC MPI::MPI_CXX)
 target_link_libraries(dolfinx PUBLIC PkgConfig::PETSC)
 
 # HDF5
-if(TARGET hdf5::hdf5)
-  target_link_libraries(dolfinx PUBLIC hdf5::hdf5)
-  target_link_libraries(dolfinx PRIVATE hdf5::hdf5_hl)
-else()
-  # This is the old-style CMake (3.18 and earlier), remove when no longer
-  # supporting older CMake
-  target_compile_definitions(dolfinx PUBLIC ${HDF5_DEFINITIONS})
-  target_link_libraries(dolfinx PUBLIC ${HDF5_C_LIBRARIES})
-  target_include_directories(dolfinx SYSTEM PUBLIC ${HDF5_INCLUDE_DIRS})
-endif()
+target_link_libraries(dolfinx PUBLIC hdf5::hdf5)
 
 # ------------------------------------------------------------------------------
 # Optional packages

--- a/cpp/dolfinx/io/HDF5Interface.h
+++ b/cpp/dolfinx/io/HDF5Interface.h
@@ -18,10 +18,9 @@
 #include <string>
 #include <vector>
 
-#include <H5LTpublic.h>
-
 namespace dolfinx::io::hdf5
 {
+
 /// C++ type to HDF5 data type
 template <typename T>
 hid_t hdf5_type()
@@ -268,17 +267,10 @@ std::vector<T> read_dataset(hid_t dset_id, std::array<std::int64_t, 2> range,
       throw std::runtime_error("HDF5 datatype equality test failed.");
     else if (!eq)
     {
-      hid_t native_type = H5Tget_native_type(dtype, H5T_DIR_DEFAULT);
-      std::size_t str_len;
-      H5LTdtype_to_text(dtype, NULL, H5LT_DDL, &str_len);
-      std::string name("*", str_len);
-      H5LTdtype_to_text(dtype, name.data(), H5LT_DDL, &str_len);
-      H5Tclose(native_type);
-      throw std::runtime_error(
-          "Wrong type for reading from HDF5. HDF5 type in file is \"" + name
-          + "\".");
+      H5Tclose(dtype);
+      throw std::runtime_error("Wrong type for reading from HDF5. Use \"h5ls "
+                               "-v\" to inspect the types in the HDF5 file.");
     }
-    H5Tclose(dtype);
   }
 
   // Open dataspace


### PR DESCRIPTION
Reverts change that gets string version of the native HDF5 type for printing when a exception is raised.

The "HL" component is an extra dependency but brought little benefit.  Fixes Spack build failure.