### PR TITLE
Sort ghost indices in sub-dofmap based on original ordering

### DIFF
--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -177,6 +177,8 @@ def test_collapse(W, V):
 
     f_0 = Function(Ws[0][0])
     f_1 = Function(V)
+    for (Wi, _) in Ws:
+        assert np.allclose(Wi.dofmap.index_map.ghosts, W.dofmap.index_map.ghosts)
     assert f_0.vector.getSize() == f_1.vector.getSize()
 
 


### PR DESCRIPTION
Relates to: #2881, but now in the context of usage in #2929.
Currently, collapsing a dofmap of a blocked space states that is does not reorder the degrees of freedom.
However, the ghost dofs are re-ordered, as the new index map is created with `create_sub_map`.

This PR adds in a sorting of the ghost indices, based on the indices of the initial ghosts.
It also relates to #2919.