### PR TITLE
Re-design gmsh import in `io.gmshio`

### DIFF
--- a/python/doc/source/api.rst
+++ b/python/doc/source/api.rst
@@ -17,6 +17,7 @@ Public user interface
    dolfinx.geometry
    dolfinx.graph
    dolfinx.io
+   dolfinx.io.gmshio
    dolfinx.jit
    dolfinx.la
    dolfinx.mesh

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -3,7 +3,8 @@
 # This file is part of DOLFINx (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
-"""Tools to extract data from Gmsh models"""
+"""Tools to extract data from Gmsh models."""
+
 import typing
 
 import basix
@@ -19,13 +20,8 @@ from mpi4py import MPI as _MPI
 from dolfinx import cpp as _cpp
 from dolfinx import default_real_type
 
-__all__ = ["cell_perm_array", "ufl_mesh"]
-
-try:
-    import gmsh
-    _has_gmsh = True
-except ModuleNotFoundError:
-    _has_gmsh = False
+__all__ = ["cell_perm_array", "ufl_mesh", "extract_topology_and_markers",
+           "extract_geometry", "model_to_mesh", "read_from_msh"]
 
 
 def ufl_mesh(gmsh_cell: int, gdim: int) -> ufl.Mesh:
@@ -48,9 +44,8 @@ def ufl_mesh(gmsh_cell: int, gdim: int) -> ufl.Mesh:
         raise e
     cell = ufl.Cell(shape, geometric_dimension=gdim)
 
-    element = basix.ufl.element(
-        basix.ElementFamily.P, cell.cellname(), degree, basix.LagrangeVariant.equispaced, shape=(gdim, ),
-        gdim=gdim)
+    element = basix.ufl.element(basix.ElementFamily.P, cell.cellname(), degree,
+                                basix.LagrangeVariant.equispaced, shape=(gdim, ), gdim=gdim)
     return ufl.Mesh(element)
 
 
@@ -68,260 +63,267 @@ def cell_perm_array(cell_type: CellType, num_nodes: int) -> typing.List[int]:
     return _cpp.io.perm_gmsh(cell_type, num_nodes)
 
 
-if _has_gmsh:
-    __all__ += ["extract_topology_and_markers", "extract_geometry", "model_to_mesh", "read_from_msh"]
+def extract_topology_and_markers(model: "gmsh.model", name: typing.Optional[str] = None):
+    """Extract all entities tagged with a physical marker in the gmsh
+    model, and collect the data per cell type.
 
-    def extract_topology_and_markers(model: gmsh.model, name: typing.Optional[str] = None):
-        """Extract all entities tagged with a physical marker in the gmsh
-        model, and collect the data per cell type.
+    Returns a nested dictionary where the first key is the gmsh MSH
+    element type integer. Each element type present in the model
+    contains the cell topology of the elements and corresponding
+    markers.
 
-        Returns a nested dictionary where the first key is the gmsh MSH
-        element type integer. Each element type present in the model
-        contains the cell topology of the elements and corresponding
-        markers.
+    Args:
+        model: Gmsh model.
+        name: Name of the gmsh model. If not set the current
+            model will be used.
 
-        Args:
-            model: Gmsh model.
-            name: Name of the gmsh model. If not set the current
-                model will be used.
+    Returns:
+        A nested dictionary where each key corresponds to a gmsh cell
+        type. Each cell type found in the mesh has a 2D array containing
+        the topology of the marked cell and a list with the
+        corresponding markers.
 
-        Returns:
-            A nested dictionary where each key corresponds to a gmsh
-            cell type. Each cell type found in the mesh has a 2D array
-            containing the topology of the marked cell and a list with
-            the corresponding markers.
+    """
+    if name is not None:
+        model.setCurrent(name)
 
-        """
-        if name is not None:
-            model.setCurrent(name)
+    # Get the physical groups from gmsh in the form [(dim1, tag1),
+    # (dim1, tag2), (dim2, tag3),...]
+    phys_grps = model.getPhysicalGroups()
+    topologies: typing.Dict[int, typing.Dict[str, npt.NDArray[typing.Any]]] = {}
+    for dim, tag in phys_grps:
+        # Get the entities of dimension `dim`, dim=0 -> Points, dim=1 -
+        # >Lines, dim=2 -> Triangles/Quadrilaterals, etc.
+        entities = model.getEntitiesForPhysicalGroup(dim, tag)
+        for entity in entities:
+            # Get cell type, list of cells with given tag and topology
+            # of tagged cells NOTE: Assumes that each entity only have
+            # one cell-type,
+            # i.e. facets of prisms and pyramid meshes are not supported
+            (entity_types, entity_tags, entity_topologies) = model.mesh.getElements(dim, tag=entity)
+            assert len(entity_types) == 1
 
-        # Get the physical groups from gmsh in the form [(dim1, tag1),(dim1,
-        # tag2), (dim2, tag3),...]
-        phys_grps = model.getPhysicalGroups()
-        topologies: typing.Dict[int, typing.Dict[str, npt.NDArray[typing.Any]]] = {}
-        for dim, tag in phys_grps:
-            # Get the entities of dimension `dim`, dim=0 -> Points,
-            # dim=1 - >Lines, dim=2 -> Triangles/Quadrilaterals, etc.
-            entities = model.getEntitiesForPhysicalGroup(dim, tag)
-            for entity in entities:
-                # Get cell type, list of cells with given tag and
-                # topology of tagged cells
-                # NOTE: Assumes that each entity only have one
-                # cell-type, i.e. facets of prisms and pyramid meshes
-                # are not supported
-                (entity_types, entity_tags, entity_topologies) = model.mesh.getElements(dim, tag=entity)
-                assert len(entity_types) == 1
+            # Determine number of local nodes per element to create the
+            # topology of the elements
+            properties = model.mesh.getElementProperties(entity_types[0])
+            name, dim, _, num_nodes, _, _ = properties
 
-                # Determine number of local nodes per element to create the
-                # topology of the elements
-                properties = model.mesh.getElementProperties(entity_types[0])
-                name, dim, _, num_nodes, _, _ = properties
+            # Array of shape (num_elements,num_nodes_per_element)
+            # containing the topology of the elements on this entity.
+            # NOTE: Gmsh indexing starts with one, we therefore subtract
+            # 1 from each node to use zero-based numbering
+            topology = entity_topologies[0].reshape(-1, num_nodes) - 1
 
-                # Array of shape (num_elements,num_nodes_per_element)
-                # containing the topology of the elements on this
-                # entity.
-                # NOTE: Gmsh indexing starts with one, we therefore
-                # subtract 1 from each node to use zero-based numbering
-                topology = entity_topologies[0].reshape(-1, num_nodes) - 1
+            # Create marker array of length of number of tagged cells
+            marker = np.full_like(entity_tags[0], tag)
 
