### PR TITLE
Rename ‘MatrixCSR::finalize’ to ‘MatrixCSR::scatter_rev’

### DIFF
--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -160,7 +160,7 @@ public:
   /// There is some overlap of matrix rows between processes to allow for
   /// independent Finite Element assembly, after which, the ghost rows
   /// should be sent to the row owning processes by calling
-  /// `finalize()`.
+  /// `scatter_rev()`.
   ///
   /// @note The block size of the matrix is given by the block size of
   /// the input `SparsityPattern`.
@@ -189,9 +189,9 @@ public:
   /// initialize the matrix can be set.
   /// @note All indices are local to the calling MPI rank and entries
   /// cannot be set in ghost rows.
-  /// @note This should be called after `finalize`. Using before
-  /// `finalize` will set the values correctly, but incoming values may
-  /// get added to them during a subsequent finalize operation.
+  /// @note This should be called after `scatter_rev`. Using before
+  /// `scatter_rev` will set the values correctly, but incoming values may
+  /// get added to them during a subsequent reverse scatter operation.
   /// @tparam BS0 Data row block size
   /// @tparam BS1 Data column block size
   /// @param[in] x The `m` by `n` dense block of values (row-major) to
@@ -233,9 +233,9 @@ public:
   /// initialize the matrix can be accumulated into.
   /// @note All indices are local to the calling MPI rank and entries
   /// may go into ghost rows.
-  /// @note Use `finalize` after all entries have been added to send
-  /// ghost rows to owners. Adding more entries after `finalize` is
-  /// allowed, but another call to `finalize` will then be required.
+  /// @note Use `scatter_rev` after all entries have been added to send
+  /// ghost rows to owners. Adding more entries after `scatter_rev` is
+  /// allowed, but another call to `scatter_rev` will then be required.
   ///
   /// @tparam BS0 Row block size of data
   /// @tparam BS1 Column block size of data
@@ -288,28 +288,29 @@ public:
 
   /// @brief Transfer ghost row data to the owning ranks accumulating
   /// received values on the owned rows, and zeroing any existing data
-  /// in ghost rows.
-  void finalize()
+  /// in ghost rows. This process is analogous to `scatter_rev` for `Vector`
+  /// except that the values are always accumulated on the owning process.
+  void scatter_rev()
   {
-    finalize_begin();
-    finalize_end();
+    scatter_rev_begin();
+    scatter_rev_end();
   }
 
   /// @brief Begin transfer of ghost row data to owning ranks, where it
   /// will be accumulated into existing owned rows.
   /// @note Calls to this function must be followed by
-  /// MatrixCSR::finalize_end(). Between the two calls matrix values
+  /// MatrixCSR::scatter_rev_end(). Between the two calls matrix values
   /// must not be changed.
   /// @note This function does not change the matrix data. Data update only
-  /// occurs with `finalize_end()`.
-  void finalize_begin();
+  /// occurs with `scatter_rev_end()`.
+  void scatter_rev_begin();
 
   /// @brief End transfer of ghost row data to owning ranks.
-  /// @note Must be preceded by MatrixCSR::finalize_begin().
+  /// @note Must be preceded by MatrixCSR::scatter_rev_begin().
   /// @note Matrix data received from other processes will be
   /// accumulated into locally owned rows, and ghost rows will be
   /// zeroed.
-  void finalize_end();
+  void scatter_rev_end();
 
   /// @brief Compute the Frobenius norm squared across all processes.
   /// @note MPI Collective
@@ -380,7 +381,7 @@ private:
   // Neighborhood communicator (ghost->owner communicator for rows)
   dolfinx::MPI::Comm _comm;
 
-  // -- Precomputed data for finalize/update
+  // -- Precomputed data for scatter_rev/update
 
   // Request in non-blocking communication
   MPI_Request _request;
@@ -396,7 +397,7 @@ private:
   // on _comm)
   std::vector<int> _ghost_row_to_rank;
 
-  // Temporary stores for finalize data during non-blocking communication
+  // Temporary stores for data during non-blocking communication
   container_type _ghost_value_data;
   container_type _ghost_value_data_in;
 };
@@ -641,7 +642,7 @@ MatrixCSR<U, V, W, X>::to_dense() const
 }
 //-----------------------------------------------------------------------------
 template <typename U, typename V, typename W, typename X>
-void MatrixCSR<U, V, W, X>::finalize_begin()
+void MatrixCSR<U, V, W, X>::scatter_rev_begin()
 {
   const std::int32_t local_size0 = _index_maps[0]->size_local();
   const std::int32_t num_ghosts0 = _index_maps[0]->num_ghosts();
@@ -684,7 +685,7 @@ void MatrixCSR<U, V, W, X>::finalize_begin()
 }
 //-----------------------------------------------------------------------------
 template <typename U, typename V, typename W, typename X>
