### PR TITLE
Add shape argument to `FunctionSpace` for creating blocked scalar element spaces

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -80,7 +80,7 @@ jobs:
           python3 -m isort --check .
       - name: mypy checks
         run: |
-          python3 -m pip install types-setuptools
+          python3 -m pip install types-setuptools mypy --upgrade
           cd python/
           mypy dolfinx
           mypy demo

--- a/python/demo/demo_axis/demo_axis.py
+++ b/python/demo/demo_axis/demo_axis.py
@@ -370,7 +370,7 @@ if have_pyvista:
 degree = 3
 curl_el = element("N1curl", msh.basix_cell(), degree)
 lagr_el = element("Lagrange", msh.basix_cell(), degree)
-V = fem.FunctionSpace(msh, mixed_element([curl_el, lagr_el]))
+V = fem.functionspace(msh, mixed_element([curl_el, lagr_el]))
 
 # The integration domains of our problem are the following:
 
@@ -388,7 +388,7 @@ n_bkg = 1  # Background refractive index
 eps_bkg = n_bkg**2  # Background relative permittivity
 eps_au = -1.0782 + 1j * 5.8089
 
-D = fem.FunctionSpace(msh, ("DG", 0))
+D = fem.functionspace(msh, ("DG", 0))
 eps = fem.Function(D)
 au_cells = cell_tags.find(au_tag)
 bkg_cells = cell_tags.find(bkg_tag)
@@ -625,7 +625,7 @@ assert eps_au == -1.0782 + 1j * 5.8089
 
 if has_vtx:
     v_dg_el = element("DG", msh.basix_cell(), degree, shape=(3, ))
-    W = fem.FunctionSpace(msh, v_dg_el)
+    W = fem.functionspace(msh, v_dg_el)
     Es_dg = fem.Function(W)
     Es_expr = fem.Expression(Esh, W.element.interpolation_points())
     Es_dg.interpolate(Es_expr)

--- a/python/demo/demo_biharmonic.py
+++ b/python/demo/demo_biharmonic.py
@@ -65,10 +65,8 @@
 # and considering the boundary conditions
 #
 # $$
-# \begin{align}
 # u &= 0 \quad {\rm on} \ \partial\Omega, \\
 # \nabla^{2} u &= 0 \quad {\rm on} \ \partial\Omega,
-# \end{align}
 # $$
 #
 # a weak formulation of the biharmonic problem reads: find $u \in V$ such that

--- a/python/demo/demo_biharmonic.py
+++ b/python/demo/demo_biharmonic.py
@@ -126,17 +126,17 @@ from petsc4py.PETSc import ScalarType
 # We begin by using {py:func}`create_rectangle
 # <dolfinx.mesh.create_rectangle>` to create a rectangular
 # {py:class}`Mesh <dolfinx.mesh.Mesh>` of the domain, and creating a
-# finite element {py:class}`FunctionSpace <dolfinx.fem.FunctionSpace>`
+# finite element {py:class}`FunctionSpaceBase <dolfinx.fem.FunctionSpaceBase>`
 # $V$ on the mesh.
 
 msh = mesh.create_rectangle(comm=MPI.COMM_WORLD,
                             points=((0.0, 0.0), (1.0, 1.0)), n=(32, 32),
                             cell_type=CellType.triangle,
                             ghost_mode=GhostMode.shared_facet)
-V = fem.FunctionSpace(msh, ("Lagrange", 2))
+V = fem.functionspace(msh, ("Lagrange", 2))
 
-# The second argument to {py:class}`FunctionSpace
-# <dolfinx.fem.FunctionSpace>` is a tuple consisting of `(family,
+# The second argument to {py:func}`functionspace
+# <dolfinx.fem.functionspace>` is a tuple consisting of `(family,
 # degree)`, where `family` is the finite element family, and `degree`
 # specifies the polynomial degree. in this case `V` consists of
 # second-order, continuous Lagrange finite element functions.
@@ -220,7 +220,7 @@ uh = problem.solve()
 # <dolfinx.io.XDMFFile>` file visualization with ParaView or VisIt
 
 with io.XDMFFile(msh.comm, "out_biharmonic/biharmonic.xdmf", "w") as file:
-    V1 = fem.FunctionSpace(msh, ("Lagrange", 1))
+    V1 = fem.functionspace(msh, ("Lagrange", 1))
     u1 = fem.Function(V1)
     u1.interpolate(uh)
     file.write_mesh(msh)

--- a/python/demo/demo_cahn-hilliard.py
+++ b/python/demo/demo_cahn-hilliard.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.13.6
+#       jupytext_version: 1.15.1
 # ---
 
 # # Cahn-Hilliard equation
@@ -22,7 +22,8 @@
 #   ({py:class}`NewtonSolver<dolfinx.nls.petsc.NewtonSolver>`)
 # - Form compiler options
 # - Interpolation of functions
-# - Visualisation of a running simulation with pyvista
+# - Visualisation of a running simulation with
+#   [PyVista](https://pyvista.org/)
 #
 # This demo is implemented in {download}`demo_cahn-hilliard.py`.
 #
@@ -34,7 +35,6 @@
 # derivatives.  The equation reads:
 #
 # $$
-# \begin{align}
 # \frac{\partial c}{\partial t} -
 #   \nabla \cdot M \left(\nabla\left(\frac{d f}{dc}
 #   - \lambda \nabla^{2}c\right)\right) &= 0 \quad {\rm in} \ \Omega, \\
@@ -42,7 +42,6 @@
 #   \lambda \nabla^{2}c\right)\right) \cdot n
 #   &= 0 \quad {\rm on} \ \partial\Omega, \\
 # M \lambda \nabla c \cdot n &= 0 \quad {\rm on} \ \partial\Omega.
-# \end{align}
 # $$
 #
 # where $c$ is the unknown field, the function $f$ is usually non-convex
@@ -58,25 +57,21 @@
 # as two coupled second-order equations:
 #
 # $$
-# \begin{align}
 # \frac{\partial c}{\partial t} - \nabla \cdot M \nabla\mu
 #     &= 0 \quad {\rm in} \ \Omega, \\
 # \mu -  \frac{d f}{d c} + \lambda \nabla^{2}c &= 0 \quad {\rm in} \ \Omega.
-# \end{align}
 # $$
 #
 # The unknown fields are now $c$ and $\mu$. The weak (variational) form
 # of the problem reads: find $(c, \mu) \in V \times V$ such that
 #
 # $$
-# \begin{align}
 # \int_{\Omega} \frac{\partial c}{\partial t} q \, {\rm d} x +
 #     \int_{\Omega} M \nabla\mu \cdot \nabla q \, {\rm d} x
 #     &= 0 \quad \forall \ q \in V,  \\
 # \int_{\Omega} \mu v \, {\rm d} x - \int_{\Omega} \frac{d f}{d c} v \, {\rm d} x
 #   - \int_{\Omega} \lambda \nabla c \cdot \nabla v \, {\rm d} x
 #    &= 0 \quad \forall \ v \in V.
-# \end{align}
 # $$
 #
 # ### Time discretisation
@@ -86,19 +81,17 @@
 # equation:
 #
 # $$
-# \begin{align}
 # \int_{\Omega} \frac{c_{n+1} - c_{n}}{dt} q \, {\rm d} x
 # + \int_{\Omega} M \nabla \mu_{n+\theta} \cdot \nabla q \, {\rm d} x
 #        &= 0 \quad \forall \ q \in V  \\
 # \int_{\Omega} \mu_{n+1} v  \, {\rm d} x - \int_{\Omega} \frac{d f_{n+1}}{d c} v  \, {\rm d} x
 # - \int_{\Omega} \lambda \nabla c_{n+1} \cdot \nabla v \, {\rm d} x
 #        &= 0 \quad \forall \ v \in V
-# \end{align}
 # $$
 #
-# where $dt = t_{n+1} - t_{n}$ and $\mu_{n+\theta} = (1-\theta) \mu_{n}
-# + \theta \mu_{n+1}$.  The task is: given $c_{n}$ and $\mu_{n}$, solve
-# the above equation to find $c_{n+1}$ and $\mu_{n+1}$.
+# where $dt = t_{n+1} - t_{n}$ and $\mu_{n+\theta} = (1-\theta) \mu_{n} + \theta \mu_{n+1}$.
+# The task is: given $c_{n}$ and $\mu_{n}$, solve the above equation to
+# find $c_{n+1}$ and $\mu_{n+1}$.
 #
 # ### Demo parameters
 #

--- a/python/demo/demo_cahn-hilliard.py
+++ b/python/demo/demo_cahn-hilliard.py
@@ -116,7 +116,7 @@ import os
 import numpy as np
 import ufl
 from basix.ufl import element, mixed_element
-from dolfinx.fem import Function, FunctionSpace
+from dolfinx.fem import Function, functionspace
 from dolfinx.fem.petsc import NonlinearProblem
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import CellType, create_unit_square
@@ -149,12 +149,12 @@ theta = 0.5  # time stepping family, e.g. theta=1 -> backward Euler, theta=0.5 -
 
 # A unit square mesh with 96 cells edges in each direction is created,
 # and on this mesh a
-# {py:class}`FunctionSpace<dolfinx.fem.FunctionSpace>` `ME` is built
+# {py:class}`FunctionSpaceBase <dolfinx.fem.FunctionSpaceBase>` `ME` is built
 # using a pair of linear Lagrange elements.
 
 msh = create_unit_square(MPI.COMM_WORLD, 96, 96, CellType.triangle)
 P1 = element("Lagrange", msh.basix_cell(), 1)
-ME = FunctionSpace(msh, mixed_element([P1, P1]))
+ME = functionspace(msh, mixed_element([P1, P1]))
 
 # Trial and test functions of the space `ME` are now defined:
 

--- a/python/demo/demo_elasticity.py
+++ b/python/demo/demo_elasticity.py
@@ -25,8 +25,9 @@
 # +
 import numpy as np
 import ufl
-from dolfinx.fem import (Expression, Function, FunctionSpace, dirichletbc,
-                         form, locate_dofs_topological)
+from dolfinx.fem import (Expression, Function, FunctionSpace,
+                         FunctionSpaceBase, dirichletbc, form,
+                         locate_dofs_topological)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                set_bc)
 from dolfinx.io import XDMFFile
@@ -52,7 +53,7 @@ dtype = PETSc.ScalarType
 # modes.
 
 
-def build_nullspace(V: FunctionSpace):
+def build_nullspace(V: FunctionSpaceBase):
     """Build PETSc nullspace for 3D elasticity"""
 
     # Create vectors that will span the nullspace

--- a/python/demo/demo_elasticity.py
+++ b/python/demo/demo_elasticity.py
@@ -25,9 +25,8 @@
 # +
 import numpy as np
 import ufl
-from dolfinx.fem import (Expression, Function, FunctionSpace,
-                         FunctionSpaceBase, dirichletbc, form,
-                         locate_dofs_topological)
+from dolfinx.fem import (Expression, Function, FunctionSpaceBase, dirichletbc,
+                         form, functionspace, locate_dofs_topological)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                set_bc)
 from dolfinx.io import XDMFFile
@@ -122,7 +121,7 @@ def σ(v):
 # problem defined:
 
 
-V = FunctionSpace(msh, ("Lagrange", 1, (msh.geometry.dim,)))
+V = functionspace(msh, ("Lagrange", 1, (msh.geometry.dim,)))
 u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
 a = form(inner(σ(u), grad(v)) * dx)
 L = form(inner(f, v) * dx)
@@ -226,7 +225,7 @@ sigma_vm = ufl.sqrt((3 / 2) * inner(sigma_dev, sigma_dev))
 # {py:class}`Function<dolfinx.fem.Function>` `sigma_vm_h`.
 
 # +
-W = FunctionSpace(msh, ("Discontinuous Lagrange", 0))
+W = functionspace(msh, ("Discontinuous Lagrange", 0))
 sigma_vm_expr = Expression(sigma_vm, W.element.interpolation_points())
 sigma_vm_h = Function(W)
 sigma_vm_h.interpolate(sigma_vm_expr)

--- a/python/demo/demo_elasticity.py
+++ b/python/demo/demo_elasticity.py
@@ -25,9 +25,8 @@
 # +
 import numpy as np
 import ufl
-from dolfinx.fem import (Expression, Function, FunctionSpace,
-                         VectorFunctionSpace, dirichletbc, form,
-                         locate_dofs_topological)
+from dolfinx.fem import (Expression, Function, FunctionSpace, dirichletbc,
+                         form, locate_dofs_topological)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                set_bc)
 from dolfinx.io import XDMFFile
@@ -122,7 +121,7 @@ def σ(v):
 # problem defined:
 
 
-V = VectorFunctionSpace(msh, ("Lagrange", 1))
+V = FunctionSpace(msh, ("Lagrange", 1, (msh.geometry.dim,)))
 u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
 a = form(inner(σ(u), grad(v)) * dx)
 L = form(inner(f, v) * dx)

--- a/python/demo/demo_helmholtz.py
+++ b/python/demo/demo_helmholtz.py
@@ -21,16 +21,14 @@
 
 # +
 import numpy as np
-
 import ufl
-from dolfinx.fem import Function, FunctionSpace, assemble_scalar, form
+from dolfinx.fem import Function, assemble_scalar, form, functionspace
 from dolfinx.fem.petsc import LinearProblem
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import create_unit_square
-from ufl import dx, grad, inner
-
 from mpi4py import MPI
 from petsc4py import PETSc
+from ufl import dx, grad, inner
 
 # Wavenumber
 k0 = 4 * np.pi
@@ -51,7 +49,7 @@ else:
     A = 1
 
 # Test and trial function space
-V = FunctionSpace(msh, ("Lagrange", deg))
+V = functionspace(msh, ("Lagrange", deg))
 
 # Define variational problem
 u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
