### PR TITLE
Perform checks on matrix insertion in `MatrixCSR`

### DIFF
--- a/cpp/dolfinx/la/matrix_csr_impl.h
+++ b/cpp/dolfinx/la/matrix_csr_impl.h
@@ -129,8 +129,9 @@ void impl::insert_csr(U&& data, const V& cols, const W& row_ptr, const X& x,
     {
       // Find position of column index
       auto it = std::lower_bound(cit0, cit1, xcols[c]);
-      assert(*it == xcols[c]);
-      assert(it != cit1);
+
+      if (*it != xcols[c] or it == cit1)
+        throw std::runtime_error("Entry not in sparsity");
 
       std::size_t d = std::distance(cols.begin(), it);
       int di = d * BS0 * BS1;
@@ -177,8 +178,10 @@ void impl::insert_blocked_csr(U&& data, const V& cols, const W& row_ptr,
       {
         // Find position of column index
         auto it = std::lower_bound(cit0, cit1, xcols[c] * BS1);
-        assert(*it == xcols[c] * BS1);
-        assert(it != cit1);
+
+        if (*it != xcols[c] * BS1 or it == cit1)
+          throw std::runtime_error("Entry not in sparsity");
+
         std::size_t d = std::distance(cols.begin(), it);
         assert(d < data.size());
         int xi = c * BS1;
@@ -222,8 +225,9 @@ void impl::insert_nonblocked_csr(U&& data, const V& cols, const W& row_ptr,
       // Find position of column index
       auto cdiv = std::div(xcols[c], bs1);
       auto it = std::lower_bound(cit0, cit1, cdiv.quot);
-      assert(it != cit1);
-      assert(*it == cdiv.quot);
+
+      if (*it != cdiv.quot or it == cit1)
+        throw std::runtime_error("Entry not in sparsity");
 
       std::size_t d = std::distance(cols.begin(), it);
       const int di = d * nbs + rdiv.rem * bs1 + cdiv.rem;

--- a/cpp/dolfinx/la/matrix_csr_impl.h
+++ b/cpp/dolfinx/la/matrix_csr_impl.h
@@ -130,7 +130,7 @@ void impl::insert_csr(U&& data, const V& cols, const W& row_ptr, const X& x,
       // Find position of column index
       auto it = std::lower_bound(cit0, cit1, xcols[c]);
 
-      if (*it != xcols[c] or it == cit1)
+      if (it == cit1 or *it != xcols[c])
         throw std::runtime_error("Entry not in sparsity");
 
       std::size_t d = std::distance(cols.begin(), it);
@@ -179,7 +179,7 @@ void impl::insert_blocked_csr(U&& data, const V& cols, const W& row_ptr,
         // Find position of column index
         auto it = std::lower_bound(cit0, cit1, xcols[c] * BS1);
 
-        if (*it != xcols[c] * BS1 or it == cit1)
+        if (it == cit1 or *it != xcols[c] * BS1)
           throw std::runtime_error("Entry not in sparsity");
 
         std::size_t d = std::distance(cols.begin(), it);
@@ -226,7 +226,7 @@ void impl::insert_nonblocked_csr(U&& data, const V& cols, const W& row_ptr,
       auto cdiv = std::div(xcols[c], bs1);
       auto it = std::lower_bound(cit0, cit1, cdiv.quot);
 
-      if (*it != cdiv.quot or it == cit1)
+      if (it == cit1 or *it != cdiv.quot)
         throw std::runtime_error("Entry not in sparsity");
 
       std::size_t d = std::distance(cols.begin(), it);

--- a/python/test/unit/la/test_matrix_csr.py
+++ b/python/test/unit/la/test_matrix_csr.py
@@ -222,15 +222,16 @@ def test_bad_entry(dtype):
     sp = create_test_sparsity(6, 1)
     mat1 = matrix_csr(sp, dtype=dtype)
 
-    # Set block in bs=1 matrix
+    # Set block in bs=1 matrix (tests insert_blocked_csr)
     with pytest.raises(RuntimeError):
         mat1.set([1.0, 2.0, 3.0, 4.0], [0], [0], 2)
-    # Normal
+
+    # Set an single entry in bs=1 matrix (tests insert_csr)
     with pytest.raises(RuntimeError):
         mat1.add([1.0], [0], [0], 1)
 
     sp = create_test_sparsity(3, 2)
     mat2 = matrix_csr(sp, BlockMode.compact, dtype=dtype)
-    # set unblocked in bs=2 matrix
+    # set unblocked in bs=2 matrix (tests insert_nonblocked_csr)
     with pytest.raises(RuntimeError):
         mat2.add([2.0, 3.0, 4.0, 5.0], [0, 1], [0, 1], 1)

--- a/python/test/unit/la/test_matrix_csr.py
+++ b/python/test/unit/la/test_matrix_csr.py
@@ -215,3 +215,22 @@ def test_set_diagonal_distributed(dtype):
     A.finalize()
     assert (As.diagonal()[nlocal:] == dtype(0.)).all()
     assert (As.diagonal()[:nlocal] == dtype(1.)).all()
+
+
+@pytest.mark.parametrize('dtype', [np.float32, np.float64, np.complex64, np.complex128])
+def test_bad_entry(dtype):
+    sp = create_test_sparsity(6, 1)
+    mat1 = matrix_csr(sp, dtype=dtype)
+
+    # Set block in bs=1 matrix
+    with pytest.raises(RuntimeError):
+        mat1.set([1.0, 2.0, 3.0, 4.0], [0], [0], 2)
+    # Normal
+    with pytest.raises(RuntimeError):
+        mat1.add([1.0], [0], [0], 1)
+
+    sp = create_test_sparsity(3, 2)
+    mat2 = matrix_csr(sp, BlockMode.compact, dtype=dtype)
+    # set unblocked in bs=2 matrix
+    with pytest.raises(RuntimeError):
+        mat2.add([2.0, 3.0, 4.0, 5.0], [0, 1], [0, 1], 1)


### PR DESCRIPTION
Currently, there is no runtime check that matrix entries are correctly added (exist in sparsity), except in Debug mode.
The overhead to doing so is negligible, so this PR adds that check.

