### PR TITLE
Adds an action to quickly update stable image tag

### DIFF
--- a/.github/workflows/docker-update-stable.yml
+++ b/.github/workflows/docker-update-stable.yml
@@ -6,7 +6,6 @@ name: Docker update stable tag
 #
 #   dolfinx/dolfinx:stable 
 #   dolfinx/lab:stable 
-#   dolfinx/dev-env:stable 
 #   dolfinx/dolfinx-onbuild:stable
 
 on:
@@ -47,12 +46,10 @@ jobs:
         run: |
            ./regctl image copy dolfinx/dolfinx:${{ inputs.tag }} dolfinx/dolfinx:stable 
            ./regctl image copy dolfinx/lab:${{ inputs.tag }} dolfinx/lab:stable 
-           ./regctl image copy dolfinx/dev-env:${{ inputs.tag }} dolfinx/dev-env:stable 
            ./regctl image copy dolfinx/dolfinx-onbuild:${{ inputs.tag }} dolfinx/dolfinx-onbuild:stable
       
       - name: Link supplied tag to stable on ghcr.io
         run: |
            ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx:stable 
            ./regctl image copy ghcr.io/fenics/dolfinx/lab:${{ inputs.tag }} ghcr.io/fenics/dolfinx/lab:stable 
-           ./regctl image copy ghcr.io/fenics/dolfinx/dev-env:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dev-env:stable 
            ./regctl image copy ghcr.io/dolfinx/dolfinx-onbuild:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx-onbuild:stable

--- a/.github/workflows/docker-update-stable.yml
+++ b/.github/workflows/docker-update-stable.yml
@@ -38,13 +38,14 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install regclient
+      - name: Install regctl
         run: |
           wget -O ./regctl https://github.com/regclient/regclient/releases/download/v0.5.4/regctl-linux-amd64
           chmod +x ./regctl
 
       - name: Link supplied tag to stable on docker.io
         run: |
+           ls -a
            regctl image copy dolfinx/dolfinx:${{ inputs.tag }} dolfinx/dolfinx:stable 
            regctl image copy dolfinx/lab:${{ inputs.tag }} dolfinx/lab:stable 
            regctl image copy dolfinx/dev-env:${{ inputs.tag }} dolfinx/dev-env:stable 

--- a/.github/workflows/docker-update-stable.yml
+++ b/.github/workflows/docker-update-stable.yml
@@ -45,15 +45,14 @@ jobs:
 
       - name: Link supplied tag to stable on docker.io
         run: |
-           ls -a
-           regctl image copy dolfinx/dolfinx:${{ inputs.tag }} dolfinx/dolfinx:stable 
-           regctl image copy dolfinx/lab:${{ inputs.tag }} dolfinx/lab:stable 
-           regctl image copy dolfinx/dev-env:${{ inputs.tag }} dolfinx/dev-env:stable 
-           regctl image copy dolfinx/dolfinx-onbuild:${{ inputs.tag }} dolfinx/dolfinx-onbuild:stable
+           ./regctl image copy dolfinx/dolfinx:${{ inputs.tag }} dolfinx/dolfinx:stable 
+           ./regctl image copy dolfinx/lab:${{ inputs.tag }} dolfinx/lab:stable 
+           ./regctl image copy dolfinx/dev-env:${{ inputs.tag }} dolfinx/dev-env:stable 
+           ./regctl image copy dolfinx/dolfinx-onbuild:${{ inputs.tag }} dolfinx/dolfinx-onbuild:stable
       
       - name: Link supplied tag to stable on ghcr.io
         run: |
-           regctl image copy ghcr.io/fenics/dolfinx/dolfinx:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx:stable 
-           regctl image copy ghcr.io/fenics/dolfinx/lab:${{ inputs.tag }} ghcr.io/fenics/dolfinx/lab:stable 
-           regctl image copy ghcr.io/fenics/dolfinx/dev-env:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dev-env:stable 
-           regctl image copy ghcr.io/dolfinx/dolfinx-onbuild:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx-onbuild:stable
+           ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx:stable 
+           ./regctl image copy ghcr.io/fenics/dolfinx/lab:${{ inputs.tag }} ghcr.io/fenics/dolfinx/lab:stable 
+           ./regctl image copy ghcr.io/fenics/dolfinx/dev-env:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dev-env:stable 
+           ./regctl image copy ghcr.io/dolfinx/dolfinx-onbuild:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx-onbuild:stable

