### PR TITLE
Fix LaTeX text formatting issue

### DIFF
--- a/python/demo/demo_biharmonic.py
+++ b/python/demo/demo_biharmonic.py
@@ -65,10 +65,8 @@
 # and considering the boundary conditions
 #
 # $$
-# \begin{align}
 # u &= 0 \quad {\rm on} \ \partial\Omega, \\
 # \nabla^{2} u &= 0 \quad {\rm on} \ \partial\Omega,
-# \end{align}
 # $$
 #
 # a weak formulation of the biharmonic problem reads: find $u \in V$ such that

--- a/python/demo/demo_cahn-hilliard.py
+++ b/python/demo/demo_cahn-hilliard.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.13.6
+#       jupytext_version: 1.15.1
 # ---
 
 # # Cahn-Hilliard equation
@@ -22,7 +22,8 @@
 #   ({py:class}`NewtonSolver<dolfinx.nls.petsc.NewtonSolver>`)
 # - Form compiler options
 # - Interpolation of functions
-# - Visualisation of a running simulation with pyvista
+# - Visualisation of a running simulation with
+#   [PyVista](https://pyvista.org/)
 #
 # This demo is implemented in {download}`demo_cahn-hilliard.py`.
 #
@@ -34,7 +35,6 @@
 # derivatives.  The equation reads:
 #
 # $$
-# \begin{align}
 # \frac{\partial c}{\partial t} -
 #   \nabla \cdot M \left(\nabla\left(\frac{d f}{dc}
 #   - \lambda \nabla^{2}c\right)\right) &= 0 \quad {\rm in} \ \Omega, \\
@@ -42,7 +42,6 @@
 #   \lambda \nabla^{2}c\right)\right) \cdot n
 #   &= 0 \quad {\rm on} \ \partial\Omega, \\
 # M \lambda \nabla c \cdot n &= 0 \quad {\rm on} \ \partial\Omega.
-# \end{align}
 # $$
 #
 # where $c$ is the unknown field, the function $f$ is usually non-convex
@@ -58,25 +57,21 @@
 # as two coupled second-order equations:
 #
 # $$
-# \begin{align}
 # \frac{\partial c}{\partial t} - \nabla \cdot M \nabla\mu
 #     &= 0 \quad {\rm in} \ \Omega, \\
 # \mu -  \frac{d f}{d c} + \lambda \nabla^{2}c &= 0 \quad {\rm in} \ \Omega.
-# \end{align}
 # $$
 #
 # The unknown fields are now $c$ and $\mu$. The weak (variational) form
 # of the problem reads: find $(c, \mu) \in V \times V$ such that
 #
 # $$
-# \begin{align}
 # \int_{\Omega} \frac{\partial c}{\partial t} q \, {\rm d} x +
 #     \int_{\Omega} M \nabla\mu \cdot \nabla q \, {\rm d} x
 #     &= 0 \quad \forall \ q \in V,  \\
 # \int_{\Omega} \mu v \, {\rm d} x - \int_{\Omega} \frac{d f}{d c} v \, {\rm d} x
 #   - \int_{\Omega} \lambda \nabla c \cdot \nabla v \, {\rm d} x
 #    &= 0 \quad \forall \ v \in V.
-# \end{align}
 # $$
 #
 # ### Time discretisation
@@ -86,19 +81,17 @@
 # equation:
 #
 # $$
-# \begin{align}
 # \int_{\Omega} \frac{c_{n+1} - c_{n}}{dt} q \, {\rm d} x
 # + \int_{\Omega} M \nabla \mu_{n+\theta} \cdot \nabla q \, {\rm d} x
 #        &= 0 \quad \forall \ q \in V  \\
 # \int_{\Omega} \mu_{n+1} v  \, {\rm d} x - \int_{\Omega} \frac{d f_{n+1}}{d c} v  \, {\rm d} x
 # - \int_{\Omega} \lambda \nabla c_{n+1} \cdot \nabla v \, {\rm d} x
 #        &= 0 \quad \forall \ v \in V
-# \end{align}
 # $$
 #
-# where $dt = t_{n+1} - t_{n}$ and $\mu_{n+\theta} = (1-\theta) \mu_{n}
-# + \theta \mu_{n+1}$.  The task is: given $c_{n}$ and $\mu_{n}$, solve
-# the above equation to find $c_{n+1}$ and $\mu_{n+1}$.
+# where $dt = t_{n+1} - t_{n}$ and $\mu_{n+\theta} = (1-\theta) \mu_{n} + \theta \mu_{n+1}$.
+# The task is: given $c_{n}$ and $\mu_{n}$, solve the above equation to
+# find $c_{n+1}$ and $\mu_{n+1}$.
 #
 # ### Demo parameters
 #

--- a/python/demo/demo_pml/demo_pml.py
+++ b/python/demo/demo_pml/demo_pml.py
@@ -114,10 +114,10 @@ def curl_2d(a: fem.Function):
 # waves impinging them. Mathematically, we can use a complex coordinate
 # transformation of this kind to obtain this absorption:
 #
