### PR TITLE
Remove "create" prefix from some functions

### DIFF
--- a/python/demo/demo_axis/demo_axis.py
+++ b/python/demo/demo_axis/demo_axis.py
@@ -349,7 +349,7 @@ MPI.COMM_WORLD.barrier()
 # Visually check of the mesh and of the subdomains using PyVista:
 
 if have_pyvista:
-    topology, cell_types, geometry = plot.create_vtk_mesh(msh, 2)
+    topology, cell_types, geometry = plot.vtk_mesh(msh, 2)
     grid = pyvista.UnstructuredGrid(topology, cell_types, geometry)
     plotter = pyvista.Plotter()
     num_local_cells = msh.topology.index_map(msh.topology.dim).size_local

--- a/python/demo/demo_biharmonic.py
+++ b/python/demo/demo_biharmonic.py
@@ -231,7 +231,7 @@ with io.XDMFFile(msh.comm, "out_biharmonic/biharmonic.xdmf", "w") as file:
 # +
 try:
     import pyvista
-    cells, types, x = plot.create_vtk_mesh(V)
+    cells, types, x = plot.vtk_mesh(V)
     grid = pyvista.UnstructuredGrid(cells, types, x)
     grid.point_data["u"] = uh.x.array.real
     grid.set_active_scalars("u")

--- a/python/demo/demo_cahn-hilliard.py
+++ b/python/demo/demo_cahn-hilliard.py
@@ -289,7 +289,7 @@ V0, dofs = ME.sub(0).collapse()
 # Prepare viewer for plotting the solution during the computation
 if have_pyvista:
     # Create a VTK 'mesh' with 'nodes' at the function dofs
-    topology, cell_types, x = plot.create_vtk_mesh(V0)
+    topology, cell_types, x = plot.vtk_mesh(V0)
     grid = pv.UnstructuredGrid(topology, cell_types, x)
 
     # Set output data

--- a/python/demo/demo_interpolation-io.py
+++ b/python/demo/demo_interpolation-io.py
@@ -75,7 +75,7 @@ except ImportError:
 
 try:
     import pyvista
-    cells, types, x = plot.create_vtk_mesh(V0)
+    cells, types, x = plot.vtk_mesh(V0)
     grid = pyvista.UnstructuredGrid(cells, types, x)
     values = np.zeros((x.shape[0], 3), dtype=np.float64)
     values[:, :msh.topology.dim] = u0.x.array.reshape(x.shape[0], msh.topology.dim).real

--- a/python/demo/demo_pml/demo_pml.py
+++ b/python/demo/demo_pml/demo_pml.py
@@ -186,7 +186,7 @@ MPI.COMM_WORLD.barrier()
 # [PyVista](https://docs.pyvista.org/)
 
 if have_pyvista:
-    topology, cell_types, geometry = plot.create_vtk_mesh(msh, 2)
+    topology, cell_types, geometry = plot.vtk_mesh(msh, 2)
     grid = pyvista.UnstructuredGrid(topology, cell_types, geometry)
     plotter = pyvista.Plotter()
     num_local_cells = msh.topology.index_map(msh.topology.dim).size_local
@@ -434,7 +434,7 @@ with VTXWriter(msh.comm, "Esh.bp", Esh_dg) as vtx:
 # DOLFINx demo.
 
 if have_pyvista:
-    V_cells, V_types, V_x = plot.create_vtk_mesh(V_dg)
+    V_cells, V_types, V_x = plot.vtk_mesh(V_dg)
     V_grid = pyvista.UnstructuredGrid(V_cells, V_types, V_x)
     Esh_values = np.zeros((V_x.shape[0], 3), dtype=np.float64)
     Esh_values[:, :msh.topology.dim] = Esh_dg.x.array.reshape(V_x.shape[0], msh.topology.dim).real

--- a/python/demo/demo_poisson.py
+++ b/python/demo/demo_poisson.py
@@ -152,7 +152,7 @@ with io.XDMFFile(msh.comm, "out_poisson/poisson.xdmf", "w") as file:
 # +
 try:
     import pyvista
-    cells, types, x = plot.create_vtk_mesh(V)
+    cells, types, x = plot.vtk_mesh(V)
     grid = pyvista.UnstructuredGrid(cells, types, x)
     grid.point_data["u"] = uh.x.array.real
     grid.set_active_scalars("u")

