### PR TITLE
Remove deprecated `fem.FunctionSpace` function

### DIFF
--- a/python/demo/demo_biharmonic.py
+++ b/python/demo/demo_biharmonic.py
@@ -126,7 +126,7 @@ from petsc4py.PETSc import ScalarType  # type: ignore
 # We begin by using {py:func}`create_rectangle
 # <dolfinx.mesh.create_rectangle>` to create a rectangular
 # {py:class}`Mesh <dolfinx.mesh.Mesh>` of the domain, and creating a
-# finite element {py:class}`FunctionSpaceBase <dolfinx.fem.FunctionSpaceBase>`
+# finite element {py:class}`FunctionSpace <dolfinx.fem.FunctionSpace>`
 # $V$ on the mesh.
 
 msh = mesh.create_rectangle(comm=MPI.COMM_WORLD,

--- a/python/demo/demo_cahn-hilliard.py
+++ b/python/demo/demo_cahn-hilliard.py
@@ -150,7 +150,7 @@ theta = 0.5  # time stepping family, e.g. theta=1 -> backward Euler, theta=0.5 -
 
 # A unit square mesh with 96 cells edges in each direction is created,
 # and on this mesh a
-# {py:class}`FunctionSpaceBase <dolfinx.fem.FunctionSpaceBase>` `ME` is built
+# {py:class}`FunctionSpace <dolfinx.fem.FunctionSpace>` `ME` is built
 # using a pair of linear Lagrange elements.
 
 msh = create_unit_square(MPI.COMM_WORLD, 96, 96, CellType.triangle)

--- a/python/demo/demo_elasticity.py
+++ b/python/demo/demo_elasticity.py
@@ -28,7 +28,7 @@ import numpy as np
 import dolfinx
 import ufl
 from dolfinx import la
-from dolfinx.fem import (Expression, Function, FunctionSpaceBase, dirichletbc,
+from dolfinx.fem import (Expression, Function, FunctionSpace, dirichletbc,
                          form, functionspace, locate_dofs_topological)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                set_bc)
@@ -53,7 +53,7 @@ dtype = PETSc.ScalarType  # type: ignore
 # modes.
 
 
-def build_nullspace(V: FunctionSpaceBase):
+def build_nullspace(V: FunctionSpace):
     """Build PETSc nullspace for 3D elasticity"""
 
     # Create vectors that will span the nullspace

--- a/python/demo/demo_poisson.py
+++ b/python/demo/demo_poisson.py
@@ -13,7 +13,7 @@
 # This demo is implemented in {download}`demo_poisson.py`. It
 # illustrates how to:
 #
-# - Create a {py:class}`function space <dolfinx.fem.FunctionSpaceBase>`
+# - Create a {py:class}`function space <dolfinx.fem.FunctionSpace>`
 # - Solve a linear partial differential equation
 #
 # ## Equation and problem definition
@@ -76,7 +76,7 @@ from petsc4py.PETSc import ScalarType  # type: ignore
 # We create a rectangular {py:class}`Mesh <dolfinx.mesh.Mesh>` using
 # {py:func}`create_rectangle <dolfinx.mesh.create_rectangle>`, and
 # create a finite element {py:class}`function space
-# <dolfinx.fem.FunctionSpaceBase>` $V$ on the mesh.
+# <dolfinx.fem.FunctionSpace>` $V$ on the mesh.
 
 # +
 msh = mesh.create_rectangle(comm=MPI.COMM_WORLD,

--- a/python/demo/demo_stokes.py
+++ b/python/demo/demo_stokes.py
@@ -124,7 +124,7 @@ def lid_velocity_expression(x):
     return np.stack((np.ones(x.shape[1]), np.zeros(x.shape[1])))
 # -
 
-# Two {py:class}`function spaces <dolfinx.fem.FunctionSpaceBase>` are
+# Two {py:class}`function spaces <dolfinx.fem.FunctionSpace>` are
 # defined using different finite elements. `P2` corresponds to a
 # continuous piecewise quadratic basis (vector) and `P1` to a continuous
 # piecewise linear basis (scalar).

--- a/python/demo/demo_tnt-elements.py
+++ b/python/demo/demo_tnt-elements.py
@@ -216,7 +216,7 @@ def create_tnt_quad(degree):
 # the solution.
 
 
-def poisson_error(V: fem.FunctionSpaceBase):
+def poisson_error(V: fem.FunctionSpace):
     msh = V.mesh
     u, v = TrialFunction(V), TestFunction(V)
 

--- a/python/dolfinx/fem/__init__.py
+++ b/python/dolfinx/fem/__init__.py
@@ -17,8 +17,7 @@ from dolfinx.fem.bcs import (DirichletBC, bcs_by_block, dirichletbc,
 from dolfinx.fem.dofmap import DofMap
 from dolfinx.fem.forms import Form, extract_function_spaces, form
 from dolfinx.fem.function import (Constant, ElementMetaData, Expression,
-                                  Function, FunctionSpace, FunctionSpaceBase,
-                                  VectorFunctionSpace, functionspace)
+                                  Function, FunctionSpaceBase, functionspace)
 
 
 def create_sparsity_pattern(a: Form):
@@ -40,8 +39,7 @@ def create_sparsity_pattern(a: Form):
 
 __all__ = [
     "Constant", "Expression", "Function", "ElementMetaData", "create_matrix",
-    "functionspace", "FunctionSpace", "FunctionSpaceBase", "VectorFunctionSpace",
-    "create_sparsity_pattern",
+    "functionspace", "FunctionSpaceBase", "create_sparsity_pattern",
     "assemble_scalar", "assemble_matrix", "assemble_vector", "apply_lifting", "set_bc",
     "DirichletBC", "dirichletbc", "bcs_by_block", "DofMap", "Form",
     "form", "IntegralType", "create_vector",

--- a/python/dolfinx/fem/__init__.py
+++ b/python/dolfinx/fem/__init__.py
@@ -17,7 +17,7 @@ from dolfinx.fem.bcs import (DirichletBC, bcs_by_block, dirichletbc,
 from dolfinx.fem.dofmap import DofMap
 from dolfinx.fem.forms import Form, extract_function_spaces, form
 from dolfinx.fem.function import (Constant, ElementMetaData, Expression,
-                                  Function, FunctionSpaceBase, functionspace)
+                                  Function, FunctionSpace, functionspace)
 
 
 def create_sparsity_pattern(a: Form):
@@ -39,7 +39,7 @@ def create_sparsity_pattern(a: Form):
 
 __all__ = [
     "Constant", "Expression", "Function", "ElementMetaData", "create_matrix",
-    "functionspace", "FunctionSpaceBase", "create_sparsity_pattern",
+    "functionspace", "FunctionSpace", "create_sparsity_pattern",
     "assemble_scalar", "assemble_matrix", "assemble_vector", "apply_lifting", "set_bc",
     "DirichletBC", "dirichletbc", "bcs_by_block", "DofMap", "Form",
     "form", "IntegralType", "create_vector",

--- a/python/dolfinx/fem/bcs.py
+++ b/python/dolfinx/fem/bcs.py
@@ -22,8 +22,8 @@ import dolfinx
 from dolfinx import cpp as _cpp
 
 
-def locate_dofs_geometrical(V: typing.Union[dolfinx.fem.FunctionSpaceBase,
-                                            typing.Iterable[dolfinx.fem.FunctionSpaceBase]],
+def locate_dofs_geometrical(V: typing.Union[dolfinx.fem.FunctionSpace,
+                                            typing.Iterable[dolfinx.fem.FunctionSpace]],
                             marker: typing.Callable) -> np.ndarray:
     """Locate degrees-of-freedom geometrically using a marker function.
 
@@ -54,8 +54,8 @@ def locate_dofs_geometrical(V: typing.Union[dolfinx.fem.FunctionSpaceBase,
         return _cpp.fem.locate_dofs_geometrical(_V, marker)
 
 
-def locate_dofs_topological(V: typing.Union[dolfinx.fem.FunctionSpaceBase,
-                                            typing.Iterable[dolfinx.fem.FunctionSpaceBase]],
+def locate_dofs_topological(V: typing.Union[dolfinx.fem.FunctionSpace,
+                                            typing.Iterable[dolfinx.fem.FunctionSpace]],
                             entity_dim: int, entities: numpy.typing.NDArray[np.int32],
                             remote: bool = True) -> np.ndarray:
     """Locate degrees-of-freedom belonging to mesh entities topologically.
@@ -116,14 +116,14 @@ class DirichletBC:
         return self._cpp_object.value
 
     @property
-    def function_space(self) -> dolfinx.fem.FunctionSpaceBase:
+    def function_space(self) -> dolfinx.fem.FunctionSpace:
         """The function space on which the boundary condition is defined"""
         return self._cpp_object.function_space
 
 
 def dirichletbc(value: typing.Union[Function, Constant, np.ndarray],
                 dofs: numpy.typing.NDArray[np.int32],
-                V: typing.Optional[dolfinx.fem.FunctionSpaceBase] = None) -> DirichletBC:
+                V: typing.Optional[dolfinx.fem.FunctionSpace] = None) -> DirichletBC:
     """Create a representation of Dirichlet boundary condition which
     is imposed on a linear system.
 
@@ -181,7 +181,7 @@ def dirichletbc(value: typing.Union[Function, Constant, np.ndarray],
     return DirichletBC(bc)
 
 
-def bcs_by_block(spaces: typing.Iterable[typing.Union[dolfinx.fem.FunctionSpaceBase, None]],
+def bcs_by_block(spaces: typing.Iterable[typing.Union[dolfinx.fem.FunctionSpace, None]],
                  bcs: typing.Iterable[DirichletBC]) -> typing.List[typing.List[DirichletBC]]:
     """Arrange Dirichlet boundary conditions by the function space that
     they constrain.

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -16,7 +16,7 @@ import ufl
 from dolfinx import cpp as _cpp
 from dolfinx import default_scalar_type, jit
 from dolfinx.fem import IntegralType
-from dolfinx.fem.function import FunctionSpaceBase
+from dolfinx.fem.function import FunctionSpace
 
 if typing.TYPE_CHECKING:
     from dolfinx.fem import function
@@ -59,7 +59,7 @@ class Form:
         return self._cpp_object.rank
 
     @property
-    def function_spaces(self) -> typing.List[FunctionSpaceBase]:
+    def function_spaces(self) -> typing.List[FunctionSpace]:
         """Function spaces on which this form is defined"""
         return self._cpp_object.function_spaces
 
@@ -190,7 +190,7 @@ def form(form: typing.Union[ufl.Form, typing.Iterable[ufl.Form]],
 
 def extract_function_spaces(forms: typing.Union[typing.Iterable[Form],  # type: ignore [return]
                                                 typing.Iterable[typing.Iterable[Form]]],
-                            index: int = 0) -> typing.Iterable[typing.Union[None, function.FunctionSpaceBase]]:
+                            index: int = 0) -> typing.Iterable[typing.Union[None, function.FunctionSpace]]:
     """Extract common function spaces from an array of forms. If `forms`
     is a list of linear form, this function returns of list of the
     corresponding test functions. If `forms` is a 2D array of bilinear

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 import typing
-import warnings
 from functools import singledispatch
 
 import numpy as np
@@ -558,29 +557,6 @@ def functionspace(mesh: Mesh,
     return FunctionSpaceBase(mesh, ufl_e, cppV)
 
 
-def FunctionSpace(mesh: Mesh,
-                  element: typing.Union[ufl.FiniteElementBase, ElementMetaData,
-                                        typing.Tuple[str, int, typing.Tuple, bool]],
-                  form_compiler_options: typing.Optional[dict[str, typing.Any]] = None,
-                  jit_options: typing.Optional[dict[str, typing.Any]] = None) -> FunctionSpaceBase:
-    """Create a finite element function space.
-
-    .. deprecated:: 0.7
-        Use :func:`functionspace` (no caps) instead.
-
-    Args:
-        mesh: Mesh that space is defined on
-        element: Finite element description
-        form_compiler_options: Options passed to the form compiler
-        jit_options: Options controlling just-in-time compilation
-
-    Returns:
-        A function space.
-
-    """
-    return functionspace(mesh, element, form_compiler_options, jit_options)
-
-
 class FunctionSpaceBase(ufl.FunctionSpace):
     """A space on which Functions (fields) can be defined."""
 
@@ -719,34 +695,3 @@ class FunctionSpaceBase(ufl.FunctionSpace):
 
          """
         return self._cpp_object.tabulate_dof_coordinates()
-
-
-def VectorFunctionSpace(mesh: Mesh,
-                        element: typing.Union[ElementMetaData, typing.Tuple[str, int]],
-                        dim: typing.Optional[int] = None) -> FunctionSpaceBase:
-    """Create a vector finite element (composition of scalar elements) function space.
-
-    .. deprecated:: 0.7
-        Use :func:`FunctionSpace` with a shape argument instead.
-
-    Args:
-        mesh: Mesh that space is defined on
-        element: Finite element description. Must be a scalar element,
-           e.g. Lagrange.
-        dim: Dimension of the vector, e.g. number of vector components.
-            It defaults to the geometric dimension of the mesh.
-
-    Returns:
-        A blocked vector function space.
-
-    """
-    warnings.warn('This method is deprecated. Use FunctionSpace with an element shape argument instead',
-                  DeprecationWarning, stacklevel=2)
-    ed = ElementMetaData(*element)
-    e = basix.ufl.element(ed.family, mesh.basix_cell(), ed.degree, gdim=mesh.geometry.dim)
-    if len(e.value_shape) != 0:
-        raise ValueError("Cannot create vector element containing a non-scalar.")
-    ufl_e = basix.ufl.element(ed.family, mesh.basix_cell(), ed.degree,
-                              shape=(mesh.geometry.dim,) if dim is None else (dim,),
-                              gdim=mesh.geometry.dim)
-    return FunctionSpace(mesh, ufl_e)

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -7,7 +7,6 @@
 
 from __future__ import annotations
 
-
 import typing
 
 import numpy as np

--- a/python/dolfinx/plot.py
+++ b/python/dolfinx/plot.py
@@ -88,8 +88,8 @@ def vtk_mesh(msh: mesh.Mesh, dim: typing.Optional[int] = None, entities=None):
     return topology.reshape(-1), cell_types, msh.geometry.x
 
 
-@vtk_mesh.register(fem.FunctionSpaceBase)
-def _(V: fem.FunctionSpaceBase, entities=None):
+@vtk_mesh.register(fem.FunctionSpace)
+def _(V: fem.FunctionSpace, entities=None):
     """Creates a VTK mesh topology (topology array and array of cell
     types) that is based on the degree-of-freedom coordinates.
 

--- a/python/test/unit/fem/test_assemble_cppimport.py
+++ b/python/test/unit/fem/test_assemble_cppimport.py
@@ -15,7 +15,7 @@ import scipy.sparse.linalg
 
 import dolfinx.pkgconfig
 import ufl
-from dolfinx.fem import (FunctionSpace, assemble_matrix, dirichletbc, form,
+from dolfinx.fem import (assemble_matrix, dirichletbc, form, functionspace,
                          locate_dofs_geometrical)
 from dolfinx.mesh import create_unit_square
 from dolfinx.wrappers import get_include_path as pybind_inc
@@ -120,7 +120,7 @@ PYBIND11_MODULE(eigen_csr, m)
 
     realtype = np.real(dtype(1.0)).dtype
     mesh = create_unit_square(MPI.COMM_SELF, 12, 12, dtype=realtype)
-    Q = FunctionSpace(mesh, ("Lagrange", 1))
+    Q = functionspace(mesh, ("Lagrange", 1))
     u = ufl.TrialFunction(Q)
     v = ufl.TestFunction(Q)
 
@@ -201,8 +201,8 @@ PYBIND11_MODULE(assemble_csr, m)
 
     mesh = create_unit_square(MPI.COMM_SELF, 11, 7)
     gdim = mesh.geometry.dim
-    Q = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
-    Q2 = FunctionSpace(mesh, ("Lagrange", 1, (3,)))
+    Q = functionspace(mesh, ("Lagrange", 1, (gdim,)))
+    Q2 = functionspace(mesh, ("Lagrange", 1, (3,)))
     u = ufl.TrialFunction(Q)
     v = ufl.TestFunction(Q2)
 

--- a/python/test/unit/fem/test_assemble_domains.py
+++ b/python/test/unit/fem/test_assemble_domains.py
@@ -11,8 +11,8 @@ import pytest
 import ufl
 from dolfinx import cpp as _cpp
 from dolfinx import default_scalar_type, fem, la
-from dolfinx.fem import (Constant, Function, FunctionSpace, assemble_scalar,
-                         dirichletbc, form)
+from dolfinx.fem import (Constant, Function, assemble_scalar,
+                         dirichletbc, form, functionspace)
 from dolfinx.mesh import (GhostMode, Mesh, create_unit_square, locate_entities,
                           locate_entities_boundary, meshtags,
                           meshtags_from_entities)
@@ -43,7 +43,7 @@ parametrize_ghost_mode = pytest.mark.parametrize("mode", [
 @pytest.mark.parametrize("meshtags_factory", [meshtags, create_cell_meshtags_from_entities])
 def test_assembly_dx_domains(mode, meshtags_factory):
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10, ghost_mode=mode)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
 
     # Prepare a marking structures
@@ -100,7 +100,7 @@ def test_assembly_dx_domains(mode, meshtags_factory):
 @pytest.mark.parametrize("mode", [GhostMode.none, GhostMode.shared_facet])
 def test_assembly_ds_domains(mode):
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10, ghost_mode=mode)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
 
     def bottom(x):
@@ -188,7 +188,7 @@ def test_assembly_dS_domains(mode):
 @parametrize_ghost_mode
 def test_additivity(mode):
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 12, ghost_mode=mode)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
 
     f1 = Function(V)
     f2 = Function(V)
@@ -225,7 +225,7 @@ def test_manual_integration_domains():
     n = 4
     msh = create_unit_square(MPI.COMM_WORLD, n, n)
 
-    V = FunctionSpace(msh, ("Lagrange", 1))
+    V = functionspace(msh, ("Lagrange", 1))
     u = ufl.TrialFunction(V)
     v = ufl.TestFunction(V)
 

--- a/python/test/unit/fem/test_assemble_domains.py
+++ b/python/test/unit/fem/test_assemble_domains.py
@@ -11,8 +11,8 @@ import pytest
 import ufl
 from dolfinx import cpp as _cpp
 from dolfinx import default_scalar_type, fem, la
-from dolfinx.fem import (Constant, Function, assemble_scalar,
-                         dirichletbc, form, functionspace)
+from dolfinx.fem import (Constant, Function, assemble_scalar, dirichletbc,
+                         form, functionspace)
 from dolfinx.mesh import (GhostMode, Mesh, create_unit_square, locate_entities,
                           locate_entities_boundary, meshtags,
                           meshtags_from_entities)

--- a/python/test/unit/fem/test_assemble_submesh.py
+++ b/python/test/unit/fem/test_assemble_submesh.py
@@ -19,7 +19,7 @@ from mpi4py import MPI
 
 
 def assemble(mesh, space, k):
-    V = fem.FunctionSpace(mesh, (space, k))
+    V = fem.functionspace(mesh, (space, k))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     dx = ufl.Measure("dx", domain=mesh)
     ds = ufl.Measure("ds", domain=mesh)

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -16,9 +16,9 @@ import ufl
 from basix.ufl import element, mixed_element
 from dolfinx import cpp as _cpp
 from dolfinx import default_real_type, fem, graph, la
-from dolfinx.fem import (Constant, Function, FunctionSpace, assemble_scalar,
+from dolfinx.fem import (Constant, Function, assemble_scalar,
                          bcs_by_block, dirichletbc, extract_function_spaces,
-                         form, locate_dofs_geometrical,
+                         form, functionspace, locate_dofs_geometrical,
                          locate_dofs_topological)
 from dolfinx.fem.petsc import apply_lifting as petsc_apply_lifting
 from dolfinx.fem.petsc import apply_lifting_nest as petsc_apply_lifting_nest
@@ -91,7 +91,7 @@ def test_assemble_derivatives(dtype):
     under differentiation (some coefficients and constants are
     eliminated)"""
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 12, dtype=dtype(0).real.dtype)
-    Q = FunctionSpace(mesh, ("Lagrange", 1))
+    Q = functionspace(mesh, ("Lagrange", 1))
     u = Function(Q, dtype=dtype)
     v = ufl.TestFunction(Q)
     du = ufl.TrialFunction(Q)
@@ -117,7 +117,7 @@ def test_assemble_derivatives(dtype):
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
 def test_basic_assembly(mode, dtype):
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 12, ghost_mode=mode, dtype=dtype(0).real.dtype)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
 
     f = Function(V, dtype=dtype)
@@ -162,7 +162,7 @@ def test_basic_assembly(mode, dtype):
 @pytest.mark.parametrize("mode", [GhostMode.none, GhostMode.shared_facet])
 def test_basic_assembly_petsc_matrixcsr(mode):
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 12, ghost_mode=mode)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = form(inner(u, v) * dx + inner(u, v) * ds)
 
@@ -176,7 +176,7 @@ def test_basic_assembly_petsc_matrixcsr(mode):
     A1.destroy()
 
     gdim = mesh.geometry.dim
-    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+    V = functionspace(mesh, ("Lagrange", 1, (gdim,)))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = form(inner(u, v) * dx + inner(u, v) * ds)
     A0 = fem.assemble_matrix(a)
@@ -192,7 +192,7 @@ def test_basic_assembly_petsc_matrixcsr(mode):
 @pytest.mark.parametrize("mode", [GhostMode.none, GhostMode.shared_facet])
 def test_assembly_bcs(mode):
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 12, ghost_mode=mode)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = form(inner(u, v) * dx + inner(u, v) * ds)
     L = form(inner(1.0, v) * dx)
