### PR TITLE
Revert change to Python interface of non-matching interpolation data

### DIFF
--- a/python/dolfinx/fem/__init__.py
+++ b/python/dolfinx/fem/__init__.py
@@ -97,7 +97,7 @@ def create_nonmatching_meshes_interpolation_data(
     else:
         return PointOwnershipData(
             *_create_nonmatching_meshes_interpolation_data(
-                mesh_to._cpp_object, element, mesh_from._cpp_object, cells, padding
+                mesh_to, element, mesh_from._cpp_object, cells, padding
             )
         )
 

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -888,9 +888,8 @@ def test_nonmatching_mesh_interpolation(xtype, cell_type0, cell_type1):
     num_cells_on_proc = fine_mesh_cell_map.size_local + fine_mesh_cell_map.num_ghosts
     cells = np.arange(num_cells_on_proc, dtype=np.int32)
     interpolation_data = create_nonmatching_meshes_interpolation_data(
-        V1.mesh.geometry,
-        V1.element,
-        V0.mesh, cells, padding=padding)
+        V1.mesh.geometry, V1.element, V0.mesh, cells, padding=padding
+    )
     other_interpolation_data = create_nonmatching_meshes_interpolation_data(
         V1.mesh,
         V1.element,
@@ -903,10 +902,7 @@ def test_nonmatching_mesh_interpolation(xtype, cell_type0, cell_type1):
     # Interpolate 3D->2D
     u1 = Function(V1, dtype=xtype)
 
-    u1.interpolate(
-        u0,
-        nmm_interpolation_data=interpolation_data
-    )
+    u1.interpolate(u0, nmm_interpolation_data=interpolation_data)
     u1.x.scatter_forward()
 
     # Exact interpolation on 2D mesh

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -882,16 +882,30 @@ def test_nonmatching_mesh_interpolation(xtype, cell_type0, cell_type1):
     u0.interpolate(f)
     u0.x.scatter_forward()
     padding = 1e-14
+
+    # Check that both interfaces of create nonmatching meshes interpolation data returns the same
+    fine_mesh_cell_map = mesh1.topology.index_map(mesh1.topology.dim)
+    num_cells_on_proc = fine_mesh_cell_map.size_local + fine_mesh_cell_map.num_ghosts
+    cells = np.arange(num_cells_on_proc, dtype=np.int32)
+    interpolation_data = create_nonmatching_meshes_interpolation_data(
+        V1.mesh.geometry,
+        V1.element,
+        V0.mesh, cells, padding=padding)
+    other_interpolation_data = create_nonmatching_meshes_interpolation_data(
+        V1.mesh,
+        V1.element,
+        V0.mesh,
+        padding=padding,
+    )
+    for data_0, data_1 in zip(interpolation_data, other_interpolation_data):
+        np.testing.assert_allclose(data_0, data_1)
+
     # Interpolate 3D->2D
     u1 = Function(V1, dtype=xtype)
+
     u1.interpolate(
         u0,
-        nmm_interpolation_data=create_nonmatching_meshes_interpolation_data(
-            u1.function_space.mesh,
-            u1.function_space.element,
-            u0.function_space.mesh,
-            padding=padding,
-        ),
+        nmm_interpolation_data=interpolation_data
     )
     u1.x.scatter_forward()
 


### PR DESCRIPTION
Reverting: https://github.com/FEniCS/dolfinx/pull/3078/ as it wasn't quite right.

Added test to catch the actual user interface.