### PR TITLE
Remove dynamic memory allocation inside tight loops in the Plaza refinement code

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -28,7 +28,7 @@ jobs:
           echo "/opt/homebrew/anaconda3/bin:/usr/local/anaconda3/bin" >> $GITHUB_PATH
       - name: Update conda
         run: |
-          conda -y update conda
+          conda update conda
 
       - name: Install DOLFINx (py3-10)
         run: |

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -283,7 +283,7 @@ void plaza::impl::enforce_rules(MPI_Comm comm,
   }
 }
 //-----------------------------------------------------------------------------
-std::vector<std::int32_t>
+std::pair<std::array<std::int32_t, 121>, std::size_t>
 plaza::impl::get_simplices(std::span<const std::int64_t> indices,
                            std::span<const std::int32_t> longest_edge, int tdim,
                            bool uniform)
@@ -291,14 +291,15 @@ plaza::impl::get_simplices(std::span<const std::int64_t> indices,
   if (tdim == 2)
   {
     assert(longest_edge.size() == 1);
-    auto [d, size] = get_triangles(indices, longest_edge[0], uniform);
-    return std::vector(d.data(), d.data() + size);
+    auto [_d, size] = get_triangles(indices, longest_edge[0], uniform);
+    std::array<std::int32_t, 121> d;
+    std::copy_n(_d.begin(), size, d.begin());
+    return {d, size};
   }
   else if (tdim == 3)
   {
     assert(longest_edge.size() == 4);
-    auto [d, size] = get_tetrahedra(indices, longest_edge);
-    return std::vector(d.data(), d.data() + size);
+    return get_tetrahedra(indices, longest_edge);
   }
   else
     throw std::runtime_error("Topological dimension not supported");

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -53,24 +53,54 @@ std::vector<std::int32_t> get_triangles(std::span<const std::int64_t> indices,
 
   // If all edges marked, consider uniform refinement
   if (uniform and indices[e0] >= 0 and indices[e1] >= 0)
-    return {e0, e1, v2, e1, e2, v0, e2, e0, v1, e2, e1, e0};
-
-  // Break each half of triangle into one or two sub-triangles
-  std::vector<std::int32_t> tri_set;
-  if (indices[e0] >= 0)
-    tri_set = {e2, v2, e0, e2, e0, v1};
-  else
-    tri_set = {e2, v2, v1};
-
-  if (indices[e1] >= 0)
   {
-    tri_set.insert(tri_set.end(), {e2, v2, e1});
-    tri_set.insert(tri_set.end(), {e2, e1, v0});
+    return {e0, e1, v2, e1, e2, v0, e2, e0, v1, e2, e1, e0};
   }
   else
-    tri_set.insert(tri_set.end(), {e2, v2, v0});
+  {
+    // Break each half of triangle into one or two sub-triangles
+    std::array<std::int32_t, 12> tri_set = {-1};
+    std::size_t tri_set_size = 0;
+    if (indices[e0] >= 0)
+    {
+      std::array<std::int32_t, 6> tri_set0 = {e2, v2, e0, e2, e0, v1};
+      std::copy(tri_set0.begin(), tri_set0.end(),
+                std::next(tri_set.begin(), tri_set_size));
+      tri_set_size += tri_set0.size();
+    }
+    else
+    {
+      std::array<std::int32_t, 3> tri_set0 = {e2, v2, v1};
+      std::copy(tri_set0.begin(), tri_set0.end(),
+                std::next(tri_set.begin(), tri_set_size));
+      tri_set_size += tri_set0.size();
+    }
 
-  return tri_set;
+    if (indices[e1] >= 0)
+    {
+      // tri_set.insert(tri_set.end(), {e2, v2, e1});
+      std::array<std::int32_t, 3> tri_set0 = {e2, v2, e1};
+      std::copy(tri_set0.begin(), tri_set0.end(),
+                std::next(tri_set.begin(), tri_set_size));
+      tri_set_size += tri_set0.size();
+
+      // tri_set.insert(tri_set.end(), {e2, e1, v0});
+      std::array<std::int32_t, 3> tri_set1 = {e2, e1, v0};
+      std::copy(tri_set1.begin(), tri_set1.end(),
+                std::next(tri_set.begin(), tri_set_size));
+      tri_set_size += tri_set1.size();
+    }
+    else
+    {
+      // tri_set.insert(tri_set.end(), {e2, v2, v0});
+      std::array<std::int32_t, 3> tri_set0 = {e2, v2, v0};
+      std::copy(tri_set0.begin(), tri_set0.end(),
+                std::next(tri_set.begin(), tri_set_size));
+      tri_set_size += tri_set0.size();
+    }
+
+    return std::vector(tri_set.data(), tri_set.data() + tri_set_size);
+  }
 }
 //-----------------------------------------------------------------------------
 // 3D version of subdivision
@@ -148,7 +178,6 @@ get_tetrahedra(std::span<const std::int64_t> indices,
   }
 
   // Iterate through all possible new vertices
-  // std::vector<std::int32_t> facet_set;
   std::array<std::int32_t, 121> tet_set = {-1};
   std::size_t tet_set_size = 0;
   for (std::int32_t i = 0; i < 10; ++i)
@@ -157,7 +186,6 @@ get_tetrahedra(std::span<const std::int64_t> indices,
     {
       if (conn[i][j])
       {
-        // facet_set.clear();
         std::array<std::int32_t, 10> facet_set;
         std::size_t facet_set_size = 0;
         for (std::int32_t k = j + 1; k < 10; ++k)
@@ -179,7 +207,6 @@ get_tetrahedra(std::span<const std::int64_t> indices,
               }
             }
             facet_set[facet_set_size++] = k;
-            // facet_set.push_back(k);
           }
         }
       }

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -18,6 +18,8 @@
 #include <numeric>
 #include <vector>
 
