### PR TITLE
Simplify `fem::Expression`

### DIFF
--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -235,7 +235,7 @@ int main(int argc, char* argv[])
         mesh, S_element, pow(mesh->geometry().dim(), 2)));
 
     auto sigma_expression = fem::create_expression<T, U>(
-        *expression_hyperelasticity_sigma, {{"u", u}}, {}, mesh);
+        *expression_hyperelasticity_sigma, {{"u", u}}, {});
 
     auto sigma = fem::Function<T>(S);
     sigma.name = "cauchy_stress";

--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -39,13 +39,27 @@ template <dolfinx::scalar T,
 class Expression
 {
 public:
+  /// @brief Scalar type (T)
+  ///
+  /// Field type for the Expression, e.g. `double`,
+  /// `std::complex<float>`, etc.
+  using value_type = T;
+
+  /// @brief Scalar type (T)
+  ///
+  /// Field type for the Expression, e.g. `double`,
+  /// `std::complex<float>`, etc.
+  using scalar_type = T;
+
+  /// Geometry type of the points.
+  using geometry_type = U;
+
   /// @brief Create an Expression.
   ///
   /// @note Users should prefer the @ref create_expression factory functions.
   ///
   /// @param[in] coefficients Coefficients in the Expression
   /// @param[in] constants Constants in the Expression
-  /// @param[in] mesh
   /// @param[in] X points on reference cell, `shape=(number of points,
   /// tdim)` and storage is row-major.
   /// @param[in] Xshape Shape of `X`.
@@ -53,31 +67,32 @@ public:
   /// @param[in] value_shape shape of expression evaluated at single point
   /// @param[in] argument_function_space Function space for Argument
   Expression(
-      const std::vector<std::shared_ptr<const Function<T, U>>>& coefficients,
-      const std::vector<std::shared_ptr<const Constant<T>>>& constants,
-      std::span<const U> X, std::array<std::size_t, 2> Xshape,
-      std::function<void(T*, const T*, const T*,
-                         const dolfinx::scalar_value_type_t<T>*, const int*,
-                         const uint8_t*)>
+      const std::vector<std::shared_ptr<
+          const Function<value_type, geometry_type>>>& coefficients,
+      const std::vector<std::shared_ptr<const Constant<value_type>>>& constants,
+      std::span<const geometry_type> X, std::array<std::size_t, 2> Xshape,
+      std::function<void(value_type*, const value_type*, const value_type*,
+                         const geometry_type*, const int*, const uint8_t*)>
           fn,
       const std::vector<int>& value_shape,
-      std::shared_ptr<const mesh::Mesh<U>> mesh = nullptr,
-      std::shared_ptr<const FunctionSpace<U>> argument_function_space = nullptr)
-      : _coefficients(coefficients), _constants(constants), _mesh(mesh),
-        _x_ref(std::vector<U>(X.begin(), X.end()), Xshape), _fn(fn),
+      std::shared_ptr<const FunctionSpace<geometry_type>>
+          argument_function_space
+      = nullptr)
+      : _coefficients(coefficients), _constants(constants),
+        _x_ref(std::vector<geometry_type>(X.begin(), X.end()), Xshape), _fn(fn),
         _value_shape(value_shape),
         _argument_function_space(argument_function_space)
   {
     // Extract mesh from argument's function space
-    if (!_mesh and argument_function_space)
-      _mesh = argument_function_space->mesh();
-    if (argument_function_space and _mesh != argument_function_space->mesh())
-      throw std::runtime_error("Incompatible mesh");
-    if (!_mesh)
-    {
-      throw std::runtime_error(
-          "No mesh could be associated with the Expression.");
-    }
+    // if (!_mesh and argument_function_space)
+    //   _mesh = argument_function_space->mesh();
+    // if (argument_function_space and _mesh != argument_function_space->mesh())
+    //   throw std::runtime_error("Incompatible mesh");
+    // if (!_mesh)
+    // {
+    //   throw std::runtime_error(
+    //       "No mesh could be associated with the Expression.");
+    // }
   }
 
   /// Move constructor
@@ -88,14 +103,16 @@ public:
 
   /// @brief Get argument function space.
   /// @return The argument function space, nullptr if there is no argument.
-  std::shared_ptr<const FunctionSpace<U>> argument_function_space() const
+  std::shared_ptr<const FunctionSpace<geometry_type>>
+  argument_function_space() const
   {
     return _argument_function_space;
   };
 
   /// @brief Get coefficients,
   /// @return Vector of attached coefficients.
-  const std::vector<std::shared_ptr<const Function<T, U>>>& coefficients() const
+  const std::vector<std::shared_ptr<const Function<value_type, geometry_type>>>&
+  coefficients() const
   {
     return _coefficients;
   }
@@ -104,7 +121,8 @@ public:
   /// @return Vector of attached constants with their names. Names are
   /// used to set constants in user's c++ code. Index in the vector is
   /// the position of the constant in the original (nonsimplified) form.
-  const std::vector<std::shared_ptr<const Constant<T>>>& constants() const
+  const std::vector<std::shared_ptr<const Constant<value_type>>>&
+  constants() const
   {
     return _constants;
   }
@@ -126,44 +144,45 @@ public:
     return n;
   }
 
-  /// @brief Evaluate the expression on cells
-  /// @param[in] cells Cells on which to evaluate the Expression
+  /// @brief Evaluate Expression on cells.
+  /// @param[in] mesh Cells on which to evaluate the Expression.
+  /// @param[in] cells Cells on which to evaluate the Expression.
   /// @param[out] values A 2D array to store the result. Caller
   /// is responsible for correct sizing which should be `(num_cells,
   /// num_points * value_size * num_all_argument_dofs columns)`.
   /// @param[in] vshape The shape of @p values (row-major storage).
