### PR TITLE
Support DG-0 functions in VTXWriter

### DIFF
--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -875,7 +875,7 @@ public:
             std::shared_ptr<const mesh::Mesh<T>> mesh,
             std::string engine = "BPFile")
       : ADIOS2Writer(comm, filename, "VTX mesh writer", engine), _mesh(mesh),
-        _mesh_reuse_policy(VTXMeshPolicy::update)
+        _mesh_reuse_policy(VTXMeshPolicy::update), _is_piecewise_constant(false)
   {
     // Define VTK scheme attribute for mesh
     std::string vtk_scheme = impl_vtx::create_vtk_schema({}, {}).str();
@@ -902,7 +902,7 @@ public:
             VTXMeshPolicy mesh_policy = VTXMeshPolicy::update)
       : ADIOS2Writer(comm, filename, "VTX function writer", engine),
         _mesh(impl_adios2::extract_common_mesh<T>(u)),
-        _mesh_reuse_policy(mesh_policy), _u(u)
+        _mesh_reuse_policy(mesh_policy), _u(u), _is_piecewise_constant(false)
   {
     if (u.empty())
       throw std::runtime_error("VTXWriter fem::Function list is empty.");
@@ -934,12 +934,14 @@ public:
     // Check if function is DG 0
     if (element0->space_dimension() / element0->block_size() == 1)
     {
-      throw std::runtime_error(
-          "VTK does not support cell-wise fields. See "
-          "https://gitlab.kitware.com/vtk/vtk/-/issues/18458.");
+      _is_piecewise_constant = true;
+      // throw std::runtime_error(
+      //     "VTK does not support cell-wise fields. See "
+      //     "https://gitlab.kitware.com/vtk/vtk/-/issues/18458.");
     }
 
     // Check that all functions come from same element type
+
     for (auto& v : _u)
     {
       std::visit(
@@ -970,7 +972,12 @@ public:
 
     // Define VTK scheme attribute for set of functions
     std::vector<std::string> names = impl_vtx::extract_function_names<T>(u);
-    std::string vtk_scheme = impl_vtx::create_vtk_schema(names, {}).str();
+    std::string vtk_scheme;
+    if (_is_piecewise_constant)
+      vtk_scheme = impl_vtx::create_vtk_schema({}, names).str();
+    else
+      vtk_scheme = impl_vtx::create_vtk_schema(names, {}).str();
+
     impl_adios2::define_attribute<std::string>(*_io, "vtk.xml", vtk_scheme);
   }
 
@@ -1022,9 +1029,20 @@ public:
     _engine->BeginStep();
     _engine->template Put<double>(var_step, t);
 
-    // If we have no functions write the mesh to file
-    if (_u.empty())
+    // If we have no functions or DG functions write the mesh to file
+    if (_is_piecewise_constant or _u.empty())
+    {
       impl_vtx::vtx_write_mesh(*_io, *_engine, *_mesh);
+      if (_is_piecewise_constant)
+      {
+        for (auto& v : _u)
+        {
+          std::visit([&](auto& u)
+                     { impl_vtx::vtx_write_data(*_io, *_engine, *u); },
+                     v);
+        }
+      }
+    }
     else
     {
       if (_mesh_reuse_policy == VTXMeshPolicy::update
@@ -1072,6 +1090,9 @@ private:
   VTXMeshPolicy _mesh_reuse_policy;
   std::vector<std::int64_t> _x_id;
   std::vector<std::uint8_t> _x_ghost;
+
+  // Special handling of piecewise constant functions
+  bool _is_piecewise_constant;
 };
 
 /// Type deduction

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -936,7 +936,6 @@ public:
       _is_piecewise_constant = true;
 
     // Check that all functions come from same element type
-
     for (auto& v : _u)
     {
       std::visit(

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -933,12 +933,7 @@ public:
 
     // Check if function is DG 0
     if (element0->space_dimension() / element0->block_size() == 1)
-    {
       _is_piecewise_constant = true;
-      // throw std::runtime_error(
-      //     "VTK does not support cell-wise fields. See "
-      //     "https://gitlab.kitware.com/vtk/vtk/-/issues/18458.");
-    }
 
     // Check that all functions come from same element type
 

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -251,10 +251,9 @@ def test_save_vtkx_cell_point(tempdir):
     u.name = "A"
 
     filename = Path(tempdir, "v.bp")
-    with pytest.raises(RuntimeError):
-        f = VTXWriter(mesh.comm, filename, [u])
-        f.write(0)
-        f.close()
+    f = VTXWriter(mesh.comm, filename, [u])
+    f.write(0)
+    f.close()
 
 
 def test_empty_rank_mesh(tempdir):


### PR DESCRIPTION
Resolve #2720. Works with Paraview 5.12.0.RC3.

I've decided to keep it such that only single function-space functions should be saved in a single bp file.
This could of course be changed now, to store a mixture of DG-0 and a single other element function.

This is up for discussion.

We could also discuss how to implement the VTX mesh sharing policy for DG-0 functions.

Another point we now could address is meshtags (at least celltags) for VTXWriter.

@massimiliano-leoni do you mind testing this as well?:)