--- a/.github/workflows/docker-update-stable.yml
+++ b/.github/workflows/docker-update-stable.yml
@@ -4,7 +4,7 @@ name: Docker update stable tag
 # Links/updates stable docker tags to specified version.
 # This should be used after building a specific tagged image e.g. `:v0.7.2`.
 #
-#   dolfinx/dolfinx:stable 
+#   dolfinx/dolfinx:stable
 #   dolfinx/lab:stable
 #   dolfinx/dev-env:stable
 #   dolfinx/dolfinx-onbuild:stable
@@ -30,7 +30,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -45,14 +45,14 @@ jobs:
 
       - name: Link supplied tag to stable on docker.io
         run: |
-           ./regctl image copy dolfinx/dolfinx:${{ inputs.tag }} dolfinx/dolfinx:stable 
+           ./regctl image copy dolfinx/dolfinx:${{ inputs.tag }} dolfinx/dolfinx:stable
            ./regctl image copy dolfinx/dev-env:${{ inputs.tag }} dolfinx/dev-env:stable
-           ./regctl image copy dolfinx/lab:${{ inputs.tag }} dolfinx/lab:stable 
+           ./regctl image copy dolfinx/lab:${{ inputs.tag }} dolfinx/lab:stable
            ./regctl image copy dolfinx/dolfinx-onbuild:${{ inputs.tag }} dolfinx/dolfinx-onbuild:stable
-      
+
       - name: Link supplied tag to stable on ghcr.io
         run: |
-           ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx:stable 
+           ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx:stable
            ./regctl image copy ghcr.io/fenics/dolfinx/dev-env:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dev-env:stable
-           ./regctl image copy ghcr.io/fenics/dolfinx/lab:${{ inputs.tag }} ghcr.io/fenics/dolfinx/lab:stable 
+           ./regctl image copy ghcr.io/fenics/dolfinx/lab:${{ inputs.tag }} ghcr.io/fenics/dolfinx/lab:stable
            ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx-onbuild:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx-onbuild:stable

--- a/.github/workflows/docker-update-stable.yml
+++ b/.github/workflows/docker-update-stable.yml
@@ -55,4 +55,4 @@ jobs:
            ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx:stable 
            ./regctl image copy ghcr.io/fenics/dolfinx/dev-env:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dev-env:stable
            ./regctl image copy ghcr.io/fenics/dolfinx/lab:${{ inputs.tag }} ghcr.io/fenics/dolfinx/lab:stable 
-           ./regctl image copy ghcr.io/dolfinx/dolfinx-onbuild:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx-onbuild:stable
+           ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx-onbuild:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx-onbuild:stable

--- a/.github/workflows/docker-update-stable.yml
+++ b/.github/workflows/docker-update-stable.yml
@@ -5,7 +5,8 @@ name: Docker update stable tag
 # This should be used after building a specific tagged image e.g. `:v0.7.2`.
 #
 #   dolfinx/dolfinx:stable 
-#   dolfinx/lab:stable 
+#   dolfinx/lab:stable
+#   dolfinx/dev-env:stable
 #   dolfinx/dolfinx-onbuild:stable
 
 on:
@@ -45,11 +46,13 @@ jobs:
       - name: Link supplied tag to stable on docker.io
         run: |
            ./regctl image copy dolfinx/dolfinx:${{ inputs.tag }} dolfinx/dolfinx:stable 
+           ./regctl image copy dolfinx/dev-env:${{ inputs.tag }} dolfinx/dev-env:stable
            ./regctl image copy dolfinx/lab:${{ inputs.tag }} dolfinx/lab:stable 
            ./regctl image copy dolfinx/dolfinx-onbuild:${{ inputs.tag }} dolfinx/dolfinx-onbuild:stable
       
       - name: Link supplied tag to stable on ghcr.io
         run: |
            ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx:stable 
+           ./regctl image copy ghcr.io/fenics/dolfinx/dev-env:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dev-env:stable
            ./regctl image copy ghcr.io/fenics/dolfinx/lab:${{ inputs.tag }} ghcr.io/fenics/dolfinx/lab:stable 
            ./regctl image copy ghcr.io/dolfinx/dolfinx-onbuild:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx-onbuild:stable

--- a/.github/workflows/docker-update-stable.yml
+++ b/.github/workflows/docker-update-stable.yml
@@ -45,14 +45,14 @@ jobs:
 
       - name: Link supplied tag to stable on docker.io
         run: |