-  void eval(std::span<const std::int32_t> cells, std::span<T> values,
+  void eval(const mesh::Mesh<geometry_type>& mesh,
+            std::span<const std::int32_t> cells, std::span<value_type> values,
             std::array<std::size_t, 2> vshape) const
   {
     namespace stdex = std::experimental;
 
     // Prepare coefficients and constants
     const auto [coeffs, cstride] = pack_coefficients(*this, cells);
-    const std::vector<T> constant_data = pack_constants(*this);
+    const std::vector<value_type> constant_data = pack_constants(*this);
     auto fn = this->get_tabulate_expression();
 
     // Prepare cell geometry
-    assert(_mesh);
-    auto x_dofmap = _mesh->geometry().dofmap();
+    auto x_dofmap = mesh.geometry().dofmap();
 
     // Get geometry data
-    auto cmaps = _mesh->geometry().cmaps();
+    auto cmaps = mesh.geometry().cmaps();
     assert(cmaps.size() == 1);
 
     const std::size_t num_dofs_g = cmaps.back().dim();
-    std::span<const U> x_g = _mesh->geometry().x();
+    auto x_g = mesh.geometry().x();
 
     // Create data structures used in evaluation
-    std::vector<dolfinx::scalar_value_type_t<T>> coord_dofs(3 * num_dofs_g);
+    std::vector<geometry_type> coord_dofs(3 * num_dofs_g);
 
     int num_argument_dofs = 1;
     std::span<const std::uint32_t> cell_info;
-    std::function<void(const std::span<T>&,
+    std::function<void(const std::span<value_type>&,
                        const std::span<const std::uint32_t>&, std::int32_t,
                        int)>
         dof_transform_to_transpose
-        = [](const std::span<T>&, const std::span<const std::uint32_t>&,
-             std::int32_t, int)
+        = [](const std::span<value_type>&,
+             const std::span<const std::uint32_t>&, std::int32_t, int)
     {
       // Do nothing
     };
@@ -177,17 +196,17 @@ public:
       assert(element);
       if (element->needs_dof_transformations())
       {
-        _mesh->topology_mutable()->create_entity_permutations();
-        cell_info = std::span(_mesh->topology()->get_cell_permutation_info());
+        mesh.topology_mutable()->create_entity_permutations();
+        cell_info = std::span(mesh.topology()->get_cell_permutation_info());
         dof_transform_to_transpose
-            = element
-                  ->template get_dof_transformation_to_transpose_function<T>();
+            = element->template get_dof_transformation_to_transpose_function<
+                value_type>();
       }
     }
 
     // Iterate over cells and 'assemble' into values
     const int size0 = _x_ref.second[0] * value_size();
-    std::vector<T> values_local(size0 * num_argument_dofs, 0);
+    std::vector<value_type> values_local(size0 * num_argument_dofs, 0);
     for (std::size_t c = 0; c < cells.size(); ++c)
     {
       const std::int32_t cell = cells[c];
@@ -198,7 +217,7 @@ public:
                     std::next(coord_dofs.begin(), 3 * i));
       }
 
-      const T* coeff_cell = coeffs.data() + c * cstride;
+      const value_type* coeff_cell = coeffs.data() + c * cstride;
       std::fill(values_local.begin(), values_local.end(), 0);
       _fn(values_local.data(), coeff_cell, constant_data.data(),
           coord_dofs.data(), nullptr, nullptr);
@@ -211,17 +230,12 @@ public:
 
   /// @brief Get function for tabulate_expression.
   /// @return fn Function to tabulate expression.
-  const std::function<void(T*, const T*, const T*,
-                           const dolfinx::scalar_value_type_t<T>*, const int*,
-                           const uint8_t*)>&
+  const std::function<void(value_type*, const value_type*, const value_type*,
+                           const geometry_type*, const int*, const uint8_t*)>&
   get_tabulate_expression() const
   {
     return _fn;
   }
-
-  /// @brief Get mesh.
-  /// @return The mesh.
-  std::shared_ptr<const mesh::Mesh<U>> mesh() const { return _mesh; }
 
   /// @brief Get value size
   /// @return The value size.
@@ -237,41 +251,33 @@ public:
 
   /// @brief Evaluation points on the reference cell.
   /// @return Evaluation points.
-  std::pair<std::vector<U>, std::array<std::size_t, 2>> X() const
+  std::pair<std::vector<geometry_type>, std::array<std::size_t, 2>> X() const
   {
     return _x_ref;
   }
 
-  /// @brief Scalar type (T)
-  ///
-  /// The scalar type for the form, e.g. `double`,
-  /// `std::complex<float>`, etc.
-  using scalar_type = T;
-
 private:
   // Function space for Argument
-  std::shared_ptr<const FunctionSpace<U>> _argument_function_space;
+  std::shared_ptr<const FunctionSpace<geometry_type>> _argument_function_space;
 
   // Coefficients associated with the Expression
-  std::vector<std::shared_ptr<const Function<T, U>>> _coefficients;
+  std::vector<std::shared_ptr<const Function<value_type, geometry_type>>>
+      _coefficients;
 
   // Constants associated with the Expression
-  std::vector<std::shared_ptr<const Constant<T>>> _constants;
+  std::vector<std::shared_ptr<const Constant<value_type>>> _constants;
 
   // Function to evaluate the Expression
-  std::function<void(T*, const T*, const T*,
-                     const dolfinx::scalar_value_type_t<T>*, const int*,
-                     const uint8_t*)>
+  std::function<void(value_type*, const value_type*, const value_type*,
+                     const dolfinx::scalar_value_type_t<value_type>*,
+                     const int*, const uint8_t*)>
       _fn;
-
-  // The mesh
-  std::shared_ptr<const mesh::Mesh<U>> _mesh;
 
   // Shape of the evaluated expression
   std::vector<int> _value_shape;
 
   // Evaluation points on reference cell. Synonymous with X in public
   // interface.
-  std::pair<std::vector<U>, std::array<std::size_t, 2>> _x_ref;
+  std::pair<std::vector<geometry_type>, std::array<std::size_t, 2>> _x_ref;
 };
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -79,10 +79,19 @@ public:
         _value_shape(value_shape),
         _argument_function_space(argument_function_space)
   {
+    for (auto& c : _coefficients)
+    {
+      assert(c);
+      if (c->function_space()->mesh()
+          != _coefficients.front()->function_space()->mesh())
+      {
+        throw std::runtime_error("Coefficients not all defined on same mesh.");
+      }
+    }
   }
 
   /// Move constructor
