### PR TITLE
Update GMSH quadrilateral recombination options to force pure quadrilateral meshes

### DIFF
--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -607,7 +607,9 @@ def test_gmsh_input_2d(order, cell_type):
     gmsh.option.setNumber("Mesh.CharacteristicLengthMax", res)
 
     if cell_type == CellType.quadrilateral:
-        gmsh.option.setNumber("Mesh.Algorithm", 2 if order == 2 else 5)
+        gmsh.option.setNumber("Mesh.Algorithm", 2)
+        # Force mesh to have no triangles
+        gmsh.option.setNumber("Mesh.RecombinationAlgorithm", 3)
 
     gmsh.model.occ.addSphere(0, 0, 0, 1, tag=1)
     gmsh.model.occ.synchronize()


### PR DESCRIPTION
Resolves #2938.
Follows guidance from: https://gmsh.info/doc/texinfo/gmsh.html
> // The default recombination algorithm might leave some triangles in the mesh,
// if recombining all the triangles leads to badly shaped quads. In such cases,
// to generate full-quad meshes, you can either subdivide the resulting hybrid
// mesh (with Mesh.SubdivisionAlgorithm = 1), or use the full-quad recombination
// algorithm, which will automatically perform a coarser mesh followed by
// recombination, smoothing and subdivision. Uncomment the following line to try
// the full-quad algorithm:

Tested locally with: `ghcr.io/fenics/dolfinx/dolfinx:v0.7.2-r1@sha256:29c96c06ceda98a234de0d5f1a2c94e839fe0335a065d62c2ed1f56b9df76b22`