+#include <iostream>
+
 using namespace dolfinx;
 using namespace dolfinx::refinement;
 
@@ -32,7 +34,7 @@ namespace
 /// @param[in] longest_edge Local index of the longest edge in the triangle.
 /// @param[in] uniform If true, the triangle is subdivided into four similar
 /// sub-triangles.
-/// @returns Local indices for each sub-divided triangle
+/// @returns Local indices for each sub-divived triangle
 std::pair<std::array<std::int32_t, 12>, std::size_t>
 get_triangles(std::span<const std::int64_t> indices,
               const std::int32_t longest_edge, bool uniform)
@@ -196,7 +198,7 @@ get_tetrahedra(std::span<const std::int64_t> indices,
             {
               if (conn[m][k])
               {
-                assert(tet_set_size + 4 < tet_set.size());
+                assert(tet_set_size + 4 <= tet_set.size());
                 tet_set[tet_set_size++] = i;
                 tet_set[tet_set_size++] = j;
                 tet_set[tet_set_size++] = m;

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -102,7 +102,7 @@ get_triangles(std::span<const std::int64_t> indices,
 }
 //-----------------------------------------------------------------------------
 // 3D version of subdivision
-std::pair<std::array<std::int32_t, 121>, std::size_t>
+std::pair<std::array<std::int32_t, 32>, std::size_t>
 get_tetrahedra(std::span<const std::int64_t> indices,
                std::span<const std::int32_t> longest_edge)
 {
@@ -176,7 +176,7 @@ get_tetrahedra(std::span<const std::int64_t> indices,
   }
 
   // Iterate through all possible new vertices
-  std::array<std::int32_t, 121> tet_set;
+  std::array<std::int32_t, 32> tet_set;
   tet_set.fill(-1);
   std::size_t tet_set_size = 0;
   for (std::int32_t i = 0; i < 10; ++i)
@@ -283,7 +283,7 @@ void plaza::impl::enforce_rules(MPI_Comm comm,
   }
 }
 //-----------------------------------------------------------------------------
-std::pair<std::array<std::int32_t, 121>, std::size_t>
+std::pair<std::array<std::int32_t, 32>, std::size_t>
 plaza::impl::get_simplices(std::span<const std::int64_t> indices,
                            std::span<const std::int32_t> longest_edge, int tdim,
                            bool uniform)
@@ -292,7 +292,7 @@ plaza::impl::get_simplices(std::span<const std::int64_t> indices,
   {
     assert(longest_edge.size() == 1);
     auto [_d, size] = get_triangles(indices, longest_edge[0], uniform);
-    std::array<std::int32_t, 121> d;
+    std::array<std::int32_t, 32> d;
     std::copy_n(_d.begin(), size, d.begin());
     return {d, size};
   }

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -18,8 +18,6 @@
 #include <numeric>
 #include <vector>
 
-#include <iostream>
-
 using namespace dolfinx;
 using namespace dolfinx::refinement;
 

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -55,53 +55,18 @@ get_triangles(std::span<const std::int64_t> indices,
 
   // If all edges marked, consider uniform refinement
   if (uniform and indices[e0] >= 0 and indices[e1] >= 0)
-  {
     return {{e0, e1, v2, e1, e2, v0, e2, e0, v1, e2, e1, e0}, 12};
-  }
+
+  if (indices[e0] >= 0 and indices[e1] >= 0)
+    return {{e2, v2, e0, e2, e0, v1, e2, v2, e1, e2, e1, v0}, 12};
+  else if (indices[e0] >= 0 and indices[e1] < 0)
+    return {{e2, v2, e0, e2, e0, v1, e2, v2, v0}, 9};
+  else if (indices[e0] < 0 and indices[e1] >= 0)
+    return {{e2, v2, v1, e2, v2, e1, e2, e1, v0}, 9};
   else
-  {
-    // Break each half of triangle into one or two sub-triangles
-    std::array<std::int32_t, 12> tri_set;
-    tri_set.fill(-1);
-    std::size_t tri_set_size = 0;
-    if (indices[e0] >= 0)
-    {
-      std::array<std::int32_t, 6> tri_set0 = {e2, v2, e0, e2, e0, v1};
-      std::copy(tri_set0.begin(), tri_set0.end(),
-                std::next(tri_set.begin(), tri_set_size));
-      tri_set_size += tri_set0.size();
-    }
-    else
-    {
-      std::array<std::int32_t, 3> tri_set0 = {e2, v2, v1};
-      std::copy(tri_set0.begin(), tri_set0.end(),
-                std::next(tri_set.begin(), tri_set_size));
-      tri_set_size += tri_set0.size();
-    }
-
-    if (indices[e1] >= 0)
-    {
-      std::array<std::int32_t, 3> tri_set0 = {e2, v2, e1};
-      std::copy(tri_set0.begin(), tri_set0.end(),
-                std::next(tri_set.begin(), tri_set_size));
-      tri_set_size += tri_set0.size();
-
-      std::array<std::int32_t, 3> tri_set1 = {e2, e1, v0};
-      std::copy(tri_set1.begin(), tri_set1.end(),
-                std::next(tri_set.begin(), tri_set_size));
-      tri_set_size += tri_set1.size();
-    }
-    else
-    {
-      std::array<std::int32_t, 3> tri_set0 = {e2, v2, v0};
-      std::copy(tri_set0.begin(), tri_set0.end(),
-                std::next(tri_set.begin(), tri_set_size));
-      tri_set_size += tri_set0.size();
-    }
-
-    return {tri_set, tri_set_size};
-  }
+    return {{e2, v2, v1, e2, v2, v0}, 6};
 }
+
 //-----------------------------------------------------------------------------
 // 3D version of subdivision
 std::pair<std::array<std::int32_t, 32>, std::size_t>

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -185,17 +185,15 @@ get_tetrahedra(std::span<const std::int64_t> indices,
     {
       if (conn[i][j])
       {
-        std::array<std::int32_t, 10> facet_set;
-        std::size_t facet_set_size = 0;
+        std::array<std::int32_t, 10> facet_set_b;
+        std::span<std::int32_t> facet_set(facet_set_b.data(), 0);
         for (std::int32_t k = j + 1; k < 10; ++k)
         {
           if (conn[i][k] and conn[j][k])
           {
             // Note that i < j < m < k
-            // for (const std::int32_t& m : facet_set)
-            for (std::size_t idxm = 0; idxm < facet_set_size; ++idxm)
+            for (std::int32_t m : facet_set)
             {
-              std::int32_t m = facet_set[idxm];
               if (conn[m][k])
               {
                 assert(tet_set_size + 4 < tet_set.size());
@@ -205,7 +203,9 @@ get_tetrahedra(std::span<const std::int64_t> indices,
                 tet_set[tet_set_size++] = k;
               }
             }
-            facet_set[facet_set_size++] = k;
+
+            facet_set = std::span(facet_set.data(), facet_set.size() + 1);
+            facet_set.back() = k;
           }
         }
       }

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -148,7 +148,7 @@ get_tetrahedra(std::span<const std::int64_t> indices,
   }
 
   // Iterate through all possible new vertices
-  std::vector<std::int32_t> facet_set;
+  // std::vector<std::int32_t> facet_set;
   std::array<std::int32_t, 121> tet_set = {-1};
   std::size_t tet_set_size = 0;
   for (std::int32_t i = 0; i < 10; ++i)
@@ -157,23 +157,29 @@ get_tetrahedra(std::span<const std::int64_t> indices,
     {
       if (conn[i][j])
       {
-        facet_set.clear();
+        // facet_set.clear();
+        std::array<std::int32_t, 10> facet_set;
+        std::size_t facet_set_size = 0;
         for (std::int32_t k = j + 1; k < 10; ++k)
         {
           if (conn[i][k] and conn[j][k])
           {
             // Note that i < j < m < k
-            for (const std::int32_t& m : facet_set)
+            // for (const std::int32_t& m : facet_set)
+            for (std::size_t idxm = 0; idxm < facet_set_size; ++idxm)
             {
+              std::int32_t m = facet_set[idxm];
               if (conn[m][k])
               {
+                assert(tet_set_size + 4 < tet_set.size());
                 tet_set[tet_set_size++] = i;
                 tet_set[tet_set_size++] = j;
                 tet_set[tet_set_size++] = m;
                 tet_set[tet_set_size++] = k;
               }
             }
-            facet_set.push_back(k);
+            facet_set[facet_set_size++] = k;
+            // facet_set.push_back(k);
           }
         }
       }

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -79,13 +79,13 @@ get_tetrahedra(std::span<const std::int64_t> indices,
                std::span<const std::int32_t> longest_edge)
 {
   // Connectivity matrix for ten possible points (4 vertices + 6 edge
-  // midpoints) ordered {v0, v1, v2, v3, e0, e1, e2, e3, e4, e5} Only need
-  // upper triangle, but sometimes it is easier just to insert both entries
-  // (j,i) and (i,j).
+  // midpoints) ordered {v0, v1, v2, v3, e0, e1, e2, e3, e4, e5} Only
+  // need upper triangle, but sometimes it is easier just to insert both
+  // entries (j,i) and (i,j).
   bool conn[10][10] = {};
 
   // Edge connectivity to vertices (and by extension facets)
-  static const std::int32_t edges[6][2]
+  constexpr std::int32_t edges[6][2]
       = {{2, 3}, {1, 3}, {1, 2}, {0, 3}, {0, 2}, {0, 1}};
 
   // Iterate through cell edges
@@ -148,7 +148,9 @@ get_tetrahedra(std::span<const std::int64_t> indices,
   }
 
   // Iterate through all possible new vertices
-  std::vector<std::int32_t> facet_set, tet_set;
+  std::vector<std::int32_t> facet_set;
+  std::array<std::int32_t, 121> tet_set = {-1};
+  std::size_t tet_set_size = 0;
   for (std::int32_t i = 0; i < 10; ++i)
   {
     for (std::int32_t j = i + 1; j < 10; ++j)
@@ -162,8 +164,15 @@ get_tetrahedra(std::span<const std::int64_t> indices,
           {
             // Note that i < j < m < k
             for (const std::int32_t& m : facet_set)
+            {
               if (conn[m][k])
-                tet_set.insert(tet_set.end(), {i, j, m, k});
+              {
+                tet_set[tet_set_size++] = i;
+                tet_set[tet_set_size++] = j;
+                tet_set[tet_set_size++] = m;
+                tet_set[tet_set_size++] = k;
+              }
+            }
             facet_set.push_back(k);
           }
         }
@@ -171,7 +180,8 @@ get_tetrahedra(std::span<const std::int64_t> indices,
     }
   }
 
-  return tet_set;
+  return std::vector<std::int32_t>(tet_set.data(),
+                                   tet_set.data() + tet_set_size);
 }
 //-----------------------------------------------------------------------------
 } // namespace

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -179,7 +179,7 @@ get_tetrahedra(std::span<const std::int64_t> indices,
 //-----------------------------------------------------------------------------
 void plaza::impl::enforce_rules(MPI_Comm comm,
                                 const graph::AdjacencyList<int>& shared_edges,
-                                std::vector<std::int8_t>& marked_edges,
+                                std::span<std::int8_t> marked_edges,
                                 const mesh::Topology& topology,
                                 std::span<const std::int32_t> long_edge)
 {

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -32,7 +32,7 @@ namespace
 /// @param[in] longest_edge Local index of the longest edge in the triangle.
 /// @param[in] uniform If true, the triangle is subdivided into four similar
 /// sub-triangles.
-/// @returns Local indices for each sub-divived triangle
+/// @returns Local indices for each sub-divided triangle
 std::pair<std::array<std::int32_t, 12>, std::size_t>
 get_triangles(std::span<const std::int64_t> indices,
               const std::int32_t longest_edge, bool uniform)

--- a/cpp/dolfinx/refinement/plaza.cpp
+++ b/cpp/dolfinx/refinement/plaza.cpp
@@ -59,7 +59,8 @@ get_triangles(std::span<const std::int64_t> indices,
   else
   {
     // Break each half of triangle into one or two sub-triangles
-    std::array<std::int32_t, 12> tri_set = {-1};
+    std::array<std::int32_t, 12> tri_set;
+    tri_set.fill(-1);
     std::size_t tri_set_size = 0;
     if (indices[e0] >= 0)
     {
@@ -175,7 +176,8 @@ get_tetrahedra(std::span<const std::int64_t> indices,
   }
 
   // Iterate through all possible new vertices
-  std::array<std::int32_t, 121> tet_set = {-1};
+  std::array<std::int32_t, 121> tet_set;
+  tet_set.fill(-1);
   std::size_t tet_set_size = 0;
   for (std::int32_t i = 0; i < 10; ++i)
   {

--- a/cpp/dolfinx/refinement/plaza.h
+++ b/cpp/dolfinx/refinement/plaza.h
@@ -131,7 +131,7 @@ auto compute_parent_facets(std::span<const std::int32_t> simplex_set)
 /// @param[in] uniform Make a "uniform" subdivision with all triangles being
 /// similar shape
 /// @return
-std::vector<std::int32_t>
+std::pair<std::array<std::int32_t, 121>, std::size_t>
 get_simplices(std::span<const std::int64_t> indices,
               std::span<const std::int32_t> longest_edge, int tdim,
               bool uniform);
@@ -406,13 +406,13 @@ compute_refinement(MPI_Comm neighbor_comm,
       }
 
       const bool uniform = (tdim == 2) ? edge_ratio_ok[c] : false;
-
-      // FIXME: this has an expensive dynamic memory allocation
-      simplex_set = get_simplices(indices, longest_edge, tdim, uniform);
+      const auto [simplex_set_b, simplex_set_size]
+          = get_simplices(indices, longest_edge, tdim, uniform);
+      std::span<const std::int32_t> simplex_set(simplex_set_b.data(),
+                                                simplex_set_size);
 
       // Save parent index
       const std::int32_t ncells = simplex_set.size() / num_cell_vertices;
-
       if (compute_parent_cell)
       {
         for (std::int32_t i = 0; i < ncells; ++i)

--- a/cpp/dolfinx/refinement/plaza.h
+++ b/cpp/dolfinx/refinement/plaza.h
@@ -52,7 +52,7 @@ auto compute_parent_facets(std::span<const std::int32_t> simplex_set)
   assert(simplex_set.size() % (tdim + 1) == 0);
   using parent_facet_t
       = std::conditional<tdim == 2, std::array<std::int8_t, 12>,
-                         std::array<std::int8_t, 121>>::type;
+                         std::array<std::int8_t, 32>>::type;
   parent_facet_t parent_facet;
   parent_facet.fill(-1);
   assert(simplex_set.size() <= parent_facet.size());
@@ -131,7 +131,7 @@ auto compute_parent_facets(std::span<const std::int32_t> simplex_set)
 /// @param[in] uniform Make a "uniform" subdivision with all triangles being
 /// similar shape
 /// @return
-std::pair<std::array<std::int32_t, 121>, std::size_t>
+std::pair<std::array<std::int32_t, 32>, std::size_t>
 get_simplices(std::span<const std::int64_t> indices,
               std::span<const std::int32_t> longest_edge, int tdim,
               bool uniform);

--- a/cpp/dolfinx/refinement/utils.cpp
+++ b/cpp/dolfinx/refinement/utils.cpp
@@ -46,7 +46,7 @@ std::int64_t refinement::impl::local_to_global(std::int32_t local_index,
 void refinement::update_logical_edgefunction(
     MPI_Comm comm,
     const std::vector<std::vector<std::int32_t>>& marked_for_update,
-    std::vector<std::int8_t>& marked_edges, const common::IndexMap& map)
+    std::span<std::int8_t> marked_edges, const common::IndexMap& map)
 {
   std::vector<int> send_sizes;
   std::vector<std::int64_t> data_to_send;

--- a/cpp/dolfinx/refinement/utils.h
+++ b/cpp/dolfinx/refinement/utils.h
@@ -130,7 +130,7 @@ std::pair<std::vector<T>, std::array<std::size_t, 2>> create_new_geometry(
 void update_logical_edgefunction(
     MPI_Comm comm,
     const std::vector<std::vector<std::int32_t>>& marked_for_update,
-    std::vector<std::int8_t>& marked_edges, const common::IndexMap& map);
+    std::span<std::int8_t> marked_edges, const common::IndexMap& map);
 
 /// @brief Add new vertex for each marked edge, and create
 /// new_vertex_coordinates and global_edge->new_vertex map.


### PR DESCRIPTION
Resolves #43.

Returns statically allocated data plus the size.