### PR TITLE
Ensure that explicitly requested packages are enabled by CMake (and otherwise fail)

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -88,7 +88,11 @@ add_feature_info(
 # Enable or disable optional packages
 
 # List optional packages
+if (DOLFINX_ENABLE_ADIOS2)
+  set(_REQUIRE_ADIOS2 TRUE)
+endif()
 option(DOLFINX_ENABLE_ADIOS2 "Compile with support for ADIOS2." ON)
+
 option(DOLFINX_ENABLE_PARMETIS "Compile with support for ParMETIS." ON)
 option(DOLFINX_ENABLE_SCOTCH "Compile with support for SCOTCH." ON)
 option(DOLFINX_ENABLE_SLEPC "Compile with support for SLEPc." ON)
@@ -274,8 +278,13 @@ set_package_properties(
 
 # ------------------------------------------------------------------------------
 # Find optional packages
+
 if(DOLFINX_ENABLE_ADIOS2)
-  find_package(ADIOS2 2.8.1)
+  if (_REQUIRE_ADIOS2)
+    find_package(ADIOS2 2.8.1 REQUIRED)
+  else()
+    find_package(ADIOS2 2.8.1)
+  endif()
 endif()
 
 set_package_properties(

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -381,6 +381,10 @@ elseif(DOLFINX_ENABLE_KAHIP)
   find_package(KaHIP)
 endif()
 
+# ------------------------------------------------------------------------------
+# Print summary of found and not found optional packages
+feature_summary(WHAT ALL)
+
 # Check that at least one graph partitioner has been found
 if(NOT SCOTCH_FOUND AND NOT PARMETIS_FOUND AND NOT KAHIP_FOUND)
   message(
@@ -388,10 +392,6 @@ if(NOT SCOTCH_FOUND AND NOT PARMETIS_FOUND AND NOT KAHIP_FOUND)
       "No graph partitioner found. SCOTCH, ParMETIS or KaHIP is required."
   )
 endif()
-
-# ------------------------------------------------------------------------------
-# Print summary of found and not found optional packages
-feature_summary(WHAT ALL)
 
 # ------------------------------------------------------------------------------
 # Installation of DOLFINx library

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -87,16 +87,66 @@ add_feature_info(
 # ------------------------------------------------------------------------------
 # Enable or disable optional packages
 
-# List optional packages
 if (DOLFINX_ENABLE_ADIOS2)
   set(_REQUIRE_ADIOS2 TRUE)
 endif()
 option(DOLFINX_ENABLE_ADIOS2 "Compile with support for ADIOS2." ON)
+set_package_properties(
+  ADIOS2 PROPERTIES
+  TYPE OPTIONAL
+  DESCRIPTION "Adaptable Input/Output (I/O) System."
+  URL "https://adios2.readthedocs.io/en/latest/"
+  PURPOSE "IO, including in parallel"
+)
 
+if (DOLFINX_ENABLE_PARMETIS)
+  set(_REQUIRE_PARMETIS TRUE)
+endif()
 option(DOLFINX_ENABLE_PARMETIS "Compile with support for ParMETIS." ON)
+set_package_properties(
+  ParMETIS PROPERTIES
+  TYPE RECOMMENDED
+  DESCRIPTION "Parallel Graph Partitioning and Fill-reducing Matrix Ordering"
+  URL "http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview"
+  PURPOSE "Parallel graph partitioning"
+)
+
+if (DOLFINX_ENABLE_SCOTCH)
+  set(_REQUIRE_SCOTCH TRUE)
+endif()
 option(DOLFINX_ENABLE_SCOTCH "Compile with support for SCOTCH." ON)
+set_package_properties(
+  SCOTCH PROPERTIES
+  TYPE OPTIONAL
+  DESCRIPTION
+    "Programs and libraries for graph, mesh and hypergraph partitioning"
+  URL "https://www.labri.fr/perso/pelegrin/scotch"
+  PURPOSE "Parallel graph partitioning"
+)
+
+if (DOLFINX_ENABLE_SLEPC)
+  set(_REQUIRE_SLEPC TRUE)
+endif()
 option(DOLFINX_ENABLE_SLEPC "Compile with support for SLEPc." ON)
+set_package_properties(
+  SLEPc PROPERTIES
+  TYPE RECOMMENDED
+  DESCRIPTION "Scalable Library for Eigenvalue Problem Computations"
+  URL "http://slepc.upv.es/"
+  PURPOSE "Eigenvalue computation"
+)
+
+if (DOLFINX_ENABLE_KAHIP)
+  set(_REQUIRE_KAHIP TRUE)
+endif()
 option(DOLFINX_ENABLE_KAHIP "Compile with support for KaHIP." OFF)
+set_package_properties(
+  KaHIP PROPERTIES
+  TYPE OPTIONAL
+  DESCRIPTION "A family of graph partitioning programs"
+  URL "https://kahip.github.io/"
+  PURPOSE "Parallel graph partitioning"
+)
 
 # ------------------------------------------------------------------------------
 # Check for MPI
@@ -279,21 +329,11 @@ set_package_properties(
 # ------------------------------------------------------------------------------
 # Find optional packages
 
-if(DOLFINX_ENABLE_ADIOS2)
-  if (_REQUIRE_ADIOS2)
-    find_package(ADIOS2 2.8.1 REQUIRED)
-  else()
-    find_package(ADIOS2 2.8.1)
-  endif()
+if(DOLFINX_ENABLE_ADIOS2 AND _REQUIRE_ADIOS2)
+  find_package(ADIOS2 2.8.1 REQUIRED)
+elseif(DOLFINX_ENABLE_ADIOS2)
+  find_package(ADIOS2 2.8.1)
 endif()
-
-set_package_properties(
-  ADIOS2 PROPERTIES
-  TYPE OPTIONAL
-  DESCRIPTION "Adaptable Input/Output (I/O) System."
-  URL "https://adios2.readthedocs.io/en/latest/"
-  PURPOSE "IO, including in parallel"
-)
 
 if(DOLFINX_ENABLE_SLEPC)
   find_package(PkgConfig REQUIRED)
@@ -306,7 +346,11 @@ if(DOLFINX_ENABLE_SLEPC)
   set(ENV{PKG_CONFIG_PATH}
       "$ENV{PETSC_DIR}/$ENV{PETSC_ARCH}:$ENV{PETSC_DIR}:$ENV{PKG_CONFIG_PATH}"
   )
-  pkg_search_module(SLEPC IMPORTED_TARGET slepc>=3.15)
+  if (_REQUIRE_SLEPC)
+    pkg_search_module(SLEPC REQUIRED IMPORTED_TARGET slepc>=3.15)
+  else()
+    pkg_search_module(SLEPC IMPORTED_TARGET slepc>=3.15)
+  endif()
 
   # Setting for FeatureSummary
   if(SLEPC_FOUND)
@@ -319,56 +363,26 @@ if(DOLFINX_ENABLE_SLEPC)
   endif()
 endif()
 
-set_package_properties(
-  SLEPc PROPERTIES
-  TYPE RECOMMENDED
-  DESCRIPTION "Scalable Library for Eigenvalue Problem Computations"
-  URL "http://slepc.upv.es/"
-  PURPOSE "Eigenvalue computation"
-)
-
-if(DOLFINX_ENABLE_SCOTCH)
+if(DOLFINX_ENABLE_SCOTCH AND _REQUIRE_SCOTCH)
+  find_package(SCOTCH REQUIRED)
+elseif(DOLFINX_ENABLE_SCOTCH)
   find_package(SCOTCH)
 endif()
 
-set_package_properties(
-  SCOTCH PROPERTIES
-  TYPE OPTIONAL
-  DESCRIPTION
-    "Programs and libraries for graph, mesh and hypergraph partitioning"
-  URL "https://www.labri.fr/perso/pelegrin/scotch"
-  PURPOSE "Parallel graph partitioning"
-)
-
-if(DOLFINX_ENABLE_PARMETIS)
+if(DOLFINX_ENABLE_PARMETIS AND _REQUIRE_PARMETIS)
+  find_package(ParMETIS 4.0.2 REQUIRED)
+elseif(DOLFINX_ENABLE_PARMETIS)
   find_package(ParMETIS 4.0.2)
 endif()
 
-set_package_properties(
-  ParMETIS PROPERTIES
-  TYPE RECOMMENDED
-  DESCRIPTION "Parallel Graph Partitioning and Fill-reducing Matrix Ordering"
-  URL "http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview"
-  PURPOSE "Parallel graph partitioning"
-)
-
-if(DOLFINX_ENABLE_KAHIP)
+if(DOLFINX_ENABLE_KAHIP AND _REQUIRE_KAHIP)
+  find_package(KaHIP REQUIRED)
+elseif(DOLFINX_ENABLE_KAHIP)
   find_package(KaHIP)
 endif()
 
-set_package_properties(
-  KaHIP PROPERTIES
-  TYPE OPTIONAL
-  DESCRIPTION "A family of graph partitioning programs"
-  URL "https://kahip.github.io/"
-  PURPOSE "Parallel graph partitioning"
-)
-
 # Check that at least one graph partitioner has been found
-if(NOT SCOTCH_FOUND
-   AND NOT PARMETIS_FOUND
-   AND NOT KAHIP_FOUND
-)
+if(NOT SCOTCH_FOUND AND NOT PARMETIS_FOUND AND NOT KAHIP_FOUND)
   message(
     FATAL_ERROR
       "No graph partitioner found. SCOTCH, ParMETIS or KaHIP is required."

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -87,7 +87,7 @@ add_feature_info(
 # ------------------------------------------------------------------------------
 # Enable or disable optional packages
 
-if (DOLFINX_ENABLE_ADIOS2)
+if(DOLFINX_ENABLE_ADIOS2)
   set(_REQUIRE_ADIOS2 TRUE)
 endif()
 option(DOLFINX_ENABLE_ADIOS2 "Compile with support for ADIOS2." ON)
@@ -99,7 +99,7 @@ set_package_properties(
   PURPOSE "IO, including in parallel"
 )
 
-if (DOLFINX_ENABLE_PARMETIS)
+if(DOLFINX_ENABLE_PARMETIS)
   set(_REQUIRE_PARMETIS TRUE)
 endif()
 option(DOLFINX_ENABLE_PARMETIS "Compile with support for ParMETIS." ON)
@@ -111,7 +111,7 @@ set_package_properties(
   PURPOSE "Parallel graph partitioning"
 )
 
-if (DOLFINX_ENABLE_SCOTCH)
+if(DOLFINX_ENABLE_SCOTCH)
   set(_REQUIRE_SCOTCH TRUE)
 endif()
 option(DOLFINX_ENABLE_SCOTCH "Compile with support for SCOTCH." ON)
@@ -124,7 +124,7 @@ set_package_properties(
   PURPOSE "Parallel graph partitioning"
 )
 
-if (DOLFINX_ENABLE_SLEPC)
+if(DOLFINX_ENABLE_SLEPC)
   set(_REQUIRE_SLEPC TRUE)
 endif()
 option(DOLFINX_ENABLE_SLEPC "Compile with support for SLEPc." ON)
@@ -136,7 +136,7 @@ set_package_properties(
   PURPOSE "Eigenvalue computation"
 )
 
-if (DOLFINX_ENABLE_KAHIP)
+if(DOLFINX_ENABLE_KAHIP)
   set(_REQUIRE_KAHIP TRUE)
 endif()
 option(DOLFINX_ENABLE_KAHIP "Compile with support for KaHIP." OFF)
@@ -346,7 +346,7 @@ if(DOLFINX_ENABLE_SLEPC)
   set(ENV{PKG_CONFIG_PATH}
       "$ENV{PETSC_DIR}/$ENV{PETSC_ARCH}:$ENV{PETSC_DIR}:$ENV{PKG_CONFIG_PATH}"
   )
-  if (_REQUIRE_SLEPC)
+  if(_REQUIRE_SLEPC)
     pkg_search_module(SLEPC REQUIRED IMPORTED_TARGET slepc>=3.15)
   else()
     pkg_search_module(SLEPC IMPORTED_TARGET slepc>=3.15)
@@ -386,7 +386,10 @@ endif()
 feature_summary(WHAT ALL)
 
 # Check that at least one graph partitioner has been found
-if(NOT SCOTCH_FOUND AND NOT PARMETIS_FOUND AND NOT KAHIP_FOUND)
+if(NOT SCOTCH_FOUND
+   AND NOT PARMETIS_FOUND
+   AND NOT KAHIP_FOUND
+)
   message(
     FATAL_ERROR
       "No graph partitioner found. SCOTCH, ParMETIS or KaHIP is required."


### PR DESCRIPTION
If a package is explicitly enabled via CMake, e.g. `-DDOLFINX_ENABLE_KAHIP`, and is not available or cannot be configured, this change causes a CMake error. This helps package maintainers (#3011) and users.

Resolves #3011.