### PR TITLE
Let  `*_apply_dof_transformation` accept lists of cells in Python layer

### DIFF
--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -330,29 +330,24 @@ public:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
                     std::int32_t cell, int block_size)
       {
-        pre_apply_inverse_transpose_dof_transformation(
-            data, cell_info.subspan(cell, 1), block_size);
+        pre_apply_inverse_transpose_dof_transformation(data, cell_info[cell],
+                                                       block_size);
       };
     case doftransform::transpose:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
-                    std::int32_t cell, int block_size)
-      {
-        pre_apply_transpose_dof_transformation(data, cell_info.subspan(cell, 1),
+                    std::int32_t cell, int block_size) {
+        pre_apply_transpose_dof_transformation(data, cell_info[cell],
                                                block_size);
       };
     case doftransform::inverse:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
-                    std::int32_t cell, int block_size)
-      {
-        pre_apply_inverse_dof_transformation(data, cell_info.subspan(cell, 1),
-                                             block_size);
+                    std::int32_t cell, int block_size) {
+        pre_apply_inverse_dof_transformation(data, cell_info[cell], block_size);
       };
     case doftransform::standard:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
-                    std::int32_t cell, int block_size) {
-        pre_apply_dof_transformation(data, cell_info.subspan(cell, 1),
-                                     block_size);
-      };
+                    std::int32_t cell, int block_size)
+      { pre_apply_dof_transformation(data, cell_info[cell], block_size); };
     default:
       throw std::runtime_error("Unknown transformation type");
     }
@@ -444,30 +439,25 @@ public:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
                     std::int32_t cell, int block_size)
       {
-        post_apply_inverse_transpose_dof_transformation(
-            data, cell_info.subspan(cell, 1), block_size);
+        post_apply_inverse_transpose_dof_transformation(data, cell_info[cell],
+                                                        block_size);
       };
     case doftransform::transpose:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
-                    std::int32_t cell, int block_size)
-      {
-        post_apply_transpose_dof_transformation(
-            data, cell_info.subspan(cell, 1), block_size);
+                    std::int32_t cell, int block_size) {
+        post_apply_transpose_dof_transformation(data, cell_info[cell],
+                                                block_size);
       };
     case doftransform::inverse:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
-                    std::int32_t cell, int block_size)
-      {
-        post_apply_inverse_dof_transformation(data, cell_info.subspan(cell, 1),
+                    std::int32_t cell, int block_size) {
+        post_apply_inverse_dof_transformation(data, cell_info[cell],
                                               block_size);
       };
     case doftransform::standard:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
                     std::int32_t cell, int block_size)
-      {
-        post_apply_dof_transformation(data, cell_info.subspan(cell, 1),
-                                      block_size);
-      };
+      { post_apply_dof_transformation(data, cell_info[cell], block_size); };
     default:
       throw std::runtime_error("Unknown transformation type");
     }
@@ -476,23 +466,16 @@ public:
   /// Apply DOF transformation to some data
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
-  /// @param[in] cell_permutations Permutation data for the cells
+  /// with row-major layout, shape=(num_dofs, block_size)
+  /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input data per cell
   template <typename U>
-  void
-  pre_apply_dof_transformation(std::span<U> data,
-                               std::span<const std::uint32_t> cell_permutations,
-                               int block_size) const
+  void pre_apply_dof_transformation(std::span<U> data,
+                                    std::uint32_t cell_permutation,
+                                    int block_size) const
   {
     assert(_element);
-    const std::size_t data_per_cell = data.size() / cell_permutations.size();
-    for (std::size_t i = 0; i < cell_permutations.size(); i++)
-    {
-      _element->pre_apply_dof_transformation(
-          data.subspan(i * data_per_cell, data_per_cell), block_size,
-          cell_permutations[i]);
-    }
+    _element->pre_apply_dof_transformation(data, block_size, cell_permutation);
   }
 
   /// Apply inverse transpose transformation to some data. For
@@ -500,150 +483,112 @@ public:
   /// subelement.
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
-  /// @param[in] cell_permutations Permutation data for the cells
+  /// with row-major layout, shape=(num_dofs, block_size)
+  /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input data
   template <typename U>
   void pre_apply_inverse_transpose_dof_transformation(
-      std::span<U> data, std::span<const std::uint32_t> cell_permutations,
-      int block_size) const
+      std::span<U> data, std::uint32_t cell_permutation, int block_size) const
   {
     assert(_element);
-    const std::size_t data_per_cell = data.size() / cell_permutations.size();
-    for (std::size_t i = 0; i < cell_permutations.size(); i++)
-    {
-      _element->pre_apply_inverse_transpose_dof_transformation(
-          data.subspan(i * data_per_cell, data_per_cell), block_size,
-          cell_permutations[i]);
-    }
+    _element->pre_apply_inverse_transpose_dof_transformation(data, block_size,
+                                                             cell_permutation);
   }
 
   /// Apply transpose transformation to some data. For VectorElements,
   /// this applies the transformations for the scalar subelement.
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
-  /// @param[in] cell_permutations Permutation data for the cells
+  /// with row-major layout, shape=(num_dofs, block_size)
+  /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input data
   template <typename U>
