### PR TITLE
Increase tolerance in some tests

### DIFF
--- a/python/test/unit/fem/test_fem_pipeline.py
+++ b/python/test/unit/fem/test_fem_pipeline.py
@@ -197,7 +197,7 @@ def run_dg_test(mesh, V, degree):
     M = form(M)
 
     error = mesh.comm.allreduce(assemble_scalar(M), op=MPI.SUM)
-    assert np.abs(error) < 1.0e-14
+    assert np.abs(error) < 1.0e-9
 
     solver.destroy()
     A.destroy()

--- a/python/test/unit/fem/test_fem_pipeline.py
+++ b/python/test/unit/fem/test_fem_pipeline.py
@@ -82,7 +82,7 @@ def run_scalar_test(mesh, V, degree):
     M = (u_exact - uh)**2 * dx
     M = form(M)
     error = mesh.comm.allreduce(assemble_scalar(M), op=MPI.SUM)
-    assert np.abs(error) < 1.0e-12
+    assert np.abs(error) < 1.0e-9
 
     solver.destroy()
     A.destroy()
@@ -123,7 +123,7 @@ def run_vector_test(mesh, V, degree):
     M = form(M)
 
     error = mesh.comm.allreduce(assemble_scalar(M), op=MPI.SUM)
-    assert np.abs(error) < 1.0e-14
+    assert np.abs(error) < 1.0e-9
 
     solver.destroy()
     A.destroy()


### PR DESCRIPTION
The tolerance in some tests is too tight.
Changing the order in which the operations are performed (ffcx kernels) can make some tests fail.