### PR TITLE
Let dlx.la.Vector manage the scope of the petsc4py wrapper (#1)

### DIFF
--- a/python/demo/demo_elasticity.py
+++ b/python/demo/demo_elasticity.py
@@ -218,7 +218,7 @@ uh = Function(V)
 # Set a monitor, solve linear system, and display the solver
 # configuration
 solver.setMonitor(lambda _, its, rnorm: print(f"Iteration: {its}, rel. residual: {rnorm}"))
-solver.solve(b, uh.vector)
+solver.solve(b, uh.x.petsc_vec)
 solver.view()
 
 # Scatter forward the solution vector to update ghost values

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -163,7 +163,7 @@ set_bc(b, [bc])
 uc = Function(U)
 solver = PETSc.KSP().create(A_cond.getComm())  # type: ignore
 solver.setOperators(A_cond)
-solver.solve(b, uc.vector)
+solver.solve(b, uc.x.petsc_vec)
 
 # Pure displacement based formulation
 a = form(-ufl.inner(sigma_u(u), ufl.grad(v)) * ufl.dx)

--- a/python/demo/demo_stokes.py
+++ b/python/demo/demo_stokes.py
@@ -524,7 +524,7 @@ def mixed_direct():
     # Compute the solution
     U = Function(W)
     try:
-        ksp.solve(b, U.vector)
+        ksp.solve(b, U.x.petsc_vec)
     except PETSc.Error as e:
         if e.ierr == 92:
             print("The required PETSc solver/preconditioner is not available. Exiting.")

--- a/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
+++ b/python/demo/demo_waveguide/demo_half_loaded_waveguide.py
@@ -223,7 +223,7 @@ b = fem.form(b_tt + b_tz + b_zt + b_zz)
 bc_facets = exterior_facet_indices(msh.topology)
 bc_dofs = fem.locate_dofs_topological(V, msh.topology.dim - 1, bc_facets)
 u_bc = fem.Function(V)
-with u_bc.vector.localForm() as loc:
+with u_bc.x.petsc_vec.localForm() as loc:
     loc.set(0)
 bc = fem.dirichletbc(u_bc, bc_dofs)
 # -
@@ -343,7 +343,7 @@ kz_list = []
 
 for i, kz in vals:
     # Save eigenvector in eh
-    eps.getEigenpair(i, eh.vector)
+    eps.getEigenpair(i, eh.x.petsc_vec)
 
     # Compute error for i-th eigenvalue
     error = eps.computeError(i, SLEPc.EPS.ErrorType.RELATIVE)

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -498,7 +498,8 @@ class Function(ufl.Coefficient):
         warnings.warn(
             "dlx.fem.Function.vector is deprecated.\n"
             "Please use dlx.fem.Function.x.petsc_vec "
-            "to access the underlying petsc4py wrapper"
+            "to access the underlying petsc4py wrapper",
+            DeprecationWarning
         )
         return self.x.petsc_vec
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -369,7 +369,7 @@ class Function(ufl.Coefficient):
         # Store DOLFINx FunctionSpace object
         self._V = V
 
-        # Store casting to la.Vector
+        # Store Python wrapper around the underlying Vector
         self._x = la.Vector(self._cpp_object.x)
 
     @property

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -7,8 +7,8 @@
 
 from __future__ import annotations
 
-import warnings
 import typing
+import warnings
 from functools import singledispatch
 
 import numpy as np

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -498,7 +498,7 @@ class Function(ufl.Coefficient):
         warnings.warn(
             "dlx.fem.Function.vector is deprecated.\n"
             "Please use dlx.fem.Function.x.petsc_vec "
-            "to access the underlining petsc4py wrapper"
+            "to access the underlying petsc4py wrapper"
         )
         return self.x.petsc_vec
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import warnings
 import typing
 from functools import singledispatch
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -339,10 +339,6 @@ class Function(ufl.Coefficient):
             V.element.dtype, np.dtype(dtype).type(0).real.dtype
         ), "Incompatible FunctionSpace dtype and requested dtype."
 
-        # PETSc Vec wrapper around the C++ function data (constructed
-        # when first requested)
-        self._petsc_x = None
-
         # Create cpp Function
         def functiontype(dtype):
             if np.issubdtype(dtype, np.float32):
@@ -373,9 +369,8 @@ class Function(ufl.Coefficient):
         # Store DOLFINx FunctionSpace object
         self._V = V
 
-    def __del__(self):
-        if self._petsc_x is not None:
-            self._petsc_x.destroy()
+        # Store casting to la.Vector
+        self._x = la.Vector(self._cpp_object.x)
 
     @property
     def function_space(self) -> FunctionSpace:
