### PR TITLE
TST: add missing include <functional>

### DIFF
--- a/cpp/test/common/sort.cpp
+++ b/cpp/test/common/sort.cpp
@@ -8,6 +8,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <dolfinx/common/sort.h>
+#include <functional>
 #include <random>
 
 TEMPLATE_TEST_CASE("Test radix sort", "[vector][template]", std::int32_t,


### PR DESCRIPTION
needed for `std::bind`. Unclear under exactly what circumstances, but presumably it's sometimes implied by another dependency.

This is the compilation error with 0.7.0:

```
/home/conda/feedstock_root/build_artifacts/fenics-dolfinx-split_1696590289646/test_tmp/cpp/test/common/sort.cpp: In function 'void CATCH2_INTERNAL_TEMPLATE_TEST_0()':
/home/conda/feedstock_root/build_artifacts/fenics-dolfinx-split_1696590289646/test_tmp/cpp/test/common/sort.cpp:23:25: error: 'bind' is not a member of 'std'
   23 |   auto generator = std::bind(distribution, engine);
      |                         ^~~~
/home/conda/feedstock_root/build_artifacts/fenics-dolfinx-split_1696590289646/test_tmp/cpp/test/common/sort.cpp:12:1: note: 'std::bind' is defined in header '<functional>'; did you forget to '#include <functional>'?
   11 | #include <random>
  +++ |+#include <functional>
   12 | 
```

testing in https://github.com/conda-forge/fenics-dolfinx-feedstock/pull/47 if you want to wait to confirm (same as #2808)