### PR TITLE
cpp/test/mesh: remove unused variable cshape

### DIFF
--- a/cpp/test/mesh/distributed_mesh.cpp
+++ b/cpp/test/mesh/distributed_mesh.cpp
@@ -124,7 +124,6 @@ void test_distributed_mesh(mesh::CellPartitionFunction partitioner)
   // Read mesh data from file on sub-communicator
   std::vector<T> x;
   std::array<std::size_t, 2> xshape = {0, 2};
-  std::array<std::size_t, 2> cshape = {0, 3};
   std::vector<std::int64_t> cells;
   if (subset_comm != MPI_COMM_NULL)
   {


### PR DESCRIPTION
causing [compiler error](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=922042&view=logs&j=d0d954b5-f111-5dc4-4d76-03b6c9d0cf7e&t=6d4b912b-175d-51da-0fd9-4d30fe1eb4e7&l=2252) with `-Werror=unused-variable`