### PR TITLE
Clean up unused includes in PETSc nanobind casters, but leave the macro available

### DIFF
--- a/python/dolfinx/wrappers/caster_petsc.h
+++ b/python/dolfinx/wrappers/caster_petsc.h
@@ -8,11 +8,7 @@
 
 #include <nanobind/nanobind.h>
 #include <petsc4py/petsc4py.h>
-#include <petscdm.h>
-#include <petscis.h>
-#include <petscksp.h>
 #include <petscmat.h>
-#include <petscsnes.h>
 #include <petscvec.h>
 
 // nanobind casters for PETSc/petsc4py objects
@@ -83,5 +79,3 @@ namespace nanobind::detail
 PETSC_CASTER_MACRO(Mat, Mat, mat);
 PETSC_CASTER_MACRO(Vec, Vec, vec);
 } // namespace nanobind::detail
-
-#undef PETSC_CASTER_MACRO


### PR DESCRIPTION
Downstream libraries may need to define additional casters. For instance, in `multiphenicsx` I need to define a caster for `IS`.