### PR TITLE
Small tweaks to custom cell kernel demo

### DIFF
--- a/cpp/demo/custom_kernel/main.cpp
+++ b/cpp/demo/custom_kernel/main.cpp
@@ -1,7 +1,7 @@
 // Custom cell kernel assembly (C++)
 //
-// This demo shows how to define a custom cell kernel in C++ and have it
-// assembled into a dolfinx::la::MatrixCSR.
+// This demo shows various methods to define custom cell kernels in C++ and
+// have them assembled into DOLFINx linear algebra data structures.
 //
 // .. code-block:: cpp
 


### PR DESCRIPTION
- Fix typo and improve readability of timings.
- Generalise top description.

I noticed that explicit geometry typing was removed - I guess this was intentional to reduce complexity?
