### PR TITLE
Fix broken links to integration test workflows in `RELEASE.md`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -123,15 +123,13 @@ and mistakes before they reach tagged versions.
 At each of the following links run the GitHub Action Workflow manually using
 the `release` branch in all fields. *Only proceed to tagging once all tests pass.*
 
-### Basix integration
-
 Basix with FFCx: https://github.com/FEniCS/basix/actions/workflows/ffcx-tests.yml
 
-Basix with DOLFINx: https://github.com/FEniCS/basix/actions/workflows/dolfin-tests.yml
+Basix with DOLFINx: https://github.com/FEniCS/basix/actions/workflows/dolfinx-tests.yml
 
-UFL with FEniCSx (TODO): https://github.com/FEniCS/ufl/actions/workflows/fenicsx-tests.yml
+UFL with FEniCSx: https://github.com/FEniCS/ufl/actions/workflows/fenicsx-tests.yml
 
-FFCx with DOLFINx: https://github.com/FEniCS/ffcx/actions/workflows/dolfin-tests.yml
+FFCx with DOLFINx: https://github.com/FEniCS/ffcx/actions/workflows/dolfinx-tests.yml
 
 Full stack: https://github.com/FEniCS/dolfinx/actions/workflows/ccpp.yml
 
@@ -153,7 +151,7 @@ of tags. You will need to manually update the `README.md`.
 
 Run the workflow at https://github.com/FEniCS/dolfinx/actions/workflows/docker.yml
 
-Tag prefix should be the same as the DOLFINx release e.g. `v0.5.0`. 
+Tag prefix should be the same as the DOLFINx release e.g. `v0.5.0`.
 Git refs should be appropriate tags for each component.
 
 Tagged Docker images will be pushed to Dockerhub.


### PR DESCRIPTION
I renamed them in https://github.com/FEniCS/ffcx/pull/638 https://github.com/FEniCS/basix/pull/739