@@ -236,7 +236,7 @@ def test_petsc_assemble_manifold():
     assert mesh.geometry.dim == 2
     assert mesh.topology.dim == 1
 
-    U = FunctionSpace(mesh, ("P", 1))
+    U = functionspace(mesh, ("P", 1))
     u, v = ufl.TrialFunction(U), ufl.TestFunction(U)
     a = ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx(mesh)
     L = ufl.inner(1.0, v) * ufl.dx(mesh)
@@ -267,9 +267,9 @@ def test_matrix_assembly_block(mode):
     P0 = element("Lagrange", mesh.basix_cell(), p0)
     P1 = element("Lagrange", mesh.basix_cell(), p1)
     P2 = element("Lagrange", mesh.basix_cell(), p0)
-    V0 = FunctionSpace(mesh, P0)
-    V1 = FunctionSpace(mesh, P1)
-    V2 = FunctionSpace(mesh, P2)
+    V0 = functionspace(mesh, P0)
+    V1 = functionspace(mesh, P1)
+    V2 = functionspace(mesh, P2)
 
     # Locate facets on boundary
     facetdim = mesh.topology.dim - 1
@@ -342,7 +342,7 @@ def test_matrix_assembly_block(mode):
 
     def monolithic():
         """Monolithic version"""
-        W = FunctionSpace(mesh, mixed_element([P0, P1, P2]))
+        W = functionspace(mesh, mixed_element([P0, P1, P2]))
         u0, u1, u2 = ufl.TrialFunctions(W)
         v0, v1, v2 = ufl.TestFunctions(W)
         a = inner(u0, v0) * dx + inner(u1, v1) * dx + inner(u0, v1) * dx + inner(
@@ -384,7 +384,7 @@ def test_assembly_solve_block(mode):
     and test that solution is the same"""
     mesh = create_unit_square(MPI.COMM_WORLD, 32, 31, ghost_mode=mode)
     P = element("Lagrange", mesh.basix_cell(), 1)
-    V0 = FunctionSpace(mesh, P)
+    V0 = functionspace(mesh, P)
     V1 = V0.clone()
 
     # Locate facets on boundary
@@ -474,7 +474,7 @@ def test_assembly_solve_block(mode):
     def monolithic():
         """Monolithic version"""
         E = mixed_element([P, P])
-        W = FunctionSpace(mesh, E)
+        W = functionspace(mesh, E)
         u0, u1 = ufl.TrialFunctions(W)
         v0, v1 = ufl.TestFunctions(W)
         a = inner(u0, v0) * dx + inner(u1, v1) * dx
@@ -528,8 +528,8 @@ def test_assembly_solve_block(mode):
 def test_assembly_solve_taylor_hood(mesh):
     """Assemble Stokes problem with Taylor-Hood elements and solve."""
     gdim = mesh.geometry.dim
-    P2 = FunctionSpace(mesh, ("Lagrange", 2, (gdim,)))
-    P1 = FunctionSpace(mesh, ("Lagrange", 1))
+    P2 = functionspace(mesh, ("Lagrange", 2, (gdim,)))
+    P1 = functionspace(mesh, ("Lagrange", 1))
 
     def boundary0(x):
         """Define boundary x = 0"""
@@ -639,7 +639,7 @@ def test_assembly_solve_taylor_hood(mesh):
         P2_el = element("Lagrange", mesh.basix_cell(), 2, shape=(mesh.geometry.dim,))
         P1_el = element("Lagrange", mesh.basix_cell(), 1)
         TH = mixed_element([P2_el, P1_el])
-        W = FunctionSpace(mesh, TH)
+        W = functionspace(mesh, TH)
         (u, p) = ufl.TrialFunctions(W)
         (v, q) = ufl.TestFunctions(W)
         a00 = ufl.inner(ufl.grad(u), ufl.grad(v)) * dx
@@ -713,7 +713,7 @@ def test_basic_interior_facet_assembly():
     mesh = create_rectangle(MPI.COMM_WORLD, [np.array([0.0, 0.0]), np.array([1.0, 1.0])],
                             [5, 5], cell_type=CellType.triangle,
                             ghost_mode=GhostMode.shared_facet)
-    V = FunctionSpace(mesh, ("DG", 1))
+    V = functionspace(mesh, ("DG", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = ufl.inner(ufl.avg(u), ufl.avg(v)) * ufl.dS
     a = form(a)
@@ -740,7 +740,7 @@ def test_basic_assembly_constant(mode, dtype):
     """
     xtype = dtype(0).real.dtype
     mesh = create_unit_square(MPI.COMM_WORLD, 5, 5, ghost_mode=mode, dtype=xtype)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
 
     c = Constant(mesh, np.array([[1.0, 2.0], [5.0, 3.0]], dtype=dtype))
@@ -770,7 +770,7 @@ def test_basic_assembly_constant(mode, dtype):
 def test_lambda_assembler():
     """Tests assembly with a lambda function"""
     mesh = create_unit_square(MPI.COMM_WORLD, 5, 5)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
 
     a = inner(u, v) * dx
@@ -801,7 +801,7 @@ def test_lambda_assembler():
 def test_pack_coefficients():
     """Test packing of form coefficients ahead of main assembly call"""
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 15)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
 
     # Non-blocked
     u = Function(V)
@@ -864,7 +864,7 @@ def test_pack_coefficients():
 def test_coefficents_non_constant():
     "Test packing coefficients with non-constant values"
     mesh = create_unit_square(MPI.COMM_WORLD, 3, 5)
-    V = FunctionSpace(mesh, ("Lagrange", 3))  # degree 3 so that interpolation is exact
+    V = functionspace(mesh, ("Lagrange", 3))  # degree 3 so that interpolation is exact
 
     u = Function(V)
     u.interpolate(lambda x: x[0] * x[1]**2)
@@ -885,7 +885,7 @@ def test_coefficents_non_constant():
     assert np.linalg.norm(b0.array) == pytest.approx(0.0, abs=1.0e-7)
 
     # -- Interior facet integral vector
-    V = FunctionSpace(mesh, ("DG", 3))  # degree 3 so that interpolation is exact
+    V = functionspace(mesh, ("DG", 3))  # degree 3 so that interpolation is exact
 
     u0 = Function(V)
     u0.interpolate(lambda x: x[1]**2)
@@ -908,7 +908,7 @@ def test_vector_types():
     """Assemble form using different types"""
     mesh0 = create_unit_square(MPI.COMM_WORLD, 3, 5, dtype=np.float32)
     mesh1 = create_unit_square(MPI.COMM_WORLD, 3, 5, dtype=np.float64)
-    V0, V1 = FunctionSpace(mesh0, ("Lagrange", 3)), FunctionSpace(mesh1, ("Lagrange", 3))
+    V0, V1 = functionspace(mesh0, ("Lagrange", 3)), functionspace(mesh1, ("Lagrange", 3))
     v0, v1 = ufl.TestFunction(V0), ufl.TestFunction(V1)
 
     c = Constant(mesh1, np.float64(1))
@@ -965,7 +965,7 @@ def test_assemble_empty_rank_mesh():
 
     mesh = create_mesh(comm, cells, x, domain, partitioner)
 
-    V = FunctionSpace(mesh, ("Lagrange", 2))
+    V = functionspace(mesh, ("Lagrange", 2))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
 
     f, k, zero = Function(V), Function(V), Function(V)
@@ -1001,7 +1001,7 @@ def test_assemble_empty_rank_mesh():
 def test_matrix_assembly_rectangular(mode):
     """Test assembly of block rectangular block matrices"""
     msh = create_unit_square(MPI.COMM_WORLD, 4, 8, ghost_mode=mode)
-    V0 = FunctionSpace(msh, ("Lagrange", 1))
+    V0 = functionspace(msh, ("Lagrange", 1))
     V1 = V0.clone()
     u = ufl.TrialFunction(V0)
     v0, v1 = ufl.TestFunction(V0), ufl.TestFunction(V1)

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -16,9 +16,9 @@ import ufl
 from basix.ufl import element, mixed_element
 from dolfinx import cpp as _cpp
 from dolfinx import default_real_type, fem, graph, la
-from dolfinx.fem import (Constant, Function, assemble_scalar,
-                         bcs_by_block, dirichletbc, extract_function_spaces,
-                         form, functionspace, locate_dofs_geometrical,
+from dolfinx.fem import (Constant, Function, assemble_scalar, bcs_by_block,
+                         dirichletbc, extract_function_spaces, form,
+                         functionspace, locate_dofs_geometrical,
                          locate_dofs_topological)
 from dolfinx.fem.petsc import apply_lifting as petsc_apply_lifting
 from dolfinx.fem.petsc import apply_lifting_nest as petsc_apply_lifting_nest

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -10,9 +10,9 @@ import pytest
 import ufl
 from basix.ufl import element, mixed_element
 from dolfinx import default_real_type, default_scalar_type, la
-from dolfinx.fem import (Constant, Function, FunctionSpace, apply_lifting,
+from dolfinx.fem import (Constant, Function, apply_lifting,
                          assemble_matrix, assemble_vector, create_matrix,
-                         create_vector, dirichletbc, form,
+                         create_vector, dirichletbc, form, functionspace,
                          locate_dofs_geometrical, locate_dofs_topological,
                          set_bc)
 from dolfinx.mesh import (CellType, create_unit_cube, create_unit_square,
@@ -30,7 +30,7 @@ def test_locate_dofs_geometrical():
     P0 = element("Lagrange", mesh.basix_cell(), p0)
     P1 = element("Lagrange", mesh.basix_cell(), p1)
 
-    W = FunctionSpace(mesh, mixed_element([P0, P1]))
+    W = functionspace(mesh, mixed_element([P0, P1]))
     V = W.sub(0).collapse()[0]
 
     with pytest.raises(RuntimeError):
@@ -63,7 +63,7 @@ def test_overlapping_bcs():
     boundary condition is applied"""
     n = 23
     mesh = create_unit_square(MPI.COMM_WORLD, n, n)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = form(inner(u, v) * dx)
     L = form(inner(1, v) * dx)
@@ -103,9 +103,9 @@ def test_constant_bc_constructions():
     """Test construction from constant values"""
     msh = create_unit_square(MPI.COMM_WORLD, 4, 4, dtype=default_real_type)
     gdim = msh.geometry.dim
-    V0 = FunctionSpace(msh, ("Lagrange", 1))
-    V1 = FunctionSpace(msh, ("Lagrange", 1, (gdim,)))
-    V2 = FunctionSpace(msh, ("Lagrange", 1, (gdim, gdim)))
+    V0 = functionspace(msh, ("Lagrange", 1))
+    V1 = functionspace(msh, ("Lagrange", 1, (gdim,)))
+    V2 = functionspace(msh, ("Lagrange", 1, (gdim, gdim)))
 
     tdim = msh.topology.dim
     boundary_facets = locate_entities_boundary(msh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool))
@@ -145,7 +145,7 @@ def test_constant_bc(mesh_factory):
     result as setting it with a function"""
     func, args = mesh_factory
     mesh = func(*args)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     c = default_scalar_type(2)
     tdim = mesh.topology.dim
     boundary_facets = locate_entities_boundary(mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool))
@@ -179,7 +179,7 @@ def test_vector_constant_bc(mesh_factory):
     mesh = func(*args)
     tdim = mesh.topology.dim
     gdim = mesh.geometry.dim
-    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+    V = functionspace(mesh, ("Lagrange", 1, (gdim,)))
     assert V.num_sub_spaces == gdim
     c = np.arange(1, mesh.geometry.dim + 1, dtype=default_scalar_type)
     boundary_facets = locate_entities_boundary(mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool))
@@ -218,7 +218,7 @@ def test_sub_constant_bc(mesh_factory):
     func, args = mesh_factory
     mesh = func(*args)
     gdim = mesh.geometry.dim
-    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+    V = functionspace(mesh, ("Lagrange", 1, (gdim,)))
     c = Constant(mesh, default_scalar_type(3.14))
     tdim = mesh.topology.dim
     boundary_facets = locate_entities_boundary(mesh, tdim - 1, lambda x: np.ones(x.shape[1], dtype=bool))
@@ -255,7 +255,7 @@ def test_mixed_constant_bc(mesh_factory):
     TH = mixed_element([
         element("Lagrange", mesh.basix_cell(), 1),
         element("Lagrange", mesh.basix_cell(), 2)])
-    W = FunctionSpace(mesh, TH)
+    W = functionspace(mesh, TH)
     u = Function(W)
 
     bc_val = default_scalar_type(3)
@@ -290,7 +290,7 @@ def test_mixed_blocked_constant():
 
     TH = mixed_element([element("Lagrange", mesh.basix_cell(), 1),
                         element("Lagrange", mesh.basix_cell(), 2, shape=(mesh.geometry.dim,))])
-    W = FunctionSpace(mesh, TH)
+    W = functionspace(mesh, TH)
     u = Function(W)
     c0 = default_scalar_type(3)
     dofs0 = locate_dofs_topological(W.sub(0), tdim - 1, boundary_facets)

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -10,9 +10,9 @@ import pytest
 import ufl
 from basix.ufl import element, mixed_element
 from dolfinx import default_real_type, default_scalar_type, la
-from dolfinx.fem import (Constant, Function, apply_lifting,
-                         assemble_matrix, assemble_vector, create_matrix,
-                         create_vector, dirichletbc, form, functionspace,
+from dolfinx.fem import (Constant, Function, apply_lifting, assemble_matrix,
+                         assemble_vector, create_matrix, create_vector,
+                         dirichletbc, form, functionspace,
                          locate_dofs_geometrical, locate_dofs_topological,
                          set_bc)
 from dolfinx.mesh import (CellType, create_unit_cube, create_unit_square,

--- a/python/test/unit/fem/test_complex_assembler.py
+++ b/python/test/unit/fem/test_complex_assembler.py
@@ -10,7 +10,7 @@ import pytest
 
 import ufl
 from basix.ufl import element
-from dolfinx.fem import Function, FunctionSpace, form
+from dolfinx.fem import Function, form, functionspace
 from dolfinx.fem.petsc import assemble_matrix, assemble_vector
 from dolfinx.mesh import create_unit_square
 from ufl import dx, grad, inner
@@ -27,7 +27,7 @@ def test_complex_assembly():
 
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10)
     P2 = element("Lagrange", mesh.basix_cell(), 2)
-    V = FunctionSpace(mesh, P2)
+    V = functionspace(mesh, P2)
     u = ufl.TrialFunction(V)
     v = ufl.TestFunction(V)
     g = -2 + 3.0j
@@ -80,7 +80,7 @@ def test_complex_assembly_solve():
     degree = 3
     mesh = create_unit_square(MPI.COMM_WORLD, 20, 20)
     P = element("Lagrange", mesh.basix_cell(), degree)
-    V = FunctionSpace(mesh, P)
+    V = functionspace(mesh, P)
 
     x = ufl.SpatialCoordinate(mesh)
 

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -21,7 +21,7 @@ import pytest
 import dolfinx
 import dolfinx.pkgconfig
 import ufl
-from dolfinx.fem import Function, FunctionSpace, form
+from dolfinx.fem import Function, form, functionspace
 from dolfinx.fem.petsc import assemble_matrix, load_petsc_lib
 from dolfinx.mesh import create_unit_square
 from ufl import dx, inner
@@ -274,7 +274,7 @@ def assemble_petsc_matrix_ctypes(A, mesh, dofmap, num_cells, set_vals, mode):
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
 def test_custom_mesh_loop_rank1(dtype):
     mesh = create_unit_square(MPI.COMM_WORLD, 64, 64, dtype=dtype(0).real.dtype)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
 
     # Unpack mesh and dofmap data
     num_owned_cells = mesh.topology.index_map(mesh.topology.dim).size_local
@@ -369,7 +369,7 @@ def test_custom_mesh_loop_petsc_ctypes_rank2():
 
     # Create mesh and function space
     mesh = create_unit_square(MPI.COMM_WORLD, 64, 64)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
 
     # Extract mesh and dofmap data
     num_owned_cells = mesh.topology.index_map(mesh.topology.dim).size_local
@@ -412,7 +412,7 @@ def test_custom_mesh_loop_petsc_cffi_rank2(set_vals):
     """Test numba assembler for bilinear form"""
 
     mesh = create_unit_square(MPI.COMM_WORLD, 64, 64)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
 
     # Test against generated code and general assembler
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)

--- a/python/test/unit/fem/test_custom_basix_element.py
+++ b/python/test/unit/fem/test_custom_basix_element.py
@@ -4,8 +4,8 @@ import pytest
 import basix
 import basix.ufl
 import ufl
-from dolfinx.fem import (Function, FunctionSpace, assemble_scalar, dirichletbc,
-                         form, locate_dofs_topological)
+from dolfinx.fem import (Function, assemble_scalar, dirichletbc,
+                         form, functionspace, locate_dofs_topological)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                set_bc)
 from dolfinx.mesh import (CellType, create_unit_cube, create_unit_square,
@@ -81,7 +81,7 @@ def test_basix_element_wrapper(degree):
     ufl_element = basix.ufl.element(
         basix.ElementFamily.P, basix.CellType.triangle, degree, basix.LagrangeVariant.gll_isaac)
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10)
-    V = FunctionSpace(mesh, ufl_element)
+    V = functionspace(mesh, ufl_element)
     run_scalar_test(V, degree)
 
 