@@ -485,7 +480,7 @@ class Function(ufl.Coefficient):
     @property
     def x(self) -> la.Vector:
         """Vector holding the degrees-of-freedom."""
-        return la.Vector(self._cpp_object.x)  # type: ignore
+        return self._x  # type: ignore
 
     @property
     def vector(self):
@@ -499,11 +494,7 @@ class Function(ufl.Coefficient):
             Prefer :func`x` where possible.
 
         """
-        if self._petsc_x is None:
-            from dolfinx.la import create_petsc_vector_wrap
-
-            self._petsc_x = create_petsc_vector_wrap(self.x)
-        return self._petsc_x
+        return self.x.vector
 
     @property
     def dtype(self) -> np.dtype:

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -495,9 +495,11 @@ class Function(ufl.Coefficient):
             Prefer :func`x` where possible.
 
         """
-        warnings.warn("dlx.fem.Function.vector is deprecated.\n"
-                      "Please use dlx.fem.Function.x.petsc_vec "
-                      "to access the underlining petsc4py wrapper")
+        warnings.warn(
+            "dlx.fem.Function.vector is deprecated.\n"
+            "Please use dlx.fem.Function.x.petsc_vec "
+            "to access the underlining petsc4py wrapper"
+        )
         return self.x.petsc_vec
 
     @property

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -499,7 +499,7 @@ class Function(ufl.Coefficient):
             "dlx.fem.Function.vector is deprecated.\n"
             "Please use dlx.fem.Function.x.petsc_vec "
             "to access the underlying petsc4py wrapper",
-            DeprecationWarning
+            DeprecationWarning,
         )
         return self.x.petsc_vec
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -494,7 +494,10 @@ class Function(ufl.Coefficient):
             Prefer :func`x` where possible.
 
         """
-        return self.x.vector
+        warnings.warn("dlx.fem.Function.vector is deprecated.\n"
+                      "Please use dlx.fem.Function.x.petsc_vec "
+                      "to access the underlining petsc4py wrapper")
+        return self.x.petsc_vec
 
     @property
     def dtype(self) -> np.dtype:

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -480,7 +480,7 @@ class Function(ufl.Coefficient):
     @property
     def x(self) -> la.Vector:
         """Vector holding the degrees-of-freedom."""
-        return self._x  # type: ignore
+        return self._x
 
     @property
     def vector(self):

--- a/python/dolfinx/la.py
+++ b/python/dolfinx/la.py
@@ -251,7 +251,7 @@ class Vector:
         return self._cpp_object.array
 
     @property
-    def vector(self):
+    def petsc_vec(self):
         """PETSc vector holding the entries of the vector.
 
         Upon first call, this function creates a PETSc ``Vec`` object

