### PR TITLE
Remove catch2 from docker images

### DIFF
--- a/docker/Dockerfile.oneapi
+++ b/docker/Dockerfile.oneapi
@@ -32,7 +32,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     libpugixml-dev \
     ninja-build \
     pkg-config \
-    catch2 \
     git \
     wget \
     zlib1g-dev && \

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -96,7 +96,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     python3-setuptools && \
     #
     apt-get -y install \
-    catch2 \
     git \
     graphviz \
     libeigen3-dev \


### PR DESCRIPTION
As it is v 2.13.8 (https://packages.ubuntu.com/jammy/catch2), which is not compatible with our tests, and will mess up: https://github.com/FEniCS/dolfinx/blob/main/cpp/test/CMakeLists.txt#L20-L31.