-  Expression(Expression&& form) = default;
+  Expression(Expression&& e) = default;
 
   /// Destructor
   virtual ~Expression() = default;

--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -83,16 +83,6 @@ public:
         _value_shape(value_shape),
         _argument_function_space(argument_function_space)
   {
-    // Extract mesh from argument's function space
-    // if (!_mesh and argument_function_space)
-    //   _mesh = argument_function_space->mesh();
-    // if (argument_function_space and _mesh != argument_function_space->mesh())
-    //   throw std::runtime_error("Incompatible mesh");
-    // if (!_mesh)
-    // {
-    //   throw std::runtime_error(
-    //       "No mesh could be associated with the Expression.");
-    // }
   }
 
   /// Move constructor

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -319,7 +319,9 @@ public:
         fdata.data(), num_cells, num_points, value_size);
 
     // Evaluate Expression at points
-    e.eval(cells, fdata, {num_cells, num_points * value_size});
+    assert(_function_space->mesh());
+    e.eval(*_function_space->mesh(), cells, fdata,
+           {num_cells, num_points * value_size});
 
     // Reshape evaluated data to fit interpolate
     // Expression returns matrix of shape (num_cells, num_points *

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -1036,7 +1036,6 @@ Expression<T, U> create_expression(
     const ufcx_expression& e,
     const std::vector<std::shared_ptr<const Function<T, U>>>& coefficients,
     const std::vector<std::shared_ptr<const Constant<T>>>& constants,
-    std::shared_ptr<const mesh::Mesh<U>> mesh = nullptr,
     std::shared_ptr<const FunctionSpace<U>> argument_function_space = nullptr)
 {
   if (e.rank > 0 and !argument_function_space)
@@ -1077,8 +1076,7 @@ Expression<T, U> create_expression(
 
   assert(tabulate_tensor);
   return Expression(coefficients, constants, std::span<const U>(X), Xshape,
-                    tabulate_tensor, value_shape, mesh,
-                    argument_function_space);
+                    tabulate_tensor, value_shape, argument_function_space);
 }
 
 /// @brief Create Expression from UFC input (with named coefficients and
@@ -1089,7 +1087,6 @@ Expression<T, U> create_expression(
     const std::map<std::string, std::shared_ptr<const Function<T, U>>>&
         coefficients,
     const std::map<std::string, std::shared_ptr<const Constant<T>>>& constants,
-    std::shared_ptr<const mesh::Mesh<U>> mesh = nullptr,
     std::shared_ptr<const FunctionSpace<U>> argument_function_space = nullptr)
 {
   // Place coefficients in appropriate order
@@ -1126,8 +1123,7 @@ Expression<T, U> create_expression(
     }
   }
 
-  return create_expression(e, coeff_map, const_map, mesh,
-                           argument_function_space);
+  return create_expression(e, coeff_map, const_map, argument_function_space);
 }
 
 /// @warning This is subject to change

--- a/python/demo/demo_pyvista.py
+++ b/python/demo/demo_pyvista.py
@@ -42,6 +42,10 @@ except ModuleNotFoundError:
 # otherwise create interactive plot
 if pyvista.OFF_SCREEN:
     pyvista.start_xvfb(wait=0.1)
+
+# Set some global options for all plots
+transparent = False
+figsize = 800
 # -
 
 # ## Plotting a finite element Function using warp by scalar

--- a/python/demo/demo_pyvista.py
+++ b/python/demo/demo_pyvista.py
@@ -42,11 +42,6 @@ except ModuleNotFoundError:
 # otherwise create interactive plot
 if pyvista.OFF_SCREEN:
     pyvista.start_xvfb(wait=0.1)
-
-# Set some global options for all plots
-transparent = False
-figsize = 800
-pyvista.rcParams["background"] = [0.5, 0.5, 0.5]
 # -
 
 # ## Plotting a finite element Function using warp by scalar

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -91,17 +91,18 @@ _ufl_to_dolfinx_domain = {"cell": IntegralType.cell,
 
 def form(form: typing.Union[ufl.Form, typing.Iterable[ufl.Form]],
          dtype: typing.Optional[npt.DTypeLike] = default_scalar_type,
-         form_compiler_options: dict = {}, jit_options: dict = {}):
+         form_compiler_options: typing.Optional[dict] = None,
+         jit_options: typing.Optional[dict] = None):
     """Create a Form or an array of Forms.
 
     Args:
-        form: A UFL form or list(s) of UFL forms
-        dtype: Scalar type to use for the compiled form
+        form: A UFL form or list(s) of UFL forms.
+        dtype: Scalar type to use for the compiled form.
         form_compiler_options: See :func:`ffcx_jit <dolfinx.jit.ffcx_jit>`
-        jit_options:See :func:`ffcx_jit <dolfinx.jit.ffcx_jit>`
+        jit_options: See :func:`ffcx_jit <dolfinx.jit.ffcx_jit>`.
 
     Returns:
-        Compiled finite element Form
+        Compiled finite element Form.
 
     Notes:
         This function is responsible for the compilation of a UFL form
@@ -111,6 +112,9 @@ def form(form: typing.Union[ufl.Form, typing.Iterable[ufl.Form]],
         scalar type, e.g. `_cpp.fem.Form_float64`.
 
     """
