### PR TITLE
Remove some implicit PETSc from tests when not needed

### DIFF
--- a/python/test/unit/fem/test_dof_permuting.py
+++ b/python/test/unit/fem/test_dof_permuting.py
@@ -255,7 +255,7 @@ def test_evaluation(cell_type, space_type, space_order):
 
         for d in dofs:
             v = Function(V)
-            v.vector[:] = [1 if i == d else 0 for i in range(v.vector.local_size)]
+            v.x.array[:] = [1 if i == d else 0 for i in range(v.x.index_map.size_local)]
             values0 = v.eval(eval_points, [0 for i in eval_points])
             values1 = v.eval(eval_points, [1 for i in eval_points])
             if len(eval_points) == 1:
@@ -303,7 +303,7 @@ def test_integral(cell_type, space_type, space_order):
         tdim = mesh.topology.dim
         for d in dofs:
             v = Function(V)
-            v.vector[:] = [1 if i == d else 0 for i, _ in enumerate(v.vector[:])]
+            v.x.array[:] = [1 if i == d else 0 for i, _ in enumerate(v.x.array[:])]
             if space_type in ["RT", "BDM", "RTCF", "NCF", "BDMCF", "AAF"]:
                 # Hdiv
                 def normal(x):

--- a/python/test/unit/fem/test_function.py
+++ b/python/test/unit/fem/test_function.py
@@ -165,9 +165,9 @@ def test_interpolation_rank1(W):
 
     w = Function(W)
     w.interpolate(f)
-    x = w.vector
-    assert x.max()[1] == 3.0  # /NOSONAR
-    assert x.min()[1] == 1.0  # /NOSONAR
+    x = w.x.array
+    assert x.max() == 3.0  # /NOSONAR
+    assert x.min() == 1.0  # /NOSONAR
 
     num_vertices = W.mesh.topology.index_map(0).size_global
     assert round(w.x.norm(la.Norm.l1) - 6 * num_vertices, 7) == 0

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -177,7 +177,7 @@ def test_collapse(W, V):
 
     f_0 = Function(Ws[0][0])
     f_1 = Function(V)
-    assert f_0.vector.getSize() == f_1.vector.getSize()
+    assert f_0.x.index_map.size_global == f_1.x.index_map.size_global
 
 
 def test_argument_equality(mesh, V, V2, W, W2):


### PR DESCRIPTION
Change use of `.vector` to `.x.array` which removes a PETSc dependency for these tests.