--- a/python/dolfinx/la.py
+++ b/python/dolfinx/la.py
@@ -229,6 +229,11 @@ class Vector:
             User code should call :func:`vector` to create a vector object.
         """
         self._cpp_object = x
+        self._petsc_x = None
+
+    def __del__(self):
+        if self._petsc_x is not None:
+            self._petsc_x.destroy()
 
     @property
     def index_map(self) -> IndexMap:
@@ -244,6 +249,18 @@ class Vector:
     def array(self) -> np.ndarray:
         """Local representation of the vector."""
         return self._cpp_object.array
+
+    @property
+    def vector(self):
+        """PETSc vector holding the entries of the vector.
+
+        Upon first call, this function creates a PETSc ``Vec`` object
+        that wraps the degree-of-freedom data. The ``Vec`` object is
+        cached and the cached ``Vec`` is returned upon subsequent calls.
+        """
+        if self._petsc_x is None:
+            self._petsc_x = create_petsc_vector_wrap(self)
+        return self._petsc_x
 
     def scatter_forward(self) -> None:
         """Update ghost entries."""

--- a/python/dolfinx/nls/petsc.py
+++ b/python/dolfinx/nls/petsc.py
@@ -44,7 +44,7 @@ class NewtonSolver(_cpp.nls.petsc.NewtonSolver):
     def solve(self, u: fem.Function):
         """Solve non-linear problem into function u. Returns the number
         of iterations and if the solver converged."""
-        n, converged = super().solve(u.vector)
+        n, converged = super().solve(u.x.petsc_vec)
         u.x.scatter_forward()
         return n, converged
 

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -262,8 +262,8 @@ def test_custom_mesh_loop_rank1(dtype):
     #     assemble_vector_parallel(b, x_dofs, x, dofmap_t.array, dofmap_t.offsets, num_owned_cells)
     #     end = time.time()
     #     print("Time (numba parallel, pass {}): {}".format(i, end - start))
-    # btmp.vector.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
-    # assert (btmp.vector - b0.vector).norm() == pytest.approx(0.0)
+    # btmp.x.petsc_vec.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
+    # assert (btmp.x.petsc_vec - b0.x.petsc_vec).norm() == pytest.approx(0.0)
 
     # Test against generated code and general assembler
     v = ufl.TestFunction(V)

--- a/python/test/unit/fem/test_custom_basix_element.py
+++ b/python/test/unit/fem/test_custom_basix_element.py
@@ -70,7 +70,7 @@ def run_scalar_test(V, degree):
     solver.setOperators(A)
 
     uh = Function(V)
-    solver.solve(b, uh.vector)
+    solver.solve(b, uh.x.petsc_vec)
     uh.x.scatter_forward()
 
     M = (u_exact - uh) ** 2 * dx

--- a/python/test/unit/fem/test_dof_coordinates.py
+++ b/python/test/unit/fem/test_dof_coordinates.py
@@ -15,7 +15,7 @@ def test_dof_coords_2d(degree):
     u.interpolate(lambda x: x[0])
     u.x.scatter_forward()
     x = V.tabulate_dof_coordinates()
-    val = u.vector.array
+    val = u.x.array
     for i in range(len(val)):
         assert np.isclose(x[i, 0], val[i], rtol=1e-3)
 
@@ -28,6 +28,6 @@ def test_dof_coords_3d(degree):
     u.interpolate(lambda x: x[0])
     u.x.scatter_forward()
     x = V.tabulate_dof_coordinates()
-    val = u.vector.array
+    val = u.x.array
     for i in range(len(val)):
         assert np.isclose(x[i, 0], val[i], rtol=1e-3)

--- a/python/test/unit/fem/test_fem_pipeline.py
+++ b/python/test/unit/fem/test_fem_pipeline.py
@@ -103,7 +103,7 @@ def run_scalar_test(mesh, V, degree):
     solver.setOperators(A)
 
     uh = Function(V)
-    solver.solve(b, uh.vector)
+    solver.solve(b, uh.x.petsc_vec)
     uh.x.scatter_forward()
 
     M = (u_exact - uh) ** 2 * dx
@@ -140,7 +140,7 @@ def run_vector_test(mesh, V, degree):
 
     # Solve
     uh = Function(V)
-    solver.solve(b, uh.vector)
+    solver.solve(b, uh.x.petsc_vec)
     uh.x.scatter_forward()
 
     # Calculate error
@@ -225,7 +225,7 @@ def run_dg_test(mesh, V, degree):
 
     # Solve
     uh = Function(V)
-    solver.solve(b, uh.vector)
+    solver.solve(b, uh.x.petsc_vec)
     uh.x.scatter_forward()
 
     # Calculate error
@@ -406,7 +406,7 @@ def test_biharmonic(family):
     solver.setOperators(A)
 
     x_h = Function(V)
-    solver.solve(b, x_h.vector)
+    solver.solve(b, x_h.x.petsc_vec)
     x_h.x.scatter_forward()
 
     # Recall that x_h has flattened indices

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -257,7 +257,7 @@ class NonlinearPDE_SNESProblem:
             var.x.petsc_vec.array[:] = x_array[offset : offset + size_local]
             var.x.petsc_vec.ghostUpdate(
                 addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD
-                )
+            )
             offset += size_local
 
         assemble_vector_block(F, self.L, self.a, bcs=self.bcs, x0=x, scale=-1.0)

--- a/python/test/unit/fem/test_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_nonlinear_assembler.py
@@ -255,7 +255,9 @@ class NonlinearPDE_SNESProblem:
         for var in self.soln_vars:
             size_local = var.x.petsc_vec.getLocalSize()
             var.x.petsc_vec.array[:] = x_array[offset : offset + size_local]
-            var.x.petsc_vec.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+            var.x.petsc_vec.ghostUpdate(
+                addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD
+                )
             offset += size_local
 
         assemble_vector_block(F, self.L, self.a, bcs=self.bcs, x0=x, scale=-1.0)

--- a/python/test/unit/fem/test_petsc_discrete_operators.py
+++ b/python/test/unit/fem/test_petsc_discrete_operators.py
@@ -92,7 +92,7 @@ def test_gradient_interpolation_petsc(cell_type, p, q):
 
     # Compute global matrix vector product
     w = Function(W)
-    G.mult(u.vector, w.vector)
+    G.mult(u.x.petsc_vec, w.x.petsc_vec)
     w.x.scatter_forward()
 
     atol = 100 * np.finfo(default_real_type).resolution
@@ -154,7 +154,7 @@ def test_interpolation_matrix_petsc(cell_type, p, q, from_lagrange):
 
     # Compute global matrix vector product
     w = Function(W)
-    G.mult(u.vector, w.vector)
+    G.mult(u.x.petsc_vec, w.x.petsc_vec)
     w.x.scatter_forward()
 
     atol = 100 * np.finfo(default_real_type).resolution
@@ -215,7 +215,7 @@ def test_nonaffine_discrete_operator_petsc():
 
     # Compute global matrix vector product
     v_vec = Function(V)
-    G.mult(w.vector, v_vec.vector)
+    G.mult(w.x.petsc_vec, v_vec.x.petsc_vec)
     v_vec.x.scatter_forward()
     atol = 10 * np.finfo(default_real_type).resolution
     assert np.allclose(v_vec.x.array, v.x.array, atol=atol)

--- a/python/test/unit/la/test_krylov_solver.py
+++ b/python/test/unit/la/test_krylov_solver.py
@@ -117,7 +117,7 @@ def test_krylov_samg_solver_elasticity():
         u = Function(V)
 
         # Create near null space basis and orthonormalize
-        null_space = build_nullspace(V, u.vector)
+        null_space = build_nullspace(V, u.x.petsc_vec)
 
         # Attached near-null space to matrix
         A.set_near_nullspace(null_space)
@@ -134,7 +134,7 @@ def test_krylov_samg_solver_elasticity():
         solver.setOperators(A)
 
         # Compute solution and return number of iterations
-        return solver.solve(b, u.vector)
+        return solver.solve(b, u.x.petsc_vec)
 
     # Set some multigrid smoother parameters
     opts = PETSc.Options()

--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -75,8 +75,8 @@ class NonlinearPDE_SNESProblem:
     def F(self, snes, x, F):
         """Assemble residual vector."""
         x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
-        x.copy(self.u.vector)
-        self.u.vector.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+        x.copy(self.u.x.petsc_vec)
+        self.u.x.petsc_vec.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
         with F.localForm() as f_local:
             f_local.set(0.0)
@@ -123,13 +123,13 @@ def test_linear_pde():
     solver.set_update(update)
     solver.atol = 1.0e-8
     solver.rtol = 1.0e2 * np.finfo(default_real_type).eps
-    n, converged = solver.solve(u.vector)
+    n, converged = solver.solve(u.x.petsc_vec)
     assert converged
     assert n == 1
 
     # Increment boundary condition and solve again
     bc.g.value[...] = PETSc.ScalarType(2.0)
-    n, converged = solver.solve(u.vector)
+    n, converged = solver.solve(u.x.petsc_vec)
     assert converged
     assert n == 1
 
@@ -161,13 +161,13 @@ def test_nonlinear_pde():
     solver.set_form(problem.form)
     solver.atol = 1.0e-8
     solver.rtol = 1.0e2 * np.finfo(default_real_type).eps
-    n, converged = solver.solve(u.vector)
+    n, converged = solver.solve(u.x.petsc_vec)
     assert converged
     assert n < 6
 
     # Modify boundary condition and solve again
     bc.g.value[...] = 0.5
-    n, converged = solver.solve(u.vector)
+    n, converged = solver.solve(u.x.petsc_vec)
     assert converged
     assert n > 0 and n < 6
 
@@ -206,13 +206,13 @@ def test_nonlinear_pde_snes():
     snes.getKSP().setTolerances(rtol=1.0e-9)
     snes.getKSP().getPC().setType("lu")
 
-    snes.solve(None, u.vector)
+    snes.solve(None, u.x.petsc_vec)
     assert snes.getConvergedReason() > 0
     assert snes.getIterationNumber() < 6
 
     # Modify boundary condition and solve again
     u_bc.x.array[:] = 0.6
-    snes.solve(None, u.vector)
+    snes.solve(None, u.x.petsc_vec)
     assert snes.getConvergedReason() > 0
     assert snes.getIterationNumber() < 6
     # print(snes.getIterationNumber())


### PR DESCRIPTION
This PR allows for a `dlx.la.Vector` (rather than a `dlx.fem.Function`) to manage the memory and the scope of the `petsc4py.PETSc.vec` object that wraps the underlying data.

The implementation of the property `dlx.fem.Function.vector` was also modified to delegate the creation of the wrapper to the underlying `dlx.la.Vector`.

All changes are backward compatible.

See also Issue #3061
@jorgensd 
@garth-wells
@jhale   