### PR TITLE
Fix sub index map destination rank computation

### DIFF
--- a/python/test/unit/common/test_index_map.py
+++ b/python/test/unit/common/test_index_map.py
@@ -9,11 +9,11 @@ import math
 from mpi4py import MPI
 
 import numpy as np
+import pytest
 
 import dolfinx
 from dolfinx import cpp as _cpp
 from dolfinx.mesh import GhostMode, create_unit_square
-import pytest
 
 
 def test_sub_index_map():

--- a/python/test/unit/common/test_index_map.py
+++ b/python/test/unit/common/test_index_map.py
@@ -13,6 +13,7 @@ import numpy as np
 import dolfinx
 from dolfinx import cpp as _cpp
 from dolfinx.mesh import GhostMode, create_unit_square
+import pytest
 
 
 def test_sub_index_map():
@@ -200,7 +201,7 @@ def test_sub_index_map_multiple_possible_owners():
     comm = MPI.COMM_WORLD
 
     if comm.size < 3:
-        return
+        pytest.skip("Test requires 3 or more processes")
 
     # Create an index map with an index on process 2 that is ghosted by processes 0 and 1
     if comm.rank == 0:


### PR DESCRIPTION
The method for computing submap destination ranks in `main` does not work in general (see [this](https://github.com/FEniCS/dolfinx/issues/3097) issue). This is because, when a index changes owner in the submap and there are multiple possible owners, the new owning process does not know to include the other processes as destination ranks.

This PR fixes the issue by using NBX to compute the submap destination ranks from the submap source ranks and adds a test that fails on `main`.

In a future PR, I will add an extra communication step to replace NBX, which should be cheaper.