### PR TITLE
Remove deprecated function from Cahn-Hilliard demo

### DIFF
--- a/python/demo/demo_cahn-hilliard.py
+++ b/python/demo/demo_cahn-hilliard.py
@@ -194,7 +194,7 @@ c0, mu0 = ufl.split(u0)
 u.x.array[:] = 0.0
 
 # Interpolate initial condition
-u.sub(0).interpolate(lambda x: 0.63 + 0.02 * (0.5 - np.random.rand(x.shape[1])))
+u.sub(0).interpolate(lambda x: 0.63 + 0.02 * (0.5 - np.numpy.Generator.random(x.shape[1])))
 u.x.scatter_forward()
 # -
 

--- a/python/demo/demo_cahn-hilliard.py
+++ b/python/demo/demo_cahn-hilliard.py
@@ -194,7 +194,7 @@ c0, mu0 = ufl.split(u0)
 u.x.array[:] = 0.0
 
 # Interpolate initial condition
-u.sub(0).interpolate(lambda x: 0.63 + 0.02 * (0.5 - np.numpy.Generator.random(x.shape[1])))
+u.sub(0).interpolate(lambda x: 0.63 + 0.02 * (0.5 - np.random.Generator.random(x.shape[1])))
 u.x.scatter_forward()
 # -
 


### PR DESCRIPTION
Adressing: https://github.com/FEniCS/dolfinx/security/code-scanning/1 by replacing deprecated function as shown in https://sonarcloud.io/organizations/fenics/rules?open=python%3AS6711&rule_key=python%3AS6711