### PR TITLE
Add conda to macos-13 runner.

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -20,11 +20,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Install conda (macos-13)
+        if: ${{ matrix.os == 'macos-13' }}
+        run: |
+          brew install anaconda
       - name: Update conda
         run: |
           conda update conda
-
-
+      
       - name: Install DOLFINx (py3-9)
         run: conda create -n env3-9 -c conda-forge python=3.9 fenics-dolfinx mpich
       - name: Test (py3-9)


### PR DESCRIPTION
macos-13 runner does not have conda in default image.
