### PR TITLE
Import mpi4py early for MPI initialisation

### DIFF
--- a/python/.isort.cfg
+++ b/python/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 src_paths = demo,dolfinx,test
 known_first_party = basix,dolfinx,ffcx,ufl
-known_third_party = gmsh,numpy,pytest
+known_third_party = gmsh,numba,numpy,pytest,pyvista
 known_mpi = mpi4py,petsc4py
-sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,MPI,LOCALFOLDER
+sections=FUTURE,STDLIB,MPI,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/python/demo/demo_axis/demo_axis.py
+++ b/python/demo/demo_axis/demo_axis.py
@@ -17,6 +17,8 @@
 import sys
 from functools import partial
 
+from mpi4py import MPI
+
 import numpy as np
 from mesh_sphere_axis import generate_mesh_sphere_axis
 from scipy.special import jv, jvp
@@ -25,8 +27,6 @@ import ufl
 from basix.ufl import element, mixed_element
 from dolfinx import default_scalar_type, fem, io, mesh, plot
 from dolfinx.fem.petsc import LinearProblem
-
-from mpi4py import MPI
 
 try:
     from dolfinx.io import VTXWriter

--- a/python/demo/demo_biharmonic.py
+++ b/python/demo/demo_biharmonic.py
@@ -108,6 +108,9 @@
 #
 # We first import the modules and functions that the program uses:
 
+from mpi4py import MPI
+from petsc4py.PETSc import ScalarType  # type: ignore
+
 # +
 import numpy as np
 
@@ -117,9 +120,6 @@ from dolfinx.fem.petsc import LinearProblem
 from dolfinx.mesh import CellType, GhostMode
 from ufl import (CellDiameter, FacetNormal, avg, div, dS, dx, grad, inner,
                  jump, pi, sin)
-
-from mpi4py import MPI
-from petsc4py.PETSc import ScalarType  # type: ignore
 
 # -
 

--- a/python/demo/demo_cahn-hilliard.py
+++ b/python/demo/demo_cahn-hilliard.py
@@ -113,6 +113,9 @@
 # +
 import os
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 
 import ufl
@@ -124,9 +127,6 @@ from dolfinx.io import XDMFFile
 from dolfinx.mesh import CellType, create_unit_square
 from dolfinx.nls.petsc import NewtonSolver
 from ufl import dx, grad, inner
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 try:
     import pyvista as pv

--- a/python/demo/demo_elasticity.py
+++ b/python/demo/demo_elasticity.py
@@ -22,6 +22,9 @@
 #
 # The required modules are first imported:
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 # +
 import numpy as np
 
@@ -36,9 +39,6 @@ from dolfinx.io import XDMFFile
 from dolfinx.mesh import (CellType, GhostMode, create_box,
                           locate_entities_boundary)
 from ufl import dx, grad, inner
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 dtype = PETSc.ScalarType  # type: ignore
 # -

--- a/python/demo/demo_gmsh.py
+++ b/python/demo/demo_gmsh.py
@@ -17,10 +17,10 @@
 #
 # The Gmsh module is required for this demo.
 
+from mpi4py import MPI
+
 # +
 from dolfinx.io import XDMFFile, gmshio
-
-from mpi4py import MPI
 
 try:
     import gmsh  # type: ignore

--- a/python/demo/demo_helmholtz.py
+++ b/python/demo/demo_helmholtz.py
@@ -19,6 +19,9 @@
 # Scattering" p138-139. In real mode, the Method of Manufactured
 # Solutions is used to produce the exact solution and source term.
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 # +
 import numpy as np
 
@@ -28,9 +31,6 @@ from dolfinx.fem.petsc import LinearProblem
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import create_unit_square
 from ufl import dx, grad, inner
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 # Wavenumber
 k0 = 4 * np.pi

--- a/python/demo/demo_interpolation-io.py
+++ b/python/demo/demo_interpolation-io.py
@@ -18,14 +18,14 @@
 # elements in discontinuous Lagrange spaces for artifact-free
 # visualisation.
 
+from mpi4py import MPI
+
 # +
 import numpy as np
 
 from dolfinx import default_scalar_type, plot
 from dolfinx.fem import Function, functionspace
 from dolfinx.mesh import CellType, create_rectangle, locate_entities
-
-from mpi4py import MPI
 
 # -
 

--- a/python/demo/demo_lagrange_variants.py
+++ b/python/demo/demo_lagrange_variants.py
@@ -17,6 +17,8 @@
 #
 # We begin this demo by importing the required modules.
 
+from mpi4py import MPI
+
 # +
 import matplotlib.pylab as plt
 import numpy as np
@@ -27,8 +29,6 @@ import ufl
 from dolfinx import default_scalar_type, fem, mesh
 from dolfinx.fem.petsc import LinearProblem
 from ufl import ds, dx, grad, inner
-
-from mpi4py import MPI
 
 # -
 

--- a/python/demo/demo_mixed-poisson.py
+++ b/python/demo/demo_mixed-poisson.py
@@ -84,6 +84,9 @@
 
 # +
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 
 from basix.ufl import element, mixed_element
@@ -91,9 +94,6 @@ from dolfinx import fem, io, mesh
 from dolfinx.fem.petsc import LinearProblem
 from ufl import (Measure, SpatialCoordinate, TestFunctions, TrialFunctions,
                  div, exp, inner)
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 domain = mesh.create_unit_square(MPI.COMM_WORLD, 32, 32, mesh.CellType.quadrilateral)
 