--- a/python/demo/demo_pyvista.py
+++ b/python/demo/demo_pyvista.py
@@ -61,7 +61,7 @@ def plot_scalar():
 
     # To visualize the function u, we create a VTK-compatible grid to
     # values of u to
-    cells, types, x = plot.create_vtk_mesh(V)
+    cells, types, x = plot.vtk_mesh(V)
     grid = pyvista.UnstructuredGrid(cells, types, x)
     grid.point_data["u"] = u.x.array
 
@@ -112,7 +112,7 @@ def plot_meshtags():
     cell_tags = meshtags(msh, msh.topology.dim, np.arange(num_cells), in_circle(midpoints))
 
     # Create VTK mesh
-    cells, types, x = plot.create_vtk_mesh(msh)
+    cells, types, x = plot.vtk_mesh(msh)
     grid = pyvista.UnstructuredGrid(cells, types, x)
 
     # Attach the cells tag data to the pyvita grid
@@ -130,7 +130,7 @@ def plot_meshtags():
     # We can visualize subsets of data, by creating a smaller topology
     # (set of cells). Here we create VTK mesh data for only cells with
     # that tag '1'.
-    cells, types, x = plot.create_vtk_mesh(msh, entities=cell_tags.find(1))
+    cells, types, x = plot.vtk_mesh(msh, entities=cell_tags.find(1))
 
     # Add this grid to the second plotter window
     sub_grid = pyvista.UnstructuredGrid(cells, types, x)
@@ -175,7 +175,7 @@ def plot_higher_order():
 
     # Create a topology that has a 1-1 correspondence with the
     # degrees-of-freedom in the function space V
-    cells, types, x = plot.create_vtk_mesh(V)
+    cells, types, x = plot.vtk_mesh(V)
 
     # Create a pyvista mesh and attach the values of u
     grid = pyvista.UnstructuredGrid(cells, types, x)
@@ -186,7 +186,7 @@ def plot_higher_order():
     # that as we have done previously
     num_cells = msh.topology.index_map(msh.topology.dim).size_local
     cell_entities = np.arange(num_cells, dtype=np.int32)
-    cells, types, x = plot.create_vtk_mesh(msh, entities=cell_entities)
+    cells, types, x = plot.vtk_mesh(msh, entities=cell_entities)
     org_grid = pyvista.UnstructuredGrid(cells, types, x)
 
     # We visualize the data
@@ -220,7 +220,7 @@ def plot_nedelec():
                      position="upper_edge", font_size=14, color="black")
 
     # Next, we create a pyvista.UnstructuredGrid based on the mesh
-    pyvista_cells, cell_types, x = plot.create_vtk_mesh(msh)
+    pyvista_cells, cell_types, x = plot.vtk_mesh(msh)
     grid = pyvista.UnstructuredGrid(pyvista_cells, cell_types, x)
 
     # Add this grid (as a wireframe) to the plotter
@@ -242,7 +242,7 @@ def plot_nedelec():
 
     # Create a second grid, whose geometry and topology is based on the
     # output function space
-    cells, cell_types, x = plot.create_vtk_mesh(V0)
+    cells, cell_types, x = plot.vtk_mesh(V0)
     grid = pyvista.UnstructuredGrid(cells, cell_types, x)
 
     # Create point cloud of vertices, and add the vertex values to the cloud
@@ -271,7 +271,7 @@ def plot_streamlines():
     u = Function(V, dtype=np.float64)
     u.interpolate(lambda x: np.vstack((-(x[1] - 0.5), x[0] - 0.5, np.zeros(x.shape[1]))))
 
-    cells, types, x = plot.create_vtk_mesh(V)
+    cells, types, x = plot.vtk_mesh(V)
     num_dofs = x.shape[0]
     values = np.zeros((num_dofs, 3), dtype=np.float64)
     values[:, :msh.geometry.dim] = u.x.array.reshape(num_dofs, V.dofmap.index_map_bs)

--- a/python/demo/demo_scattering_boundary_conditions/demo_scattering_boundary_conditions.py
+++ b/python/demo/demo_scattering_boundary_conditions/demo_scattering_boundary_conditions.py
@@ -243,7 +243,7 @@ MPI.COMM_WORLD.barrier()
 # The mesh is visualized with [PyVista](https://docs.pyvista.org/)
 
 if have_pyvista:
