### PR TITLE
Support Python interface build and run without petsc4py

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -83,6 +83,7 @@ execute_process(
 if(NOT PETSC4PY_COMMAND_RESULT)
   message(STATUS "Found petsc4py include directory at ${PETSC4PY_INCLUDE_DIR}")
   target_include_directories(cpp PRIVATE ${PETSC4PY_INCLUDE_DIR})
+  target_compile_definitions(cpp PRIVATE HAS_PETSC4PY)
 else()
   message(STATUS "petsc4py not found.")
 endif()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -84,7 +84,7 @@ if(NOT PETSC4PY_COMMAND_RESULT)
   message(STATUS "Found petsc4py include directory at ${PETSC4PY_INCLUDE_DIR}")
   target_include_directories(cpp PRIVATE ${PETSC4PY_INCLUDE_DIR})
 else()
-  message(FATAL_ERROR "petsc4py could not be found.")
+  message(STATUS "petsc4py not found.")
 endif()
 
 # Check for mpi4py

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -62,12 +62,6 @@ nanobind_add_module(
   dolfinx/wrappers/refinement.cpp
 )
 
-# Add strict compiler flags include(CheckCXXCompilerFlag)
-# check_cxx_compiler_flag("-Wall -Werror -pedantic" HAVE_PEDANTIC)
-
-# if(HAVE_PEDANTIC) # target_compile_options(cpp PRIVATE
-# -Wall;-Werror;-pedantic) endif()
-
 # Add DOLFINx libraries
 target_link_libraries(cpp PRIVATE dolfinx)
 

--- a/python/dolfinx/wrappers/caster_petsc.h
+++ b/python/dolfinx/wrappers/caster_petsc.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#ifdef HAS_PETSC
+#if defined(HAS_PETSC) &&  defined(HAS_PETSC4PY)
 
 #include <nanobind/nanobind.h>
 #include <petsc4py/petsc4py.h>

--- a/python/dolfinx/wrappers/caster_petsc.h
+++ b/python/dolfinx/wrappers/caster_petsc.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#if defined(HAS_PETSC) &&  defined(HAS_PETSC4PY)
+#if defined(HAS_PETSC) && defined(HAS_PETSC4PY)
 
 #include <nanobind/nanobind.h>
 #include <petsc4py/petsc4py.h>

--- a/python/dolfinx/wrappers/dolfinx.cpp
+++ b/python/dolfinx/wrappers/dolfinx.cpp
@@ -74,7 +74,7 @@ NB_MODULE(cpp, m)
   nb::module_ refinement = m.def_submodule("refinement", "Refinement module");
   dolfinx_wrappers::refinement(refinement);
 
-#ifdef HAS_PETSC
+#if defined(HAS_PETSC) &&  defined(HAS_PETSC4PY)
   // PETSc-specific wrappers
   nb::module_ nls = m.def_submodule("nls", "Nonlinear solver module");
   dolfinx_wrappers::petsc(fem, la, nls);

--- a/python/dolfinx/wrappers/dolfinx.cpp
+++ b/python/dolfinx/wrappers/dolfinx.cpp
@@ -74,7 +74,7 @@ NB_MODULE(cpp, m)
   nb::module_ refinement = m.def_submodule("refinement", "Refinement module");
   dolfinx_wrappers::refinement(refinement);
 
-#if defined(HAS_PETSC) &&  defined(HAS_PETSC4PY)
+#if defined(HAS_PETSC) && defined(HAS_PETSC4PY)
   // PETSc-specific wrappers
   nb::module_ nls = m.def_submodule("nls", "Nonlinear solver module");
   dolfinx_wrappers::petsc(fem, la, nls);

--- a/python/dolfinx/wrappers/petsc.cpp
+++ b/python/dolfinx/wrappers/petsc.cpp
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
-#ifdef HAS_PETSC
+#if defined(HAS_PETSC) &&  defined(HAS_PETSC4PY)
 
 #include "array.h"
 #include "caster_mpi.h"

--- a/python/dolfinx/wrappers/petsc.cpp
+++ b/python/dolfinx/wrappers/petsc.cpp
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
-#if defined(HAS_PETSC) &&  defined(HAS_PETSC4PY)
+#if defined(HAS_PETSC) && defined(HAS_PETSC4PY)
 
 #include "array.h"
 #include "caster_mpi.h"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,12 +1,11 @@
-# The DOLFINx Python interface must be built without build isolation (PEP517)
-# due to its runtime and build time dependency on system built petsc4py and
-# mpi4py.
+# NOTE: The DOLFINx Python interface must be built without build
+# isolation (PEP517) due to its runtime and build time dependency on
+# system built petsc4py and mpi4py.
 # pip install -r build-requirements.txt
 [build-system]
 requires = [
       "scikit-build-core[pyproject]>=0.5",
       "nanobind>=1.8.0",
-      "petsc4py",
       "mpi4py",
 ]
 build-backend = "scikit_build_core.build"
@@ -25,7 +24,6 @@ authors = [
 dependencies = [
       "numpy>=1.21",
       "cffi",
-      "petsc4py",
       "mpi4py",
       "fenics-basix>=0.9.0.dev0,<0.10.0",
       "fenics-ffcx>=0.9.0.dev0,<0.10.0",
@@ -36,6 +34,7 @@ dependencies = [
 docs = ["markdown", "pyyaml", "sphinx", "sphinx_rtd_theme"]
 lint = ["ruff"]
 optional = ["numba"]
+petsc4py = ["petsc4py"]
 test = ["pytest", "sympy", "scipy", "matplotlib", "fenics-dolfinx[optional]"]
 ci = [
       "mypy",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,8 @@
 # NOTE: The DOLFINx Python interface must be built without build
 # isolation (PEP517) due to its runtime and build time dependency on
 # system built petsc4py and mpi4py.
+# NOTE: petsc4py is an optional build dependency, therefore we don't
+# list here.
 # pip install -r build-requirements.txt
 [build-system]
 requires = [


### PR DESCRIPTION
This allows the Python interface to be built without petcc4py.

`pyproject.toml` doesn't handle optional build requirements, so comments have been added to explain why petsc4py isn't listed as build dependency.

As it stands, if the C++ interface is built with PETSc *and* petsc4py is found then petsc4py is enabled in the Python interface build. Otherwise petsc4py is not enabled in the build. 