-# \begin{align}
-# & x^\prime= x\left\{1+j\frac{\alpha}{k_0}\left[\frac{|x|-l_{dom}/2}
-# {(l_{pml}/2 - l_{dom}/2)^2}\right] \right\}\\
-# \end{align}
+# $$
+# x^\prime= x\left\{1+j\frac{\alpha}{k_0}\left[\frac{|x|-l_{dom}/2}
+# {(l_{pml}/2 - l_{dom}/2)^2}\right] \right\}
+# $$
 #
 # with $l_{dom}$ and $l_{pml}$ being the lengths of the domain without
 # and with PML, respectively, and with $\alpha$ being a parameter that
@@ -207,13 +207,13 @@ if have_pyvista:
 # different PML regions have different coordinate transformation, as
 # specified here below:
 #
-# \begin{align}
+# $$
 # \text{PML}_\text{corners} \rightarrow \mathbf{r}^\prime & = (x^\prime, y^\prime) \\
 # \text{PML}_\text{rectangles along x} \rightarrow
 #                                       \mathbf{r}^\prime & = (x^\prime, y) \\
 # \text{PML}_\text{rectangles along y} \rightarrow
 #                                       \mathbf{r}^\prime & = (x, y^\prime).
-# \end{align}
+# $$
 #
 # Now we define some other problem specific parameters:
 

--- a/python/demo/demo_pml/efficiencies_pml_demo.py
+++ b/python/demo/demo_pml/efficiencies_pml_demo.py
@@ -57,13 +57,11 @@
 # efficiencies as:
 #
 # $$
-# \begin{align}
 # & q_{\mathrm{sca}}=(2 / \alpha)\left[\left|a_0\right|^{2}
 # +2 \sum_{\nu=1}^{\infty}\left|a_\nu\right|^{2}\right] \\
 # & q_{\mathrm{ext}}=(2 / \alpha) \operatorname{Re}\left[ a_0
 # +2 \sum_{\nu=1}^{\infty} a_\nu\right] \\
 # & q_{\mathrm{abs}} = q_{\mathrm{ext}} - q_{\mathrm{sca}}
-# \end{align}
 # $$
 
 from typing import Tuple

--- a/python/demo/demo_poisson.py
+++ b/python/demo/demo_poisson.py
@@ -24,11 +24,9 @@
 # particular boundary conditions reads:
 #
 # $$
-# \begin{align}
 # - \nabla^{2} u &= f \quad {\rm in} \ \Omega, \\
 # u &= 0 \quad {\rm on} \ \Gamma_{D}, \\
 # \nabla u \cdot n &= g \quad {\rm on} \ \Gamma_{N}. \\
-# \end{align}
 # $$
 #
 # where $f$ and $g$ are input data and $n$ denotes the outward directed
@@ -42,10 +40,8 @@
 # where $V$ is a suitable function space and
 #
 # $$
-# \begin{align}
 # a(u, v) &:= \int_{\Omega} \nabla u \cdot \nabla v \, {\rm d} x, \\
 # L(v)    &:= \int_{\Omega} f v \, {\rm d} x + \int_{\Gamma_{N}} g v \, {\rm d} s.
-# \end{align}
 # $$
 #
 # The expression $a(u, v)$ is the bilinear form and $L(v)$

--- a/python/demo/demo_scattering_boundary_conditions/analytical_efficiencies_wire.py
+++ b/python/demo/demo_scattering_boundary_conditions/analytical_efficiencies_wire.py
@@ -57,13 +57,11 @@
 # efficiencies as:
 #
 # $$
-# \begin{align}
 # & q_{\mathrm{sca}}=(2 / \alpha)\left[\left|a_0\right|^{2}
 # +2 \sum_{\nu=1}^{\infty}\left|a_\nu\right|^{2}\right] \\
 # & q_{\mathrm{ext}}=(2 / \alpha) \operatorname{Re}\left[ a_0
 # +2 \sum_{\nu=1}^{\infty} a_\nu\right] \\
 # & q_{\mathrm{abs}} = q_{\mathrm{ext}} - q_{\mathrm{sca}}
-# \end{align}
 # $$
 
 from typing import Tuple

--- a/python/demo/demo_scattering_boundary_conditions/demo_scattering_boundary_conditions.py
+++ b/python/demo/demo_scattering_boundary_conditions/demo_scattering_boundary_conditions.py
@@ -329,7 +329,6 @@ eps.x.scatter_forward()
 # integrate the terms over the corresponding domains:
 #
 # $$
-# \begin{align}
 # & \int_{\Omega}-\nabla \times( \nabla \times \mathbf{E}_s) \cdot
 # \bar{\mathbf{v}}+\varepsilon_{r} k_{0}^{2} \mathbf{E}_s \cdot
 # \bar{\mathbf{v}}+k_{0}^{2}\left(\varepsilon_{r}-\varepsilon_b\right)
