### PR TITLE
Add maps for mixed domain assembly

### DIFF
--- a/cpp/demo/custom_kernel/main.cpp
+++ b/cpp/demo/custom_kernel/main.cpp
@@ -139,10 +139,12 @@ double assemble_matrix1(const mesh::Geometry<T>& g, const fem::DofMap& dofmap,
   sp.finalize();
   la::MatrixCSR<T> A(sp);
   auto ident = [](auto, auto, auto, auto) {}; // DOF permutation not required
+  auto ident_map = [](std::int32_t c){ return c; };  // Entity map is the identity
   common::Timer timer("Assembler1 lambda (matrix)");
   fem::impl::assemble_cells(A.mat_add_values(), g.dofmap(), g.x(), cells, ident,
                             dofmap.map(), 1, ident, dofmap.map(), 1, {}, {},
-                            kernel, std::span<const T>(), 0, {}, {});
+                            kernel, std::span<const T>(), 0, {}, {}, {},
+                            ident_map, ident_map);
   A.scatter_rev();
   return A.squared_norm();
 }

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -122,6 +122,12 @@ public:
       for (auto& [id, kern, e] : kernels)
         itg.insert({id, {kern, std::vector(e.begin(), e.end())}});
     }
+
+    // Store entity maps
+    for (auto [msh, map] : entity_maps)
+    {
+      _entity_maps.insert({msh, std::vector(map.begin(), map.end())});
+    }
   }
 
   /// Copy constructor
@@ -261,6 +267,13 @@ public:
     return _constants;
   }
 
+  /// Access entity maps
+  const std::span<const std::int32_t> entity_maps(
+    std::shared_ptr<const mesh::Mesh<U>> mesh) const
+  {
+    return _entity_maps.at(mesh);
+  }
+
 private:
   using kern_t = std::function<void(T*, const T*, const T*,
                                     const scalar_value_type_t<T>*, const int*,
@@ -285,5 +298,8 @@ private:
 
   // True if permutation data needs to be passed into these integrals
   bool _needs_facet_permutations;
+
+  std::map<std::shared_ptr<const mesh::Mesh<U>>,
+           std::vector<std::int32_t>> _entity_maps;
 };
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -282,7 +282,7 @@ public:
       return [](std::int32_t e) { return e; };
     else
     {
-      std::span<std::int32_t> map = _entity_maps.at(msh);
+      std::span<const std::int32_t> map = _entity_maps.at(msh);
       return [map](std::int32_t e){ return map[e]; };
     }
   }

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -95,18 +95,20 @@ public:
        const std::vector<std::shared_ptr<const Function<T, U>>>& coefficients,
        const std::vector<std::shared_ptr<const Constant<T>>>& constants,
        bool needs_facet_permutations,
-       std::shared_ptr<const mesh::Mesh<U>> mesh = nullptr)
+       std::shared_ptr<const mesh::Mesh<U>> mesh = nullptr,
+       const std::vector<std::span<const std::int32_t>>& entity_maps = {})
       : _function_spaces(V), _coefficients(coefficients), _constants(constants),
         _mesh(mesh), _needs_facet_permutations(needs_facet_permutations)
   {
     // Extract _mesh from FunctionSpace, and check they are the same
     if (!_mesh and !V.empty())
       _mesh = V[0]->mesh();
-    for (auto& space : V)
-    {
-      if (_mesh != space->mesh())
-        throw std::runtime_error("Incompatible mesh");
-    }
+    // TODO Update and enable
+    // for (auto& space : V)
+    // {
+    //   if (_mesh != space->mesh())
+    //     throw std::runtime_error("Incompatible mesh");
+    // }
     if (!_mesh)
       throw std::runtime_error("No mesh could be associated with the Form.");
 

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -274,10 +274,17 @@ public:
   }
 
   /// Access entity maps
