### PR TITLE
Update documentation of `dolfinx.fem`

### DIFF
--- a/python/dolfinx/fem/__init__.py
+++ b/python/dolfinx/fem/__init__.py
@@ -6,11 +6,13 @@
 """Tools for assembling and manipulating finite element forms."""
 
 from dolfinx.cpp.fem import (IntegralType,
-                             create_nonmatching_meshes_interpolation_data, transpose_dofmap)
+                             create_nonmatching_meshes_interpolation_data)
 from dolfinx.cpp.fem import create_sparsity_pattern as _create_sparsity_pattern
+from dolfinx.cpp.fem import transpose_dofmap
 from dolfinx.fem.assemble import (apply_lifting, assemble_matrix,
                                   assemble_scalar, assemble_vector,
-                                  create_matrix, create_vector, set_bc)
+                                  create_matrix, create_vector,
+                                  pack_coefficients, pack_constants, set_bc)
 from dolfinx.fem.bcs import (DirichletBC, bcs_by_block, dirichletbc,
                              locate_dofs_geometrical, locate_dofs_topological)
 from dolfinx.fem.dofmap import DofMap
@@ -43,4 +45,5 @@ __all__ = [
     "DirichletBC", "dirichletbc", "bcs_by_block", "DofMap", "Form",
     "form", "IntegralType", "create_vector",
     "locate_dofs_geometrical", "locate_dofs_topological",
-    "extract_function_spaces", "transpose_dofmap", "create_nonmatching_meshes_interpolation_data"]
+    "extract_function_spaces", "transpose_dofmap", "create_nonmatching_meshes_interpolation_data",
+    "pack_coefficients", "pack_constants"]

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -146,7 +146,7 @@ def assemble_vector(b: np.ndarray, L: Form, constants=None, coeffs=None) -> np.n
     Args:
         b: The array to assemble the contribution from the calling MPI
             rank into. It must have the required size.
-        L: The linear form assemble.
+        L: The linear form to assemble.
         constants: Constants that appear in the form. If not provided,
             any required constants will be computed.
         coeffs: Coefficients that appear in the form. If not provided,

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -221,10 +221,9 @@ def assemble_matrix(A: la.MatrixCSR, a: Form, bcs: typing.Optional[typing.List[D
         bcs: Boundary conditions that affect the assembled matrix.
             Degrees-of-freedom constrained by a boundary condition will
             have their rows/columns zeroed and the value ``diagonal``
-            set on on
+            set on the matrix diagonal.
         constants: Constants that appear in the form. If not provided,
             any required constants will be computed.
-            the matrix diagonal.
         coeffs: Coefficients that appear in the form. If not provided,
             any required coefficients will be computed.
 
@@ -256,7 +255,7 @@ def _assemble_new_matrix(a: Form, bcs: typing.Optional[typing.List[DirichletBC]]
         bcs: Boundary conditions that affect the assembled matrix.
             Degrees-of-freedom constrained by a boundary condition will
             have their rows/columns zeroed and the value ``diagonal``
-            set on on the matrix diagonal.
+            set on the matrix diagonal.
         constants: Constants that appear in the form. If not provided,
             any required constants will be computed.
         coeffs: Coefficients that appear in the form. If not provided,

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -199,10 +199,10 @@ def assemble_vector(b: PETSc.Vec, L: Form, constants=None, coeffs=None) -> PETSc
 
 @assemble_vector.register
 def _assemble_vector_new(L: Form, constants=None, coeffs=None) -> PETSc.Vec:
-    """Assemble linear form into a new PETSc vector.
+    """Create a PETSc vector and assemble linear form into it.
 
     Note:
-        The returned vector is not finalised, i.e. ghost values arefunctools not
+        The returned vector is not finalised, i.e. ghost values are not
         accumulated on the owning processes.
 
     Args:

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -448,7 +448,7 @@ def _assemble_matrix_nest_mat(A: PETSc.Mat, a: typing.List[typing.List[Form]],
         for j, (a_block, const, coeff) in enumerate(zip(a_row, const_row, coeff_row)):
             if a_block is not None:
                 Asub = A.getNestSubMatrix(i, j)
-                assemble_matrix_mat(Asub, a_block, bcs, diagonal, const, coeff)
+                assemble_matrix(Asub, a_block, bcs, diagonal, const, coeff)
             elif i == j:
                 for bc in bcs:
                     row_forms = [row_form for row_form in a_row if row_form is not None]
@@ -787,7 +787,7 @@ class NonlinearProblem:
 
         """
         A.zeroEntries()
-        assemble_matrix_mat(A, self._a, self.bcs)
+        assemble_matrix(A, self._a, self.bcs)
         A.assemble()
 
 

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -339,7 +339,7 @@ def assemble_matrix(A: PETSc.Mat, a: Form, bcs: typing.List[DirichletBC] = [],
     """Assemble bilinear form into an existing matrix.
 
     Note:
-        The returned matrix is not 'assembled', i.e. ghost contributions
+        The matrix is not zeroed before assembly and is not 'assembled', i.e. ghost contributions
         have not been communicated.
 
     Args:

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -215,7 +215,7 @@ def _assemble_vector_new(L: Form, constants=None, coeffs=None) -> PETSc.Vec:
     b = create_petsc_vector(L.function_spaces[0].dofmap.index_map,
                             L.function_spaces[0].dofmap.index_map_bs)
     with b.localForm() as b_local:
-        _assemble._assemble_vector_array(b_local.array_w, L, constants, coeffs)
+        _assemble.assemble_vector(b_local.array_w, L, constants, coeffs)
     return b
 
 
@@ -246,7 +246,7 @@ def _assemble_vector_nest_vec(b: PETSc.Vec, L: typing.List[Form], constants=None
     coeffs = [None] * len(L) if coeffs is None else coeffs
     for b_sub, L_sub, const, coeff in zip(b.getNestSubVecs(), L, constants, coeffs):
         with b_sub.localForm() as b_local:
-            _assemble._assemble_vector_array(b_local.array_w, L_sub, const, coeff)
+            _assemble.assemble_vector(b_local.array_w, L_sub, const, coeff)
     return b
 
 


### PR DESCRIPTION
Documenting function with most arguments first, as it is the only one picked up by sphinx.

It is also more natural, as we want people to be aware of assembling into an existing tensor.

Also exposes `pack_constants` and `pack_coefficients`, as they can be used with assembly.