### PR TITLE
Correct CMAKE_BUILD_TYPE in end user Docker images

### DIFF
--- a/.github/workflows/docker-end-user.yml
+++ b/.github/workflows/docker-end-user.yml
@@ -134,7 +134,6 @@ jobs:
         with:
           build-args: |
             DOLFINX_CMAKE_BUILD_TYPE=RelWithDebInfo
-            DOLFINX_CMAKE_CXX_FLAGS=-O2
             BASEIMAGE=${{ env.BASEIMAGE }}
           context: .
           file: dolfinx/${{ env.DOCKERFILE }}
@@ -147,7 +146,6 @@ jobs:
         with:
           build-args: |
             DOLFINX_CMAKE_BUILD_TYPE=RelWithDebInfo
-            DOLFINX_CMAKE_CXX_FLAGS=-O2
             BASEIMAGE=${{ env.BASEIMAGE }}
           context: .
           file: dolfinx/${{ env.DOCKERFILE }}
@@ -158,7 +156,6 @@ jobs:
         with:
           build-args: |
             DOLFINX_CMAKE_BUILD_TYPE=RelWithDebInfo
-            DOLFINX_CMAKE_CXX_FLAGS=-O2
             BASEIMAGE=${{ env.BASEIMAGE }}
           context: .
           file: dolfinx/${{ env.DOCKERFILE }}
@@ -171,7 +168,6 @@ jobs:
         with:
           build-args: |
             DOLFINX_CMAKE_BUILD_TYPE=RelWithDebInfo
-            DOLFINX_CMAKE_CXX_FLAGS=-O2
             BASEIMAGE=${{ env.BASEIMAGE }}
           context: .
           file: dolfinx/${{ env.DOCKERFILE }}

--- a/.github/workflows/docker-end-user.yml
+++ b/.github/workflows/docker-end-user.yml
@@ -133,7 +133,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           build-args: |
-            DOLFINX_CMAKE_BUILD_TYPE=RelWithDebug
+            DOLFINX_CMAKE_BUILD_TYPE=RelWithDebInfo
             DOLFINX_CMAKE_CXX_FLAGS=-O2
             BASEIMAGE=${{ env.BASEIMAGE }}
           context: .
@@ -146,7 +146,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           build-args: |
-            DOLFINX_CMAKE_BUILD_TYPE=RelWithDebug
+            DOLFINX_CMAKE_BUILD_TYPE=RelWithDebInfo
             DOLFINX_CMAKE_CXX_FLAGS=-O2
             BASEIMAGE=${{ env.BASEIMAGE }}
           context: .
@@ -157,7 +157,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           build-args: |
-            DOLFINX_CMAKE_BUILD_TYPE=RelWithDebug
+            DOLFINX_CMAKE_BUILD_TYPE=RelWithDebInfo
             DOLFINX_CMAKE_CXX_FLAGS=-O2
             BASEIMAGE=${{ env.BASEIMAGE }}
           context: .
@@ -170,7 +170,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           build-args: |
-            DOLFINX_CMAKE_BUILD_TYPE=RelWithDebug
+            DOLFINX_CMAKE_BUILD_TYPE=RelWithDebInfo
             DOLFINX_CMAKE_CXX_FLAGS=-O2
             BASEIMAGE=${{ env.BASEIMAGE }}
           context: .

--- a/docker/Dockerfile.end-user
+++ b/docker/Dockerfile.end-user
@@ -90,7 +90,7 @@ ONBUILD RUN cd dolfinx && \
     PETSC_ARCH=linux-gnu-real64-32 cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-real -DCMAKE_BUILD_TYPE=${DOLFINX_CMAKE_BUILD_TYPE} -DCMAKE_CXX_FLAGS=${DOLFINX_CMAKE_CXX_FLAGS} ../cpp && \
     ninja install && \
     cd ../python && \
-    PETSC_ARCH=linux-gnu-real64-32 pip3 install -v --config-settings=cmake.define.-DCMAKE_CXX_FLAGS="${DOLFINX_CMAKE_CXX_FLAGS}" \
+    PETSC_ARCH=linux-gnu-real64-32 pip3 install -v \
       --config-settings=cmake.build-type="${DOLFINX_CMAKE_BUILD_TYPE}"  --no-build-isolation --check-build-dependencies \
       --target /usr/local/dolfinx-real/lib/python${PYTHON_VERSION}/dist-packages --no-dependencies --no-cache-dir . && \
     git clean -fdx && \
@@ -101,7 +101,7 @@ ONBUILD RUN cd dolfinx && \
     ninja install && \
     . /usr/local/dolfinx-complex/lib/dolfinx/dolfinx.conf && \
     cd ../python && \
-    PETSC_ARCH=linux-gnu-complex128-32 pip3 install -v --config-settings=cmake.define.-DCMAKE_CXX_FLAGS="${DOLFINX_CMAKE_CXX_FLAGS}" \
+    PETSC_ARCH=linux-gnu-complex128-32 pip3 install -v \
       --config-settings=cmake.build-type="${DOLFINX_CMAKE_BUILD_TYPE}" --no-build-isolation --check-build-dependencies \
       --target /usr/local/dolfinx-complex/lib/python${PYTHON_VERSION}/dist-packages --no-dependencies --no-cache-dir .
 


### PR DESCRIPTION
Related to the nightly timings #2891.
We still have a regression with the introduction of nanobind, but now we are down to a halving in performance.