### PR TITLE
Don't run build steps if linting fails

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -67,8 +67,8 @@ jobs:
           find . -type f \( -name "*.cmake" -o -name "*.cmake.in" -o -name "CMakeLists.txt" \) | xargs cmake-format --check
 
   build:
-    if: "!(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
     runs-on: ubuntu-latest
+    needs: lint
     container: ghcr.io/fenics/test-env:current-openmpi
     env:
       SCOTCH_DIR: /usr/local/petsc/linux-gnu-real64-32
@@ -100,8 +100,8 @@ jobs:
         run: python3 -c "import dolfinx; print(dolfinx.__version__)"
 
   build-with-petsc:
-    if: "!(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
     runs-on: ubuntu-latest
+    needs: lint
     container: ghcr.io/fenics/test-env:current-openmpi
     env:
       PETSC_ARCH: ${{ matrix.petsc_arch }}


### PR DESCRIPTION
Also removes deprecated [skip ci] check.