### PR TITLE
Post-release fixes for 0.7.0

### DIFF
--- a/python/doc/source/jupytext_process.py
+++ b/python/doc/source/jupytext_process.py
@@ -51,7 +51,7 @@ def process():
                 demo = demo.resolve()
                 here = os.getcwd()
                 os.chdir(demo_dir)
-                runpy.run_path(demo)
+                runpy.run_path(str(demo))
                 os.chdir(here)
 
         # Copy images used in demos

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -49,7 +49,7 @@ void xdmf_real_fn(auto&& m)
       { self.write_meshtags(meshtags, x, geometry_xpath, xpath); },
       py::arg("meshtags"), py::arg("x"), py::arg("geometry_xpath"),
       py::arg("xpath") = "/Xdmf/Domain");
-};
+}
 
 template <typename T, typename U>
 void xdmf_scalar_fn(auto&& m)
@@ -61,7 +61,7 @@ void xdmf_scalar_fn(auto&& m)
       { self.write_function(u, t, mesh_xpath); },
       py::arg("u"), py::arg("t"),
       py::arg("mesh_xpath") = "/Xdmf/Domain/Grid[@GridType='Uniform'][1]");
-};
+}
 
 template <typename T>
 void vtk_real_fn(auto&& m)


### PR DESCRIPTION
- Convert PathLib.Path so string, from Drew Parsons related to Debian packaging.
- Did not compile with pedantic warnings on GCC 10 series.

Will backport onto release and tag v0.7.0.post0.
Functionally identical to v0.7.0 so will not bump version numbers.
