### PR TITLE
Adjust tolerances

### DIFF
--- a/cpp/dolfinx/geometry/gjk.h
+++ b/cpp/dolfinx/geometry/gjk.h
@@ -261,7 +261,7 @@ std::array<T, 3> compute_distance_gjk(std::span<const T> p,
   constexpr int maxk = 15; // Maximum number of iterations of the GJK algorithm
 
   // Tolerance
-  constexpr T eps = 1.0e4 * std::numeric_limits<T>::epsilon();
+  constexpr T eps = 1.0e2 * std::numeric_limits<T>::epsilon();
 
   // Initialise vector and simplex
   std::array<T, 3> v = {p[0] - q[0], p[1] - q[1], p[2] - q[2]};

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -509,7 +509,7 @@ std::int32_t compute_first_colliding_cell(const mesh::Mesh<T>& mesh,
     return -1;
   else
   {
-    constexpr T eps2 = 1e-20;
+    constexpr T eps2 = 1.0e4 * std::numeric_limits<T>::epsilon();
     const mesh::Geometry<T>& geometry = mesh.geometry();
     std::span<const T> geom_dofs = geometry.x();
     auto x_dofmap = geometry.dofmap();
@@ -618,7 +618,7 @@ graph::AdjacencyList<std::int32_t> compute_colliding_cells(
   std::vector<std::int32_t> offsets = {0};
   offsets.reserve(candidate_cells.num_nodes() + 1);
   std::vector<std::int32_t> colliding_cells;
-  constexpr T eps2 = 1e-12;
+  constexpr T eps2 = 1.0e2 * std::numeric_limits<T>::epsilon();
   const int tdim = mesh.topology()->dim();
   for (std::int32_t i = 0; i < candidate_cells.num_nodes(); i++)
   {


### PR DESCRIPTION
To make #2774 work.
It does not resolve the underlying issue, as we should replace `compute_first_colliding_cell` with `compute_closest_entity` (see #2786) for details on more robust but complicated fix.