### PR TITLE
Require MPI ADIOS2 build during configuration.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -375,6 +375,13 @@ elseif(DOLFINX_ENABLE_ADIOS2)
   find_package(ADIOS2 2.8.1)
 endif()
 
+if(ADIOS2_FOUND AND NOT ADIOS2_HAVE_MPI)
+  message(
+    FATAL_ERROR
+      "Found serial ADIOS2 build, MPI ADIOS2 build required, try setting ADIOS2_DIR or ADIOS2_ROOT"
+  )
+endif()
+
 if(DOLFINX_ENABLE_SLEPC)
   find_package(PkgConfig REQUIRED)
   set(ENV{PKG_CONFIG_PATH}


### PR DESCRIPTION
Partial implementation of #3124.