-                # Create marker array of length of number of tagged cells
-                marker = np.full_like(entity_tags[0], tag)
+            # Group element topology and markers of the same entity type
+            entity_type = entity_types[0]
+            if entity_type in topologies.keys():
+                topologies[entity_type]["topology"] = np.concatenate(
+                    (topologies[entity_type]["topology"], topology), axis=0)
+                topologies[entity_type]["cell_data"] = np.hstack([topologies[entity_type]["cell_data"], marker])
+            else:
+                topologies[entity_type] = {"topology": topology, "cell_data": marker}
 
-                # Group element topology and markers of the same entity type
-                entity_type = entity_types[0]
-                if entity_type in topologies.keys():
-                    topologies[entity_type]["topology"] = np.concatenate(
-                        (topologies[entity_type]["topology"], topology), axis=0)
-                    topologies[entity_type]["cell_data"] = np.hstack([topologies[entity_type]["cell_data"], marker])
-                else:
-                    topologies[entity_type] = {"topology": topology, "cell_data": marker}
+    return topologies
 
-        return topologies
 
-    def extract_geometry(model: gmsh.model, name: typing.Optional[str] = None) -> npt.NDArray[np.float64]:
-        """Extract the mesh geometry from a gmsh model as an array of shape
-        (num_nodes, 3), where the i-th row corresponds to the i-th node in the
-        mesh.
+def extract_geometry(model: "gmsh.model", name: typing.Optional[str] = None) -> npt.NDArray[np.float64]:
+    """Extract the mesh geometry from a gmsh model as an array of shape
+    ``(num_nodes, 3)`, where the i-th row corresponds to the i-th node
+    in the mesh.
 
-        Args:
-            model: The Gmsh model
-            name: The name of the gmsh model. If not set the current
-                model will be used.
+    Args:
+        model: The Gmsh model
+        name: The name of the gmsh model. If not set the current
+            model will be used.
 
-        Returns:
-            The mesh geometry as an array of shape (num_nodes, 3).
+    Returns:
+        The mesh geometry as an array of shape (num_nodes, 3).
 
-        """
-        if name is not None:
-            model.setCurrent(name)
+    """
+    if name is not None:
+        model.setCurrent(name)
 
-        # Get the unique tag and coordinates for nodes in mesh
-        indices, points, _ = model.mesh.getNodes()
-        points = points.reshape(-1, 3)
+    # Get the unique tag and coordinates for nodes in mesh
+    indices, points, _ = model.mesh.getNodes()
+    points = points.reshape(-1, 3)
 
-        # Gmsh indices starts at 1. We therefore subtract one to use
-        # zero-based numbering
-        indices -= 1
+    # Gmsh indices starts at 1. We therefore subtract one to use
+    # zero-based numbering
+    indices -= 1
 
-        # In some cases, Gmsh does not return the points in the same
-        # order as their unique node index. We therefore sort nodes in
-        # geometry according to the unique index
-        perm_sort = np.argsort(indices)
-        assert np.all(indices[perm_sort] == np.arange(len(indices)))
-        return points[perm_sort]
+    # In some cases, Gmsh does not return the points in the same
+    # order as their unique node index. We therefore sort nodes in
+    # geometry according to the unique index
+    perm_sort = np.argsort(indices)
+    assert np.all(indices[perm_sort] == np.arange(len(indices)))
+    return points[perm_sort]
 
-    def model_to_mesh(model: gmsh.model, comm: _MPI.Comm, rank: int, gdim: int = 3,
-                      partitioner: typing.Optional[typing.Callable[
-                          [_MPI.Comm, int, int, AdjacencyList_int32], AdjacencyList_int32]] = None,
-                      dtype=default_real_type) -> typing.Tuple[
-            Mesh, _cpp.mesh.MeshTags_int32, _cpp.mesh.MeshTags_int32]:
-        """Given a Gmsh model, take all physical entities of the highest
-        topological dimension and create the corresponding DOLFINx mesh.
 
-        In parallel, the gmsh model is processed on one MPI rank, and
-        the resulting mesh is distributed by DOLFINx. For performance,
-        this function should only be called once for large problems. For
-        re-use, it is recommended to save the mesh and corresponding
-        tags using XDMFFile after creation for efficient access.
+def model_to_mesh(model: "gmsh.model", comm: _MPI.Comm, rank: int, gdim: int = 3,
+                  partitioner: typing.Optional[typing.Callable[
+                      [_MPI.Comm, int, int, AdjacencyList_int32], AdjacencyList_int32]] = None,
+                  dtype=default_real_type) -> typing.Tuple[
+        Mesh, _cpp.mesh.MeshTags_int32, _cpp.mesh.MeshTags_int32]:
+    """Given a Gmsh model, take all physical entities of the highest
+    topological dimension and create the corresponding DOLFINx mesh.
 
-        Args:
-            model: Gmsh model.
-            comm: MPI communicator to use for mesh creation.
-            rank: MPI rank that the Gmsh model is initialized on.
-            gdim: Geometrical dimension of the mesh
-            partitioner: Function that computes the parallel
-                distribution of cells across MPI ranks
+    In parallel, the gmsh model is processed on one MPI rank, and the
+    resulting mesh is distributed by DOLFINx. For performance, this
+    function should only be called once for large problems. For re-use,
+    it is recommended to save the mesh and corresponding tags using
+    XDMFFile after creation for efficient access.
 
-        Returns:
-            A triplet (mesh, cell_tags, facet_tags) where cell_tags hold
-            markers for the cells and facet tags holds markers for
-            facets (if tags are found in Gmsh model).
+    Args:
+        model: Gmsh model.
+        comm: MPI communicator to use for mesh creation.
+        rank: MPI rank that the Gmsh model is initialized on.
+        gdim: Geometrical dimension of the mesh
+        partitioner: Function that computes the parallel
+            distribution of cells across MPI ranks
 
-        """
-        if comm.rank == rank:
-            assert model is not None, "Gmsh model is None on rank responsible for mesh creation."
-            # Get mesh geometry and mesh topology for each element
-            x = extract_geometry(model)
-            topologies = extract_topology_and_markers(model)
+    Returns:
+        A triplet (mesh, cell_tags, facet_tags) where cell_tags hold
+        markers for the cells and facet tags holds markers for facets
+        (if tags are found in Gmsh model).
 
-            # Extract Gmsh cell id, dimension of cell and number of
-            # nodes to cell for each
-            num_cell_types = len(topologies.keys())
-            cell_information = dict()
-            cell_dimensions = np.zeros(num_cell_types, dtype=np.int32)
-            for i, element in enumerate(topologies.keys()):
-                _, dim, _, num_nodes, _, _ = model.mesh.getElementProperties(element)
-                cell_information[i] = {"id": element, "dim": dim, "num_nodes": num_nodes}
-                cell_dimensions[i] = dim
+    """
+    if comm.rank == rank:
+        assert model is not None, "Gmsh model is None on rank responsible for mesh creation."
+        # Get mesh geometry and mesh topology for each element
+        x = extract_geometry(model)
+        topologies = extract_topology_and_markers(model)
 
-            # Sort elements by ascending dimension
-            perm_sort = np.argsort(cell_dimensions)
+        # Extract Gmsh cell id, dimension of cell and number of nodes to
+        # cell for each
+        num_cell_types = len(topologies.keys())
+        cell_information = dict()
+        cell_dimensions = np.zeros(num_cell_types, dtype=np.int32)
+        for i, element in enumerate(topologies.keys()):
+            _, dim, _, num_nodes, _, _ = model.mesh.getElementProperties(element)
+            cell_information[i] = {"id": element, "dim": dim, "num_nodes": num_nodes}
+            cell_dimensions[i] = dim
 
-            # Broadcast cell type data and geometric dimension
-            cell_id = cell_information[perm_sort[-1]]["id"]
-            tdim = cell_information[perm_sort[-1]]["dim"]
-            num_nodes = cell_information[perm_sort[-1]]["num_nodes"]
-            cell_id, num_nodes = comm.bcast([cell_id, num_nodes], root=rank)
+        # Sort elements by ascending dimension
+        perm_sort = np.argsort(cell_dimensions)
 
-            # Check for facet data and broadcast relevant info if True
-            has_facet_data = False
-            if tdim - 1 in cell_dimensions:
-                has_facet_data = True
+        # Broadcast cell type data and geometric dimension
+        cell_id = cell_information[perm_sort[-1]]["id"]
+        tdim = cell_information[perm_sort[-1]]["dim"]
+        num_nodes = cell_information[perm_sort[-1]]["num_nodes"]
+        cell_id, num_nodes = comm.bcast([cell_id, num_nodes], root=rank)
 
-            has_facet_data = comm.bcast(has_facet_data, root=rank)
-            if has_facet_data:
-                num_facet_nodes = comm.bcast(cell_information[perm_sort[-2]]["num_nodes"], root=rank)
-                gmsh_facet_id = cell_information[perm_sort[-2]]["id"]
-                marked_facets = np.asarray(topologies[gmsh_facet_id]["topology"], dtype=np.int64)
-                facet_values = np.asarray(topologies[gmsh_facet_id]["cell_data"], dtype=np.int32)
+        # Check for facet data and broadcast relevant info if True
+        has_facet_data = False
+        if tdim - 1 in cell_dimensions:
+            has_facet_data = True
 
-            cells = np.asarray(topologies[cell_id]["topology"], dtype=np.int64)
-            cell_values = np.asarray(topologies[cell_id]["cell_data"], dtype=np.int32)
-        else:
-            cell_id, num_nodes = comm.bcast([None, None], root=rank)
-            cells, x = np.empty([0, num_nodes], dtype=np.int32), np.empty([0, gdim], dtype=dtype)
-            cell_values = np.empty((0,), dtype=np.int32)
-            has_facet_data = comm.bcast(None, root=rank)
-            if has_facet_data:
-                num_facet_nodes = comm.bcast(None, root=rank)
-                marked_facets = np.empty((0, num_facet_nodes), dtype=np.int32)
-                facet_values = np.empty((0,), dtype=np.int32)
-
-        # Create distributed mesh
-        ufl_domain = ufl_mesh(cell_id, gdim)
-        gmsh_cell_perm = cell_perm_array(_cpp.mesh.to_type(str(ufl_domain.ufl_cell())), num_nodes)
-        cells = cells[:, gmsh_cell_perm]
-        mesh = create_mesh(comm, cells, x[:, :gdim].astype(dtype, copy=False), ufl_domain, partitioner)
-
-        # Create MeshTags for cells
-        local_entities, local_values = _cpp.io.distribute_entity_data(
-            mesh._cpp_object, mesh.topology.dim, cells, cell_values)
-        mesh.topology.create_connectivity(mesh.topology.dim, 0)
-        adj = _cpp.graph.AdjacencyList_int32(local_entities)
-        ct = meshtags_from_entities(mesh, mesh.topology.dim, adj, local_values.astype(np.int32, copy=False))
-        ct.name = "Cell tags"
-
-        # Create MeshTags for facets
-        topology = mesh.topology
-        tdim = topology.dim
+        has_facet_data = comm.bcast(has_facet_data, root=rank)
         if has_facet_data:
-            # Permute facets from MSH to DOLFINx ordering
-            # FIXME: This does not work for prism meshes
-            if topology.cell_types[0] == CellType.prism or topology.cell_types[0] == CellType.pyramid:
-                raise RuntimeError(f"Unsupported cell type {topology.cell_types[0]}")
+            num_facet_nodes = comm.bcast(cell_information[perm_sort[-2]]["num_nodes"], root=rank)
+            gmsh_facet_id = cell_information[perm_sort[-2]]["id"]
+            marked_facets = np.asarray(topologies[gmsh_facet_id]["topology"], dtype=np.int64)
+            facet_values = np.asarray(topologies[gmsh_facet_id]["cell_data"], dtype=np.int32)
 
-            facet_type = _cpp.mesh.cell_entity_type(_cpp.mesh.to_type(str(ufl_domain.ufl_cell())), tdim - 1, 0)
-            gmsh_facet_perm = cell_perm_array(facet_type, num_facet_nodes)
-            marked_facets = marked_facets[:, gmsh_facet_perm]
+        cells = np.asarray(topologies[cell_id]["topology"], dtype=np.int64)
+        cell_values = np.asarray(topologies[cell_id]["cell_data"], dtype=np.int32)
+    else:
+        cell_id, num_nodes = comm.bcast([None, None], root=rank)
+        cells, x = np.empty([0, num_nodes], dtype=np.int32), np.empty([0, gdim], dtype=dtype)
+        cell_values = np.empty((0,), dtype=np.int32)
+        has_facet_data = comm.bcast(None, root=rank)
+        if has_facet_data:
+            num_facet_nodes = comm.bcast(None, root=rank)
+            marked_facets = np.empty((0, num_facet_nodes), dtype=np.int32)
+            facet_values = np.empty((0,), dtype=np.int32)
 
-            local_entities, local_values = _cpp.io.distribute_entity_data(
-                mesh._cpp_object, tdim - 1, marked_facets, facet_values)
-            mesh.topology.create_connectivity(topology.dim - 1, tdim)
-            adj = _cpp.graph.AdjacencyList_int32(local_entities)
-            ft = meshtags_from_entities(mesh, tdim - 1, adj, local_values.astype(np.int32, copy=False))
-            ft.name = "Facet tags"
-        else:
-            ft = meshtags(mesh, tdim - 1, np.empty(0, dtype=np.int32), np.empty(0, dtype=np.int32))
+    # Create distributed mesh
+    ufl_domain = ufl_mesh(cell_id, gdim)
+    gmsh_cell_perm = cell_perm_array(_cpp.mesh.to_type(str(ufl_domain.ufl_cell())), num_nodes)
+    cells = cells[:, gmsh_cell_perm]
+    mesh = create_mesh(comm, cells, x[:, :gdim].astype(dtype, copy=False), ufl_domain, partitioner)
 
-        return (mesh, ct, ft)
+    # Create MeshTags for cells
+    local_entities, local_values = _cpp.io.distribute_entity_data(
+        mesh._cpp_object, mesh.topology.dim, cells, cell_values)
+    mesh.topology.create_connectivity(mesh.topology.dim, 0)
+    adj = _cpp.graph.AdjacencyList_int32(local_entities)
+    ct = meshtags_from_entities(mesh, mesh.topology.dim, adj, local_values.astype(np.int32, copy=False))
+    ct.name = "Cell tags"
 
-    def read_from_msh(filename: str, comm: _MPI.Comm, rank: int = 0, gdim: int = 3,
-                      partitioner: typing.Optional[typing.Callable[
-                          [_MPI.Comm, int, int, AdjacencyList_int32], AdjacencyList_int32]] = None) -> typing.Tuple[
-            Mesh, _cpp.mesh.MeshTags_int32, _cpp.mesh.MeshTags_int32]:
-        """Read a mesh from a msh-file and return a distributed DOLFINx
-        mesh and cell and facet markers associated with physical groups
-        in the msh file.
+    # Create MeshTags for facets
+    topology = mesh.topology
+    tdim = topology.dim
+    if has_facet_data:
+        # Permute facets from MSH to DOLFINx ordering
+        # FIXME: This does not work for prism meshes
+        if topology.cell_types[0] == CellType.prism or topology.cell_types[0] == CellType.pyramid:
+            raise RuntimeError(f"Unsupported cell type {topology.cell_types[0]}")
 
-        Args:
-            filename: Name of msh file
-            comm: The MPI communicator to initialize the mesh with
-            rank: Rank for `comm` responsible for reading the msh file
-            gdim: Geometrical dimension of the mesh
+        facet_type = _cpp.mesh.cell_entity_type(_cpp.mesh.to_type(str(ufl_domain.ufl_cell())), tdim - 1, 0)
+        gmsh_facet_perm = cell_perm_array(facet_type, num_facet_nodes)
+        marked_facets = marked_facets[:, gmsh_facet_perm]
 
-        Returns:
-            A triplet (mesh, cell_tags, facet_tags) with meshtags for
-            associated physical groups for cells and facets.
+        local_entities, local_values = _cpp.io.distribute_entity_data(
+            mesh._cpp_object, tdim - 1, marked_facets, facet_values)
+        mesh.topology.create_connectivity(topology.dim - 1, tdim)
+        adj = _cpp.graph.AdjacencyList_int32(local_entities)
+        ft = meshtags_from_entities(mesh, tdim - 1, adj, local_values.astype(np.int32, copy=False))
+        ft.name = "Facet tags"
+    else:
+        ft = meshtags(mesh, tdim - 1, np.empty(0, dtype=np.int32), np.empty(0, dtype=np.int32))
 
-        """
-        if comm.rank == rank:
-            gmsh.initialize()
-            gmsh.model.add("Mesh from file")
-            gmsh.merge(filename)
-            msh = model_to_mesh(gmsh.model, comm, rank, gdim=gdim, partitioner=partitioner)
-            gmsh.finalize()
-            return msh
-        else:
-            return model_to_mesh(gmsh.model, comm, rank, gdim=gdim, partitioner=partitioner)
+    return (mesh, ct, ft)
 
-    # Map from Gmsh cell type identifier (integer) to DOLFINx cell type
-    # and degree http://gmsh.info//doc/texinfo/gmsh.html#MSH-file-format
-    _gmsh_to_cells = {1: ("interval", 1), 2: ("triangle", 1),
-                      3: ("quadrilateral", 1), 4: ("tetrahedron", 1),
-                      5: ("hexahedron", 1), 8: ("interval", 2),
-                      9: ("triangle", 2), 10: ("quadrilateral", 2),
-                      11: ("tetrahedron", 2), 12: ("hexahedron", 2),
-                      15: ("point", 0), 21: ("triangle", 3),
-                      26: ("interval", 3), 29: ("tetrahedron", 3),
-                      36: ("quadrilateral", 3),
-                      92: ("hexahedron", 3)}
+
+def read_from_msh(filename: str, comm: _MPI.Comm, rank: int = 0, gdim: int = 3,
+                  partitioner: typing.Optional[typing.Callable[
+                      [_MPI.Comm, int, int, AdjacencyList_int32], AdjacencyList_int32]] = None) -> typing.Tuple[
+        Mesh, _cpp.mesh.MeshTags_int32, _cpp.mesh.MeshTags_int32]:
+    """Read a mesh from a msh-file and return a distributed DOLFINx
+    mesh and cell and facet markers associated with physical groups in
+    the msh file.
+
+    Notes:
+        This function requires the Gmsh Python module.
+
+    Args:
+        filename: Name of msh file
+        comm: The MPI communicator to initialize the mesh with
+        rank: Rank for `comm` responsible for reading the msh file
+        gdim: Geometrical dimension of the mesh
+
+    Returns:
+        A triplet (mesh, cell_tags, facet_tags) with meshtags for
+        associated physical groups for cells and facets.
+
+    """
+    if comm.rank == rank:
+        try:
+            import gmsh
+        except ModuleNotFoundError:
+            print("The Gmsh Python module could not be imported.")
+            raise
+        gmsh.initialize()
+        gmsh.model.add("Mesh from file")
+        gmsh.merge(filename)
+        msh = model_to_mesh(gmsh.model, comm, rank, gdim=gdim, partitioner=partitioner)
+        gmsh.finalize()
+        return msh
+    else:
+        return model_to_mesh(gmsh.model, comm, rank, gdim=gdim, partitioner=partitioner)
+
+
+# Map from Gmsh cell type identifier (integer) to DOLFINx cell type
+# and degree http://gmsh.info//doc/texinfo/gmsh.html#MSH-file-format
+_gmsh_to_cells = {1: ("interval", 1), 2: ("triangle", 1),
+                  3: ("quadrilateral", 1), 4: ("tetrahedron", 1),
+                  5: ("hexahedron", 1), 8: ("interval", 2),
+                  9: ("triangle", 2), 10: ("quadrilateral", 2),
+                  11: ("tetrahedron", 2), 12: ("hexahedron", 2),
+                  15: ("point", 0), 21: ("triangle", 3),
+                  26: ("interval", 3), 29: ("tetrahedron", 3),
+                  36: ("quadrilateral", 3),
+                  92: ("hexahedron", 3)}

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -131,7 +131,10 @@ def extract_topology_and_markers(model, name: typing.Optional[str] = None):
 
 
 def extract_geometry(model, name: typing.Optional[str] = None) -> npt.NDArray[np.float64]:
-    """Extract the mesh geometry from a gmsh model as an array of shape ``(num_nodes, 3)``, where the i-th row corresponds to the i-th node in the mesh.
+    """Extract the mesh geometry from a Gmsh model.
+
+    Returns an array of shape ``(num_nodes, 3)``, where the i-th row
+    corresponds to the i-th node in the mesh.
 
     Args:
         model: Gmsh model

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -34,8 +34,9 @@ def ufl_mesh(gmsh_cell: int, gdim: int) -> ufl.Mesh:
         gdim: The geometric dimension of the mesh
 
     Returns:
-        A ufl Mesh using Lagrange elements (equispaced) of the
-        corresponding DOLFINx cell
+        A UFL Mesh using Lagrange elements (equispaced) of the
+        corresponding DOLFINx cell.
+
     """
     try:
         shape, degree = _gmsh_to_cells[gmsh_cell]
@@ -53,17 +54,17 @@ def cell_perm_array(cell_type: CellType, num_nodes: int) -> typing.List[int]:
     """The permutation array for permuting Gmsh ordering to DOLFINx ordering.
 
     Args:
-        cell_type: The DOLFINx cell type
-        num_nodes: The number of nodes in the cell
+        cell_type: DOLFINx cell type
+        num_nodes: Number of nodes in the cell
 
     Returns:
-        An array `p` such that `a_dolfinx[i] = a_gmsh[p[i]]`.
+        An array ``p`` such that ``a_dolfinx[i] = a_gmsh[p[i]]``.
 
     """
     return _cpp.io.perm_gmsh(cell_type, num_nodes)
 
 
-def extract_topology_and_markers(model: "gmsh.model", name: typing.Optional[str] = None):
+def extract_topology_and_markers(model, name: typing.Optional[str] = None):
     """Extract all entities tagged with a physical marker in the gmsh
     model, and collect the data per cell type.
 
@@ -129,14 +130,12 @@ def extract_topology_and_markers(model: "gmsh.model", name: typing.Optional[str]
     return topologies
 
 
-def extract_geometry(model: "gmsh.model", name: typing.Optional[str] = None) -> npt.NDArray[np.float64]:
-    """Extract the mesh geometry from a gmsh model as an array of shape
-    ``(num_nodes, 3)`, where the i-th row corresponds to the i-th node
-    in the mesh.
+def extract_geometry(model, name: typing.Optional[str] = None) -> npt.NDArray[np.float64]:
+    """Extract the mesh geometry from a gmsh model as an array of shape ``(num_nodes, 3)``, where the i-th row corresponds to the i-th node in the mesh.
 
     Args:
-        model: The Gmsh model
-        name: The name of the gmsh model. If not set the current
+        model: Gmsh model
+        name: Name of the Gmsh model. If not set the current
             model will be used.
 
     Returns:
@@ -162,7 +161,7 @@ def extract_geometry(model: "gmsh.model", name: typing.Optional[str] = None) -> 
     return points[perm_sort]
 
 
-def model_to_mesh(model: "gmsh.model", comm: _MPI.Comm, rank: int, gdim: int = 3,
+def model_to_mesh(model, comm: _MPI.Comm, rank: int, gdim: int = 3,
                   partitioner: typing.Optional[typing.Callable[
                       [_MPI.Comm, int, int, AdjacencyList_int32], AdjacencyList_int32]] = None,
                   dtype=default_real_type) -> typing.Tuple[

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -305,15 +305,15 @@ def read_from_msh(filename: str, comm: _MPI.Comm, rank: int = 0, gdim: int = 3,
     if comm.rank == rank:
         try:
             import gmsh
+            gmsh.initialize()
+            gmsh.model.add("Mesh from file")
+            gmsh.merge(filename)
+            msh = model_to_mesh(gmsh.model, comm, rank, gdim=gdim, partitioner=partitioner)
+            gmsh.finalize()
+            return msh
         except ModuleNotFoundError:
             print("The Gmsh Python module could not be imported.")
             raise
-        gmsh.initialize()
-        gmsh.model.add("Mesh from file")
-        gmsh.merge(filename)
-        msh = model_to_mesh(gmsh.model, comm, rank, gdim=gdim, partitioner=partitioner)
-        gmsh.finalize()
-        return msh
     else:
         return model_to_mesh(gmsh.model, comm, rank, gdim=gdim, partitioner=partitioner)
 

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -302,18 +302,18 @@ def read_from_msh(filename: str, comm: _MPI.Comm, rank: int = 0, gdim: int = 3,
         associated physical groups for cells and facets.
 
     """
