### PR TITLE
Missing from __future__ import annotations

### DIFF
--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Creation, refining and marking of meshes"""
 
+from __future__ import annotations
+
 
 import typing
 


### PR DESCRIPTION
prevents failure to import dolfinx.mesh in Python 3.8 due to the use of `tuple[...]`, which requires Python 3.9. Since this is in an annotation, deferring annotation evaluation via the annotations `__future__` ought to work, as is done in some other files already.

This suggests that there aren't CI jobs to verify that dolfinx builds and then imports with Python 3.8, I think?

testing in https://github.com/conda-forge/fenics-dolfinx-feedstock/pull/47 if you want to wait for that to confirm this is sufficient.