### PR TITLE
Fix bounding box leaf collision check

### DIFF
--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -300,8 +300,7 @@ void _compute_collisions_point(const geometry::BoundingBoxTree<T>& tree,
   while (next != -1)
   {
     const std::array<int, 2> bbox = tree.bbox(next);
-    std::int32_t current_bbox = next;
-    if (is_leaf(bbox) and point_in_bbox(tree.get_bbox(current_bbox), p))
+    if (is_leaf(bbox) and point_in_bbox(tree.get_bbox(next), p))
     {
       // If box is a leaf node then add it to the list of colliding
       // entities

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -303,7 +303,7 @@ void _compute_collisions_point(const geometry::BoundingBoxTree<T>& tree,
     const std::array<int, 2> bbox = tree.bbox(next);
     next = -1;
 
-    if (is_leaf(bbox))
+    if ((is_leaf(bbox)) && point_in_bbox(tree.get_bbox(next), p))
     {
       // If box is a leaf node then add it to the list of colliding entities
       entities.push_back(bbox[1]);
@@ -683,7 +683,16 @@ determine_point_ownership(const mesh::Mesh<T>& mesh, std::span<const T> points)
   // Compute collisions:
   // For each point in `x` get the processes it should be sent to
   graph::AdjacencyList collisions = compute_collisions(global_bbtree, points);
-
+  for (std::size_t i = 0; i < collisions.num_nodes(); ++i)
+  {
+    std::cout << points[3 * i] << " " << points[3 * i + 1] << " "
+              << points[3 * i + 2] << ": ";
+    for (auto col : collisions.links(i))
+    {
+      std::cout << col << "  ";
+    }
+    std::cout << std::endl;
+  }
   // Get unique list of outgoing ranks
   std::vector<std::int32_t> out_ranks = collisions.array();
   std::sort(out_ranks.begin(), out_ranks.end());
@@ -711,7 +720,9 @@ determine_point_ownership(const mesh::Mesh<T>& mesh, std::span<const T> points)
   for (std::size_t i = 0; i < points.size() / 3; ++i)
     for (auto p : collisions.links(i))
       send_sizes[rank_to_neighbor[p]] += 3;
-
+  for (auto rank : send_sizes)
+    std::cout << rank << ", ";
+  std::cout << "\n";
   // Compute receive sizes
   std::vector<std::int32_t> recv_sizes(in_ranks.size());
   send_sizes.reserve(1);

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -303,7 +303,7 @@ void _compute_collisions_point(const geometry::BoundingBoxTree<T>& tree,
     const std::array<int, 2> bbox = tree.bbox(next);
     next = -1;
 
-    if ((is_leaf(bbox)) && point_in_bbox(tree.get_bbox(next), p))
+    if ((is_leaf(bbox)) and point_in_bbox(tree.get_bbox(next), p))
     {
       // If box is a leaf node then add it to the list of colliding entities
       entities.push_back(bbox[1]);
@@ -313,7 +313,7 @@ void _compute_collisions_point(const geometry::BoundingBoxTree<T>& tree,
       // Check whether the point collides with child nodes (left and right)
       bool left = point_in_bbox(tree.get_bbox(bbox[0]), p);
       bool right = point_in_bbox(tree.get_bbox(bbox[1]), p);
-      if (left && right)
+      if (left and right)
       {
         // If the point collides with both child nodes, add the right node to
         // the stack (for later visiting) and continue the tree traversal with
@@ -683,16 +683,7 @@ determine_point_ownership(const mesh::Mesh<T>& mesh, std::span<const T> points)
   // Compute collisions:
   // For each point in `x` get the processes it should be sent to
   graph::AdjacencyList collisions = compute_collisions(global_bbtree, points);
-  for (std::size_t i = 0; i < collisions.num_nodes(); ++i)
-  {
-    std::cout << points[3 * i] << " " << points[3 * i + 1] << " "
-              << points[3 * i + 2] << ": ";
-    for (auto col : collisions.links(i))
-    {
-      std::cout << col << "  ";
-    }
-    std::cout << std::endl;
-  }
+
   // Get unique list of outgoing ranks
   std::vector<std::int32_t> out_ranks = collisions.array();
   std::sort(out_ranks.begin(), out_ranks.end());
@@ -720,9 +711,7 @@ determine_point_ownership(const mesh::Mesh<T>& mesh, std::span<const T> points)
   for (std::size_t i = 0; i < points.size() / 3; ++i)
     for (auto p : collisions.links(i))
       send_sizes[rank_to_neighbor[p]] += 3;
-  for (auto rank : send_sizes)
-    std::cout << rank << ", ";
-  std::cout << "\n";
+
   // Compute receive sizes
   std::vector<std::int32_t> recv_sizes(in_ranks.size());
   send_sizes.reserve(1);

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -679,7 +679,6 @@ determine_point_ownership(const mesh::Mesh<T>& mesh, std::span<const T> points)
   BoundingBoxTree bb(mesh, tdim, cells, padding);
   BoundingBoxTree midpoint_tree = create_midpoint_tree(mesh, tdim, cells);
   BoundingBoxTree global_bbtree = bb.create_global_tree(comm);
-  std::cout << "HERE!\n";
 
   // Compute collisions:
   // For each point in `x` get the processes it should be sent to
@@ -689,9 +688,6 @@ determine_point_ownership(const mesh::Mesh<T>& mesh, std::span<const T> points)
   std::sort(out_ranks.begin(), out_ranks.end());
   out_ranks.erase(std::unique(out_ranks.begin(), out_ranks.end()),
                   out_ranks.end());
-  for (auto rank : out_ranks)
-    std::cout << rank << " ";
-  std::cout << "\n";
   // Compute incoming edges (source processes)
   std::vector in_ranks = dolfinx::MPI::compute_graph_edges_nbx(comm, out_ranks);
   std::sort(in_ranks.begin(), in_ranks.end());

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -124,7 +124,6 @@ template <std::floating_point T>
 T compute_squared_distance_bbox(std::span<const T, 6> b,
                                 std::span<const T, 3> x)
 {
-  assert(b.size() == 6);
   auto b0 = b.template subspan<0, 3>();
   auto b1 = b.template subspan<3, 3>();
   return std::transform_reduce(x.begin(), x.end(), b0.begin(), 0.0,
@@ -187,7 +186,6 @@ constexpr bool is_leaf(std::array<int, 2> bbox)
 template <std::floating_point T>
 constexpr bool point_in_bbox(const std::array<T, 6>& b, std::span<const T, 3> x)
 {
-  assert(b.size() == 6);
   constexpr T rtol = 1e-14;
   bool in = true;
   for (std::size_t i = 0; i < 3; i++)
@@ -287,10 +285,11 @@ _compute_closest_entity(const geometry::BoundingBoxTree<T>& tree,
   }
 }
 
-/// Compute collisions with a single point
+/// @brief Compute collisions with a single point.
 /// @param[in] tree The bounding box tree
-/// @param[in] points The points (shape=(num_points, 3))
-/// @param[in, out] entities The list of colliding entities (local to process)
+/// @param[in] points The points (`shape=(num_points, 3)`)
+/// @param[in, out] entities The list of colliding entities (local to
+/// process)
 template <std::floating_point T>
 void _compute_collisions_point(const geometry::BoundingBoxTree<T>& tree,
                                std::span<const T, 3> p,
@@ -302,22 +301,24 @@ void _compute_collisions_point(const geometry::BoundingBoxTree<T>& tree,
   {
     const std::array<int, 2> bbox = tree.bbox(next);
     std::int32_t current_bbox = next;
-    next = -1;
-    if ((is_leaf(bbox)) and point_in_bbox(tree.get_bbox(current_bbox), p))
+    if (is_leaf(bbox) and point_in_bbox(tree.get_bbox(current_bbox), p))
     {
-      // If box is a leaf node then add it to the list of colliding entities
+      // If box is a leaf node then add it to the list of colliding
+      // entities
       entities.push_back(bbox[1]);
+      next = -1;
     }
     else
     {
-      // Check whether the point collides with child nodes (left and right)
+      // Check whether the point collides with child nodes (left and
+      // right)
       bool left = point_in_bbox(tree.get_bbox(bbox[0]), p);
       bool right = point_in_bbox(tree.get_bbox(bbox[1]), p);
       if (left and right)
       {
-        // If the point collides with both child nodes, add the right node to
-        // the stack (for later visiting) and continue the tree traversal with
-        // the left subtree
+        // If the point collides with both child nodes, add the right
+        // node to the stack (for later visiting) and continue the tree
+        // traversal with the left subtree
         stack.push_back(bbox[1]);
         next = bbox[0];
       }
@@ -331,10 +332,12 @@ void _compute_collisions_point(const geometry::BoundingBoxTree<T>& tree,
         // Traverse the current node's right subtree
         next = bbox[1];
       }
+      else
+        next = -1;
     }
 
     // If tree traversal reaches a dead end (box is a leaf node or no
-    // collision detected), check the stack for deferred subtrees.
+    // collision detected), check the stack for deferred subtrees
     if (next == -1 and !stack.empty())
     {
       next = stack.back();

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -301,9 +301,9 @@ void _compute_collisions_point(const geometry::BoundingBoxTree<T>& tree,
   while (next != -1)
   {
     const std::array<int, 2> bbox = tree.bbox(next);
+    std::int32_t current_bbox = next;
     next = -1;
-
-    if ((is_leaf(bbox)) and point_in_bbox(tree.get_bbox(next), p))
+    if ((is_leaf(bbox)) and point_in_bbox(tree.get_bbox(current_bbox), p))
     {
       // If box is a leaf node then add it to the list of colliding entities
       entities.push_back(bbox[1]);
@@ -679,17 +679,19 @@ determine_point_ownership(const mesh::Mesh<T>& mesh, std::span<const T> points)
   BoundingBoxTree bb(mesh, tdim, cells, padding);
   BoundingBoxTree midpoint_tree = create_midpoint_tree(mesh, tdim, cells);
   BoundingBoxTree global_bbtree = bb.create_global_tree(comm);
+  std::cout << "HERE!\n";
 
   // Compute collisions:
   // For each point in `x` get the processes it should be sent to
   graph::AdjacencyList collisions = compute_collisions(global_bbtree, points);
-
   // Get unique list of outgoing ranks
   std::vector<std::int32_t> out_ranks = collisions.array();
   std::sort(out_ranks.begin(), out_ranks.end());
   out_ranks.erase(std::unique(out_ranks.begin(), out_ranks.end()),
                   out_ranks.end());
-
+  for (auto rank : out_ranks)
+    std::cout << rank << " ";
+  std::cout << "\n";
   // Compute incoming edges (source processes)
   std::vector in_ranks = dolfinx::MPI::compute_graph_edges_nbx(comm, out_ranks);
   std::sort(in_ranks.begin(), in_ranks.end());

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -686,11 +686,13 @@ determine_point_ownership(const mesh::Mesh<T>& mesh, std::span<const T> points)
   // Compute collisions:
   // For each point in `x` get the processes it should be sent to
   graph::AdjacencyList collisions = compute_collisions(global_bbtree, points);
+
   // Get unique list of outgoing ranks
   std::vector<std::int32_t> out_ranks = collisions.array();
   std::sort(out_ranks.begin(), out_ranks.end());
   out_ranks.erase(std::unique(out_ranks.begin(), out_ranks.end()),
                   out_ranks.end());
+
   // Compute incoming edges (source processes)
   std::vector in_ranks = dolfinx::MPI::compute_graph_edges_nbx(comm, out_ranks);
   std::sort(in_ranks.begin(), in_ranks.end());

--- a/python/test/unit/geometry/test_bounding_box_tree.py
+++ b/python/test/unit/geometry/test_bounding_box_tree.py
@@ -406,6 +406,31 @@ def test_sub_bbtree(dtype):
         assert len(cells.links(0)) == 0
 
 
+@pytest.mark.parametrize("comm", [MPI.COMM_WORLD, MPI.COMM_SELF])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_serial_global_bb_tree(dtype, comm):
+
+    # Test if global bb tree with only one node returns the correct collision
+    mesh = create_unit_cube(comm, 4, 5, 3)
+
+    # First point should not be in any tree
+    # Second point should always be in the global tree, but only in
+    # entity tree with a serial mesh
+    x = np.array([[2.0, 2.0, 3.0],
+                  [0.3, 0.2, 0.1]], dtype=dtype)
+
+    tree = bb_tree(mesh, mesh.topology.dim)
+    global_tree = tree.create_global_tree(mesh.comm)
+
+    tree_col = compute_collisions_points(tree, x)
+    global_tree_col = compute_collisions_points(global_tree, x)
+    assert len(tree_col.links(0)) == 0 and len(global_tree_col.links(0)) == 0
+    assert len(global_tree_col.links(1)) > 0
+    # Only guaranteed local tree collision if mesh is on one process
+    if comm.size == 1:
+        assert len(tree_col.links(1)) > 0
+
+
 @pytest.mark.parametrize("ct", [CellType.hexahedron, CellType.tetrahedron])
 @pytest.mark.parametrize("N", [7, 13])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])


### PR DESCRIPTION
Reported by @nate-sime 
The following MWE produces the wrong collision for the global_bb_tree
```python
import numpy as np
import dolfinx
from mpi4py import MPI

mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 10, 10)

xp = np.array([[100.0, 100.0, 0.0]], dtype=np.double)

tree = dolfinx.geometry.bb_tree(mesh, mesh.topology.dim, padding=1e-4)
global_tree = tree.create_global_tree(mesh.comm)


def pprint(*msg):
    print(f"[{mesh.comm.rank}]: " + " ".join(map(str, msg)), flush=True)


pprint(dolfinx.common.git_commit_hash)
pprint(dolfinx.geometry.compute_collisions_points(tree, xp))
pprint(dolfinx.geometry.compute_collisions_points(global_tree, xp))

```
giving the following in serial:
```bash
[0]: f488f4ecc687d0065315bc9a74939634b18e11ff
[0]: <AdjacencyList> with 1 nodes
  0: []

[0]: <AdjacencyList> with 1 nodes
  0: [0 ]
```
and the correct result in parallel
```bash
[0]: f488f4ecc687d0065315bc9a74939634b18e11ff
[0]: <AdjacencyList> with 1 nodes
  0: []

[0]: <AdjacencyList> with 1 nodes
  0: []

[1]: f488f4ecc687d0065315bc9a74939634b18e11ff
[1]: <AdjacencyList> with 1 nodes
  0: []

[1]: <AdjacencyList> with 1 nodes
  0: []
```

This is due to a bug in `_compute_collisions_point` where we don't check if the leaf node actually collides with the point.
@massimiliano-leoni could you see if this impacts your mesh interpolation (in serial)? As the `global_bb_tree` is used it would add any interpolation point from the other mesh to the process, even if it doesn't collide.