### PR TITLE
Change nanobind build options to remove `-Os`

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -41,6 +41,7 @@ endif()
 # target_link_libraries
 nanobind_add_module(
   cpp
+  NOMINSIZE
   MODULE
   dolfinx/wrappers/dolfinx.cpp
   dolfinx/wrappers/assemble.cpp

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -42,7 +42,6 @@ endif()
 nanobind_add_module(
   cpp
   NOMINSIZE
-  MODULE
   dolfinx/wrappers/dolfinx.cpp
   dolfinx/wrappers/assemble.cpp
   dolfinx/wrappers/common.cpp


### PR DESCRIPTION
With gcc, `-Os` (recommended by nanobind) can lead to significantly slower binaries than `-O2`. DOLFINx has considerable templated code, which gets compiled by the nanobind wrappers. This makes performance of the wrapper library sensitive to the compiler options.

This improves the run-time of #2891 to be better than in 0.7.1