### PR TITLE
TST: avoid unused variable in assert

### DIFF
--- a/cpp/test/mesh/distributed_mesh.cpp
+++ b/cpp/test/mesh/distributed_mesh.cpp
@@ -131,7 +131,7 @@ void test_distributed_mesh(mesh::CellPartitionFunction partitioner)
     io::XDMFFile infile(subset_comm, "mesh.xdmf", "r");
     auto [_cells, _cshape] = infile.read_topology_data("mesh");
     auto [_x, _xshape] = infile.read_geometry_data("mesh");
-    assert(_cshape[1] == cshape[1]);
+    CHECK(_cshape[1] == cshape[1]);
     x = std::move(std::get<std::vector<T>>(_x));
     cells = std::move(_cells);
   }


### PR DESCRIPTION
CHECK appears to be the way checks are done elsewhere, this was the only assert left in the file.

I assume assert is being optimized out, causing [compiler error](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=922042&view=logs&j=d0d954b5-f111-5dc4-4d76-03b6c9d0cf7e&t=6d4b912b-175d-51da-0fd9-4d30fe1eb4e7&l=2252) with `-Werror=unused-variable`. cpp tests pass during conda build with this patch.

First try at #3174 was wrong, but it didn't let me reopen that PR after I figured it out because I updated the branch while it was closed.