-    topology, cell_types, geometry = plot.create_vtk_mesh(domain, 2)
+    topology, cell_types, geometry = plot.vtk_mesh(domain, 2)
     grid = pyvista.UnstructuredGrid(topology, cell_types, geometry)
     plotter = pyvista.Plotter()
     num_local_cells = domain.topology.index_map(domain.topology.dim).size_local
@@ -423,7 +423,7 @@ with io.VTXWriter(domain.comm, "Esh.bp", Esh_dg) as vtx:
 # DOLFINx demo.
 
 if have_pyvista:
-    V_cells, V_types, V_x = plot.create_vtk_mesh(V_dg)
+    V_cells, V_types, V_x = plot.vtk_mesh(V_dg)
     V_grid = pyvista.UnstructuredGrid(V_cells, V_types, V_x)
     Esh_values = np.zeros((V_x.shape[0], 3), dtype=np.float64)
     Esh_values[:, : domain.topology.dim] = Esh_dg.x.array.reshape(V_x.shape[0], domain.topology.dim).real

--- a/python/demo/demo_types.py
+++ b/python/demo/demo_types.py
@@ -46,7 +46,7 @@ def display_scalar(u, name, filter=np.real):
     """Plot the solution using pyvista"""
     try:
         import pyvista
-        cells, types, x = plot.create_vtk_mesh(u.function_space)
+        cells, types, x = plot.vtk_mesh(u.function_space)
         grid = pyvista.UnstructuredGrid(cells, types, x)
         grid.point_data["u"] = filter(u.x.array)
         grid.set_active_scalars("u")
@@ -68,7 +68,7 @@ def display_vector(u, name, filter=np.real):
     try:
         import pyvista
         V = u.function_space
-        cells, types, x = plot.create_vtk_mesh(V)
+        cells, types, x = plot.vtk_mesh(V)
         grid = pyvista.UnstructuredGrid(cells, types, x)
         grid.point_data["u"] = filter(np.insert(u.x.array.reshape(x.shape[0], V.dofmap.index_map_bs), 2, 0, axis=1))
         plotter = pyvista.Plotter()

--- a/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
+++ b/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
@@ -375,7 +375,7 @@ for i, kz in vals:
 
         # Visualize solutions with Pyvista
         if have_pyvista:
-            V_cells, V_types, V_x = plot.create_vtk_mesh(V_dg)
+            V_cells, V_types, V_x = plot.vtk_mesh(V_dg)
             V_grid = pyvista.UnstructuredGrid(V_cells, V_types, V_x)
             Et_values = np.zeros((V_x.shape[0], 3), dtype=np.float64)
             Et_values[:, : msh.topology.dim] = Et_dg.x.array.reshape(V_x.shape[0], msh.topology.dim).real
@@ -394,7 +394,7 @@ for i, kz in vals:
 
         if have_pyvista:
             V_lagr, lagr_dofs = V.sub(1).collapse()
-            V_cells, V_types, V_x = plot.create_vtk_mesh(V_lagr)
+            V_cells, V_types, V_x = plot.vtk_mesh(V_lagr)
             V_grid = pyvista.UnstructuredGrid(V_cells, V_types, V_x)
             V_grid.point_data["u"] = ezh.x.array.real[lagr_dofs]
             plotter = pyvista.Plotter()

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -170,7 +170,7 @@ class Expression:
         else:
             raise RuntimeError("Expressions with more that one Argument not allowed.")
 
-        def create_expression(dtype):
+        def _create_expression(dtype):
             if dtype == np.float32:
                 return _cpp.fem.create_expression_float32
             elif dtype == np.float64:
@@ -183,8 +183,8 @@ class Expression:
                 raise NotImplementedError(f"Type {dtype} not supported.")
 
         ffi = module.ffi
-        self._cpp_object = create_expression(dtype)(ffi.cast("uintptr_t", ffi.addressof(self._ufcx_expression)),
-                                                    coeffs, constants, self.argument_function_space)
+        self._cpp_object = _create_expression(dtype)(ffi.cast("uintptr_t", ffi.addressof(self._ufcx_expression)),
+                                                     coeffs, constants, self.argument_function_space)
 
     def eval(self, mesh: Mesh, cells: np.ndarray, values: typing.Optional[np.ndarray] = None) -> np.ndarray:
         """Evaluate Expression in cells.

--- a/python/dolfinx/graph.py
+++ b/python/dolfinx/graph.py
@@ -31,10 +31,10 @@ except ImportError:
     pass
 
 
-__all__ = ["create_adjacencylist", "partitioner"]
+__all__ = ["adjacencylist", "partitioner"]
 
 
-def create_adjacencylist(data: np.ndarray, offsets=None):
+def adjacencylist(data: np.ndarray, offsets=None):
     """Create an AdjacencyList for int32 or int64 datasets.
 
     Args:

--- a/python/dolfinx/plot.py
+++ b/python/dolfinx/plot.py
@@ -89,7 +89,7 @@ def vtk_mesh(msh: mesh.Mesh, dim: typing.Optional[int] = None, entities=None):
 
 
 @vtk_mesh.register(fem.FunctionSpaceBase)
-def _(V: fem.FunctionSpace, entities=None):
+def _(V: fem.FunctionSpaceBase, entities=None):
     """Creates a VTK mesh topology (topology array and array of cell
     types) that is based on the degree-of-freedom coordinates.
 

--- a/python/dolfinx/plot.py
+++ b/python/dolfinx/plot.py
@@ -30,7 +30,7 @@ _first_order_vtk = {mesh.CellType.interval: 3,
 
 
 @functools.singledispatch
-def create_vtk_mesh(msh: mesh.Mesh, dim: typing.Optional[int] = None, entities=None):
+def vtk_mesh(msh: mesh.Mesh, dim: typing.Optional[int] = None, entities=None):
     """Create vtk mesh topology data for mesh entities of a given
     dimension. The vertex indices in the returned topology array are the
     indices for the associated entry in the mesh geometry.
@@ -88,7 +88,7 @@ def create_vtk_mesh(msh: mesh.Mesh, dim: typing.Optional[int] = None, entities=N
     return topology.reshape(-1), cell_types, msh.geometry.x
 
 
-@create_vtk_mesh.register(fem.FunctionSpace)
+@vtk_mesh.register(fem.FunctionSpace)
 def _(V: fem.FunctionSpace, entities=None):
     """Creates a VTK mesh topology (topology array and array of cell
     types) that is based on the degree-of-freedom coordinates.

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -948,16 +948,16 @@ def test_assemble_empty_rank_mesh():
     def partitioner(comm, nparts, local_graph, num_ghost_nodes):
         """Leave cells on the curent rank"""
         dest = np.full(len(cells), comm.rank, dtype=np.int32)
-        return graph.create_adjacencylist(dest)
+        return graph.adjacencylist(dest)
 
     if comm.rank == 0:
         # Put cells on rank 0
         cells = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int64)
-        cells = graph.create_adjacencylist(cells)
+        cells = graph.adjacencylist(cells)
         x = np.array([[0., 0.], [1., 0.], [1., 1.], [0., 1.]], dtype=default_real_type)
     else:
         # No cells on other ranks
-        cells = graph.create_adjacencylist(np.empty((0, 3), dtype=np.int64))
+        cells = graph.adjacencylist(np.empty((0, 3), dtype=np.int64))
         x = np.empty((0, 2), dtype=default_real_type)
 
     mesh = create_mesh(comm, cells, x, domain, partitioner)

--- a/python/test/unit/graph/test_adjacencylist.py
+++ b/python/test/unit/graph/test_adjacencylist.py
@@ -7,12 +7,12 @@
 import numpy as np
 import pytest
 
-from dolfinx.graph import create_adjacencylist
+from dolfinx.graph import adjacencylist
 
 
 @pytest.mark.parametrize("dtype", [np.int32, np.int64])
 def test_create_adj2d(dtype):
     data = np.zeros([2, 4], dtype=dtype)
-    adj = create_adjacencylist(data)
+    adj = adjacencylist(data)
     num_nodes, num_links = data.shape[0], data.shape[1]
     assert np.array_equal(adj.offsets, np.arange(0, num_nodes * num_links + num_links, num_links, dtype=np.int32))

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -12,7 +12,7 @@ import ufl
 from basix.ufl import element
 from dolfinx.common import has_adios2
 from dolfinx.fem import Function, FunctionSpace, VectorFunctionSpace
-from dolfinx.graph import create_adjacencylist
+from dolfinx.graph import adjacencylist
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
                           create_unit_square)
 from mpi4py import MPI
@@ -268,14 +268,14 @@ def test_empty_rank_mesh(tempdir):
     def partitioner(comm, nparts, local_graph, num_ghost_nodes):
         """Leave cells on the current rank"""
         dest = np.full(len(cells), comm.rank, dtype=np.int32)
-        return create_adjacencylist(dest)
+        return adjacencylist(dest)
 
     if comm.rank == 0:
         cells = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int64)
-        cells = create_adjacencylist(cells)
+        cells = adjacencylist(cells)
         x = np.array([[0., 0.], [1., 0.], [1., 1.], [0., 1.]], dtype=default_real_type)
     else:
-        cells = create_adjacencylist(np.empty((0, 3), dtype=np.int64))
+        cells = adjacencylist(np.empty((0, 3), dtype=np.int64))
         x = np.empty((0, 2), dtype=default_real_type)
 
     mesh = create_mesh(comm, cells, x, domain, partitioner)

--- a/python/test/unit/io/test_vtk.py
+++ b/python/test/unit/io/test_vtk.py
@@ -16,7 +16,7 @@ from dolfinx.io import VTKFile
 from dolfinx.io.utils import cell_perm_vtk  # noqa F401
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
                           create_unit_interval, create_unit_square)
-from dolfinx.plot import create_vtk_mesh
+from dolfinx.plot import vtk_mesh
 from mpi4py import MPI
 from numpy.testing import assert_array_equal
 

--- a/python/test/unit/io/test_vtk.py
+++ b/python/test/unit/io/test_vtk.py
@@ -265,4 +265,4 @@ def test_vtk_mesh():
     comm = MPI.COMM_WORLD
     mesh = create_unit_square(comm, 2 * comm.size, 2 * comm.size)
     V = FunctionSpace(mesh, ("Lagrange", 1))
-    create_vtk_mesh(V)
+    vtk_mesh(V)

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -506,14 +506,14 @@ def test_empty_rank_mesh(dtype):
     def partitioner(comm, nparts, local_graph, num_ghost_nodes):
         """Leave cells on the curent rank"""
         dest = np.full(len(cells), comm.rank, dtype=np.int32)
-        return graph.create_adjacencylist(dest)
+        return graph.adjacencylist(dest)
 
     if comm.rank == 0:
         cells = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int64)
-        cells = graph.create_adjacencylist(cells)
+        cells = graph.adjacencylist(cells)
         x = np.array([[0., 0.], [1., 0.], [1., 1.], [0., 1.]], dtype=dtype)
     else:
-        cells = graph.create_adjacencylist(np.empty((0, 3), dtype=np.int64))
+        cells = graph.adjacencylist(np.empty((0, 3), dtype=np.int64))
         x = np.empty((0, 2), dtype=dtype)
 
     mesh = _mesh.create_mesh(comm, cells, x, domain, partitioner)

--- a/python/test/unit/mesh/test_meshtags.py
+++ b/python/test/unit/mesh/test_meshtags.py
@@ -7,7 +7,7 @@
 import numpy as np
 import pytest
 
-from dolfinx.graph import create_adjacencylist
+from dolfinx.graph import adjacencylist
 from dolfinx.mesh import (CellType, create_unit_cube, locate_entities,
                           meshtags_from_entities)
 from ufl import Measure
@@ -25,7 +25,7 @@ def test_create(cell_type):
     marked_lines = locate_entities(mesh, 1, lambda x: np.isclose(x[1], 0.5))
     f_v = mesh.topology.connectivity(1, 0).array.reshape(-1, 2)
 
-    entities = create_adjacencylist(f_v[marked_lines])
+    entities = adjacencylist(f_v[marked_lines])
     values = np.full(marked_lines.shape[0], 2, dtype=np.int32)
     mt = meshtags_from_entities(mesh, 1, entities, values)
 
@@ -43,7 +43,7 @@ def test_ufl_id():
     marked_facets = locate_entities(msh, tdim - 1, lambda x: np.isclose(x[1], 1))
     f_v = msh.topology.connectivity(tdim - 1, 0).array.reshape(-1, 3)
 
-    entities = create_adjacencylist(f_v[marked_facets])
+    entities = adjacencylist(f_v[marked_facets])
     values = np.full(marked_facets.shape[0], 2, dtype=np.int32)
     ft = meshtags_from_entities(msh, tdim - 1, entities, values)
     ds = Measure("ds", domain=msh, subdomain_data=ft, subdomain_id=(2, 3))


### PR DESCRIPTION
Fixes #2760.

`plot.create_vtk_mesh` -> `plot.vtk_mesh`
`create_adjacencylist` -> `adjacencylist`