@@ -96,7 +96,7 @@ def test_custom_element_triangle_degree1():
     ufl_element = basix.ufl.custom_element(basix.CellType.triangle, [], wcoeffs,
                                            x, M, 0, basix.MapType.identity, basix.SobolevSpace.H1, False, 1, 1)
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10)
-    V = FunctionSpace(mesh, ufl_element)
+    V = functionspace(mesh, ufl_element)
     run_scalar_test(V, 1)
 
 
@@ -113,7 +113,7 @@ def test_custom_element_triangle_degree4():
     ufl_element = basix.ufl.custom_element(basix.CellType.triangle, [], wcoeffs,
                                            x, M, 0, basix.MapType.identity, basix.SobolevSpace.H1, False, 4, 4)
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10)
-    V = FunctionSpace(mesh, ufl_element)
+    V = functionspace(mesh, ufl_element)
     run_scalar_test(V, 4)
 
 
@@ -140,7 +140,7 @@ def test_custom_element_triangle_degree4_integral():
     ufl_element = basix.ufl.custom_element(basix.CellType.triangle, [], wcoeffs,
                                            x, M, 0, basix.MapType.identity, basix.SobolevSpace.H1, False, 4, 4)
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10)
-    V = FunctionSpace(mesh, ufl_element)
+    V = functionspace(mesh, ufl_element)
     run_scalar_test(V, 4)
 
 
@@ -155,7 +155,7 @@ def test_custom_element_quadrilateral_degree1():
     ufl_element = basix.ufl.custom_element(basix.CellType.quadrilateral, [], wcoeffs,
                                            x, M, 0, basix.MapType.identity, basix.SobolevSpace.H1, False, 1, 1)
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10, CellType.quadrilateral)
-    V = FunctionSpace(mesh, ufl_element)
+    V = functionspace(mesh, ufl_element)
     run_scalar_test(V, 1)
 
 
@@ -182,8 +182,8 @@ def test_vector_copy_degree1(cell_type, element_family):
         e1.element.M, 0, e1.element.map_type, e1.element.sobolev_space,
         e1.element.discontinuous, e1.element.highest_complete_degree, e1.element.highest_degree)
 
-    space1 = FunctionSpace(mesh, e1)
-    space2 = FunctionSpace(mesh, e2)
+    space1 = functionspace(mesh, e1)
+    space2 = functionspace(mesh, e2)
 
     f1 = Function(space1)
     f2 = Function(space2)
@@ -220,8 +220,8 @@ def test_scalar_copy_degree1(cell_type, element_family):
         e1.element.M, 0, e1.element.map_type, e1.element.sobolev_space,
         e1.element.discontinuous, e1.element.highest_complete_degree, e1.element.highest_degree)
 
-    space1 = FunctionSpace(mesh, e1)
-    space2 = FunctionSpace(mesh, e2)
+    space1 = functionspace(mesh, e1)
+    space2 = functionspace(mesh, e2)
 
     f1 = Function(space1)
     f2 = Function(space2)

--- a/python/test/unit/fem/test_custom_basix_element.py
+++ b/python/test/unit/fem/test_custom_basix_element.py
@@ -4,8 +4,8 @@ import pytest
 import basix
 import basix.ufl
 import ufl
-from dolfinx.fem import (Function, assemble_scalar, dirichletbc,
-                         form, functionspace, locate_dofs_topological)
+from dolfinx.fem import (Function, assemble_scalar, dirichletbc, form,
+                         functionspace, locate_dofs_topological)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                set_bc)
 from dolfinx.mesh import (CellType, create_unit_cube, create_unit_square,

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -17,7 +17,7 @@ from dolfinx import TimingType
 from dolfinx import cpp as _cpp
 from dolfinx import (default_real_type, default_scalar_type, fem, la,
                      list_timings)
-from dolfinx.fem import Form, Function, FunctionSpace, IntegralType
+from dolfinx.fem import Form, Function, IntegralType, functionspace
 from dolfinx.mesh import create_unit_square
 
 from mpi4py import MPI
@@ -93,7 +93,7 @@ def test_numba_assembly():
         raise RuntimeError("Unknown scalar type")
 
     mesh = create_unit_square(MPI.COMM_WORLD, 13, 13)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
 
     cells = range(mesh.topology.index_map(mesh.topology.dim).size_local)
 
@@ -131,8 +131,8 @@ def test_coefficient():
         raise RuntimeError("Unknown scalar type")
 
     mesh = create_unit_square(MPI.COMM_WORLD, 13, 13)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
-    DG0 = FunctionSpace(mesh, ("DG", 0))
+    V = functionspace(mesh, ("Lagrange", 1))
+    DG0 = functionspace(mesh, ("DG", 0))
     vals = Function(DG0)
     vals.vector.set(2.0)
 
@@ -150,7 +150,7 @@ def test_coefficient():
 @pytest.mark.skip_in_parallel
 def test_cffi_assembly():
     mesh = create_unit_square(MPI.COMM_WORLD, 13, 13, dtype=np.float64)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
 
     if mesh.comm.rank == 0:
         from cffi import FFI

--- a/python/test/unit/fem/test_discrete_operators.py
+++ b/python/test/unit/fem/test_discrete_operators.py
@@ -12,7 +12,7 @@ import scipy
 import dolfinx.la
 import ufl
 from dolfinx.cpp.fem import discrete_gradient
-from dolfinx.fem import Expression, Function, FunctionSpace
+from dolfinx.fem import Expression, Function, functionspace
 from dolfinx.mesh import (CellType, GhostMode, create_unit_cube,
                           create_unit_square)
 
@@ -29,8 +29,8 @@ from mpi4py import MPI
                                                    ghost_mode=GhostMode.shared_facet, dtype=np.float32)])
 def test_gradient(mesh):
     """Test discrete gradient computation for lowest order elements."""
-    V = FunctionSpace(mesh, ("Lagrange", 1))
-    W = FunctionSpace(mesh, ("Nedelec 1st kind H(curl)", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
+    W = functionspace(mesh, ("Nedelec 1st kind H(curl)", 1))
     G = discrete_gradient(V._cpp_object, W._cpp_object)
     # N.B. do not scatter_rev G - doing so would transfer rows to other processes
     # where they will be summed to give an incorrect matrix
@@ -69,8 +69,8 @@ def test_gradient_interpolation(cell_type, p, q, dtype):
         family0 = "Lagrange"
         family1 = "Nedelec 1st kind H(curl)"
 
-    V = FunctionSpace(mesh, (family0, p))
-    W = FunctionSpace(mesh, (family1, q))
+    V = functionspace(mesh, (family0, p))
+    W = functionspace(mesh, (family1, q))
     G = discrete_gradient(V._cpp_object, W._cpp_object)
     # N.B. do not scatter_rev G - doing so would transfer rows to other processes
     # where they will be summed to give an incorrect matrix

--- a/python/test/unit/fem/test_dof_coordinates.py
+++ b/python/test/unit/fem/test_dof_coordinates.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from dolfinx.fem import Function, FunctionSpace
+from dolfinx.fem import Function, functionspace
 from dolfinx.mesh import create_unit_cube, create_unit_square
 
 from mpi4py import MPI
@@ -10,7 +10,7 @@ from mpi4py import MPI
 @pytest.mark.parametrize("degree", range(1, 5))
 def test_dof_coords_2d(degree):
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10)
-    V = FunctionSpace(mesh, ("Lagrange", degree))
+    V = functionspace(mesh, ("Lagrange", degree))
     u = Function(V)
     u.interpolate(lambda x: x[0])
     u.x.scatter_forward()
@@ -23,7 +23,7 @@ def test_dof_coords_2d(degree):
 @pytest.mark.parametrize("degree", range(1, 5))
 def test_dof_coords_3d(degree):
     mesh = create_unit_cube(MPI.COMM_WORLD, 10, 10, 10)
-    V = FunctionSpace(mesh, ("Lagrange", degree))
+    V = functionspace(mesh, ("Lagrange", degree))
     u = Function(V)
     u.interpolate(lambda x: x[0])
     u.x.scatter_forward()

--- a/python/test/unit/fem/test_dof_permuting.py
+++ b/python/test/unit/fem/test_dof_permuting.py
@@ -13,7 +13,7 @@ import pytest
 import ufl
 from basix.ufl import element
 from dolfinx import default_real_type
-from dolfinx.fem import Function, FunctionSpace, assemble_scalar, form
+from dolfinx.fem import Function, assemble_scalar, form, functionspace
 from dolfinx.mesh import create_mesh
 
 from mpi4py import MPI
@@ -129,7 +129,7 @@ def test_dof_positions(cell_type, space_type):
     cmap = mesh.geometry.cmaps[0]
     tdim = mesh.topology.dim
 
-    V = FunctionSpace(mesh, space_type)
+    V = functionspace(mesh, space_type)
     entities = {i: {} for i in range(1, tdim)}
     for cell in range(coord_dofs.shape[0]):
         # Push coordinates forward
@@ -235,7 +235,7 @@ def test_evaluation(cell_type, space_type, space_order):
     random.seed(4)
     for repeat in range(10):
         mesh = random_evaluation_mesh(cell_type)
-        V = FunctionSpace(mesh, (space_type, space_order))
+        V = functionspace(mesh, (space_type, space_order))
         dofs = [i for i in V.dofmap.cell_dofs(0) if i in V.dofmap.cell_dofs(1)]
 
         N = 5
@@ -290,9 +290,9 @@ def test_integral(cell_type, space_type, space_order):
     random.seed(4)
     for repeat in range(10):
         mesh = random_evaluation_mesh(cell_type)
-        V = FunctionSpace(mesh, (space_type, space_order))
+        V = functionspace(mesh, (space_type, space_order))
         gdim = mesh.geometry.dim
-        Vvec = FunctionSpace(mesh, ("P", 1, (gdim,)))
+        Vvec = functionspace(mesh, ("P", 1, (gdim,)))
         dofs = [i for i in V.dofmap.cell_dofs(0) if i in V.dofmap.cell_dofs(1)]
 
         tdim = mesh.topology.dim

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -13,7 +13,7 @@ import pytest
 import dolfinx
 import ufl
 from basix.ufl import element, mixed_element
-from dolfinx.fem import FunctionSpace
+from dolfinx.fem import functionspace
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
                           create_unit_interval, create_unit_square)
 
@@ -37,7 +37,7 @@ def test_tabulate_dofs(mesh_factory):
     mesh = func(*args)
     W0 = element("Lagrange", mesh.basix_cell(), 1)
     W1 = element("Lagrange", mesh.basix_cell(), 1, shape=(mesh.geometry.dim,))
-    W = FunctionSpace(mesh, W0 * W1)
+    W = functionspace(mesh, W0 * W1)
 
     L0 = W.sub(0)
     L1 = W.sub(1)
@@ -61,38 +61,38 @@ def test_entity_dofs(mesh):
     """Test that num entity dofs is correctly wrapped to dolfinx::DofMap"""
     gdim = mesh.geometry.dim
 
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     assert V.dofmap.dof_layout.num_entity_dofs(0) == 1
     assert V.dofmap.dof_layout.num_entity_dofs(1) == 0
     assert V.dofmap.dof_layout.num_entity_dofs(2) == 0
 
-    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+    V = functionspace(mesh, ("Lagrange", 1, (gdim,)))
     bs = V.dofmap.dof_layout.block_size
     assert V.dofmap.dof_layout.num_entity_dofs(0) * bs == 2
     assert V.dofmap.dof_layout.num_entity_dofs(1) * bs == 0
     assert V.dofmap.dof_layout.num_entity_dofs(2) * bs == 0
 
-    V = FunctionSpace(mesh, ("Lagrange", 2))
+    V = functionspace(mesh, ("Lagrange", 2))
     assert V.dofmap.dof_layout.num_entity_dofs(0) == 1
     assert V.dofmap.dof_layout.num_entity_dofs(1) == 1
     assert V.dofmap.dof_layout.num_entity_dofs(2) == 0
 
-    V = FunctionSpace(mesh, ("Lagrange", 3))
+    V = functionspace(mesh, ("Lagrange", 3))
     assert V.dofmap.dof_layout.num_entity_dofs(0) == 1
     assert V.dofmap.dof_layout.num_entity_dofs(1) == 2
     assert V.dofmap.dof_layout.num_entity_dofs(2) == 1
 
-    V = FunctionSpace(mesh, ("DG", 0))
+    V = functionspace(mesh, ("DG", 0))
     assert V.dofmap.dof_layout.num_entity_dofs(0) == 0
     assert V.dofmap.dof_layout.num_entity_dofs(1) == 0
     assert V.dofmap.dof_layout.num_entity_dofs(2) == 1
 
-    V = FunctionSpace(mesh, ("DG", 1))
+    V = functionspace(mesh, ("DG", 1))
     assert V.dofmap.dof_layout.num_entity_dofs(0) == 0
     assert V.dofmap.dof_layout.num_entity_dofs(1) == 0
     assert V.dofmap.dof_layout.num_entity_dofs(2) == 3
 
-    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+    V = functionspace(mesh, ("Lagrange", 1, (gdim,)))
     bs = V.dofmap.dof_layout.block_size
     for i, cdofs in enumerate([[0, 1], [2, 3], [4, 5]]):
         dofs = [bs * d + b for d in V.dofmap.dof_layout.entity_dofs(0, i)
@@ -111,7 +111,7 @@ def test_entity_closure_dofs(mesh_factory):
     tdim = mesh.topology.dim
 
     for degree in (1, 2, 3):
-        V = FunctionSpace(mesh, ("Lagrange", degree))
+        V = functionspace(mesh, ("Lagrange", degree))
         for d in range(tdim + 1):
             map = mesh.topology.index_map(d)
             num_entities = map.size_local + map.num_ghosts
@@ -149,19 +149,19 @@ def test_block_size():
               create_unit_cube(MPI.COMM_WORLD, 4, 4, 4, CellType.hexahedron)]
     for mesh in meshes:
         P2 = element("Lagrange", mesh.basix_cell(), 2)
-        V = FunctionSpace(mesh, P2)
+        V = functionspace(mesh, P2)
         assert V.dofmap.bs == 1
 
         # Only BlockedElements have index_map_bs > 1
-        V = FunctionSpace(mesh, mixed_element([P2, P2]))
+        V = functionspace(mesh, mixed_element([P2, P2]))
         assert V.dofmap.index_map_bs == 1
 
         for i in range(1, 6):
-            W = FunctionSpace(mesh, mixed_element(i * [P2]))
+            W = functionspace(mesh, mixed_element(i * [P2]))
             assert W.dofmap.index_map_bs == 1
 
         gdim = mesh.geometry.dim
-        V = FunctionSpace(mesh, ("Lagrange", 2, (gdim,)))
+        V = functionspace(mesh, ("Lagrange", 2, (gdim,)))
         assert V.dofmap.index_map_bs == mesh.geometry.dim
 
 
@@ -170,7 +170,7 @@ def test_block_size_real():
     mesh = create_unit_interval(MPI.COMM_WORLD, 12)
     V = element('DG', mesh.basix_cell(), 0)
     R = element('R', mesh.basix_cell(), 0)
-    X = FunctionSpace(mesh, V * R)
+    X = functionspace(mesh, V * R)
     assert X.dofmap.index_map_bs == 1
 
 
@@ -186,9 +186,9 @@ def test_local_dimension(mesh_factory):
     q = element("Lagrange", mesh.basix_cell(), 1, shape=(mesh.geometry.dim,))
     w = v * q
 
-    V = FunctionSpace(mesh, v)
-    Q = FunctionSpace(mesh, q)
-    W = FunctionSpace(mesh, w)
+    V = functionspace(mesh, v)
+    Q = functionspace(mesh, q)
+    W = functionspace(mesh, w)
     for space in [V, Q, W]:
         dofmap = space.dofmap
         local_to_global_map = dofmap.tabulate_local_to_global_dofs()
@@ -203,7 +203,7 @@ def test_local_dimension(mesh_factory):
 def test_readonly_view_local_to_global_unwoned(mesh):
     """Test that local_to_global_unwoned() returns readonly
     view into the data; in particular test lifetime of data owner"""
-    V = FunctionSpace(mesh, "P", 1)
+    V = functionspace(mesh, "P", 1)
     dofmap = V.dofmap
     index_map = dofmap().index_map
 
@@ -251,7 +251,7 @@ def test_higher_order_coordinate_map(points, celltype, order):
     domain = ufl.Mesh(element("Lagrange", celltype.name, order, shape=(points.shape[1],)))
     mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
 
-    V = FunctionSpace(mesh, ("Lagrange", 2))
+    V = functionspace(mesh, ("Lagrange", 2))
     X = V.element.interpolation_points()
     coord_dofs = mesh.geometry.dofmap
     x_g = mesh.geometry.x
@@ -298,7 +298,7 @@ def test_higher_order_tetra_coordinate_map(order):
     cells = np.array([range(len(points))])
     domain = ufl.Mesh(element("Lagrange", celltype.name, order, shape=(3,)))
     mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
-    V = FunctionSpace(mesh, ("Lagrange", order))
+    V = functionspace(mesh, ("Lagrange", order))
     X = V.element.interpolation_points()
     coord_dofs = mesh.geometry.dofmap
     x_g = mesh.geometry.x

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -14,9 +14,8 @@ import pytest
 import dolfinx
 import ufl
 from basix.ufl import element
-from dolfinx.fem import (Constant, Function, assemble_matrix,
-                         assemble_scalar, assemble_vector, form,
-                         functionspace)
+from dolfinx.fem import (Constant, Function, assemble_matrix, assemble_scalar,
+                         assemble_vector, form, functionspace)
 from dolfinx.mesh import CellType, create_mesh, meshtags
 
 from mpi4py import MPI

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -14,8 +14,9 @@ import pytest
 import dolfinx
 import ufl
 from basix.ufl import element
-from dolfinx.fem import (Constant, Function, FunctionSpace, assemble_matrix,
-                         assemble_scalar, assemble_vector, form)
+from dolfinx.fem import (Constant, Function, assemble_matrix,
+                         assemble_scalar, assemble_vector, form,
+                         functionspace)
 from dolfinx.mesh import CellType, create_mesh, meshtags
 
 from mpi4py import MPI
@@ -139,7 +140,7 @@ def test_facet_integral(cell_type, dtype):
         mesh = unit_cell(cell_type, xtype)
         tdim = mesh.topology.dim
 
-        V = FunctionSpace(mesh, ("Lagrange", 2))
+        V = functionspace(mesh, ("Lagrange", 2))
         v = Function(V, dtype=dtype)
 
         mesh.topology.create_entities(tdim - 1)
@@ -186,7 +187,7 @@ def test_facet_normals(cell_type, dtype):
         mesh.topology.create_entities(tdim - 1)
 
         gdim = mesh.geometry.dim
-        V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+        V = functionspace(mesh, ("Lagrange", 1, (gdim,)))
         normal = ufl.FacetNormal(mesh)
         v = Function(V, dtype=dtype)
 
@@ -251,7 +252,7 @@ def test_plus_minus(cell_type, space_type, dtype):
     for count in range(3):
         for agree in [True, False]:
             mesh = two_unit_cells(cell_type, xtype, agree)
