### PR TITLE
Change binary stripping settings for scikit-build-core

### DIFF
--- a/docker/Dockerfile.end-user
+++ b/docker/Dockerfile.end-user
@@ -71,12 +71,10 @@ ONBUILD ADD dolfinx/docker/ffcx_options.json /root/.config/ffcx/ffcx_options.jso
 # They are safe defaults.
 # CMake build type for DOLFINx C++ build. See CMake documentation.
 ONBUILD ARG DOLFINX_CMAKE_BUILD_TYPE="Release"
-# Extra CMake C++ compiler flags for DOLFINx C++ build.
-ONBUILD ARG DOLFINX_CMAKE_CXX_FLAGS
 
 # The dolfinx-onbuild container expects to have folders basix/ ufl/
 # ffcx/ and dolfinx/ mounted/shared at /src.
-ONBUILD RUN cd basix && cmake -G Ninja -DCMAKE_BUILD_TYPE=${DOLFINX_CMAKE_BUILD_TYPE} -DCMAKE_CXX_FLAGS=${DOLFINX_CMAKE_CXX_FLAGS} -B build-dir -S ./cpp && \
+ONBUILD RUN cd basix && cmake -G Ninja -DCMAKE_BUILD_TYPE=${DOLFINX_CMAKE_BUILD_TYPE} -B build-dir -S ./cpp && \
     cmake --build build-dir && \
     cmake --install build-dir && \
     python3 -m pip install ./python && \
@@ -87,7 +85,7 @@ ONBUILD RUN cd basix && cmake -G Ninja -DCMAKE_BUILD_TYPE=${DOLFINX_CMAKE_BUILD_
 ONBUILD RUN cd dolfinx && \
     mkdir -p build-real && \
     cd build-real && \
-    PETSC_ARCH=linux-gnu-real64-32 cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-real -DCMAKE_BUILD_TYPE=${DOLFINX_CMAKE_BUILD_TYPE} -DCMAKE_CXX_FLAGS=${DOLFINX_CMAKE_CXX_FLAGS} ../cpp && \
+    PETSC_ARCH=linux-gnu-real64-32 cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-real -DCMAKE_BUILD_TYPE=${DOLFINX_CMAKE_BUILD_TYPE} ../cpp && \
     ninja install && \
     cd ../python && \
     PETSC_ARCH=linux-gnu-real64-32 pip3 install -v \
@@ -97,12 +95,12 @@ ONBUILD RUN cd dolfinx && \
     cd ../ && \
     mkdir -p build-complex && \
     cd build-complex && \
-    PETSC_ARCH=linux-gnu-complex128-32 cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-complex -DCMAKE_BUILD_TYPE=${DOLFINX_CMAKE_BUILD_TYPE} --config-settings=install.strip=false -DCMAKE_CXX_FLAGS=${DOLFIN_CMAKE_CXX_FLAGS} ../cpp && \
+    PETSC_ARCH=linux-gnu-complex128-32 cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-complex -DCMAKE_BUILD_TYPE=${DOLFINX_CMAKE_BUILD_TYPE} ../cpp && \
     ninja install && \
     . /usr/local/dolfinx-complex/lib/dolfinx/dolfinx.conf && \
     cd ../python && \
     PETSC_ARCH=linux-gnu-complex128-32 pip3 install -v \
-      --config-settings=cmake.build-type="${DOLFINX_CMAKE_BUILD_TYPE}" --no-build-isolation --check-build-dependencies \
+      --config-settings=cmake.build-type="${DOLFINX_CMAKE_BUILD_TYPE}" --config-settings=install.strip=false --no-build-isolation --check-build-dependencies \
       --target /usr/local/dolfinx-complex/lib/python${PYTHON_VERSION}/dist-packages --no-dependencies --no-cache-dir .
 
 # Real by default.

--- a/docker/Dockerfile.end-user
+++ b/docker/Dockerfile.end-user
@@ -70,7 +70,7 @@ ONBUILD ADD dolfinx/docker/ffcx_options.json /root/.config/ffcx/ffcx_options.jso
 # The following ARGS are used in the DOLFINx layer.
 # They are safe defaults.
 # CMake build type for DOLFINx C++ build. See CMake documentation.
-ONBUILD ARG DOLFINX_CMAKE_BUILD_TYPE="RelWithDebInfo"
+ONBUILD ARG DOLFINX_CMAKE_BUILD_TYPE="Release"
 # Extra CMake C++ compiler flags for DOLFINx C++ build.
 ONBUILD ARG DOLFINX_CMAKE_CXX_FLAGS
 
@@ -91,13 +91,13 @@ ONBUILD RUN cd dolfinx && \
     ninja install && \
     cd ../python && \
     PETSC_ARCH=linux-gnu-real64-32 pip3 install -v \
-      --config-settings=cmake.build-type="${DOLFINX_CMAKE_BUILD_TYPE}"  --no-build-isolation --check-build-dependencies \
+      --config-settings=cmake.build-type="${DOLFINX_CMAKE_BUILD_TYPE}" --config-settings=install.strip=false --no-build-isolation --check-build-dependencies \
       --target /usr/local/dolfinx-real/lib/python${PYTHON_VERSION}/dist-packages --no-dependencies --no-cache-dir . && \
     git clean -fdx && \
     cd ../ && \
     mkdir -p build-complex && \
     cd build-complex && \
-    PETSC_ARCH=linux-gnu-complex128-32 cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-complex -DCMAKE_BUILD_TYPE=${DOLFINX_CMAKE_BUILD_TYPE} -DCMAKE_CXX_FLAGS=${DOLFIN_CMAKE_CXX_FLAGS} ../cpp && \
+    PETSC_ARCH=linux-gnu-complex128-32 cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local/dolfinx-complex -DCMAKE_BUILD_TYPE=${DOLFINX_CMAKE_BUILD_TYPE} --config-settings=install.strip=false -DCMAKE_CXX_FLAGS=${DOLFIN_CMAKE_CXX_FLAGS} ../cpp && \
     ninja install && \
     . /usr/local/dolfinx-complex/lib/dolfinx/dolfinx.conf && \
     cd ../python && \

--- a/python/README.md
+++ b/python/README.md
@@ -14,4 +14,4 @@ Below is guidance for building the DOLFINx Python interface.
 
 To build in debug and editable mode for development:
 
-     pip -v install --check-build-dependencies --config-settings=build-dir="build" --config-settings=cmake.build-type="Debug" --no-build-isolation --config-settings=install.strip=false -e .
+     pip -v install --check-build-dependencies --config-settings=build-dir="build" --config-settings=cmake.build-type="Debug"  --config-settings=install.strip=false --no-build-isolation -e .

--- a/python/README.md
+++ b/python/README.md
@@ -14,4 +14,4 @@ Below is guidance for building the DOLFINx Python interface.
 
 To build in debug and editable mode for development:
 
-     pip -v install --check-build-dependencies --config-settings=build-dir="build" --config-settings=cmake.build-type="Debug" --no-build-isolation -e .
+     pip -v install --check-build-dependencies --config-settings=build-dir="build" --config-settings=cmake.build-type="Debug" --no-build-isolation --config-settings=install.strip=false -e .


### PR DESCRIPTION
This does not change the default stripping policy of scikit-build-core (true).

The docker end user images are built by default in release mode without binary stripping. This leads to small binaries as there are no debug symbols in release mode.

The README is updated to add a scikit-build-core config flag to not strip debug symbols, so that it is possible to debug!

Also removes the broken CMAKE_CXX_FLAGS stuff as pointed out by @mhabera.

Resolves #2948.