### PR TITLE
Remove call to `compute_graph_edges` in `compute_owned_indices`

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -168,18 +168,19 @@ common::stack_index_maps(
                    std::next(local_offset.begin()));
 
   // Build list of src ranks (ranks that own ghosts)
-  std::vector<int> src;
+  std::set<int> src_set;
+  std::set<int> dest_set;
   for (auto& [map, _] : maps)
   {
-    src.insert(src.end(), map.get().owners().begin(), map.get().owners().end());
-    std::sort(src.begin(), src.end());
-    src.erase(std::unique(src.begin(), src.end()), src.end());
+    const std::vector<std::int32_t>& _src = map.get().src();
+    const std::vector<std::int32_t>& _dest = map.get().dest();
+
+    src_set.insert(_src.begin(), _src.end());
+    dest_set.insert(_dest.begin(), _dest.end());
   }
 
-  // Get destination ranks (ranks that ghost my indices), and sort
-  std::vector<int> dest = dolfinx::MPI::compute_graph_edges_nbx(
-      maps.at(0).first.get().comm(), src);
-  std::sort(dest.begin(), dest.end());
+  std::vector<int> src(src_set.begin(), src_set.end());
+  std::vector<int> dest(dest_set.begin(), dest_set.end());
 
   // Create neighbour comms (0: ghost -> owner, 1: (owner -> ghost)
   MPI_Comm comm0, comm1;

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -72,16 +72,16 @@ common::compute_owned_indices(std::span<const std::int32_t> indices,
   const std::vector<std::int32_t>& src = map.src();
 
   // Count number of ghost per destination
-  std::vector<int> send_sizes(dest.size(), 0);
-  std::vector<int> send_disp(dest.size() + 1, 0);
+  std::vector<int> send_sizes(src.size(), 0);
+  std::vector<int> send_disp(src.size() + 1, 0);
   auto it = ghost_owners.begin();
-  for (std::size_t i = 0; i < dest.size(); i++)
+  for (std::size_t i = 0; i < src.size(); i++)
   {
-    int owner = dest[i];
+    int owner = src[i];
     auto begin = std::find(it, ghost_owners.end(), owner);
     auto end = std::upper_bound(begin, ghost_owners.end(), owner);
 
-    // Count number of ghosts for this destination (if any)
+    // Count number of ghosts (if any)
     send_sizes[i] = std::distance(begin, end);
     send_disp[i + 1] = send_disp[i] + send_sizes[i];
 

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -39,50 +39,52 @@ std::vector<int32_t>
 common::compute_owned_indices(std::span<const std::int32_t> indices,
                               const IndexMap& map)
 {
-  // Build list of (owner, index) pairs for each ghost in indices, and
-  // sort
-  std::vector<std::pair<int, std::int64_t>> send_idx;
-  std::for_each(indices.begin(), indices.end(),
-                [&send_idx, &owners = map.owners(), &ghosts = map.ghosts(),
-                 size = map.size_local()](auto idx)
-                {
-                  if (idx >= size)
-                  {
-                    std::int32_t pos = idx - size;
-                    send_idx.push_back({owners[pos], ghosts[pos]});
-                  }
-                });
-  std::sort(send_idx.begin(), send_idx.end());
+  // Assume that indices are sorted and unique
+  assert(std::is_sorted(indices.begin(), indices.end()));
 
-  // Build (i) list of src ranks, (ii) send buffer, (iii) send sizes and
-  // (iv) send displacements
-  std::vector<int> src;
-  std::vector<std::int64_t> send_buffer;
-  std::vector<int> send_sizes, send_disp(1, 0);
-  auto it = send_idx.begin();
-  while (it != send_idx.end())
+  std::vector<std::int64_t> ghosts = map.ghosts();
+  std::vector<int> owners = map.owners();
+
+  // Find first index that is not owned by this rank
+  int size_local = map.size_local();
+  auto owned_end = std::lower_bound(indices.begin(), indices.end(), size_local);
+  int first_ghost_index = std::distance(indices.begin(), owned_end);
+  int num_ghost_indices = indices.size() - first_ghost_index;
+
+  std::vector<std::int64_t> global_indices(num_ghost_indices);
+  std::vector<int> ghost_owners(num_ghost_indices);
+
+  for (int i = 0; i < num_ghost_indices; ++i)
   {
-    src.push_back(it->first);
-    auto it1
-        = std::find_if(it, send_idx.end(),
-                       [r = src.back()](auto& idx) { return idx.first != r; });
-
-    // Pack send buffer
-    std::transform(it, it1, std::back_inserter(send_buffer),
-                   [](auto& idx) { return idx.second; });
-
-    // Send sizes and displacements
-    send_sizes.push_back(std::distance(it, it1));
-    send_disp.push_back(send_disp.back() + send_sizes.back());
-
-    // Advance iterator
-    it = it1;
+    int idx = indices[first_ghost_index + i];
+    int pos = idx - size_local;
+    global_indices[i] = ghosts[pos];
+    ghost_owners[i] = owners[pos];
   }
 
-  // Determine destination ranks
-  std::vector<int> dest
-      = dolfinx::MPI::compute_graph_edges_nbx(map.comm(), src);
-  std::sort(dest.begin(), dest.end());
+  // Sort indices and owners
+  std::sort(global_indices.begin(), global_indices.end());
+  std::sort(ghost_owners.begin(), ghost_owners.end());
+
+  const std::vector<std::int32_t>& dest = map.dest();
+  const std::vector<std::int32_t>& src = map.src();
+
+  // Count number of ghost per destination
+  std::vector<int> send_sizes(dest.size(), 0);
+  std::vector<int> send_disp(dest.size() + 1, 0);
+  auto it = ghost_owners.begin();
+  for (std::size_t i = 0; i < dest.size(); i++)
+  {
+    int owner = dest[i];
+    auto it1 = std::upper_bound(it, ghost_owners.end(), owner);
+
+    if (it1 != ghost_owners.end() and *it1 == owner)
+    {
+      send_sizes[i] = std::distance(it, it1);
+      it = it1;
+    }
+    send_disp[i + 1] = send_disp[i] + send_sizes[i];
+  }
 
   // Create ghost -> owner comm
   MPI_Comm comm;
@@ -106,6 +108,7 @@ common::compute_owned_indices(std::span<const std::int32_t> indices,
 
   // Send ghost indices to owner, and receive owned indices
   std::vector<std::int64_t> recv_buffer(recv_disp.back());
+  std::vector<std::int64_t>& send_buffer = global_indices;
   ierr = MPI_Neighbor_alltoallv(send_buffer.data(), send_sizes.data(),
                                 send_disp.data(), MPI_INT64_T,
                                 recv_buffer.data(), recv_sizes.data(),
@@ -122,13 +125,13 @@ common::compute_owned_indices(std::span<const std::int32_t> indices,
 
   // Copy owned and ghost indices into return array
   std::vector<std::int32_t> owned;
-  std::copy_if(indices.begin(), indices.end(), std::back_inserter(owned),
-               [size = map.size_local()](auto idx) { return idx < size; });
+  owned.reserve(num_ghost_indices + recv_buffer.size());
+  std::copy(indices.begin(), owned_end, std::back_inserter(owned));
   std::transform(recv_buffer.begin(), recv_buffer.end(),
                  std::back_inserter(owned),
                  [range = map.local_range()](auto idx)
                  {
-                   assert(idx >= range[0]); // problem
+                   assert(idx >= range[0]);
                    assert(idx < range[1]);
                    return idx - range[0];
                  });
@@ -919,7 +922,7 @@ std::vector<std::int32_t> IndexMap::shared_indices() const
                    assert(idx < range[1]);
                    return idx - range[0];
                  });
-  
+
   // Sort and remove duplicates
   std::sort(shared.begin(), shared.end());
   shared.erase(std::unique(shared.begin(), shared.end()), shared.end());

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -54,6 +54,7 @@ common::compute_owned_indices(std::span<const std::int32_t> indices,
   std::vector<std::int64_t> global_indices(num_ghost_indices);
   std::vector<int> ghost_owners(num_ghost_indices);
 
+  // Get global indices and owners for ghost indices
   for (int i = 0; i < num_ghost_indices; ++i)
   {
     int idx = indices[first_ghost_index + i];
@@ -78,6 +79,7 @@ common::compute_owned_indices(std::span<const std::int32_t> indices,
     int owner = dest[i];
     auto it1 = std::upper_bound(it, ghost_owners.end(), owner);
 
+    // Count number of ghosts for this destination (if any)
     if (it1 != ghost_owners.end() and *it1 == owner)
     {
       send_sizes[i] = std::distance(it, it1);

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -19,10 +19,10 @@ namespace dolfinx::common
 // Forward declaration
 class IndexMap;
 
-/// @brief Given a vector of indices (local numbering, owned or ghost)
-/// and an index map, this function returns the indices owned by this
-/// process, including indices that might have been in the list of
-/// indices on another processes.
+/// @brief Given a sorted vector of indices (local numbering, owned or ghost)
+/// and an index map, this function returns the indices owned by this process,
+/// including indices that might have been in the list of indices on another
+/// processes.
 /// @param[in] indices List of indices
 /// @param[in] map The index map
 /// @return Indices owned by the calling process

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -328,7 +328,7 @@ create_subgeometry(const Topology& topology, const Geometry<T>& geometry,
   // Get the sub-geometry dofs owned by this process
   auto x_index_map = geometry.index_map();
   assert(x_index_map);
-  auto subx_to_x_dofmap
+  std::vector<std::int32_t> subx_to_x_dofmap
       = common::compute_owned_indices(sub_x_dofs, *x_index_map);
   std::shared_ptr<common::IndexMap> sub_x_dof_index_map;
   {

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -1195,8 +1195,11 @@ mesh::create_subtopology(const Topology& topology, int dim,
   // Get the vertices in the sub-topology owned by this process
   auto map0 = topology.index_map(0);
   assert(map0);
-  std::vector<int32_t> subvertices0 = common::compute_owned_indices(
-      compute_incident_entities(topology, subentities, dim, 0), *map0);
+  std::vector<std::int32_t> indices
+      = compute_incident_entities(topology, subentities, dim, 0);
+  std::sort(indices.begin(), indices.end());
+  std::vector<std::int32_t> subvertices0
+      = common::compute_owned_indices(indices, *map0);
 
   // Create map from the vertices in the sub-topology to the vertices in the
   // parent topology, and an index map


### PR DESCRIPTION
Reduces one step of communication to discover dest ranks (ranks that ghost indices owned by the caller.).
