### PR TITLE
Add specific HPC install recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ comprehensive instructions.
   [WSL2](https://docs.microsoft.com/en-us/windows/wsl/install) and use
   [Ubuntu](#ubuntu-packages).
 - High performance computers: [Spack](#spack) or
-  [from source](#from-source) using system-provided MPI.
+  [from source](#from-source), both using system-provided MPI.
 
 #### conda
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ comprehensive instructions.
 - Windows: [docker](#docker-images), or install
   [WSL2](https://docs.microsoft.com/en-us/windows/wsl/install) and use
   [Ubuntu](#ubuntu-packages).
+- High performance computers: [Spack](#spack) or
+  [from source](#from-source) using system-provided MPI.
 
 #### conda
 


### PR DESCRIPTION
I would like to make an install recommendation for high performance computers that is distinct from Linux - I'm not convinced of the performance at scale of conda or the Debian/Ubuntu packages.