-  void pre_apply_transpose_dof_transformation(
-      std::span<U> data, std::span<const std::uint32_t> cell_permutations,
-      int block_size) const
+  void pre_apply_transpose_dof_transformation(std::span<U> data,
+                                              std::uint32_t cell_permutation,
+                                              int block_size) const
   {
     assert(_element);
-    const std::size_t data_per_cell = data.size() / cell_permutations.size();
-    for (std::size_t i = 0; i < cell_permutations.size(); i++)
-    {
-      _element->pre_apply_transpose_dof_transformation(
-          data.subspan(i * data_per_cell, data_per_cell), block_size,
-          cell_permutations[i]);
-    }
+    _element->pre_apply_transpose_dof_transformation(data, block_size,
+                                                     cell_permutation);
   }
 
   /// Apply inverse transformation to some data. For VectorElements,
   /// this applies the transformations for the scalar subelement.
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
-  /// @param[in] cell_permutations Permutation data for the cells
+  /// with row-major layout, shape=(num_dofs, block_size)
+  /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input data
   template <typename U>
-  void pre_apply_inverse_dof_transformation(
-      std::span<U> data, std::span<const std::uint32_t> cell_permutations,
-      int block_size) const
+  void pre_apply_inverse_dof_transformation(std::span<U> data,
+                                            std::uint32_t cell_permutation,
+                                            int block_size) const
   {
     assert(_element);
-    const std::size_t data_per_cell = data.size() / cell_permutations.size();
-    for (std::size_t i = 0; i < cell_permutations.size(); i++)
-    {
-      _element->pre_apply_inverse_dof_transformation(
-          data.subspan(i * data_per_cell, data_per_cell), block_size,
-          cell_permutations[i]);
-    }
+    _element->pre_apply_inverse_dof_transformation(data, block_size,
+                                                   cell_permutation);
   }
 
   /// Apply DOF transformation to some transposed data
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
-  /// @param[in] cell_permutations Permutation data for the cells
+  /// with row-major layout, shape=(num_dofs, block_size)
+  /// @param[in] cell_permutation Permutation data for the cells
   /// @param[in] block_size The block_size of the input data
   template <typename U>
-  void post_apply_dof_transformation(
-      std::span<U> data, std::span<const std::uint32_t> cell_permutations,
-      int block_size) const
+  void post_apply_dof_transformation(std::span<U> data,
+                                     std::uint32_t cell_permutation,
+                                     int block_size) const
   {
     assert(_element);
-    const std::size_t data_per_cell = data.size() / cell_permutations.size();
-    for (std::size_t i = 0; i < cell_permutations.size(); i++)
-    {
-      _element->post_apply_dof_transformation(
-          data.subspan(i * data_per_cell, data_per_cell), block_size,
-          cell_permutations[i]);
-    }
+    _element->post_apply_dof_transformation(data, block_size, cell_permutation);
   }
 
   /// Apply inverse of DOF transformation to some transposed data.
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
-  /// @param[in] cell_permutations Permutation data for the cells
+  /// with row-major layout, shape=(num_dofs, block_size)
+  /// @param[in] cell_permutation Permutation data for the cells
   /// @param[in] block_size The block_size of the input data
   template <typename U>
-  void post_apply_inverse_dof_transformation(
-      std::span<U> data, std::span<const std::uint32_t> cell_permutations,
-      int block_size) const
+  void post_apply_inverse_dof_transformation(std::span<U> data,
+                                             std::uint32_t cell_permutation,
+                                             int block_size) const
   {
     assert(_element);
-    const std::size_t data_per_cell = data.size() / cell_permutations.size();
-    for (std::size_t i = 0; i < cell_permutations.size(); i++)
-    {
-      _element->post_apply_inverse_dof_transformation(
-          data.subspan(i * data_per_cell, data_per_cell), block_size,
-          cell_permutations[i]);
-    }
+    _element->post_apply_inverse_dof_transformation(data, block_size,
+                                                    cell_permutation);
   }
 
   /// Apply transpose of transformation to some transposed data.
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
-  /// @param[in] cell_permutations Permutation data for the cell
+  /// with row-major layout, shape=(num_dofs, block_size)
+  /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input datas
   template <typename U>
