### PR TITLE
Further typing fixes

### DIFF
--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -260,7 +260,7 @@ class Function(ufl.Coefficient):
                               _cpp.fem.Function_float32, _cpp.fem.Function_float64]
 
     def __init__(self, V: FunctionSpace, x: typing.Optional[la.Vector] = None,
-                 name: typing.Optional[str] = None, dtype: npt.DTypeLike = None):
+                 name: typing.Optional[str] = None, dtype: typing.Optional[npt.DTypeLike] = None):
         """Initialize a finite element Function.
 
         Args:

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -38,7 +38,7 @@ _gmsh_to_cells = {1: ("interval", 1), 2: ("triangle", 1),
                   92: ("hexahedron", 3)}
 
 
-def ufl_mesh(gmsh_cell: int, gdim: int, dtype=npt.DTypeLike) -> ufl.Mesh:
+def ufl_mesh(gmsh_cell: int, gdim: int, dtype: npt.DTypeLike) -> ufl.Mesh:
     """Create a UFL mesh from a Gmsh cell identifier and geometric dimension.
 
     See https://gmsh.info//doc/texinfo/gmsh.html#MSH-file-format.
@@ -60,7 +60,7 @@ def ufl_mesh(gmsh_cell: int, gdim: int, dtype=npt.DTypeLike) -> ufl.Mesh:
     cell = ufl.Cell(shape, geometric_dimension=gdim)
     element = basix.ufl.element(basix.ElementFamily.P, cell.cellname(), degree,
                                 basix.LagrangeVariant.equispaced, shape=(gdim,),
-                                gdim=gdim, dtype=dtype)
+                                gdim=gdim, dtype=dtype)  # type: ignore[arg-type]
     return ufl.Mesh(element)
 
 


### PR DESCRIPTION
Fixes to #2960 in addition to those already in #2967.

Should fix the runtime error 
```
E       TypeError: Cannot interpret 'typing.Union[numpy.dtype[typing.Any], NoneType, type[typing.Any], numpy._typing._dtype_like._SupportsDType[numpy.dtype[typing.Any]], str, tuple[typing.Any, int], tuple[typing.Any, typing.Union[typing.SupportsIndex, collections.abc.Sequence[typing.SupportsIndex]]], list[typing.Any], numpy._typing._dtype_like._DTypeDict, tuple[typing.Any, typing.Any]]' as a data type
```
that appears when calling `dolfinx.io.gmshio.ufl_mesh` e.g. in ngsPETSc by @UZerbinati at
https://github.com/NGSolve/ngsPETSc/actions/runs/7437684405/job/20235586388
(or at least, make it into the more meaningful error "from now on you must also pass dtype")