+    if form_compiler_options is None:
+        form_compiler_options = dict()
+
     if dtype == np.float32:
         ftype = _cpp.fem.Form_float32
         form_compiler_options["scalar_type"] = "float"

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -464,8 +464,7 @@ class Function(ufl.Coefficient):
 
     def collapse(self) -> Function:
         u_collapsed = self._cpp_object.collapse()
-        V_collapsed = FunctionSpace(
-            self.function_space._mesh, self.ufl_element(), u_collapsed.function_space)
+        V_collapsed = FunctionSpace(self.function_space._mesh, self.ufl_element(), u_collapsed.function_space)
         return Function(V_collapsed, Vector(u_collapsed.x))
 
 
@@ -666,8 +665,7 @@ def VectorFunctionSpace(mesh: Mesh,
                         dim=None) -> FunctionSpace:
     """Create vector finite element (composition of scalar elements) function space."""
     if not _is_scalar(mesh, element):
-        raise ValueError(
-            "Cannot create vector element containing a non-scalar.")
+        raise ValueError("Cannot create vector element containing a non-scalar.")
 
     try:
         ufl_e = basix.ufl.element(element.family(), element.cell_type,         # type: ignore
@@ -687,8 +685,7 @@ def TensorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typin
                         symmetry: typing.Optional[bool] = None) -> FunctionSpace:
     """Create tensor finite element (composition of scalar elements) function space."""
     if not _is_scalar(mesh, element):
-        raise ValueError(
-            "Cannot create tensor element containing a non-scalar.")
+        raise ValueError("Cannot create tensor element containing a non-scalar.")
 
     e = ElementMetaData(*element)
     gdim = mesh.geometry.dim

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -85,7 +85,7 @@ class Constant(ufl.Constant):
 
 class Expression:
     def __init__(self, ufl_expression: ufl.core.expr.Expr, X: np.ndarray,
-                 comm: typing.Optional[_MPI.comm] = None, form_compiler_options: dict = {},
+                 comm: typing.Optional[_MPI.Comm] = None, form_compiler_options: dict = {},
                  jit_options: dict = {}, dtype=default_scalar_type):
         """Create DOLFINx Expression.
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -85,8 +85,10 @@ class Constant(ufl.Constant):
 
 class Expression:
     def __init__(self, e: ufl.core.expr.Expr, X: np.ndarray,
-                 comm: typing.Optional[_MPI.Comm] = None, form_compiler_options: dict = {},
-                 jit_options: dict = {}, dtype=None):
+                 comm: typing.Optional[_MPI.Comm] = None,
+                 form_compiler_options: typing.Optional[dict] = None,
+                 jit_options: typing.Optional[dict] = None,
+                 dtype: typing.Optional[npt.DTypeLike] = None):
         """Create DOLFINx Expression.
 
         Represents a mathematical expression evaluated at a pre-defined
@@ -135,6 +137,8 @@ class Expression:
                 dtype = default_scalar_type
 
         # Compile UFL expression with JIT
+        if form_compiler_options is None:
+            form_compiler_options = dict()
         if dtype == np.float32:
             form_compiler_options["scalar_type"] = "float"
         elif dtype == np.float64:

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -490,7 +490,8 @@ class FunctionSpace(ufl.FunctionSpace):
                  element: typing.Union[ufl.FiniteElementBase, ElementMetaData, typing.Tuple[str, int]],
                  cppV: typing.Optional[typing.Union[_cpp.fem.FunctionSpace_float32,
                                                     _cpp.fem.FunctionSpace_float64]] = None,
-                 form_compiler_options: dict[str, typing.Any] = {}, jit_options: dict[str, typing.Any] = {}):
+                 form_compiler_options: typing.Optional[dict[str, typing.Any]] = None,
+                 jit_options: typing.Optional[dict[str, typing.Any]] = None):
         """Create a finite element function space."""
         dtype = mesh.geometry.x.dtype
         assert dtype == np.float32 or dtype == np.float64
@@ -508,6 +509,8 @@ class FunctionSpace(ufl.FunctionSpace):
                 super().__init__(mesh.ufl_domain(), ufl_e)
 
             # Compile dofmap and element and create DOLFIN objects
+            if form_compiler_options is None:
+                form_compiler_options = dict()
             if dtype == np.float32:
                 form_compiler_options["scalar_type"] = "float"
             elif dtype == np.float64:

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -370,8 +370,7 @@ class Function(ufl.Coefficient):
         @_interpolate.register(Function)
         def _(u: Function, cells: typing.Optional[np.ndarray] = None):
             """Interpolate a fem.Function"""
-            self._cpp_object.interpolate(
-                u._cpp_object, cells, nmm_interpolation_data)
+            self._cpp_object.interpolate(u._cpp_object, cells, nmm_interpolation_data)
 
         @_interpolate.register(int)
         def _(u_ptr: int, cells: typing.Optional[np.ndarray] = None):
@@ -394,10 +393,8 @@ class Function(ufl.Coefficient):
         except TypeError:
             # u is callable
             assert callable(u)