-void MatrixCSR<U, V, W, X>::finalize_end()
+void MatrixCSR<U, V, W, X>::scatter_rev_end()
 {
   int status = MPI_Wait(&_request, MPI_STATUS_IGNORE);
   assert(status == MPI_SUCCESS);

--- a/cpp/test/matrix.cpp
+++ b/cpp/test/matrix.cpp
@@ -123,7 +123,7 @@ la::MatrixCSR<double> create_operator(MPI_Comm comm)
   sp.finalize();
   la::MatrixCSR<double> A(sp);
   fem::assemble_matrix(A.mat_add_values(), *a, {});
-  A.finalize();
+  A.scatter_rev();
 
   return A;
 }
@@ -162,7 +162,7 @@ la::MatrixCSR<double> create_operator(MPI_Comm comm)
   // Assemble matrix
   la::MatrixCSR<double> A(sp);
   fem::assemble_matrix(A.mat_add_values(), *a, {});
-  A.finalize();
+  A.scatter_rev();
   CHECK((V->dofmap()->index_map->size_local() == A.num_owned_rows()));
 
   // Get compatible vectors

--- a/python/demo/demo_types.py
+++ b/python/demo/demo_types.py
@@ -127,7 +127,7 @@ def poisson(dtype):
 
     # Assemble forms
     A = fem.assemble_matrix(a0, [bc])
-    A.finalize()
+    A.scatter_rev()
     b = fem.assemble_vector(L0)
     fem.apply_lifting(b.array, [a0], bcs=[[bc]])
     b.scatter_reverse(la.InsertMode.add)
@@ -182,7 +182,7 @@ def elasticity(dtype) -> fem.Function:
 
     # Assemble forms (CSR matrix)
     A = fem.assemble_matrix(a0, [bc], block_mode=la.BlockMode.expanded)
-    A.finalize()
+    A.scatter_rev()
     assert A.block_size == [1, 1]
 
     b = fem.assemble_vector(L0)

--- a/python/demo/demo_types.py
+++ b/python/demo/demo_types.py
@@ -127,7 +127,7 @@ def poisson(dtype):
 
     # Assemble forms
     A = fem.assemble_matrix(a0, [bc])
-    A.scatter_rev()
+    A.scatter_reverse()
     b = fem.assemble_vector(L0)
     fem.apply_lifting(b.array, [a0], bcs=[[bc]])
     b.scatter_reverse(la.InsertMode.add)
@@ -182,7 +182,7 @@ def elasticity(dtype) -> fem.Function:
 
     # Assemble forms (CSR matrix)
     A = fem.assemble_matrix(a0, [bc], block_mode=la.BlockMode.expanded)
-    A.scatter_rev()
+    A.scatter_reverse()
     assert A.block_size == [1, 1]
 
     b = fem.assemble_vector(L0)

--- a/python/dolfinx/la.py
+++ b/python/dolfinx/la.py
@@ -62,9 +62,9 @@ class MatrixCSR:
         """
         self._cpp_object.set_value(x)
 
-    def scatter_rev(self) -> None:
+    def scatter_reverse(self) -> None:
         """Scatter and accumulate ghost values."""
-        self._cpp_object.scatter_rev()
+        self._cpp_object.scatter_reverse()
 
     def squared_norm(self) -> np.floating:
         """Compute the squared Frobenius norm.

--- a/python/dolfinx/la.py
+++ b/python/dolfinx/la.py
@@ -62,9 +62,9 @@ class MatrixCSR:
         """
         self._cpp_object.set_value(x)
 
-    def finalize(self) -> None:
+    def scatter_rev(self) -> None:
         """Scatter and accumulate ghost values."""
-        self._cpp_object.finalize()
+        self._cpp_object.scatter_rev()
 
     def squared_norm(self) -> np.floating:
         """Compute the squared Frobenius norm.

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -128,7 +128,7 @@ void declare_objects(py::module& m, const std::string& type)
            static_cast<void (dolfinx::la::MatrixCSR<T>::*)(T)>(
                &dolfinx::la::MatrixCSR<T>::set),
            py::arg("x"))
-      .def("finalize", &dolfinx::la::MatrixCSR<T>::finalize)
+      .def("scatter_rev", &dolfinx::la::MatrixCSR<T>::scatter_rev)
       .def("to_dense",
            [](const dolfinx::la::MatrixCSR<T>& self)
            {
@@ -161,8 +161,8 @@ void declare_objects(py::module& m, const std::string& type)
                                return py::array_t(array.size(), array.data(),
                                                   py::cast(self));
                              })
-      .def("finalize_begin", &dolfinx::la::MatrixCSR<T>::finalize_begin)
-      .def("finalize_end", &dolfinx::la::MatrixCSR<T>::finalize_end);
+      .def("scatter_rev_begin", &dolfinx::la::MatrixCSR<T>::scatter_rev_begin)
+      .def("scatter_rev_end", &dolfinx::la::MatrixCSR<T>::scatter_rev_end);
 }
 
 // Declare objects that have multiple scalar types

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -128,7 +128,7 @@ void declare_objects(py::module& m, const std::string& type)
            static_cast<void (dolfinx::la::MatrixCSR<T>::*)(T)>(
                &dolfinx::la::MatrixCSR<T>::set),
            py::arg("x"))
