### PR TITLE
Put adios2 python interface in usr/local/lib

### DIFF
--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -178,11 +178,11 @@ RUN wget -nc --quiet https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${HDF5_
     cmake --install build-dir && \
     rm -rf /tmp/*
 
-# Install ADIOS2
+# Install ADIOS2 (Python interface in /usr/local/lib), same as GMSH
 RUN wget -nc --quiet https://github.com/ornladios/ADIOS2/archive/v${ADIOS2_VERSION}.tar.gz -O adios2-v${ADIOS2_VERSION}.tar.gz && \
     mkdir -p adios2-v${ADIOS2_VERSION} && \
     tar -xf adios2-v${ADIOS2_VERSION}.tar.gz -C adios2-v${ADIOS2_VERSION} --strip-components 1 && \
-    cmake -G Ninja -DADIOS2_USE_HDF5=on -DADIOS2_USE_Fortran=off -DBUILD_TESTING=off -DADIOS2_BUILD_EXAMPLES=off -DADIOS2_USE_ZeroMQ=off -B build-dir -S ./adios2-v${ADIOS2_VERSION} && \
+    cmake -G Ninja -DADIOS2_USE_HDF5=on -DCMAKE_INSTALL_PYTHONDIR=/usr/local/lib/ -DADIOS2_USE_Fortran=off -DBUILD_TESTING=off -DADIOS2_BUILD_EXAMPLES=off -DADIOS2_USE_ZeroMQ=off -B build-dir -S ./adios2-v${ADIOS2_VERSION} && \
     cmake --build build-dir && \
     cmake --install build-dir && \
     rm -rf /tmp/*


### PR DESCRIPTION
ADIOS2 python interface is currently not exposed in the docker images.
This is because ADIOS defaults the installation to: `/usr/local/lib/python3/dist-packages`
which is not in our Python path.

I initially thought I could set it to `/usr/local/lib/python3.10` which is on our path, but I couldn't find a nice way to determine the python version automatically and set the relevant env variable, ref: https://github.com/moby/moby/issues/29110