-  const std::span<const std::int32_t> entity_maps(
-    std::shared_ptr<const mesh::Mesh<U>> mesh) const
+  // TODO See if it's better to pass entity maps as lambda to begin with
+  std::function<std::int32_t(std::int32_t)>
+  entity_maps(std::shared_ptr<const mesh::Mesh<U>> msh) const
   {
-    return _entity_maps.at(mesh);
+    if (msh == _mesh)
+      return [](std::int32_t e) { return e; };
+    else
+    {
+      std::span<std::int32_t> map = _entity_maps.at(msh);
+      return [map](std::int32_t e){ return map[e]; };
+    }
   }
 
 private:
@@ -305,7 +312,7 @@ private:
   // True if permutation data needs to be passed into these integrals
   bool _needs_facet_permutations;
 
-  std::map<std::shared_ptr<const mesh::Mesh<U>>,
-           std::vector<std::int32_t>> _entity_maps;
+  std::map<std::shared_ptr<const mesh::Mesh<U>>, std::vector<std::int32_t>>
+      _entity_maps;
 };
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -84,6 +84,12 @@ public:
   /// @param[in] mesh Mesh of the domain. This is required when there
   /// are no argument functions from which the mesh can be extracted,
   /// e.g. for functionals.
+  /// @param[in] entity_maps If any trial functions, test functions, or
+  /// coefficients in the form are not defined over the same mesh as the
+  /// integration domain, `entity_maps` must be supplied. For each key
+  /// (a mesh, different to the integration domain mesh) a map should
+  /// be provided relating the entities in the integration domain mesh
+  /// to the entities in the key mesh.
   Form(const std::vector<std::shared_ptr<const FunctionSpace<U>>>& V,
        const std::map<IntegralType,
                       std::vector<std::tuple<

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -96,19 +96,22 @@ public:
        const std::vector<std::shared_ptr<const Constant<T>>>& constants,
        bool needs_facet_permutations,
        std::shared_ptr<const mesh::Mesh<U>> mesh = nullptr,
-       const std::vector<std::span<const std::int32_t>>& entity_maps = {})
+       const std::map<std::shared_ptr<const mesh::Mesh<U>>,
+                      std::span<const std::int32_t>>& entity_maps
+       = {})
       : _function_spaces(V), _coefficients(coefficients), _constants(constants),
         _mesh(mesh), _needs_facet_permutations(needs_facet_permutations)
   {
     // Extract _mesh from FunctionSpace, and check they are the same
     if (!_mesh and !V.empty())
       _mesh = V[0]->mesh();
-    // TODO Update and enable
-    // for (auto& space : V)
-    // {
-    //   if (_mesh != space->mesh())
-    //     throw std::runtime_error("Incompatible mesh");
-    // }
+    for (auto& space : V)
+    {
+      if (_mesh != space->mesh()
+          and entity_maps.find(space->mesh()) == entity_maps.end())
+        throw std::runtime_error(
+            "Incompatible mesh. entity_maps must be provided.");
+    }
     if (!_mesh)
       throw std::runtime_error("No mesh could be associated with the Form.");
 

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -68,6 +68,9 @@ void assemble_cells(la::MatSet<T> auto mat_set, mdspan2_t x_dofmap,
     // TODO Add assert?
     std::int32_t c_0 = cell_map0(c);
     std::int32_t c_1 = cell_map1(c);
+    // TODO Also check upper limit?
+    assert(c_0 >= 0);
+    assert(c_1 >= 0);
 
     // Get cell coordinates/geometry
     auto x_dofs

--- a/cpp/dolfinx/fem/sparsitybuild.cpp
+++ b/cpp/dolfinx/fem/sparsitybuild.cpp
@@ -23,8 +23,15 @@ void sparsitybuild::cells(
   const DofMap& map0 = dofmaps[0].get();
   const DofMap& map1 = dofmaps[1].get();
   for (auto c : cells)
-    pattern.insert(map0.cell_dofs(cell_maps[0](c)),
-                   map1.cell_dofs(cell_maps[1](c)));
+  {
+    std::int32_t c_0 = cell_maps[0](c);
+    std::int32_t c_1 = cell_maps[1](c);
+    // TODO Also check upper limit?
+    assert(c_0 >= 0);
+    assert(c_1 >= 0);
+    pattern.insert(map0.cell_dofs(c_0),
+                   map1.cell_dofs(c_1));
+  }
 }
 //-----------------------------------------------------------------------------
 void sparsitybuild::interior_facets(

--- a/cpp/dolfinx/fem/sparsitybuild.cpp
+++ b/cpp/dolfinx/fem/sparsitybuild.cpp
@@ -23,7 +23,8 @@ void sparsitybuild::cells(
   const DofMap& map0 = dofmaps[0].get();
   const DofMap& map1 = dofmaps[1].get();
   for (auto c : cells)
-    pattern.insert(map0.cell_dofs(c), map1.cell_dofs(c));
+    pattern.insert(map0.cell_dofs(cell_maps[0](c)),
+                   map1.cell_dofs(cell_maps[1](c)));
 }
 //-----------------------------------------------------------------------------
 void sparsitybuild::interior_facets(

--- a/cpp/dolfinx/fem/sparsitybuild.cpp
+++ b/cpp/dolfinx/fem/sparsitybuild.cpp
@@ -17,7 +17,8 @@ using namespace dolfinx::fem;
 //-----------------------------------------------------------------------------
 void sparsitybuild::cells(
     la::SparsityPattern& pattern, std::span<const std::int32_t> cells,
-    std::array<std::reference_wrapper<const DofMap>, 2> dofmaps)
+    std::array<std::reference_wrapper<const DofMap>, 2> dofmaps,
+    const std::array<std::function<std::int32_t(std::int32_t)>, 2>& cell_maps)
 {
   const DofMap& map0 = dofmaps[0].get();
   const DofMap& map1 = dofmaps[1].get();

--- a/cpp/dolfinx/fem/sparsitybuild.h
+++ b/cpp/dolfinx/fem/sparsitybuild.h
@@ -11,11 +11,6 @@
 #include <functional>
 #include <span>
 
-namespace
-{
-std::int32_t identity_map(std::int32_t e) { return e; }
-} // namespace
-
 namespace dolfinx::la
 {
 class SparsityPattern;
@@ -43,8 +38,7 @@ namespace sparsitybuild
 void cells(
     la::SparsityPattern& pattern, std::span<const std::int32_t> cells,
     std::array<std::reference_wrapper<const DofMap>, 2> dofmaps,
-    const std::array<std::function<std::int32_t(std::int32_t)>, 2>& cell_maps
-    = {identity_map, identity_map});
+    const std::array<std::function<std::int32_t(std::int32_t)>, 2>& cell_maps);
 
 /// @brief Iterate over interior facets and insert entries into sparsity
 /// pattern.

--- a/cpp/dolfinx/fem/sparsitybuild.h
+++ b/cpp/dolfinx/fem/sparsitybuild.h
@@ -11,6 +11,11 @@
 #include <functional>
 #include <span>
 
+namespace
+{
+std::int32_t identity_map(std::int32_t e) { return e; }
+} // namespace
+
 namespace dolfinx::la
 {
 class SparsityPattern;
@@ -33,9 +38,13 @@ namespace sparsitybuild
 /// @param[in,out] pattern The sparsity pattern to insert into
 /// @param[in] cells The cell indices
 /// @param[in] dofmaps Dofmaps to used in building the sparsity pattern
+/// @param[in] cell_maps The cell maps to used in building the sparsity pattern
 /// @note The sparsity pattern is not finalised
-void cells(la::SparsityPattern& pattern, std::span<const std::int32_t> cells,
-           std::array<std::reference_wrapper<const DofMap>, 2> dofmaps);
+void cells(
+    la::SparsityPattern& pattern, std::span<const std::int32_t> cells,
+    std::array<std::reference_wrapper<const DofMap>, 2> dofmaps,
+    const std::array<std::function<std::int32_t(std::int32_t)>, 2>& cell_maps
+    = {identity_map, identity_map});
 
 /// @brief Iterate over interior facets and insert entries into sparsity
 /// pattern.

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -286,7 +286,9 @@ Form<T, U> create_form(
         std::vector<std::pair<std::int32_t, std::span<const std::int32_t>>>>&
         subdomains,
     std::shared_ptr<const mesh::Mesh<U>> mesh = nullptr,
-    const std::vector<std::span<const std::int32_t>>& entity_maps = {})
+    const std::map<std::shared_ptr<const mesh::Mesh<U>>,
+                   std::span<const std::int32_t>>& entity_maps
+    = {})
 {
   if (ufcx_form.rank != (int)spaces.size())
     throw std::runtime_error("Wrong number of argument spaces for Form.");
@@ -320,12 +322,12 @@ Form<T, U> create_form(
   // Extract mesh from FunctionSpace, and check they are the same
   if (!mesh and !spaces.empty())
     mesh = spaces[0]->mesh();
-  // TODO Update and enable
-  // for (auto& V : spaces)
-  // {
-  //   if (mesh != V->mesh())
-  //     throw std::runtime_error("Incompatible mesh");
-  // }
+  for (auto& V : spaces)
+  {
+    if (mesh != V->mesh() and entity_maps.find(V->mesh()) == entity_maps.end())
+      throw std::runtime_error(
+          "Incompatible mesh. entity_maps must be provided.");
+  }
   if (!mesh)
     throw std::runtime_error("No mesh could be associated with the Form.");
 

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -285,7 +285,8 @@ Form<T, U> create_form(
         IntegralType,
         std::vector<std::pair<std::int32_t, std::span<const std::int32_t>>>>&
         subdomains,
-    std::shared_ptr<const mesh::Mesh<U>> mesh = nullptr)
+    std::shared_ptr<const mesh::Mesh<U>> mesh = nullptr,
+    const std::vector<std::span<const std::int32_t>>& entity_maps = {})
 {
   if (ufcx_form.rank != (int)spaces.size())
     throw std::runtime_error("Wrong number of argument spaces for Form.");
@@ -319,11 +320,12 @@ Form<T, U> create_form(
   // Extract mesh from FunctionSpace, and check they are the same
   if (!mesh and !spaces.empty())
     mesh = spaces[0]->mesh();
-  for (auto& V : spaces)
-  {
-    if (mesh != V->mesh())
-      throw std::runtime_error("Incompatible mesh");
-  }
+  // TODO Update and enable
+  // for (auto& V : spaces)
+  // {
+  //   if (mesh != V->mesh())
+  //     throw std::runtime_error("Incompatible mesh");
+  // }
   if (!mesh)
     throw std::runtime_error("No mesh could be associated with the Form.");
 
@@ -572,7 +574,7 @@ Form<T, U> create_form(
   }
 
   return Form<T, U>(spaces, integral_data, coefficients, constants,
-                    needs_facet_permutations, mesh);
+                    needs_facet_permutations, mesh, entity_maps);
 }
 
 /// @brief Create a Form from UFC input.

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -172,6 +172,10 @@ la::SparsityPattern create_sparsity_pattern(const Form<T, U>& a)
   std::shared_ptr mesh = a.mesh();
   assert(mesh);
 
+  std::array<std::function<std::int32_t(std::int32_t)>, 2> entity_maps{
+      a.entity_maps(a.function_spaces().at(0)->mesh()),
+      a.entity_maps(a.function_spaces().at(1)->mesh())};
+
   const std::set<IntegralType> types = a.integral_types();
   if (types.find(IntegralType::interior_facet) != types.end()
       or types.find(IntegralType::exterior_facet) != types.end())
@@ -201,7 +205,7 @@ la::SparsityPattern create_sparsity_pattern(const Form<T, U>& a)
       for (int id : ids)
       {
         sparsitybuild::cells(pattern, a.domain(type, id),
-                             {{dofmaps[0], dofmaps[1]}});
+                             {{dofmaps[0], dofmaps[1]}}, entity_maps);
       }
       break;
     case IntegralType::interior_facet:
@@ -223,7 +227,8 @@ la::SparsityPattern create_sparsity_pattern(const Form<T, U>& a)
         cells.reserve(facets.size() / 2);
         for (std::size_t i = 0; i < facets.size(); i += 2)
           cells.push_back(facets[i]);
-        sparsitybuild::cells(pattern, cells, {{dofmaps[0], dofmaps[1]}});
+        sparsitybuild::cells(pattern, cells, {{dofmaps[0], dofmaps[1]}},
+                             entity_maps);
       }
       break;
     default:

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -275,6 +275,7 @@ std::vector<std::string> get_constant_names(const ufcx_form& ufcx_form);
 /// @param[in] subdomains Subdomain markers
 /// @pre Each value in `subdomains` must be sorted by domain id
 /// @param[in] mesh The mesh of the domain
+/// @param[in] entity_maps The entity maps for the form
 template <dolfinx::scalar T, typename U = dolfinx::scalar_value_type_t<T>>
 Form<T, U> create_form(
     const ufcx_form& ufcx_form,

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -139,7 +139,7 @@ def tabulate_A(A_, w_, c_, coords_, entity_local_index, permutation=ffi.NULL):
 formtype = form_cpp_class(PETSc.ScalarType)  # type: ignore
 cells = np.arange(msh.topology.index_map(msh.topology.dim).size_local)
 integrals = {IntegralType.cell: [(-1, tabulate_A.address, cells)]}
-a_cond = Form(formtype([U._cpp_object, U._cpp_object], integrals, [], [], False, None))
+a_cond = Form(formtype([U._cpp_object, U._cpp_object], integrals, [], [], False, None, {}))
 
 A_cond = assemble_matrix(a_cond, bcs=[bc])
 A_cond.assemble()

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -128,8 +128,12 @@ def form(form: typing.Union[ufl.Form, typing.Iterable[ufl.Form]],
         dtype: Scalar type to use for the compiled form.
         form_compiler_options: See :func:`ffcx_jit <dolfinx.jit.ffcx_jit>`
         jit_options: See :func:`ffcx_jit <dolfinx.jit.ffcx_jit>`.
-        entity_maps: The entity maps required to assemble the form.
-
+        entity_maps: If any trial functions, test functions, or coefficients in
+                     the form are not defined over the same mesh as the integration
+                     domain, `entity_maps` must be supplied. For each key (a mesh,
+                     different to the integration domain mesh) a map should be
+                     provided relating the entities in the integration domain mesh
+                     to the entities in the key mesh.
     Returns:
         Compiled finite element Form.
 

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -120,7 +120,7 @@ def form(form: typing.Union[ufl.Form, typing.Iterable[ufl.Form]],
          dtype: npt.DTypeLike = default_scalar_type,
          form_compiler_options: typing.Optional[dict] = None,
          jit_options: typing.Optional[dict] = None,
-         entity_maps: list[np.typing.NDArray[np.int32]] = []):
+         entity_maps: dict[_cpp.mesh.Mesh, np.typing.NDArray[np.int32]] = {}):
     """Create a Form or an array of Forms.
 
     Args:

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -119,7 +119,8 @@ _ufl_to_dolfinx_domain = {"cell": IntegralType.cell,
 def form(form: typing.Union[ufl.Form, typing.Iterable[ufl.Form]],
          dtype: npt.DTypeLike = default_scalar_type,
          form_compiler_options: typing.Optional[dict] = None,
-         jit_options: typing.Optional[dict] = None):
+         jit_options: typing.Optional[dict] = None,
+         entity_maps: list[np.typing.NDArray[np.int32]] = []):
     """Create a Form or an array of Forms.
 
     Args:
@@ -127,6 +128,7 @@ def form(form: typing.Union[ufl.Form, typing.Iterable[ufl.Form]],
         dtype: Scalar type to use for the compiled form.
         form_compiler_options: See :func:`ffcx_jit <dolfinx.jit.ffcx_jit>`
         jit_options: See :func:`ffcx_jit <dolfinx.jit.ffcx_jit>`.
+        entity_maps: The entity maps required to assemble the form.
 
     Returns:
         Compiled finite element Form.
@@ -193,7 +195,7 @@ def form(form: typing.Union[ufl.Form, typing.Iterable[ufl.Form]],
             _ufl_to_dolfinx_domain[key], subdomain_data[0]) for (key, subdomain_data) in sd.get(domain).items()}
 
         f = ftype(module.ffi.cast("uintptr_t", module.ffi.addressof(ufcx_form)), V, coeffs,
-                  constants, subdomains, mesh)
+                  constants, subdomains, mesh, entity_maps)
         return Form(f, ufcx_form, code)
 
     def _create_form(form):

--- a/python/dolfinx/wrappers/assemble.cpp
+++ b/python/dolfinx/wrappers/assemble.cpp
@@ -75,7 +75,9 @@ void declare_discrete_operators(nb::module_& m)
         assert(map);
         std::vector<std::int32_t> c(map->size_local(), 0);
         std::iota(c.begin(), c.end(), 0);
-        dolfinx::fem::sparsitybuild::cells(sp, c, {*dofmap1, *dofmap0});
+        auto identity = [](std::int32_t c) { return c; };
+        dolfinx::fem::sparsitybuild::cells(sp, c, {*dofmap1, *dofmap0},
+                                           {identity, identity});
         sp.finalize();
 
         // Build operator

--- a/python/dolfinx/wrappers/petsc.cpp
+++ b/python/dolfinx/wrappers/petsc.cpp
@@ -70,7 +70,9 @@ void declare_petsc_discrete_operators(nb::module_& m)
         assert(map);
         std::vector<std::int32_t> c(map->size_local(), 0);
         std::iota(c.begin(), c.end(), 0);
-        dolfinx::fem::sparsitybuild::cells(sp, c, {*dofmap1, *dofmap0});
+        auto identity = [](std::int32_t c) { return c; };
+        dolfinx::fem::sparsitybuild::cells(sp, c, {*dofmap1, *dofmap0},
+                                           {identity, identity});
         sp.finalize();
 
         // Build operator
@@ -111,7 +113,9 @@ void declare_petsc_discrete_operators(nb::module_& m)
         assert(map);
         std::vector<std::int32_t> c(map->size_local(), 0);
         std::iota(c.begin(), c.end(), 0);
-        dolfinx::fem::sparsitybuild::cells(sp, c, {*dofmap1, *dofmap0});
+        auto identity = [](std::int32_t c) { return c; };
+        dolfinx::fem::sparsitybuild::cells(sp, c, {*dofmap1, *dofmap0},
+                                           {identity, identity});
         sp.finalize();
 
         // Build operator

--- a/python/test/unit/fem/test_assemble_submesh.py
+++ b/python/test/unit/fem/test_assemble_submesh.py
@@ -14,9 +14,17 @@ import pytest
 import ufl
 from dolfinx import default_scalar_type, fem, la
 from dolfinx.fem.petsc import assemble_matrix
-from dolfinx.mesh import (GhostMode, create_box, create_rectangle, create_submesh,
-                          create_unit_cube, create_unit_square, locate_entities,
-                          locate_entities_boundary, meshtags)
+from dolfinx.mesh import (
+    GhostMode,
+    create_box,
+    create_rectangle,
+    create_submesh,
+    create_unit_cube,
+    create_unit_square,
+    locate_entities,
+    locate_entities_boundary,
+    meshtags,
+)
 
 
 def assemble(mesh, space, k):
@@ -56,8 +64,7 @@ def assemble(mesh, space, k):
 @pytest.mark.parametrize("n", [2, 6])
 @pytest.mark.parametrize("k", [1, 4])
 @pytest.mark.parametrize("space", ["Lagrange", "Discontinuous Lagrange"])
-@pytest.mark.parametrize("ghost_mode", [GhostMode.none,
-                                        GhostMode.shared_facet])
+@pytest.mark.parametrize("ghost_mode", [GhostMode.none, GhostMode.shared_facet])
 def test_submesh_cell_assembly(d, n, k, space, ghost_mode):
     """Check that assembling a form over a unit square gives the same
     result as assembling over half of a 2x1 rectangle with the same
@@ -67,8 +74,7 @@ def test_submesh_cell_assembly(d, n, k, space, ghost_mode):
         mesh_1 = create_rectangle(MPI.COMM_WORLD, ((0.0, 0.0), (2.0, 1.0)), (2 * n, n), ghost_mode=ghost_mode)
     else:
         mesh_0 = create_unit_cube(MPI.COMM_WORLD, n, n, n, ghost_mode=ghost_mode)
-        mesh_1 = create_box(MPI.COMM_WORLD, ((0.0, 0.0, 0.0), (2.0, 1.0, 1.0)),
-                            (2 * n, n, n), ghost_mode=ghost_mode)
+        mesh_1 = create_box(MPI.COMM_WORLD, ((0.0, 0.0, 0.0), (2.0, 1.0, 1.0)), (2 * n, n, n), ghost_mode=ghost_mode)
 
     A_mesh_0, b_mesh_0, s_mesh_0 = assemble(mesh_0, space, k)
 
@@ -112,9 +118,7 @@ def test_mixed_dom_codim_0(n, k, space, ghost_mode):
     """Test assembling a form where the trial and test functions
     are defined on different meshes"""
 
-    msh = create_rectangle(
-        MPI.COMM_WORLD, ((0.0, 0.0), (2.0, 1.0)), (2 * n, n),
-        ghost_mode=ghost_mode)
+    msh = create_rectangle(MPI.COMM_WORLD, ((0.0, 0.0), (2.0, 1.0)), (2 * n, n), ghost_mode=ghost_mode)
 
     # Locate cells in left half of mesh and create mesh tags
     tdim = msh.topology.dim

--- a/python/test/unit/fem/test_assemble_submesh.py
+++ b/python/test/unit/fem/test_assemble_submesh.py
@@ -14,17 +14,8 @@ import pytest
 import ufl
 from dolfinx import default_scalar_type, fem, la
 from dolfinx.fem.petsc import assemble_matrix
-from dolfinx.mesh import (
-    GhostMode,
-    create_box,
-    create_rectangle,
-    create_submesh,
-    create_unit_cube,
-    create_unit_square,
-    locate_entities,
-    locate_entities_boundary,
-    meshtags,
-)
+from dolfinx.mesh import (GhostMode, create_box, create_rectangle, create_submesh, create_unit_cube, create_unit_square,
+                          locate_entities, locate_entities_boundary, meshtags)
 
 
 def assemble(mesh, space, k):

--- a/python/test/unit/fem/test_assemble_submesh.py
+++ b/python/test/unit/fem/test_assemble_submesh.py
@@ -13,9 +13,10 @@ import pytest
 
 import ufl
 from dolfinx import default_scalar_type, fem, la
-import dolfinx.fem.petsc
-from dolfinx.mesh import (GhostMode, create_box, create_rectangle, create_submesh, create_unit_cube, create_unit_square,
-                          locate_entities, locate_entities_boundary, meshtags)
+from dolfinx.fem.petsc import assemble_matrix
+from dolfinx.mesh import (GhostMode, create_box, create_rectangle, create_submesh,
+                          create_unit_cube, create_unit_square, locate_entities,
+                          locate_entities_boundary, meshtags)
 
 
 def assemble(mesh, space, k):
@@ -141,12 +142,12 @@ def test_mixed_dom_codim_0(n, k, space, ghost_mode):
     # Create entity maps, define form, and assemble
     entity_maps = {msh._cpp_object: np.array(smhs_to_msh, dtype=np.int32)}
     a_0 = fem.form(ufl.inner(u, w) * ufl.dx(smsh), entity_maps=entity_maps)
-    A_0 = fem.petsc.assemble_matrix(a_0)
+    A_0 = assemble_matrix(a_0)
     A_0.assemble()
 
     # Define form to compare to and assemble
     a_1 = fem.form(ufl.inner(u, v) * dx_msh(1))
-    A_1 = fem.petsc.assemble_matrix(a_1)
+    A_1 = assemble_matrix(a_1)
     A_1.assemble()
 
     assert np.isclose(A_0.norm(), A_1.norm())

--- a/python/test/unit/fem/test_assemble_submesh.py
+++ b/python/test/unit/fem/test_assemble_submesh.py
@@ -147,9 +147,15 @@ def test_mixed_dom_codim_0(n, k, space, ghost_mode):
 
     assert np.isclose(A_0.norm(), A_1.norm())
 
-    # TODO
-    # cell_imap = msh.topology.index_map(tdim)
-    # num_cells = cell_imap.size_local + cell_imap.num_ghosts
-    # msh_to_smsh = np.full(num_cells, -1)
-    # msh_to_smsh[smhs_to_msh] = np.arange(len(smhs_to_msh))
-    # entity_maps = {smsh: msh_to_smsh}
+    # Now assemble using msh as integration domain
+    cell_imap = msh.topology.index_map(tdim)
+    num_cells = cell_imap.size_local + cell_imap.num_ghosts
+    msh_to_smsh = np.full(num_cells, -1)
+    msh_to_smsh[smhs_to_msh] = np.arange(len(smhs_to_msh))
+    entity_maps = {smsh._cpp_object: np.array(msh_to_smsh, dtype=np.int32)}
+
+    a_2 = fem.form(ufl.inner(u, w) * dx_msh(1), entity_maps=entity_maps)
+    A_2 = assemble_matrix(a_2)
+    A_2.assemble()
+
+    assert np.isclose(A_2.norm(), A_1.norm())

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -90,9 +90,9 @@ def test_numba_assembly(dtype):
                                      (12, k2.address, np.arange(0)),
                                      (2, k2.address, np.arange(0))]}
     formtype = form_cpp_class(dtype)
-    a = Form(formtype([V._cpp_object, V._cpp_object], integrals, [], [], False, None))
+    a = Form(formtype([V._cpp_object, V._cpp_object], integrals, [], [], False, None, {}))
     integrals = {IntegralType.cell: [(-1, k1.address, cells)]}
-    L = Form(formtype([V._cpp_object], integrals, [], [], False, None))
+    L = Form(formtype([V._cpp_object], integrals, [], [], False, None, {}))
 
     A = dolfinx.fem.assemble_matrix(a)
     A.scatter_reverse()
@@ -122,7 +122,7 @@ def test_coefficient(dtype):
     num_cells = mesh.topology.index_map(tdim).size_local + mesh.topology.index_map(tdim).num_ghosts
     integrals = {IntegralType.cell: [(1, k1.address, np.arange(num_cells, dtype=np.int32))]}
     formtype = form_cpp_class(dtype)
-    L = Form(formtype([V._cpp_object], integrals, [vals._cpp_object], [], False, None))
+    L = Form(formtype([V._cpp_object], integrals, [vals._cpp_object], [], False, None, {}))
 
     b = dolfinx.fem.assemble_vector(L)
     b.scatter_reverse(la.InsertMode.add)
@@ -237,11 +237,11 @@ def test_cffi_assembly():
 
     ptrA = ffi.cast("intptr_t", ffi.addressof(lib, "tabulate_tensor_poissonA"))
     integrals = {IntegralType.cell: [(-1, ptrA, cells)]}
-    a = Form(_cpp.fem.Form_float64([V._cpp_object, V._cpp_object], integrals, [], [], False, None))
+    a = Form(_cpp.fem.Form_float64([V._cpp_object, V._cpp_object], integrals, [], [], False, None, {}))
 
     ptrL = ffi.cast("intptr_t", ffi.addressof(lib, "tabulate_tensor_poissonL"))
     integrals = {IntegralType.cell: [(-1, ptrL, cells)]}
-    L = Form(_cpp.fem.Form_float64([V._cpp_object], integrals, [], [], False, None))
+    L = Form(_cpp.fem.Form_float64([V._cpp_object], integrals, [], [], False, None, {}))
 
     A = fem.assemble_matrix(a)
     A.scatter_reverse()


### PR DESCRIPTION
This PR adds the maps that allow mixed domain forms to be assembled. The maps take entities in the integration domain mesh (the mesh associated with the integration measure) to the corresponding entities in the meshes of other domains in the problem.

In this PR, I've only implemented mixed domain assembly for cell integrals without coefficients to keep it more manageable. If everyone is happy with this approach, I will implement other integral type, coefficient packing, and add a much more thorough set of tests. This will mean that `entity_maps` will appear in many places where the dofmap is used to access cell dofs (e.g. `assemble_scalar`, `assemble_vector`, `apply_lifting` and `pack_coefficients` etc.). If this is problematic, we can discuss some alternative ideas.

It would be great to hear everyones thoughts on this approach. 