-  void post_apply_transpose_dof_transformation(
-      std::span<U> data, std::span<const std::uint32_t> cell_permutations,
-      int block_size) const
+  void post_apply_transpose_dof_transformation(std::span<U> data,
+                                               std::uint32_t cell_permutation,
+                                               int block_size) const
   {
     assert(_element);
-    const std::size_t data_per_cell = data.size() / cell_permutations.size();
-    for (std::size_t i = 0; i < cell_permutations.size(); i++)
-    {
-      _element->post_apply_transpose_dof_transformation(
-          data.subspan(i * data_per_cell, data_per_cell), block_size,
-          cell_permutations[i]);
-    }
+    _element->post_apply_transpose_dof_transformation(data, block_size,
+                                                      cell_permutation);
   }
 
   /// Apply inverse transpose transformation to some transposed data
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
-  /// @param[in] cell_permutations Permutation data for the cells
+  /// with row-major layout, shape=(num_dofs, block_size)
+  /// @param[in] cell_permutation Permutation data for the cells
   /// @param[in] block_size The block_size of the input data
   template <typename U>
   void post_apply_inverse_transpose_dof_transformation(
-      std::span<U> data, std::span<const std::uint32_t> cell_permutations,
-      int block_size) const
+      std::span<U> data, std::uint32_t cell_permutation, int block_size) const
   {
     assert(_element);
-    const std::size_t data_per_cell = data.size() / cell_permutations.size();
-    for (std::size_t i = 0; i < cell_permutations.size(); i++)
-    {
-      _element->post_apply_inverse_transpose_dof_transformation(
-          data.subspan(i * data_per_cell, data_per_cell), block_size,
-          cell_permutations[i]);
-    }
+    _element->post_apply_inverse_transpose_dof_transformation(data, block_size,
+                                                              cell_permutation);
   }
 
   /// Permute the DOFs of the element

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -468,7 +468,7 @@ public:
   /// @param[in,out] data The data to be transformed. This data is flattened
   /// with row-major layout, shape=(num_dofs, block_size)
   /// @param[in] cell_permutation Permutation data for the cell
-  /// @param[in] block_size The block_size of the input data per cell
+  /// @param[in] block_size The block_size of the input data
   template <typename U>
   void pre_apply_dof_transformation(std::span<U> data,
                                     std::uint32_t cell_permutation,
@@ -533,7 +533,7 @@ public:
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
   /// with row-major layout, shape=(num_dofs, block_size)
-  /// @param[in] cell_permutation Permutation data for the cells
+  /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input data
   template <typename U>
   void post_apply_dof_transformation(std::span<U> data,
@@ -548,7 +548,7 @@ public:
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
   /// with row-major layout, shape=(num_dofs, block_size)
-  /// @param[in] cell_permutation Permutation data for the cells
+  /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input data
   template <typename U>
   void post_apply_inverse_dof_transformation(std::span<U> data,
@@ -565,7 +565,7 @@ public:
   /// @param[in,out] data The data to be transformed. This data is flattened
   /// with row-major layout, shape=(num_dofs, block_size)
   /// @param[in] cell_permutation Permutation data for the cell
-  /// @param[in] block_size The block_size of the input datas
+  /// @param[in] block_size The block_size of the input data
   template <typename U>
   void post_apply_transpose_dof_transformation(std::span<U> data,
                                                std::uint32_t cell_permutation,
@@ -580,7 +580,7 @@ public:
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
   /// with row-major layout, shape=(num_dofs, block_size)
-  /// @param[in] cell_permutation Permutation data for the cells
+  /// @param[in] cell_permutation Permutation data for the cell
   /// @param[in] block_size The block_size of the input data
   template <typename U>
   void post_apply_inverse_transpose_dof_transformation(

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -330,24 +330,29 @@ public:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
                     std::int32_t cell, int block_size)
       {
-        pre_apply_inverse_transpose_dof_transformation(data, cell_info[cell],
-                                                       block_size);
+        pre_apply_inverse_transpose_dof_transformation(
+            data, cell_info.subspan(cell, 1), block_size);
       };
     case doftransform::transpose:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
-                    std::int32_t cell, int block_size) {
-        pre_apply_transpose_dof_transformation(data, cell_info[cell],
+                    std::int32_t cell, int block_size)
+      {
+        pre_apply_transpose_dof_transformation(data, cell_info.subspan(cell, 1),
                                                block_size);
       };
     case doftransform::inverse:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
-                    std::int32_t cell, int block_size) {
-        pre_apply_inverse_dof_transformation(data, cell_info[cell], block_size);
+                    std::int32_t cell, int block_size)
+      {
+        pre_apply_inverse_dof_transformation(data, cell_info.subspan(cell, 1),
+                                             block_size);
       };
     case doftransform::standard:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
-                    std::int32_t cell, int block_size)
-      { pre_apply_dof_transformation(data, cell_info[cell], block_size); };
+                    std::int32_t cell, int block_size) {
+        pre_apply_dof_transformation(data, cell_info.subspan(cell, 1),
+                                     block_size);
+      };
     default:
       throw std::runtime_error("Unknown transformation type");
     }