-            x = _cpp.fem.interpolation_coords(
-                self._V.element, self._V.mesh.geometry, cells)
-            self._cpp_object.interpolate(
-                np.asarray(u(x), dtype=self.dtype), cells)
+            x = _cpp.fem.interpolation_coords(self._V.element, self._V.mesh.geometry, cells)
+            self._cpp_object.interpolate(np.asarray(u(x), dtype=self.dtype), cells)
 
     def copy(self) -> Function:
         """Create a copy of the Function. The FunctionSpace is shared and the
@@ -496,11 +493,10 @@ class FunctionSpace(ufl.FunctionSpace):
                 # UFL element
                 super().__init__(mesh.ufl_domain(), element)
             except BaseException:
-                assert len(
-                    element) == 2, "Expected sequence of (element_type, degree)"
+                assert len(element) == 2, "Expected sequence of (element_type, degree)"
                 e = ElementMetaData(*element)
-                ufl_e = basix.ufl.element(
-                    e.family, mesh.basix_cell(), e.degree, gdim=mesh.ufl_cell().geometric_dimension())
+                ufl_e = basix.ufl.element(e.family, mesh.basix_cell(), e.degree,
+                                          gdim=mesh.ufl_cell().geometric_dimension())
                 super().__init__(mesh.ufl_domain(), ufl_e)
 
             # Compile dofmap and element and create DOLFIN objects
@@ -515,11 +511,9 @@ class FunctionSpace(ufl.FunctionSpace):
 
             ffi = module.ffi
             if dtype == np.float32:
-                cpp_element = _cpp.fem.FiniteElement_float32(
-                    ffi.cast("uintptr_t", ffi.addressof(self._ufcx_element)))
+                cpp_element = _cpp.fem.FiniteElement_float32(ffi.cast("uintptr_t", ffi.addressof(self._ufcx_element)))
             elif dtype == np.float64:
-                cpp_element = _cpp.fem.FiniteElement_float64(
-                    ffi.cast("uintptr_t", ffi.addressof(self._ufcx_element)))
+                cpp_element = _cpp.fem.FiniteElement_float64(ffi.cast("uintptr_t", ffi.addressof(self._ufcx_element)))
             cpp_dofmap = _cpp.fem.create_dofmap(mesh.comm, ffi.cast(
                 "uintptr_t", ffi.addressof(self._ufcx_dofmap)), mesh.topology, cpp_element)
 
@@ -533,8 +527,7 @@ class FunctionSpace(ufl.FunctionSpace):
             # Create function space from a UFL element and an existing
             # C++ FunctionSpace
             if mesh._cpp_object is not cppV.mesh:
-                raise RecursionError(
-                    "Meshes do not match in FunctionSpace initialisation.")
+                raise RecursionError("Meshes do not match in FunctionSpace initialisation.")
             ufl_domain = mesh.ufl_domain()
             super().__init__(ufl_domain, element)
             self._cpp_object = cppV
@@ -700,7 +693,6 @@ def TensorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typin
     e = ElementMetaData(*element)
     gdim = mesh.geometry.dim
     shape_ = (gdim, gdim) if shape is None else shape
-    ufl_element = basix.ufl.element(e.family, mesh.basix_cell(),
-                                    e.degree, shape=shape_, symmetry=symmetry,
+    ufl_element = basix.ufl.element(e.family, mesh.basix_cell(), e.degree, shape=shape_, symmetry=symmetry,
                                     gdim=mesh.geometry.dim, rank=2)
     return FunctionSpace(mesh, ufl_element)

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -553,7 +553,8 @@ class LinearProblem:
     """
 
     def __init__(self, a: ufl.Form, L: ufl.Form, bcs: typing.List[DirichletBC] = [],
-                 u: typing.Optional[_Function] = None, petsc_options={}, form_compiler_options={}, jit_options={}):
+                 u: typing.Optional[_Function] = None, petsc_options=None,
+                 form_compiler_options=None, jit_options=None):
         """Initialize solver for a linear variational problem.
 
         Args:
@@ -682,7 +683,7 @@ class NonlinearProblem:
     """
 
     def __init__(self, F: ufl.form.Form, u: _Function, bcs: typing.List[DirichletBC] = [],
-                 J: ufl.form.Form = None, form_compiler_options={}, jit_options={}):
+                 J: ufl.form.Form = None, form_compiler_options=None, jit_options=None):
         """Initialize solver for solving a non-linear problem using Newton's method, :math:`(dF/du)(u) du = -F(u)`.
 
         Args:

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -553,8 +553,10 @@ class LinearProblem:
     """
 
     def __init__(self, a: ufl.Form, L: ufl.Form, bcs: typing.List[DirichletBC] = [],
-                 u: typing.Optional[_Function] = None, petsc_options=None,
-                 form_compiler_options=None, jit_options=None):
+                 u: typing.Optional[_Function] = None,
+                 petsc_options: typing.Optional[dict] = None,
+                 form_compiler_options: typing.Optional[dict] = None,
+                 jit_options: typing.Optional[dict] = None):
         """Initialize solver for a linear variational problem.
 
         Args:
@@ -608,8 +610,9 @@ class LinearProblem:
         # Set PETSc options
         opts = PETSc.Options()
         opts.prefixPush(problem_prefix)
-        for k, v in petsc_options.items():
-            opts[k] = v
+        if petsc_options is not None:
+            for k, v in petsc_options.items():
+                opts[k] = v
         opts.prefixPop()
         self._solver.setFromOptions()
 
@@ -683,7 +686,8 @@ class NonlinearProblem:
     """
 
     def __init__(self, F: ufl.form.Form, u: _Function, bcs: typing.List[DirichletBC] = [],
-                 J: ufl.form.Form = None, form_compiler_options=None, jit_options=None):
+                 J: ufl.form.Form = None, form_compiler_options: typing.Optional[dict] = None,
+                 jit_options: typing.Optional[dict] = None):
         """Initialize solver for solving a non-linear problem using Newton's method, :math:`(dF/du)(u) du = -F(u)`.
 
         Args:

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -203,7 +203,7 @@ if _has_gmsh:
             # Extract Gmsh cell id, dimension of cell and number of
             # nodes to cell for each
             num_cell_types = len(topologies.keys())
-            cell_information = {}
+            cell_information = dict()
             cell_dimensions = np.zeros(num_cell_types, dtype=np.int32)
             for i, element in enumerate(topologies.keys()):
                 _, dim, _, num_nodes, _, _ = model.mesh.getElementProperties(element)

--- a/python/dolfinx/jit.py
+++ b/python/dolfinx/jit.py
@@ -14,7 +14,6 @@ from typing import Optional
 import ffcx
 import ffcx.codegeneration.jit
 import ufl
-
 from mpi4py import MPI
 
 __all__ = ["ffcx_jit", "get_options", "mpi_jit_decorator"]
@@ -105,14 +104,14 @@ def _load_options():
         with open(user_config_file) as f:
             user_options = json.load(f)
     except FileNotFoundError:
-        user_options = {}
+        user_options = dict()
 
     pwd_config_file = Path.cwd().joinpath("dolfinx_jit_options.json")
     try:
         with open(pwd_config_file) as f:
             pwd_options = json.load(f)
     except FileNotFoundError:
-        pwd_options = {}
+        pwd_options = dict()
 
     return (user_options, pwd_options)
 
@@ -131,8 +130,7 @@ def get_options(priority_options: Optional[dict] = None) -> dict:
         See :func:`ffcx_jit` for user facing documentation.
 
     """