-            V = FunctionSpace(mesh, (space_type, 1))
+            V = functionspace(mesh, (space_type, 1))
             v = Function(V, dtype=dtype)
             v.interpolate(lambda x: x[0] - 2 * x[1])
             # Check that these two integrals are equal
@@ -277,9 +278,9 @@ def test_plus_minus_simple_vector(cell_type, pm, dtype):
             # Two cell mesh with randomly numbered points
             mesh, order = two_unit_cells(cell_type, xtype, agree, return_order=True)
             if cell_type in [CellType.interval, CellType.triangle, CellType.tetrahedron]:
-                V = FunctionSpace(mesh, ("DG", 1))
+                V = functionspace(mesh, ("DG", 1))
             else:
-                V = FunctionSpace(mesh, ("DQ", 1))
+                V = functionspace(mesh, ("DQ", 1))
 
             # Assemble vectors v['+'] * dS and v['-'] * dS for a few
             # different numberings
@@ -328,9 +329,9 @@ def test_plus_minus_vector(cell_type, pm1, pm2, dtype):
             # Two cell mesh with randomly numbered points
             mesh, order = two_unit_cells(cell_type, xtype, agree, return_order=True)
             if cell_type in [CellType.interval, CellType.triangle, CellType.tetrahedron]:
-                V = FunctionSpace(mesh, ("DG", 1))
+                V = functionspace(mesh, ("DG", 1))
             else:
-                V = FunctionSpace(mesh, ("DQ", 1))
+                V = functionspace(mesh, ("DQ", 1))
 
             # Assemble vectors with combinations of + and - for a few
             # different numberings
@@ -380,7 +381,7 @@ def test_plus_minus_matrix(cell_type, pm1, pm2, dtype):
         for agree in [True, False]:
             # Two cell mesh with randomly numbered points
             mesh, order = two_unit_cells(cell_type, xtype, agree, return_order=True)
-            V = FunctionSpace(mesh, ("DG", 1))
+            V = functionspace(mesh, ("DG", 1))
             u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
 
             # Assemble matrices with combinations of + and - for a few
@@ -441,7 +442,7 @@ def test_curl(space_type, order, dtype):
         random.shuffle(cell)
         domain = ufl.Mesh(element("Lagrange", "tetrahedron", 1, shape=(3,)))
         mesh = create_mesh(MPI.COMM_WORLD, [cell], points, domain)
-        V = FunctionSpace(mesh, (space_type, order))
+        V = functionspace(mesh, (space_type, order))
         v = ufl.TestFunction(V)
         f = ufl.as_vector(tuple(1 if i == 0 else 0 for i in range(tdim)))
         L = form(ufl.inner(f, ufl.curl(v)) * ufl.dx)
@@ -506,8 +507,8 @@ def test_div_general_quads_mat(k, dtype):
 
     def assemble_div_matrix(k, offset):
         mesh = create_quad_mesh(offset, dtype=xtype)
-        V = FunctionSpace(mesh, ("DQ", k))
-        W = FunctionSpace(mesh, ("RTCF", k + 1))
+        V = functionspace(mesh, ("DQ", k))
+        W = functionspace(mesh, ("RTCF", k + 1))
         u, w = ufl.TrialFunction(V), ufl.TestFunction(W)
         a = form(ufl.inner(u, ufl.div(w)) * ufl.dx, dtype=dtype)
         A = assemble_matrix(a)
@@ -535,7 +536,7 @@ def test_div_general_quads_vec(k, dtype):
 
     def assemble_div_vector(k, offset):
         mesh = create_quad_mesh(offset, dtype=xtype)
-        V = FunctionSpace(mesh, ("RTCF", k + 1))
+        V = functionspace(mesh, ("RTCF", k + 1))
         v = ufl.TestFunction(V)
         L = form(ufl.inner(Constant(mesh, dtype(1)), ufl.div(v)) * ufl.dx, dtype=dtype)
         b = assemble_vector(L)

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -12,7 +12,7 @@ import dolfinx.cpp
 import ufl
 from basix.ufl import blocked_element
 from dolfinx import fem, la
-from dolfinx.fem import Constant, Expression, Function, FunctionSpace, form
+from dolfinx.fem import Constant, Expression, Function, form, functionspace
 from dolfinx.mesh import create_unit_square
 from ffcx.element_interface import QuadratureElement
 
@@ -34,8 +34,8 @@ def test_rank0(dtype):
     """
     mesh = create_unit_square(MPI.COMM_WORLD, 5, 5, dtype=dtype(0).real.dtype)
     gdim = mesh.geometry.dim
-    P2 = FunctionSpace(mesh, ("P", 2))
-    vdP1 = FunctionSpace(mesh, ("DG", 1, (gdim,)))
+    P2 = functionspace(mesh, ("P", 2))
+    vdP1 = functionspace(mesh, ("DG", 1, (gdim,)))
 
     f = Function(P2, dtype=dtype)
     f.interpolate(lambda x: x[0] ** 2 + 2.0 * x[1] ** 2)
@@ -77,8 +77,8 @@ def test_rank1_hdiv(dtype):
     """
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10, dtype=dtype(0).real.dtype)
     gdim = mesh.geometry.dim
-    vdP1 = FunctionSpace(mesh, ("DG", 2, (gdim,)))
-    RT1 = FunctionSpace(mesh, ("RT", 2))
+    vdP1 = functionspace(mesh, ("DG", 2, (gdim,)))
+    RT1 = functionspace(mesh, ("RT", 2))
     f = ufl.TrialFunction(RT1)
 
     points = vdP1.element.interpolation_points()
@@ -148,7 +148,7 @@ def test_simple_evaluation(dtype):
     """
     xtype = dtype(0).real.dtype
     mesh = create_unit_square(MPI.COMM_WORLD, 3, 3, dtype=xtype)
-    P2 = FunctionSpace(mesh, ("P", 2))
+    P2 = functionspace(mesh, ("P", 2))
 
     # NOTE: The scaling by a constant factor of 3.0 to get f(x, y) is
     # implemented within the UFL Expression. This is to check that the
@@ -235,8 +235,8 @@ def test_assembly_into_quadrature_function(dtype):
     quadrature_points = quadrature_points.astype(xtype)
     Q_element = blocked_element(QuadratureElement(
         "triangle", (), degree=quadrature_degree, scheme="default"), shape=(2, ))
-    Q = FunctionSpace(mesh, Q_element)
-    P2 = FunctionSpace(mesh, ("P", 2))
+    Q = functionspace(mesh, Q_element)
+    P2 = functionspace(mesh, ("P", 2))
 
     T = Function(P2, dtype=dtype)
     T.interpolate(lambda x: x[0] + 2.0 * x[1])
@@ -299,7 +299,7 @@ def test_assembly_into_quadrature_function(dtype):
 def test_expression_eval_cells_subset(dtype):
     xtype = dtype(0).real.dtype
     mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 2, 4, dtype=xtype)
-    V = dolfinx.fem.FunctionSpace(mesh, ("DG", 0))
+    V = dolfinx.fem.functionspace(mesh, ("DG", 0))
 
     cells_imap = mesh.topology.index_map(mesh.topology.dim)
     all_cells = np.arange(cells_imap.size_local + cells_imap.num_ghosts, dtype=np.int32)
@@ -332,6 +332,6 @@ def test_expression_comm(dtype):
     xtype = dtype(0).real.dtype
     mesh = create_unit_square(MPI.COMM_WORLD, 4, 4, dtype=xtype)
     v = Constant(mesh, dtype(1))
-    u = Function(FunctionSpace(mesh, ("Lagrange", 1)), dtype=dtype)
+    u = Function(functionspace(mesh, ("Lagrange", 1)), dtype=dtype)
     Expression(v, u.function_space.element.interpolation_points(), comm=MPI.COMM_WORLD)
     Expression(v, u.function_space.element.interpolation_points(), comm=MPI.COMM_SELF)

--- a/python/test/unit/fem/test_fem_pipeline.py
+++ b/python/test/unit/fem/test_fem_pipeline.py
@@ -13,8 +13,8 @@ import basix
 import ufl
 from basix.ufl import element, mixed_element
 from dolfinx import default_real_type
-from dolfinx.fem import (Function, FunctionSpace, assemble_scalar, dirichletbc,
-                         form, locate_dofs_topological)
+from dolfinx.fem import (Function, assemble_scalar, dirichletbc,
+                         form, functionspace, locate_dofs_topological)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                set_bc)
 from dolfinx.io import XDMFFile
@@ -219,7 +219,7 @@ def test_curl_curl_eigenvalue(family, order):
                                              np.array([np.pi, np.pi])], [24, 24], CellType.triangle)
 
     e = element(family, basix.CellType.triangle, order)
-    V = FunctionSpace(mesh, e)
+    V = functionspace(mesh, e)
 
     u = ufl.TrialFunction(V)
     v = ufl.TestFunction(V)
@@ -284,7 +284,7 @@ def test_biharmonic(family):
     e = mixed_element([element(family, basix.CellType.triangle, 1),
                        element(basix.ElementFamily.P, basix.CellType.triangle, 2)])
 
-    V = FunctionSpace(mesh, e)
+    V = functionspace(mesh, e)
     sigma, u = ufl.TrialFunctions(V)
     tau, v = ufl.TestFunctions(V)
 
@@ -410,7 +410,7 @@ def test_P_simplex(family, degree, cell_type, datadir):
     if cell_type == CellType.tetrahedron and degree == 4:
         pytest.skip("Skip expensive test on tetrahedron")
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_scalar_test(mesh, V, degree)
 
 
@@ -422,7 +422,7 @@ def test_P_simplex_built_in(family, degree, cell_type, datadir):
         mesh = create_unit_cube(MPI.COMM_WORLD, 5, 5, 5)
     elif cell_type == CellType.triangle:
         mesh = create_unit_square(MPI.COMM_WORLD, 5, 5)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_scalar_test(mesh, V, degree)
 
 
@@ -435,7 +435,7 @@ def test_vector_P_simplex(family, degree, cell_type, datadir):
         pytest.skip("Skip expensive test on tetrahedron")
     mesh = get_mesh(cell_type, datadir)
     gdim = mesh.geometry.dim
-    V = FunctionSpace(mesh, (family, degree, (gdim,)))
+    V = functionspace(mesh, (family, degree, (gdim,)))
     run_vector_test(mesh, V, degree)
 
 
@@ -445,7 +445,7 @@ def test_vector_P_simplex(family, degree, cell_type, datadir):
 @pytest.mark.parametrize("degree", [2, 3])
 def test_dP_simplex(family, degree, cell_type, datadir):
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_dg_test(mesh, V, degree)
 
 
@@ -457,7 +457,7 @@ def test_RT_N1curl_simplex(family, degree, cell_type, datadir):
     if cell_type == CellType.tetrahedron and degree == 4:
         pytest.skip("Skip expensive test on tetrahedron")
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_vector_test(mesh, V, degree - 1)
 
 
@@ -469,7 +469,7 @@ def test_discontinuous_RT(family, degree, cell_type, datadir):
     if cell_type == CellType.tetrahedron and degree == 4:
         pytest.skip("Skip expensive test on tetrahedron")
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_vector_test(mesh, V, degree - 1)
 
 
@@ -479,7 +479,7 @@ def test_discontinuous_RT(family, degree, cell_type, datadir):
 @pytest.mark.parametrize("degree", [1, 2])
 def test_BDM_N2curl_simplex(family, degree, cell_type, datadir):
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_vector_test(mesh, V, degree)
 
 
@@ -491,7 +491,7 @@ def test_BDM_N2curl_simplex(family, degree, cell_type, datadir):
 @pytest.mark.parametrize("degree", [3])
 def test_BDM_N2curl_simplex_highest_order(family, degree, cell_type, datadir):
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_vector_test(mesh, V, degree)
 
 
@@ -503,7 +503,7 @@ def test_BDM_N2curl_simplex_highest_order(family, degree, cell_type, datadir):
 @pytest.mark.parametrize("degree", [2, 3, 4])
 def test_P_tp(family, degree, cell_type, datadir):
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_scalar_test(mesh, V, degree)
 
 
@@ -517,7 +517,7 @@ def test_P_tp_built_in_mesh(family, degree, cell_type, datadir):
     elif cell_type == CellType.quadrilateral:
         mesh = create_unit_square(MPI.COMM_WORLD, 5, 5, cell_type)
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_scalar_test(mesh, V, degree)
 
 
@@ -530,7 +530,7 @@ def test_vector_P_tp(family, degree, cell_type, datadir):
         pytest.skip("Skip expensive test on hexahedron")
     mesh = get_mesh(cell_type, datadir)
     gdim = mesh.geometry.dim
-    V = FunctionSpace(mesh, (family, degree, (gdim,)))
+    V = functionspace(mesh, (family, degree, (gdim,)))
     run_vector_test(mesh, V, degree)
 
 
@@ -540,7 +540,7 @@ def test_vector_P_tp(family, degree, cell_type, datadir):
 @pytest.mark.parametrize("degree", [1, 2, 3])
 def test_dP_quad(family, degree, cell_type, datadir):
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_dg_test(mesh, V, degree)
 
 
@@ -550,7 +550,7 @@ def test_dP_quad(family, degree, cell_type, datadir):
 @pytest.mark.parametrize("degree", [1, 2])
 def test_dP_hex(family, degree, cell_type, datadir):
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_dg_test(mesh, V, degree)
 
 
@@ -560,7 +560,7 @@ def test_dP_hex(family, degree, cell_type, datadir):
 @pytest.mark.parametrize("degree", [2, 3, 4])
 def test_S_tp(family, degree, cell_type, datadir):
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_scalar_test(mesh, V, degree // 2)
 
 
@@ -574,7 +574,7 @@ def test_S_tp_built_in_mesh(family, degree, cell_type, datadir):
     elif cell_type == CellType.quadrilateral:
         mesh = create_unit_square(MPI.COMM_WORLD, 5, 5, cell_type)
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_scalar_test(mesh, V, degree // 2)
 
 
@@ -587,7 +587,7 @@ def test_vector_S_tp(family, degree, cell_type, datadir):
         pytest.skip("Skip expensive test on hexahedron")
     mesh = get_mesh(cell_type, datadir)
     gdim = mesh.geometry.dim
-    V = FunctionSpace(mesh, (family, degree, (gdim,)))
+    V = functionspace(mesh, (family, degree, (gdim,)))
     run_vector_test(mesh, V, degree // 2)
 
 
@@ -597,7 +597,7 @@ def test_vector_S_tp(family, degree, cell_type, datadir):
 @pytest.mark.parametrize("degree", [2, 3, 4])
 def test_DPC_quad(family, degree, cell_type, datadir):
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_dg_test(mesh, V, degree // 2)
 
 
@@ -607,7 +607,7 @@ def test_DPC_quad(family, degree, cell_type, datadir):
 @pytest.mark.parametrize("degree", [2])
 def test_DPC_hex(family, degree, cell_type, datadir):
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_dg_test(mesh, V, degree // 2)
 
 
@@ -617,7 +617,7 @@ def test_DPC_hex(family, degree, cell_type, datadir):
 @pytest.mark.parametrize("degree", [1, 2, 3])
 def test_RTC_quad(family, degree, cell_type, datadir):
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_vector_test(mesh, V, degree - 1)
 
 
@@ -627,7 +627,7 @@ def test_RTC_quad(family, degree, cell_type, datadir):
 @pytest.mark.parametrize("degree", [1, 2, 3])
 def test_NC_hex(family, degree, cell_type, datadir):
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_vector_test(mesh, V, degree - 1)
 
 
@@ -637,7 +637,7 @@ def test_NC_hex(family, degree, cell_type, datadir):
 @pytest.mark.parametrize("degree", [1, 2, 3, 4])
 def test_BDM_quad(family, degree, cell_type, datadir):
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_vector_test(mesh, V, (degree - 1) // 2)
 
 
@@ -647,5 +647,5 @@ def test_BDM_quad(family, degree, cell_type, datadir):
 @pytest.mark.parametrize("degree", [1, 2, 3])
 def test_AA_hex(family, degree, cell_type, datadir):
     mesh = get_mesh(cell_type, datadir)
-    V = FunctionSpace(mesh, (family, degree))
+    V = functionspace(mesh, (family, degree))
     run_vector_test(mesh, V, (degree - 1) // 2)

--- a/python/test/unit/fem/test_fem_pipeline.py
+++ b/python/test/unit/fem/test_fem_pipeline.py
@@ -13,8 +13,8 @@ import basix
 import ufl
 from basix.ufl import element, mixed_element
 from dolfinx import default_real_type
-from dolfinx.fem import (Function, assemble_scalar, dirichletbc,
-                         form, functionspace, locate_dofs_topological)
+from dolfinx.fem import (Function, assemble_scalar, dirichletbc, form,
+                         functionspace, locate_dofs_topological)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                set_bc)
 from dolfinx.io import XDMFFile

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -8,7 +8,7 @@
 
 import pytest
 
-from dolfinx.fem import FunctionSpace, extract_function_spaces, form
+from dolfinx.fem import extract_function_spaces, form, functionspace
 from dolfinx.mesh import create_unit_square
 from ufl import TestFunction, TrialFunction, dx, inner
 
@@ -19,8 +19,8 @@ def test_extract_forms():
     """Test extraction on unique function spaces for rows and columns of
     a block system"""
     mesh = create_unit_square(MPI.COMM_WORLD, 32, 31)
-    V0 = FunctionSpace(mesh, ("Lagrange", 1))
-    V1 = FunctionSpace(mesh, ("Lagrange", 2))
+    V0 = functionspace(mesh, ("Lagrange", 1))
+    V1 = functionspace(mesh, ("Lagrange", 2))
     V2 = V0.clone()
     V3 = V1.clone()
 

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -11,7 +11,7 @@ import pytest
 
 from basix.ufl import element, mixed_element
 from dolfinx import default_real_type
-from dolfinx.fem import Function, FunctionSpace, FunctionSpaceBase
+from dolfinx.fem import Function, FunctionSpaceBase, functionspace
 from dolfinx.mesh import create_mesh, create_unit_cube
 from ufl import Cell, Mesh, TestFunction, TrialFunction, grad
 
@@ -25,20 +25,20 @@ def mesh():
 
 @pytest.fixture
 def V(mesh):
-    return FunctionSpace(mesh, ('Lagrange', 1))
+    return functionspace(mesh, ('Lagrange', 1))
 
 
 @pytest.fixture
 def W(mesh):
     gdim = mesh.geometry.dim
-    return FunctionSpace(mesh, ('Lagrange', 1, (gdim,)))
+    return functionspace(mesh, ('Lagrange', 1, (gdim,)))
 
 
 @pytest.fixture
 def Q(mesh):
     W = element('Lagrange', mesh.basix_cell(), 1, shape=(mesh.geometry.dim,))
     V = element('Lagrange', mesh.basix_cell(), 1)
-    return FunctionSpace(mesh, mixed_element([W, V]))
+    return functionspace(mesh, mixed_element([W, V]))
 
 
 @pytest.fixture
@@ -62,7 +62,7 @@ def W2(g):
 
 
 def test_python_interface(V, V2, W, W2, Q):
-    # Test Python interface of cpp generated FunctionSpace
+    # Test Python interface of cpp generated functionspace
     assert isinstance(V, FunctionSpaceBase)
     assert isinstance(W, FunctionSpaceBase)
     assert isinstance(V2, FunctionSpaceBase)
@@ -176,8 +176,8 @@ def test_argument_equality(mesh, V, V2, W, W2):
     function spaces"""
     mesh2 = create_unit_cube(MPI.COMM_WORLD, 8, 8, 8)
     gdim = mesh2.geometry.dim