@@ -78,7 +76,7 @@ with XDMFFile(MPI.COMM_WORLD, "out_helmholtz/plane_wave.xdmf", "w", encoding=XDM
 
 # +
 # Function space for exact solution - need it to be higher than deg
-V_exact = FunctionSpace(msh, ("Lagrange", deg + 3))
+V_exact = functionspace(msh, ("Lagrange", deg + 3))
 u_exact = Function(V_exact)
 u_exact.interpolate(lambda x: A * np.cos(k0 * x[0]) * np.cos(k0 * x[1]))
 

--- a/python/demo/demo_interpolation-io.py
+++ b/python/demo/demo_interpolation-io.py
@@ -22,7 +22,7 @@
 import numpy as np
 
 from dolfinx import default_scalar_type, plot
-from dolfinx.fem import Function, FunctionSpace, VectorFunctionSpace
+from dolfinx.fem import Function, FunctionSpace
 from dolfinx.mesh import CellType, create_rectangle, locate_entities
 
 from mpi4py import MPI
@@ -55,7 +55,8 @@ u.interpolate(lambda x: np.vstack((x[0] + 1, x[1])), cells1)
 # Create a vector-valued discontinuous Lagrange space and function, and
 # interpolate the $H({\rm curl})$ function `u`
 
-V0 = VectorFunctionSpace(msh, ("Discontinuous Lagrange", 1))
+gdim = msh.geometry.dim
+V0 = FunctionSpace(msh, ("Discontinuous Lagrange", 1, (gdim,)))
 u0 = Function(V0, dtype=default_scalar_type)
 u0.interpolate(u)
 

--- a/python/demo/demo_interpolation-io.py
+++ b/python/demo/demo_interpolation-io.py
@@ -20,12 +20,11 @@
 
 # +
 import numpy as np
+from dolfinx.fem import Function, functionspace
+from dolfinx.mesh import CellType, create_rectangle, locate_entities
+from mpi4py import MPI
 
 from dolfinx import default_scalar_type, plot
-from dolfinx.fem import Function, FunctionSpace
-from dolfinx.mesh import CellType, create_rectangle, locate_entities
-
-from mpi4py import MPI
 
 # -
 
@@ -36,7 +35,7 @@ msh = create_rectangle(MPI.COMM_WORLD, ((0.0, 0.0), (1.0, 1.0)), (16, 16), CellT
 
 # Create a Nédélec function space and finite element Function
 
-V = FunctionSpace(msh, ("Nedelec 1st kind H(curl)", 1))
+V = functionspace(msh, ("Nedelec 1st kind H(curl)", 1))
 u = Function(V, dtype=default_scalar_type)
 
 # Find cells with *all* vertices (0) $x_0 <= 0.5$ or (1) $x_0 >= 0.5$:
@@ -56,7 +55,7 @@ u.interpolate(lambda x: np.vstack((x[0] + 1, x[1])), cells1)
 # interpolate the $H({\rm curl})$ function `u`
 
 gdim = msh.geometry.dim
-V0 = FunctionSpace(msh, ("Discontinuous Lagrange", 1, (gdim,)))
+V0 = functionspace(msh, ("Discontinuous Lagrange", 1, (gdim,)))
 u0 = Function(V0, dtype=default_scalar_type)
 u0.interpolate(u)
 

--- a/python/demo/demo_lagrange_variants.py
+++ b/python/demo/demo_lagrange_variants.py
@@ -113,7 +113,7 @@ ufl_element = basix.ufl.element(basix.ElementFamily.P, basix.CellType.triangle, 
 msh = mesh.create_rectangle(comm=MPI.COMM_WORLD,
                             points=((0.0, 0.0), (2.0, 1.0)), n=(32, 16),
                             cell_type=mesh.CellType.triangle,)
-V = fem.FunctionSpace(msh, ufl_element)
+V = fem.functionspace(msh, ufl_element)
 facets = mesh.locate_entities_boundary(msh, dim=1,
                                        marker=lambda x: np.logical_or(np.isclose(x[0], 0.0),
                                                                       np.isclose(x[0], 2.0)))
@@ -158,7 +158,7 @@ u_exact = saw_tooth(x[0])
 
 for variant in [basix.LagrangeVariant.equispaced, basix.LagrangeVariant.gll_warped]:
     ufl_element = basix.ufl.element(basix.ElementFamily.P, basix.CellType.interval, 10, variant)
-    V = fem.FunctionSpace(msh, ufl_element)
+    V = fem.functionspace(msh, ufl_element)
     uh = fem.Function(V)
     uh.interpolate(lambda x: saw_tooth(x[0]))
     if MPI.COMM_WORLD.size == 1:  # Skip this plotting in parallel
@@ -197,7 +197,7 @@ for variant in [basix.LagrangeVariant.equispaced, basix.LagrangeVariant.gll_warp
 # +
 for variant in [basix.LagrangeVariant.equispaced, basix.LagrangeVariant.gll_warped]:
     ufl_element = basix.ufl.element(basix.ElementFamily.P, basix.CellType.interval, 10, variant)
-    V = fem.FunctionSpace(msh, ufl_element)
+    V = fem.functionspace(msh, ufl_element)
     uh = fem.Function(V)
     uh.interpolate(lambda x: saw_tooth(x[0]))
     M = fem.form((u_exact - uh)**2 * dx)

--- a/python/demo/demo_mixed-poisson.py
+++ b/python/demo/demo_mixed-poisson.py
@@ -104,7 +104,7 @@ k = 1
 Q_el = element("BDMCF", domain.basix_cell(), k)
 P_el = element("DG", domain.basix_cell(), k - 1)
 V_el = mixed_element([Q_el, P_el])
-V = fem.FunctionSpace(domain, V_el)
+V = fem.functionspace(domain, V_el)
 
 (sigma, u) = TrialFunctions(V)
 (tau, v) = TestFunctions(V)

--- a/python/demo/demo_navier-stokes.py
+++ b/python/demo/demo_navier-stokes.py
@@ -228,12 +228,12 @@ k = 1  # Polynomial degree
 msh = mesh.create_unit_square(MPI.COMM_WORLD, n, n)
 
 # Function spaces for the velocity and for the pressure
-V = fem.FunctionSpace(msh, ("Raviart-Thomas", k + 1))
-Q = fem.FunctionSpace(msh, ("Discontinuous Lagrange", k))
+V = fem.functionspace(msh, ("Raviart-Thomas", k + 1))
+Q = fem.functionspace(msh, ("Discontinuous Lagrange", k))
 
 # Funcion space for visualising the velocity field
 gdim = msh.geometry.dim
-W = fem.FunctionSpace(msh, ("Discontinuous Lagrange", k + 1, (gdim,)))
+W = fem.functionspace(msh, ("Discontinuous Lagrange", k + 1, (gdim,)))
 
 # Define trial and test functions
 
@@ -406,8 +406,8 @@ except NameError:
 
 # +
 # Function spaces for exact velocity and pressure
-V_e = fem.FunctionSpace(msh, ("Lagrange", k + 3, (gdim,)))
-Q_e = fem.FunctionSpace(msh, ("Lagrange", k + 2))
+V_e = fem.functionspace(msh, ("Lagrange", k + 3, (gdim,)))
+Q_e = fem.functionspace(msh, ("Lagrange", k + 2))
 
 u_e = fem.Function(V_e)
 u_e.interpolate(u_e_expr)

--- a/python/demo/demo_navier-stokes.py
+++ b/python/demo/demo_navier-stokes.py
@@ -232,7 +232,8 @@ V = fem.FunctionSpace(msh, ("Raviart-Thomas", k + 1))
 Q = fem.FunctionSpace(msh, ("Discontinuous Lagrange", k))
 
 # Funcion space for visualising the velocity field
-W = fem.VectorFunctionSpace(msh, ("Discontinuous Lagrange", k + 1))
+gdim = msh.geometry.dim
+W = fem.FunctionSpace(msh, ("Discontinuous Lagrange", k + 1, (gdim,)))
 
 # Define trial and test functions
 
@@ -405,7 +406,7 @@ except NameError:
 
 # +
 # Function spaces for exact velocity and pressure
-V_e = fem.VectorFunctionSpace(msh, ("Lagrange", k + 3))
+V_e = fem.FunctionSpace(msh, ("Lagrange", k + 3, (gdim,)))
 Q_e = fem.FunctionSpace(msh, ("Lagrange", k + 2))
 
 u_e = fem.Function(V_e)

--- a/python/demo/demo_pml/demo_pml.py
+++ b/python/demo/demo_pml/demo_pml.py
@@ -229,7 +229,7 @@ theta = 0  # Angle of incidence of the background field
 
 degree = 3
 curl_el = element("N1curl", msh.basix_cell(), degree)
-V = fem.FunctionSpace(msh, curl_el)
+V = fem.functionspace(msh, curl_el)
 
 # Next, we interpolate $\mathbf{E}_b$ into the function space $V$,
 # define our trial and test function, and the integration domains:
@@ -270,7 +270,7 @@ eps_au = -1.0782 + 1j * 5.8089
 # it takes the value of the background permittivity $\varepsilon_b$ in
 # the background region:
 
-D = fem.FunctionSpace(msh, ("DG", 0))
+D = fem.functionspace(msh, ("DG", 0))
 eps = fem.Function(D)
 au_cells = cell_tags.find(au_tag)
 bkg_cells = cell_tags.find(bkg_tag)
@@ -421,7 +421,7 @@ Esh = problem.solve()
 
 # +
 gdim = msh.geometry.dim
-V_dg = fem.FunctionSpace(msh, ("DG", degree, (gdim,)))
+V_dg = fem.functionspace(msh, ("DG", degree, (gdim,)))
 Esh_dg = fem.Function(V_dg)
 Esh_dg.interpolate(Esh)
 

--- a/python/demo/demo_pml/demo_pml.py
+++ b/python/demo/demo_pml/demo_pml.py
@@ -114,10 +114,10 @@ def curl_2d(a: fem.Function):
 # waves impinging them. Mathematically, we can use a complex coordinate
 # transformation of this kind to obtain this absorption:
 #
-# \begin{align}
-# & x^\prime= x\left\{1+j\frac{\alpha}{k_0}\left[\frac{|x|-l_{dom}/2}
-# {(l_{pml}/2 - l_{dom}/2)^2}\right] \right\}\\
-# \end{align}
+# $$
+# x^\prime= x\left\{1+j\frac{\alpha}{k_0}\left[\frac{|x|-l_{dom}/2}
+# {(l_{pml}/2 - l_{dom}/2)^2}\right] \right\}
+# $$
 #
 # with $l_{dom}$ and $l_{pml}$ being the lengths of the domain without
 # and with PML, respectively, and with $\alpha$ being a parameter that
@@ -207,13 +207,13 @@ if have_pyvista:
 # different PML regions have different coordinate transformation, as
 # specified here below:
 #
-# \begin{align}
+# $$
 # \text{PML}_\text{corners} \rightarrow \mathbf{r}^\prime & = (x^\prime, y^\prime) \\
 # \text{PML}_\text{rectangles along x} \rightarrow
 #                                       \mathbf{r}^\prime & = (x^\prime, y) \\
 # \text{PML}_\text{rectangles along y} \rightarrow
 #                                       \mathbf{r}^\prime & = (x, y^\prime).
-# \end{align}
+# $$
 #
 # Now we define some other problem specific parameters:
 

--- a/python/demo/demo_pml/demo_pml.py
+++ b/python/demo/demo_pml/demo_pml.py
@@ -420,7 +420,8 @@ Esh = problem.solve()
 # compatible discontinuous Lagrange space.
 
 # +
-V_dg = fem.VectorFunctionSpace(msh, ("DG", degree))
+gdim = msh.geometry.dim
+V_dg = fem.FunctionSpace(msh, ("DG", degree, (gdim,)))
 Esh_dg = fem.Function(V_dg)
 Esh_dg.interpolate(Esh)
 

--- a/python/demo/demo_pml/efficiencies_pml_demo.py
+++ b/python/demo/demo_pml/efficiencies_pml_demo.py
@@ -57,13 +57,11 @@
 # efficiencies as:
 #
 # $$
-# \begin{align}
 # & q_{\mathrm{sca}}=(2 / \alpha)\left[\left|a_0\right|^{2}
 # +2 \sum_{\nu=1}^{\infty}\left|a_\nu\right|^{2}\right] \\
 # & q_{\mathrm{ext}}=(2 / \alpha) \operatorname{Re}\left[ a_0
 # +2 \sum_{\nu=1}^{\infty} a_\nu\right] \\
 # & q_{\mathrm{abs}} = q_{\mathrm{ext}} - q_{\mathrm{sca}}
-# \end{align}
 # $$
 
 from typing import Tuple

--- a/python/demo/demo_poisson.py
+++ b/python/demo/demo_poisson.py
@@ -24,11 +24,9 @@
 # particular boundary conditions reads:
 #
 # $$
-# \begin{align}
 # - \nabla^{2} u &= f \quad {\rm in} \ \Omega, \\
 # u &= 0 \quad {\rm on} \ \Gamma_{D}, \\
 # \nabla u \cdot n &= g \quad {\rm on} \ \Gamma_{N}. \\
-# \end{align}
 # $$
 #
 # where $f$ and $g$ are input data and $n$ denotes the outward directed
@@ -42,10 +40,8 @@
 # where $V$ is a suitable function space and
 #
 # $$
-# \begin{align}
 # a(u, v) &:= \int_{\Omega} \nabla u \cdot \nabla v \, {\rm d} x, \\
 # L(v)    &:= \int_{\Omega} f v \, {\rm d} x + \int_{\Gamma_{N}} g v \, {\rm d} s.
-# \end{align}
 # $$
 #
 # The expression $a(u, v)$ is the bilinear form and $L(v)$

--- a/python/demo/demo_poisson.py
+++ b/python/demo/demo_poisson.py
@@ -13,8 +13,7 @@
 # This demo is implemented in {download}`demo_poisson.py`. It
 # illustrates how to:
 #
-# - Define a {py:class}`FunctionSpace <dolfinx.fem.FunctionSpace>`
-# - Define a {py:class}`FunctionSpace <dolfinx.fem.FunctionSpace>`
+# - Create a {py:class}`function space <dolfinx.fem.FunctionSpaceBase>`
 # - Solve a linear partial differential equation
 #
 # ## Equation and problem definition
@@ -76,18 +75,18 @@ from petsc4py.PETSc import ScalarType
 
 # We create a rectangular {py:class}`Mesh <dolfinx.mesh.Mesh>` using
 # {py:func}`create_rectangle <dolfinx.mesh.create_rectangle>`, and
-# create a finite element {py:class}`FunctionSpace
-# <dolfinx.fem.FunctionSpace>` $V$ on the mesh.
+# create a finite element {py:class}`function space
+# <dolfinx.fem.FunctionSpaceBase>` $V$ on the mesh.
 
 # +
 msh = mesh.create_rectangle(comm=MPI.COMM_WORLD,
                             points=((0.0, 0.0), (2.0, 1.0)), n=(32, 16),
                             cell_type=mesh.CellType.triangle)
-V = fem.FunctionSpace(msh, ("Lagrange", 1))
+V = fem.functionspace(msh, ("Lagrange", 1))
 # -
 
-# The second argument to {py:class}`FunctionSpace
-# <dolfinx.fem.FunctionSpace>` is a tuple `(family, degree)`, where
+# The second argument to {py:func}`functionspace
+# <dolfinx.fem.functionspace>` is a tuple `(family, degree)`, where
 # `family` is the finite element family, and `degree` specifies the
 # polynomial degree. In this case `V` is a space of continuous Lagrange
 # finite elements of degree 1.

--- a/python/demo/demo_pyvista.py
+++ b/python/demo/demo_pyvista.py
@@ -22,14 +22,12 @@
 # To start, the required modules are imported and some PyVista
 # parameters set.
 
+import dolfinx.plot as plot
 # +
 import numpy as np
-
-import dolfinx.plot as plot
-from dolfinx.fem import Function, FunctionSpace
+from dolfinx.fem import Function, functionspace
 from dolfinx.mesh import (CellType, compute_midpoints, create_unit_cube,
                           create_unit_square, meshtags)
-
 from mpi4py import MPI
 
 try:
@@ -55,7 +53,7 @@ def plot_scalar():
     # We start by creating a unit square mesh and interpolating a
     # function into a degree 1 Lagrange space
     msh = create_unit_square(MPI.COMM_WORLD, 12, 12, cell_type=CellType.quadrilateral)
-    V = FunctionSpace(msh, ("Lagrange", 1))
+    V = functionspace(msh, ("Lagrange", 1))
     u = Function(V, dtype=np.float64)
     u.interpolate(lambda x: np.sin(np.pi * x[0]) * np.sin(2 * x[1] * np.pi))
 
@@ -167,7 +165,7 @@ def plot_higher_order():
     # We start by interpolating a discontinuous function (discontinuous
     # between cells with different mesh tag values) into a degree 2
     # discontinuous Lagrange space.
-    V = FunctionSpace(msh, ("Discontinuous Lagrange", 2))
+    V = functionspace(msh, ("Discontinuous Lagrange", 2))
     u = Function(V, dtype=msh.geometry.x.dtype)
     u.interpolate(lambda x: x[0], cell_tags.find(0))
     u.interpolate(lambda x: x[1] + 1, cell_tags.find(1))
@@ -228,7 +226,7 @@ def plot_nedelec():
 
     # Create a function space consisting of first order Nédélec (first kind)
     # elements and interpolate a vector-valued expression
-    V = FunctionSpace(msh, ("N1curl", 2))
+    V = functionspace(msh, ("N1curl", 2))
     u = Function(V, dtype=np.float64)
     u.interpolate(lambda x: (x[2]**2, np.zeros(x.shape[1]), -x[0] * x[2]))
 
@@ -237,7 +235,7 @@ def plot_nedelec():
     # interpolate the Nédélec function into a first-order discontinuous
     # Lagrange space.
     gdim = msh.geometry.dim
-    V0 = FunctionSpace(msh, ("Discontinuous Lagrange", 2, (gdim,)))
+    V0 = functionspace(msh, ("Discontinuous Lagrange", 2, (gdim,)))
     u0 = Function(V0, dtype=np.float64)
     u0.interpolate(u)
 
@@ -269,7 +267,7 @@ def plot_streamlines():
 
     msh = create_unit_cube(MPI.COMM_WORLD, 4, 4, 4, CellType.hexahedron)
     gdim = msh.geometry.dim
-    V = FunctionSpace(msh, ("Discontinuous Lagrange", 2, (gdim,)))
+    V = functionspace(msh, ("Discontinuous Lagrange", 2, (gdim,)))
     u = Function(V, dtype=np.float64)
     u.interpolate(lambda x: np.vstack((-(x[1] - 0.5), x[0] - 0.5, np.zeros(x.shape[1]))))
 

--- a/python/demo/demo_pyvista.py
+++ b/python/demo/demo_pyvista.py
@@ -26,7 +26,7 @@
 import numpy as np
 
 import dolfinx.plot as plot
-from dolfinx.fem import Function, FunctionSpace, VectorFunctionSpace
+from dolfinx.fem import Function, FunctionSpace
 from dolfinx.mesh import (CellType, compute_midpoints, create_unit_cube,
                           create_unit_square, meshtags)
 
@@ -236,7 +236,8 @@ def plot_nedelec():
     # discontinuous Lagrange finite element functions. Therefore, we
     # interpolate the Nédélec function into a first-order discontinuous
     # Lagrange space.
-    V0 = VectorFunctionSpace(msh, ("Discontinuous Lagrange", 2))
+    gdim = msh.geometry.dim
+    V0 = FunctionSpace(msh, ("Discontinuous Lagrange", 2, (gdim,)))
     u0 = Function(V0, dtype=np.float64)
     u0.interpolate(u)
 
@@ -267,7 +268,8 @@ def plot_nedelec():
 def plot_streamlines():
 
     msh = create_unit_cube(MPI.COMM_WORLD, 4, 4, 4, CellType.hexahedron)
-    V = VectorFunctionSpace(msh, ("Discontinuous Lagrange", 2))
+    gdim = msh.geometry.dim
+    V = FunctionSpace(msh, ("Discontinuous Lagrange", 2, (gdim,)))
     u = Function(V, dtype=np.float64)
     u.interpolate(lambda x: np.vstack((-(x[1] - 0.5), x[0] - 0.5, np.zeros(x.shape[1]))))
 

--- a/python/demo/demo_scattering_boundary_conditions/analytical_efficiencies_wire.py
+++ b/python/demo/demo_scattering_boundary_conditions/analytical_efficiencies_wire.py
@@ -57,13 +57,11 @@
 # efficiencies as:
 #
 # $$
-# \begin{align}
 # & q_{\mathrm{sca}}=(2 / \alpha)\left[\left|a_0\right|^{2}
 # +2 \sum_{\nu=1}^{\infty}\left|a_\nu\right|^{2}\right] \\
 # & q_{\mathrm{ext}}=(2 / \alpha) \operatorname{Re}\left[ a_0
 # +2 \sum_{\nu=1}^{\infty} a_\nu\right] \\
 # & q_{\mathrm{abs}} = q_{\mathrm{ext}} - q_{\mathrm{sca}}
-# \end{align}
 # $$
 
 from typing import Tuple

--- a/python/demo/demo_scattering_boundary_conditions/demo_scattering_boundary_conditions.py
+++ b/python/demo/demo_scattering_boundary_conditions/demo_scattering_boundary_conditions.py
@@ -329,7 +329,6 @@ eps.x.scatter_forward()
 # integrate the terms over the corresponding domains:
 #
 # $$
-# \begin{align}
 # & \int_{\Omega}-\nabla \times( \nabla \times \mathbf{E}_s) \cdot
 # \bar{\mathbf{v}}+\varepsilon_{r} k_{0}^{2} \mathbf{E}_s \cdot
 # \bar{\mathbf{v}}+k_{0}^{2}\left(\varepsilon_{r}-\varepsilon_b\right)
@@ -337,7 +336,6 @@ eps.x.scatter_forward()
 # (\mathbf{n} \times \nabla \times \mathbf{E}_s) \cdot \bar{\mathbf{v}}
 # +\left(j n_bk_{0}+\frac{1}{2r}\right) (\mathbf{n} \times \mathbf{E}_s
 # \times \mathbf{n}) \cdot \bar{\mathbf{v}}~\mathrm{d}s=0
-# \end{align}.
 # $$
 #
 # By using $(\nabla \times \mathbf{A}) \cdot \mathbf{B}=\mathbf{A}
@@ -345,7 +343,6 @@ eps.x.scatter_forward()
 # \mathbf{B}),$ we can change the first term into:
 #
 # $$
-# \begin{align}
 # & \int_{\Omega}-\nabla \cdot(\nabla\times\mathbf{E}_s \times
 # \bar{\mathbf{v}})-\nabla \times \mathbf{E}_s \cdot \nabla
 # \times\bar{\mathbf{v}}+\varepsilon_{r} k_{0}^{2} \mathbf{E}_s
@@ -354,7 +351,6 @@ eps.x.scatter_forward()
 # (\mathbf{n} \times \nabla \times \mathbf{E}_s) \cdot \bar{\mathbf{v}}
 # +\left(j n_bk_{0}+\frac{1}{2r}\right) (\mathbf{n} \times \mathbf{E}_s
 # \times \mathbf{n}) \cdot \bar{\mathbf{v}}~\mathrm{d}s=0,
-# \end{align}
 # $$
 #
 # using the divergence theorem
@@ -362,7 +358,6 @@ eps.x.scatter_forward()
 # \mathbf{F}\cdot\mathbf{n}~\mathrm{d}s$, we can write:
 #
 # $$
-# \begin{align}
 # & \int_{\Omega}-(\nabla \times \mathbf{E}_s) \cdot (\nabla \times
 # \bar{\mathbf{v}})+\varepsilon_{r} k_{0}^{2} \mathbf{E}_s \cdot
 # \bar{\mathbf{v}}+k_{0}^{2}\left(\varepsilon_{r}-\varepsilon_b\right)
@@ -371,7 +366,6 @@ eps.x.scatter_forward()
 # + (\mathbf{n} \times \nabla \times \mathbf{E}_s) \cdot \bar{\mathbf{v}}
 # +\left(j n_bk_{0}+\frac{1}{2r}\right) (\mathbf{n} \times \mathbf{E}_s
 # \times \mathbf{n}) \cdot \bar{\mathbf{v}}~\mathrm{d}s=0.
-# \end{align}
 # $$
 #
 # Cancelling $-(\nabla\times\mathbf{E}_s \times \bar{\mathbf{V}})
@@ -381,14 +375,12 @@ eps.x.scatter_forward()
 # \mathbf{A})=\mathbf{C} \cdot(\mathbf{A} \times \mathbf{B})$, we get:
 #
 # $$
-# \begin{align}
 # & \int_{\Omega}-(\nabla \times \mathbf{E}_s) \cdot (\nabla \times
 # \bar{\mathbf{v}})+\varepsilon_{r} k_{0}^{2} \mathbf{E}_s \cdot
 # \bar{\mathbf{v}}+k_{0}^{2}\left(\varepsilon_{r}-\varepsilon_b\right)
 # \mathbf{E}_b \cdot \bar{\mathbf{v}}~\mathrm{d}x \\ +&\int_{\partial \Omega}
 # \left(j n_bk_{0}+\frac{1}{2r}\right)( \mathbf{n} \times \mathbf{E}_s \times
 # \mathbf{n}) \cdot \bar{\mathbf{v}} ~\mathrm{d} s = 0.
-# \end{align}
 # $$
 #
 # We use the [UFL](https://github.com/FEniCS/ufl/) to implement the

--- a/python/demo/demo_scattering_boundary_conditions/demo_scattering_boundary_conditions.py
+++ b/python/demo/demo_scattering_boundary_conditions/demo_scattering_boundary_conditions.py
@@ -271,7 +271,7 @@ theta = np.pi / 4  # Angle of incidence of the background field
 
 degree = 3
 curl_el = element("N1curl", domain.basix_cell(), degree)
-V = fem.FunctionSpace(domain, curl_el)
+V = fem.functionspace(domain, curl_el)
 
 # Next, we can interpolate $\mathbf{E}_b$ into the function space $V$:
 
@@ -315,7 +315,7 @@ eps_au = -1.0782 + 1j * 5.8089
 # of the gold permittivity $\varepsilon_m$ for cells inside the wire,
 # while it takes the value of the background permittivity otherwise:
 
-D = fem.FunctionSpace(domain, ("DG", 0))
+D = fem.functionspace(domain, ("DG", 0))
 eps = fem.Function(D)
 au_cells = cell_tags.find(au_tag)
 bkg_cells = cell_tags.find(bkg_tag)
@@ -409,7 +409,7 @@ Esh = problem.solve()
 
 # +
 gdim = domain.geometry.dim
-V_dg = fem.FunctionSpace(domain, ("Discontinuous Lagrange", degree, (gdim,)))
+V_dg = fem.functionspace(domain, ("Discontinuous Lagrange", degree, (gdim,)))
 Esh_dg = fem.Function(V_dg)
 Esh_dg.interpolate(Esh)
 

--- a/python/demo/demo_scattering_boundary_conditions/demo_scattering_boundary_conditions.py
+++ b/python/demo/demo_scattering_boundary_conditions/demo_scattering_boundary_conditions.py
@@ -408,7 +408,8 @@ Esh = problem.solve()
 # Lagrange space.
 
 # +
-V_dg = fem.VectorFunctionSpace(domain, ("Discontinuous Lagrange", degree))
+gdim = domain.geometry.dim
+V_dg = fem.FunctionSpace(domain, ("Discontinuous Lagrange", degree, (gdim,)))
 Esh_dg = fem.Function(V_dg)
 Esh_dg.interpolate(Esh)
 

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -30,8 +30,8 @@ import ufl
 from basix.ufl import element
 from dolfinx.cpp.fem import (Form_complex64, Form_complex128, Form_float32,
                              Form_float64)
-from dolfinx.fem import (Form, Function, FunctionSpace, IntegralType,
-                         dirichletbc, form, locate_dofs_topological)
+from dolfinx.fem import (Form, Function, IntegralType, dirichletbc, form,
+                         functionspace, locate_dofs_topological)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                set_bc)
 from dolfinx.io import XDMFFile
@@ -56,8 +56,8 @@ infile.close()
 Se = element("DG", msh.basix_cell(), 1, rank=2, symmetry=True)
 Ue = element("Lagrange", msh.basix_cell(), 2, rank=1)
 
-S = FunctionSpace(msh, Se)
-U = FunctionSpace(msh, Ue)
+S = functionspace(msh, Se)
+U = functionspace(msh, Ue)
 
 # Get local dofmap sizes for later local tensor tabulations
 Ssize = S.element.space_dimension

--- a/python/demo/demo_stokes.py
+++ b/python/demo/demo_stokes.py
@@ -88,7 +88,7 @@ import numpy as np
 import ufl
 from basix.ufl import element, mixed_element
 from dolfinx import fem, la
-from dolfinx.fem import (Constant, Function, FunctionSpace, dirichletbc,
+from dolfinx.fem import (Constant, Function, functionspace, dirichletbc,
                          extract_function_spaces, form,
                          locate_dofs_topological)
 from dolfinx.fem.petsc import assemble_matrix_block, assemble_vector_block
@@ -125,15 +125,15 @@ def lid_velocity_expression(x):
     return np.stack((np.ones(x.shape[1]), np.zeros(x.shape[1])))
 # -
 
-# Two {py:class}`FunctionSpace <dolfinx.fem.FunctionSpace>`s are defined
-# using different finite elements. `P2` corresponds to a continuous
-# piecewise quadratic basis (vector) and `P1` to a continuous piecewise
-# linear basis (scalar).
+# Two {py:class}`function spaces <dolfinx.fem.FunctionSpaceBase>` are
+# defined using different finite elements. `P2` corresponds to a
+# continuous piecewise quadratic basis (vector) and `P1` to a continuous
+# piecewise linear basis (scalar).
 
 
 P2 = element("Lagrange", msh.basix_cell(), 2, rank=1)
 P1 = element("Lagrange", msh.basix_cell(), 1)
-V, Q = FunctionSpace(msh, P2), FunctionSpace(msh, P1)
+V, Q = functionspace(msh, P2), functionspace(msh, P1)
 
 # Boundary conditions for the velocity field are defined:
 
@@ -276,7 +276,7 @@ def nested_iterative_solver():
     with XDMFFile(MPI.COMM_WORLD, "out_stokes/velocity.xdmf", "w") as ufile_xdmf:
         u.x.scatter_forward()
         P1 = element("Lagrange", msh.basix_cell(), 1, rank=1)
-        u1 = Function(FunctionSpace(msh, P1))
+        u1 = Function(functionspace(msh, P1))
         u1.interpolate(u)
         ufile_xdmf.write_mesh(msh)
         ufile_xdmf.write_function(u1)
@@ -458,7 +458,7 @@ def mixed_direct():
 
     # Create the Taylot-Hood function space
     TH = mixed_element([P2, P1])
-    W = FunctionSpace(msh, TH)
+    W = functionspace(msh, TH)
 
     # No slip boundary condition
     W0, _ = W.sub(0).collapse()

--- a/python/demo/demo_tnt-elements.py
+++ b/python/demo/demo_tnt-elements.py
@@ -59,6 +59,34 @@ matplotlib.use('agg')
 
 wcoeffs = np.eye(8, 9)
 
+# For elements where the coefficients matrix is not an identity, we can
+# use the properties of orthonormal polynomials to compute `wcoeffs`.
+# Let $\{q_0, q_1,\dots\}$ be the orthonormal polynomials of a given
+# degree for a given cell, and suppose that we're trying to represent a function
+# $f_i\in\operatorname{span}\{q_1, q_2,\dots\}$ (as $\{f_0, f_1,\dots\}$ is a
+# basis of the polynomial space for our element). Using the properties of
+# orthonormal polynomials, we see that
+# \[f_i = \sum_j\left(\int_R f_iq_j\,\mathrm{d}\mathbf{x}\right)q_j,\]
+# and so the coefficients are given by
+# \[
+#   a_{ij}=\int_R f_iq_j\,\mathrm{d}\mathbf{x}.
+# \]
+# Hence we could compute `wcoeffs` as follows:
+
+# +
+wcoeffs2 = np.empty((8, 9))
+pts, wts = basix.make_quadrature(basix.CellType.quadrilateral, 4)
+evals = basix.tabulate_polynomials(basix.PolynomialType.legendre, basix.CellType.quadrilateral, 2, pts)
+
+for j, v in enumerate(evals):
+    wcoeffs2[0, j] = sum(v * wts)  # 1
+    wcoeffs2[1, j] = sum(v * pts[:, 1] * wts)  # y
+    wcoeffs2[2, j] = sum(v * pts[:, 1]**2 * wts)  # y^2
+    wcoeffs2[3, j] = sum(v * pts[:, 0] * pts[:, 1] * wts)  # xy
+    wcoeffs2[4, j] = sum(v * pts[:, 0] * pts[:, 1] ** 2 * wts)  # xy^2
+    wcoeffs2[5, j] = sum(v * pts[:, 0]**2 * pts[:, 1] * wts)  # x^2y
+# -
+
 # ### Interpolation operators
 #
 # We provide the information that defines the DOFs associated with each

--- a/python/demo/demo_tnt-elements.py
+++ b/python/demo/demo_tnt-elements.py
@@ -257,13 +257,13 @@ tnt_ndofs = []
 tnt_degrees = []
 tnt_errors = []
 
-V = fem.FunctionSpace(msh, tnt_degree1)
+V = fem.functionspace(msh, tnt_degree1)
 tnt_degrees.append(2)
 tnt_ndofs.append(V.dofmap.index_map.size_global)
 tnt_errors.append(poisson_error(V))
 print(f"TNT degree 2 error: {tnt_errors[-1]}")
 for degree in range(2, 9):
-    V = fem.FunctionSpace(msh, create_tnt_quad(degree))
+    V = fem.functionspace(msh, create_tnt_quad(degree))
     tnt_degrees.append(degree + 1)
     tnt_ndofs.append(V.dofmap.index_map.size_global)
     tnt_errors.append(poisson_error(V))
@@ -273,7 +273,7 @@ q_ndofs = []
 q_degrees = []
 q_errors = []
 for degree in range(1, 9):
-    V = fem.FunctionSpace(msh, ("Q", degree))
+    V = fem.functionspace(msh, ("Q", degree))
     q_degrees.append(degree)
     q_ndofs.append(V.dofmap.index_map.size_global)
     q_errors.append(poisson_error(V))

--- a/python/demo/demo_tnt-elements.py
+++ b/python/demo/demo_tnt-elements.py
@@ -215,7 +215,7 @@ def create_tnt_quad(degree):
 # the solution.
 
 
-def poisson_error(V: fem.FunctionSpace):
+def poisson_error(V: fem.FunctionSpaceBase):
     msh = V.mesh
     u, v = TrialFunction(V), TestFunction(V)
 

--- a/python/demo/demo_types.py
+++ b/python/demo/demo_types.py
@@ -21,11 +21,10 @@
 import numpy as np
 import scipy.sparse
 import scipy.sparse.linalg
-
 import ufl
-from dolfinx import fem, la, mesh, plot
-
 from mpi4py import MPI
+
+from dolfinx import fem, la, mesh, plot
 
 # -
 
@@ -100,7 +99,7 @@ def poisson(dtype):
                                                                           np.isclose(x[0], 2.0)))
 
     # Define a variational problem.
-    V = fem.FunctionSpace(msh, ("Lagrange", 1))
+    V = fem.functionspace(msh, ("Lagrange", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     x = ufl.SpatialCoordinate(msh)
     fr = 10 * ufl.exp(-((x[0] - 0.5) ** 2 + (x[1] - 0.5) ** 2) / 0.02)
@@ -157,7 +156,7 @@ def elasticity(dtype) -> fem.Function:
 
     # Define the variational problem.
     gdim = msh.geometry.dim
-    V = fem.FunctionSpace(msh, ("Lagrange", 1, (gdim,)))
+    V = fem.functionspace(msh, ("Lagrange", 1, (gdim,)))
     ω, ρ = 300.0, 10.0
     x = ufl.SpatialCoordinate(msh)
     f = ufl.as_vector((ρ * ω**2 * x[0], ρ * ω**2 * x[1]))

--- a/python/demo/demo_types.py
+++ b/python/demo/demo_types.py
@@ -156,7 +156,8 @@ def elasticity(dtype) -> fem.Function:
                                                                           np.isclose(x[0], 2.0)))
 
     # Define the variational problem.
-    V = fem.VectorFunctionSpace(msh, ("Lagrange", 1))
+    gdim = msh.geometry.dim
+    V = fem.FunctionSpace(msh, ("Lagrange", 1, (gdim,)))
     ω, ρ = 300.0, 10.0
     x = ufl.SpatialCoordinate(msh)
     f = ufl.as_vector((ρ * ω**2 * x[0], ρ * ω**2 * x[1]))

--- a/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
+++ b/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
@@ -98,7 +98,7 @@ def Omega_v(x):
     return x[1] >= d
 
 
-D = fem.FunctionSpace(msh, ("DQ", 0))
+D = fem.functionspace(msh, ("DQ", 0))
 eps = fem.Function(D)
 
 cells_v = locate_entities(msh, msh.topology.dim, Omega_v)
@@ -188,7 +188,7 @@ eps.x.array[cells_v] = np.full_like(cells_v, eps_v, dtype=default_scalar_type)
 degree = 1
 RTCE = element("RTCE", msh.basix_cell(), degree)
 Q = element("Lagrange", msh.basix_cell(), degree)
-V = fem.FunctionSpace(msh, mixed_element([RTCE, Q]))
+V = fem.functionspace(msh, mixed_element([RTCE, Q]))
 
 # Now we can define our weak form:
 
@@ -363,7 +363,7 @@ for i, kz in vals:
         ezh.x.array[:] = ezh.x.array[:] * 1j
 
         gdim = msh.geometry.dim
-        V_dg = fem.FunctionSpace(msh, ("DQ", degree, (gdim,)))
+        V_dg = fem.functionspace(msh, ("DQ", degree, (gdim,)))
         Et_dg = fem.Function(V_dg)
         Et_dg.interpolate(eth)
 

--- a/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
+++ b/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
@@ -113,11 +113,9 @@ eps.x.array[cells_v] = np.full_like(cells_v, eps_v, dtype=default_scalar_type)
 # waveguide wall:
 #
 # $$
-# \begin{align}
 # &\nabla \times \frac{1}{\mu_{r}} \nabla \times \mathbf{E}-k_{o}^{2}
 # \epsilon_{r} \mathbf{E}=0 \quad &\text { in } \Omega\\
 # &\hat{n}\times\mathbf{E} = 0 &\text { on } \Gamma
-# \end{align}
 # $$
 #
 # with $k_0$ and $\lambda_0 = 2\pi/k_0$ being the wavevector and the
@@ -140,10 +138,8 @@ eps.x.array[cells_v] = np.full_like(cells_v, eps_v, dtype=default_scalar_type)
 # the following substitution:
 #
 # $$
-# \begin{align}
 # & \mathbf{e}_t = k_z\mathbf{E}_t\\
 # & e_z = -jE_z
-# \end{align}
 # $$
 #
 # The final weak form can be written as:

--- a/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
+++ b/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
@@ -362,7 +362,8 @@ for i, kz in vals:
         eth.x.array[:] = eth.x.array[:] / kz
         ezh.x.array[:] = ezh.x.array[:] * 1j
 
-        V_dg = fem.VectorFunctionSpace(msh, ("DQ", degree))
+        gdim = msh.geometry.dim
+        V_dg = fem.FunctionSpace(msh, ("DQ", degree, (gdim,)))
         Et_dg = fem.Function(V_dg)
         Et_dg.interpolate(eth)
 

--- a/python/dolfinx/fem/__init__.py
+++ b/python/dolfinx/fem/__init__.py
@@ -11,13 +11,14 @@ from dolfinx.cpp.fem import (IntegralType,
 from dolfinx.cpp.fem import create_sparsity_pattern as _create_sparsity_pattern
 from dolfinx.fem.assemble import (apply_lifting, assemble_matrix,
                                   assemble_scalar, assemble_vector,
-                                  create_matrix, set_bc, create_vector)
+                                  create_matrix, create_vector, set_bc)
 from dolfinx.fem.bcs import (DirichletBC, bcs_by_block, dirichletbc,
                              locate_dofs_geometrical, locate_dofs_topological)
 from dolfinx.fem.dofmap import DofMap
 from dolfinx.fem.forms import Form, extract_function_spaces, form
-from dolfinx.fem.function import (Constant, Expression, Function, ElementMetaData,
-                                  FunctionSpace, FunctionSpaceBase, VectorFunctionSpace)
+from dolfinx.fem.function import (Constant, ElementMetaData, Expression,
+                                  Function, FunctionSpace, FunctionSpaceBase,
+                                  VectorFunctionSpace, functionspace)
 
 
 def create_sparsity_pattern(a: Form):
@@ -39,7 +40,7 @@ def create_sparsity_pattern(a: Form):
 
 __all__ = [
     "Constant", "Expression", "Function", "ElementMetaData", "create_matrix",
-    "FunctionSpace", "FunctionSpaceBase", "VectorFunctionSpace",
+    "functionspace", "FunctionSpace", "FunctionSpaceBase", "VectorFunctionSpace",
     "create_sparsity_pattern",
     "assemble_scalar", "assemble_matrix", "assemble_vector", "apply_lifting", "set_bc",
     "DirichletBC", "dirichletbc", "bcs_by_block", "DofMap", "Form",

--- a/python/dolfinx/fem/__init__.py
+++ b/python/dolfinx/fem/__init__.py
@@ -24,10 +24,14 @@ def create_sparsity_pattern(a: Form):
     """Create a sparsity pattern from a bilinear form.
 
     Args:
-        a: The bilinear form to build a sparsity pattern for.
+        a: Bilinear form to build a sparsity pattern for.
 
     Returns:
         Sparsity pattern for the form ``a``.
+
+    Note:
+        The pattern is not finalised, i.e. the caller is responsible for
+        calling ``assemble`` on the sparsity pattern.
 
     """
     return _create_sparsity_pattern(a._cpp_object)

--- a/python/dolfinx/fem/__init__.py
+++ b/python/dolfinx/fem/__init__.py
@@ -17,8 +17,7 @@ from dolfinx.fem.bcs import (DirichletBC, bcs_by_block, dirichletbc,
 from dolfinx.fem.dofmap import DofMap
 from dolfinx.fem.forms import Form, extract_function_spaces, form
 from dolfinx.fem.function import (Constant, Expression, Function,
-                                  FunctionSpace, TensorFunctionSpace,
-                                  VectorFunctionSpace)
+                                  FunctionSpace, VectorFunctionSpace)
 
 
 def create_sparsity_pattern(a: Form):
@@ -35,8 +34,7 @@ def create_sparsity_pattern(a: Form):
 
 
 __all__ = [
-    "Constant", "Expression", "Function", "create_matrix",
-    "FunctionSpace", "TensorFunctionSpace",
+    "Constant", "Expression", "Function", "create_matrix", "FunctionSpace",
     "VectorFunctionSpace", "create_sparsity_pattern",
     "assemble_scalar", "assemble_matrix", "assemble_vector", "apply_lifting", "set_bc",
     "DirichletBC", "dirichletbc", "bcs_by_block", "DofMap", "Form",

--- a/python/dolfinx/fem/__init__.py
+++ b/python/dolfinx/fem/__init__.py
@@ -16,7 +16,7 @@ from dolfinx.fem.bcs import (DirichletBC, bcs_by_block, dirichletbc,
                              locate_dofs_geometrical, locate_dofs_topological)
 from dolfinx.fem.dofmap import DofMap
 from dolfinx.fem.forms import Form, extract_function_spaces, form
-from dolfinx.fem.function import (Constant, Expression, Function,
+from dolfinx.fem.function import (Constant, Expression, Function, ElementMetaData,
                                   FunctionSpace, FunctionSpaceBase, VectorFunctionSpace)
 
 
@@ -34,7 +34,7 @@ def create_sparsity_pattern(a: Form):
 
 
 __all__ = [
-    "Constant", "Expression", "Function", "create_matrix",
+    "Constant", "Expression", "Function", "ElementMetaData", "create_matrix",
     "FunctionSpace", "FunctionSpaceBase", "VectorFunctionSpace",
     "create_sparsity_pattern",
     "assemble_scalar", "assemble_matrix", "assemble_vector", "apply_lifting", "set_bc",

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -120,7 +120,7 @@ def assemble_scalar(M: Form, constants=None, coeffs=None):
         coeffs: Coefficients that appear in the form. If not provided,
             any required coefficients will be computed.
 
-    Return:
+    Returns:
         The computed scalar on the calling rank.
 
     Note:
@@ -156,7 +156,7 @@ def _assemble_vector_form(L: Form, constants=None, coeffs=None) -> la.Vector:
         coeffs: Coefficients that appear in the form. If not provided,
             any required coefficients will be computed.
 
-    Return:
+    Returns:
         The assembled vector for the calling rank.
 
     Note:
@@ -317,10 +317,11 @@ def apply_lifting(b: np.ndarray, a: typing.List[Form],
 
 def set_bc(b: np.ndarray, bcs: typing.List[DirichletBC],
            x0: typing.Optional[np.ndarray] = None, scale: float = 1.0) -> None:
-    """Insert boundary condition values into vector. Only local (owned)
-    entries are set, hence communication after calling this function is
-    not required unless ghost entries need to be updated to the boundary
-    condition value.
+    """Insert boundary condition values into vector.
+
+    Only local (owned) entries are set, hence communication after
+    calling this function is not required unless ghost entries need to
+    be updated to the boundary condition value.
 
     """
     _bcs = [bc._cpp_object for bc in bcs]

--- a/python/dolfinx/fem/bcs.py
+++ b/python/dolfinx/fem/bcs.py
@@ -91,7 +91,7 @@ class DirichletBC:
         """Representation of Dirichlet boundary condition which is imposed on
         a linear system.
 
-        Notes:
+        Note:
             Dirichlet boundary conditions  should normally be
             constructed using :func:`fem.dirichletbc` and not using this
             class initialiser. This class is combined with different
@@ -106,6 +106,7 @@ class DirichletBC:
                 Otherwise assumes function space of the problem is the same
                 of function space of boundary values function.
             V: Function space of a problem to which boundary conditions are applied.
+
         """
         self._cpp_object = bc
 

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import collections
-import collections.abc
 import typing
 
 import numpy as np

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -25,22 +25,19 @@ if typing.TYPE_CHECKING:
 
 
 class Form:
-    def __init__(self, form, ufcx_form=None, code=None):
+    def __init__(self, form, ufcx_form=None, code: typing.Optional[str] = None):
         """A finite element form
 
-        Notes:
-            Forms should normally be constructed using
-            :func:`forms.form` and not using this class initialiser.
-            This class is combined with different base classes that
-            depend on the scalar type used in the Form.
+        Note:
+            Forms should normally be constructed using :func:`form` and
+            not using this class initialiser. This class is combined
+            with different base classes that depend on the scalar type
+            used in the Form.
 
         Args:
-            form: Compiled UFC form
-            V: The argument function spaces
-            coeffs: Finite element coefficients that appear in the form
-            constants: Constants appearing in the form
-            subdomains: Subdomains for integrals
-            mesh: The mesh that the form is defined on
+            form: Compiled form object.
+            ufcx_form: UFCx form
+            code: Form C++ code
 
         """
 
@@ -104,12 +101,12 @@ def form(form: typing.Union[ufl.Form, typing.Iterable[ufl.Form]],
     Returns:
         Compiled finite element Form.
 
-    Notes:
+    Note:
         This function is responsible for the compilation of a UFL form
         (using FFCx) and attaching coefficients and domains specific
         data to the underlying C++ form. It dynamically create a
         :class:`Form` instance with an appropriate base class for the
-        scalar type, e.g. `_cpp.fem.Form_float64`.
+        scalar type, e.g. :func:`_cpp.fem.Form_float64`.
 
     """
     if form_compiler_options is None:

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -479,7 +479,7 @@ class Function(ufl.Coefficient):
 
 
 class ElementMetaData(typing.NamedTuple):
-    """Data for representing a finite element.
+    """Data for representing a finite element
 
     :param family: Element type.
     :param degree: Polynomial degree of the element.
@@ -518,7 +518,7 @@ def FunctionSpace(mesh: Mesh,
         ufl_e = basix.ufl.element(e.family, mesh.basix_cell(), e.degree, shape=e.shape,
                                   gdim=mesh.ufl_cell().geometric_dimension())
     except TypeError:
-        ufl_e = element
+        ufl_e = element  # type: ignore
 
     # Check that element and mesh cell types match
     if ufl_e.cell() != mesh.ufl_domain().ufl_cell():

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -498,7 +498,7 @@ class ElementMetaData(typing.NamedTuple):
     symmetry: typing.Optional[bool] = None
 
 
-def FunctionSpace(mesh: Mesh,
+def functionspace(mesh: Mesh,
                   element: typing.Union[ufl.FiniteElementBase, ElementMetaData,
                                         typing.Tuple[str, int, typing.Tuple, bool]],
                   form_compiler_options: typing.Optional[dict[str, typing.Any]] = None,
@@ -515,7 +515,6 @@ def FunctionSpace(mesh: Mesh,
         A function space.
 
     """
-
     # Create UFL element
     try:
         e = ElementMetaData(*element)
@@ -557,6 +556,29 @@ def FunctionSpace(mesh: Mesh,
         cppV = _cpp.fem.FunctionSpace_float32(mesh._cpp_object, cpp_element, cpp_dofmap)
 
     return FunctionSpaceBase(mesh, ufl_e, cppV)
+
+
+def FunctionSpace(mesh: Mesh,
+                  element: typing.Union[ufl.FiniteElementBase, ElementMetaData,
+                                        typing.Tuple[str, int, typing.Tuple, bool]],
+                  form_compiler_options: typing.Optional[dict[str, typing.Any]] = None,
+                  jit_options: typing.Optional[dict[str, typing.Any]] = None) -> FunctionSpaceBase:
+    """Create a finite element function space.
+
+    .. deprecated:: 0.7
+        Use :func:`functionspace` (no caps) instead.
+
+    Args:
+        mesh: Mesh that space is defined on
+        element: Finite element description
+        form_compiler_options: Options passed to the form compiler
+        jit_options: Options controlling just-in-time compilation
+
+    Returns:
+        A function space.
+
+    """
+    return functionspace(mesh, element, form_compiler_options, jit_options)
 
 
 class FunctionSpaceBase(ufl.FunctionSpace):

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import typing
+import warnings
 
 if typing.TYPE_CHECKING:
     from dolfinx.mesh import Mesh
@@ -688,6 +689,9 @@ def VectorFunctionSpace(mesh: Mesh,
                                               ElementMetaData, typing.Tuple[str, int]],
                         dim=None) -> FunctionSpace:
     """Create vector finite element (composition of scalar elements) function space."""
+    warnings.warn('This method is deprecated. Use FunctionSpace with an element shape argument instead',
+                  DeprecationWarning, stacklevel=2)
+
     if not _is_scalar(mesh, element):
         raise ValueError("Cannot create vector element containing a non-scalar.")
 
@@ -703,16 +707,3 @@ def VectorFunctionSpace(mesh: Mesh,
                                   shape=(mesh.geometry.dim,) if dim is None else (dim, ),
                                   gdim=mesh.geometry.dim, rank=1)
     return FunctionSpace(mesh, ufl_e)
-
-
-def TensorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typing.Tuple[str, int]], shape=None,
-                        symmetry: typing.Optional[bool] = None) -> FunctionSpace:
-    """Create tensor finite element (composition of scalar elements) function space."""
-    if not _is_scalar(mesh, element):
-        raise ValueError("Cannot create tensor element containing a non-scalar.")
-    e = ElementMetaData(*element)
-    gdim = mesh.geometry.dim
-    ufl_element = basix.ufl.element(e.family, mesh.basix_cell(), e.degree,
-                                    shape=(gdim, gdim) if shape is None else shape,
-                                    symmetry=symmetry, gdim=mesh.geometry.dim, rank=2)
-    return FunctionSpace(mesh, ufl_element)

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -489,7 +489,8 @@ class FunctionSpace(ufl.FunctionSpace):
     """A space on which Functions (fields) can be defined."""
 
     def __init__(self, mesh: Mesh,
-                 element: typing.Union[ufl.FiniteElementBase, ElementMetaData, typing.Tuple[str, int, typing.Tuple, bool]],
+                 element: typing.Union[ufl.FiniteElementBase, ElementMetaData,
+                                       typing.Tuple[str, int, typing.Tuple, bool]],
                  cppV: typing.Optional[typing.Union[_cpp.fem.FunctionSpace_float32,
                                                     _cpp.fem.FunctionSpace_float64]] = None,
                  form_compiler_options: typing.Optional[dict[str, typing.Any]] = None,
@@ -711,6 +712,7 @@ def TensorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typin
         raise ValueError("Cannot create tensor element containing a non-scalar.")
     e = ElementMetaData(*element)
     gdim = mesh.geometry.dim
-    ufl_element = basix.ufl.element(e.family, mesh.basix_cell(), e.degree, shape=(gdim, gdim) if shape is None else shape,
+    ufl_element = basix.ufl.element(e.family, mesh.basix_cell(), e.degree,
+                                    shape=(gdim, gdim) if shape is None else shape,
                                     symmetry=symmetry, gdim=mesh.geometry.dim, rank=2)
     return FunctionSpace(mesh, ufl_element)

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -3,7 +3,7 @@
 # This file is part of DOLFINx (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
-"""Finite element function spaces and functions"""
+"""Finite element function spaces and functions."""
 
 from __future__ import annotations
 
@@ -20,11 +20,7 @@ import basix
 import numpy as np
 import numpy.typing as npt
 import ufl
-# import ufl.algorithms
-# import ufl.algorithms.analysis
 from dolfinx.fem import dofmap
-from dolfinx.la import Vector
-# from ufl.domain import extract_unique_domain
 
 from dolfinx import cpp as _cpp
 from dolfinx import default_scalar_type, jit, la
@@ -410,12 +406,12 @@ class Function(ufl.Coefficient):
         degree-of-freedom vector is copied.
 
         """
-        return Function(self.function_space, Vector(type(self.x._cpp_object)(self.x._cpp_object)))
+        return Function(self.function_space, la.Vector(type(self.x._cpp_object)(self.x._cpp_object)))
 
     @property
-    def x(self) -> Vector:
+    def x(self) -> la.Vector:
         """Vector holding the degrees-of-freedom."""
-        return Vector(self._cpp_object.x)
+        return la.Vector(self._cpp_object.x)
 
     @property
     def vector(self):
@@ -483,7 +479,7 @@ class Function(ufl.Coefficient):
     def collapse(self) -> Function:
         u_collapsed = self._cpp_object.collapse()
         V_collapsed = FunctionSpaceBase(self.function_space._mesh, self.ufl_element(), u_collapsed.function_space)
-        return Function(V_collapsed, Vector(u_collapsed.x))
+        return Function(V_collapsed, la.Vector(u_collapsed.x))
 
 
 class ElementMetaData(typing.NamedTuple):

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -479,7 +479,15 @@ class Function(ufl.Coefficient):
 
 
 class ElementMetaData(typing.NamedTuple):
-    """Data for representing a finite element"""
+    """Data for representing a finite element.
+
+    :param family: Element type.
+    :param degree: Polynomial degree of the element.
+    :param shape: Shape for vector/tensor valued elements that are
+        constructed from blocked scalar elements (e.g., Lagrange).
+    :param symmetry: Symmetry option for blocked tensor elements.
+
+    """
     family: str
     degree: int
     shape: typing.Optional[typing.Tuple[int, ...]] = None
@@ -552,7 +560,18 @@ class FunctionSpaceBase(ufl.FunctionSpace):
 
     def __init__(self, mesh: Mesh, element: ufl.FiniteElementBase,
                  cppV: typing.Union[_cpp.fem.FunctionSpace_float32, _cpp.fem.FunctionSpace_float64]):
-        """Create a finite element function space."""
+        """Create a finite element function space.
+
+        Note:
+            This initialiser is for internal use and not normally called
+            in user code. Use :func:`FunctionSpace` to create a function space.
+
+        Args:
+            mesh: Mesh that space is defined on
+            element: UFL finite element
+            cppV: Compiled C++ function space.
+
+        """
         if mesh._cpp_object is not cppV.mesh:
             raise RuntimeError("Meshes do not match in FunctionSpace initialisation.")
         ufl_domain = mesh.ufl_domain()

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -495,7 +495,6 @@ class FunctionSpace(ufl.FunctionSpace):
                  form_compiler_options: typing.Optional[dict[str, typing.Any]] = None,
                  jit_options: typing.Optional[dict[str, typing.Any]] = None):
         """Create a finite element function space."""
-        print(element)
         dtype = mesh.geometry.x.dtype
         assert dtype == np.float32 or dtype == np.float64
 
@@ -506,7 +505,6 @@ class FunctionSpace(ufl.FunctionSpace):
             except BaseException:
                 # assert len(element) == 2, "Expected sequence of (element_type, degree)"
                 e = ElementMetaData(*element)
-                print(e)
                 ufl_e = basix.ufl.element(e.family, mesh.basix_cell(), e.degree,
                                           shape=e.shape,
                                           gdim=mesh.ufl_cell().geometric_dimension())
@@ -691,7 +689,6 @@ def VectorFunctionSpace(mesh: Mesh,
                                   gdim=mesh.geometry.dim, rank=1)
     except AttributeError:
         ed = ElementMetaData(*element)
-        print("ffffff", ed)
         ufl_e = basix.ufl.element(ed.family, mesh.basix_cell(), ed.degree,
                                   shape=(mesh.geometry.dim,) if dim is None else (dim, ),
                                   gdim=mesh.geometry.dim, rank=1)
@@ -703,10 +700,8 @@ def TensorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typin
     """Create tensor finite element (composition of scalar elements) function space."""
     if not _is_scalar(mesh, element):
         raise ValueError("Cannot create tensor element containing a non-scalar.")
-
     e = ElementMetaData(*element)
     gdim = mesh.geometry.dim
-    shape_ = (gdim, gdim) if shape is None else shape
-    ufl_element = basix.ufl.element(e.family, mesh.basix_cell(), e.degree, shape=shape_, symmetry=symmetry,
-                                    gdim=mesh.geometry.dim, rank=2)
+    ufl_element = basix.ufl.element(e.family, mesh.basix_cell(), e.degree, shape=(gdim, gdim) if shape is None else shape,
+                                    symmetry=symmetry, gdim=mesh.geometry.dim, rank=2)
     return FunctionSpace(mesh, ufl_element)

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -519,7 +519,7 @@ def functionspace(mesh: Mesh,
     try:
         e = ElementMetaData(*element)
         ufl_e = basix.ufl.element(e.family, mesh.basix_cell(), e.degree, shape=e.shape,
-                                  gdim=mesh.ufl_cell().geometric_dimension())
+                                  symmetry=e.symmetry, gdim=mesh.ufl_cell().geometric_dimension())
     except TypeError:
         ufl_e = element  # type: ignore
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -695,15 +695,15 @@ def VectorFunctionSpace(mesh: Mesh,
     if not _is_scalar(mesh, element):
         raise ValueError("Cannot create vector element containing a non-scalar.")
 
-    try:
-        ufl_e = basix.ufl.element(element.family(), element.cell_type,         # type: ignore
-                                  element.degree(), element.lagrange_variant,  # type: ignore
-                                  element.dpc_variant, element.discontinuous,  # type: ignore
-                                  shape=(mesh.geometry.dim,) if dim is None else (dim, ),
-                                  gdim=mesh.geometry.dim, rank=1)
-    except AttributeError:
-        ed = ElementMetaData(*element)
-        ufl_e = basix.ufl.element(ed.family, mesh.basix_cell(), ed.degree,
-                                  shape=(mesh.geometry.dim,) if dim is None else (dim, ),
-                                  gdim=mesh.geometry.dim, rank=1)
+    # try:
+    #     ufl_e = basix.ufl.element(element.family(), element.cell_type,         # type: ignore
+    #                               element.degree(), element.lagrange_variant,  # type: ignore
+    #                               element.dpc_variant, element.discontinuous,  # type: ignore
+    #                               shape=(mesh.geometry.dim,) if dim is None else (dim, ),
+    #                               gdim=mesh.geometry.dim, rank=1)
+    # except AttributeError:
+    ed = ElementMetaData(*element)
+    ufl_e = basix.ufl.element(ed.family, mesh.basix_cell(), ed.degree,
+                                shape=(mesh.geometry.dim,) if dim is None else (dim, ),
+                                gdim=mesh.geometry.dim, rank=1)
     return FunctionSpace(mesh, ufl_e)

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -434,7 +434,6 @@ class Function(ufl.Coefficient):
             self._petsc_x = create_petsc_vector_wrap(self.x)
         return self._petsc_x
 
-
     @property
     def dtype(self) -> np.dtype:
         return self._cpp_object.x.array.dtype

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -684,11 +684,11 @@ def _is_scalar(mesh, element):
     return len(e.value_shape()) == 0
 
 
-def VectorFunctionSpace(mesh: Mesh,
-                        element: typing.Union[basix.ufl._ElementBase,
-                                              ElementMetaData, typing.Tuple[str, int]],
-                        dim=None) -> FunctionSpace:
-    """Create vector finite element (composition of scalar elements) function space."""
+def VectorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typing.Tuple[str, int]],
+                        dim: typing.Optional[int] = None) -> FunctionSpace:
+    """Create vector finite element (composition of scalar elements) function space.
+
+    """
     warnings.warn('This method is deprecated. Use FunctionSpace with an element shape argument instead',
                   DeprecationWarning, stacklevel=2)
 
@@ -704,6 +704,6 @@ def VectorFunctionSpace(mesh: Mesh,
     # except AttributeError:
     ed = ElementMetaData(*element)
     ufl_e = basix.ufl.element(ed.family, mesh.basix_cell(), ed.degree,
-                                shape=(mesh.geometry.dim,) if dim is None else (dim, ),
-                                gdim=mesh.geometry.dim, rank=1)
+                              shape=(mesh.geometry.dim,) if dim is None else (dim, ),
+                              gdim=mesh.geometry.dim, rank=1)
     return FunctionSpace(mesh, ufl_e)

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -572,7 +572,7 @@ class FunctionSpace(ufl.FunctionSpace):
         conditions.
 
         Returns:
-            A new function space that shares data
+            A new function space that shares data.
 
         """
         try:
@@ -585,7 +585,7 @@ class FunctionSpace(ufl.FunctionSpace):
 
     @property
     def num_sub_spaces(self) -> int:
-        """Number of sub spaces"""
+        """Number of sub spaces."""
         return self.element.num_sub_elements
 
     def sub(self, i: int) -> FunctionSpace:
@@ -661,11 +661,11 @@ class FunctionSpace(ufl.FunctionSpace):
     def tabulate_dof_coordinates(self) -> npt.NDArray[np.float64]:
         """Tabulate the coordinates of the degrees-of-freedom in the function space.
 
-            Returns:
-                Coordinates of the degrees-of-freedom.
+        Returns:
+            Coordinates of the degrees-of-freedom.
 
-            Notes:
-                This method should be used only for elements with point
+        Notes:
+            This method should be used only for elements with point
                 evaluation degrees-of-freedom.
 
          """
@@ -704,6 +704,6 @@ def VectorFunctionSpace(mesh: Mesh, element: typing.Union[ElementMetaData, typin
     # except AttributeError:
     ed = ElementMetaData(*element)
     ufl_e = basix.ufl.element(ed.family, mesh.basix_cell(), ed.degree,
-                              shape=(mesh.geometry.dim,) if dim is None else (dim, ),
+                              shape=(mesh.geometry.dim,) if dim is None else (dim,),
                               gdim=mesh.geometry.dim, rank=1)
     return FunctionSpace(mesh, ufl_e)

--- a/python/dolfinx/jit.py
+++ b/python/dolfinx/jit.py
@@ -126,7 +126,7 @@ def get_options(priority_options: Optional[dict] = None) -> dict:
     Returns:
         dict: Merged option values.
 
-    Notes:
+    Note:
         See :func:`ffcx_jit` for user facing documentation.
 
     """
@@ -166,7 +166,7 @@ def ffcx_jit(ufl_object, form_compiler_options: Optional[dict] = None,
     Returns:
         (compiled object, module, (header code, implementation code))
 
-    Notes:
+    Note:
         Priority ordering of options controlling DOLFINx JIT
         compilation from highest to lowest is:
 

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -307,6 +307,7 @@ class MeshTags:
         self._cpp_object = meshtags
 
     def ufl_id(self) -> int:
+        """Identiftying integer used by UFL."""
         return id(self)
 
     @property
@@ -331,6 +332,7 @@ class MeshTags:
 
     @property
     def name(self) -> str:
+        "Name of the mesh tags object."
         return self._cpp_object.name
 
     @name.setter
@@ -343,7 +345,7 @@ class MeshTags:
         Args:
             value: Mesh tag value to search for.
 
-        Return:
+        Returns:
             Indices of entities with tag ``value``.
 
         """

--- a/python/test/unit/fem/test_assemble_cppimport.py
+++ b/python/test/unit/fem/test_assemble_cppimport.py
@@ -8,20 +8,19 @@
 import pathlib
 
 import cppimport
+import dolfinx.pkgconfig
 import numpy as np
 import pybind11
 import pytest
 import scipy.sparse.linalg
-
-import dolfinx
-import dolfinx.pkgconfig
 import ufl
-from dolfinx.fem import (FunctionSpace, VectorFunctionSpace, dirichletbc, form,
-                         locate_dofs_geometrical, assemble_matrix)
+from dolfinx.fem import (FunctionSpace, assemble_matrix, dirichletbc, form,
+                         locate_dofs_geometrical)
 from dolfinx.mesh import create_unit_square
 from dolfinx.wrappers import get_include_path as pybind_inc
-
 from mpi4py import MPI
+
+import dolfinx
 
 
 @pytest.mark.skip_in_parallel
@@ -201,8 +200,9 @@ PYBIND11_MODULE(assemble_csr, m)
         return cppimport.imp(p)
 
     mesh = create_unit_square(MPI.COMM_SELF, 11, 7)
-    Q = VectorFunctionSpace(mesh, ("Lagrange", 1))
-    Q2 = VectorFunctionSpace(mesh, ("Lagrange", 1), dim=3)
+    gdim = mesh.geometry.dim
+    Q = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+    Q2 = FunctionSpace(mesh, ("Lagrange", 1), (3,))
     u = ufl.TrialFunction(Q)
     v = ufl.TestFunction(Q2)
 

--- a/python/test/unit/fem/test_assemble_cppimport.py
+++ b/python/test/unit/fem/test_assemble_cppimport.py
@@ -202,7 +202,7 @@ PYBIND11_MODULE(assemble_csr, m)
     mesh = create_unit_square(MPI.COMM_SELF, 11, 7)
     gdim = mesh.geometry.dim
     Q = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
-    Q2 = FunctionSpace(mesh, ("Lagrange", 1), (3,))
+    Q2 = FunctionSpace(mesh, ("Lagrange", 1, (3,)))
     u = ufl.TrialFunction(Q)
     v = ufl.TestFunction(Q2)
 

--- a/python/test/unit/fem/test_assemble_cppimport.py
+++ b/python/test/unit/fem/test_assemble_cppimport.py
@@ -8,7 +8,6 @@
 import pathlib
 
 import cppimport
-import dolfinx.pkgconfig
 import numpy as np
 import pybind11
 import pytest

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -13,10 +13,10 @@ import pytest
 import scipy.sparse
 import ufl
 from basix.ufl import element, mixed_element
-from dolfinx.fem import (Constant, Function, FunctionSpace,
-                         VectorFunctionSpace, assemble_scalar, bcs_by_block,
-                         dirichletbc, extract_function_spaces, form,
-                         locate_dofs_geometrical, locate_dofs_topological)
+from dolfinx.fem import (Constant, Function, FunctionSpace, assemble_scalar,
+                         bcs_by_block, dirichletbc, extract_function_spaces,
+                         form, locate_dofs_geometrical,
+                         locate_dofs_topological)
 from dolfinx.fem.petsc import apply_lifting as petsc_apply_lifting
 from dolfinx.fem.petsc import apply_lifting_nest as petsc_apply_lifting_nest
 from dolfinx.fem.petsc import assemble_matrix as petsc_assemble_matrix
@@ -174,7 +174,8 @@ def test_basic_assembly_petsc_matrixcsr(mode):
     assert np.sqrt(A0.squared_norm()) == pytest.approx(A1.norm(), 1.0e-5)
     A1.destroy()
 
-    V = VectorFunctionSpace(mesh, ("Lagrange", 1))
+    gdim = mesh.geometry.dim
+    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = form(inner(u, v) * dx + inner(u, v) * ds)
     A0 = fem.assemble_matrix(a)
@@ -523,7 +524,8 @@ def test_assembly_solve_block(mode):
     create_unit_cube(MPI.COMM_WORLD, 3, 7, 3, ghost_mode=GhostMode.shared_facet)])
 def test_assembly_solve_taylor_hood(mesh):
     """Assemble Stokes problem with Taylor-Hood elements and solve."""
-    P2 = VectorFunctionSpace(mesh, ("Lagrange", 2))
+    gdim = mesh.geometry.dim
+    P2 = FunctionSpace(mesh, ("Lagrange", 2, (gdim,)))
     P1 = FunctionSpace(mesh, ("Lagrange", 1))
 
     def boundary0(x):

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -8,10 +8,9 @@ import numpy as np
 import pytest
 import ufl
 from basix.ufl import element, mixed_element
-from dolfinx.fem import (Constant, Function, FunctionSpace,
-                         VectorFunctionSpace,
-                         apply_lifting, assemble_matrix, assemble_vector,
-                         create_matrix, create_vector, dirichletbc, form,
+from dolfinx.fem import (Constant, Function, FunctionSpace, apply_lifting,
+                         assemble_matrix, assemble_vector, create_matrix,
+                         create_vector, dirichletbc, form,
                          locate_dofs_geometrical, locate_dofs_topological,
                          set_bc)
 from dolfinx.mesh import (CellType, create_unit_cube, create_unit_square,
@@ -178,8 +177,9 @@ def test_vector_constant_bc(mesh_factory):
     func, args = mesh_factory
     mesh = func(*args)
     tdim = mesh.topology.dim
-    V = VectorFunctionSpace(mesh, ("Lagrange", 1))
-    assert V.num_sub_spaces == mesh.geometry.dim
+    gdim = mesh.geometry.dim
+    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+    assert V.num_sub_spaces == gdim
     c = np.arange(1, mesh.geometry.dim + 1, dtype=default_scalar_type)
     boundary_facets = locate_entities_boundary(mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool))
 
@@ -216,9 +216,10 @@ def test_sub_constant_bc(mesh_factory):
     function"""
     func, args = mesh_factory
     mesh = func(*args)
-    tdim = mesh.topology.dim
-    V = VectorFunctionSpace(mesh, ("Lagrange", 1))
+    gdim = mesh.geometry.dim
+    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
     c = Constant(mesh, default_scalar_type(3.14))
+    tdim = mesh.topology.dim
     boundary_facets = locate_entities_boundary(mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool))
 
     for i in range(V.num_sub_spaces):

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -9,7 +9,7 @@ import pytest
 import ufl
 from basix.ufl import element, mixed_element
 from dolfinx.fem import (Constant, Function, FunctionSpace,
-                         TensorFunctionSpace, VectorFunctionSpace,
+                         VectorFunctionSpace,
                          apply_lifting, assemble_matrix, assemble_vector,
                          create_matrix, create_vector, dirichletbc, form,
                          locate_dofs_geometrical, locate_dofs_topological,
@@ -102,9 +102,10 @@ def test_overlapping_bcs():
 def test_constant_bc_constructions():
     """Test construction from constant values"""
     msh = create_unit_square(MPI.COMM_WORLD, 4, 4, dtype=default_real_type)
+    gdim = msh.geometry.dim
     V0 = FunctionSpace(msh, ("Lagrange", 1))
-    V1 = VectorFunctionSpace(msh, ("Lagrange", 1))
-    V2 = TensorFunctionSpace(msh, ("Lagrange", 1))
+    V1 = FunctionSpace(msh, ("Lagrange", 1, (gdim,)))
+    V2 = FunctionSpace(msh, ("Lagrange", 1, (gdim, gdim)))
 
     tdim = msh.topology.dim
     boundary_facets = locate_entities_boundary(msh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool))

--- a/python/test/unit/fem/test_dof_permuting.py
+++ b/python/test/unit/fem/test_dof_permuting.py
@@ -11,8 +11,7 @@ import numpy as np
 import pytest
 import ufl
 from basix.ufl import element
-from dolfinx.fem import (Function, FunctionSpace, VectorFunctionSpace,
-                         assemble_scalar, form)
+from dolfinx.fem import Function, FunctionSpace, assemble_scalar, form
 from dolfinx.mesh import create_mesh
 from mpi4py import MPI
 
@@ -280,11 +279,12 @@ def test_integral(cell_type, space_type, space_order):
     random.seed(4)
     for repeat in range(10):
         mesh = random_evaluation_mesh(cell_type)
-        tdim = mesh.topology.dim
         V = FunctionSpace(mesh, (space_type, space_order))
-        Vvec = VectorFunctionSpace(mesh, ("P", 1))
+        gdim = mesh.geometry.dim
+        Vvec = FunctionSpace(mesh, ("P", 1, (gdim,)))
         dofs = [i for i in V.dofmap.cell_dofs(0) if i in V.dofmap.cell_dofs(1)]
 
+        tdim = mesh.topology.dim
         for d in dofs:
             v = Function(V)
             v.vector[:] = [1 if i == d else 0 for i, _ in enumerate(v.vector[:])]

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -13,7 +13,7 @@ import pytest
 import dolfinx
 import ufl
 from basix.ufl import element, mixed_element
-from dolfinx.fem import FunctionSpace, VectorFunctionSpace
+from dolfinx.fem import FunctionSpace
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
                           create_unit_interval, create_unit_square)
 
@@ -59,12 +59,14 @@ def test_tabulate_dofs(mesh_factory):
 
 def test_entity_dofs(mesh):
     """Test that num entity dofs is correctly wrapped to dolfinx::DofMap"""
+    gdim = mesh.geometry.dim
+
     V = FunctionSpace(mesh, ("Lagrange", 1))
     assert V.dofmap.dof_layout.num_entity_dofs(0) == 1
     assert V.dofmap.dof_layout.num_entity_dofs(1) == 0
     assert V.dofmap.dof_layout.num_entity_dofs(2) == 0
 
-    V = VectorFunctionSpace(mesh, ("Lagrange", 1))
+    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
     bs = V.dofmap.dof_layout.block_size
     assert V.dofmap.dof_layout.num_entity_dofs(0) * bs == 2
     assert V.dofmap.dof_layout.num_entity_dofs(1) * bs == 0
@@ -90,7 +92,7 @@ def test_entity_dofs(mesh):
     assert V.dofmap.dof_layout.num_entity_dofs(1) == 0
     assert V.dofmap.dof_layout.num_entity_dofs(2) == 3
 
-    V = VectorFunctionSpace(mesh, ("Lagrange", 1))
+    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
     bs = V.dofmap.dof_layout.block_size
     for i, cdofs in enumerate([[0, 1], [2, 3], [4, 5]]):
         dofs = [bs * d + b for d in V.dofmap.dof_layout.entity_dofs(0, i)
@@ -158,7 +160,8 @@ def test_block_size(mesh):
             W = FunctionSpace(mesh, mixed_element(i * [P2]))
             assert W.dofmap.index_map_bs == 1
 
-        V = VectorFunctionSpace(mesh, ("Lagrange", 2))
+        gdim = mesh.geometry.dim
+        V = FunctionSpace(mesh, ("Lagrange", 2, (gdim,)))
         assert V.dofmap.index_map_bs == mesh.geometry.dim
 
 

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -12,9 +12,8 @@ import numpy as np
 import pytest
 import ufl
 from basix.ufl import element
-from dolfinx.fem import (Constant, Function, FunctionSpace,
-                         VectorFunctionSpace, assemble_matrix, assemble_scalar,
-                         assemble_vector, form)
+from dolfinx.fem import (Constant, Function, FunctionSpace, assemble_matrix,
+                         assemble_scalar, assemble_vector, form)
 from dolfinx.mesh import CellType, create_mesh, meshtags
 from mpi4py import MPI
 
@@ -185,7 +184,8 @@ def test_facet_normals(cell_type, dtype):
         tdim = mesh.topology.dim
         mesh.topology.create_entities(tdim - 1)
 
-        V = VectorFunctionSpace(mesh, ("Lagrange", 1))
+        gdim = mesh.geometry.dim
+        V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
         normal = ufl.FacetNormal(mesh)
         v = Function(V, dtype=dtype)
 

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -9,8 +9,7 @@ import numpy as np
 import pytest
 import ufl
 from basix.ufl import blocked_element
-from dolfinx.fem import (Constant, Expression, Function, FunctionSpace,
-                         VectorFunctionSpace, form)
+from dolfinx.fem import Constant, Expression, Function, FunctionSpace, form
 from dolfinx.mesh import create_unit_square
 from ffcx.element_interface import QuadratureElement
 from mpi4py import MPI
@@ -34,7 +33,7 @@ def test_rank0(dtype):
     """
     mesh = create_unit_square(MPI.COMM_WORLD, 5, 5, dtype=dtype(0).real.dtype)
     P2 = FunctionSpace(mesh, ("P", 2))
-    vdP1 = VectorFunctionSpace(mesh, ("DG", 1))
+    vdP1 = FunctionSpace(mesh, ("DG", 1))
 
     f = Function(P2, dtype=dtype)
     f.interpolate(lambda x: x[0] ** 2 + 2.0 * x[1] ** 2)
@@ -75,7 +74,8 @@ def test_rank1_hdiv(dtype):
 
     """
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10, dtype=dtype(0).real.dtype)
-    vdP1 = VectorFunctionSpace(mesh, ("DG", 2))
+    gdim = mesh.geometry.gdim
+    vdP1 = FunctionSpace(mesh, ("DG", 2, (gdim,)))
     RT1 = FunctionSpace(mesh, ("RT", 2))
     f = ufl.TrialFunction(RT1)
 

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -74,7 +74,7 @@ def test_rank1_hdiv(dtype):
 
     """
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10, dtype=dtype(0).real.dtype)
-    gdim = mesh.geometry.gdim
+    gdim = mesh.geometry.dim
     vdP1 = FunctionSpace(mesh, ("DG", 2, (gdim,)))
     RT1 = FunctionSpace(mesh, ("RT", 2))
     f = ufl.TrialFunction(RT1)

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -32,8 +32,9 @@ def test_rank0(dtype):
 
     """
     mesh = create_unit_square(MPI.COMM_WORLD, 5, 5, dtype=dtype(0).real.dtype)
+    gdim = mesh.geometry.dim
     P2 = FunctionSpace(mesh, ("P", 2))
-    vdP1 = FunctionSpace(mesh, ("DG", 1))
+    vdP1 = FunctionSpace(mesh, ("DG", 1, (gdim,)))
 
     f = Function(P2, dtype=dtype)
     f.interpolate(lambda x: x[0] ** 2 + 2.0 * x[1] ** 2)

--- a/python/test/unit/fem/test_fem_pipeline.py
+++ b/python/test/unit/fem/test_fem_pipeline.py
@@ -11,9 +11,8 @@ import numpy as np
 import pytest
 import ufl
 from basix.ufl import element, mixed_element
-from dolfinx.fem import (Function, FunctionSpace, VectorFunctionSpace,
-                         assemble_scalar, dirichletbc, form,
-                         locate_dofs_topological)
+from dolfinx.fem import (Function, FunctionSpace, assemble_scalar, dirichletbc,
+                         form, locate_dofs_topological)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                set_bc)
 from dolfinx.io import XDMFFile
@@ -434,7 +433,8 @@ def test_vector_P_simplex(family, degree, cell_type, datadir):
     if cell_type == CellType.tetrahedron and degree == 4:
         pytest.skip("Skip expensive test on tetrahedron")
     mesh = get_mesh(cell_type, datadir)
-    V = VectorFunctionSpace(mesh, (family, degree))
+    gdim = mesh.geometry.dim
+    V = FunctionSpace(mesh, (family, degree, (gdim,)))
     run_vector_test(mesh, V, degree)
 
 
@@ -528,7 +528,8 @@ def test_vector_P_tp(family, degree, cell_type, datadir):
     if cell_type == CellType.hexahedron and degree == 4:
         pytest.skip("Skip expensive test on hexahedron")
     mesh = get_mesh(cell_type, datadir)
-    V = VectorFunctionSpace(mesh, (family, degree))
+    gdim = mesh.geometry.dim
+    V = FunctionSpace(mesh, (family, degree, (gdim,)))
     run_vector_test(mesh, V, degree)
 
 
@@ -584,7 +585,8 @@ def test_vector_S_tp(family, degree, cell_type, datadir):
     if cell_type == CellType.hexahedron and degree == 4:
         pytest.skip("Skip expensive test on hexahedron")
     mesh = get_mesh(cell_type, datadir)
-    V = VectorFunctionSpace(mesh, (family, degree))
+    gdim = mesh.geometry.dim
+    V = FunctionSpace(mesh, (family, degree, (gdim,)))
     run_vector_test(mesh, V, degree // 2)
 
 

--- a/python/test/unit/fem/test_function.py
+++ b/python/test/unit/fem/test_function.py
@@ -12,8 +12,7 @@ import numpy as np
 import pytest
 import ufl
 from basix.ufl import element, mixed_element
-from dolfinx.fem import (Function, FunctionSpace, TensorFunctionSpace,
-                         VectorFunctionSpace)
+from dolfinx.fem import Function, FunctionSpace
 from dolfinx.geometry import (bb_tree, compute_colliding_cells,
                               compute_collisions_points)
 from dolfinx.mesh import create_mesh, create_unit_cube
@@ -34,12 +33,14 @@ def V(mesh):
 
 @pytest.fixture
 def W(mesh):
-    return VectorFunctionSpace(mesh, ('Lagrange', 1))
+    gdim = mesh.geometry.dim
+    return FunctionSpace(mesh, ('Lagrange', 1, (gdim,)))
 
 
 @pytest.fixture
 def Q(mesh):
-    return TensorFunctionSpace(mesh, ('Lagrange', 1))
+    gdim = mesh.geometry.dim
+    return FunctionSpace(mesh, ('Lagrange', 1, (gdim, gdim)))
 
 
 def test_name_argument(W):

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -8,8 +8,7 @@ import basix
 import numpy as np
 import pytest
 from basix.ufl import element, mixed_element
-from dolfinx.fem import (Function, FunctionSpace, TensorFunctionSpace,
-                         VectorFunctionSpace)
+from dolfinx.fem import Function, FunctionSpace, VectorFunctionSpace
 from dolfinx.mesh import create_mesh, create_unit_cube
 from mpi4py import MPI
 from ufl import Cell, Mesh, TestFunction, TrialFunction, grad
@@ -265,8 +264,9 @@ def test_manifold_spaces():
     cells = [(0, 1, 2), (0, 1, 3)]
     domain = Mesh(element("Lagrange", "triangle", 1, gdim=3, rank=1))
     mesh = create_mesh(MPI.COMM_WORLD, cells, vertices, domain)
-    QV = VectorFunctionSpace(mesh, ("Lagrange", 1))
-    QT = TensorFunctionSpace(mesh, ("Lagrange", 1))
+    gdim = mesh.geometry.dim
+    QV = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+    QT = FunctionSpace(mesh, ("Lagrange", 1, (gdim, gdim)))
     u = Function(QV)
     v = Function(QT)
     assert u.ufl_shape == (3,)

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -8,8 +8,7 @@ import basix
 import numpy as np
 import pytest
 from basix.ufl import element, mixed_element
-from dolfinx.fem import (Function, FunctionSpace, FunctionSpaceBase,
-                         VectorFunctionSpace)
+from dolfinx.fem import (Function, FunctionSpace, FunctionSpaceBase)
 from dolfinx.mesh import create_mesh, create_unit_cube
 from mpi4py import MPI
 from ufl import Cell, Mesh, TestFunction, TrialFunction, grad
@@ -29,7 +28,8 @@ def V(mesh):
 
 @pytest.fixture
 def W(mesh):
-    return VectorFunctionSpace(mesh, ('Lagrange', 1))
+    gdim = mesh.geometry.dim
+    return FunctionSpace(mesh, ('Lagrange', 1, (gdim,)))
 
 
 @pytest.fixture
@@ -173,8 +173,9 @@ def test_argument_equality(mesh, V, V2, W, W2):
     """Placed this test here because it's mainly about detecting differing
     function spaces"""
     mesh2 = create_unit_cube(MPI.COMM_WORLD, 8, 8, 8)
+    gdim = mesh2.geometry.dim
     V3 = FunctionSpace(mesh2, ("Lagrange", 1))
-    W3 = VectorFunctionSpace(mesh2, ("Lagrange", 1))
+    W3 = FunctionSpace(mesh2, ("Lagrange", 1, (gdim,)))
 
     for TF in (TestFunction, TrialFunction):
         v = TF(V)
@@ -252,7 +253,7 @@ def test_vector_function_space_cell_type():
 
     # Create functions space over mesh, and check element cell
     # is correct
-    V = VectorFunctionSpace(mesh, ('Lagrange', 1))
+    V = FunctionSpace(mesh, ('Lagrange', 1, (gdim,)))
     assert V.ufl_element().cell() == cell
 
 

--- a/python/test/unit/fem/test_mixed_element.py
+++ b/python/test/unit/fem/test_mixed_element.py
@@ -51,19 +51,17 @@ def test_vector_element():
                               ghost_mode=GhostMode.shared_facet)
     gdim = mesh.geometry.dim
     U = FunctionSpace(mesh, ("P", 2, (gdim,)))
-    u = ufl.TrialFunction(U)
-    v = ufl.TestFunction(U)
+    u, v = ufl.TrialFunction(U), ufl.TestFunction(U)
     a = form(ufl.inner(u, v) * ufl.dx)
     A = dolfinx.fem.assemble_matrix(a)
     A.scatter_reverse()
 
     with pytest.raises(ValueError):
-        # FunctionSpace containing a vector should throw an error
-        # rather than segfaulting
+        # FunctionSpace containing a vector should throw an error rather
+        # than segfaulting
         gdim = mesh.geometry.dim
-        U = FunctionSpace(mesh, ("RT", 2, (gdim,)))
-        u = ufl.TrialFunction(U)
-        v = ufl.TestFunction(U)
+        U = FunctionSpace(mesh, ("RT", 2, (gdim + 1, )))
+        u, v = ufl.TrialFunction(U), ufl.TestFunction(U)
         a = form(ufl.inner(u, v) * ufl.dx)
         A = dolfinx.fem.assemble_matrix(a)
         A.scatter_reverse()

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -9,13 +9,12 @@ import math
 
 import numpy as np
 import pytest
-
 import ufl
 from basix.ufl import element, mixed_element
 from dolfinx.cpp.la.petsc import scatter_local_vectors
-from dolfinx.fem import (Function, FunctionSpace, VectorFunctionSpace,
-                         bcs_by_block, dirichletbc, extract_function_spaces,
-                         form, locate_dofs_topological)
+from dolfinx.fem import (Function, FunctionSpace, bcs_by_block, dirichletbc,
+                         extract_function_spaces, form,
+                         locate_dofs_topological)
 from dolfinx.fem.petsc import (apply_lifting, apply_lifting_nest,
                                assemble_matrix, assemble_matrix_block,
                                assemble_matrix_nest, assemble_vector,
@@ -26,10 +25,9 @@ from dolfinx.fem.petsc import (apply_lifting, apply_lifting_nest,
                                set_bc_nest)
 from dolfinx.mesh import (GhostMode, create_unit_cube, create_unit_square,
                           locate_entities_boundary)
-from ufl import derivative, dx, inner
-
 from mpi4py import MPI
 from petsc4py import PETSc
+from ufl import derivative, dx, inner
 
 
 def nest_matrix_norm(A):
@@ -454,7 +452,7 @@ def test_assembly_solve_block_nl():
 def test_assembly_solve_taylor_hood_nl(mesh):
     """Assemble Stokes problem with Taylor-Hood elements and solve."""
     gdim = mesh.geometry.dim
-    P2 = VectorFunctionSpace(mesh, ("Lagrange", 2))
+    P2 = FunctionSpace(mesh, ("Lagrange", 2, (gdim,)))
     P1 = FunctionSpace(mesh, ("Lagrange", 1))
 
     def boundary0(x):

--- a/python/test/unit/fem/test_petsc_discrete_operators.py
+++ b/python/test/unit/fem/test_petsc_discrete_operators.py
@@ -10,8 +10,8 @@ import pytest
 import ufl
 from basix.ufl import element
 from dolfinx.cpp.fem.petsc import discrete_gradient, interpolation_matrix
-from dolfinx.fem import (Expression, Function, FunctionSpace,
-                         VectorFunctionSpace, assemble_scalar, form)
+from dolfinx.fem import (Expression, Function, FunctionSpace, assemble_scalar,
+                         form)
 from dolfinx.mesh import (CellType, GhostMode, create_mesh, create_unit_cube,
                           create_unit_square)
 from mpi4py import MPI
@@ -171,7 +171,8 @@ def test_nonaffine_discrete_operator():
     cell_type = CellType.hexahedron
     domain = ufl.Mesh(element("Lagrange", cell_type.name, 2, rank=1))
     mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
-    W = VectorFunctionSpace(mesh, ("DG", 1))
+    gdim = mesh.geometry.dim
+    W = FunctionSpace(mesh, ("DG", 1, (gdim,)))
     V = FunctionSpace(mesh, ("NCE", 4))
     w, v = Function(W), Function(V)
     w.interpolate(lambda x: x)

--- a/python/test/unit/fem/test_vector_assemble.py
+++ b/python/test/unit/fem/test_vector_assemble.py
@@ -7,7 +7,7 @@
 
 
 import ufl
-from dolfinx.fem import VectorFunctionSpace, assemble_matrix, form
+from dolfinx.fem import FunctionSpace, assemble_matrix, form
 from dolfinx.mesh import create_unit_square
 
 from mpi4py import MPI
@@ -15,7 +15,8 @@ from mpi4py import MPI
 
 def test_vector_assemble_matrix_exterior():
     mesh = create_unit_square(MPI.COMM_WORLD, 3, 3)
-    V = VectorFunctionSpace(mesh, ("Lagrange", 1))
+    gdim = mesh.geometry.dim
+    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = form(ufl.inner(u, v) * ufl.ds)
     A = assemble_matrix(a)
@@ -24,7 +25,8 @@ def test_vector_assemble_matrix_exterior():
 
 def test_vector_assemble_matrix_interior():
     mesh = create_unit_square(MPI.COMM_WORLD, 3, 3)
-    V = VectorFunctionSpace(mesh, ("Lagrange", 1))
+    gdim = mesh.geometry.dim
+    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = form(ufl.inner(ufl.jump(u), ufl.jump(v)) * ufl.dS)
     A = assemble_matrix(a)

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -11,7 +11,7 @@ import pytest
 import ufl
 from basix.ufl import element
 from dolfinx.common import has_adios2
-from dolfinx.fem import Function, FunctionSpace, VectorFunctionSpace
+from dolfinx.fem import Function, FunctionSpace
 from dolfinx.graph import create_adjacencylist
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
                           create_unit_square)
@@ -64,7 +64,8 @@ def test_fides_mesh(tempdir, dim, simplex):
 def test_two_fides_functions(tempdir, dim, simplex):
     """Test saving two functions with Fides"""
     mesh = generate_mesh(dim, simplex)
-    v = Function(VectorFunctionSpace(mesh, ("Lagrange", 1)))
+    gdim = mesh.geometry.dim
+    v = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim,))))
     q = Function(FunctionSpace(mesh, ("Lagrange", 1)))
     filename = Path(tempdir, "v.bp")
     with FidesWriter(mesh.comm, filename, [v._cpp_object, q]) as f:
@@ -98,9 +99,9 @@ def test_findes_single_function(tempdir, dim, simplex):
 @pytest.mark.parametrize("simplex", [True, False])
 def test_fides_function_at_nodes(tempdir, dim, simplex):
     """Test saving P1 functions with Fides (with changing geometry)"""
-
     mesh = generate_mesh(dim, simplex)
-    v = Function(VectorFunctionSpace(mesh, ("Lagrange", 1)), dtype=default_scalar_type)
+    gdim = mesh.geometry.dim
+    v = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim,))), dtype=default_scalar_type)
     v.name = "v"
     q = Function(FunctionSpace(mesh, ("Lagrange", 1)))
     q.name = "q"