-    options = {}
-
+    options = dict()
     for param, (value, _) in DOLFINX_DEFAULT_JIT_OPTIONS.items():
         options[param] = value
 
@@ -150,7 +148,8 @@ def get_options(priority_options: Optional[dict] = None) -> dict:
 
 
 @mpi_jit_decorator
-def ffcx_jit(ufl_object, form_compiler_options={}, jit_options={}):
+def ffcx_jit(ufl_object, form_compiler_options: Optional[dict] = None,
+             jit_options: Optional[dict] = None):
     """Compile UFL object with FFCx and CFFI.
 
     Args:
@@ -205,8 +204,7 @@ def ffcx_jit(ufl_object, form_compiler_options={}, jit_options={}):
     elif isinstance(ufl_object, ufl.FiniteElementBase):
         r = ffcx.codegeneration.jit.compile_elements([ufl_object], options=p_ffcx, **p_jit)
     elif isinstance(ufl_object, ufl.Mesh):
-        r = ffcx.codegeneration.jit.compile_coordinate_maps(
-            [ufl_object], options=p_ffcx, **p_jit)
+        r = ffcx.codegeneration.jit.compile_coordinate_maps([ufl_object], options=p_ffcx, **p_jit)
     elif isinstance(ufl_object, tuple) and isinstance(ufl_object[0], ufl.core.expr.Expr):
         r = ffcx.codegeneration.jit.compile_expressions([ufl_object], options=p_ffcx, **p_jit)
     else:

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -312,3 +312,13 @@ def test_expression_eval_cells_subset():
     cells = np.arange(cells_imap.size_local, dtype=np.int32)[::-2]
     u_ = e.eval(cells)
     assert np.allclose(u_.ravel(), cells)
+
+
+def test_expression_comm():
+    mesh = create_unit_square(MPI.COMM_WORLD, 4, 4)
+    v = Constant(mesh.ufl_cell(), 1.0)
+    u = Function(FunctionSpace(mesh, ("Lagrange", 1)))
+
+    with pytest.raises(AttributeError):
+        expr = Expression(v, u.function_space.element.interpolation_points())
+    expr = Expression(v, u.function_space.element.interpolation_points(), comm=MPI.COMM_WORLD)

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -318,7 +318,6 @@ def test_expression_comm():
     mesh = create_unit_square(MPI.COMM_WORLD, 4, 4)
     v = Constant(mesh.ufl_cell(), 1.0)
     u = Function(FunctionSpace(mesh, ("Lagrange", 1)))
-
     with pytest.raises(AttributeError):
         Expression(v, u.function_space.element.interpolation_points())
     Expression(v, u.function_space.element.interpolation_points(), comm=MPI.COMM_WORLD)

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -22,23 +22,24 @@ from dolfinx import default_real_type, default_scalar_type, fem, la
 dolfinx.cpp.common.init_logging(["-v"])
 
 
-def test_rank0():
+@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
+def test_rank0(dtype):
     """Test evaluation of UFL expression.
     This test evaluates gradient of P2 function at interpolation points
     of vector dP1 element.
     For a donor function f(x, y) = x^2 + 2*y^2 result is compared with the
     exact gradient grad f(x, y) = [2*x, 4*y]."""
-    mesh = create_unit_square(MPI.COMM_WORLD, 5, 5)
+    mesh = create_unit_square(MPI.COMM_WORLD, 5, 5, dtype=dtype(0).real.dtype)
     P2 = FunctionSpace(mesh, ("P", 2))
     vdP1 = VectorFunctionSpace(mesh, ("DG", 1))
 
-    f = Function(P2)
+    f = Function(P2, dtype=dtype)
     f.interpolate(lambda x: x[0] ** 2 + 2.0 * x[1] ** 2)
 
     ufl_expr = ufl.grad(f)
     points = vdP1.element.interpolation_points()
 
-    compiled_expr = Expression(ufl_expr, points)
+    compiled_expr = Expression(ufl_expr, points, dtype=dtype)
     num_cells = mesh.topology.index_map(2).size_local
     array_evaluated = compiled_expr.eval(mesh, np.arange(num_cells, dtype=np.int32))
 
@@ -49,12 +50,12 @@ def test_rank0():
                     vec[2 * dofmap[i * 3 + j] + k] = array_evaluated[i, 2 * j + k]
 
     # Data structure for the result
-    b = Function(vdP1)
+    b = Function(vdP1, dtype=dtype)
     dofmap = vdP1.dofmap.list.flatten()
     scatter(b.x.array, array_evaluated, dofmap)
     b.x.scatter_forward()
 
-    b2 = Function(vdP1)
+    b2 = Function(vdP1, dtype=dtype)
     b2.interpolate(lambda x: np.vstack((2.0 * x[0], 4.0 * x[1])))
 
     assert np.allclose(b2.x.array, b.x.array, rtol=1.0e-5, atol=1.0e-5)
@@ -116,7 +117,8 @@ def test_rank1_hdiv(dtype):
     assert np.linalg.norm(h2.x.array - h.x.array) == pytest.approx(0.0, abs=1.0e-4)
 
 
-def test_simple_evaluation():
+@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
+def test_simple_evaluation(dtype):
     """Test evaluation of UFL Expression.
 
     This test evaluates a UFL Expression on cells of the mesh and
