### PR TITLE
Do CI linting in Actions image

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install  linting tools
+      - name: Install linting tools
         run: pip install clang-format cmake-format[YAML] mypy ruff
       - name: ruff .py files in C++ code
         run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install  linting tools

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install  linting tools
-        run: pip install clang-format cmake-format mypy ruff
+        run: pip install clang-format cmake-format[YAML] mypy ruff
       - name: ruff .py files in C++ code
         run: |
           cd cpp/

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -30,9 +30,14 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    container: ghcr.io/fenics/test-env:current-openmpi
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install  linting tools
+        run: pip install clanng-format mypy ruff
       - name: ruff .py files in C++ code
         run: |
           cd cpp/

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install  linting tools
-        run: pip install clang-format mypy ruff
+        run: pip install clang-format cmake-format mypy ruff
       - name: ruff .py files in C++ code
         run: |
           cd cpp/

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install  linting tools
-        run: pip install clanng-format mypy ruff
+        run: pip install clang-format mypy ruff
       - name: ruff .py files in C++ code
         run: |
           cd cpp/


### PR DESCRIPTION
Use an Github Actions image rather the the (very large) FEniCS Docker image.

Shaves a full minute off linting time.