-    V3 = FunctionSpace(mesh2, ("Lagrange", 1))
-    W3 = FunctionSpace(mesh2, ("Lagrange", 1, (gdim,)))
+    V3 = functionspace(mesh2, ("Lagrange", 1))
+    W3 = functionspace(mesh2, ("Lagrange", 1, (gdim,)))
 
     for TF in (TestFunction, TrialFunction):
         v = TF(V)
@@ -225,7 +225,7 @@ def test_cell_mismatch(mesh):
     """Test that cell mismatch raises early enough from UFL"""
     e = element("P", "triangle", 1)
     with pytest.raises(BaseException):
-        FunctionSpace(mesh, e)
+        functionspace(mesh, e)
 
 
 # NOTE: Test relies on Basix and DOLFINx both using pybind11
@@ -256,7 +256,7 @@ def test_vector_function_space_cell_type():
 
     # Create functions space over mesh, and check element cell
     # is correct
-    V = FunctionSpace(mesh, ('Lagrange', 1, (gdim,)))
+    V = functionspace(mesh, ('Lagrange', 1, (gdim,)))
     assert V.ufl_element().cell == cell
 
 
@@ -269,8 +269,8 @@ def test_manifold_spaces():
     domain = Mesh(element("Lagrange", "triangle", 1, gdim=3, shape=(2,)))
     mesh = create_mesh(MPI.COMM_WORLD, cells, vertices, domain)
     gdim = mesh.geometry.dim
-    QV = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
-    QT = FunctionSpace(mesh, ("Lagrange", 1, (gdim, gdim)))
+    QV = functionspace(mesh, ("Lagrange", 1, (gdim,)))
+    QT = functionspace(mesh, ("Lagrange", 1, (gdim, gdim)))
     u, v = Function(QV), Function(QT)
     assert u.ufl_shape == (3,)
     assert v.ufl_shape == (3, 3)

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -11,7 +11,7 @@ import pytest
 
 from basix.ufl import element, mixed_element
 from dolfinx import default_real_type
-from dolfinx.fem import Function, FunctionSpaceBase, functionspace
+from dolfinx.fem import Function, FunctionSpace, functionspace
 from dolfinx.mesh import create_mesh, create_unit_cube
 from ufl import Cell, Mesh, TestFunction, TrialFunction, grad
 
@@ -63,10 +63,10 @@ def W2(g):
 
 def test_python_interface(V, V2, W, W2, Q):
     # Test Python interface of cpp generated functionspace
-    assert isinstance(V, FunctionSpaceBase)
-    assert isinstance(W, FunctionSpaceBase)
-    assert isinstance(V2, FunctionSpaceBase)
-    assert isinstance(W2, FunctionSpaceBase)
+    assert isinstance(V, FunctionSpace)
+    assert isinstance(W, FunctionSpace)
+    assert isinstance(V2, FunctionSpace)
+    assert isinstance(W2, FunctionSpace)
 
     assert V.mesh.ufl_cell() == V2.mesh.ufl_cell()
     assert W.mesh.ufl_cell() == W2.mesh.ufl_cell()

--- a/python/test/unit/fem/test_ghost_mesh_assembly.py
+++ b/python/test/unit/fem/test_ghost_mesh_assembly.py
@@ -10,7 +10,7 @@ import pytest
 
 import ufl
 from dolfinx import fem, la
-from dolfinx.fem import Function, FunctionSpace, form
+from dolfinx.fem import Function, form, functionspace
 from dolfinx.mesh import GhostMode, create_unit_square
 from ufl import avg, inner
 
@@ -37,7 +37,7 @@ def dS_from_ufl(mesh):
 @pytest.mark.parametrize("ds", [ds_from_ufl])
 def test_ghost_mesh_assembly(mode, dx, ds):
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 12, ghost_mode=mode)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     dx, ds = dx(mesh), ds(mesh)
 
@@ -72,7 +72,7 @@ def test_ghost_mesh_assembly(mode, dx, ds):
 @pytest.mark.parametrize("dS", [dS_from_ufl])
 def test_ghost_mesh_dS_assembly(mode, dS):
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 12, ghost_mode=mode)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     dS = dS(mesh)
     a = form(inner(avg(u), avg(v)) * dS)

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -15,8 +15,9 @@ import ufl
 from basix.ufl import (blocked_element, custom_element, element,
                        enriched_element, mixed_element)
 from dolfinx import default_real_type
-from dolfinx.fem import (Expression, Function, FunctionSpace, assemble_scalar,
-                         create_nonmatching_meshes_interpolation_data, form)
+from dolfinx.fem import (Expression, Function, assemble_scalar,
+                         create_nonmatching_meshes_interpolation_data, form,
+                         functionspace)
 from dolfinx.geometry import bb_tree, compute_collisions_points
 from dolfinx.mesh import (CellType, create_mesh, create_rectangle,
                           create_unit_cube, create_unit_square,
@@ -197,9 +198,9 @@ def run_vector_test(V, poly_order):
 @parametrize_cell_types
 @pytest.mark.parametrize("order", range(1, 5))
 def test_Lagrange_interpolation(cell_type, order):
-    """Test that interpolation is correct in a FunctionSpace"""
+    """Test that interpolation is correct in a function space"""
     mesh = one_cell_mesh(cell_type)
-    V = FunctionSpace(mesh, ("Lagrange", order))
+    V = functionspace(mesh, ("Lagrange", order))
     run_scalar_test(V, order)
 
 
@@ -207,9 +208,9 @@ def test_Lagrange_interpolation(cell_type, order):
 @pytest.mark.parametrize("cell_type", [CellType.interval, CellType.quadrilateral, CellType.hexahedron])
 @pytest.mark.parametrize("order", range(1, 5))
 def test_serendipity_interpolation(cell_type, order):
-    """Test that interpolation is correct in a FunctionSpace"""
+    """Test that interpolation is correct in a function space"""
     mesh = one_cell_mesh(cell_type)
-    V = FunctionSpace(mesh, ("S", order))
+    V = functionspace(mesh, ("S", order))
     run_scalar_test(V, order)
 
 
@@ -217,10 +218,10 @@ def test_serendipity_interpolation(cell_type, order):
 @parametrize_cell_types
 @pytest.mark.parametrize('order', range(1, 5))
 def test_vector_interpolation(cell_type, order):
-    """Test that interpolation is correct in a blocked (vector) FunctionSpace."""
+    """Test that interpolation is correct in a blocked (vector) function space."""
     mesh = one_cell_mesh(cell_type)
     gdim = mesh.geometry.dim
-    V = FunctionSpace(mesh, ("Lagrange", order, (gdim,)))
+    V = functionspace(mesh, ("Lagrange", order, (gdim,)))
     run_vector_test(V, order)
 
 
@@ -230,7 +231,7 @@ def test_vector_interpolation(cell_type, order):
 def test_N1curl_interpolation(cell_type, order):
     random.seed(8)
     mesh = one_cell_mesh(cell_type)
-    V = FunctionSpace(mesh, ("Nedelec 1st kind H(curl)", order))
+    V = functionspace(mesh, ("Nedelec 1st kind H(curl)", order))
     run_vector_test(V, order - 1)
 
 
@@ -239,7 +240,7 @@ def test_N1curl_interpolation(cell_type, order):
 @pytest.mark.parametrize("order", [1, 2])
 def test_N2curl_interpolation(cell_type, order):
     mesh = one_cell_mesh(cell_type)
-    V = FunctionSpace(mesh, ("Nedelec 2nd kind H(curl)", order))
+    V = functionspace(mesh, ("Nedelec 2nd kind H(curl)", order))
     run_vector_test(V, order)
 
 
@@ -249,7 +250,7 @@ def test_N2curl_interpolation(cell_type, order):
 def test_RTCE_interpolation(cell_type, order):
     random.seed(8)
     mesh = one_cell_mesh(cell_type)
-    V = FunctionSpace(mesh, ("RTCE", order))
+    V = functionspace(mesh, ("RTCE", order))
     run_vector_test(V, order - 1)
 
 
@@ -259,7 +260,7 @@ def test_RTCE_interpolation(cell_type, order):
 def test_NCE_interpolation(cell_type, order):
     random.seed(8)
     mesh = one_cell_mesh(cell_type)
-    V = FunctionSpace(mesh, ("NCE", order))
+    V = functionspace(mesh, ("NCE", order))
     run_vector_test(V, order - 1)
 
 
@@ -273,12 +274,12 @@ def test_mixed_sub_interpolation():
     P2 = element("Lagrange", mesh.basix_cell(), 2, shape=(mesh.geometry.dim,))
     P1 = element("Lagrange", mesh.basix_cell(), 1)
     for i, P in enumerate((mixed_element([P2, P1]), mixed_element([P1, P2]))):
-        W = FunctionSpace(mesh, P)
+        W = functionspace(mesh, P)
         U = Function(W)
         U.sub(i).interpolate(f)
 
         # Same element
-        V = FunctionSpace(mesh, P2)
+        V = functionspace(mesh, P2)
         u, v = Function(V), Function(V)
         u.interpolate(U.sub(i))
         v.interpolate(f)
@@ -286,14 +287,14 @@ def test_mixed_sub_interpolation():
 
         # Same map, different elements
         gdim = mesh.geometry.dim
-        V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+        V = functionspace(mesh, ("Lagrange", 1, (gdim,)))
         u, v = Function(V), Function(V)
         u.interpolate(U.sub(i))
         v.interpolate(f)
         assert np.allclose(u.x.array, v.x.array)
 
         # Different maps (0)
-        V = FunctionSpace(mesh, ("N1curl", 1))
+        V = functionspace(mesh, ("N1curl", 1))
         u, v = Function(V), Function(V)
         u.interpolate(U.sub(i))
         v.interpolate(f)
@@ -301,7 +302,7 @@ def test_mixed_sub_interpolation():
         assert np.allclose(u.x.array, v.x.array, atol=atol)
 
         # Different maps (1)
-        V = FunctionSpace(mesh, ("RT", 2))
+        V = functionspace(mesh, ("RT", 2))
         u, v = Function(V), Function(V)
         u.interpolate(U.sub(i))
         v.interpolate(f)
@@ -309,8 +310,8 @@ def test_mixed_sub_interpolation():
         assert np.allclose(u.x.array, v.x.array, atol=atol)
 
         # Test with wrong shape
-        V0 = FunctionSpace(mesh, P.sub_elements[0])
-        V1 = FunctionSpace(mesh, P.sub_elements[1])
+        V0 = functionspace(mesh, P.sub_elements[0])
+        V1 = functionspace(mesh, P.sub_elements[1])
         v0, v1 = Function(V0), Function(V1)
         with pytest.raises(RuntimeError):
             v0.interpolate(U.sub(1))
@@ -324,7 +325,7 @@ def test_mixed_interpolation():
     mesh = one_cell_mesh(CellType.triangle)
     A = element("Lagrange", mesh.basix_cell(), 1)
     B = element("Lagrange", mesh.basix_cell(), 1, shape=(mesh.geometry.dim,))
-    v = Function(FunctionSpace(mesh, mixed_element([A, B])))
+    v = Function(functionspace(mesh, mixed_element([A, B])))
     with pytest.raises(RuntimeError):
         v.interpolate(lambda x: (x[1], 2 * x[0], 3 * x[1]))
 
@@ -333,8 +334,8 @@ def test_mixed_interpolation():
 @pytest.mark.parametrize("order2", [2, 3, 4])
 def test_interpolation_nedelec(order1, order2):
     mesh = create_unit_cube(MPI.COMM_WORLD, 2, 2, 2)
-    V = FunctionSpace(mesh, ("N1curl", order1))
-    V1 = FunctionSpace(mesh, ("N1curl", order2))
+    V = functionspace(mesh, ("N1curl", order1))
+    V1 = functionspace(mesh, ("N1curl", order2))
     u, v = Function(V), Function(V1)
 
     # The expression "lambda x: x" is contained in the N1curl function
@@ -345,7 +346,7 @@ def test_interpolation_nedelec(order1, order2):
 
     # The target expression is also contained in N2curl space of any
     # order
-    V2 = FunctionSpace(mesh, ("N2curl", 1))
+    V2 = functionspace(mesh, ("N2curl", 1))
     w = Function(V2)
     w.interpolate(u)
     assert assemble_scalar(form(ufl.inner(u - w, u - w) * ufl.dx)) == pytest.approx(0, abs=1.0e-10)
@@ -358,8 +359,8 @@ def test_interpolation_dg_to_n1curl(tdim, order):
         mesh = create_unit_square(MPI.COMM_WORLD, 5, 5)
     else:
         mesh = create_unit_cube(MPI.COMM_WORLD, 2, 2, 2)
-    V = FunctionSpace(mesh, ("DG", order, (tdim,)))
-    V1 = FunctionSpace(mesh, ("N1curl", order + 1))
+    V = functionspace(mesh, ("DG", order, (tdim,)))
+    V1 = functionspace(mesh, ("N1curl", order + 1))
     u, v = Function(V), Function(V1)
     u.interpolate(lambda x: x[:tdim] ** order)
     v.interpolate(u)
@@ -373,8 +374,8 @@ def test_interpolation_n1curl_to_dg(tdim, order):
         mesh = create_unit_square(MPI.COMM_WORLD, 5, 5)
     else:
         mesh = create_unit_cube(MPI.COMM_WORLD, 2, 2, 2)
-    V = FunctionSpace(mesh, ("N1curl", order + 1))
-    V1 = FunctionSpace(mesh, ("DG", order, (tdim,)))
+    V = functionspace(mesh, ("N1curl", order + 1))
+    V1 = functionspace(mesh, ("DG", order, (tdim,)))
     u, v = Function(V), Function(V1)
     u.interpolate(lambda x: x[:tdim] ** order)
     v.interpolate(u)
@@ -388,8 +389,8 @@ def test_interpolation_n2curl_to_bdm(tdim, order):
         mesh = create_unit_square(MPI.COMM_WORLD, 5, 5)
     else:
         mesh = create_unit_cube(MPI.COMM_WORLD, 2, 2, 2)
-    V = FunctionSpace(mesh, ("N2curl", order))
-    V1 = FunctionSpace(mesh, ("BDM", order))
+    V = functionspace(mesh, ("N2curl", order))
+    V1 = functionspace(mesh, ("BDM", order))
     u, v = Function(V), Function(V1)
     u.interpolate(lambda x: x[:tdim] ** order)
     v.interpolate(u)
@@ -400,14 +401,14 @@ def test_interpolation_n2curl_to_bdm(tdim, order):
 @pytest.mark.parametrize("order2", [1, 2, 3])
 def test_interpolation_p2p(order1, order2):
     mesh = create_unit_cube(MPI.COMM_WORLD, 2, 2, 2)
-    V = FunctionSpace(mesh, ("Lagrange", order1))
-    V1 = FunctionSpace(mesh, ("Lagrange", order2))
+    V = functionspace(mesh, ("Lagrange", order1))
+    V1 = functionspace(mesh, ("Lagrange", order2))
     u, v = Function(V), Function(V1)
     u.interpolate(lambda x: x[0])
     v.interpolate(u)
     assert assemble_scalar(form(ufl.inner(u - v, u - v) * ufl.dx)) == pytest.approx(0.0, abs=1e-10)
 
-    DG = FunctionSpace(mesh, ("DG", order2))
+    DG = functionspace(mesh, ("DG", order2))
     w = Function(DG)
     w.interpolate(u)
     assert assemble_scalar(form(ufl.inner(u - w, u - w) * ufl.dx)) == pytest.approx(0.0, abs=1e-10)
@@ -418,14 +419,14 @@ def test_interpolation_p2p(order1, order2):
 def test_interpolation_vector_elements(order1, order2):
     mesh = create_unit_cube(MPI.COMM_WORLD, 2, 2, 2)
     gdim = mesh.geometry.dim
-    V = FunctionSpace(mesh, ("Lagrange", order1, (gdim,)))
-    V1 = FunctionSpace(mesh, ("Lagrange", order2, (gdim,)))
+    V = functionspace(mesh, ("Lagrange", order1, (gdim,)))
+    V1 = functionspace(mesh, ("Lagrange", order2, (gdim,)))
     u, v = Function(V), Function(V1)
     u.interpolate(lambda x: x)
     v.interpolate(u)
     assert assemble_scalar(form(ufl.inner(u - v, u - v) * ufl.dx)) == pytest.approx(0)
 
-    DG = FunctionSpace(mesh, ("DG", order2, (gdim,)))
+    DG = functionspace(mesh, ("DG", order2, (gdim,)))
     w = Function(DG)
     w.interpolate(u)
     assert assemble_scalar(form(ufl.inner(u - w, u - w) * ufl.dx)) == pytest.approx(0)
@@ -443,8 +444,8 @@ def test_interpolation_non_affine():
     cells = np.array([range(len(points))], dtype=np.int32)
     domain = ufl.Mesh(element("Lagrange", "hexahedron", 2, shape=(3,)))
     mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
-    W = FunctionSpace(mesh, ("NCE", 1))
-    V = FunctionSpace(mesh, ("NCE", 2))
+    W = functionspace(mesh, ("NCE", 1))
+    V = functionspace(mesh, ("NCE", 2))
     w, v = Function(W), Function(V)
     w.interpolate(lambda x: x)
     v.interpolate(w)
@@ -464,8 +465,8 @@ def test_interpolation_non_affine_nonmatching_maps():
     domain = ufl.Mesh(element("Lagrange", "hexahedron", 2, shape=(3,)))
     mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
     gdim = mesh.geometry.dim
-    W = FunctionSpace(mesh, ("DG", 1, (gdim,)))
-    V = FunctionSpace(mesh, ("NCE", 4))
+    W = functionspace(mesh, ("DG", 1, (gdim,)))
+    V = functionspace(mesh, ("NCE", 4))
     w, v = Function(W), Function(V)
     w.interpolate(lambda x: x)
     v.interpolate(w)
@@ -480,7 +481,7 @@ def test_nedelec_spatial(order, dim):
     elif dim == 3:
         mesh = create_unit_cube(MPI.COMM_WORLD, 2, 2, 2)
 
-    V = FunctionSpace(mesh, ("N1curl", order))
+    V = functionspace(mesh, ("N1curl", order))
     u = Function(V)
     x = ufl.SpatialCoordinate(mesh)
 
@@ -493,7 +494,7 @@ def test_nedelec_spatial(order, dim):
 
     # The target expression is also contained in N2curl space of any
     # order
-    V2 = FunctionSpace(mesh, ("N2curl", 1))
+    V2 = functionspace(mesh, ("N2curl", 1))
     w = Function(V2)
     f2 = Expression(f_ex, V2.element.interpolation_points())
     w.interpolate(f2)
@@ -511,7 +512,7 @@ def test_vector_interpolation_spatial(order, dim, affine):
         ct = CellType.tetrahedron if affine else CellType.hexahedron
         mesh = create_unit_cube(MPI.COMM_WORLD, 3, 2, 2, ct)
 
-    V = FunctionSpace(mesh, ("Lagrange", order, (dim,)))
+    V = functionspace(mesh, ("Lagrange", order, (dim,)))
     u = Function(V)
     x = ufl.SpatialCoordinate(mesh)
 
@@ -524,7 +525,7 @@ def test_vector_interpolation_spatial(order, dim, affine):
 @pytest.mark.parametrize("order", [1, 2, 3, 4])
 def test_2D_lagrange_to_curl(order):
     mesh = create_unit_square(MPI.COMM_WORLD, 3, 4)
-    V, W = FunctionSpace(mesh, ("N1curl", order)), FunctionSpace(mesh, ("Lagrange", order))
+    V, W = functionspace(mesh, ("N1curl", order)), functionspace(mesh, ("Lagrange", order))
     u, u0 = Function(V), Function(W)
     u0.interpolate(lambda x: -x[1])
     u1 = Function(W)
@@ -540,18 +541,18 @@ def test_2D_lagrange_to_curl(order):
 @pytest.mark.parametrize("order", [2, 3, 4])
 def test_de_rahm_2D(order):
     mesh = create_unit_square(MPI.COMM_WORLD, 3, 4)
-    W = FunctionSpace(mesh, ("Lagrange", order))
+    W = functionspace(mesh, ("Lagrange", order))
     w = Function(W)
     w.interpolate(lambda x: x[0] + x[0] * x[1] + 2 * x[1]**2)
     g = ufl.grad(w)
-    Q = FunctionSpace(mesh, ("N2curl", order - 1))
+    Q = functionspace(mesh, ("N2curl", order - 1))
     q = Function(Q)
     q.interpolate(Expression(g, Q.element.interpolation_points()))
     x = ufl.SpatialCoordinate(mesh)
     g_ex = ufl.as_vector((1 + x[1], 4 * x[1] + x[0]))
     assert np.abs(assemble_scalar(form(ufl.inner(q - g_ex, q - g_ex) * ufl.dx))) == pytest.approx(0, abs=1e-10)
 
-    V = FunctionSpace(mesh, ("BDM", order - 1))
+    V = functionspace(mesh, ("BDM", order - 1))
     v = Function(V)
 
     def curl2D(u):
@@ -574,7 +575,7 @@ def test_interpolate_subset(order, dim, affine, callable_):
         ct = CellType.tetrahedron if affine else CellType.hexahedron
         mesh = create_unit_cube(MPI.COMM_WORLD, 3, 2, 2, ct)
 
-    V = FunctionSpace(mesh, ("DG", order))
+    V = functionspace(mesh, ("DG", order))
     u = Function(V)
 
     cells = locate_entities(mesh, mesh.topology.dim, lambda x: x[1] <= 0.5 + 1e-10)
@@ -598,7 +599,7 @@ def test_interpolate_callable():
     """Test interpolation with callables"""
     numba = pytest.importorskip("numba")
     mesh = create_unit_square(MPI.COMM_WORLD, 2, 1)
-    V = FunctionSpace(mesh, ("Lagrange", 2))
+    V = functionspace(mesh, ("Lagrange", 2))
     u0, u1 = Function(V), Function(V)
 
     @ numba.njit
@@ -619,7 +620,7 @@ def test_interpolate_callable_subset(bound):
     cells = locate_entities(mesh, mesh.topology.dim, lambda x: x[1] <= bound + 1e-10)
     num_local_cells = mesh.topology.index_map(mesh.topology.dim).size_local
     cells_local = cells[cells < num_local_cells]
-    V = FunctionSpace(mesh, ("DG", 2))
+    V = functionspace(mesh, ("DG", 2))
     u0, u1 = Function(V), Function(V)
     x = ufl.SpatialCoordinate(mesh)
     f = x[0]
@@ -645,7 +646,7 @@ def test_interpolate_callable_subset(bound):
 def test_vector_element_interpolation(scalar_element):
     """Test interpolation into a range of vector elements."""
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10, getattr(CellType, scalar_element.cell.cellname()))
-    V = FunctionSpace(mesh, blocked_element(scalar_element, shape=(2, )))
+    V = functionspace(mesh, blocked_element(scalar_element, shape=(2, )))
     u = Function(V)
     u.interpolate(lambda x: (x[0], x[1]))
     u2 = Function(V)