@@ -439,25 +444,30 @@ public:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
                     std::int32_t cell, int block_size)
       {
-        post_apply_inverse_transpose_dof_transformation(data, cell_info[cell],
-                                                        block_size);
+        post_apply_inverse_transpose_dof_transformation(
+            data, cell_info.subspan(cell, 1), block_size);
       };
     case doftransform::transpose:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
-                    std::int32_t cell, int block_size) {
-        post_apply_transpose_dof_transformation(data, cell_info[cell],
-                                                block_size);
+                    std::int32_t cell, int block_size)
+      {
+        post_apply_transpose_dof_transformation(
+            data, cell_info.subspan(cell, 1), block_size);
       };
     case doftransform::inverse:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
-                    std::int32_t cell, int block_size) {
-        post_apply_inverse_dof_transformation(data, cell_info[cell],
+                    std::int32_t cell, int block_size)
+      {
+        post_apply_inverse_dof_transformation(data, cell_info.subspan(cell, 1),
                                               block_size);
       };
     case doftransform::standard:
       return [this](std::span<U> data, std::span<const std::uint32_t> cell_info,
                     std::int32_t cell, int block_size)
-      { post_apply_dof_transformation(data, cell_info[cell], block_size); };
+      {
+        post_apply_dof_transformation(data, cell_info.subspan(cell, 1),
+                                      block_size);
+      };
     default:
       throw std::runtime_error("Unknown transformation type");
     }
@@ -466,16 +476,23 @@ public:
   /// Apply DOF transformation to some data
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_dofs, block_size)
-  /// @param[in] cell_permutation Permutation data for the cell
-  /// @param[in] block_size The block_size of the input data
+  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
+  /// @param[in] cell_permutations Permutation data for the cells
+  /// @param[in] block_size The block_size of the input data per cell
   template <typename U>
-  void pre_apply_dof_transformation(std::span<U> data,
-                                    std::uint32_t cell_permutation,
-                                    int block_size) const
+  void
+  pre_apply_dof_transformation(std::span<U> data,
+                               std::span<const std::uint32_t> cell_permutations,
+                               int block_size) const
   {
     assert(_element);
-    _element->pre_apply_dof_transformation(data, block_size, cell_permutation);
+    const std::size_t data_per_cell = data.size() / cell_permutations.size();
+    for (std::size_t i = 0; i < cell_permutations.size(); i++)
+    {
+      _element->pre_apply_dof_transformation(
+          data.subspan(i * data_per_cell, data_per_cell), block_size,
+          cell_permutations[i]);
+    }
   }
 
   /// Apply inverse transpose transformation to some data. For
@@ -483,112 +500,150 @@ public:
   /// subelement.
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_dofs, block_size)
-  /// @param[in] cell_permutation Permutation data for the cell
+  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
+  /// @param[in] cell_permutations Permutation data for the cells
   /// @param[in] block_size The block_size of the input data
   template <typename U>
   void pre_apply_inverse_transpose_dof_transformation(
-      std::span<U> data, std::uint32_t cell_permutation, int block_size) const
+      std::span<U> data, std::span<const std::uint32_t> cell_permutations,
+      int block_size) const
   {
     assert(_element);
-    _element->pre_apply_inverse_transpose_dof_transformation(data, block_size,
-                                                             cell_permutation);
+    const std::size_t data_per_cell = data.size() / cell_permutations.size();
+    for (std::size_t i = 0; i < cell_permutations.size(); i++)
+    {
+      _element->pre_apply_inverse_transpose_dof_transformation(
+          data.subspan(i * data_per_cell, data_per_cell), block_size,
+          cell_permutations[i]);
+    }
   }
 
   /// Apply transpose transformation to some data. For VectorElements,
   /// this applies the transformations for the scalar subelement.
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_dofs, block_size)
-  /// @param[in] cell_permutation Permutation data for the cell
+  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
+  /// @param[in] cell_permutations Permutation data for the cells
   /// @param[in] block_size The block_size of the input data
   template <typename U>
-  void pre_apply_transpose_dof_transformation(std::span<U> data,
-                                              std::uint32_t cell_permutation,
-                                              int block_size) const
+  void pre_apply_transpose_dof_transformation(
+      std::span<U> data, std::span<const std::uint32_t> cell_permutations,
+      int block_size) const
   {
     assert(_element);
-    _element->pre_apply_transpose_dof_transformation(data, block_size,
-                                                     cell_permutation);
+    const std::size_t data_per_cell = data.size() / cell_permutations.size();
+    for (std::size_t i = 0; i < cell_permutations.size(); i++)
+    {
+      _element->pre_apply_transpose_dof_transformation(
+          data.subspan(i * data_per_cell, data_per_cell), block_size,
+          cell_permutations[i]);
+    }
   }
 
   /// Apply inverse transformation to some data. For VectorElements,
   /// this applies the transformations for the scalar subelement.
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_dofs, block_size)
-  /// @param[in] cell_permutation Permutation data for the cell
+  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
+  /// @param[in] cell_permutations Permutation data for the cells
   /// @param[in] block_size The block_size of the input data
   template <typename U>
