### PR TITLE
Avoid Basix enums in the DOLFINx pybind11 interface

### DIFF
--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -347,9 +347,9 @@ def create_mesh(comm: _MPI.Comm, cells: typing.Union[np.ndarray, _cpp.graph.Adja
     cell_shape = ufl_element.cell().cellname()
     cell_degree = ufl_element.degree()
     try:
-        variant = ufl_element.lagrange_variant
+        variant = _cpp.fem.BasixLagrangeVariant(int(ufl_element.lagrange_variant))
     except AttributeError:
-        variant = basix.LagrangeVariant.unset
+        variant = _cpp.fem.BasixLagrangeVariant(int(basix.LagrangeVariant.unset))
 
     x = np.asarray(x, order='C')
     if x.dtype == np.float32:
@@ -371,9 +371,11 @@ def create_submesh(msh, dim, entities):
     submsh, entity_map, vertex_map, geom_map = _cpp.mesh.create_submesh(msh._cpp_object, dim, entities)
     assert len(submsh.geometry.cmaps) == 1
     submsh_ufl_cell = ufl.Cell(submsh.topology.cell_name(), geometric_dimension=submsh.geometry.dim)
-    submsh_domain = ufl.Mesh(basix.ufl.element(
-        "Lagrange", submsh_ufl_cell.cellname(), submsh.geometry.cmaps[0].degree, submsh.geometry.cmaps[0].variant,
-        shape=(submsh.geometry.dim, ), gdim=submsh.geometry.dim))
+    submsh_domain = ufl.Mesh(basix.ufl.element("Lagrange", submsh_ufl_cell.cellname(),
+                                               submsh.geometry.cmaps[0].degree,
+                                               basix.LagrangeVariant(int(submsh.geometry.cmaps[0].variant)),
+                                               shape=(submsh.geometry.dim,),
+                                               gdim=submsh.geometry.dim))
     return (Mesh(submsh, submsh_domain), entity_map, vertex_map, geom_map)
 
 

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -347,9 +347,9 @@ def create_mesh(comm: _MPI.Comm, cells: typing.Union[np.ndarray, _cpp.graph.Adja
     cell_shape = ufl_element.cell().cellname()
     cell_degree = ufl_element.degree()
     try:
-        variant = _cpp.fem.BasixLagrangeVariant(int(ufl_element.lagrange_variant))
+        variant = int(ufl_element.lagrange_variant)
     except AttributeError:
-        variant = _cpp.fem.BasixLagrangeVariant(int(basix.LagrangeVariant.unset))
+        variant = int(basix.LagrangeVariant.unset)
 
     x = np.asarray(x, order='C')
     if x.dtype == np.float32:
@@ -373,7 +373,7 @@ def create_submesh(msh, dim, entities):
     submsh_ufl_cell = ufl.Cell(submsh.topology.cell_name(), geometric_dimension=submsh.geometry.dim)
     submsh_domain = ufl.Mesh(basix.ufl.element("Lagrange", submsh_ufl_cell.cellname(),
                                                submsh.geometry.cmaps[0].degree,
-                                               basix.LagrangeVariant(int(submsh.geometry.cmaps[0].variant)),
+                                               basix.LagrangeVariant(submsh.geometry.cmaps[0].variant),
                                                shape=(submsh.geometry.dim,),
                                                gdim=submsh.geometry.dim))
     return (Mesh(submsh, submsh_domain), entity_map, vertex_map, geom_map)

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -1086,6 +1086,13 @@ void fem(py::module& m)
       .value("interior_facet", dolfinx::fem::IntegralType::interior_facet)
       .value("vertex", dolfinx::fem::IntegralType::vertex);
 
+  py::enum_<basix::element::lagrange_variant>(m, "BasixLagrangeVariant")
+      .value("unset", basix::element::lagrange_variant::unset)
+      .value("equispaced", basix::element::lagrange_variant::equispaced)
+      .value("gll_warped", basix::element::lagrange_variant::gll_warped)
+      .value("gll_isaac", basix::element::lagrange_variant::gll_isaac)
+      .value("gll_centroid", basix::element::lagrange_variant::gll_centroid);
+
   declare_function_space<float>(m, "float32");
   declare_function_space<double>(m, "float64");
 

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -693,9 +693,6 @@ void declare_cmap(py::module& m, std::string type)
                      static_cast<basix::element::lagrange_variant>(variant));
                }),
            py::arg("celltype"), py::arg("degree"), py::arg("variant"))
