### PR TITLE
Fix `IndexMap->global_to_local()`

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -3,12 +3,12 @@
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
-
 #include "IndexMap.h"
 #include "sort.h"
 #include <algorithm>
 #include <cstdint>
 #include <functional>
+#include <iostream>
 #include <numeric>
 #include <span>
 #include <utility>
@@ -872,9 +872,6 @@ void IndexMap::global_to_local(std::span<const std::int64_t> global,
                  {
                    if (index >= range[0] and index < range[1])
                      return index - range[0];
-                   else if (index < global_to_local.front().first
-                            or index > global_to_local.back().first)
-                     return -1;
                    else
                    {
                      auto it = std::lower_bound(

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -865,8 +865,7 @@ void IndexMap::global_to_local(std::span<const std::int64_t> global,
   for (std::size_t i = 0; i < _ghosts.size(); ++i)
     global_to_local[i] = {_ghosts[i], i + local_size};
 
-  std::sort(global_to_local.begin(), global_to_local.end(),
-            [](auto a, auto b) { return a.first < b.first; });
+  std::sort(global_to_local.begin(), global_to_local.end());
   std::transform(global.begin(), global.end(), local.begin(),
                  [range = _local_range,
                   &global_to_local](std::int64_t index) -> std::int32_t

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -3,12 +3,12 @@
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
+
 #include "IndexMap.h"
 #include "sort.h"
 #include <algorithm>
 #include <cstdint>
 #include <functional>
-#include <iostream>
 #include <numeric>
 #include <span>
 #include <utility>


### PR DESCRIPTION
**Issue**
Current check for a global value coming into `global_to_local`  has several issues

1. If the global value is lower than the lowest existing ghost on process
2. If the value is within the range of the smallest and largest ghost value, but not equal

**Fixes**
- Check for equality if not at end of ghost array

Resolves #2962 
