### PR TITLE
Fix dtype assumption on Debian 32-bit architectures

### DIFF
--- a/python/test/unit/mesh/test_dual_graph.py
+++ b/python/test/unit/mesh/test_dual_graph.py
@@ -13,7 +13,7 @@ def to_adj(cells):
         cflat += c
         cc = coff[-1] + len(c)
         coff += [cc]
-    adj = _cpp.graph.AdjacencyList_int64(np.array(cflat, dtype=np.int64), np.array(coff))
+    adj = _cpp.graph.AdjacencyList_int64(np.array(cflat, dtype=np.int64), np.array(coff, dtype=np.int64))
     return adj
 
 

--- a/python/test/unit/mesh/test_dual_graph.py
+++ b/python/test/unit/mesh/test_dual_graph.py
@@ -13,7 +13,7 @@ def to_adj(cells):
         cflat += c
         cc = coff[-1] + len(c)
         coff += [cc]
-    adj = _cpp.graph.AdjacencyList_int64(np.array(cflat), np.array(coff))
+    adj = _cpp.graph.AdjacencyList_int64(np.array(cflat, dtype=np.int64), np.array(coff))
     return adj
 
 


### PR DESCRIPTION
The default conversion between a list of Python ints and an ndarray (without dtype) on 32-bit architectures uses 32-bit integers. This patch makes the dtype explicitly `int64`.