--- a/python/demo/demo_navier-stokes.py
+++ b/python/demo/demo_navier-stokes.py
@@ -155,6 +155,9 @@
 #
 # We begin by importing the required modules and functions
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 # +
 import numpy as np
 
@@ -162,9 +165,6 @@ from dolfinx import default_real_type, fem, io, mesh
 from dolfinx.fem.petsc import assemble_matrix_block, assemble_vector_block
 from ufl import (CellDiameter, FacetNormal, TestFunction, TrialFunction, avg,
                  conditional, div, dot, dS, ds, dx, grad, gt, inner, outer)
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 if np.issubdtype(PETSc.ScalarType, np.complexfloating):  # type: ignore
     print("Demo should only be executed with DOLFINx real mode")

--- a/python/demo/demo_pml/demo_pml.py
+++ b/python/demo/demo_pml/demo_pml.py
@@ -19,6 +19,8 @@ import sys
 from functools import partial
 from typing import Tuple, Union
 
+from mpi4py import MPI
+
 from efficiencies_pml_demo import calculate_analytical_efficiencies
 from mesh_wire_pml import generate_mesh_wire
 
@@ -27,8 +29,6 @@ from basix.ufl import element
 from dolfinx import default_scalar_type, fem, mesh, plot
 from dolfinx.fem.petsc import LinearProblem
 from dolfinx.io import VTXWriter, gmshio
-
-from mpi4py import MPI
 
 try:
     import gmsh

--- a/python/demo/demo_poisson.py
+++ b/python/demo/demo_poisson.py
@@ -73,6 +73,9 @@ from ufl import ds, dx, grad, inner
 
 # -
 
+# Note that it is important to first `from mpi4py import MPI` to
+# ensure that MPI is correctly initialised.
+
 # We create a rectangular {py:class}`Mesh <dolfinx.mesh.Mesh>` using
 # {py:func}`create_rectangle <dolfinx.mesh.create_rectangle>`, and
 # create a finite element {py:class}`function space

--- a/python/demo/demo_poisson.py
+++ b/python/demo/demo_poisson.py
@@ -60,6 +60,9 @@
 #
 # The modules that will be used are imported:
 
+from mpi4py import MPI
+from petsc4py.PETSc import ScalarType  # type: ignore
+
 # +
 import numpy as np
 
@@ -67,9 +70,6 @@ import ufl
 from dolfinx import fem, io, mesh, plot
 from dolfinx.fem.petsc import LinearProblem
 from ufl import ds, dx, grad, inner
-
-from mpi4py import MPI
-from petsc4py.PETSc import ScalarType  # type: ignore
 
 # -
 

--- a/python/demo/demo_pyvista.py
+++ b/python/demo/demo_pyvista.py
@@ -22,6 +22,8 @@
 # To start, the required modules are imported and some PyVista
 # parameters set.
 
+from mpi4py import MPI
+
 # +
 import numpy as np
 
@@ -29,8 +31,6 @@ import dolfinx.plot as plot
 from dolfinx.fem import Function, functionspace
 from dolfinx.mesh import (CellType, compute_midpoints, create_unit_cube,
                           create_unit_square, meshtags)
-
-from mpi4py import MPI
 
 try:
     import pyvista

--- a/python/demo/demo_scattering_boundary_conditions/demo_scattering_boundary_conditions.py
+++ b/python/demo/demo_scattering_boundary_conditions/demo_scattering_boundary_conditions.py
@@ -33,6 +33,8 @@
 import sys
 from typing import Tuple
 
+from mpi4py import MPI
+
 from analytical_efficiencies_wire import calculate_analytical_efficiencies
 from mesh_wire import generate_mesh_wire
 
@@ -40,8 +42,6 @@ import ufl
 from basix.ufl import element
 from dolfinx import default_scalar_type, fem, io, plot
 from dolfinx.fem.petsc import LinearProblem
-
-from mpi4py import MPI
 
 try:
     import gmsh

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -22,6 +22,9 @@
 # +
 from pathlib import Path
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import cffi
 import numba
 import numba.core.typing.cffi_utils as cffi_support
@@ -39,9 +42,6 @@ from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
 from dolfinx.io import XDMFFile
 from dolfinx.jit import ffcx_jit
 from dolfinx.mesh import locate_entities_boundary, meshtags
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 if default_real_type == np.float32:
     print("float32 not yet supported for this demo.")

--- a/python/demo/demo_stokes.py
+++ b/python/demo/demo_stokes.py
@@ -82,6 +82,9 @@
 #
 # The required modules are first imported:
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 
 import ufl
@@ -94,9 +97,6 @@ from dolfinx.fem.petsc import assemble_matrix_block, assemble_vector_block
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import CellType, create_rectangle, locate_entities_boundary
 from ufl import div, dx, grad, inner
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 # We create a {py:class}`Mesh <dolfinx.mesh.Mesh>`, define functions for
 # locating geometrically subsets of the boundary, and define a function

--- a/python/demo/demo_tnt-elements.py
+++ b/python/demo/demo_tnt-elements.py
@@ -20,6 +20,8 @@
 #
 # We begin this demo by importing the required modules.
 
+from mpi4py import MPI
+
 # +
 import matplotlib
 import matplotlib.pylab as plt
@@ -31,8 +33,6 @@ from dolfinx import fem, mesh
 from dolfinx.fem.petsc import LinearProblem
 from ufl import (SpatialCoordinate, TestFunction, TrialFunction, cos, div, dx,
                  grad, inner, sin)