+    try:
+        import gmsh
+    except ModuleNotFoundError:
+        print("The Gmsh Python module could not be imported.")
+        raise
     if comm.rank == rank:
-        try:
-            import gmsh
-            gmsh.initialize()
-            gmsh.model.add("Mesh from file")
-            gmsh.merge(filename)
-            msh = model_to_mesh(gmsh.model, comm, rank, gdim=gdim, partitioner=partitioner)
-            gmsh.finalize()
-            return msh
-        except ModuleNotFoundError:
-            print("The Gmsh Python module could not be imported.")
-            raise
+        gmsh.initialize()
+        gmsh.model.add("Mesh from file")
+        gmsh.merge(filename)
+        msh = model_to_mesh(gmsh.model, comm, rank, gdim=gdim, partitioner=partitioner)
+        gmsh.finalize()
+        return msh
     else:
         return model_to_mesh(gmsh.model, comm, rank, gdim=gdim, partitioner=partitioner)
 

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -305,8 +305,10 @@ def read_from_msh(filename: str, comm: _MPI.Comm, rank: int = 0, gdim: int = 3,
     try:
         import gmsh
     except ModuleNotFoundError:
-        print("The Gmsh Python module could not be imported.")
-        raise
+        # Python 3.11+ adds the add_note method to exceptions
+        # e.add_note("Gmsh must be installed to import dolfinx.io.gmshio")
+        raise ModuleNotFoundError("No module named 'gmsh': dolfinx.io.gmshio.read_from_msh requires Gmsh.", name="gmsh")
+
     if comm.rank == rank:
         gmsh.initialize()
         gmsh.model.add("Mesh from file")

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -181,9 +181,9 @@ def model_to_mesh(model, comm: _MPI.Comm, rank: int, gdim: int = 3,
                       [_MPI.Comm, int, int, AdjacencyList_int32], AdjacencyList_int32]] = None,
                   dtype=default_real_type) -> typing.Tuple[
         Mesh, _cpp.mesh.MeshTags_int32, _cpp.mesh.MeshTags_int32]:
-    """Create a  from a Gmsh model.
+    """Create a mesh from a Gmsh model.
 
-    Creates a DOLFINx mesh from the physical entities of the highest
+    Creates a :class:`dolfinx.mesh.Mesh` from the physical entities of the highest
     topological dimension in the Gmsh model.
 
     In parallel, the gmsh model is processed on one MPI rank, and the
@@ -196,9 +196,9 @@ def model_to_mesh(model, comm: _MPI.Comm, rank: int, gdim: int = 3,
         model: Gmsh model.
         comm: MPI communicator to use for mesh creation.
         rank: MPI rank that the Gmsh model is initialized on.
-        gdim: Geometrical dimension of the mesh
+        gdim: Geometrical dimension of the mesh.
         partitioner: Function that computes the parallel
-            distribution of cells across MPI ranks
+            distribution of cells across MPI ranks.
 
     Returns:
         A triplet (mesh, cell_tags, facet_tags) where cell_tags hold

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Creation, refining and marking of meshes"""
 
-from __future__ import annotations
 
 import typing
 
@@ -42,12 +41,14 @@ def compute_midpoints(mesh: Mesh, dim: int, entities: npt.NDArray[np.int32]):
 
 
 class Mesh:
+    """A class for representing meshes."""
+
     def __init__(self, mesh: _cpp.mesh.Mesh, domain: ufl.Mesh):
-        """A class for representing meshes
+        """Initialize mesh from a C++ mesh.
 
         Args:
-            mesh: The C++ mesh object
-            domain: The UFL domain
+            mesh: The C++ mesh object.
+            domain: The UFL domain.
 
         Note:
             Mesh objects should not usually be created using this class
@@ -71,11 +72,19 @@ class Mesh:
         self._cpp_object.name = value
 
     def ufl_cell(self) -> ufl.Cell:
-        """Return the UFL cell type."""
+        """Return the UFL cell type.
+
+        Note: This method is required for UFL compatibility.
+
+        """
         return ufl.Cell(self.topology.cell_name(), geometric_dimension=self.geometry.dim)
 
     def ufl_domain(self) -> ufl.Mesh:
-        """Return the ufl domain corresponding to the mesh."""
+        """Return the ufl domain corresponding to the mesh.
+
+        Note: This method is required for UFL compatibility.
+
+        """
         return self._ufl_domain
 
     def basix_cell(self) -> ufl.Cell:
@@ -83,15 +92,28 @@ class Mesh:
         return getattr(basix.CellType, self.topology.cell_name())
 
     def h(self, dim: int, entities: npt.NDArray[np.int32]) -> npt.NDArray[np.float64]:
-        """Size measure for each cell."""
+        """Geometric size measure of cell entities.
+
+        Args:
+            dim: Topological dimension of the entities to compute the
+                size measure of.
+            entities: Indices of entities of dimension ``dim`` to
+                compute size measure of.
+
+        Returns:
+            Size measure for each requested entity.
+
+        """
         return _cpp.mesh.h(self._cpp_object, dim, entities)
 
     @property
     def topology(self):
+        "Mesh topology."
         return self._cpp_object.topology
 
     @property
     def geometry(self):
+        "Mesh geometry."
         return self._cpp_object.geometry
 
 
@@ -122,7 +144,7 @@ def locate_entities_boundary(mesh: Mesh, dim: int, marker: typing.Callable) -> n
     example, it is possible for a process to have a vertex that lies on
     the boundary without any of the attached facets being a boundary
     facet. When used to find degrees-of-freedom, e.g. using
-    fem.locate_dofs_topological, the function that uses the data
+    :func:`dolfinx.fem.locate_dofs_topological`, the function that uses the data
     returned by this function must typically perform some parallel
     communication.
 
@@ -188,7 +210,7 @@ def refine(mesh: Mesh, edges: typing.Optional[np.ndarray] = None, redistribute: 
     Args:
         mesh: Mesh from which to create the refined mesh.
         edges: Indices of edges to split during refinement. If ``None``,
-            uniform refinement is uses.
+            mesh refinement is uniform.
         redistribute:
             Refined mesh is re-partitioned if ``True``.
 
@@ -213,7 +235,7 @@ def refine_plaza(mesh: Mesh, edges: typing.Optional[np.ndarray] = None, redistri
     Args:
         mesh: Mesh from which to create the refined mesh.
         edges: Indices of edges to split during refinement. If ``None``,
-            uniform refinement is uses.
+            mesh refinement is uniform.
         redistribute:
             Refined mesh is re-partitioned if ``True``.
         option:
@@ -287,8 +309,10 @@ def create_submesh(msh, dim, entities):
 
 
 class MeshTags:
+    """Mesh tags associate data (markers) with a subset of mesh entities of a given dimension."""
+
     def __init__(self, meshtags):
-        """Mesh tags associate data (markers) with a subset of mesh entities of a given dimension.
+        """Initialize tags from a C++ MeshTags object.
 
         Args:
             meshtags: C++ mesh tags object.
@@ -298,9 +322,9 @@ class MeshTags:
             initializer directly.
 
             A Python mesh is passed to the initializer as it may have
-            UFL data attached that is not attached the C++ Mesh that is
-            associated with the C++ ``meshtags`` object. If `mesh` is
-            passed, ``mesh`` and ``meshtags`` must share the same C++
+            UFL data attached that is not attached the C + + Mesh that is
+            associated with the C + + ``meshtags`` object. If `mesh` is
+            passed, ``mesh`` and ``meshtags`` must share the same C + +
             mesh.
 
         """
@@ -343,7 +367,7 @@ class MeshTags:
         """Get a list of all entity indices with a given value.
 
         Args:
-            value: Mesh tag value to search for.
+            value: Tag value to search for.
 
         Returns:
             Indices of entities with tag ``value``.
@@ -359,8 +383,8 @@ def meshtags(mesh: Mesh, dim: int, entities: npt.NDArray[np.int32],
     Args:
         mesh: The mesh.
         dim: Topological dimension of the mesh entity.
-        entities: Indices (local to process) of entities to associate
-            values with. The array must be sorted and must not contain
+        entities: Indices(local to process) of entities to associate
+            values with . The array must be sorted and must not contain
             duplicates.
         values: The corresponding value for each entity.
 
@@ -396,8 +420,9 @@ def meshtags(mesh: Mesh, dim: int, entities: npt.NDArray[np.int32],
 
 def meshtags_from_entities(mesh: Mesh, dim: int, entities: _cpp.graph.AdjacencyList_int32,
                            values: npt.NDArray[typing.Any]):
-    """Create a MeshTags object that associates data with a subset of
-    mesh entities, where the entities are defined by their vertices.
+    """Create a :class:dolfinx.mesh.MeshTags` object that associates
+    data with a subset of mesh entities, where the entities are defined
+    by their vertices.
 
     Args:
         mesh: The mesh.
@@ -433,8 +458,8 @@ def create_interval(comm: _MPI.Comm, nx: int, points: npt.ArrayLike,
         comm: MPI communicator.
         nx: Number of cells.
         points: Coordinates of the end points.
-        dtype: Float type for the mesh geometry (``numpy.float32`` or
-            ``numpy.float64``).
+        dtype: Float type for the mesh geometry(``numpy.float32``
+            or ``numpy.float64``).
         ghost_mode: Ghost mode used in the mesh partitioning. Options
             are ``GhostMode.none`` and ``GhostMode.shared_facet``.
         partitioner: Partitioning function to use for determining the
@@ -464,8 +489,8 @@ def create_unit_interval(comm: _MPI.Comm, nx: int, dtype: typing.Optional[npt.DT
         comm: MPI communicator.
         nx: Number of cells.
         points: Coordinates of the end points.
-        dtype: Float type for the mesh geometry (``numpy.float32`` or
-            ``numpy.float64``).
+        dtype: Float type for the mesh geometry(``numpy.float32``
+            or ``numpy.float64``).
         ghost_mode: Ghost mode used in the mesh partitioning. Options
             are ``GhostMode.none`` and ``GhostMode.shared_facet``.
         partitioner: Partitioning function to use for determining the
@@ -486,18 +511,18 @@ def create_rectangle(comm: _MPI.Comm, points: npt.ArrayLike, n: npt.ArrayLike,
 
     Args:
         comm: MPI communicator.
-        points: Coordinates of the lower-left and upper-right corners of
+        points: Coordinates of the lower - left and upper - right corners of
             the rectangle.
         n: Number of cells in each direction.
         cell_type: Mesh cell type.
-        dtype: Float type for the mesh geometry (``numpy.float32`` or
-            ``numpy.float64``)
+        dtype: Float type for the mesh geometry(``numpy.float32``
+            or ``numpy.float64``)
         ghost_mode: Ghost mode used in the mesh partitioning.
         partitioner: Function that computes the parallel distribution of
             cells across MPI ranks.
         diagonal: Direction of diagonal of triangular meshes. The
-            options are ``left``, ``right``, ``crossed``, ``left/right``,
-            ``right/left``.
+            options are ``left``, ``right``, ``crossed``, ``left / right``,
+            ``right / left``.
 
     Returns:
         A mesh of a rectangle.
@@ -526,16 +551,16 @@ def create_unit_square(comm: _MPI.Comm, nx: int, ny: int, cell_type=CellType.tri
         nx: Number of cells in the "x" direction.
         ny: Number of cells in the "y" direction.
         cell_type: Mesh cell type.
-        dtype: Float type for the mesh geometry (``numpy.float32`` or
-            ``numpy.float64``).
+        dtype: Float type for the mesh geometry(``numpy.float32``
+            or ``numpy.float64``).
         ghost_mode: Ghost mode used in the mesh partitioning.
-        partitioner:Function that computes the parallel distribution of
+        partitioner: Function that computes the parallel distribution of
             cells across MPI ranks.
         diagonal:
             Direction of diagonal.
 
     Returns:
-        A mesh of a square with corners at (0, 0) and (1, 1).
+        A mesh of a square with corners at(0, 0) and (1, 1).
 
     """
     return create_rectangle(comm, [np.array([0.0, 0.0]), np.array([1.0, 1.0])],
@@ -555,8 +580,8 @@ def create_box(comm: _MPI.Comm, points: typing.List[npt.ArrayLike], n: list,
             corners of the box.
         n: List of cells in each direction
         cell_type: The cell type.
-        dtype: Float type for the mesh geometry (``numpy.float32`` or
-            ``numpy.float64``).
+        dtype: Float type for the mesh geometry(``numpy.float32``
+            or ``numpy.float64``).
         ghost_mode: The ghost mode used in the mesh partitioning.
         partitioner: Function that computes the parallel distribution of
             cells across MPI ranks.
@@ -588,15 +613,15 @@ def create_unit_cube(comm: _MPI.Comm, nx: int, ny: int, nz: int, cell_type=CellT
         ny: Number of cells in "y" direction.
         nz: Number of cells in "z" direction.
         cell_type: Mesh cell type
-        dtype: Float type for the mesh geometry (``numpy.float32`` or
-            ``numpy.float64``).
+        dtype: Float type for the mesh geometry(``numpy.float32``
+            or ``numpy.float64``).
         ghost_mode: Ghost mode used in the mesh partitioning.
         partitioner: Function that computes the parallel distribution of
             cells across MPI ranks.
 
     Returns:
-        A mesh of an axis-aligned unit cube with corners at (0, 0, 0)
-        and (1, 1, 1).
+        A mesh of an axis - aligned unit cube with corners at ``(0, 0, 0)``
+        and ``(1, 1, 1)``.
 
     """
     return create_box(comm, [np.array([0.0, 0.0, 0.0]), np.array([1.0, 1.0, 1.0])],

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -35,7 +35,7 @@ __all__ = ["meshtags_from_entities", "locate_entities", "locate_entities_boundar
 class Mesh:
     """A class for representing meshes."""
 
-    def __init__(self, mesh: _cpp.mesh.Mesh, domain: ufl.Mesh):
+    def __init__(self, mesh, domain: ufl.Mesh):
         """Initialize mesh from a C++ mesh.
 
         Args:

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -32,14 +32,6 @@ __all__ = ["meshtags_from_entities", "locate_entities", "locate_entities_boundar
            "transfer_meshtag"]
 
 
-def compute_incident_entities(topology, entities: npt.NDArray[np.int32], d0: int, d1: int):
-    return _cpp.mesh.compute_incident_entities(topology, entities, d0, d1)
-
-
-def compute_midpoints(mesh: Mesh, dim: int, entities: npt.NDArray[np.int32]):
-    return _cpp.mesh.compute_midpoints(mesh._cpp_object, dim, entities)
-
-
 class Mesh:
     """A class for representing meshes."""
 
@@ -115,6 +107,82 @@ class Mesh:
     def geometry(self):
         "Mesh geometry."
         return self._cpp_object.geometry
+
+
+class MeshTags:
+    """Mesh tags associate data (markers) with a subset of mesh entities of a given dimension."""
+
+    def __init__(self, meshtags):
+        """Initialize tags from a C++ MeshTags object.
+
+        Args:
+            meshtags: C++ mesh tags object.
+
+        Note:
+            MeshTags objects should not usually be created using this
+            initializer directly.
+
+            A Python mesh is passed to the initializer as it may have
+            UFL data attached that is not attached the C + + Mesh that is
+            associated with the C + + ``meshtags`` object. If `mesh` is
+            passed, ``mesh`` and ``meshtags`` must share the same C + +
+            mesh.
+
+        """
+        self._cpp_object = meshtags
+
+    def ufl_id(self) -> int:
+        """Identiftying integer used by UFL."""
+        return id(self)
+
+    @property
+    def topology(self) -> _cpp.mesh.Topology:
+        """Mesh topology with which the the tags are associated."""
+        return self._cpp_object.topology
+
+    @property
+    def dim(self) -> int:
+        """Topological dimension of the tagged entities."""
+        return self._cpp_object.dim
+
+    @property
+    def indices(self) -> npt.NDArray[np.int32]:
+        """Indices of tagged mesh entities."""
+        return self._cpp_object.indices
+
+    @property
+    def values(self):
+        """Values associated with tagged mesh entities."""
+        return self._cpp_object.values
+
+    @property
+    def name(self) -> str:
+        "Name of the mesh tags object."
+        return self._cpp_object.name
+
+    @name.setter
+    def name(self, value):
+        self._cpp_object.name = value
+
+    def find(self, value) -> npt.NDArray[np.int32]:
+        """Get a list of all entity indices with a given value.
+
+        Args:
+            value: Tag value to search for.
+
+        Returns:
+            Indices of entities with tag ``value``.
+
+        """
+        return self._cpp_object.find(value)
+
+
+def compute_incident_entities(topology, entities: npt.NDArray[np.int32], d0: int, d1: int):
+    return _cpp.mesh.compute_incident_entities(topology, entities, d0, d1)
+
+
+def compute_midpoints(mesh: Mesh, dim: int, entities: npt.NDArray[np.int32]):
+    return _cpp.mesh.compute_midpoints(mesh._cpp_object, dim, entities)
 
 
 def locate_entities(mesh: Mesh, dim: int, marker: typing.Callable) -> np.ndarray:
@@ -306,74 +374,6 @@ def create_submesh(msh, dim, entities):
         "Lagrange", submsh_ufl_cell.cellname(), submsh.geometry.cmaps[0].degree, submsh.geometry.cmaps[0].variant,
         shape=(submsh.geometry.dim, ), gdim=submsh.geometry.dim))
     return (Mesh(submsh, submsh_domain), entity_map, vertex_map, geom_map)
-
-
-class MeshTags:
-    """Mesh tags associate data (markers) with a subset of mesh entities of a given dimension."""
-
-    def __init__(self, meshtags):
-        """Initialize tags from a C++ MeshTags object.
-
-        Args:
-            meshtags: C++ mesh tags object.
-
-        Note:
-            MeshTags objects should not usually be created using this
-            initializer directly.
-
-            A Python mesh is passed to the initializer as it may have
-            UFL data attached that is not attached the C + + Mesh that is
-            associated with the C + + ``meshtags`` object. If `mesh` is
-            passed, ``mesh`` and ``meshtags`` must share the same C + +
-            mesh.
-
-        """
-        self._cpp_object = meshtags
-
-    def ufl_id(self) -> int:
-        """Identiftying integer used by UFL."""
-        return id(self)
-
-    @property
-    def topology(self) -> _cpp.mesh.Topology:
-        """Mesh topology with which the the tags are associated."""
-        return self._cpp_object.topology
-
-    @property
-    def dim(self) -> int:
-        """Topological dimension of the tagged entities."""
-        return self._cpp_object.dim
-
-    @property
-    def indices(self) -> npt.NDArray[np.int32]:
-        """Indices of tagged mesh entities."""
-        return self._cpp_object.indices
-
-    @property
-    def values(self):
-        """Values associated with tagged mesh entities."""
-        return self._cpp_object.values
-
-    @property
-    def name(self) -> str:
-        "Name of the mesh tags object."
-        return self._cpp_object.name
-
-    @name.setter
-    def name(self, value):
-        self._cpp_object.name = value
-
-    def find(self, value) -> npt.NDArray[np.int32]:
-        """Get a list of all entity indices with a given value.
-
-        Args:
-            value: Tag value to search for.
-
-        Returns:
-            Indices of entities with tag ``value``.
-
-        """
-        return self._cpp_object.find(value)
 
 
 def meshtags(mesh: Mesh, dim: int, entities: npt.NDArray[np.int32],

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -560,7 +560,7 @@ def create_unit_square(comm: _MPI.Comm, nx: int, ny: int, cell_type=CellType.tri
             Direction of diagonal.
 
     Returns:
-        A mesh of a square with corners at(0, 0) and (1, 1).
+        A mesh of a square with corners at (0, 0) and (1, 1).
 
     """
     return create_rectangle(comm, [np.array([0.0, 0.0]), np.array([1.0, 1.0])],

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -620,8 +620,8 @@ def create_unit_cube(comm: _MPI.Comm, nx: int, ny: int, nz: int, cell_type=CellT
             cells across MPI ranks.
 
     Returns:
-        A mesh of an axis - aligned unit cube with corners at ``(0, 0, 0)``
-        and ``(1, 1, 1)``.
+        A mesh of an axis-aligned unit cube with corners at ``(0, 0, 0)``
+            and ``(1, 1, 1)``.
 
     """
     return create_box(comm, [np.array([0.0, 0.0, 0.0]), np.array([1.0, 1.0, 1.0])],


### PR DESCRIPTION
- Makes documentation generation independent on whether or not gmsh can be imported
- Adds errors message if function that requires gmsh is called and gmsh is not available
- Required a small number of type hints for gmsh types to be removed

Supersedes #2771.