### PR TITLE
Fix misleading commit message when updating documentation repository

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -210,5 +210,5 @@ jobs:
           git config --global user.email "fenics@github.com"
           git config --global user.name "FEniCS GitHub Actions"
           git add --all
-          git commit --allow-empty -m "Update dolfinx docs FEniCS/dolfinx@${{ github.sha }}"
+          git commit --allow-empty -m "C++/Python FEniCS/dolfinx@${{ github.sha }}"
           git push

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -210,5 +210,5 @@ jobs:
           git config --global user.email "fenics@github.com"
           git config --global user.name "FEniCS GitHub Actions"
           git add --all
-          git commit --allow-empty -m "C++ FEniCS/dolfinx@${{ github.sha }}"
+          git commit --allow-empty -m "Update dolfinx docs FEniCS/dolfinx@${{ github.sha }}"
           git push


### PR DESCRIPTION
Noticed this while I was investigating whether to prepare an equivalent of https://github.com/FEniCS/basix/pull/751 for `dolfinx`. At first glance I couldn't understand why there wasn't a push of the python part of the documentation: there was, but it was stored alongside the cpp in a commit message starting with `C++`.