### PR TITLE
ADIOS2 for Spack by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ git clone https://github.com/spack/spack.git
 . ./spack/share/spack/setup-env.sh
 spack env create fenicsx-env
 spack env activate fenicsx-env
-spack add py-fenics-dolfinx cflags="-O3" fflags="-O3"
+spack add py-fenics-dolfinx+adios2 cflags="-O3" fflags="-O3"
 spack install
 ```
 


### PR DESCRIPTION
Given Spack/HPC users need to do parallel IO we should probably hint at building with ADIOS2.