@@ -155,7 +156,8 @@ def test_vtx_mesh(tempdir, dim, simplex):
 def test_vtx_functions_fail(tempdir, dim, simplex):
     "Test for error when elements differ"
     mesh = generate_mesh(dim, simplex)
-    v = Function(VectorFunctionSpace(mesh, ("Lagrange", 2)))
+    gdim = mesh.geometry.dim
+    v = Function(FunctionSpace(mesh, ("Lagrange", 2, (gdim,))))
     w = Function(FunctionSpace(mesh, ("Lagrange", 1)))
     filename = Path(tempdir, "v.bp")
     with pytest.raises(RuntimeError):
@@ -207,7 +209,8 @@ def test_vtx_functions(tempdir, dtype, dim, simplex):
     "Test saving high order Lagrange functions"
     xtype = np.real(dtype(0)).dtype
     mesh = generate_mesh(dim, simplex, dtype=xtype)
-    V = VectorFunctionSpace(mesh, ("DG", 2))
+    gdim = mesh.geometry.dim
+    V = FunctionSpace(mesh, ("DG", 2, (gdim,)))
     v = Function(V, dtype=dtype)
     bs = V.dofmap.index_map_bs
 

--- a/python/test/unit/io/test_vtk.py
+++ b/python/test/unit/io/test_vtk.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 import ufl
 from basix.ufl import element, mixed_element
