### PR TITLE
Re-enable basix element test

### DIFF
--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -7,7 +7,7 @@
 
 from mpi4py import MPI
 
-# import basix
+import basix
 import numpy as np
 import pytest
 
@@ -228,16 +228,15 @@ def test_cell_mismatch(mesh):
         functionspace(mesh, e)
 
 
-# NOTE: Test relies on Basix and DOLFINx both using pybind11
-# @pytest.mark.skipif(default_real_type != np.float64, reason="float32 not supported yet")
-# def test_basix_element(V, W, Q, V2):
-#     for V_ in (V, W, V2):
-#         e = V_.element.basix_element
-#         assert isinstance(e, basix.finite_element.FiniteElement)
+@pytest.mark.skipif(default_real_type != np.float64, reason="float32 not supported yet")
+def test_basix_element(V, W, Q, V2):
+    for V_ in (V, W, V2):
+        e = V_.element.basix_element
+        assert isinstance(e, basix.finite_element.FiniteElement)
 
-#     # Mixed spaces do not yet return a basix element
-#     with pytest.raises(RuntimeError):
-#         e = Q.element.basix_element
+    # Mixed spaces do not yet return a basix element
+    with pytest.raises(RuntimeError):
+        e = Q.element.basix_element
 
 
 @pytest.mark.skip_in_parallel


### PR DESCRIPTION
Was disabled when `basix` was using `nanobind` and `dolfinx` was using `pybind11` instead. It may have not been working when the `nanobind` PR was merged because the version of `nanobind` used by `basix` was slightly different then the one installed during CI for `dolfinx`, but that is sorted now that both `basix` and `dolfinx` use the same `nanobind` from the docker image.