-      .def("scatter_rev", &dolfinx::la::MatrixCSR<T>::scatter_rev)
+      .def("scatter_reverse", &dolfinx::la::MatrixCSR<T>::scatter_rev)
       .def("to_dense",
            [](const dolfinx::la::MatrixCSR<T>& self)
            {

--- a/python/test/unit/fem/test_assemble_cppimport.py
+++ b/python/test/unit/fem/test_assemble_cppimport.py
@@ -131,7 +131,7 @@ PYBIND11_MODULE(eigen_csr, m)
     bc = dirichletbc(dtype(1), bdofsQ, Q)
 
     A1 = assemble_matrix(a, [bc])
-    A1.finalize()
+    A1.scatter_rev()
     A2 = assemble_csr_matrix(a._cpp_object, [bc._cpp_object])
     assert np.isclose(np.sqrt(A1.squared_norm()), scipy.sparse.linalg.norm(A2))
 

--- a/python/test/unit/fem/test_assemble_cppimport.py
+++ b/python/test/unit/fem/test_assemble_cppimport.py
@@ -131,7 +131,7 @@ PYBIND11_MODULE(eigen_csr, m)
     bc = dirichletbc(dtype(1), bdofsQ, Q)
 
     A1 = assemble_matrix(a, [bc])
-    A1.scatter_rev()
+    A1.scatter_reverse()
     A2 = assemble_csr_matrix(a._cpp_object, [bc._cpp_object])
     assert np.isclose(np.sqrt(A1.squared_norm()), scipy.sparse.linalg.norm(A2))
 

--- a/python/test/unit/fem/test_assemble_domains.py
+++ b/python/test/unit/fem/test_assemble_domains.py
@@ -62,10 +62,10 @@ def test_assembly_dx_domains(mode, meshtags_factory):
     # Assemble matrix
     a = form(w * ufl.inner(u, v) * (dx(1) + dx(2) + dx(3)))
     A = fem.assemble_matrix(a)
-    A.finalize()
+    A.scatter_rev()
     a2 = form(w * ufl.inner(u, v) * dx)
     A2 = fem.assemble_matrix(a2)
-    A2.finalize()
+    A2.scatter_rev()
     assert np.allclose(A.data, A2.data)
 
     bc = dirichletbc(Function(V), range(30))
@@ -142,10 +142,10 @@ def test_assembly_ds_domains(mode):
     # Assemble matrix
     a = form(w * ufl.inner(u, v) * (ds(1) + ds(2) + ds(3) + ds(6)))
     A = fem.assemble_matrix(a)
-    A.finalize()
+    A.scatter_rev()
     a2 = form(w * ufl.inner(u, v) * ds)
     A2 = fem.assemble_matrix(a2)
-    A2.finalize()
+    A2.scatter_rev()
     assert np.allclose(A.data, A2.data)
 
     # Assemble vector
@@ -267,7 +267,7 @@ def test_manual_integration_domains():
     # Create forms and assemble
     a, L = create_forms(dx_mt, ds_mt, dS_mt)
     A_mt = fem.assemble_matrix(a)
-    A_mt.finalize()
+    A_mt.scatter_rev()
     b_mt = fem.assemble_vector(L)
 
     # Manually specify cells to integrate over (removing ghosts
@@ -313,7 +313,7 @@ def test_manual_integration_domains():
     # Assemble forms and check
     a, L = create_forms(dx_manual, ds_manual, dS_manual)
     A = fem.assemble_matrix(a)
-    A.finalize()
+    A.scatter_rev()
     b = fem.assemble_vector(L)
 
     assert np.allclose(A.data, A_mt.data)

--- a/python/test/unit/fem/test_assemble_domains.py
+++ b/python/test/unit/fem/test_assemble_domains.py
@@ -62,10 +62,10 @@ def test_assembly_dx_domains(mode, meshtags_factory):
     # Assemble matrix
     a = form(w * ufl.inner(u, v) * (dx(1) + dx(2) + dx(3)))
     A = fem.assemble_matrix(a)
-    A.scatter_rev()
+    A.scatter_reverse()
     a2 = form(w * ufl.inner(u, v) * dx)
     A2 = fem.assemble_matrix(a2)
-    A2.scatter_rev()
+    A2.scatter_reverse()
     assert np.allclose(A.data, A2.data)
 
     bc = dirichletbc(Function(V), range(30))
@@ -142,10 +142,10 @@ def test_assembly_ds_domains(mode):
     # Assemble matrix
     a = form(w * ufl.inner(u, v) * (ds(1) + ds(2) + ds(3) + ds(6)))
     A = fem.assemble_matrix(a)
-    A.scatter_rev()
+    A.scatter_reverse()
     a2 = form(w * ufl.inner(u, v) * ds)
     A2 = fem.assemble_matrix(a2)
-    A2.scatter_rev()
+    A2.scatter_reverse()
     assert np.allclose(A.data, A2.data)
 
     # Assemble vector
@@ -267,7 +267,7 @@ def test_manual_integration_domains():
     # Create forms and assemble
     a, L = create_forms(dx_mt, ds_mt, dS_mt)
     A_mt = fem.assemble_matrix(a)
-    A_mt.scatter_rev()
+    A_mt.scatter_reverse()
     b_mt = fem.assemble_vector(L)
 
     # Manually specify cells to integrate over (removing ghosts
@@ -313,7 +313,7 @@ def test_manual_integration_domains():
     # Assemble forms and check
     a, L = create_forms(dx_manual, ds_manual, dS_manual)
     A = fem.assemble_matrix(a)
-    A.scatter_rev()
+    A.scatter_reverse()
     b = fem.assemble_vector(L)
 
     assert np.allclose(A.data, A_mt.data)

--- a/python/test/unit/fem/test_assemble_submesh.py
+++ b/python/test/unit/fem/test_assemble_submesh.py
@@ -37,7 +37,7 @@ def assemble(mesh, space, k):
     bc = fem.dirichletbc(bc_func, dofs)
 
     A = fem.assemble_matrix(a, bcs=[bc])
-    A.finalize()
+    A.scatter_rev()
 
     # TODO Test assembly with fem.Function
     x = ufl.SpatialCoordinate(mesh)

--- a/python/test/unit/fem/test_assemble_submesh.py
+++ b/python/test/unit/fem/test_assemble_submesh.py
@@ -37,7 +37,7 @@ def assemble(mesh, space, k):
     bc = fem.dirichletbc(bc_func, dofs)
 
     A = fem.assemble_matrix(a, bcs=[bc])
-    A.scatter_rev()
+    A.scatter_reverse()
 
     # TODO Test assembly with fem.Function
     x = ufl.SpatialCoordinate(mesh)

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -105,10 +105,10 @@ def test_assemble_derivatives(dtype):
     a = form(derivative(L, u, du), dtype=dtype)
 
     A1 = fem.assemble_matrix(a)
-    A1.finalize()
+    A1.scatter_rev()
     a = form(c2 * b * inner(du, v) * dx, dtype=dtype)
     A2 = fem.assemble_matrix(a)
-    A2.finalize()
+    A2.scatter_rev()
     assert np.allclose(A1.data, A2.data)
 
 
@@ -127,7 +127,7 @@ def test_basic_assembly(mode, dtype):
 
     # Initial assembly
     A = fem.assemble_matrix(a)
-    A.finalize()
+    A.scatter_rev()
     assert isinstance(A, la.MatrixCSR)
     b = fem.assemble_vector(L)
     b.scatter_reverse(la.InsertMode.add)
@@ -137,7 +137,7 @@ def test_basic_assembly(mode, dtype):
     normA = A.squared_norm()
     A.set_value(0)
     A = fem.assemble_matrix(A, a)
-    A.finalize()
+    A.scatter_rev()
     assert isinstance(A, la.MatrixCSR)
     assert normA == pytest.approx(A.squared_norm())
     normb = b.norm()
@@ -154,7 +154,7 @@ def test_basic_assembly(mode, dtype):
 
     # Matrix re-assembly (no zeroing)
     fem.assemble_matrix(A, a)
-    A.finalize()
+    A.scatter_rev()
     assert 4 * normA == pytest.approx(A.squared_norm())
 
 
@@ -166,7 +166,7 @@ def test_basic_assembly_petsc_matrixcsr(mode):
     a = form(inner(u, v) * dx + inner(u, v) * ds)
 
     A0 = fem.assemble_matrix(a)
-    A0.finalize()
+    A0.scatter_rev()
     assert isinstance(A0, la.MatrixCSR)
     A1 = petsc_assemble_matrix(a)
     A1.assemble()
@@ -178,7 +178,7 @@ def test_basic_assembly_petsc_matrixcsr(mode):
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = form(inner(u, v) * dx + inner(u, v) * ds)
     A0 = fem.assemble_matrix(a)
-    A0.finalize()
+    A0.scatter_rev()
     assert isinstance(A0, la.MatrixCSR)
     A1 = petsc_assemble_matrix(a)
     A1.assemble()

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -105,10 +105,10 @@ def test_assemble_derivatives(dtype):
     a = form(derivative(L, u, du), dtype=dtype)
 
     A1 = fem.assemble_matrix(a)
-    A1.scatter_rev()
+    A1.scatter_reverse()
     a = form(c2 * b * inner(du, v) * dx, dtype=dtype)
     A2 = fem.assemble_matrix(a)
-    A2.scatter_rev()
+    A2.scatter_reverse()
     assert np.allclose(A1.data, A2.data)
 
 
@@ -127,7 +127,7 @@ def test_basic_assembly(mode, dtype):
 
     # Initial assembly
     A = fem.assemble_matrix(a)
-    A.scatter_rev()
+    A.scatter_reverse()
     assert isinstance(A, la.MatrixCSR)
     b = fem.assemble_vector(L)
     b.scatter_reverse(la.InsertMode.add)
@@ -137,7 +137,7 @@ def test_basic_assembly(mode, dtype):
     normA = A.squared_norm()
     A.set_value(0)
     A = fem.assemble_matrix(A, a)
-    A.scatter_rev()
+    A.scatter_reverse()
     assert isinstance(A, la.MatrixCSR)
     assert normA == pytest.approx(A.squared_norm())
     normb = b.norm()
@@ -154,7 +154,7 @@ def test_basic_assembly(mode, dtype):
 
     # Matrix re-assembly (no zeroing)
     fem.assemble_matrix(A, a)
-    A.scatter_rev()
+    A.scatter_reverse()
     assert 4 * normA == pytest.approx(A.squared_norm())
 
 
@@ -166,7 +166,7 @@ def test_basic_assembly_petsc_matrixcsr(mode):
     a = form(inner(u, v) * dx + inner(u, v) * ds)
 
     A0 = fem.assemble_matrix(a)
-    A0.scatter_rev()
+    A0.scatter_reverse()
     assert isinstance(A0, la.MatrixCSR)
     A1 = petsc_assemble_matrix(a)
     A1.assemble()
@@ -178,7 +178,7 @@ def test_basic_assembly_petsc_matrixcsr(mode):
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = form(inner(u, v) * dx + inner(u, v) * ds)
     A0 = fem.assemble_matrix(a)
-    A0.scatter_rev()
+    A0.scatter_reverse()
     assert isinstance(A0, la.MatrixCSR)
     A1 = petsc_assemble_matrix(a)
     A1.assemble()

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -80,7 +80,7 @@ def test_overlapping_bcs():
 
     A, b = create_matrix(a), create_vector(L)
     assemble_matrix(A, a, bcs=bcs)
-    A.scatter_rev()
+    A.scatter_reverse()
 
     # Check the diagonal (only on the rank that owns the row)
     As = A.to_scipy(ghosted=True)

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -80,7 +80,7 @@ def test_overlapping_bcs():
 
     A, b = create_matrix(a), create_vector(L)
     assemble_matrix(A, a, bcs=bcs)
-    A.finalize()
+    A.scatter_rev()
 
     # Check the diagonal (only on the rank that owns the row)
     As = A.to_scipy(ghosted=True)

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -105,7 +105,7 @@ def test_numba_assembly():
     L = Form(formtype([V._cpp_object], integrals, [], [], False))
 
     A = dolfinx.fem.assemble_matrix(a)
-    A.finalize()
+    A.scatter_rev()
     b = dolfinx.fem.assemble_vector(L)
     b.scatter_reverse(dolfinx.la.InsertMode.add)
 
@@ -260,7 +260,7 @@ def test_cffi_assembly():
     L = Form(_cpp.fem.Form_float64([V._cpp_object], integrals, [], [], False))
 
     A = fem.assemble_matrix(a)
-    A.finalize()
+    A.scatter_rev()
     assert np.isclose(np.sqrt(A.squared_norm()), 56.124860801609124)
 
     b = fem.assemble_vector(L)

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -105,7 +105,7 @@ def test_numba_assembly():
     L = Form(formtype([V._cpp_object], integrals, [], [], False))
 
     A = dolfinx.fem.assemble_matrix(a)
-    A.scatter_rev()
+    A.scatter_reverse()
     b = dolfinx.fem.assemble_vector(L)
     b.scatter_reverse(dolfinx.la.InsertMode.add)
 
@@ -260,7 +260,7 @@ def test_cffi_assembly():
     L = Form(_cpp.fem.Form_float64([V._cpp_object], integrals, [], [], False))
 
     A = fem.assemble_matrix(a)
-    A.scatter_rev()
+    A.scatter_reverse()
     assert np.isclose(np.sqrt(A.squared_norm()), 56.124860801609124)
 
     b = fem.assemble_vector(L)

--- a/python/test/unit/fem/test_discrete_operators.py
+++ b/python/test/unit/fem/test_discrete_operators.py
@@ -29,7 +29,7 @@ def test_gradient(mesh):
     V = FunctionSpace(mesh, ("Lagrange", 1))
     W = FunctionSpace(mesh, ("Nedelec 1st kind H(curl)", 1))
     G = discrete_gradient(V._cpp_object, W._cpp_object)
-    # N.B. do not finalize G - doing so would transfer rows to other processes
+    # N.B. do not scatter_rev G - doing so would transfer rows to other processes
     # where they will be summed to give an incorrect matrix
 
     num_edges = mesh.topology.index_map(1).size_global
@@ -69,7 +69,7 @@ def test_gradient_interpolation(cell_type, p, q, dtype):
     V = FunctionSpace(mesh, (family0, p))
     W = FunctionSpace(mesh, (family1, q))
     G = discrete_gradient(V._cpp_object, W._cpp_object)
-    # N.B. do not finalize G - doing so would transfer rows to other processes
+    # N.B. do not scatter_rev G - doing so would transfer rows to other processes
     # where they will be summed to give an incorrect matrix
 
     # Vector for 'u' needs additional ghosts defined in columns of G

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -386,7 +386,7 @@ def test_plus_minus_matrix(cell_type, pm1, pm2, dtype):
             # different numberings
             a = form(ufl.inner(u(pm1), v(pm2)) * ufl.dS, dtype=dtype)
             result = assemble_matrix(a, [])
-            result.finalize()
+            result.scatter_rev()
             spaces.append(V)
             results.append(result.to_dense())
             orders.append(order)

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -386,7 +386,7 @@ def test_plus_minus_matrix(cell_type, pm1, pm2, dtype):
             # different numberings
             a = form(ufl.inner(u(pm1), v(pm2)) * ufl.dS, dtype=dtype)
             result = assemble_matrix(a, [])
-            result.scatter_rev()
+            result.scatter_reverse()
             spaces.append(V)
             results.append(result.to_dense())
             orders.append(order)

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -94,7 +94,7 @@ def test_rank1_hdiv(dtype):
     A = fem.create_matrix(a, block_mode=la.BlockMode.expanded)
     As = A.to_scipy(ghosted=True)
     scatter(As, array_evaluated, dofmap_row, dofmap_col)
-    A.scatter_rev()
+    A.scatter_reverse()
 
     gvec = la.vector(A.index_map(1), bs=A.block_size[1], dtype=dtype)
     g = Function(RT1, gvec, name="g", dtype=dtype)

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -94,7 +94,7 @@ def test_rank1_hdiv(dtype):
     A = fem.create_matrix(a, block_mode=la.BlockMode.expanded)
     As = A.to_scipy(ghosted=True)
     scatter(As, array_evaluated, dofmap_row, dofmap_col)
-    A.finalize()
+    A.scatter_rev()
 
     gvec = la.vector(A.index_map(1), bs=A.block_size[1], dtype=dtype)
     g = Function(RT1, gvec, name="g", dtype=dtype)

--- a/python/test/unit/fem/test_ghost_mesh_assembly.py
+++ b/python/test/unit/fem/test_ghost_mesh_assembly.py
@@ -47,7 +47,7 @@ def test_ghost_mesh_assembly(mode, dx, ds):
 
     # Initial assembly
     A = fem.assemble_matrix(a)
-    A.scatter_rev()
+    A.scatter_reverse()
     assert isinstance(A, la.MatrixCSR)
     b = fem.assemble_vector(L)
     b.scatter_reverse(la.InsertMode.add)
@@ -78,7 +78,7 @@ def test_ghost_mesh_dS_assembly(mode, dS):
 
     # Initial assembly
     A = fem.assemble_matrix(a)
-    A.scatter_rev()
+    A.scatter_reverse()
     assert isinstance(A, la.MatrixCSR)
 
     # Check that the norms are the same for all three modes

--- a/python/test/unit/fem/test_ghost_mesh_assembly.py
+++ b/python/test/unit/fem/test_ghost_mesh_assembly.py
@@ -47,7 +47,7 @@ def test_ghost_mesh_assembly(mode, dx, ds):
 
     # Initial assembly
     A = fem.assemble_matrix(a)
-    A.finalize()
+    A.scatter_rev()
     assert isinstance(A, la.MatrixCSR)
     b = fem.assemble_vector(L)
     b.scatter_reverse(la.InsertMode.add)
@@ -78,7 +78,7 @@ def test_ghost_mesh_dS_assembly(mode, dS):
 
     # Initial assembly
     A = fem.assemble_matrix(a)
-    A.finalize()
+    A.scatter_rev()
     assert isinstance(A, la.MatrixCSR)
 
     # Check that the norms are the same for all three modes

--- a/python/test/unit/fem/test_mixed_element.py
+++ b/python/test/unit/fem/test_mixed_element.py
@@ -36,7 +36,7 @@ def test_mixed_element(rank, family, cell, degree):
         a = form(ufl.inner(u, v) * ufl.dx)
 
         A = dolfinx.fem.assemble_matrix(a)
-        A.finalize()
+        A.scatter_rev()
         norms.append(A.squared_norm())
 
         U_el = mixed_element([U_el])
@@ -55,7 +55,7 @@ def test_vector_element():
     v = ufl.TestFunction(U)
     a = form(ufl.inner(u, v) * ufl.dx)
     A = dolfinx.fem.assemble_matrix(a)
-    A.finalize()
+    A.scatter_rev()
 
     with pytest.raises(ValueError):
         # VectorFunctionSpace containing a vector should throw an error
@@ -65,7 +65,7 @@ def test_vector_element():
         v = ufl.TestFunction(U)
         a = form(ufl.inner(u, v) * ufl.dx)
         A = dolfinx.fem.assemble_matrix(a)
-        A.finalize()
+        A.scatter_rev()
 
 
 @pytest.mark.skip_in_parallel
@@ -82,13 +82,13 @@ def test_element_product(d1, d2):
     v = ufl.TestFunction(W)
     a = form(ufl.inner(u[0], v[0]) * ufl.dx)
     A = dolfinx.fem.assemble_matrix(a)
-    A.finalize()
+    A.scatter_rev()
 
     W = FunctionSpace(mesh, P3)
     u = ufl.TrialFunction(W)
     v = ufl.TestFunction(W)
     a = form(ufl.inner(u[0], v[0]) * ufl.dx)
     B = dolfinx.fem.assemble_matrix(a)
-    B.finalize()
+    B.scatter_rev()
 
     assert np.isclose(A.squared_norm(), B.squared_norm())

--- a/python/test/unit/fem/test_mixed_element.py
+++ b/python/test/unit/fem/test_mixed_element.py
@@ -36,7 +36,7 @@ def test_mixed_element(rank, family, cell, degree):
         a = form(ufl.inner(u, v) * ufl.dx)
 
         A = dolfinx.fem.assemble_matrix(a)
-        A.scatter_rev()
+        A.scatter_reverse()
         norms.append(A.squared_norm())
 
         U_el = mixed_element([U_el])
@@ -55,7 +55,7 @@ def test_vector_element():
     v = ufl.TestFunction(U)
     a = form(ufl.inner(u, v) * ufl.dx)
     A = dolfinx.fem.assemble_matrix(a)
-    A.scatter_rev()
+    A.scatter_reverse()
 
     with pytest.raises(ValueError):
         # VectorFunctionSpace containing a vector should throw an error
@@ -65,7 +65,7 @@ def test_vector_element():
         v = ufl.TestFunction(U)
         a = form(ufl.inner(u, v) * ufl.dx)
         A = dolfinx.fem.assemble_matrix(a)
-        A.scatter_rev()
+        A.scatter_reverse()
 
 
 @pytest.mark.skip_in_parallel
@@ -82,13 +82,13 @@ def test_element_product(d1, d2):
     v = ufl.TestFunction(W)
     a = form(ufl.inner(u[0], v[0]) * ufl.dx)
     A = dolfinx.fem.assemble_matrix(a)
-    A.scatter_rev()
+    A.scatter_reverse()
 
     W = FunctionSpace(mesh, P3)
     u = ufl.TrialFunction(W)
     v = ufl.TestFunction(W)
     a = form(ufl.inner(u[0], v[0]) * ufl.dx)
     B = dolfinx.fem.assemble_matrix(a)
-    B.scatter_rev()
+    B.scatter_reverse()
 
     assert np.isclose(A.squared_norm(), B.squared_norm())

--- a/python/test/unit/fem/test_symmetry.py
+++ b/python/test/unit/fem/test_symmetry.py
@@ -37,7 +37,7 @@ def run_symmetry_test(cell_type, e, form_f):
     f = form(form_f(u, v), dtype=dtype)
 
     A = dolfinx.fem.assemble_matrix(f)
-    A.scatter_rev()
+    A.scatter_reverse()
     tol = np.sqrt(np.finfo(dtype).eps)
     check_symmetry(A, tol)
 
@@ -121,7 +121,7 @@ def test_mixed_element_form(cell_type, sign, order, dtype):
     f = form(inner(u, v) * ufl.dx + inner(p, q)(sign) * ufl.dS, dtype=dtype)
 
     A = dolfinx.fem.assemble_matrix(f)
-    A.scatter_rev()
+    A.scatter_reverse()
     tol = np.sqrt(np.finfo(dtype).eps)
     check_symmetry(A, tol)
 
@@ -147,7 +147,7 @@ def test_mixed_element_vector_element_form(cell_type, sign, order, dtype):
     f = form(inner(u, v) * ufl.dx + inner(p, q)(sign) * ufl.dS, dtype=dtype)
 
     A = dolfinx.fem.assemble_matrix(f)
-    A.scatter_rev()
+    A.scatter_reverse()
 
     tol = np.sqrt(np.finfo(dtype).eps)
     check_symmetry(A, tol)

--- a/python/test/unit/fem/test_symmetry.py
+++ b/python/test/unit/fem/test_symmetry.py
@@ -37,7 +37,7 @@ def run_symmetry_test(cell_type, e, form_f):
     f = form(form_f(u, v), dtype=dtype)
 
     A = dolfinx.fem.assemble_matrix(f)
-    A.finalize()
+    A.scatter_rev()
     tol = np.sqrt(np.finfo(dtype).eps)
     check_symmetry(A, tol)
 
@@ -121,7 +121,7 @@ def test_mixed_element_form(cell_type, sign, order, dtype):
     f = form(inner(u, v) * ufl.dx + inner(p, q)(sign) * ufl.dS, dtype=dtype)
 
     A = dolfinx.fem.assemble_matrix(f)
-    A.finalize()
+    A.scatter_rev()
     tol = np.sqrt(np.finfo(dtype).eps)
     check_symmetry(A, tol)
 
@@ -147,7 +147,7 @@ def test_mixed_element_vector_element_form(cell_type, sign, order, dtype):
     f = form(inner(u, v) * ufl.dx + inner(p, q)(sign) * ufl.dS, dtype=dtype)
 
     A = dolfinx.fem.assemble_matrix(f)
-    A.finalize()
+    A.scatter_rev()
 
     tol = np.sqrt(np.finfo(dtype).eps)
     check_symmetry(A, tol)

--- a/python/test/unit/fem/test_vector_assemble.py
+++ b/python/test/unit/fem/test_vector_assemble.py
@@ -19,7 +19,7 @@ def test_vector_assemble_matrix_exterior():
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = form(ufl.inner(u, v) * ufl.ds)
     A = assemble_matrix(a)
-    A.finalize()
+    A.scatter_rev()
 
 
 def test_vector_assemble_matrix_interior():
@@ -28,4 +28,4 @@ def test_vector_assemble_matrix_interior():
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = form(ufl.inner(ufl.jump(u), ufl.jump(v)) * ufl.dS)
     A = assemble_matrix(a)
-    A.finalize()
+    A.scatter_rev()

--- a/python/test/unit/fem/test_vector_assemble.py
+++ b/python/test/unit/fem/test_vector_assemble.py
@@ -19,7 +19,7 @@ def test_vector_assemble_matrix_exterior():
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = form(ufl.inner(u, v) * ufl.ds)
     A = assemble_matrix(a)
-    A.scatter_rev()
+    A.scatter_reverse()
 
 
 def test_vector_assemble_matrix_interior():
@@ -28,4 +28,4 @@ def test_vector_assemble_matrix_interior():
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = form(ufl.inner(ufl.jump(u), ufl.jump(v)) * ufl.dS)
     A = assemble_matrix(a)
-    A.scatter_rev()
+    A.scatter_reverse()

--- a/python/test/unit/la/test_matrix_csr.py
+++ b/python/test/unit/la/test_matrix_csr.py
@@ -140,7 +140,7 @@ def test_distributed_csr(dtype):
     data = np.ones(len(irow) * len(icol), dtype=dtype)
     mat.add(data, irow, icol, 1)
     pre_final_sum = mat.data.sum()
-    mat.finalize()
+    mat.scatter_rev()
     assert np.isclose(mat.data.sum(), pre_final_sum)
 
 
@@ -182,9 +182,9 @@ def test_set_diagonal_distributed(dtype):
     reference = np.full_like(diag, value, dtype=dtype)
     assert np.allclose(diag, reference)
 
-    # Finalize matrix: this will remove ghost rows and diagonal values of
+    # Update matrix: this will remove ghost rows and diagonal values of
     # ghost rows will be added to diagonal of corresponding process
-    A.finalize()
+    A.scatter_rev()
 
     diag = As.diagonal()
     nlocal = index_map.size_local
@@ -210,9 +210,9 @@ def test_set_diagonal_distributed(dtype):
     assert np.allclose(diag[:nlocal], reference[:nlocal])
     assert np.allclose(diag[nlocal:], np.zeros_like(diag[nlocal:]))
 
-    # Finalize matrix:
+    # Update matrix:
     # this will zero ghost rows and diagonal values are already zero.
-    A.finalize()
+    A.scatter_rev()
     assert (As.diagonal()[nlocal:] == dtype(0.)).all()
     assert (As.diagonal()[:nlocal] == dtype(1.)).all()
 

--- a/python/test/unit/la/test_matrix_csr.py
+++ b/python/test/unit/la/test_matrix_csr.py
@@ -140,7 +140,7 @@ def test_distributed_csr(dtype):
     data = np.ones(len(irow) * len(icol), dtype=dtype)
     mat.add(data, irow, icol, 1)
     pre_final_sum = mat.data.sum()
-    mat.scatter_rev()
+    mat.scatter_reverse()
     assert np.isclose(mat.data.sum(), pre_final_sum)
 
 
@@ -184,7 +184,7 @@ def test_set_diagonal_distributed(dtype):
 
     # Update matrix: this will remove ghost rows and diagonal values of
     # ghost rows will be added to diagonal of corresponding process
-    A.scatter_rev()
+    A.scatter_reverse()
 
     diag = As.diagonal()
     nlocal = index_map.size_local
@@ -212,7 +212,7 @@ def test_set_diagonal_distributed(dtype):
 
     # Update matrix:
     # this will zero ghost rows and diagonal values are already zero.
-    A.scatter_rev()
+    A.scatter_reverse()
     assert (As.diagonal()[nlocal:] == dtype(0.)).all()
     assert (As.diagonal()[:nlocal] == dtype(1.)).all()
 


### PR DESCRIPTION
Rename matrix csr finalize to scatter_rev.

Fixes #2710.