-  void pre_apply_inverse_dof_transformation(std::span<U> data,
-                                            std::uint32_t cell_permutation,
-                                            int block_size) const
+  void pre_apply_inverse_dof_transformation(
+      std::span<U> data, std::span<const std::uint32_t> cell_permutations,
+      int block_size) const
   {
     assert(_element);
-    _element->pre_apply_inverse_dof_transformation(data, block_size,
-                                                   cell_permutation);
+    const std::size_t data_per_cell = data.size() / cell_permutations.size();
+    for (std::size_t i = 0; i < cell_permutations.size(); i++)
+    {
+      _element->pre_apply_inverse_dof_transformation(
+          data.subspan(i * data_per_cell, data_per_cell), block_size,
+          cell_permutations[i]);
+    }
   }
 
   /// Apply DOF transformation to some transposed data
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_dofs, block_size)
-  /// @param[in] cell_permutation Permutation data for the cell
+  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
+  /// @param[in] cell_permutations Permutation data for the cells
   /// @param[in] block_size The block_size of the input data
   template <typename U>
-  void post_apply_dof_transformation(std::span<U> data,
-                                     std::uint32_t cell_permutation,
-                                     int block_size) const
+  void post_apply_dof_transformation(
+      std::span<U> data, std::span<const std::uint32_t> cell_permutations,
+      int block_size) const
   {
     assert(_element);
-    _element->post_apply_dof_transformation(data, block_size, cell_permutation);
+    const std::size_t data_per_cell = data.size() / cell_permutations.size();
+    for (std::size_t i = 0; i < cell_permutations.size(); i++)
+    {
+      _element->post_apply_dof_transformation(
+          data.subspan(i * data_per_cell, data_per_cell), block_size,
+          cell_permutations[i]);
+    }
   }
 
   /// Apply inverse of DOF transformation to some transposed data.
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_dofs, block_size)
-  /// @param[in] cell_permutation Permutation data for the cell
+  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
+  /// @param[in] cell_permutations Permutation data for the cells
   /// @param[in] block_size The block_size of the input data
   template <typename U>
-  void post_apply_inverse_dof_transformation(std::span<U> data,
-                                             std::uint32_t cell_permutation,
-                                             int block_size) const
+  void post_apply_inverse_dof_transformation(
+      std::span<U> data, std::span<const std::uint32_t> cell_permutations,
+      int block_size) const
   {
     assert(_element);
-    _element->post_apply_inverse_dof_transformation(data, block_size,
-                                                    cell_permutation);
+    const std::size_t data_per_cell = data.size() / cell_permutations.size();
+    for (std::size_t i = 0; i < cell_permutations.size(); i++)
+    {
+      _element->post_apply_inverse_dof_transformation(
+          data.subspan(i * data_per_cell, data_per_cell), block_size,
+          cell_permutations[i]);
+    }
   }
 
   /// Apply transpose of transformation to some transposed data.
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_dofs, block_size)
-  /// @param[in] cell_permutation Permutation data for the cell
-  /// @param[in] block_size The block_size of the input data
+  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
+  /// @param[in] cell_permutations Permutation data for the cell
+  /// @param[in] block_size The block_size of the input datas
   template <typename U>
-  void post_apply_transpose_dof_transformation(std::span<U> data,
-                                               std::uint32_t cell_permutation,
-                                               int block_size) const
+  void post_apply_transpose_dof_transformation(
+      std::span<U> data, std::span<const std::uint32_t> cell_permutations,
+      int block_size) const
   {
     assert(_element);
-    _element->post_apply_transpose_dof_transformation(data, block_size,
-                                                      cell_permutation);
+    const std::size_t data_per_cell = data.size() / cell_permutations.size();
+    for (std::size_t i = 0; i < cell_permutations.size(); i++)
+    {
+      _element->post_apply_transpose_dof_transformation(
+          data.subspan(i * data_per_cell, data_per_cell), block_size,
+          cell_permutations[i]);
+    }
   }
 
   /// Apply inverse transpose transformation to some transposed data
   ///
   /// @param[in,out] data The data to be transformed. This data is flattened