-
-from mpi4py import MPI
 
 matplotlib.use('agg')
 # -

--- a/python/demo/demo_types.py
+++ b/python/demo/demo_types.py
@@ -17,6 +17,8 @@
 # - Interfacing with [SciPy](https://scipy.org/) sparse linear algebra
 #   functionality
 
+from mpi4py import MPI
+
 # +
 import numpy as np
 import scipy.sparse
@@ -24,8 +26,6 @@ import scipy.sparse.linalg
 
 import ufl
 from dolfinx import fem, la, mesh, plot
-
-from mpi4py import MPI
 
 # -
 

--- a/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
+++ b/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
@@ -41,6 +41,8 @@
 # +
 import sys
 
+from mpi4py import MPI
+
 import numpy as np
 from analytical_modes import verify_mode
 
@@ -50,8 +52,6 @@ from dolfinx import default_scalar_type, fem, io, plot
 from dolfinx.fem.petsc import assemble_matrix
 from dolfinx.mesh import (CellType, create_rectangle, exterior_facet_indices,
                           locate_entities)
-
-from mpi4py import MPI
 
 try:
     import pyvista

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -20,9 +20,9 @@ from dolfinx import default_scalar_type, jit, la
 from dolfinx.fem import dofmap
 
 if typing.TYPE_CHECKING:
-    from dolfinx.mesh import Mesh
-
     from mpi4py import MPI as _MPI
+
+    from dolfinx.mesh import Mesh
 
 
 class Constant(ufl.Constant):

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -18,6 +18,10 @@ import functools
 import os
 import typing
 
+import petsc4py
+import petsc4py.lib
+from petsc4py import PETSc
+
 import ufl
 from dolfinx import cpp as _cpp
 from dolfinx import la
@@ -31,10 +35,6 @@ from dolfinx.fem.forms import extract_function_spaces as _extract_spaces
 from dolfinx.fem.forms import form as _create_form
 from dolfinx.fem.function import Function as _Function
 from dolfinx.la import create_petsc_vector