@@ -674,9 +675,9 @@ def test_custom_vector_element():
     e = custom_element(basix.CellType.triangle, [2], wcoeffs, x, M, 0, basix.MapType.identity,
                        basix.SobolevSpace.H1, False, 1, 1)
 
-    V = FunctionSpace(mesh, e)
+    V = functionspace(mesh, e)
     gdim = mesh.geometry.dim
-    W = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+    W = functionspace(mesh, ("Lagrange", 1, (gdim,)))
     v = Function(V)
     w = Function(W)
     v.interpolate(lambda x: (x[0], x[1]))
@@ -701,13 +702,13 @@ def test_mixed_interpolation_permuting(cell_type, order):
     vlag_el = element("Lagrange", mesh.basix_cell(), 1, shape=(mesh.geometry.dim,))
     lagr_el = element("Lagrange", mesh.basix_cell(), order)
 
-    V = FunctionSpace(mesh, mixed_element([curl_el, lagr_el]))
+    V = functionspace(mesh, mixed_element([curl_el, lagr_el]))
     Eb_m = Function(V)
     Eb_m.sub(1).interpolate(g)
     diff = Eb_m[2].dx(1) - dgdy
     error = assemble_scalar(form(ufl.dot(diff, diff) * ufl.dx))
 
-    V = FunctionSpace(mesh, mixed_element([vlag_el, lagr_el]))
+    V = functionspace(mesh, mixed_element([vlag_el, lagr_el]))
     Eb_m = Function(V)
     Eb_m.sub(1).interpolate(g)
     diff = Eb_m[2].dx(1) - dgdy
@@ -725,9 +726,9 @@ def test_nonmatching_mesh_interpolation(xtype, cell_type0, cell_type1):
         return (7 * x[1], 3 * x[0], x[2] + 0.4)
 
     el0 = element("Lagrange", mesh0.basix_cell(), 1, shape=(3, ))
-    V0 = FunctionSpace(mesh0, el0)
+    V0 = functionspace(mesh0, el0)
     el1 = element("Lagrange", mesh1.basix_cell(), 1, shape=(3, ))
-    V1 = FunctionSpace(mesh1, el1)
+    V1 = functionspace(mesh1, el1)
 
     # Interpolate on 3D mesh
     u0 = Function(V0, dtype=xtype)
@@ -780,8 +781,8 @@ def test_nonmatching_mesh_single_cell_overlap_interpolation(xtype):
     mesh2 = create_rectangle(MPI.COMM_WORLD, [[0.0, 0.0], [p0_mesh2, p0_mesh2]], [n_mesh2, n_mesh2],
                              cell_type=CellType.triangle, dtype=xtype)
 
-    u1 = Function(FunctionSpace(mesh1, ("Lagrange", 1)), name="u1", dtype=xtype)
-    u2 = Function(FunctionSpace(mesh2, ("Lagrange", 1)), name="u2", dtype=xtype)
+    u1 = Function(functionspace(mesh1, ("Lagrange", 1)), name="u1", dtype=xtype)
+    u2 = Function(functionspace(mesh2, ("Lagrange", 1)), name="u2", dtype=xtype)
 
     def f_test1(x):
         return 1.0 - x[0] * x[1]

--- a/python/test/unit/fem/test_mixed_element.py
+++ b/python/test/unit/fem/test_mixed_element.py
@@ -10,7 +10,7 @@ import pytest
 import dolfinx
 import ufl
 from basix.ufl import element, mixed_element
-from dolfinx.fem import FunctionSpace, form
+from dolfinx.fem import form, functionspace
 from dolfinx.mesh import (CellType, GhostMode, create_unit_cube,
                           create_unit_square)
 
@@ -31,7 +31,7 @@ def test_mixed_element(rank, family, cell, degree):
     norms = []
     U_el = element(family, cell.cellname(), degree, shape=shape)
     for i in range(3):
-        U = FunctionSpace(mesh, U_el)
+        U = functionspace(mesh, U_el)
         u = ufl.TrialFunction(U)
         v = ufl.TestFunction(U)
         a = form(ufl.inner(u, v) * ufl.dx)
@@ -48,21 +48,21 @@ def test_mixed_element(rank, family, cell, degree):
 
 @pytest.mark.skip_in_parallel
 def test_vector_element():
-    # FunctionSpace containing a scalar should work
+    # Function space containing a scalar should work
     mesh = create_unit_square(MPI.COMM_WORLD, 1, 1, CellType.triangle,
                               ghost_mode=GhostMode.shared_facet)
     gdim = mesh.geometry.dim
-    U = FunctionSpace(mesh, ("P", 2, (gdim,)))
+    U = functionspace(mesh, ("P", 2, (gdim,)))
     u, v = ufl.TrialFunction(U), ufl.TestFunction(U)
     a = form(ufl.inner(u, v) * ufl.dx)
     A = dolfinx.fem.assemble_matrix(a)
     A.scatter_reverse()
 
     with pytest.raises(ValueError):
-        # FunctionSpace containing a vector should throw an error rather
+        # Function space containing a vector should throw an error rather
         # than segfaulting
         gdim = mesh.geometry.dim
-        U = FunctionSpace(mesh, ("RT", 2, (gdim + 1, )))
+        U = functionspace(mesh, ("RT", 2, (gdim + 1, )))
         u, v = ufl.TrialFunction(U), ufl.TestFunction(U)
         a = form(ufl.inner(u, v) * ufl.dx)
         A = dolfinx.fem.assemble_matrix(a)
@@ -77,7 +77,7 @@ def test_element_product(d1, d2):
     P3 = element("Lagrange", mesh.basix_cell(), d1, shape=(mesh.geometry.dim,))
     P1 = element("Lagrange", mesh.basix_cell(), d2)
     TH = mixed_element([P3, P1])
-    W = FunctionSpace(mesh, TH)
+    W = functionspace(mesh, TH)
 
     u = ufl.TrialFunction(W)
     v = ufl.TestFunction(W)
@@ -85,7 +85,7 @@ def test_element_product(d1, d2):
     A = dolfinx.fem.assemble_matrix(a)
     A.scatter_reverse()
 
-    W = FunctionSpace(mesh, P3)
+    W = functionspace(mesh, P3)
     u = ufl.TrialFunction(W)
     v = ufl.TestFunction(W)
     a = form(ufl.inner(u[0], v[0]) * ufl.dx)

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -13,8 +13,8 @@ import pytest
 import ufl
 from basix.ufl import element, mixed_element
 from dolfinx.cpp.la.petsc import scatter_local_vectors
-from dolfinx.fem import (Function, FunctionSpace, bcs_by_block, dirichletbc,
-                         extract_function_spaces, form,
+from dolfinx.fem import (Function, bcs_by_block, dirichletbc,
+                         extract_function_spaces, form, functionspace,
                          locate_dofs_topological)
 from dolfinx.fem.petsc import (apply_lifting, apply_lifting_nest,
                                assemble_matrix, assemble_matrix_block,
@@ -54,8 +54,8 @@ def test_matrix_assembly_block_nl():
     p0, p1 = 1, 2
     P0 = element("Lagrange", mesh.basix_cell(), p0)
     P1 = element("Lagrange", mesh.basix_cell(), p1)
-    V0 = FunctionSpace(mesh, P0)
-    V1 = FunctionSpace(mesh, P1)
+    V0 = functionspace(mesh, P0)
+    V1 = functionspace(mesh, P1)
 
     def initial_guess_u(x):
         return np.sin(x[0]) * np.sin(x[1])
@@ -143,7 +143,7 @@ def test_matrix_assembly_block_nl():
     def monolithic():
         """Monolithic version"""
         E = mixed_element([P0, P1])
-        W = FunctionSpace(mesh, E)
+        W = functionspace(mesh, E)
         dU = ufl.TrialFunction(W)
         U = Function(W)
         u0, u1 = ufl.split(U)
@@ -280,7 +280,7 @@ def test_assembly_solve_block_nl():
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 11)
     p = 1
     P = element("Lagrange", mesh.basix_cell(), p)
-    V0 = FunctionSpace(mesh, P)
+    V0 = functionspace(mesh, P)
     V1 = V0.clone()
 
     def bc_val_0(x):
@@ -389,7 +389,7 @@ def test_assembly_solve_block_nl():
     def monolithic_solve():
         """Monolithic version"""
         E = mixed_element([P, P])
-        W = FunctionSpace(mesh, E)
+        W = functionspace(mesh, E)
         U = Function(W)
         dU = ufl.TrialFunction(W)
         u0, u1 = ufl.split(U)
@@ -454,8 +454,8 @@ def test_assembly_solve_block_nl():
 def test_assembly_solve_taylor_hood_nl(mesh):
     """Assemble Stokes problem with Taylor-Hood elements and solve."""
     gdim = mesh.geometry.dim
-    P2 = FunctionSpace(mesh, ("Lagrange", 2, (gdim,)))
-    P1 = FunctionSpace(mesh, ("Lagrange", 1))
+    P2 = functionspace(mesh, ("Lagrange", 2, (gdim,)))
+    P1 = functionspace(mesh, ("Lagrange", 1))
 
     def boundary0(x):
         """Define boundary x = 0"""
@@ -580,7 +580,7 @@ def test_assembly_solve_taylor_hood_nl(mesh):
         P2_el = element("Lagrange", mesh.basix_cell(), 2, shape=(mesh.geometry.dim,))
         P1_el = element("Lagrange", mesh.basix_cell(), 1)
         TH = mixed_element([P2_el, P1_el])
-        W = FunctionSpace(mesh, TH)
+        W = functionspace(mesh, TH)
         U = Function(W)
         dU = ufl.TrialFunction(W)
         u, p = ufl.split(U)

--- a/python/test/unit/fem/test_petsc_discrete_operators.py
+++ b/python/test/unit/fem/test_petsc_discrete_operators.py
@@ -12,8 +12,8 @@ import ufl
 from basix.ufl import element
 from dolfinx import default_real_type
 from dolfinx.cpp.fem.petsc import discrete_gradient, interpolation_matrix
-from dolfinx.fem import (Expression, Function, FunctionSpace, assemble_scalar,
-                         form)
+from dolfinx.fem import (Expression, Function, assemble_scalar,
+                         form, functionspace)
 from dolfinx.mesh import (CellType, GhostMode, create_mesh, create_unit_cube,
                           create_unit_square)
 
@@ -28,8 +28,8 @@ from petsc4py import PETSc
                                   create_unit_cube(MPI.COMM_WORLD, 4, 3, 7, ghost_mode=GhostMode.shared_facet)])
 def test_gradient(mesh):
     """Test discrete gradient computation for lowest order elements."""
-    V = FunctionSpace(mesh, ("Lagrange", 1))
-    W = FunctionSpace(mesh, ("Nedelec 1st kind H(curl)", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
+    W = functionspace(mesh, ("Nedelec 1st kind H(curl)", 1))
     G = discrete_gradient(V._cpp_object, W._cpp_object)
     assert G.getRefCount() == 1
     num_edges = mesh.topology.index_map(1).size_global
@@ -67,8 +67,8 @@ def test_gradient_interpolation(cell_type, p, q):
         family0 = "Lagrange"
         family1 = "Nedelec 1st kind H(curl)"
 
-    V = FunctionSpace(mesh, (family0, p))
-    W = FunctionSpace(mesh, (family1, q))
+    V = functionspace(mesh, (family0, p))
+    W = functionspace(mesh, (family1, q))
     G = discrete_gradient(V._cpp_object, W._cpp_object)
     G.assemble()
 
@@ -130,8 +130,8 @@ def test_interpolation_matrix(cell_type, p, q, from_lagrange):
         el0 = s_el
         el1 = v_el
 
-    V = FunctionSpace(mesh, el0)
-    W = FunctionSpace(mesh, el1)
+    V = functionspace(mesh, el0)
+    W = functionspace(mesh, el1)
     G = interpolation_matrix(V._cpp_object, W._cpp_object)
     G.assemble()
 
@@ -173,8 +173,8 @@ def test_nonaffine_discrete_operator():
     domain = ufl.Mesh(element("Lagrange", cell_type.name, 2, shape=(3,)))
     mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
     gdim = mesh.geometry.dim
-    W = FunctionSpace(mesh, ("DG", 1, (gdim,)))
-    V = FunctionSpace(mesh, ("NCE", 4))
+    W = functionspace(mesh, ("DG", 1, (gdim,)))
+    V = functionspace(mesh, ("NCE", 4))
     w, v = Function(W), Function(V)
     w.interpolate(lambda x: x)
     v.interpolate(w)

--- a/python/test/unit/fem/test_petsc_discrete_operators.py
+++ b/python/test/unit/fem/test_petsc_discrete_operators.py
@@ -12,8 +12,8 @@ import ufl
 from basix.ufl import element
 from dolfinx import default_real_type
 from dolfinx.cpp.fem.petsc import discrete_gradient, interpolation_matrix
-from dolfinx.fem import (Expression, Function, assemble_scalar,
-                         form, functionspace)
+from dolfinx.fem import (Expression, Function, assemble_scalar, form,
+                         functionspace)
 from dolfinx.mesh import (CellType, GhostMode, create_mesh, create_unit_cube,
                           create_unit_square)
 

--- a/python/test/unit/fem/test_symmetry.py
+++ b/python/test/unit/fem/test_symmetry.py
@@ -12,7 +12,7 @@ import basix
 import dolfinx
 import ufl
 from basix.ufl import element, mixed_element
-from dolfinx.fem import FunctionSpace, form
+from dolfinx.fem import form, functionspace
 from dolfinx.mesh import CellType, create_unit_cube, create_unit_square
 from ufl import grad, inner
 
@@ -32,7 +32,7 @@ def run_symmetry_test(cell_type, e, form_f):
     else:
         mesh = create_unit_cube(MPI.COMM_WORLD, 2, 2, 2, cell_type, dtype=dtype)
 
-    space = FunctionSpace(mesh, e)
+    space = functionspace(mesh, e)
     u = ufl.TrialFunction(space)
     v = ufl.TestFunction(space)
     f = form(form_f(u, v), dtype=dtype)
@@ -116,7 +116,7 @@ def test_mixed_element_form(cell_type, sign, order, dtype):
     U_el = mixed_element([element(basix.ElementFamily.P, cell_type.name, order),
                           element(basix.ElementFamily.N1E, cell_type.name, order)])
 
-    U = FunctionSpace(mesh, U_el)
+    U = functionspace(mesh, U_el)
     u, p = ufl.TrialFunctions(U)
     v, q = ufl.TestFunctions(U)
     f = form(inner(u, v) * ufl.dx + inner(p, q)(sign) * ufl.dS, dtype=dtype)
@@ -141,7 +141,7 @@ def test_mixed_element_vector_element_form(cell_type, sign, order, dtype):
     U_el = mixed_element([element(basix.ElementFamily.P, cell_type.name, order, shape=(mesh.geometry.dim,)),
                           element(basix.ElementFamily.N1E, cell_type.name, order)])
 
-    U = FunctionSpace(mesh, U_el)
+    U = functionspace(mesh, U_el)
     u, p = ufl.TrialFunctions(U)
     v, q = ufl.TestFunctions(U)
     f = form(inner(u, v) * ufl.dx + inner(p, q)(sign) * ufl.dS, dtype=dtype)

--- a/python/test/unit/fem/test_vector_assemble.py
+++ b/python/test/unit/fem/test_vector_assemble.py
@@ -7,7 +7,7 @@
 
 
 import ufl
-from dolfinx.fem import FunctionSpace, assemble_matrix, form
+from dolfinx.fem import assemble_matrix, form, functionspace
 from dolfinx.mesh import create_unit_square
 
 from mpi4py import MPI
@@ -16,7 +16,7 @@ from mpi4py import MPI
 def test_vector_assemble_matrix_exterior():
     mesh = create_unit_square(MPI.COMM_WORLD, 3, 3)
     gdim = mesh.geometry.dim
-    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+    V = functionspace(mesh, ("Lagrange", 1, (gdim,)))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = form(ufl.inner(u, v) * ufl.ds)
     A = assemble_matrix(a)
@@ -26,7 +26,7 @@ def test_vector_assemble_matrix_exterior():
 def test_vector_assemble_matrix_interior():
     mesh = create_unit_square(MPI.COMM_WORLD, 3, 3)
     gdim = mesh.geometry.dim
-    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+    V = functionspace(mesh, ("Lagrange", 1, (gdim,)))
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     a = form(ufl.inner(ufl.jump(u), ufl.jump(v)) * ufl.dS)
     A = assemble_matrix(a)

--- a/python/test/unit/fem/test_vector_function.py
+++ b/python/test/unit/fem/test_vector_function.py
@@ -11,7 +11,7 @@ import pytest
 import ufl
 from basix.ufl import element
 from dolfinx import default_real_type
-from dolfinx.fem import Function, FunctionSpace
+from dolfinx.fem import Function, functionspace
 from dolfinx.mesh import create_mesh
 
 from mpi4py import MPI
@@ -26,7 +26,7 @@ def test_div_conforming_triangle(space_type, order):
     def perform_test(points, cells):
         domain = ufl.Mesh(element("Lagrange", "triangle", 1, shape=(2,)))
         mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
-        V = FunctionSpace(mesh, (space_type, order))
+        V = functionspace(mesh, (space_type, order))
         f = Function(V)
         x = f.x.array
         output = []
@@ -56,7 +56,7 @@ def test_div_conforming_tetrahedron(space_type, order):
     def perform_test(points, cells):
         domain = ufl.Mesh(element("Lagrange", "tetrahedron", 1, shape=(3,)))
         mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
-        V = FunctionSpace(mesh, (space_type, order))
+        V = functionspace(mesh, (space_type, order))
         f = Function(V)
         output = []
         x = f.x.array

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -13,7 +13,7 @@ import ufl
 from basix.ufl import element
 from dolfinx import default_real_type, default_scalar_type
 from dolfinx.common import has_adios2
-from dolfinx.fem import Function, FunctionSpace
+from dolfinx.fem import Function, functionspace
 from dolfinx.graph import adjacencylist
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
                           create_unit_square)
@@ -66,8 +66,8 @@ def test_two_fides_functions(tempdir, dim, simplex):
     """Test saving two functions with Fides"""
     mesh = generate_mesh(dim, simplex)
     gdim = mesh.geometry.dim
-    v = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim,))))
-    q = Function(FunctionSpace(mesh, ("Lagrange", 1)))
+    v = Function(functionspace(mesh, ("Lagrange", 1, (gdim,))))
+    q = Function(functionspace(mesh, ("Lagrange", 1)))
     filename = Path(tempdir, "v.bp")
     with FidesWriter(mesh.comm, filename, [v._cpp_object, q]) as f:
         f.write(0)