@@ -135,7 +137,8 @@ def test_simple_evaluation():
     gradient.
 
     """
-    mesh = create_unit_square(MPI.COMM_WORLD, 3, 3)
+    xtype = dtype(0).real.dtype
+    mesh = create_unit_square(MPI.COMM_WORLD, 3, 3, dtype=xtype)
     P2 = FunctionSpace(mesh, ("P", 2))
 
     # NOTE: The scaling by a constant factor of 3.0 to get f(x, y) is
@@ -155,16 +158,16 @@ def test_simple_evaluation():
         values *= 3.0
         return values
 
-    expr = Function(P2)
+    expr = Function(P2, dtype=dtype)
     expr.interpolate(exact_expr)
 
-    ufl_grad_f = Constant(mesh, default_scalar_type(3.0)) * ufl.grad(expr)
+    ufl_grad_f = Constant(mesh, dtype(3.0)) * ufl.grad(expr)
     points = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
-    grad_f_expr = Expression(ufl_grad_f, points)
+    grad_f_expr = Expression(ufl_grad_f, points, dtype=dtype)
     assert grad_f_expr.X().shape[0] == points.shape[0]
     assert grad_f_expr.value_size == 2
 
-    # NOTE: Cell numbering is process local.
+    # # NOTE: Cell numbering is process local
     map_c = mesh.topology.index_map(mesh.topology.dim)
     num_cells = map_c.size_local + map_c.num_ghosts
     cells = np.arange(0, num_cells, dtype=np.int32)
@@ -175,7 +178,7 @@ def test_simple_evaluation():
 
     # Evaluate points in global space
     ufl_x = ufl.SpatialCoordinate(mesh)
-    x_expr = Expression(ufl_x, points)
+    x_expr = Expression(ufl_x, points, dtype=xtype)
     assert x_expr.X().shape[0] == points.shape[0]
     assert x_expr.value_size == 2
     x_evaluated = x_expr.eval(mesh, cells)
@@ -187,7 +190,8 @@ def test_simple_evaluation():
     assert np.allclose(grad_f_evaluated, grad_f_exact, rtol=1.0e-5, atol=1.0e-5)
 
 
-def test_assembly_into_quadrature_function():
+@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
+def test_assembly_into_quadrature_function(dtype):
     """Test assembly into a Quadrature function.
 
     This test evaluates a UFL Expression into a Quadrature function
@@ -214,25 +218,26 @@ def test_assembly_into_quadrature_function():
     after insertion into the vector.
 
     """
-    mesh = create_unit_square(MPI.COMM_WORLD, 3, 6)
+    xtype = dtype(0).real.dtype
+    mesh = create_unit_square(MPI.COMM_WORLD, 3, 6, dtype=xtype)
 
     quadrature_degree = 2
     quadrature_points, _ = basix.make_quadrature(basix.CellType.triangle, quadrature_degree)
-    quadrature_points = quadrature_points.astype(default_real_type)
+    quadrature_points = quadrature_points.astype(xtype)
     Q_element = blocked_element(QuadratureElement(
         "triangle", (), degree=quadrature_degree, scheme="default"), shape=(2, ))
     Q = FunctionSpace(mesh, Q_element)
     P2 = FunctionSpace(mesh, ("P", 2))
 
-    T = Function(P2)
+    T = Function(P2, dtype=dtype)
     T.interpolate(lambda x: x[0] + 2.0 * x[1])
-    A = Constant(mesh, default_scalar_type(1.0))
-    B = Constant(mesh, default_scalar_type(2.0))
+    A = Constant(mesh, dtype(1.0))
+    B = Constant(mesh, dtype(2.0))
 
     K = 1.0 / (A + B * T)
     e = B * K**2 * ufl.grad(T)
 
-    e_expr = Expression(e, quadrature_points)
+    e_expr = Expression(e, quadrature_points, dtype=dtype)
 
     map_c = mesh.topology.index_map(mesh.topology.dim)
     num_cells = map_c.size_local + map_c.num_ghosts
@@ -240,8 +245,8 @@ def test_assembly_into_quadrature_function():
 
     e_eval = e_expr.eval(mesh, cells)
 
-    # Assemble into Function
-    e_Q = Function(Q)
+    # # Assemble into Function
+    e_Q = Function(Q, dtype=dtype)
     e_Q_local = e_Q.x.array
     bs = e_Q.function_space.dofmap.bs
     dofs = np.empty((bs * Q.dofmap.list.flatten().size,), dtype=np.int32)
@@ -260,10 +265,9 @@ def test_assembly_into_quadrature_function():
         e = B.value * K**2 * grad_T
         return e
 
-    # FIXME: Below is only for testing purposes,
-    # never to be used in user code!
-    #
-    # Replace when interpolation into Quadrature element works.
+    # # FIXME: Below is only for testing purposes,
+    # # never to be used in user code!
+    # # TODO: Replace when interpolation into Quadrature element works.
     coord_dofs = mesh.geometry.dofmap
     x_g = mesh.geometry.x
     tdim = mesh.topology.dim
@@ -275,17 +279,19 @@ def test_assembly_into_quadrature_function():
     Q_dofs_unrolled = Q_dofs_unrolled.reshape(-1, bs * quadrature_points.shape[0]).astype(Q_dofs.dtype)
     assert len(mesh.geometry.cmaps) == 1
 
-    with e_Q.vector.localForm() as local:
-        e_exact_eval = np.zeros_like(local.array)
-        for cell in range(num_cells):
-            xg = x_g[coord_dofs[cell], :tdim]
-            x = mesh.geometry.cmaps[0].push_forward(quadrature_points, xg)
-            e_exact_eval[Q_dofs_unrolled[cell]] = e_exact(x.T).T.flatten()
-        assert np.allclose(local.array, e_exact_eval)
+    local = e_Q.x.array
+    e_exact_eval = np.zeros_like(local)
+    for cell in range(num_cells):
+        xg = x_g[coord_dofs[cell], :tdim]
+        x = mesh.geometry.cmaps[0].push_forward(quadrature_points, xg)
+        e_exact_eval[Q_dofs_unrolled[cell]] = e_exact(x.T).T.flatten()
+    assert np.allclose(local, e_exact_eval)
 
 
-def test_expression_eval_cells_subset():
-    mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 2, 4)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
+def test_expression_eval_cells_subset(dtype):
+    xtype = dtype(0).real.dtype
+    mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 2, 4, dtype=xtype)
     V = dolfinx.fem.FunctionSpace(mesh, ("DG", 0))
 
     cells_imap = mesh.topology.index_map(mesh.topology.dim)
@@ -293,7 +299,7 @@ def test_expression_eval_cells_subset():
     cells_to_dofs = np.fromiter(map(V.dofmap.cell_dofs, all_cells), dtype=np.int32)
     dofs_to_cells = np.argsort(cells_to_dofs)
 
-    u = dolfinx.fem.Function(V)
+    u = dolfinx.fem.Function(V, dtype=dtype)
     u.x.array[:] = dofs_to_cells
     u.x.scatter_forward()
     e = dolfinx.fem.Expression(u, V.element.interpolation_points())
@@ -314,10 +320,12 @@ def test_expression_eval_cells_subset():
     assert np.allclose(u_.ravel(), cells)
 
 
-def test_expression_comm():
-    mesh = create_unit_square(MPI.COMM_WORLD, 4, 4)
-    v = Constant(mesh.ufl_cell(), 1.0)
-    u = Function(FunctionSpace(mesh, ("Lagrange", 1)))
+@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
+def test_expression_comm(dtype):
+    xtype = dtype(0).real.dtype
+    mesh = create_unit_square(MPI.COMM_WORLD, 4, 4, dtype=xtype)
+    v = Constant(mesh.ufl_cell(), dtype(1))
+    u = Function(FunctionSpace(mesh, ("Lagrange", 1)), dtype=dtype)
     with pytest.raises(AttributeError):
         Expression(v, u.function_space.element.interpolation_points())
     Expression(v, u.function_space.element.interpolation_points(), comm=MPI.COMM_WORLD)

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -16,8 +16,7 @@ from ffcx.element_interface import QuadratureElement
 from mpi4py import MPI
 
 import dolfinx.cpp
-from dolfinx import default_real_type, default_scalar_type, fem, la
-
+from dolfinx import fem, la
 
 dolfinx.cpp.common.init_logging(["-v"])
 
@@ -25,10 +24,14 @@ dolfinx.cpp.common.init_logging(["-v"])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
 def test_rank0(dtype):
     """Test evaluation of UFL expression.