-  /// with row-major layout, shape=(num_dofs, block_size)
-  /// @param[in] cell_permutation Permutation data for the cell
+  /// with row-major layout, shape=(num_cells, num_dofs, block_size)
+  /// @param[in] cell_permutations Permutation data for the cells
   /// @param[in] block_size The block_size of the input data
   template <typename U>
   void post_apply_inverse_transpose_dof_transformation(
-      std::span<U> data, std::uint32_t cell_permutation, int block_size) const
+      std::span<U> data, std::span<const std::uint32_t> cell_permutations,
+      int block_size) const
   {
     assert(_element);
-    _element->post_apply_inverse_transpose_dof_transformation(data, block_size,
-                                                              cell_permutation);
+    const std::size_t data_per_cell = data.size() / cell_permutations.size();
+    for (std::size_t i = 0; i < cell_permutations.size(); i++)
+    {
+      _element->post_apply_inverse_transpose_dof_transformation(
+          data.subspan(i * data_per_cell, data_per_cell), block_size,
+          cell_permutations[i]);
+    }
   }
 
   /// Permute the DOFs of the element

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -141,10 +141,17 @@ void declare_function_space(nb::module_& m, std::string type)
                    cell_permutations,
                int dim)
             {
-              self.pre_apply_dof_transformation(
-                  std::span(x.data(), x.size()),
-                  std::span(cell_permutations.data(), cell_permutations.size()),
-                  dim);
+              const std::size_t data_per_cell
+                  = x.size() / cell_permutations.size();
+              std::span<T> x_span(x.data(), x.size());
+              std::span<const std::uint32_t> perm_span(
+                  cell_permutations.data(), cell_permutations.size());
+              for (std::size_t i = 0; i < cell_permutations.size(); i++)
+              {
+                self.pre_apply_dof_transformation(
+                    x_span.subspan(i * data_per_cell, data_per_cell),
+                    perm_span[i], dim);
+              }
             },
             nb::arg("x"), nb::arg("cell_permutations"), nb::arg("dim"))
         .def(
@@ -155,10 +162,17 @@ void declare_function_space(nb::module_& m, std::string type)
                    cell_permutations,
                int dim)
             {
-              self.pre_apply_transpose_dof_transformation(
-                  std::span(x.data(), x.size()),
-                  std::span(cell_permutations.data(), cell_permutations.size()),
-                  dim);
+              const std::size_t data_per_cell
+                  = x.size() / cell_permutations.size();
+              std::span<T> x_span(x.data(), x.size());
+              std::span<const std::uint32_t> perm_span(
+                  cell_permutations.data(), cell_permutations.size());
+              for (std::size_t i = 0; i < cell_permutations.size(); i++)
+              {
+                self.pre_apply_transpose_dof_transformation(
+                    x_span.subspan(i * data_per_cell, data_per_cell),
+                    perm_span[i], dim);
+              }
             },
             nb::arg("x"), nb::arg("cell_permutations"), nb::arg("dim"))
         .def(
@@ -169,10 +183,18 @@ void declare_function_space(nb::module_& m, std::string type)
                    cell_permutations,
                int dim)
             {
-              self.pre_apply_inverse_transpose_dof_transformation(
-                  std::span(x.data(), x.size()),
-                  std::span(cell_permutations.data(), cell_permutations.size()),
-                  dim);
+              const std::size_t data_per_cell
+                  = x.size() / cell_permutations.size();
+              std::span<T> x_span(x.data(), x.size());
+              std::span<const std::uint32_t> perm_span(
+                  cell_permutations.data(), cell_permutations.size());
+
+              for (std::size_t i = 0; i < cell_permutations.size(); i++)
+              {
+                self.pre_apply_inverse_transpose_dof_transformation(
+                    x_span.subspan(i * data_per_cell, data_per_cell),
+                    perm_span[i], dim);
+              }
             },
             nb::arg("x"), nb::arg("cell_permutations"), nb::arg("dim"))
         .def(
@@ -183,10 +205,18 @@ void declare_function_space(nb::module_& m, std::string type)
                    cell_permutations,
                int dim)
             {
-              self.pre_apply_dof_transformation(
-                  std::span((std::complex<T>*)x.data(), x.size()),
-                  std::span(cell_permutations.data(), cell_permutations.size()),
-                  dim);
+              const std::size_t data_per_cell
+                  = x.size() / cell_permutations.size();
+              std::span<std::complex<T>> x_span(x.data(), x.size());
+              std::span<const std::uint32_t> perm_span(
+                  cell_permutations.data(), cell_permutations.size());
+
+              for (std::size_t i = 0; i < cell_permutations.size(); i++)
+              {
+                self.pre_apply_dof_transformation(
+                    x_span.subspan(i * data_per_cell, data_per_cell),
+                    perm_span[i], dim);
+              }
             },
             nb::arg("x"), nb::arg("cell_permutations"), nb::arg("dim"))
         .def(
@@ -197,10 +227,18 @@ void declare_function_space(nb::module_& m, std::string type)
                    cell_permutations,
                int dim)
             {
-              self.pre_apply_transpose_dof_transformation(
-                  std::span((std::complex<T>*)x.data(), x.size()),
-                  std::span(cell_permutations.data(), cell_permutations.size()),
-                  dim);
+              const std::size_t data_per_cell
+                  = x.size() / cell_permutations.size();
+              std::span<std::complex<T>> x_span(x.data(), x.size());
+              std::span<const std::uint32_t> perm_span(
+                  cell_permutations.data(), cell_permutations.size());
+
+              for (std::size_t i = 0; i < cell_permutations.size(); i++)
+              {
+                self.pre_apply_transpose_dof_transformation(
+                    x_span.subspan(i * data_per_cell, data_per_cell),
+                    perm_span[i], dim);
+              }
             },
             nb::arg("x"), nb::arg("cell_permutations"), nb::arg("dim"))
         .def(
@@ -211,10 +249,18 @@ void declare_function_space(nb::module_& m, std::string type)
                    cell_permutations,
                int dim)
             {
-              self.pre_apply_inverse_transpose_dof_transformation(
-                  std::span(x.data(), x.shape(0) * x.shape(1)),
-                  std::span(cell_permutations.data(), cell_permutations.size()),
-                  dim);
+              const std::size_t data_per_cell
+                  = x.size() / cell_permutations.size();
+              std::span<std::complex<T>> x_span(x.data(), x.size());
+              std::span<const std::uint32_t> perm_span(
+                  cell_permutations.data(), cell_permutations.size());
+
+              for (std::size_t i = 0; i < cell_permutations.size(); i++)
+              {
+                self.pre_apply_inverse_transpose_dof_transformation(
+                    x_span.subspan(i * data_per_cell, data_per_cell),
+                    perm_span[i], dim);
+              }
             },
             nb::arg("x"), nb::arg("cell_permutations"), nb::arg("dim"))
         .def_prop_ro("needs_dof_transformations",

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -146,7 +146,7 @@ void declare_function_space(nb::module_& m, std::string type)
                   std::span(cell_permutations.data(), cell_permutations.size()),
                   dim);
             },
