### PR TITLE
Remove `dolfinx.nls` from Python documentation

### DIFF
--- a/python/doc/source/api.rst
+++ b/python/doc/source/api.rst
@@ -21,7 +21,6 @@ Public user interface
    dolfinx.jit
    dolfinx.la
    dolfinx.mesh
-   dolfinx.nls
    dolfinx.nls.petsc
    dolfinx.pkgconfig
    dolfinx.plot


### PR DESCRIPTION
Nothing in this module, except its submodule `dolfinx.nls.petsc`.