@@ -88,7 +88,7 @@ def test_two_fides_functions(tempdir, dim, simplex):
 def test_findes_single_function(tempdir, dim, simplex):
     "Test saving a single first order Lagrange functions"
     mesh = generate_mesh(dim, simplex)
-    v = Function(FunctionSpace(mesh, ("Lagrange", 1)))
+    v = Function(functionspace(mesh, ("Lagrange", 1)))
     filename = Path(tempdir, "v.bp")
     writer = FidesWriter(mesh.comm, filename, v)
     writer.write(0)
@@ -102,9 +102,9 @@ def test_fides_function_at_nodes(tempdir, dim, simplex):
     """Test saving P1 functions with Fides (with changing geometry)"""
     mesh = generate_mesh(dim, simplex)
     gdim = mesh.geometry.dim
-    v = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim,))), dtype=default_scalar_type)
+    v = Function(functionspace(mesh, ("Lagrange", 1, (gdim,))), dtype=default_scalar_type)
     v.name = "v"
-    q = Function(FunctionSpace(mesh, ("Lagrange", 1)))
+    q = Function(functionspace(mesh, ("Lagrange", 1)))
     q.name = "q"
     filename = Path(tempdir, "v.bp")
     if np.issubdtype(default_scalar_type, np.complexfloating):
@@ -157,8 +157,8 @@ def test_vtx_functions_fail(tempdir, dim, simplex):
     "Test for error when elements differ"
     mesh = generate_mesh(dim, simplex)
     gdim = mesh.geometry.dim
-    v = Function(FunctionSpace(mesh, ("Lagrange", 2, (gdim,))))
-    w = Function(FunctionSpace(mesh, ("Lagrange", 1)))
+    v = Function(functionspace(mesh, ("Lagrange", 2, (gdim,))))
+    w = Function(functionspace(mesh, ("Lagrange", 1)))
     filename = Path(tempdir, "v.bp")
     with pytest.raises(RuntimeError):
         VTXWriter(mesh.comm, filename, [v, w])
@@ -169,9 +169,9 @@ def test_vtx_functions_fail(tempdir, dim, simplex):
 def test_vtx_different_meshes_function(tempdir, simplex):
     "Test for error when functions do not share a mesh"
     mesh = generate_mesh(2, simplex)
-    v = Function(FunctionSpace(mesh, ("Lagrange", 1)))
+    v = Function(functionspace(mesh, ("Lagrange", 1)))
     mesh2 = generate_mesh(2, simplex)
-    w = Function(FunctionSpace(mesh2, ("Lagrange", 1)))
+    w = Function(functionspace(mesh2, ("Lagrange", 1)))
     filename = Path(tempdir, "v.bp")
     with pytest.raises(RuntimeError):
         VTXWriter(mesh.comm, filename, [v, w])
@@ -183,7 +183,7 @@ def test_vtx_different_meshes_function(tempdir, simplex):
 def test_vtx_single_function(tempdir, dim, simplex):
     "Test saving a single first order Lagrange functions"
     mesh = generate_mesh(dim, simplex)
-    v = Function(FunctionSpace(mesh, ("Lagrange", 1)))
+    v = Function(functionspace(mesh, ("Lagrange", 1)))
 
     filename = Path(tempdir, "v.bp")
     writer = VTXWriter(mesh.comm, filename, v)
@@ -210,7 +210,7 @@ def test_vtx_functions(tempdir, dtype, dim, simplex):
     xtype = np.real(dtype(0)).dtype
     mesh = generate_mesh(dim, simplex, dtype=xtype)
     gdim = mesh.geometry.dim
-    V = FunctionSpace(mesh, ("DG", 2, (gdim,)))
+    V = functionspace(mesh, ("DG", 2, (gdim,)))
     v = Function(V, dtype=dtype)
     bs = V.dofmap.index_map_bs
 
@@ -221,7 +221,7 @@ def test_vtx_functions(tempdir, dtype, dim, simplex):
         return values
     v.interpolate(vel)
 
-    W = FunctionSpace(mesh, ("DG", 2))
+    W = functionspace(mesh, ("DG", 2))
     w = Function(W, dtype=v.dtype)
     w.interpolate(lambda x: x[0] + x[1])
 
@@ -250,7 +250,7 @@ def test_save_vtkx_cell_point(tempdir):
     mesh = create_unit_square(MPI.COMM_WORLD, 8, 5)
     P = element("Discontinuous Lagrange", mesh.basix_cell(), 0)
 
-    V = FunctionSpace(mesh, P)
+    V = functionspace(mesh, P)
     u = Function(V)
     u.interpolate(lambda x: 0.5 * x[0])
     u.name = "A"
@@ -283,7 +283,7 @@ def test_empty_rank_mesh(tempdir):
 
     mesh = create_mesh(comm, cells, x, domain, partitioner)
 
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     u = Function(V)
 
     filename = Path(tempdir, "empty_rank_mesh.bp")

--- a/python/test/unit/io/test_vtk.py
+++ b/python/test/unit/io/test_vtk.py
@@ -13,7 +13,7 @@ from numpy.testing import assert_array_equal
 import ufl
 from basix.ufl import element, mixed_element
 from dolfinx import default_real_type
-from dolfinx.fem import Function, FunctionSpace
+from dolfinx.fem import Function, functionspace
 from dolfinx.io import VTKFile
 from dolfinx.io.utils import cell_perm_vtk  # noqa F401
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
@@ -54,7 +54,7 @@ def test_save_3d_mesh(tempdir, cell_type):
 
 def test_save_1d_scalar(tempdir):
     mesh = create_unit_interval(MPI.COMM_WORLD, 32)
-    u = Function(FunctionSpace(mesh, ("Lagrange", 2)))
+    u = Function(functionspace(mesh, ("Lagrange", 2)))
     u.interpolate(lambda x: x[0])
     filename = Path(tempdir, "u.pvd")
     with VTKFile(MPI.COMM_WORLD, filename, "w") as vtk:
@@ -64,7 +64,7 @@ def test_save_1d_scalar(tempdir):
 @pytest.mark.parametrize("cell_type", cell_types_2D)
 def test_save_2d_scalar(tempdir, cell_type):
     mesh = create_unit_square(MPI.COMM_WORLD, 16, 16, cell_type=cell_type)
-    u = Function(FunctionSpace(mesh, ("Lagrange", 2)))
+    u = Function(functionspace(mesh, ("Lagrange", 2)))
     u.x.array[:] = 1.0
 
     filename = Path(tempdir, "u.pvd")
@@ -76,7 +76,7 @@ def test_save_2d_scalar(tempdir, cell_type):
 @pytest.mark.parametrize("cell_type", cell_types_3D)
 def test_save_3d_scalar(tempdir, cell_type):
     mesh = create_unit_cube(MPI.COMM_WORLD, 8, 8, 8, cell_type=cell_type)
-    u = Function(FunctionSpace(mesh, ("Lagrange", 2)))
+    u = Function(functionspace(mesh, ("Lagrange", 2)))
     u.x.array[:] = 1.0
 
     filename = Path(tempdir, "u.pvd")
@@ -95,7 +95,7 @@ def test_save_1d_vector(tempdir):
         return vals
 
     e = element("Lagrange", mesh.basix_cell(), 2, shape=(2, ))
-    u = Function(FunctionSpace(mesh, e))
+    u = Function(functionspace(mesh, e))
     u.interpolate(f)
     filename = Path(tempdir, "u.pvd")
     with VTKFile(MPI.COMM_WORLD, filename, "w") as vtk:
@@ -106,7 +106,7 @@ def test_save_1d_vector(tempdir):
 def test_save_2d_vector(tempdir, cell_type):
     mesh = create_unit_square(MPI.COMM_WORLD, 16, 16, cell_type=cell_type)
     gdim = mesh.geometry.dim
-    u = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim,))))
+    u = Function(functionspace(mesh, ("Lagrange", 1, (gdim,))))
 
     def f(x):
         vals = np.zeros((2, x.shape[1]))
@@ -133,7 +133,7 @@ def test_save_2d_vector_CG2(tempdir):
     domain = ufl.Mesh(element("Lagrange", "triangle", 2, shape=(2,)))
     mesh = create_mesh(MPI.COMM_WORLD, cells, points, domain)
     gdim = mesh.geometry.dim
-    u = Function(FunctionSpace(mesh, ("Lagrange", 2, (gdim,))))
+    u = Function(functionspace(mesh, ("Lagrange", 2, (gdim,))))
     u.interpolate(lambda x: np.vstack((x[0], x[1])))
     filename = Path(tempdir, "u.pvd")
     with VTKFile(mesh.comm, filename, "w") as vtk:
@@ -144,9 +144,9 @@ def test_save_vtk_mixed(tempdir):
     mesh = create_unit_cube(MPI.COMM_WORLD, 3, 3, 3)
     P2 = element("Lagrange", mesh.basix_cell(), 1, shape=(mesh.geometry.dim,))
     P1 = element("Lagrange", mesh.basix_cell(), 1)
-    W = FunctionSpace(mesh, mixed_element([P2, P1]))
-    V1 = FunctionSpace(mesh, P1)
-    V2 = FunctionSpace(mesh, P2)
+    W = functionspace(mesh, mixed_element([P2, P1]))
+    V1 = functionspace(mesh, P1)
+    V2 = functionspace(mesh, P2)
 
     U = Function(W)
     U.sub(0).interpolate(lambda x: np.vstack((x[0], 0.2 * x[1], np.zeros_like(x[0]))))
@@ -177,7 +177,7 @@ def test_save_vtk_mixed(tempdir):
 @pytest.mark.parametrize("cell_type", cell_types_2D)
 def test_save_vector_element(tempdir, cell_type):
     mesh = create_unit_square(MPI.COMM_WORLD, 16, 16, cell_type=cell_type)
-    u = Function(FunctionSpace(mesh, ("RT", 1)))
+    u = Function(functionspace(mesh, ("RT", 1)))
 
     def f(x):
         vals = np.zeros((2, x.shape[1]))
@@ -199,7 +199,7 @@ def test_save_vtk_cell_point(tempdir):
     P2 = element("Lagrange", mesh.basix_cell(), 1, shape=(3, ))
     P1 = element("Discontinuous Lagrange", mesh.basix_cell(), 0)
 
-    V2, V1 = FunctionSpace(mesh, P2), FunctionSpace(mesh, P1)
+    V2, V1 = functionspace(mesh, P2), functionspace(mesh, P1)
     U2, U1 = Function(V2), Function(V1)
     U2.interpolate(lambda x: np.vstack((x[0], 0.2 * x[1], np.zeros_like(x[0]))))
     U1.interpolate(lambda x: 0.5 * x[0])
@@ -216,7 +216,7 @@ def test_save_vtk_cell_point(tempdir):
 def test_save_1d_tensor(tempdir):
     mesh = create_unit_interval(MPI.COMM_WORLD, 32)
     e = element("Lagrange", mesh.basix_cell(), 2, shape=(2, 2))
-    u = Function(FunctionSpace(mesh, e))
+    u = Function(functionspace(mesh, e))
     u.x.array[:] = 1.0
     filename = Path(tempdir, "u.pvd")
     with VTKFile(mesh.comm, filename, "w") as vtk:
@@ -226,7 +226,7 @@ def test_save_1d_tensor(tempdir):
 def test_save_2d_tensor(tempdir):
     mesh = create_unit_square(MPI.COMM_WORLD, 16, 16)
     gdim = mesh.geometry.dim
-    u = Function(FunctionSpace(mesh, ("Lagrange", 2, (gdim, gdim))))
+    u = Function(functionspace(mesh, ("Lagrange", 2, (gdim, gdim))))
     u.x.array[:] = 1.0
     filename = Path(tempdir, "u.pvd")
     with VTKFile(mesh.comm, filename, "w") as vtk:
@@ -238,7 +238,7 @@ def test_save_2d_tensor(tempdir):
 def test_save_3d_tensor(tempdir):
     mesh = create_unit_cube(MPI.COMM_WORLD, 8, 8, 8)
     gdim = mesh.geometry.dim
-    u = Function(FunctionSpace(mesh, ("Lagrange", 2, (gdim, gdim))))
+    u = Function(functionspace(mesh, ("Lagrange", 2, (gdim, gdim))))
     u.x.array[:] = 1.0
     filename = Path(tempdir, "u.pvd")
     with VTKFile(mesh.comm, filename, "w") as vtk:
@@ -268,5 +268,5 @@ def test_triangle_perm_vtk():
 def test_vtk_mesh():
     comm = MPI.COMM_WORLD
     mesh = create_unit_square(comm, 2 * comm.size, 2 * comm.size)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     vtk_mesh(V)

--- a/python/test/unit/io/test_xdmf_function.py
+++ b/python/test/unit/io/test_xdmf_function.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 import basix
-from dolfinx.fem import Function, FunctionSpace
+from dolfinx.fem import Function, functionspace
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import (CellType, create_unit_cube, create_unit_interval,
                           create_unit_square)
@@ -46,7 +46,7 @@ def test_save_1d_scalar(tempdir, encoding, dtype, use_pathlib):
     xtype = np.real(dtype(0)).dtype
     filename2 = (Path(tempdir).joinpath("u1_.xdmf")if use_pathlib else Path(tempdir, "u1_.xdmf"))
     mesh = create_unit_interval(MPI.COMM_WORLD, 32, dtype=xtype)
-    V = FunctionSpace(mesh, ("Lagrange", 2))
+    V = functionspace(mesh, ("Lagrange", 2))
     u = Function(V, dtype=dtype)
     u.x.array[:] = 1.0 + (1j if np.issubdtype(dtype, np.complexfloating) else 0)
 
@@ -55,7 +55,7 @@ def test_save_1d_scalar(tempdir, encoding, dtype, use_pathlib):
             file.write_mesh(mesh)
             file.write_function(u)
 
-    V1 = FunctionSpace(mesh, ("Lagrange", 1))
+    V1 = functionspace(mesh, ("Lagrange", 1))
     u1 = Function(V1, dtype=dtype)
     u1.interpolate(u)
     with XDMFFile(mesh.comm, filename2, "w", encoding=encoding) as file:
@@ -70,11 +70,11 @@ def test_save_2d_scalar(tempdir, encoding, dtype, cell_type):
     xtype = np.real(dtype(0)).dtype
     filename = Path(tempdir, "u2.xdmf")
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 12, cell_type, dtype=xtype)
-    V = FunctionSpace(mesh, ("Lagrange", 2))
+    V = functionspace(mesh, ("Lagrange", 2))
     u = Function(V, dtype=dtype)
     u.x.array[:] = 1.0
 
-    V1 = FunctionSpace(mesh, ("Lagrange", 1))
+    V1 = functionspace(mesh, ("Lagrange", 1))
     u1 = Function(V1, dtype=dtype)
     u1.interpolate(u)
     with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
@@ -82,14 +82,14 @@ def test_save_2d_scalar(tempdir, encoding, dtype, cell_type):
         file.write_function(u1)
 
     # Discontinuous (degree == 0)
-    V = FunctionSpace(mesh, ("Discontinuous Lagrange", 0))
+    V = functionspace(mesh, ("Discontinuous Lagrange", 0))
     u = Function(V, dtype=dtype)
     with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
         file.write_function(u)
 
     # Discontinuous (degree > 0) should raise exception
-    V = FunctionSpace(mesh, ("Discontinuous Lagrange", 1))
+    V = functionspace(mesh, ("Discontinuous Lagrange", 1))
     u = Function(V, dtype=dtype)
     with pytest.raises(RuntimeError):
         with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
@@ -104,11 +104,11 @@ def test_save_3d_scalar(tempdir, encoding, dtype, cell_type):
     xtype = np.real(dtype(0)).dtype
     filename = Path(tempdir, "u3.xdmf")
     mesh = create_unit_cube(MPI.COMM_WORLD, 4, 3, 4, cell_type, dtype=xtype)
-    V = FunctionSpace(mesh, ("Lagrange", 2))
+    V = functionspace(mesh, ("Lagrange", 2))
     u = Function(V, dtype=dtype)
     u.x.array[:] = 1.0
 
-    V1 = FunctionSpace(mesh, ("Lagrange", 1))
+    V1 = functionspace(mesh, ("Lagrange", 1))
     u1 = Function(V1, dtype=dtype)
     u1.interpolate(u)
     with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
@@ -125,11 +125,11 @@ def test_save_2d_vector(tempdir, encoding, dtype, cell_type):
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 13, cell_type, dtype=xtype)
     gdim = mesh.geometry.dim
 