+
     This test evaluates gradient of P2 function at interpolation points
     of vector dP1 element.
+
     For a donor function f(x, y) = x^2 + 2*y^2 result is compared with the
-    exact gradient grad f(x, y) = [2*x, 4*y]."""
+    exact gradient grad f(x, y) = [2*x, 4*y].
+
+    """
     mesh = create_unit_square(MPI.COMM_WORLD, 5, 5, dtype=dtype(0).real.dtype)
     P2 = FunctionSpace(mesh, ("P", 2))
     vdP1 = VectorFunctionSpace(mesh, ("DG", 1))
@@ -64,9 +67,13 @@ def test_rank0(dtype):
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
 def test_rank1_hdiv(dtype):
     """Test rank-1 Expression, i.e. Expression containing Argument
-    (TrialFunction). Test compiles linear interpolation operator RT_2 ->
+    (TrialFunction).
+
+    Test compiles linear interpolation operator RT_2 ->
     vector DG_2 and assembles it into global matrix A. Input space RT_2
-    is chosen because it requires dof permutations."""
+    is chosen because it requires dof permutations.
+
+    """
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10, dtype=dtype(0).real.dtype)
     vdP1 = VectorFunctionSpace(mesh, ("DG", 2))
     RT1 = FunctionSpace(mesh, ("RT", 2))
@@ -274,11 +281,9 @@ def test_assembly_into_quadrature_function(dtype):
     Q_dofs = Q.dofmap.list
 
     bs = Q.dofmap.bs
-
     Q_dofs_unrolled = bs * np.repeat(Q_dofs, bs).reshape(-1, bs) + np.arange(bs)
     Q_dofs_unrolled = Q_dofs_unrolled.reshape(-1, bs * quadrature_points.shape[0]).astype(Q_dofs.dtype)
     assert len(mesh.geometry.cmaps) == 1
-
     local = e_Q.x.array
     e_exact_eval = np.zeros_like(local)
     for cell in range(num_cells):

--- a/python/test/unit/mesh/test_ghost_mesh.py
+++ b/python/test/unit/mesh/test_ghost_mesh.py
@@ -76,7 +76,7 @@ def test_ghost_connectivities(mode):
     map_f = topology.index_map(tdim - 1)
     num_facets = map_f.size_local + map_f.num_ghosts
 
-    reference = {}
+    reference = dict()
     facet_mp = compute_midpoints(meshR, tdim - 1, range(num_facets))
     cell_mp = compute_midpoints(meshR, tdim, range(num_cells))
     reference = dict.fromkeys([tuple(row) for row in facet_mp], [])


### PR DESCRIPTION
C++ Expression no longer requires a mesh at construction, which supports fixing of #2363 and will avoid some unnecessary JIT. The mesh is now passed to the `Expression::eval` function.

Also remove `dict()` default parameters, use `None` instead.