-           regctl image copy dolfinx/dolfinx:${{ github.event.input.tag }} dolfinx/dolfinx:stable 
-           regctl image copy dolfinx/lab:${{ github.event.input.tag }} dolfinx/lab:stable 
-           regctl image copy dolfinx/dev-env:${{ github.event.input.tag }} dolfinx/dev-env:stable 
-           regctl image copy dolfinx/dolfinx-onbuild:${{ github.event.input.tag }} dolfinx/dolfinx-onbuild:stable
+           regctl image copy dolfinx/dolfinx:${{ inputs.tag }} dolfinx/dolfinx:stable 
+           regctl image copy dolfinx/lab:${{ inputs.tag }} dolfinx/lab:stable 
+           regctl image copy dolfinx/dev-env:${{ inputs.tag }} dolfinx/dev-env:stable 
+           regctl image copy dolfinx/dolfinx-onbuild:${{ inputs.tag }} dolfinx/dolfinx-onbuild:stable
       
       - name: Link supplied tag to stable on ghcr.io
         run: |
-           regctl image copy ghcr.io/fenics/dolfinx/dolfinx:${{ github.event.input.tag }} ghcr.io/fenics/dolfinx/dolfinx:stable 
-           regctl image copy ghcr.io/fenics/dolfinx/lab:${{ github.event.input.tag }} ghcr.io/fenics/dolfinx/lab:stable 
-           regctl image copy ghcr.io/fenics/dolfinx/dev-env:${{ github.event.input.tag }} ghcr.io/fenics/dolfinx/dev-env:stable 
-           regctl image copy ghcr.io/dolfinx/dolfinx-onbuild:${{ github.event.input.tag }} ghcr.io/fenics/dolfinx/dolfinx-onbuild:stable
+           regctl image copy ghcr.io/fenics/dolfinx/dolfinx:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx:stable 
+           regctl image copy ghcr.io/fenics/dolfinx/lab:${{ inputs.tag }} ghcr.io/fenics/dolfinx/lab:stable 
+           regctl image copy ghcr.io/fenics/dolfinx/dev-env:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dev-env:stable 
+           regctl image copy ghcr.io/dolfinx/dolfinx-onbuild:${{ inputs.tag }} ghcr.io/fenics/dolfinx/dolfinx-onbuild:stable

--- a/.github/workflows/docker-update-stable.yml
+++ b/.github/workflows/docker-update-stable.yml
@@ -1,0 +1,54 @@
+---
+name: Link stable Docker tag
+
+# Links stable docker tag to specified version.
+#
+# This should be used after building a specific version of Docker.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "link stable to this tag"
+        type: string
+        required: true
+
+jobs:
+  update_stable_tag:
+    name: Update stable tags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install regclient
+        run: |
+          wget -O regctl https://github.com/regclient/regclient/releases/download/v0.5.4/regctl-linux-amd64
+          chmod +x regctl
+
+      - name: Link supplied tag to stable on docker.io
+        run: |
+           regctl image copy dolfinx/dolfinx:${{ github.event.input.tag }} dolfinx/dolfinx:stable 
+           regctl image copy dolfinx/lab:${{ github.event.input.tag }} dolfinx/lab:stable 
+           regctl image copy dolfinx/dev-env:${{ github.event.input.tag }} dolfinx/dev-env:stable 
+           regctl image copy dolfinx/dolfinx-onbuild:${{ github.event.input.tag }} dolfinx/dolfinx-onbuild:stable
+      
+      - name: Link supplied tag to stable on ghcr.io
+        run: |
+           regctl image copy ghcr.io/fenics/dolfinx/dolfinx:${{ github.event.input.tag }} ghcr.io/fenics/dolfinx/dolfinx:stable 
+           regctl image copy ghcr.io/fenics/dolfinx/lab:${{ github.event.input.tag }} ghcr.io/fenics/dolfinx/lab:stable 
+           regctl image copy ghcr.io/fenics/dolfinx/dev-env:${{ github.event.input.tag }} ghcr.io/fenics/dolfinx/dev-env:stable 
+           regctl image copy ghcr.io/dolfinx/dolfinx-onbuild:${{ github.event.input.tag }} ghcr.io/fenics/dolfinx/dolfinx-onbuild:stable

--- a/.github/workflows/docker-update-stable.yml
+++ b/.github/workflows/docker-update-stable.yml
@@ -1,15 +1,19 @@
 ---
-name: Link stable Docker tag
+name: Update stable Docker tag
 
-# Links stable docker tag to specified version.
+# Links/updates stable docker tags to specified version.
+# This should be used after building a specific tagged image e.g. `:v0.7.2`.
 #