-
-import petsc4py
-import petsc4py.lib
-from petsc4py import PETSc
 
 __all__ = ["create_vector", "create_vector_block", "create_vector_nest",
            "create_matrix", "create_matrix_block", "create_matrix_nest",

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -7,6 +7,8 @@
 
 import typing
 
+from mpi4py import MPI as _MPI
+
 import numpy as np
 import numpy.typing as npt
 
@@ -18,8 +20,6 @@ from dolfinx import default_real_type
 from dolfinx.cpp.graph import AdjacencyList_int32
 from dolfinx.mesh import (CellType, Mesh, create_mesh, meshtags,
                           meshtags_from_entities)
-
-from mpi4py import MPI as _MPI
 
 __all__ = ["cell_perm_array", "ufl_mesh", "extract_topology_and_markers",
            "extract_geometry", "model_to_mesh", "read_from_msh"]

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -9,6 +9,8 @@
 import typing
 from pathlib import Path
 
+from mpi4py import MPI as _MPI
+
 import numpy as np
 import numpy.typing as npt
 
@@ -20,8 +22,6 @@ from dolfinx.cpp.io import perm_gmsh as cell_perm_gmsh  # noqa F401
 from dolfinx.cpp.io import perm_vtk as cell_perm_vtk  # noqa F401
 from dolfinx.fem import Function
 from dolfinx.mesh import GhostMode, Mesh, MeshTags
-
-from mpi4py import MPI as _MPI
 
 __all__ = ["VTKFile", "XDMFFile", "cell_perm_gmsh", "cell_perm_vtk",
            "distribute_entity_data"]

--- a/python/dolfinx/jit.py
+++ b/python/dolfinx/jit.py
@@ -11,11 +11,11 @@ import os
 from pathlib import Path
 from typing import Optional
 
+from mpi4py import MPI
+
 import ffcx
 import ffcx.codegeneration.jit
 import ufl
-
-from mpi4py import MPI
 
 __all__ = ["ffcx_jit", "get_options", "mpi_jit_decorator"]
 

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import typing
 
+from mpi4py import MPI as _MPI
+
 import numpy as np
 import numpy.typing as npt
 
@@ -22,8 +24,6 @@ from dolfinx.cpp.mesh import (CellType, DiagonalType, GhostMode,
                               create_cell_partitioner, exterior_facet_indices,
                               to_string, to_type)
 from dolfinx.cpp.refinement import RefinementOption
-
-from mpi4py import MPI as _MPI
 
 __all__ = ["meshtags_from_entities", "locate_entities", "locate_entities_boundary",
            "refine", "create_mesh", "Mesh", "MeshTags", "meshtags", "CellType",

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -4,9 +4,9 @@ import shutil
 import time
 from collections import defaultdict
 
-import pytest
-
 from mpi4py import MPI
+
+import pytest
 
 
 def pytest_runtest_teardown(item):

--- a/python/test/unit/common/test_index_map.py
+++ b/python/test/unit/common/test_index_map.py
@@ -4,12 +4,12 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+from mpi4py import MPI
+
 import numpy as np
 
 import dolfinx
 from dolfinx.mesh import GhostMode, create_unit_square
-
-from mpi4py import MPI
 
 
 def test_sub_index_map():

--- a/python/test/unit/common/test_mpi.py
+++ b/python/test/unit/common/test_mpi.py
@@ -8,6 +8,9 @@
 
 import pathlib
 
+import mpi4py
+from mpi4py import MPI
+
 import cppimport
 import pytest
 
@@ -16,9 +19,6 @@ import dolfinx.pkgconfig
 from dolfinx import wrappers
 from dolfinx.jit import mpi_jit_decorator
 from dolfinx.mesh import create_unit_square
-
-import mpi4py
-from mpi4py import MPI
 
 
 def test_mpi_comm_wrapper():

--- a/python/test/unit/fem/test_assemble_cppimport.py
+++ b/python/test/unit/fem/test_assemble_cppimport.py
@@ -7,6 +7,8 @@
 
 import pathlib
 
+from mpi4py import MPI
+
 import cppimport
 import numpy as np
 import pybind11
@@ -19,8 +21,6 @@ from dolfinx.fem import (assemble_matrix, dirichletbc, form, functionspace,
                          locate_dofs_geometrical)
 from dolfinx.mesh import create_unit_square
 from dolfinx.wrappers import get_include_path as pybind_inc
-
-from mpi4py import MPI
 
 
 @pytest.mark.skip_in_parallel

--- a/python/test/unit/fem/test_assemble_domains.py
+++ b/python/test/unit/fem/test_assemble_domains.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Unit tests for assembly over domains"""
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -16,8 +18,6 @@ from dolfinx.fem import (Constant, Function, assemble_scalar, dirichletbc,
 from dolfinx.mesh import (GhostMode, Mesh, create_unit_square, locate_entities,
                           locate_entities_boundary, meshtags,
                           meshtags_from_entities)
-
-from mpi4py import MPI
 
 
 @pytest.fixture

--- a/python/test/unit/fem/test_assemble_submesh.py
+++ b/python/test/unit/fem/test_assemble_submesh.py
@@ -6,6 +6,8 @@
 
 # TODO Test replacing mesh with submesh for existing assembler tests
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -14,8 +16,6 @@ from dolfinx import default_scalar_type, fem, la
 from dolfinx.mesh import (GhostMode, create_box, create_rectangle,
                           create_submesh, create_unit_cube, create_unit_square,
                           locate_entities, locate_entities_boundary)
-
-from mpi4py import MPI
 
 
 def assemble(mesh, space, k):

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -7,6 +7,9 @@
 
 import math
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 import pytest
 import scipy.sparse
@@ -39,9 +42,6 @@ from dolfinx.mesh import (CellType, GhostMode, create_mesh, create_rectangle,
                           locate_entities_boundary)
 from ufl import derivative, ds, dx, inner
 from ufl.geometry import SpatialCoordinate
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 
 def nest_matrix_norm(A):

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -18,8 +20,6 @@ from dolfinx.fem import (Constant, Function, apply_lifting, assemble_matrix,
 from dolfinx.mesh import (CellType, create_unit_cube, create_unit_square,
                           locate_entities_boundary)
 from ufl import dx, inner
-
-from mpi4py import MPI
 
 
 def test_locate_dofs_geometrical():

--- a/python/test/unit/fem/test_complex_assembler.py
+++ b/python/test/unit/fem/test_complex_assembler.py
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Unit tests for assembly in complex mode"""
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 import pytest
 
@@ -14,9 +17,6 @@ from dolfinx.fem import Function, form, functionspace
 from dolfinx.fem.petsc import assemble_matrix, assemble_vector
 from dolfinx.mesh import create_unit_square
 from ufl import dx, grad, inner
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 pytestmark = pytest.mark.skipif(
     not np.issubdtype(PETSc.ScalarType, np.complexfloating), reason="Only works in complex mode.")  # type: ignore

--- a/python/test/unit/fem/test_constant.py
+++ b/python/test/unit/fem/test_constant.py
@@ -5,13 +5,13 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Unit tests for the Constant class"""
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
 from dolfinx.fem import Constant
 from dolfinx.mesh import create_unit_cube
-
-from mpi4py import MPI
 
 
 def test_scalar_constant():

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -13,6 +13,11 @@ import os
 import pathlib
 import time
 
+import petsc4py.lib
+from mpi4py import MPI
+from petsc4py import PETSc
+from petsc4py import get_config as PETSc_get_config
+
 import cffi
 import numpy as np
 import numpy.typing
@@ -25,11 +30,6 @@ from dolfinx.fem import Function, form, functionspace
 from dolfinx.fem.petsc import assemble_matrix, load_petsc_lib
 from dolfinx.mesh import create_unit_square
 from ufl import dx, inner
-
-import petsc4py.lib
-from mpi4py import MPI
-from petsc4py import PETSc
-from petsc4py import get_config as PETSc_get_config
 
 numba = pytest.importorskip("numba")
 cffi_support = pytest.importorskip("numba.core.typing.cffi_utils")

--- a/python/test/unit/fem/test_custom_basix_element.py
+++ b/python/test/unit/fem/test_custom_basix_element.py
@@ -1,3 +1,6 @@
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 import pytest
 
@@ -12,9 +15,6 @@ from dolfinx.mesh import (CellType, create_unit_cube, create_unit_square,
                           exterior_facet_indices)
 from ufl import (SpatialCoordinate, TestFunction, TrialFunction, div, dx, grad,
                  inner)
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 
 def run_scalar_test(V, degree):

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -9,6 +9,8 @@
 import os
 import sys
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -19,8 +21,6 @@ from dolfinx import (default_real_type, default_scalar_type, fem, la,
                      list_timings)
 from dolfinx.fem import Form, Function, IntegralType, functionspace
 from dolfinx.mesh import create_unit_square
-
-from mpi4py import MPI
 
 numba = pytest.importorskip("numba")
 

--- a/python/test/unit/fem/test_discrete_operators.py
+++ b/python/test/unit/fem/test_discrete_operators.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Unit tests for the DiscreteOperator class"""
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 import scipy
@@ -15,8 +17,6 @@ from dolfinx.cpp.fem import discrete_gradient
 from dolfinx.fem import Expression, Function, functionspace
 from dolfinx.mesh import (CellType, GhostMode, create_unit_cube,
                           create_unit_square)
-
-from mpi4py import MPI
 
 
 @pytest.mark.parametrize("mesh", [create_unit_square(MPI.COMM_WORLD, 11, 6,

--- a/python/test/unit/fem/test_dof_coordinates.py
+++ b/python/test/unit/fem/test_dof_coordinates.py
@@ -1,10 +1,10 @@
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
 from dolfinx.fem import Function, functionspace
 from dolfinx.mesh import create_unit_cube, create_unit_square
-
-from mpi4py import MPI
 
 
 @pytest.mark.parametrize("degree", range(1, 5))

--- a/python/test/unit/fem/test_dof_permuting.py
+++ b/python/test/unit/fem/test_dof_permuting.py
@@ -7,6 +7,8 @@
 
 import random
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -15,8 +17,6 @@ from basix.ufl import element
 from dolfinx import default_real_type
 from dolfinx.fem import Function, assemble_scalar, form, functionspace
 from dolfinx.mesh import create_mesh
-
-from mpi4py import MPI
 
 
 def randomly_ordered_mesh(cell_type):

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -7,6 +7,8 @@
 
 import sys
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -16,8 +18,6 @@ from basix.ufl import element, mixed_element
 from dolfinx.fem import functionspace
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
                           create_unit_interval, create_unit_square)
-
-from mpi4py import MPI
 
 xfail = pytest.mark.xfail(strict=True)
 

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -8,6 +8,8 @@
 import random
 from itertools import combinations, product
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -17,8 +19,6 @@ from basix.ufl import element
 from dolfinx.fem import (Constant, Function, assemble_matrix, assemble_scalar,
                          assemble_vector, form, functionspace)
 from dolfinx.mesh import CellType, create_mesh, meshtags
-
-from mpi4py import MPI
 
 parametrize_cell_types = pytest.mark.parametrize(
     "cell_type",

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -15,8 +17,6 @@ from dolfinx import fem, la
 from dolfinx.fem import Constant, Expression, Function, form, functionspace
 from dolfinx.mesh import create_unit_square
 from ffcx.element_interface import QuadratureElement
-
-from mpi4py import MPI
 
 dolfinx.cpp.common.init_logging(["-v"])
 

--- a/python/test/unit/fem/test_fem_pipeline.py
+++ b/python/test/unit/fem/test_fem_pipeline.py
@@ -6,6 +6,9 @@
 
 from pathlib import Path
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 import pytest
 
@@ -23,9 +26,6 @@ from dolfinx.mesh import (CellType, create_rectangle, create_unit_cube,
                           locate_entities_boundary)
 from ufl import (CellDiameter, FacetNormal, SpatialCoordinate, TestFunction,
                  TrialFunction, avg, div, ds, dS, dx, grad, inner, jump)
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 
 def run_scalar_test(mesh, V, degree):

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -6,13 +6,13 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+from mpi4py import MPI
+
 import pytest
 
 from dolfinx.fem import extract_function_spaces, form, functionspace
 from dolfinx.mesh import create_unit_square
 from ufl import TestFunction, TrialFunction, dx, inner
-
-from mpi4py import MPI
 
 
 def test_extract_forms():

--- a/python/test/unit/fem/test_function.py
+++ b/python/test/unit/fem/test_function.py
@@ -7,6 +7,8 @@
 
 import importlib
 
+from mpi4py import MPI
+
 import cffi
 import numpy as np
 import pytest
@@ -18,8 +20,6 @@ from dolfinx.fem import Function, functionspace
 from dolfinx.geometry import (bb_tree, compute_colliding_cells,
                               compute_collisions_points)
 from dolfinx.mesh import create_mesh, create_unit_cube
-
-from mpi4py import MPI
 
 
 @pytest.fixture

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Unit tests for the FunctionSpace class"""
 
+from mpi4py import MPI
+
 # import basix
 import numpy as np
 import pytest
@@ -14,8 +16,6 @@ from dolfinx import default_real_type
 from dolfinx.fem import Function, FunctionSpace, functionspace
 from dolfinx.mesh import create_mesh, create_unit_cube
 from ufl import Cell, Mesh, TestFunction, TrialFunction, grad
-
-from mpi4py import MPI
 
 
 @pytest.fixture

--- a/python/test/unit/fem/test_ghost_mesh_assembly.py
+++ b/python/test/unit/fem/test_ghost_mesh_assembly.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Unit tests for assembly"""
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -13,8 +15,6 @@ from dolfinx import fem, la
 from dolfinx.fem import Function, form, functionspace
 from dolfinx.mesh import GhostMode, create_unit_square
 from ufl import avg, inner
-
-from mpi4py import MPI
 
 
 def dx_from_ufl(mesh):

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -7,6 +7,8 @@
 
 import random
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -22,8 +24,6 @@ from dolfinx.geometry import bb_tree, compute_collisions_points
 from dolfinx.mesh import (CellType, create_mesh, create_rectangle,
                           create_unit_cube, create_unit_square,
                           locate_entities, locate_entities_boundary, meshtags)
-
-from mpi4py import MPI
 
 parametrize_cell_types = pytest.mark.parametrize(
     "cell_type", [

--- a/python/test/unit/fem/test_mixed_element.py
+++ b/python/test/unit/fem/test_mixed_element.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -13,8 +15,6 @@ from basix.ufl import element, mixed_element
 from dolfinx.fem import form, functionspace
 from dolfinx.mesh import (CellType, GhostMode, create_unit_cube,
                           create_unit_square)
-
-from mpi4py import MPI
 
 
 @pytest.mark.skip_in_parallel

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -7,6 +7,9 @@
 
 import math
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 import pytest
 
@@ -27,9 +30,6 @@ from dolfinx.fem.petsc import (apply_lifting, apply_lifting_nest,
 from dolfinx.mesh import (GhostMode, create_unit_cube, create_unit_square,
                           locate_entities_boundary)
 from ufl import derivative, dx, inner
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 
 def nest_matrix_norm(A):

--- a/python/test/unit/fem/test_petsc_discrete_operators.py
+++ b/python/test/unit/fem/test_petsc_discrete_operators.py
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Unit tests for the DiscreteOperator class"""
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 import pytest
 
@@ -16,9 +19,6 @@ from dolfinx.fem import (Expression, Function, assemble_scalar, form,
                          functionspace)
 from dolfinx.mesh import (CellType, GhostMode, create_mesh, create_unit_cube,
                           create_unit_square)
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 
 @pytest.mark.skip_in_parallel

--- a/python/test/unit/fem/test_special_functions.py
+++ b/python/test/unit/fem/test_special_functions.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Unit tests for the function library"""
 
+from mpi4py import MPI
+
 import numpy
 import pytest
 
@@ -13,8 +15,6 @@ from dolfinx import default_scalar_type
 from dolfinx.fem import Constant, assemble_scalar, form
 from dolfinx.mesh import (create_unit_cube, create_unit_interval,
                           create_unit_square)
-
-from mpi4py import MPI
 
 
 def test_facet_area1D():

--- a/python/test/unit/fem/test_symmetry.py
+++ b/python/test/unit/fem/test_symmetry.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Test that matrices are symmetric."""
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -15,8 +17,6 @@ from basix.ufl import element, mixed_element
 from dolfinx.fem import form, functionspace
 from dolfinx.mesh import CellType, create_unit_cube, create_unit_square
 from ufl import grad, inner
-
-from mpi4py import MPI
 
 
 def check_symmetry(A, tol):

--- a/python/test/unit/fem/test_vector_assemble.py
+++ b/python/test/unit/fem/test_vector_assemble.py
@@ -6,11 +6,11 @@
 """Unit tests for assembly on vector spaces"""
 
 
+from mpi4py import MPI
+
 import ufl
 from dolfinx.fem import assemble_matrix, form, functionspace
 from dolfinx.mesh import create_unit_square
-
-from mpi4py import MPI
 
 
 def test_vector_assemble_matrix_exterior():

--- a/python/test/unit/fem/test_vector_function.py
+++ b/python/test/unit/fem/test_vector_function.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Test that the vectors in vector spaces are correctly oriented"""
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -13,8 +15,6 @@ from basix.ufl import element
 from dolfinx import default_real_type
 from dolfinx.fem import Function, functionspace
 from dolfinx.mesh import create_mesh
-
-from mpi4py import MPI
 
 
 @pytest.mark.skip_in_parallel

--- a/python/test/unit/geometry/test_bounding_box_tree.py
+++ b/python/test/unit/geometry/test_bounding_box_tree.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Unit tests for BoundingBoxTree"""
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -18,8 +20,6 @@ from dolfinx.mesh import (CellType, create_box, create_unit_cube,
                           create_unit_interval, create_unit_square,
                           exterior_facet_indices, locate_entities,
                           locate_entities_boundary)
-
-from mpi4py import MPI
 
 
 def extract_geometricial_data(mesh, dim, entities):

--- a/python/test/unit/geometry/test_gjk.py
+++ b/python/test/unit/geometry/test_gjk.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 from scipy.spatial.transform import Rotation
@@ -13,8 +15,6 @@ from basix.ufl import element
 from dolfinx import geometry
 from dolfinx.geometry import compute_distance_gjk
 from dolfinx.mesh import create_mesh
-
-from mpi4py import MPI
 
 
 def distance_point_to_line_3D(P1, P2, point):

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -6,6 +6,8 @@
 
 from pathlib import Path
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -17,8 +19,6 @@ from dolfinx.fem import Function, functionspace
 from dolfinx.graph import adjacencylist
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
                           create_unit_square)
-
-from mpi4py import MPI
 
 try:
     from dolfinx.io import FidesWriter, VTXWriter

--- a/python/test/unit/io/test_vtk.py
+++ b/python/test/unit/io/test_vtk.py
@@ -6,6 +6,8 @@
 
 from pathlib import Path
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
@@ -19,8 +21,6 @@ from dolfinx.io.utils import cell_perm_vtk  # noqa F401
 from dolfinx.mesh import (CellType, create_mesh, create_unit_cube,
                           create_unit_interval, create_unit_square)
 from dolfinx.plot import vtk_mesh
-
-from mpi4py import MPI
 
 cell_types_2D = [CellType.triangle, CellType.quadrilateral]
 cell_types_3D = [CellType.tetrahedron, CellType.hexahedron]

--- a/python/test/unit/io/test_xdmf_function.py
+++ b/python/test/unit/io/test_xdmf_function.py
@@ -6,6 +6,8 @@
 
 from pathlib import Path
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -14,8 +16,6 @@ from dolfinx.fem import Function, functionspace
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import (CellType, create_unit_cube, create_unit_interval,
                           create_unit_square)
-
-from mpi4py import MPI
 
 # Supported XDMF file encoding
 if MPI.COMM_WORLD.size > 1:

--- a/python/test/unit/io/test_xdmf_mesh.py
+++ b/python/test/unit/io/test_xdmf_mesh.py
@@ -6,6 +6,8 @@
 
 from pathlib import Path
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -16,8 +18,6 @@ from dolfinx.io.gmshio import cell_perm_array, ufl_mesh
 from dolfinx.mesh import (CellType, GhostMode, create_mesh, create_submesh,
                           create_unit_cube, create_unit_interval,
                           create_unit_square, locate_entities)
-
-from mpi4py import MPI
 
 # Supported XDMF file encoding
 if MPI.COMM_WORLD.size > 1:

--- a/python/test/unit/io/test_xdmf_meshdata.py
+++ b/python/test/unit/io/test_xdmf_meshdata.py
@@ -6,6 +6,8 @@
 
 from pathlib import Path
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -13,8 +15,6 @@ from dolfinx import default_real_type
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import (CellType, create_unit_cube, create_unit_interval,
                           create_unit_square)
-
-from mpi4py import MPI
 
 # Supported XDMF file encoding
 if MPI.COMM_WORLD.size > 1:

--- a/python/test/unit/io/test_xdmf_meshtags.py
+++ b/python/test/unit/io/test_xdmf_meshtags.py
@@ -7,14 +7,14 @@
 from pathlib import Path
 from xml.etree import ElementTree
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
 from dolfinx import default_real_type
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import CellType, create_unit_cube, locate_entities, meshtags
-
-from mpi4py import MPI
 
 # Supported XDMF file encoding
 if MPI.COMM_WORLD.size > 1:

--- a/python/test/unit/la/test_casters.py
+++ b/python/test/unit/la/test_casters.py
@@ -8,6 +8,10 @@
 
 import pathlib
 
+import petsc4py
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import cppimport
 import numpy as np
 import pytest
@@ -16,10 +20,6 @@ import dolfinx
 import dolfinx.pkgconfig
 from dolfinx.jit import mpi_jit_decorator
 from dolfinx.wrappers import get_include_path as pybind_inc
-
-import petsc4py
-from mpi4py import MPI
-from petsc4py import PETSc
 
 
 @pytest.mark.skipif(not dolfinx.pkgconfig.exists("dolfinx"),

--- a/python/test/unit/la/test_krylov_solver.py
+++ b/python/test/unit/la/test_krylov_solver.py
@@ -7,6 +7,9 @@
 
 from contextlib import ExitStack
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 import pytest
 
@@ -19,9 +22,6 @@ from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
 from dolfinx.mesh import create_unit_square, locate_entities_boundary
 from ufl import (Identity, TestFunction, TrialFunction, dot, dx, grad, inner,
                  sym, tr)
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 
 def test_krylov_solver_lu():

--- a/python/test/unit/la/test_matrix_csr.py
+++ b/python/test/unit/la/test_matrix_csr.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Unit tests for MatrixCSR"""
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -15,8 +17,6 @@ from dolfinx.common import IndexMap
 from dolfinx.cpp.la import BlockMode, SparsityPattern
 from dolfinx.la import matrix_csr
 from dolfinx.mesh import GhostMode, create_unit_square
-
-from mpi4py import MPI
 
 
 def create_test_sparsity(n, bs):

--- a/python/test/unit/la/test_matrix_vector.py
+++ b/python/test/unit/la/test_matrix_vector.py
@@ -6,14 +6,14 @@
 """Unit tests for MatrixCSR"""
 
 
+from mpi4py import MPI
+
 import numpy as np
 
 from dolfinx import cpp as _cpp
 from dolfinx import la
 from dolfinx.fem import functionspace
 from dolfinx.mesh import create_unit_square
-
-from mpi4py import MPI
 
 
 def test_create_matrix_csr():

--- a/python/test/unit/la/test_nullspace.py
+++ b/python/test/unit/la/test_nullspace.py
@@ -7,6 +7,9 @@
 
 from contextlib import ExitStack
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 import pytest
 
@@ -18,9 +21,6 @@ from dolfinx.la import create_petsc_vector
 from dolfinx.mesh import (CellType, GhostMode, create_box, create_unit_cube,
                           create_unit_square)
 from ufl import TestFunction, TrialFunction, dx, grad, inner
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 
 def build_elastic_nullspace(V):

--- a/python/test/unit/la/test_sparsity_pattern.py
+++ b/python/test/unit/la/test_sparsity_pattern.py
@@ -5,11 +5,11 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Unit tests for sparsity pattern creation"""
 
+from mpi4py import MPI
+
 from dolfinx.cpp.la import SparsityPattern
 from dolfinx.fem import functionspace, locate_dofs_topological
 from dolfinx.mesh import create_unit_square, exterior_facet_indices
-
-from mpi4py import MPI
 
 
 def test_add_diagonal():

--- a/python/test/unit/la/test_vector_scatter.py
+++ b/python/test/unit/la/test_vector_scatter.py
@@ -6,6 +6,8 @@
 """Unit tests for the KrylovSolver interface"""
 
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -13,8 +15,6 @@ from basix.ufl import element
 from dolfinx import la
 from dolfinx.fem import Function, functionspace
 from dolfinx.mesh import create_unit_square
-
-from mpi4py import MPI
 
 
 @pytest.mark.parametrize("e", [

--- a/python/test/unit/mesh/test_cell.py
+++ b/python/test/unit/mesh/test_cell.py
@@ -4,14 +4,14 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+from mpi4py import MPI
+
 import pytest
 
 import ufl
 from basix.ufl import element
 from dolfinx.geometry import squared_distance
 from dolfinx.mesh import create_mesh, create_unit_interval
-
-from mpi4py import MPI
 
 
 @pytest.mark.skip_in_parallel

--- a/python/test/unit/mesh/test_dual_graph.py
+++ b/python/test/unit/mesh/test_dual_graph.py
@@ -1,8 +1,8 @@
 
+from mpi4py import MPI
+
 from dolfinx import cpp as _cpp
 from dolfinx import mesh
-
-from mpi4py import MPI
 
 
 def to_adj(cells):

--- a/python/test/unit/mesh/test_face.py
+++ b/python/test/unit/mesh/test_face.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -11,8 +13,6 @@ from dolfinx import cpp as _cpp
 from dolfinx.cpp.mesh import cell_normals
 from dolfinx.mesh import (create_unit_cube, create_unit_square,
                           locate_entities_boundary)
-
-from mpi4py import MPI
 
 
 @pytest.fixture

--- a/python/test/unit/mesh/test_ghost_mesh.py
+++ b/python/test/unit/mesh/test_ghost_mesh.py
@@ -4,12 +4,12 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+from mpi4py import MPI
+
 import pytest
 
 from dolfinx.mesh import (GhostMode, compute_midpoints, create_unit_cube,
                           create_unit_interval, create_unit_square)
-
-from mpi4py import MPI
 
 
 @pytest.mark.xfail(reason="Shared vertex currently disabled")

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -8,6 +8,8 @@
 import random
 from pathlib import Path
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -21,8 +23,6 @@ from dolfinx.io import XDMFFile
 from dolfinx.io.gmshio import cell_perm_array, ufl_mesh
 from dolfinx.mesh import CellType, create_mesh, create_submesh
 from ufl import dx
-
-from mpi4py import MPI
 
 
 def check_cell_volume(points, cell, domain, volume):

--- a/python/test/unit/mesh/test_manifold_point_search.py
+++ b/python/test/unit/mesh/test_manifold_point_search.py
@@ -1,3 +1,5 @@
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -7,8 +9,6 @@ from dolfinx import cpp as _cpp
 from dolfinx import default_real_type, geometry
 from dolfinx.geometry import bb_tree
 from dolfinx.mesh import create_mesh
-
-from mpi4py import MPI
 
 
 @pytest.mark.skip_in_parallel

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -7,6 +7,8 @@
 import math
 import sys
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -24,8 +26,6 @@ from dolfinx.mesh import (CellType, DiagonalType, GhostMode, create_box,
                           create_unit_cube, create_unit_interval,
                           create_unit_square, exterior_facet_indices,
                           locate_entities, locate_entities_boundary)
-
-from mpi4py import MPI
 
 
 def submesh_topology_test(mesh, submesh, entity_map, vertex_map, entity_dim):

--- a/python/test/unit/mesh/test_mesh_partitioners.py
+++ b/python/test/unit/mesh/test_mesh_partitioners.py
@@ -6,6 +6,8 @@
 
 from pathlib import Path
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -17,8 +19,6 @@ from dolfinx import default_real_type
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import (CellType, GhostMode, compute_midpoints, create_box,
                           create_cell_partitioner, create_mesh)
-
-from mpi4py import MPI
 
 partitioners = [dolfinx.graph.partitioner()]
 try:

--- a/python/test/unit/mesh/test_meshtags.py
+++ b/python/test/unit/mesh/test_meshtags.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+from mpi4py import MPI
+
 import numpy as np
 import pytest
 
@@ -11,8 +13,6 @@ from dolfinx.graph import adjacencylist
 from dolfinx.mesh import (CellType, create_unit_cube, locate_entities,
                           meshtags_from_entities)
 from ufl import Measure
-
-from mpi4py import MPI
 
 celltypes_3D = [CellType.tetrahedron, CellType.hexahedron]
 

--- a/python/test/unit/mesh/test_refinement.py
+++ b/python/test/unit/mesh/test_refinement.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+from mpi4py import MPI
+
 import numpy
 import pytest
 from numpy import isclose, logical_and
@@ -15,8 +17,6 @@ from dolfinx.mesh import (CellType, DiagonalType, GhostMode, RefinementOption,
                           create_unit_square, locate_entities,
                           locate_entities_boundary, meshtags, refine,
                           refine_plaza, transfer_meshtag)
-
-from mpi4py import MPI
 
 
 def test_Refinecreate_unit_square():

--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Unit tests for Newton solver assembly"""
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 import numpy as np
 
 import ufl
@@ -17,9 +20,6 @@ from dolfinx.fem.petsc import (apply_lifting, assemble_matrix, assemble_vector,
 from dolfinx.la import create_petsc_vector
 from dolfinx.mesh import create_unit_square
 from ufl import TestFunction, TrialFunction, derivative, dx, grad, inner
-
-from mpi4py import MPI
-from petsc4py import PETSc
 
 
 class NonlinearPDEProblem:


### PR DESCRIPTION
Avoid later initialisation of MPI with possibly wrong thread support level.