-      //   .def(py::init<dolfinx::mesh::CellType, int,
-      //                 basix::element::lagrange_variant>(),
-      //        py::arg("celltype"), py::arg("degree"), py::arg("variant"))
       .def("create_dof_layout",
            &dolfinx::fem::CoordinateElement<T>::create_dof_layout)
       .def_property_readonly("degree",
@@ -956,7 +953,7 @@ namespace dolfinx_wrappers
 void fem(py::module& m)
 {
   // Load basix and dolfinx to use Pybindings
-  py::module_::import("basix");
+//   py::module_::import("basix");
 
   declare_objects<float>(m, "float32");
   declare_objects<double>(m, "float64");
@@ -1094,31 +1091,6 @@ void fem(py::module& m)
       .value("exterior_facet", dolfinx::fem::IntegralType::exterior_facet)
       .value("interior_facet", dolfinx::fem::IntegralType::interior_facet)
       .value("vertex", dolfinx::fem::IntegralType::vertex);
-
-  //   enum class basix_lagrange_variant
-  //   {
-  //     unset = -1,
-  //     equispaced = 0,
-  //     gll_warped = 1,
-  //     gll_isaac = 2,
-  //     gll_centroid = 3,
-  //     chebyshev_warped = 4,
-  //     chebyshev_isaac = 5,
-  //     chebyshev_centroid = 6,
-  //     gl_warped = 7,
-  //     gl_isaac = 8,
-  //     gl_centroid = 9,
-  //     legendre = 10,
-  //     bernstein = 11,
-  //     vtk = 20,
-  //   };
-
-  //   py::enum_<basix_lagrange_variant>(m, "BasixLagrangeVariant")
-  //       .value("unset", basix_lagrange_variant::unset)
-  //       .value("equispaced", basix_lagrange_variant::equispaced)
-  //       .value("gll_warped", basix_lagrange_variant::gll_warped)
-  //       .value("gll_isaac", basix_lagrange_variant::gll_isaac)
-  //       .value("gll_centroid", basix_lagrange_variant::gll_centroid);
 
   declare_function_space<float>(m, "float32");
   declare_function_space<double>(m, "float64");

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -685,15 +685,24 @@ void declare_cmap(py::module& m, std::string type)
       m, pyclass_name.c_str(), "Coordinate map element")
       .def(py::init<dolfinx::mesh::CellType, int>(), py::arg("celltype"),
            py::arg("degree"))
-      .def(py::init<dolfinx::mesh::CellType, int,
-                    basix::element::lagrange_variant>(),
+      .def(py::init(
+               [](dolfinx::mesh::CellType celltype, int degree, int variant)
+               {
+                 return dolfinx::fem::CoordinateElement<T>(
+                     celltype, degree,
+                     static_cast<basix::element::lagrange_variant>(variant));
+               }),
            py::arg("celltype"), py::arg("degree"), py::arg("variant"))
+      //   .def(py::init<dolfinx::mesh::CellType, int,
+      //                 basix::element::lagrange_variant>(),
+      //        py::arg("celltype"), py::arg("degree"), py::arg("variant"))
       .def("create_dof_layout",
            &dolfinx::fem::CoordinateElement<T>::create_dof_layout)
       .def_property_readonly("degree",
                              &dolfinx::fem::CoordinateElement<T>::degree)
       .def_property_readonly("variant",
-                             &dolfinx::fem::CoordinateElement<T>::variant)
+                             [](const dolfinx::fem::CoordinateElement<T>& self)
+                             { return static_cast<int>(self.variant()); })
       .def(
           "push_forward",
           [](const dolfinx::fem::CoordinateElement<T>& self,
@@ -1086,12 +1095,30 @@ void fem(py::module& m)
       .value("interior_facet", dolfinx::fem::IntegralType::interior_facet)
       .value("vertex", dolfinx::fem::IntegralType::vertex);
 
-  py::enum_<basix::element::lagrange_variant>(m, "BasixLagrangeVariant")
-      .value("unset", basix::element::lagrange_variant::unset)
-      .value("equispaced", basix::element::lagrange_variant::equispaced)
-      .value("gll_warped", basix::element::lagrange_variant::gll_warped)
-      .value("gll_isaac", basix::element::lagrange_variant::gll_isaac)
-      .value("gll_centroid", basix::element::lagrange_variant::gll_centroid);
+  //   enum class basix_lagrange_variant
+  //   {
+  //     unset = -1,
+  //     equispaced = 0,
+  //     gll_warped = 1,
+  //     gll_isaac = 2,
+  //     gll_centroid = 3,
+  //     chebyshev_warped = 4,
+  //     chebyshev_isaac = 5,
+  //     chebyshev_centroid = 6,
+  //     gl_warped = 7,
+  //     gl_isaac = 8,
+  //     gl_centroid = 9,
+  //     legendre = 10,
+  //     bernstein = 11,
+  //     vtk = 20,
+  //   };
+
+  //   py::enum_<basix_lagrange_variant>(m, "BasixLagrangeVariant")
+  //       .value("unset", basix_lagrange_variant::unset)
+  //       .value("equispaced", basix_lagrange_variant::equispaced)
+  //       .value("gll_warped", basix_lagrange_variant::gll_warped)
+  //       .value("gll_isaac", basix_lagrange_variant::gll_isaac)
+  //       .value("gll_centroid", basix_lagrange_variant::gll_centroid);
 
   declare_function_space<float>(m, "float32");
   declare_function_space<double>(m, "float64");

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -230,13 +230,12 @@ def test_cell_mismatch(mesh):
 @pytest.mark.skipif(default_real_type != np.float64, reason="float32 not supported yet")
 def test_basix_element(V, W, Q, V2):
     for V_ in (V, W, V2):
-        print(type(V))
-        e = V_.element
-    #     assert isinstance(e, basix.finite_element.FiniteElement)
+        e = V_.element.basix_element
+        assert isinstance(e, basix.finite_element.FiniteElement)
 
-    # # Mixed spaces do not yet return a basix element
-    # with pytest.raises(RuntimeError):
-    #     e = Q.element.basix_element
+    # Mixed spaces do not yet return a basix element
+    with pytest.raises(RuntimeError):
+        e = Q.element.basix_element
 
 
 @pytest.mark.skip_in_parallel

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -230,12 +230,13 @@ def test_cell_mismatch(mesh):
 @pytest.mark.skipif(default_real_type != np.float64, reason="float32 not supported yet")
 def test_basix_element(V, W, Q, V2):
     for V_ in (V, W, V2):
-        e = V_.element.basix_element
-        assert isinstance(e, basix.finite_element.FiniteElement)
+        print(type(V))
+        e = V_.element
+    #     assert isinstance(e, basix.finite_element.FiniteElement)
 
-    # Mixed spaces do not yet return a basix element
-    with pytest.raises(RuntimeError):
-        e = Q.element.basix_element
+    # # Mixed spaces do not yet return a basix element
+    # with pytest.raises(RuntimeError):
+    #     e = Q.element.basix_element
 
 
 @pytest.mark.skip_in_parallel


### PR DESCRIPTION
Use `int` with casting.

Need to be careful to not muddle pybind11/nanobind wrappers between Basix and DOLFINx.