### PR TITLE
Remove installation of build requirements from workflows, since they are already installed in the underlying docker images

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -86,7 +86,6 @@ jobs:
           python3 -m isort --check .
       - name: mypy checks
         run: |
-          python3 -m pip install mypy types-setuptools --upgrade # TO REMOVE
           cd python/
           mypy dolfinx
           mypy demo
@@ -118,7 +117,6 @@ jobs:
 
       - name: Build C++ interface documentation
         run: |
-          python3 -m pip install breathe # TO REMOVE
           export DOLFINX_VERSION=`cmake -L build | grep DOXYGEN_DOLFINX_VERSION | cut -f2 -d "="`
           echo $DOLFINX_VERSION
           cd cpp/doc
@@ -147,11 +145,9 @@ jobs:
 
       - name: Build Python interface
         run: |
-          python3 -m pip install -r python/build-requirements.txt # TO REMOVE
           python3 -m pip -v install --check-build-dependencies --no-build-isolation python/
       - name: Build Python interface documentation
         run: |
-          python3 -m pip install sphinx==5.0.2 # TO REMOVE
           cd python/doc
           make html
 

--- a/.github/workflows/oneapi.yml
+++ b/.github/workflows/oneapi.yml
@@ -87,7 +87,6 @@ jobs:
       - name: Build DOLFINx Python interface
         run: |
           . /opt/intel/oneapi/setvars.sh
-          pip -v install -r python/build-requirements.txt # TO REMOVE
           pip -v install --check-build-dependencies --no-build-isolation python/
       - name: Set default DOLFINx JIT options
         run: |
@@ -96,7 +95,6 @@ jobs:
       - name: Run DOLFINx demos (Python, serial)
         run: |
           . /opt/intel/oneapi/setvars.sh
-          pip install matplotlib # TO REMOVE
           pytest -v -n=2 -m serial --durations=10 python/demo/test.py
       - name: Run DOLFINx demos (Python, MPI (np=2))
         run: |

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -64,7 +64,6 @@ jobs:
 
       - name: Build Python interface (editable install)
         run: |
-          python3 -m pip -v install -r python/build-requirements.txt # TO REMOVE
           python3 -m pip -v install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type=Debug --config-settings=build-dir="build" -e python/
 
       - name: Set default DOLFINx JIT options

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -153,7 +153,7 @@ RUN if [ "$MPI" = "mpich" ]; then \
 # - Second set of packages are recommended and/or required to build
 #   documentation or run tests.
 RUN pip3 install --no-cache-dir --upgrade setuptools pip && \
-    pip3 install  -no-cache-dir cffi mpi4py numba numpy==${NUMPY_VERSION} scikit-build-core[pyproject] && \
+    pip3 install --no-cache-dir cffi mpi4py numba numpy==${NUMPY_VERSION} scikit-build-core[pyproject] && \
     pip3 install --no-cache-dir breath clang-format cppimport cmakelang flake8 isort jupytext matplotlib mypy myst-parser pybind11==${PYBIND11_VERSION} pytest pytest-xdist scipy sphinx==5.0.2 sphinx_rtd_theme types-setuptools
 
 # Install KaHIP

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -154,7 +154,7 @@ RUN if [ "$MPI" = "mpich" ]; then \
 #   documentation or run tests.
 RUN pip3 install --no-cache-dir --upgrade setuptools pip && \
     pip3 install --no-cache-dir cffi mpi4py numba numpy==${NUMPY_VERSION} scikit-build-core[pyproject] && \
-    pip3 install --no-cache-dir breath clang-format cppimport cmakelang flake8 isort jupytext matplotlib mypy myst-parser pybind11==${PYBIND11_VERSION} pytest pytest-xdist scipy sphinx==5.0.2 sphinx_rtd_theme types-setuptools
+    pip3 install --no-cache-dir breathe clang-format cppimport cmakelang flake8 isort jupytext matplotlib mypy myst-parser pybind11==${PYBIND11_VERSION} pytest pytest-xdist scipy sphinx==5.0.2 sphinx_rtd_theme types-setuptools
 
 # Install KaHIP
 RUN wget -nc --quiet https://github.com/kahip/kahip/archive/v${KAHIP_VERSION}.tar.gz && \


### PR DESCRIPTION
Turns out that most of this was already available in the docker files, but we did not trigger test/dev env workflow.
See https://github.com/FEniCS/dolfinx/actions/runs/6729006694