-            nb::arg("x"), nb::arg("cell_permutation"), nb::arg("dim"))
+            nb::arg("x"), nb::arg("cell_permutations"), nb::arg("dim"))
         .def(
             "pre_apply_transpose_dof_transformation",
             [](const dolfinx::fem::FiniteElement<T>& self,
@@ -160,7 +160,7 @@ void declare_function_space(nb::module_& m, std::string type)
                   std::span(cell_permutations.data(), cell_permutations.size()),
                   dim);
             },
-            nb::arg("x"), nb::arg("cell_permutation"), nb::arg("dim"))
+            nb::arg("x"), nb::arg("cell_permutations"), nb::arg("dim"))
         .def(
             "pre_apply_inverse_transpose_dof_transformation",
             [](const dolfinx::fem::FiniteElement<T>& self,
@@ -174,7 +174,7 @@ void declare_function_space(nb::module_& m, std::string type)
                   std::span(cell_permutations.data(), cell_permutations.size()),
                   dim);
             },
-            nb::arg("x"), nb::arg("cell_permutation"), nb::arg("dim"))
+            nb::arg("x"), nb::arg("cell_permutations"), nb::arg("dim"))
         .def(
             "pre_apply_dof_transformation",
             [](const dolfinx::fem::FiniteElement<T>& self,
@@ -188,7 +188,7 @@ void declare_function_space(nb::module_& m, std::string type)
                   std::span(cell_permutations.data(), cell_permutations.size()),
                   dim);
             },
-            nb::arg("x"), nb::arg("cell_permutation"), nb::arg("dim"))
+            nb::arg("x"), nb::arg("cell_permutations"), nb::arg("dim"))
         .def(
             "pre_apply_transpose_dof_transformation",
             [](const dolfinx::fem::FiniteElement<T>& self,
@@ -202,7 +202,7 @@ void declare_function_space(nb::module_& m, std::string type)
                   std::span(cell_permutations.data(), cell_permutations.size()),
                   dim);
             },
-            nb::arg("x"), nb::arg("cell_permutation"), nb::arg("dim"))
+            nb::arg("x"), nb::arg("cell_permutations"), nb::arg("dim"))
         .def(
             "pre_apply_inverse_transpose_dof_transformation",
             [](const dolfinx::fem::FiniteElement<T>& self,
@@ -216,7 +216,7 @@ void declare_function_space(nb::module_& m, std::string type)
                   std::span(cell_permutations.data(), cell_permutations.size()),
                   dim);
             },
