### PR TITLE
Disable Spack CI 0.7.2 Python build

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -121,7 +121,7 @@ jobs:
           spack env create py-release
           spack env activate py-release
           spack add py-fenics-dolfinx
-          spack install
+          spack install -j 2
       - name: Run DOLFINx (Python, release) test
         run: |
           . ./spack/share/spack/setup-env.sh

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -115,15 +115,16 @@ jobs:
           spack env activate py-main
           mpirun -np 2 python3 ./dolfinx-main/python/demo/demo_elasticity.py
 
-      - name: Build DOLFINx (Python, release version)
-        run: |
-          . ./spack/share/spack/setup-env.sh
-          spack env create py-release
-          spack env activate py-release
-          spack add py-fenics-dolfinx
-          spack install -j 2
-      - name: Run DOLFINx (Python, release) test
-        run: |
-          . ./spack/share/spack/setup-env.sh
-          spack env activate py-release
-          mpirun -np 2 python3 ./dolfinx-release/python/demo/demo_elasticity.py
+      # Disabled due to capicty issues on Actions and LTO with pybind11
+      # - name: Build DOLFINx (Python, release version)
+      #   run: |
+      #     . ./spack/share/spack/setup-env.sh
+      #     spack env create py-release
+      #     spack env activate py-release
+      #     spack add py-fenics-dolfinx
+      #     spack install -j 2
+      # - name: Run DOLFINx (Python, release) test
+      #   run: |
+      #     . ./spack/share/spack/setup-env.sh
+      #     spack env activate py-release
+      #     mpirun -np 2 python3 ./dolfinx-release/python/demo/demo_elasticity.py


### PR DESCRIPTION
DOFLINx v0.7.2 and earlier use pybind11 with link-time optimisation (LTO). This uses a lot of RAM, and exhausts the Actions runner.

Future v0.8 uses nanobind in place of pybind11, which is lighter and doesn't require LTO. Release version testing can be added once 0.8 is released.