-# This should be used after building a specific version of Docker.
+#   dolfinx/dolfinx:stable 
+#   dolfinx/lab:stable 
+#   dolfinx/dev-env:stable 
+#   dolfinx/dolfinx-onbuild:stable
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "link stable to this tag"
+        description: "link :stable to tag"
         type: string
         required: true
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -156,15 +156,8 @@ Tagged Docker images will be pushed to Dockerhub.
 
     docker run -ti dolfinx/dolfinx:v0.5.0
 
-Do *not* update the `stable` tag using `docker pull` and `docker push`. Instead,
-install the `regclient` utility https://github.com/regclient/regclient using the
-provided binaries. `regclient` can properly handle copying multi-architecture images.
-
-    regctl registry login docker.io
-    regctl image copy dolfinx/dolfinx:<tag> dolfinx/dolfinx:stable 
-    regctl image copy dolfinx/lab:<tag> dolfinx/lab:stable 
-    regctl image copy dolfinx/dev-env:<tag> dolfinx/dev-env:stable 
-    regctl image copy dolfinx/dolfinx-onbuild:<tag> dolfinx/dolfinx-onbuild:stable
+Use the Update stable Docker tag workflow to update/link `:stable` to e.g.
+`v0.5.0`.
 
 ### pypa
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,6 +32,7 @@ UFL still runs on the year-based release scheme.
 
 1. Merge `main` into `release` resolving all conflicts in favour of `main`.
 
+       git pull
        git checkout release
        git merge --no-commit main
        git checkout --theirs main .
@@ -47,12 +48,13 @@ UFL still runs on the year-based release scheme.
 
 4. Commit and push.
 
-5. Check `git diff main` for obvious errors.
+5. Check `git diff origin/main` for obvious errors.
 
 ### UFL version bump
 
 1. Merge `main` into `release` resolving all conflicts in favour of `main`.
 
+       git pull
        git checkout release
        git merge --no-commit main
        git checkout --theirs main .
@@ -62,12 +64,13 @@ UFL still runs on the year-based release scheme.
 
 3. Commit and push.
 
-4. Check `git diff main` for obvious errors.
+4. Check `git diff origin/main` for obvious errors.
 
 ### FFCx version bump
 
 1. Merge `main` into `release` resolving all conflicts in favour of `main`.
 
+       git pull
        git checkout release
        git merge --no-commit main
        git checkout --theirs main .
@@ -85,16 +88,17 @@ UFL still runs on the year-based release scheme.
 
 6. Commit and push.
 
-7. Check `git diff main` for obvious errors.
+7. Check `git diff origin/main` for obvious errors.
 
 ### DOLFINx
 
 1. Merge `main` into `release` resolving all conflicts in favour of `main`.
 
+       git pull
        git checkout release
        git merge --no-commit main
        git checkout --theirs main .
-       git diff main
+       git diff origin/main
 
 2. In `cpp/CMakeLists.txt` change the version number near the top of the file,
    e.g. `0.5.0`.
@@ -109,7 +113,7 @@ UFL still runs on the year-based release scheme.
 
 5. Commit and push.
 
-6. Check `git diff main` for obvious errors.
+6. Check `git diff origin/main` for obvious errors.
 
 ## Integration testing
 
@@ -133,7 +137,7 @@ Full stack: https://github.com/FEniCS/dolfinx/actions/workflows/ccpp.yml
 
 ## Tagging
 
-Make appropriate version tags in each repository. UFL does not use the v prefix.
+Make appropriate version tags in each repository. UFL does not use the `v` prefix.
 
     git tag v0.5.0
     git push --tags origin
@@ -156,7 +160,7 @@ Tagged Docker images will be pushed to Dockerhub.
 
     docker run -ti dolfinx/dolfinx:v0.5.0
 
-Use the Update stable Docker tag workflow to update/link `:stable` to e.g.
+Use the *Docker update stable* tag workflow to update/link `:stable` to e.g.
 `v0.5.0`.
 
 ### pypa
@@ -184,8 +188,9 @@ Aside from version numbering changes, it is easier to merge changes onto `main`
 and then cherry-pick or merge back onto `release`.
 
 If a mistake is noticed soon after making a tag then you can delete the tag and
-recreate it. After GitHub releases or pypa packages are pushed you must create .post0 tags
-or make minor version bumps.
+recreate it. It is also possible to recreate GitHub releases. After pypa
+packages are pushed you must create .post0 tags or make minor version bumps, as
+pypa is immutable.
 
 ### GitHub releases
 


### PR DESCRIPTION
Installs regclient and links :stable to e.g. :v0.7.2. To be used after creating tagged test/development/end-user images using the other actions.