-from dolfinx.fem import Function, FunctionSpace, VectorFunctionSpace
+from dolfinx.fem import Function, FunctionSpace
 from dolfinx.io import VTKFile
 from dolfinx.io.utils import cell_perm_vtk  # noqa F401
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
@@ -104,7 +104,8 @@ def test_save_1d_vector(tempdir):
 @pytest.mark.parametrize("cell_type", cell_types_2D)
 def test_save_2d_vector(tempdir, cell_type):
     mesh = create_unit_square(MPI.COMM_WORLD, 16, 16, cell_type=cell_type)
-    u = Function(VectorFunctionSpace(mesh, ("Lagrange", 1)))
+    gdim = mesh.geometry.gdim
+    u = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim,))))
 
     def f(x):
         vals = np.zeros((2, x.shape[1]))
@@ -130,7 +131,8 @@ def test_save_2d_vector_CG2(tempdir):
                       [1, 6, 2, 7, 3, 8]])
     domain = ufl.Mesh(element("Lagrange", "triangle", 2, rank=1))
     mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
-    u = Function(VectorFunctionSpace(mesh, ("Lagrange", 2)))
+    gdim = mesh.geometry.gdim
+    u = Function(FunctionSpace(mesh, ("Lagrange", 2, (gdim,))))
     u.interpolate(lambda x: np.vstack((x[0], x[1])))
     filename = Path(tempdir, "u.pvd")
     with VTKFile(mesh.comm, filename, "w") as vtk:

