### PR TITLE
Fix deprecation warning introduced in #3092

### DIFF
--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -496,8 +496,8 @@ class Function(ufl.Coefficient):
 
         """
         warnings.warn(
-            "dlx.fem.Function.vector is deprecated.\n"
-            "Please use dlx.fem.Function.x.petsc_vec "
+            "dolfinx.fem.Function.vector is deprecated.\n"
+            "Please use dolfinx.fem.Function.x.petsc_vec "
             "to access the underlying petsc4py wrapper",
             DeprecationWarning,
         )


### PR DESCRIPTION
Use the full library name `dolfinx`, instead of the abbreviation `dlx` which isn't used anywhere else in the code and may confuse end users.

Fixes #3092.