-    V = FunctionSpace(mesh, ("Lagrange", 2, (gdim,)))
+    V = functionspace(mesh, ("Lagrange", 2, (gdim,)))
     u = Function(V, dtype=dtype)
     u.x.array[:] = 1.0 + (1j if np.issubdtype(dtype, np.complexfloating) else 0)
 
-    V1 = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+    V1 = functionspace(mesh, ("Lagrange", 1, (gdim,)))
     u1 = Function(V1, dtype=dtype)
     u1.interpolate(u)
     with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
@@ -146,17 +146,17 @@ def test_save_3d_vector(tempdir, encoding, dtype, cell_type):
     mesh = create_unit_cube(MPI.COMM_WORLD, 2, 2, 2, cell_type, dtype=xtype)
     gdim = mesh.geometry.dim
 
-    u = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim,))), dtype=dtype)
+    u = Function(functionspace(mesh, ("Lagrange", 1, (gdim,))), dtype=dtype)
     u.x.array[:] = 1.0 + (1j if np.issubdtype(dtype, np.complexfloating) else 0)
 
-    V1 = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+    V1 = functionspace(mesh, ("Lagrange", 1, (gdim,)))
     u1 = Function(V1, dtype=dtype)
     u1.interpolate(u)
     with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
         file.write_function(u1)
 
-    V2 = FunctionSpace(mesh, ("RT", 1))
+    V2 = functionspace(mesh, ("RT", 1))
     u2 = Function(V2, dtype=dtype)
     u2.interpolate(u)
     with pytest.raises(RuntimeError):
@@ -174,9 +174,9 @@ def test_save_2d_tensor(tempdir, encoding, dtype, cell_type):
     mesh = create_unit_square(MPI.COMM_WORLD, 16, 16, cell_type, dtype=xtype)
     gdim = mesh.geometry.dim
 
-    u = Function(FunctionSpace(mesh, ("Lagrange", 2, (gdim, gdim))), dtype=dtype)
+    u = Function(functionspace(mesh, ("Lagrange", 2, (gdim, gdim))), dtype=dtype)
     u.x.array[:] = 1.0 + (1j if np.issubdtype(dtype, np.complexfloating) else 0)
-    u1 = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim, gdim))), dtype=dtype)
+    u1 = Function(functionspace(mesh, ("Lagrange", 1, (gdim, gdim))), dtype=dtype)
     u1.interpolate(u)
     with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
@@ -192,10 +192,10 @@ def test_save_3d_tensor(tempdir, encoding, dtype, cell_type):
     mesh = create_unit_cube(MPI.COMM_WORLD, 4, 4, 4, cell_type, dtype=xtype)
 
     gdim = mesh.geometry.dim
-    u = Function(FunctionSpace(mesh, ("Lagrange", 2, (gdim, gdim))), dtype=dtype)
+    u = Function(functionspace(mesh, ("Lagrange", 2, (gdim, gdim))), dtype=dtype)
     u.x.array[:] = 1.0 + (1j if np.issubdtype(dtype, np.complexfloating) else 0)
 
-    u1 = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim, gdim))), dtype=dtype)
+    u1 = Function(functionspace(mesh, ("Lagrange", 1, (gdim, gdim))), dtype=dtype)
     u1.interpolate(u)
     with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
@@ -210,7 +210,7 @@ def test_save_3d_vector_series(tempdir, encoding, dtype, cell_type):
     xtype = np.real(dtype(0)).dtype
     mesh = create_unit_cube(MPI.COMM_WORLD, 2, 2, 2, cell_type, dtype=xtype)
     gdim = mesh.geometry.dim
-    u = Function(FunctionSpace(mesh, ("Lagrange", 1, (gdim,))), dtype=dtype)
+    u = Function(functionspace(mesh, ("Lagrange", 1, (gdim,))), dtype=dtype)
     with XDMFFile(mesh.comm, filename, "w", encoding=encoding) as file:
         file.write_mesh(mesh)
         u.x.array[:] = 1.0 + (1j if np.issubdtype(dtype, np.complexfloating) else 0)
@@ -290,14 +290,14 @@ def test_higher_order_function(tempdir):
     assert msh.geometry.cmaps[0].degree == 1
 
     # Write P1 Function
-    u = Function(FunctionSpace(msh, ("Lagrange", 1, (gdim,))))
+    u = Function(functionspace(msh, ("Lagrange", 1, (gdim,))))
     filename = Path(tempdir, "u3D_P1.xdmf")
     with XDMFFile(msh.comm, filename, "w") as file:
         file.write_mesh(msh)
         file.write_function(u)
 
     # Write P2 Function (exception expected)
-    u = Function(FunctionSpace(msh, ("Lagrange", 2, (gdim,))))
+    u = Function(functionspace(msh, ("Lagrange", 2, (gdim,))))
     filename = Path(tempdir, "u3D_P2.xdmf")
     with pytest.raises(RuntimeError):
         with XDMFFile(msh.comm, filename, "w") as file:
@@ -310,7 +310,7 @@ def test_higher_order_function(tempdir):
     assert msh.geometry.cmaps[0].degree == 2
 
     # Write P1 Function (exception expected)
-    u = Function(FunctionSpace(msh, ("Lagrange", 1, (gdim,))))
+    u = Function(functionspace(msh, ("Lagrange", 1, (gdim,))))
     with pytest.raises(RuntimeError):
         filename = Path(tempdir, "u3D_P1.xdmf")
         with XDMFFile(msh.comm, filename, "w") as file:
@@ -318,7 +318,7 @@ def test_higher_order_function(tempdir):
             file.write_function(u)
 
     # Write P2 Function
-    u = Function(FunctionSpace(msh, ("Lagrange", 2, (gdim,))))
+    u = Function(functionspace(msh, ("Lagrange", 2, (gdim,))))
     filename = Path(tempdir, "u3D_P2.xdmf")
     with XDMFFile(msh.comm, filename, "w") as file:
         file.write_mesh(msh)
@@ -331,7 +331,7 @@ def test_higher_order_function(tempdir):
     assert msh.geometry.cmaps[0].degree == 3
 
     # Write P2 Function (exception expected)
-    u = Function(FunctionSpace(msh, ("Lagrange", 2, (gdim,))))
+    u = Function(functionspace(msh, ("Lagrange", 2, (gdim,))))
     with pytest.raises(RuntimeError):
         filename = Path(tempdir, "u3D_P3.xdmf")
         with XDMFFile(msh.comm, filename, "w") as file:
@@ -340,7 +340,7 @@ def test_higher_order_function(tempdir):
 
     # Write P3 GLL Function (exception expected)
     ufl_e = basix.ufl.element(basix.ElementFamily.P, basix.CellType.tetrahedron, 3, basix.LagrangeVariant.gll_warped)
-    u = Function(FunctionSpace(msh, ufl_e))
+    u = Function(functionspace(msh, ufl_e))
     with pytest.raises(RuntimeError):
         filename = Path(tempdir, "u3D_P3.xdmf")
         with XDMFFile(msh.comm, filename, "w") as file:
@@ -349,7 +349,7 @@ def test_higher_order_function(tempdir):
 
     # Write P3 equispaced Function
     ufl_e = basix.ufl.element(basix.ElementFamily.P, basix.CellType.tetrahedron, 3, basix.LagrangeVariant.equispaced)
-    u1 = Function(FunctionSpace(msh, ufl_e))
+    u1 = Function(functionspace(msh, ufl_e))
     u1.interpolate(u)
     filename = Path(tempdir, "u3D_P3.xdmf")
     with XDMFFile(msh.comm, filename, "w") as file:
@@ -362,7 +362,7 @@ def test_higher_order_function(tempdir):
     assert msh.geometry.cmaps[0].degree == 2
 
     # Write Q1 Function (exception expected)
-    u = Function(FunctionSpace(msh, ("Lagrange", 1, (gdim,))))
+    u = Function(functionspace(msh, ("Lagrange", 1, (gdim,))))
     with pytest.raises(RuntimeError):
         filename = Path(tempdir, "u3D_Q1.xdmf")
         with XDMFFile(msh.comm, filename, "w") as file:
@@ -370,7 +370,7 @@ def test_higher_order_function(tempdir):
             file.write_function(u)
 
     # Write Q2 Function
-    u = Function(FunctionSpace(msh, ("Lagrange", 2, (gdim,))))
+    u = Function(functionspace(msh, ("Lagrange", 2, (gdim,))))
     filename = Path(tempdir, "u3D_Q2.xdmf")
     with XDMFFile(msh.comm, filename, "w") as file:
         file.write_mesh(msh)
@@ -382,13 +382,13 @@ def test_higher_order_function(tempdir):
     # msh = gmsh_hex_model(3)
     # assert msh.geometry.cmaps[0].degree == 3
     # gdim = msh.geometry.dim
-    # u = Function(FunctionSpace(msh, ("Lagrange", 1, (gdim,))))
+    # u = Function(functionspace(msh, ("Lagrange", 1, (gdim,))))
     # with pytest.raises(RuntimeError):
     #     filename = Path(tempdir, "u3D_Q1.xdmf")
     #     with XDMFFile(msh.comm, filename, "w") as file:
     #         file.write_mesh(msh)
     #         file.write_function(u)
-    # u = Function(FunctionSpace(msh, ("Lagrange", 2, (gdim,))))
+    # u = Function(functionspace(msh, ("Lagrange", 2, (gdim,))))
     # filename = Path(tempdir, "u3D_Q2.xdmf")
     # with XDMFFile(msh.comm, filename, "w") as file:
     #     file.write_mesh(msh)

--- a/python/test/unit/la/test_krylov_solver.py
+++ b/python/test/unit/la/test_krylov_solver.py
@@ -12,7 +12,7 @@ import pytest
 
 import ufl
 from dolfinx import la
-from dolfinx.fem import (Function, FunctionSpace, dirichletbc, form,
+from dolfinx.fem import (Function, dirichletbc, form, functionspace,
                          locate_dofs_topological)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                set_bc)
@@ -27,7 +27,7 @@ from petsc4py import PETSc
 def test_krylov_solver_lu():
 
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 12)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     u, v = TrialFunction(V), TestFunction(V)
 
     a = form(inner(u, v) * dx)
@@ -98,7 +98,7 @@ def test_krylov_samg_solver_elasticity():
         # Define problem
         mesh = create_unit_square(MPI.COMM_WORLD, N, N)
         gdim = mesh.geometry.dim
-        V = FunctionSpace(mesh, ('Lagrange', 1, (gdim,)))
+        V = functionspace(mesh, ('Lagrange', 1, (gdim,)))
         u = TrialFunction(V)
         v = TestFunction(V)
 

--- a/python/test/unit/la/test_matrix_csr.py
+++ b/python/test/unit/la/test_matrix_csr.py
@@ -149,7 +149,7 @@ def test_set_diagonal_distributed(dtype):
     mesh_dtype = np.real(dtype(0)).dtype
     ghost_mode = GhostMode.shared_facet
     mesh = create_unit_square(MPI.COMM_WORLD, 5, 5, ghost_mode=ghost_mode, dtype=mesh_dtype)
-    V = fem.FunctionSpace(mesh, ("Lagrange", 1))
+    V = fem.functionspace(mesh, ("Lagrange", 1))
 
     tdim = mesh.topology.dim
     cellmap = mesh.topology.index_map(tdim)

--- a/python/test/unit/la/test_matrix_vector.py
+++ b/python/test/unit/la/test_matrix_vector.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from dolfinx import cpp as _cpp
 from dolfinx import la
-from dolfinx.fem import FunctionSpace
+from dolfinx.fem import functionspace
 from dolfinx.mesh import create_unit_square
 
 from mpi4py import MPI
@@ -19,7 +19,7 @@ from mpi4py import MPI
 def test_create_matrix_csr():
     """Test creation of CSR matrix with specified types"""
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 11)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     map = V.dofmap.index_map
     bs = V.dofmap.index_map_bs
 
@@ -50,7 +50,7 @@ def test_create_matrix_csr():
 def test_create_vector():
     """Test creation of a distributed vector"""
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 11)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     map = V.dofmap.index_map
     bs = V.dofmap.index_map_bs
 

--- a/python/test/unit/la/test_nullspace.py
+++ b/python/test/unit/la/test_nullspace.py
@@ -12,7 +12,7 @@ import pytest
 
 import ufl
 from dolfinx import la
-from dolfinx.fem import FunctionSpace, form
+from dolfinx.fem import form, functionspace
 from dolfinx.fem.petsc import assemble_matrix
 from dolfinx.la import create_petsc_vector
 from dolfinx.mesh import (CellType, GhostMode, create_box, create_unit_cube,
@@ -99,7 +99,7 @@ def build_broken_elastic_nullspace(V):
 def test_nullspace_orthogonal(mesh, degree):
     """Test that null spaces orthogonalisation"""
     gdim = mesh.geometry.dim
-    V = FunctionSpace(mesh, ('Lagrange', degree, (gdim,)))
+    V = functionspace(mesh, ('Lagrange', degree, (gdim,)))
     nullspace = build_elastic_nullspace(V)
     assert not la.is_orthonormal(nullspace, eps=1.0e-4)
     la.orthonormalize(nullspace)
@@ -117,7 +117,7 @@ def test_nullspace_orthogonal(mesh, degree):
 @pytest.mark.parametrize("degree", [1, 2])
 def test_nullspace_check(mesh, degree):
     gdim = mesh.geometry.dim
-    V = FunctionSpace(mesh, ('Lagrange', degree, (gdim,)))
+    V = functionspace(mesh, ('Lagrange', degree, (gdim,)))
     u, v = TrialFunction(V), TestFunction(V)
 
     E, nu = 2.0e2, 0.3

--- a/python/test/unit/la/test_sparsity_pattern.py
+++ b/python/test/unit/la/test_sparsity_pattern.py
@@ -6,7 +6,7 @@
 """Unit tests for sparsity pattern creation"""
 
 from dolfinx.cpp.la import SparsityPattern
-from dolfinx.fem import FunctionSpace, locate_dofs_topological
+from dolfinx.fem import functionspace, locate_dofs_topological
 from dolfinx.mesh import create_unit_square, exterior_facet_indices
 
 from mpi4py import MPI
@@ -16,7 +16,7 @@ def test_add_diagonal():
     """Test adding entries to diagonal of sparsity pattern"""
     mesh = create_unit_square(MPI.COMM_WORLD, 10, 10)
     gdim = mesh.geometry.dim
-    V = FunctionSpace(mesh, ("Lagrange", 1, (gdim,)))
+    V = functionspace(mesh, ("Lagrange", 1, (gdim,)))
     pattern = SparsityPattern(mesh.comm, [V.dofmap.index_map, V.dofmap.index_map],
                               [V.dofmap.index_map_bs, V.dofmap.index_map_bs])
     mesh.topology.create_connectivity(mesh.topology.dim - 1, mesh.topology.dim)

--- a/python/test/unit/la/test_vector_scatter.py
+++ b/python/test/unit/la/test_vector_scatter.py
@@ -11,7 +11,7 @@ import pytest
 
 from basix.ufl import element
 from dolfinx import la
-from dolfinx.fem import Function, FunctionSpace
+from dolfinx.fem import Function, functionspace
 from dolfinx.mesh import create_unit_square
 
 from mpi4py import MPI
@@ -23,7 +23,7 @@ from mpi4py import MPI
 def test_scatter_forward(e):
 
     mesh = create_unit_square(MPI.COMM_WORLD, 5, 5)
-    V = FunctionSpace(mesh, e)
+    V = functionspace(mesh, e)
     u = Function(V)
     bs = V.dofmap.bs
 
@@ -54,7 +54,7 @@ def test_scatter_reverse(e):
 
     comm = MPI.COMM_WORLD
     mesh = create_unit_square(MPI.COMM_WORLD, 5, 5)
-    V = FunctionSpace(mesh, e)
+    V = functionspace(mesh, e)
     u = Function(V)
     bs = V.dofmap.bs
 

--- a/python/test/unit/mesh/test_refinement.py
+++ b/python/test/unit/mesh/test_refinement.py
@@ -9,7 +9,7 @@ import pytest
 from numpy import isclose, logical_and
 
 import ufl
-from dolfinx.fem import FunctionSpace, assemble_matrix, form
+from dolfinx.fem import assemble_matrix, form, functionspace
 from dolfinx.mesh import (CellType, DiagonalType, GhostMode, RefinementOption,
                           compute_incident_entities, create_unit_cube,
                           create_unit_square, locate_entities,
@@ -42,7 +42,7 @@ def test_Refinecreate_unit_cube_repartition():
     assert mesh.topology.index_map(0).size_global == 3135
     assert mesh.topology.index_map(3).size_global == 15120
 
-    Q = FunctionSpace(mesh, ("Lagrange", 1))
+    Q = functionspace(mesh, ("Lagrange", 1))
     assert Q
 
 
@@ -53,7 +53,7 @@ def test_Refinecreate_unit_cube_keep_partition():
     mesh = refine(mesh, redistribute=False)
     assert mesh.topology.index_map(0).size_global == 3135
     assert mesh.topology.index_map(3).size_global == 15120
-    Q = FunctionSpace(mesh, ("Lagrange", 1))
+    Q = functionspace(mesh, ("Lagrange", 1))
     assert Q
 
 
@@ -63,7 +63,7 @@ def test_refine_create_form():
     mesh.topology.create_entities(1)
     mesh = refine(mesh, redistribute=True)
 
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
 
     # Define variational problem
     u = ufl.TrialFunction(V)

--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -10,7 +10,7 @@ import numpy as np
 import ufl
 from dolfinx import cpp as _cpp
 from dolfinx import default_real_type
-from dolfinx.fem import (Function, functionspace, dirichletbc, form,
+from dolfinx.fem import (Function, dirichletbc, form, functionspace,
                          locate_dofs_geometrical)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                create_matrix, create_vector, set_bc)

--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -10,7 +10,7 @@ import numpy as np
 import ufl
 from dolfinx import cpp as _cpp
 from dolfinx import default_real_type
-from dolfinx.fem import (Function, FunctionSpace, dirichletbc, form,
+from dolfinx.fem import (Function, functionspace, dirichletbc, form,
                          locate_dofs_geometrical)
 from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
                                create_matrix, create_vector, set_bc)
@@ -91,7 +91,7 @@ def test_linear_pde():
     """Test Newton solver for a linear PDE"""
     # Create mesh and function space
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 12)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     u = Function(V)
     v = TestFunction(V)
     F = inner(10.0, v) * dx - inner(grad(u), grad(v)) * dx
@@ -124,7 +124,7 @@ def test_linear_pde():
 def test_nonlinear_pde():
     """Test Newton solver for a simple nonlinear PDE"""
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 5)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     u = Function(V)
     v = TestFunction(V)
     F = inner(5.0, v) * dx - ufl.sqrt(u * u) * inner(
@@ -159,7 +159,7 @@ def test_nonlinear_pde():
 def test_nonlinear_pde_snes():
     """Test Newton solver for a simple nonlinear PDE"""
     mesh = create_unit_square(MPI.COMM_WORLD, 12, 15)
-    V = FunctionSpace(mesh, ("Lagrange", 1))
+    V = functionspace(mesh, ("Lagrange", 1))
     u = Function(V)
     v = TestFunction(V)
     F = inner(5.0, v) * dx - ufl.sqrt(u * u) * inner(grad(u), grad(v)) * dx - inner(u, v) * dx


### PR DESCRIPTION
Fixes #2767

Renames `FunctionSpace` to `functionspace` and `FunctionSpaceBase` to `FunctionSpace`.