--- a/python/test/unit/io/test_vtk.py
+++ b/python/test/unit/io/test_vtk.py
@@ -10,8 +10,7 @@ import numpy as np
 import pytest
 import ufl
 from basix.ufl import element, mixed_element
-from dolfinx.fem import (Function, FunctionSpace, TensorFunctionSpace,
-                         VectorFunctionSpace)
+from dolfinx.fem import Function, FunctionSpace, VectorFunctionSpace
 from dolfinx.io import VTKFile
 from dolfinx.io.utils import cell_perm_vtk  # noqa F401
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
@@ -223,7 +222,8 @@ def test_save_1d_tensor(tempdir):
 
 def test_save_2d_tensor(tempdir):
     mesh = create_unit_square(MPI.COMM_WORLD, 16, 16)
-    u = Function(TensorFunctionSpace(mesh, ("Lagrange", 2)))
+    gdim = mesh.geometry.dim
+    u = Function(FunctionSpace(mesh, ("Lagrange", 2, (gdim, gdim))))
     u.x.array[:] = 1.0
     filename = Path(tempdir, "u.pvd")
     with VTKFile(mesh.comm, filename, "w") as vtk:
@@ -234,7 +234,8 @@ def test_save_2d_tensor(tempdir):
 
 def test_save_3d_tensor(tempdir):
     mesh = create_unit_cube(MPI.COMM_WORLD, 8, 8, 8)
