### PR TITLE
Make ADIOS tests compatible with 2.9 and 2.10

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -370,9 +370,9 @@ set_package_properties(
 # Find optional packages
 
 if(DOLFINX_ENABLE_ADIOS2 AND _REQUIRE_ADIOS2)
-  find_package(ADIOS2 2.8.1...<2.10 REQUIRED)
+  find_package(ADIOS2 2.8.1 REQUIRED)
 elseif(DOLFINX_ENABLE_ADIOS2)
-  find_package(ADIOS2 2.8.1...<2.10)
+  find_package(ADIOS2 2.8.1)
 endif()
 
 if(ADIOS2_FOUND AND NOT ADIOS2_HAVE_MPI)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -370,9 +370,9 @@ set_package_properties(
 # Find optional packages
 
 if(DOLFINX_ENABLE_ADIOS2 AND _REQUIRE_ADIOS2)
-  find_package(ADIOS2 2.8.1 REQUIRED)
+  find_package(ADIOS2 2.8.1...<2.10 REQUIRED)
 elseif(DOLFINX_ENABLE_ADIOS2)
-  find_package(ADIOS2 2.8.1)
+  find_package(ADIOS2 2.8.1...<2.10)
 endif()
 
 if(ADIOS2_FOUND AND NOT ADIOS2_HAVE_MPI)

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -317,6 +317,7 @@ def test_vtx_reuse_mesh(tempdir, dim, simplex, reuse):
     try:
         adios_file = adios2.open(str(filename), "r", comm=mesh.comm, engine_type="BP4")
     except AttributeError:
+        # adios2 >= v2.10.0
         adios = adios2.Adios(comm=mesh.comm)
         io = adios.declare_io("TestData")
         io.set_engine("BP4")

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -313,7 +313,14 @@ def test_vtx_reuse_mesh(tempdir, dim, simplex, reuse):
         1 if reuse else 3
     )  # For mesh variables the step count is 1 if reuse else number of writes
 
-    adios_file = adios2.open(str(filename), "r", comm=mesh.comm, engine_type="BP4")
+    # backwards compatibility adios2 < 2.10.0
+    try:
+        adios_file = adios2.open(str(filename), "r", comm=mesh.comm, engine_type="BP4")
+    except AttributeError:
+        adios = adios2.Adios(comm=mesh.comm)
+        io = adios.declare_io("TestData")
+        adios_file = adios2.Stream(io, str(filename), "r", mesh.comm)
+
     for name, var in adios_file.available_variables().items():
         if name in reuse_variables:
             assert int(var["AvailableStepsCount"]) == target_mesh

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -319,6 +319,7 @@ def test_vtx_reuse_mesh(tempdir, dim, simplex, reuse):
     except AttributeError:
         adios = adios2.Adios(comm=mesh.comm)
         io = adios.declare_io("TestData")
+        io.set_engine("BP4")
         adios_file = adios2.Stream(io, str(filename), "r", mesh.comm)
 
     for name, var in adios_file.available_variables().items():


### PR DESCRIPTION
We know we are not compatible with 2.10. Will do a minor DOLFINx release once ADIOS 2.10 is widely available.