### PR TITLE
Purge `cppimport` from `Dockerfile`s

### DIFF
--- a/docker/Dockerfile.oneapi
+++ b/docker/Dockerfile.oneapi
@@ -58,7 +58,7 @@ ENV CC=icx \
 
 # Install Python packages (via pip)
 RUN . /opt/intel/oneapi/setvars.sh && \
-    pip install --no-cache-dir cppimport matplotlib mpi4py nanobind==${NANOBIND_VERSION} pytest pytest-xdist scikit-build-core[pyproject]
+    pip install --no-cache-dir matplotlib mpi4py nanobind==${NANOBIND_VERSION} pytest pytest-xdist scikit-build-core[pyproject]
 
 # Install KaHIP
 RUN . /opt/intel/oneapi/setvars.sh && \

--- a/docker/Dockerfile.redhat
+++ b/docker/Dockerfile.redhat
@@ -67,7 +67,7 @@ RUN curl -L -O https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${HDF5_SERIES
 # - Second set of dependencies for running DOLFINx tests
 RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools && \
     python3 -m pip install --no-cache-dir cffi numba mpi4py nanobind scikit-build-core[pyproject] wheel && \
-    python3 -m pip install --no-cache-dir cppimport pytest pytest-xdist scipy matplotlib
+    python3 -m pip install --no-cache-dir pytest pytest-xdist scipy matplotlib
 
 # Build PETSc
 RUN git clone -b v${PETSC_VERSION}  https://gitlab.com/petsc/petsc.git && \

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -154,7 +154,7 @@ RUN if [ "$MPI" = "mpich" ]; then \
 #   documentation or run tests.
 RUN pip3 install --no-cache-dir --upgrade setuptools pip && \
     pip3 install --no-cache-dir cffi mpi4py numba numpy==${NUMPY_VERSION} scikit-build-core[pyproject] && \
-    pip3 install --no-cache-dir breathe clang-format cppimport cmakelang flake8 isort jupytext matplotlib mypy myst-parser nanobind==${NANOBIND_VERSION} pytest pytest-xdist ruff scipy sphinx sphinx_rtd_theme types-setuptools
+    pip3 install --no-cache-dir breathe clang-format cmakelang flake8 isort jupytext matplotlib mypy myst-parser nanobind==${NANOBIND_VERSION} pytest pytest-xdist ruff scipy sphinx sphinx_rtd_theme types-setuptools
 
 # Install KaHIP
 RUN wget -nc --quiet https://github.com/kahip/kahip/archive/v${KAHIP_VERSION}.tar.gz && \


### PR DESCRIPTION
Not needed anymore after transition to `nanobind`.

Base images were manually rebuilt in:
* oneapi: https://github.com/FEniCS/dolfinx/actions/runs/7002629672
* redhat: https://github.com/FEniCS/dolfinx/actions/runs/7002634989
* debian: https://github.com/FEniCS/dolfinx/actions/runs/7002639083

before opening this PR, so that CI jobs associated to the PR would run on the updated docker images.