@@ -337,7 +336,6 @@ eps.x.scatter_forward()
 # (\mathbf{n} \times \nabla \times \mathbf{E}_s) \cdot \bar{\mathbf{v}}
 # +\left(j n_bk_{0}+\frac{1}{2r}\right) (\mathbf{n} \times \mathbf{E}_s
 # \times \mathbf{n}) \cdot \bar{\mathbf{v}}~\mathrm{d}s=0
-# \end{align}.
 # $$
 #
 # By using $(\nabla \times \mathbf{A}) \cdot \mathbf{B}=\mathbf{A}
@@ -345,7 +343,6 @@ eps.x.scatter_forward()
 # \mathbf{B}),$ we can change the first term into:
 #
 # $$
-# \begin{align}
 # & \int_{\Omega}-\nabla \cdot(\nabla\times\mathbf{E}_s \times
 # \bar{\mathbf{v}})-\nabla \times \mathbf{E}_s \cdot \nabla
 # \times\bar{\mathbf{v}}+\varepsilon_{r} k_{0}^{2} \mathbf{E}_s
@@ -354,7 +351,6 @@ eps.x.scatter_forward()
 # (\mathbf{n} \times \nabla \times \mathbf{E}_s) \cdot \bar{\mathbf{v}}
 # +\left(j n_bk_{0}+\frac{1}{2r}\right) (\mathbf{n} \times \mathbf{E}_s
 # \times \mathbf{n}) \cdot \bar{\mathbf{v}}~\mathrm{d}s=0,
-# \end{align}
 # $$
 #
 # using the divergence theorem
@@ -362,7 +358,6 @@ eps.x.scatter_forward()
 # \mathbf{F}\cdot\mathbf{n}~\mathrm{d}s$, we can write:
 #
 # $$
-# \begin{align}
 # & \int_{\Omega}-(\nabla \times \mathbf{E}_s) \cdot (\nabla \times
 # \bar{\mathbf{v}})+\varepsilon_{r} k_{0}^{2} \mathbf{E}_s \cdot
 # \bar{\mathbf{v}}+k_{0}^{2}\left(\varepsilon_{r}-\varepsilon_b\right)
@@ -371,7 +366,6 @@ eps.x.scatter_forward()
 # + (\mathbf{n} \times \nabla \times \mathbf{E}_s) \cdot \bar{\mathbf{v}}
 # +\left(j n_bk_{0}+\frac{1}{2r}\right) (\mathbf{n} \times \mathbf{E}_s
 # \times \mathbf{n}) \cdot \bar{\mathbf{v}}~\mathrm{d}s=0.
-# \end{align}
 # $$
 #
 # Cancelling $-(\nabla\times\mathbf{E}_s \times \bar{\mathbf{V}})
@@ -381,14 +375,12 @@ eps.x.scatter_forward()
 # \mathbf{A})=\mathbf{C} \cdot(\mathbf{A} \times \mathbf{B})$, we get:
 #
 # $$
-# \begin{align}
 # & \int_{\Omega}-(\nabla \times \mathbf{E}_s) \cdot (\nabla \times
 # \bar{\mathbf{v}})+\varepsilon_{r} k_{0}^{2} \mathbf{E}_s \cdot
 # \bar{\mathbf{v}}+k_{0}^{2}\left(\varepsilon_{r}-\varepsilon_b\right)
 # \mathbf{E}_b \cdot \bar{\mathbf{v}}~\mathrm{d}x \\ +&\int_{\partial \Omega}
 # \left(j n_bk_{0}+\frac{1}{2r}\right)( \mathbf{n} \times \mathbf{E}_s \times
 # \mathbf{n}) \cdot \bar{\mathbf{v}} ~\mathrm{d} s = 0.
-# \end{align}
 # $$
 #
 # We use the [UFL](https://github.com/FEniCS/ufl/) to implement the

--- a/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
+++ b/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
@@ -113,11 +113,9 @@ eps.x.array[cells_v] = np.full_like(cells_v, eps_v, dtype=default_scalar_type)
 # waveguide wall:
 #
 # $$
-# \begin{align}
 # &\nabla \times \frac{1}{\mu_{r}} \nabla \times \mathbf{E}-k_{o}^{2}
 # \epsilon_{r} \mathbf{E}=0 \quad &\text { in } \Omega\\
 # &\hat{n}\times\mathbf{E} = 0 &\text { on } \Gamma
-# \end{align}
 # $$
 #
 # with $k_0$ and $\lambda_0 = 2\pi/k_0$ being the wavevector and the
@@ -140,10 +138,8 @@ eps.x.array[cells_v] = np.full_like(cells_v, eps_v, dtype=default_scalar_type)
 # the following substitution:
 #
 # $$
-# \begin{align}
 # & \mathbf{e}_t = k_z\mathbf{E}_t\\
 # & e_z = -jE_z
-# \end{align}
 # $$
 #
 # The final weak form can be written as:


### PR DESCRIPTION
Line break of inline equation breaks jupytertext formatting. Put equation on one line.

Fixes #2752.