### PR TITLE
Increase again number of cores on ARM buildjet runners while building Docker end-user image

### DIFF
--- a/.github/workflows/docker-end-user.yml
+++ b/.github/workflows/docker-end-user.yml
@@ -64,7 +64,7 @@ jobs:
           - arch_tag: amd64
             os: ubuntu-latest
           - arch_tag: arm64
-            os: buildjet-4vcpu-ubuntu-2204-arm
+            os: buildjet-8vcpu-ubuntu-2204-arm
     runs-on: ${{ matrix.os }}
     steps:
       - name: Create tag without image name


### PR DESCRIPTION
We are now back to https://github.com/FEniCS/dolfinx/issues/2846, see log in https://github.com/FEniCS/dolfinx/actions/runs/6917539955/job/18818837676

I'll temporarily increase back to 8 cores, which was the temporary fix in https://github.com/FEniCS/dolfinx/pull/2860
and re-open https://github.com/FEniCS/dolfinx/issues/2861 as a reminder to revert this change.

After test in https://github.com/FEniCS/dolfinx/actions/runs/6919475270 runs successfully, I'll merge this