### PR TITLE
Fix leak for `MPI_Datatype`

### DIFF
--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -615,6 +615,8 @@ xdmf_utils::distribute_entity_data(
     return std::pair(std::move(entities), std::move(data));
   };
 
+  MPI_Type_free(&compound_type);
+
   return select_entities(topology, xdofmap, nodes_g, cell_vertex_dofs,
                          entities_data);
 }


### PR DESCRIPTION
Add missing `MPI_Type_free`.

Resolves #2997.