-    u = Function(TensorFunctionSpace(mesh, ("Lagrange", 2)))
+    gdim = mesh.geometry.dim
+    u = Function(FunctionSpace(mesh, ("Lagrange", 2, (gdim, gdim))))
     u.x.array[:] = 1.0
     filename = Path(tempdir, "u.pvd")
     with VTKFile(mesh.comm, filename, "w") as vtk:

--- a/python/test/unit/io/test_vtk.py
+++ b/python/test/unit/io/test_vtk.py
@@ -104,7 +104,7 @@ def test_save_1d_vector(tempdir):
 @pytest.mark.parametrize("cell_type", cell_types_2D)
 def test_save_2d_vector(tempdir, cell_type):
     mesh = create_unit_square(MPI.COMM_WORLD, 16, 16, cell_type=cell_type)
-    gdim = mesh.geometry.gdim
+    gdim = mesh.geometry.dim
     u = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim,))))
 
     def f(x):
@@ -131,7 +131,7 @@ def test_save_2d_vector_CG2(tempdir):
                       [1, 6, 2, 7, 3, 8]])
     domain = ufl.Mesh(element("Lagrange", "triangle", 2, rank=1))
     mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
-    gdim = mesh.geometry.gdim
+    gdim = mesh.geometry.dim
     u = Function(FunctionSpace(mesh, ("Lagrange", 2, (gdim,))))
     u.interpolate(lambda x: np.vstack((x[0], x[1])))
     filename = Path(tempdir, "u.pvd")

