### PR TITLE
Change `compute_graph_edges_nbx` to `compute_graph_edges`

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -39,7 +39,7 @@ std::array<std::vector<int>, 2> build_src_dest(MPI_Comm comm,
   std::sort(src.begin(), src.end());
   src.erase(std::unique(src.begin(), src.end()), src.end());
   src.shrink_to_fit();
-  std::vector<int> dest = dolfinx::MPI::compute_graph_edges_nbx(comm, src);
+  std::vector<int> dest = dolfinx::MPI::compute_graph_edges(comm, src);
   std::sort(dest.begin(), dest.end());
   return {std::move(src), std::move(dest)};
 }
@@ -372,7 +372,7 @@ compute_submap_indices(const IndexMap& imap,
   // Compute submap destination ranks
   // FIXME Remove call to NBX
   std::vector<int> submap_dest
-      = dolfinx::MPI::compute_graph_edges_nbx(imap.comm(), submap_src);
+      = dolfinx::MPI::compute_graph_edges(imap.comm(), submap_src);
   std::sort(submap_dest.begin(), submap_dest.end());
 
   return {std::move(submap_owned), std::move(submap_ghost),
@@ -947,7 +947,7 @@ graph::AdjacencyList<int> IndexMap::index_to_dest_ranks() const
   std::vector<int> src = _owners;
   std::sort(src.begin(), src.end());
   src.erase(std::unique(src.begin(), src.end()), src.end());
-  auto dest = dolfinx::MPI::compute_graph_edges_nbx(_comm.comm(), src);
+  auto dest = dolfinx::MPI::compute_graph_edges(_comm.comm(), src);
   std::sort(dest.begin(), dest.end());
 
   // Array (local idx, ghosting rank) pairs for owned indices

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -239,3 +239,8 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges)
   return other_ranks;
 }
 //-----------------------------------------------------------------------------
+std::vector<int> dolfinx::MPI::compute_graph_edges(MPI_Comm comm,
+                                                   std::span<const int> edges)
+{
+  return compute_graph_edges_nbx(comm, edges);
+}

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -185,6 +185,17 @@ std::vector<int> compute_graph_edges_pcx(MPI_Comm comm,
 std::vector<int> compute_graph_edges_nbx(MPI_Comm comm,
                                          std::span<const int> edges);
 
+/// @brief Determine incoming graph edges to this rank.
+///
+/// Given a list of outgoing edges (destination ranks) from this rank,
+/// this function returns the incoming edges (source ranks) to this rank.
+/// @note Collective.
+///
+/// @param[in] comm MPI communicator
+/// @param[in] edges Edges (ranks) from this rank (the caller).
+/// @return Ranks that have defined edges from them to this rank.
+std::vector<int> compute_graph_edges(MPI_Comm comm, std::span<const int> edges);
+
 /// @brief Distribute row data to 'post office' ranks.
 ///
 /// This function takes row-wise data that is distributed across

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -696,7 +696,7 @@ determine_point_ownership(const mesh::Mesh<T>& mesh, std::span<const T> points,
   out_ranks.erase(std::unique(out_ranks.begin(), out_ranks.end()),
                   out_ranks.end());
   // Compute incoming edges (source processes)
-  std::vector in_ranks = dolfinx::MPI::compute_graph_edges_nbx(comm, out_ranks);
+  std::vector in_ranks = dolfinx::MPI::compute_graph_edges(comm, out_ranks);
   std::sort(in_ranks.begin(), in_ranks.end());
 
   // Create neighborhood communicator in forward direction

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -99,7 +99,7 @@ graph::build::distribute(MPI_Comm comm,
 
   // Determine source ranks. Sort ranks to make distribution
   // deterministic.
-  std::vector<int> src = dolfinx::MPI::compute_graph_edges_nbx(comm, dest);
+  std::vector<int> src = dolfinx::MPI::compute_graph_edges(comm, dest);
   std::sort(src.begin(), src.end());
 
   // Create neighbourhood communicator

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -328,7 +328,7 @@ xdmf_utils::distribute_entity_data(
 
     // Determine src ranks. Sort ranks so that ownership determination is
     // deterministic for a given number of ranks.
-    std::vector<int> src = dolfinx::MPI::compute_graph_edges_nbx(comm, dest);
+    std::vector<int> src = dolfinx::MPI::compute_graph_edges(comm, dest);
     std::sort(src.begin(), src.end());
 
     // Create neighbourhood communicator for sending data to post
@@ -418,7 +418,7 @@ xdmf_utils::distribute_entity_data(
 
     // Determine src ranks. Sort ranks so that ownership determination is
     // deterministic for a given number of ranks.
-    std::vector<int> src = dolfinx::MPI::compute_graph_edges_nbx(comm, dest);
+    std::vector<int> src = dolfinx::MPI::compute_graph_edges(comm, dest);
     std::sort(src.begin(), src.end());
 
     // Create neighbourhood communicator for sending data to post offices

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -91,7 +91,7 @@ determine_sharing_ranks(MPI_Comm comm, std::span<const std::int64_t> indices)
 
   // Determine src ranks. Sort ranks so that ownership determination is
   // deterministic for a given number of ranks.
-  std::vector<int> src = dolfinx::MPI::compute_graph_edges_nbx(comm, dest);
+  std::vector<int> src = dolfinx::MPI::compute_graph_edges(comm, dest);
   std::sort(src.begin(), src.end());
 
   // Create neighbourhood communicator for sending data to post offices
@@ -1273,7 +1273,7 @@ Topology mesh::create_topology(
   // vertices owned by this rank.
   //
   // TODO: Find a away to get the 'dest' without using
-  // compute_graph_edges_nbx. Maybe transpose the
+  // compute_graph_edges. Maybe transpose the
   // exchange_ghost_indexing step, followed by another communication
   // round to the owner?
   //
@@ -1286,7 +1286,7 @@ Topology mesh::create_topology(
     std::vector<int> src = ghost_vertex_owners;
     dolfinx::radix_sort(std::span(src));
     src.erase(std::unique(src.begin(), src.end()), src.end());
-    dest = dolfinx::MPI::compute_graph_edges_nbx(comm, src);
+    dest = dolfinx::MPI::compute_graph_edges(comm, src);
   }
 
   Topology topology(comm, cell_type);

--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -160,8 +160,7 @@ graph::AdjacencyList<std::int64_t> compute_nonlocal_dual_graph(
   }
 
   // Determine source ranks
-  const std::vector<int> src
-      = dolfinx::MPI::compute_graph_edges_nbx(comm, dest);
+  const std::vector<int> src = dolfinx::MPI::compute_graph_edges(comm, dest);
   LOG(INFO) << "Number of destination and source ranks in non-local dual graph "
                "construction, and ratio to total number of ranks: "
             << dest.size() << ", " << src.size() << ", "


### PR DESCRIPTION

NBX doesn't seem to work well at large scale. This just makes a general interface, so we can try different implementations, currently using a compiler flag: `-DUSE_NBX` or `-DUSE_PCX` etc. 
Default is to use gather-scatter, which seems to be fastest on some machines.
If we can switch between implementations, we can benchmark more easily.