-            nb::arg("x"), nb::arg("cell_permutation"), nb::arg("dim"))
+            nb::arg("x"), nb::arg("cell_permutations"), nb::arg("dim"))
         .def_prop_ro("needs_dof_transformations",
                      &dolfinx::fem::FiniteElement<T>::needs_dof_transformations)
         .def("signature", &dolfinx::fem::FiniteElement<T>::signature);

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -137,63 +137,84 @@ void declare_function_space(nb::module_& m, std::string type)
             "pre_apply_dof_transformation",
             [](const dolfinx::fem::FiniteElement<T>& self,
                nb::ndarray<T, nb::ndim<1>, nb::c_contig> x,
-               std::uint32_t cell_permutation, int dim)
+               nb::ndarray<const std::uint32_t, nb::ndim<1>, nb::c_contig>
+                   cell_permutations,
+               int dim)
             {
-              self.pre_apply_dof_transformation(std::span(x.data(), x.size()),
-                                                cell_permutation, dim);
+              self.pre_apply_dof_transformation(
+                  std::span(x.data(), x.size()),
+                  std::span(cell_permutations.data(), cell_permutations.size()),
+                  dim);
             },
             nb::arg("x"), nb::arg("cell_permutation"), nb::arg("dim"))
         .def(
             "pre_apply_transpose_dof_transformation",
             [](const dolfinx::fem::FiniteElement<T>& self,
                nb::ndarray<T, nb::ndim<1>, nb::c_contig> x,
-               std::uint32_t cell_permutation, int dim)
+               nb::ndarray<const std::uint32_t, nb::ndim<1>, nb::c_contig>
+                   cell_permutations,
+               int dim)
             {
               self.pre_apply_transpose_dof_transformation(
-                  std::span(x.data(), x.size()), cell_permutation, dim);
+                  std::span(x.data(), x.size()),
+                  std::span(cell_permutations.data(), cell_permutations.size()),
+                  dim);
             },
             nb::arg("x"), nb::arg("cell_permutation"), nb::arg("dim"))
         .def(
             "pre_apply_inverse_transpose_dof_transformation",
             [](const dolfinx::fem::FiniteElement<T>& self,
                nb::ndarray<T, nb::ndim<1>, nb::c_contig> x,
-               std::uint32_t cell_permutation, int dim)
+               nb::ndarray<const std::uint32_t, nb::ndim<1>, nb::c_contig>
+                   cell_permutations,
+               int dim)
             {
               self.pre_apply_inverse_transpose_dof_transformation(
-                  std::span(x.data(), x.size()), cell_permutation, dim);
+                  std::span(x.data(), x.size()),
+                  std::span(cell_permutations.data(), cell_permutations.size()),
+                  dim);
             },
             nb::arg("x"), nb::arg("cell_permutation"), nb::arg("dim"))
         .def(
             "pre_apply_dof_transformation",
             [](const dolfinx::fem::FiniteElement<T>& self,
                nb::ndarray<std::complex<T>, nb::ndim<1>, nb::c_contig> x,
-               std::uint32_t cell_permutation, int dim)
+               nb::ndarray<const std::uint32_t, nb::ndim<1>, nb::c_contig>
+                   cell_permutations,
+               int dim)
             {
               self.pre_apply_dof_transformation(
                   std::span((std::complex<T>*)x.data(), x.size()),
-                  cell_permutation, dim);
+                  std::span(cell_permutations.data(), cell_permutations.size()),
+                  dim);
             },
             nb::arg("x"), nb::arg("cell_permutation"), nb::arg("dim"))
         .def(
             "pre_apply_transpose_dof_transformation",
             [](const dolfinx::fem::FiniteElement<T>& self,
                nb::ndarray<std::complex<T>, nb::ndim<1>, nb::c_contig> x,
-               std::uint32_t cell_permutation, int dim)
+               nb::ndarray<const std::uint32_t, nb::ndim<1>, nb::c_contig>
+                   cell_permutations,
+               int dim)
             {
               self.pre_apply_transpose_dof_transformation(
                   std::span((std::complex<T>*)x.data(), x.size()),
-                  cell_permutation, dim);
+                  std::span(cell_permutations.data(), cell_permutations.size()),
+                  dim);
             },
             nb::arg("x"), nb::arg("cell_permutation"), nb::arg("dim"))
         .def(
             "pre_apply_inverse_transpose_dof_transformation",
             [](const dolfinx::fem::FiniteElement<T>& self,
                nb::ndarray<std::complex<T>, nb::ndim<1>, nb::c_contig> x,
-               std::uint32_t cell_permutation, int dim)
+               nb::ndarray<const std::uint32_t, nb::ndim<1>, nb::c_contig>
+                   cell_permutations,
+               int dim)
             {
               self.pre_apply_inverse_transpose_dof_transformation(
                   std::span(x.data(), x.shape(0) * x.shape(1)),
-                  cell_permutation, dim);
+                  std::span(cell_permutations.data(), cell_permutations.size()),
+                  dim);
             },
             nb::arg("x"), nb::arg("cell_permutation"), nb::arg("dim"))
         .def_prop_ro("needs_dof_transformations",


### PR DESCRIPTION
Makes this function useful from Python when you have a contiguous array relating to more than a single cell with a single permutation.
Resolves #3089.
Tested for multiple cells in: https://github.com/jorgensd/adios4dolfinx/actions/runs/8179344989/job/22365266424?pr=92
while the DOLFINx C++ interface now uses the one cell version (which throws errors in `test_assembly` if not done correctly).