--- a/python/test/unit/io/test_xdmf_function.py
+++ b/python/test/unit/io/test_xdmf_function.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import basix
 import numpy as np
 import pytest
-from dolfinx.fem import Function, FunctionSpace, VectorFunctionSpace
+from dolfinx.fem import Function, FunctionSpace
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import (CellType, create_unit_cube, create_unit_interval,
                           create_unit_square)
@@ -121,11 +121,13 @@ def test_save_2d_vector(tempdir, encoding, dtype, cell_type):
     xtype = np.real(dtype(0)).dtype
     filename = Path(tempdir, "u_2dv.xdmf")
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 13, cell_type, dtype=xtype)
-    V = VectorFunctionSpace(mesh, ("Lagrange", 2))
+    gdim = mesh.geometry.dim
+
+    V = FunctionSpace(mesh, ("Lagrange", 2, (gdim,)))
     u = Function(V, dtype=dtype)
     u.x.array[:] = 1.0 + (1j if np.issubdtype(dtype, np.complexfloating) else 0)
 
-    V1 = VectorFunctionSpace(mesh, ("Lagrange", 1))
+    V1 = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
     u1 = Function(V1, dtype=dtype)
     u1.interpolate(u)
     with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
@@ -140,10 +142,12 @@ def test_save_3d_vector(tempdir, encoding, dtype, cell_type):
     xtype = np.real(dtype(0)).dtype
     filename = Path(tempdir, "u_3Dv.xdmf")
     mesh = create_unit_cube(MPI.COMM_WORLD, 2, 2, 2, cell_type, dtype=xtype)
