### PR TITLE
Re-factor a PETSc Vec creation function due to OpenMPI/PETSc interaction issue

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -312,7 +312,7 @@ common::stack_index_maps(
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 IndexMap::IndexMap(MPI_Comm comm, std::int32_t local_size)
-    : _comm(comm), _overlapping(false)
+    : _comm(comm, true), _overlapping(false)
 {
   // Get global offset (index), using partial exclusive reduction
   std::int64_t offset = 0;
@@ -349,7 +349,7 @@ IndexMap::IndexMap(MPI_Comm comm, std::int32_t local_size,
                    const std::array<std::vector<int>, 2>& src_dest,
                    std::span<const std::int64_t> ghosts,
                    std::span<const int> owners)
-    : _comm(comm), _ghosts(ghosts.begin(), ghosts.end()),
+    : _comm(comm, true), _ghosts(ghosts.begin(), ghosts.end()),
       _owners(owners.begin(), owners.end()), _src(src_dest[0]),
       _dest(src_dest[1]), _overlapping(true)
 {

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -21,7 +21,8 @@ dolfinx::MPI::Comm::Comm(MPI_Comm comm, bool duplicate)
     _comm = comm;
 }
 //-----------------------------------------------------------------------------
-dolfinx::MPI::Comm::Comm(const Comm& comm) noexcept : Comm(comm._comm)
+dolfinx::MPI::Comm::Comm(const Comm& comm) noexcept
+    : dolfinx::MPI::Comm::Comm(comm._comm, true)
 {
   // Do nothing
 }

--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -77,7 +77,7 @@ Vec la::petsc::create_vector(MPI_Comm comm, std::array<std::int64_t, 2> range,
   assert(range[1] >= range[0]);
   std::int32_t local_size = range[1] - range[0];
 
-  Vec x;
+  Vec x = nullptr;
   std::vector<PetscInt> _ghosts(ghosts.begin(), ghosts.end());
   if (bs == 1)
   {

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -523,9 +523,6 @@ def test_assembly_solve_taylor_hood_nl(mesh):
                                    (p.function_space.dofmap.index_map, p.function_space.dofmap.index_map_bs)])
         x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
-        # This causes a failure
-        # foo = x.duplicate()
-
         snes.solve(None, x)
         assert snes.getConvergedReason() > 0
         snes.destroy()
@@ -628,11 +625,11 @@ def test_assembly_solve_taylor_hood_nl(mesh):
 
     Jnorm0, Fnorm0, xnorm0 = blocked()
     Jnorm1, Fnorm1, xnorm1 = nested()
-    # assert Jnorm1 == pytest.approx(Jnorm0, 1.0e-3, abs=1.0e-6)
-    # assert Fnorm1 == pytest.approx(Fnorm0, 1.0e-6, abs=1.0e-5)
-    # assert xnorm1 == pytest.approx(xnorm0, 1.0e-6, abs=1.0e-5)
+    assert Jnorm1 == pytest.approx(Jnorm0, 1.0e-3, abs=1.0e-6)
+    assert Fnorm1 == pytest.approx(Fnorm0, 1.0e-6, abs=1.0e-5)
+    assert xnorm1 == pytest.approx(xnorm0, 1.0e-6, abs=1.0e-5)
 
     Jnorm2, Fnorm2, xnorm2 = monolithic()
     assert Jnorm2 == pytest.approx(Jnorm1, rel=1.0e-3, abs=1.0e-6)
-    # assert Fnorm2 == pytest.approx(Fnorm0, 1.0e-6, abs=1.0e-5)
-    # assert xnorm2 == pytest.approx(xnorm0, 1.0e-6, abs=1.0e-6)
+    assert Fnorm2 == pytest.approx(Fnorm0, 1.0e-6, abs=1.0e-5)
+    assert xnorm2 == pytest.approx(xnorm0, 1.0e-6, abs=1.0e-6)

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -626,7 +626,7 @@ def test_assembly_solve_taylor_hood_nl(mesh):
         x.destroy()
         return Jnorm, Fnorm, xnorm
 
-    # Jnorm0, Fnorm0, xnorm0 = blocked()
+    Jnorm0, Fnorm0, xnorm0 = blocked()
     Jnorm1, Fnorm1, xnorm1 = nested()
     # assert Jnorm1 == pytest.approx(Jnorm0, 1.0e-3, abs=1.0e-6)
     # assert Fnorm1 == pytest.approx(Fnorm0, 1.0e-6, abs=1.0e-5)


### PR DESCRIPTION
Appears to be an issue between PETSc and OpenMPI on lifetime management of MPI communicators.

Re-enable test that was disabled to this issue.

Fixes #2800 (sort of).