### PR TITLE
Remove default CMAKE_BUILD_TYPE from end-user action

### DIFF
--- a/.github/workflows/docker-end-user.yml
+++ b/.github/workflows/docker-end-user.yml
@@ -155,7 +155,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           build-args: |
-            DOLFINX_CMAKE_BUILD_TYPE=RelWithDebInfo
             BASEIMAGE=${{ env.BASEIMAGE }}
           context: .
           file: dolfinx/${{ env.DOCKERFILE }}
@@ -167,7 +166,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           build-args: |
-            DOLFINX_CMAKE_BUILD_TYPE=RelWithDebInfo
             BASEIMAGE=${{ env.BASEIMAGE }}
           context: .
           file: dolfinx/${{ env.DOCKERFILE }}


### PR DESCRIPTION
Forgot this in previous PR.