-    u = Function(VectorFunctionSpace(mesh, ("Lagrange", 1)), dtype=dtype)
+    gdim = mesh.geometry.dim
+
+    u = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim,))), dtype=dtype)
     u.x.array[:] = 1.0 + (1j if np.issubdtype(dtype, np.complexfloating) else 0)
 
-    V1 = VectorFunctionSpace(mesh, ("Lagrange", 1))
+    V1 = FunctionSpace(mesh, ("Lagrange", 1, (gdim, s)))
     u1 = Function(V1, dtype=dtype)
     u1.interpolate(u)
     with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
@@ -167,9 +171,9 @@ def test_save_2d_tensor(tempdir, encoding, dtype, cell_type):
     filename = Path(tempdir, "tensor.xdmf")
     mesh = create_unit_square(MPI.COMM_WORLD, 16, 16, cell_type, dtype=xtype)
     gdim = mesh.geometry.dim
+
     u = Function(FunctionSpace(mesh, ("Lagrange", 2, (gdim, gdim))), dtype=dtype)
     u.x.array[:] = 1.0 + (1j if np.issubdtype(dtype, np.complexfloating) else 0)
-
     u1 = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim, gdim))), dtype=dtype)
     u1.interpolate(u)
     with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
@@ -203,7 +207,8 @@ def test_save_3d_vector_series(tempdir, encoding, dtype, cell_type):
     filename = Path(tempdir, "u_3D.xdmf")
     xtype = np.real(dtype(0)).dtype
     mesh = create_unit_cube(MPI.COMM_WORLD, 2, 2, 2, cell_type, dtype=xtype)
-    u = Function(VectorFunctionSpace(mesh, ("Lagrange", 1)), dtype=dtype)
+    gdim = mesh.geometry.dim
+    u = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim,))), dtype=dtype)
     with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
         u.x.array[:] = 1.0 + (1j if np.issubdtype(dtype, np.complexfloating) else 0)
@@ -279,17 +284,18 @@ def test_higher_order_function(tempdir):
 
     # -- Degree 1 mesh (tet)
     msh = gmsh_tet_model(1)
+    gdim = msh.geometry.dim
     assert msh.geometry.cmaps[0].degree == 1
 
     # Write P1 Function
-    u = Function(VectorFunctionSpace(msh, ("Lagrange", 1)))
+    u = Function(FunctionSpace(msh, ("Lagrange", 1, (gdim,))))
     filename = Path(tempdir, "u3D_P1.xdmf")
     with XDMFFile(msh.comm, filename, "w") as file:
         file.write_mesh(msh)
         file.write_function(u)
 
     # Write P2 Function (exception expected)
-    u = Function(VectorFunctionSpace(msh, ("Lagrange", 2)))
+    u = Function(FunctionSpace(msh, ("Lagrange", 2, (gdim,))))
     filename = Path(tempdir, "u3D_P2.xdmf")
     with pytest.raises(RuntimeError):
         with XDMFFile(msh.comm, filename, "w") as file:
@@ -298,10 +304,11 @@ def test_higher_order_function(tempdir):
 
     # -- Degree 2 mesh (tet)
     msh = gmsh_tet_model(2)
+    gdim = msh.geometry.dim
     assert msh.geometry.cmaps[0].degree == 2
 
     # Write P1 Function (exception expected)
-    u = Function(VectorFunctionSpace(msh, ("Lagrange", 1)))
+    u = Function(FunctionSpace(msh, ("Lagrange", 1, (gdim,))))
     with pytest.raises(RuntimeError):
         filename = Path(tempdir, "u3D_P1.xdmf")
         with XDMFFile(msh.comm, filename, "w") as file:
@@ -309,7 +316,7 @@ def test_higher_order_function(tempdir):
             file.write_function(u)
 
     # Write P2 Function
-    u = Function(VectorFunctionSpace(msh, ("Lagrange", 2)))
+    u = Function(FunctionSpace(msh, ("Lagrange", 2, (gdim,))))
     filename = Path(tempdir, "u3D_P2.xdmf")
     with XDMFFile(msh.comm, filename, "w") as file:
         file.write_mesh(msh)
@@ -318,10 +325,11 @@ def test_higher_order_function(tempdir):
     # -- Degree 3 mesh (tet)
     # NOTE: XDMF/ParaView does not support TETRAHEDRON_20
     msh = gmsh_tet_model(3)
+    gdim = msh.geometry.dim
     assert msh.geometry.cmaps[0].degree == 3
 
     # Write P2 Function (exception expected)
-    u = Function(VectorFunctionSpace(msh, ("Lagrange", 2)))
+    u = Function(FunctionSpace(msh, ("Lagrange", 2, (gdim,))))
     with pytest.raises(RuntimeError):
         filename = Path(tempdir, "u3D_P3.xdmf")
         with XDMFFile(msh.comm, filename, "w") as file:
@@ -348,10 +356,11 @@ def test_higher_order_function(tempdir):
 
     # --  Degree 2 mesh (hex)
     msh = gmsh_hex_model(2)
+    gdim = msh.geometry.dim
     assert msh.geometry.cmaps[0].degree == 2
 
     # Write Q1 Function (exception expected)
-    u = Function(VectorFunctionSpace(msh, ("Lagrange", 1)))
+    u = Function(FunctionSpace(msh, ("Lagrange", 1, (gdim,))))
     with pytest.raises(RuntimeError):
         filename = Path(tempdir, "u3D_Q1.xdmf")
         with XDMFFile(msh.comm, filename, "w") as file:
@@ -359,7 +368,7 @@ def test_higher_order_function(tempdir):
             file.write_function(u)
 
     # Write Q2 Function
-    u = Function(VectorFunctionSpace(msh, ("Lagrange", 2)))
+    u = Function(FunctionSpace(msh, ("Lagrange", 2, (gdim,))))
     filename = Path(tempdir, "u3D_Q2.xdmf")
     with XDMFFile(msh.comm, filename, "w") as file:
         file.write_mesh(msh)
@@ -370,13 +379,14 @@ def test_higher_order_function(tempdir):
     # # Degree 3 mesh (hex)
     # msh = gmsh_hex_model(3)
     # assert msh.geometry.cmaps[0].degree == 3
-    # u = Function(VectorFunctionSpace(msh, ("Lagrange", 1)))
+    # gdim = msh.geometry.dim
+    # u = Function(FunctionSpace(msh, ("Lagrange", 1, (gdim,))))
     # with pytest.raises(RuntimeError):
     #     filename = Path(tempdir, "u3D_Q1.xdmf")
     #     with XDMFFile(msh.comm, filename, "w") as file:
     #         file.write_mesh(msh)
     #         file.write_function(u)
-    # u = Function(VectorFunctionSpace(msh, ("Lagrange", 2)))
+    # u = Function(FunctionSpace(msh, ("Lagrange", 2, (gdim,))))
     # filename = Path(tempdir, "u3D_Q2.xdmf")
     # with XDMFFile(msh.comm, filename, "w") as file:
     #     file.write_mesh(msh)

--- a/python/test/unit/io/test_xdmf_function.py
+++ b/python/test/unit/io/test_xdmf_function.py
@@ -9,8 +9,7 @@ from pathlib import Path
 import basix
 import numpy as np
 import pytest
-from dolfinx.fem import (Function, FunctionSpace, TensorFunctionSpace,
-                         VectorFunctionSpace)
+from dolfinx.fem import Function, FunctionSpace, VectorFunctionSpace
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import (CellType, create_unit_cube, create_unit_interval,
                           create_unit_square)
@@ -167,10 +166,11 @@ def test_save_2d_tensor(tempdir, encoding, dtype, cell_type):
     xtype = np.real(dtype(0)).dtype
     filename = Path(tempdir, "tensor.xdmf")
     mesh = create_unit_square(MPI.COMM_WORLD, 16, 16, cell_type, dtype=xtype)
-    u = Function(TensorFunctionSpace(mesh, ("Lagrange", 2)), dtype=dtype)
+    gdim = mesh.geometry.dim
+    u = Function(FunctionSpace(mesh, ("Lagrange", 2, (gdim, gdim))), dtype=dtype)
     u.x.array[:] = 1.0 + (1j if np.issubdtype(dtype, np.complexfloating) else 0)
 
-    u1 = Function(TensorFunctionSpace(mesh, ("Lagrange", 1)), dtype=dtype)
+    u1 = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim, gdim))), dtype=dtype)
     u1.interpolate(u)
     with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
@@ -184,10 +184,12 @@ def test_save_3d_tensor(tempdir, encoding, dtype, cell_type):
     xtype = np.real(dtype(0)).dtype
     filename = Path(tempdir, "u3t.xdmf")
     mesh = create_unit_cube(MPI.COMM_WORLD, 4, 4, 4, cell_type, dtype=xtype)
-    u = Function(TensorFunctionSpace(mesh, ("Lagrange", 2)), dtype=dtype)
+
+    gdim = mesh.geometry.dim
+    u = Function(FunctionSpace(mesh, ("Lagrange", 2, (gdim, gdim))), dtype=dtype)
     u.x.array[:] = 1.0 + (1j if np.issubdtype(dtype, np.complexfloating) else 0)
 
-    u1 = Function(TensorFunctionSpace(mesh, ("Lagrange", 1)), dtype=dtype)
+    u1 = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim, gdim))), dtype=dtype)
     u1.interpolate(u)
     with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)

--- a/python/test/unit/io/test_xdmf_function.py
+++ b/python/test/unit/io/test_xdmf_function.py
@@ -147,7 +147,7 @@ def test_save_3d_vector(tempdir, encoding, dtype, cell_type):
     u = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim,))), dtype=dtype)
     u.x.array[:] = 1.0 + (1j if np.issubdtype(dtype, np.complexfloating) else 0)
 
-    V1 = FunctionSpace(mesh, ("Lagrange", 1, (gdim, s)))
+    V1 = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
     u1 = Function(V1, dtype=dtype)
     u1.interpolate(u)
     with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:

--- a/python/test/unit/la/test_krylov_solver.py
+++ b/python/test/unit/la/test_krylov_solver.py
@@ -9,19 +9,18 @@ from contextlib import ExitStack
 
 import numpy as np
 import pytest
-
 import ufl
-from dolfinx import la
-from dolfinx.fem import (Function, FunctionSpace, VectorFunctionSpace,
-                         dirichletbc, form, locate_dofs_topological)
+from dolfinx.fem import (Function, FunctionSpace, dirichletbc, form,
+                         locate_dofs_topological)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                set_bc)
 from dolfinx.mesh import create_unit_square, locate_entities_boundary
+from mpi4py import MPI
+from petsc4py import PETSc
 from ufl import (Identity, TestFunction, TrialFunction, dot, dx, grad, inner,
                  sym, tr)
 
-from mpi4py import MPI
-from petsc4py import PETSc
+from dolfinx import la
 
 
 def test_krylov_solver_lu():
@@ -97,7 +96,8 @@ def test_krylov_samg_solver_elasticity():
 
         # Define problem
         mesh = create_unit_square(MPI.COMM_WORLD, N, N)
-        V = VectorFunctionSpace(mesh, 'Lagrange', 1)
+        gdim = mesh.geometry.dim
+        V = FunctionSpace(mesh, ('Lagrange', 1, (gdim,)))
         u = TrialFunction(V)
         v = TestFunction(V)
 

--- a/python/test/unit/la/test_nullspace.py
+++ b/python/test/unit/la/test_nullspace.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 import ufl
 from dolfinx.la import create_petsc_vector
-from dolfinx.fem import VectorFunctionSpace, form
+from dolfinx.fem import FunctionSpace, form
 from dolfinx.fem.petsc import assemble_matrix
 from dolfinx.mesh import (CellType, GhostMode, create_box, create_unit_cube,
                           create_unit_square)
@@ -97,7 +97,8 @@ def build_broken_elastic_nullspace(V):
 @pytest.mark.parametrize("degree", [1, 2])
 def test_nullspace_orthogonal(mesh, degree):
     """Test that null spaces orthogonalisation"""
-    V = VectorFunctionSpace(mesh, ('Lagrange', degree))
+    gdim = mesh.geometry.dim
+    V = FunctionSpace(mesh, ('Lagrange', degree, (gdim,)))
     nullspace = build_elastic_nullspace(V)
     assert not la.is_orthonormal(nullspace, eps=1.0e-4)
     la.orthonormalize(nullspace)
@@ -114,7 +115,8 @@ def test_nullspace_orthogonal(mesh, degree):
 ])
 @pytest.mark.parametrize("degree", [1, 2])
 def test_nullspace_check(mesh, degree):
-    V = VectorFunctionSpace(mesh, ('Lagrange', degree))
+    gdim = mesh.geometry.dim
+    V = FunctionSpace(mesh, ('Lagrange', degree, (gdim,)))
     u, v = TrialFunction(V), TestFunction(V)
 
     E, nu = 2.0e2, 0.3

--- a/python/test/unit/la/test_sparsity_pattern.py
+++ b/python/test/unit/la/test_sparsity_pattern.py
@@ -6,16 +6,16 @@
 """Unit tests for sparsity pattern creation"""
 
 from dolfinx.cpp.la import SparsityPattern
-from dolfinx.fem import VectorFunctionSpace, locate_dofs_topological
+from dolfinx.fem import FunctionSpace, locate_dofs_topological
 from dolfinx.mesh import create_unit_square, exterior_facet_indices
-
 from mpi4py import MPI
 
 
 def test_add_diagonal():
     """Test adding entries to diagonal of sparsity pattern"""
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10)
-    V = VectorFunctionSpace(mesh, ("Lagrange", 1))
+    gdim = mesh.geometry.dim
+    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
     pattern = SparsityPattern(mesh.comm, [V.dofmap.index_map, V.dofmap.index_map],
                               [V.dofmap.index_map_bs, V.dofmap.index_map_bs])
     mesh.topology.create_connectivity(mesh.topology.dim - 1, mesh.topology.dim)


### PR DESCRIPTION
The shape argument to `FunctionSpace` is for 'blocked' scalar elements. This removes the need for `VectorFunctionSpace` and `TensorFunctionSpace`. `TensorFunctionSpace` has been removed and `VectorFunctionSpace` has been deprecated.

PR also changes `FunctionSpace` to a function, and the class is renamed `FunctionSpaceBase`. This simplifies the code significantly. Eventually `FunctionSpace` can be changed to `functionspace`.

Many documentation additions and improvements.