### PR TITLE
Drop `fenics-dev@googlegroups.com` in favor of `fenics-steering-council@googlegroups.com`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@ Authors/contributors in alphabetical order:
 
   Ido Akkerman          <I.Akkerman@tudelft.nl>             (-)
   Martin Sandve Alnæs   <martinal@simula.no>                (C)
+  Francesco Ballarin    <francesco.ballarin@unicatt.it>     (C)
   Igor Baratta          <ia397@cam.ac.uk>                   (-)
   Fredrik Bengzon       <bengzon@math.chalmers.se>          (-)
   Aslak Bergersen       <aslak.bergersen@gmail.com>         (C)
@@ -80,4 +81,4 @@ Authors/contributors in alphabetical order:
 (-) = minor change, copyright form not signed
 
 Missing credits? Tell us and we will fix it.
-Send an email to fenics-dev@googlegroups.com
+Send an email to fenics-steering-council@googlegroups.com

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -31,7 +31,7 @@ ARG OPENMPI_PATCH=0
 ########################################
 
 FROM ubuntu:22.04 as dev-env
-LABEL maintainer="fenics-project <fenics-support@googlegroups.org>"
+LABEL maintainer="FEniCS Steering Council <fenics-steering-council@googlegroups.com>"
 LABEL description="FEniCS testing and development environment with PETSc real, complex, 32-bit and 64-bit modes"
 
 ARG DOXYGEN_VERSION


### PR DESCRIPTION
In preparation of `fenics-dev@googlegroups.com` shutting down.