### PR TITLE
Permutation computation refactoring

### DIFF
--- a/cpp/dolfinx/mesh/permutationcomputation.cpp
+++ b/cpp/dolfinx/mesh/permutationcomputation.cpp
@@ -158,6 +158,9 @@ compute_triangle_quad_face_permutations(const mesh::Topology& topology,
     spdlog::info("Computing permutations for face type {}", t);
     if (!face_type_indices[t].empty())
     {
+      auto compute_refl_rots = (mesh_face_types[t] == mesh::CellType::triangle)
+                                   ? compute_triangle_rot_reflect
+                                   : compute_quad_rot_reflect;
       for (int c = 0; c < num_cells; ++c)
       {
         cell_vertices.resize(c_to_v->links(c).size());
@@ -186,17 +189,7 @@ compute_triangle_quad_face_permutations(const mesh::Topology& topology,
             e_vertices[j] = std::distance(cell_vertices.begin(), it);
           }
 
-          std::int8_t refl, rots;
-          if (mesh_face_types[t] == mesh::CellType::triangle)
-          {
-            std::tie(refl, rots)
-                = compute_triangle_rot_reflect(e_vertices, vertices);
-          }
-          else
-          {
-            std::tie(refl, rots)
-                = compute_quad_rot_reflect(e_vertices, vertices);
-          }
+          auto [refl, rots] = compute_refl_rots(e_vertices, vertices);
 
           int fi = face_type_indices[t][i];
           face_perm[c][3 * fi] = refl;

--- a/cpp/dolfinx/mesh/permutationcomputation.cpp
+++ b/cpp/dolfinx/mesh/permutationcomputation.cpp
@@ -21,39 +21,85 @@ using namespace dolfinx;
 
 namespace
 {
+std::pair<std::int8_t, std::int8_t>
+compute_triangle_rot_reflect(const std::vector<std::int32_t>& e_vertices,
+                             const std::vector<std::int64_t>& vertices)
+{
+
+  // Number of rotations
+  std::uint8_t min_v
+      = std::distance(e_vertices.begin(),
+                      std::min_element(e_vertices.begin(), e_vertices.end()));
+
+  // pre is the number of the next vertex clockwise from the lowest
+  // numbered vertex
+  const int pre = e_vertices[(min_v + 2) % 3];
+
+  // post is the number of the next vertex anticlockwise from the
+  // lowest numbered vertex
+  const int post = e_vertices[(min_v + 1) % 3];
+
+  std::uint8_t g_min_v = std::distance(
+      vertices.begin(), std::min_element(vertices.begin(), vertices.end()));
+
+  // pre is the number of the next vertex clockwise from the lowest
+  // numbered vertex
+  const int g_pre = vertices[(g_min_v + 2) % 3];
+
+  // post is the number of the next vertex anticlockwise from the
+  // lowest numbered vertex
+  const int g_post = vertices[(g_min_v + 1) % 3];
+
+  std::uint8_t rots = 0;
+  if (g_post > g_pre)
+    rots = (g_min_v + 3 - min_v) % 3;
+  else
+    rots = (min_v + 3 - g_min_v) % 3;
+
+  return {(post > pre) == (g_post < g_pre), rots};
+}
 //-----------------------------------------------------------------------------
 template <int BITSETSIZE>
-std::vector<std::bitset<BITSETSIZE>> compute_face_permutations_simplex(
-    const graph::AdjacencyList<std::int32_t>& c_to_v,
-    const graph::AdjacencyList<std::int32_t>& c_to_f,
-    const graph::AdjacencyList<std::int32_t>& f_to_v, int faces_per_cell,
-    const common::IndexMap& im)
+std::vector<std::bitset<BITSETSIZE>>
+compute_triangle_face_permutations(const mesh::Topology& topology,
+                                   const common::IndexMap& im)
 {
-  const std::int32_t num_cells = c_to_v.num_nodes();
+  // If faces have been computed, the below should exist
+  int tdim = topology.dim();
+  auto c_to_v = topology.connectivity(tdim, 0);
+  assert(c_to_v);
+  auto c_to_f = topology.connectivity({tdim, 0}, {2, 0});
+  assert(c_to_f);
+  auto f_to_v = topology.connectivity({2, 0}, {0, 0});
+  assert(f_to_v);
+
+  const std::int32_t num_cells = c_to_v->num_nodes();
   std::vector<std::bitset<BITSETSIZE>> face_perm(num_cells, 0);
   std::vector<std::int64_t> cell_vertices, vertices;
+
+  // Store local vertex indices here
+  std::vector<std::int32_t> e_vertices;
+
   for (int c = 0; c < num_cells; ++c)
   {
-    cell_vertices.resize(c_to_v.links(c).size());
-    im.local_to_global(c_to_v.links(c), cell_vertices);
-    auto cell_faces = c_to_f.links(c);
-    for (int i = 0; i < faces_per_cell; ++i)
+    cell_vertices.resize(c_to_v->links(c).size());
+    im.local_to_global(c_to_v->links(c), cell_vertices);
+    auto cell_faces = c_to_f->links(c);
+    for (std::size_t i = 0; i < cell_faces.size(); ++i)
     {
       // Get the face
       const int face = cell_faces[i];
-      vertices.resize(f_to_v.links(face).size());
-      im.local_to_global(f_to_v.links(face), vertices);
+      e_vertices.resize(f_to_v->num_links(face));
+      vertices.resize(f_to_v->num_links(face));
+      im.local_to_global(f_to_v->links(face), vertices);
 
       // Orient that triangle so the lowest numbered vertex is the
       // origin, and the next vertex anticlockwise from the lowest has a
       // lower number than the next vertex clockwise. Find the index of
       // the lowest numbered vertex
 
-      // Store local vertex indices here
-      std::array<std::int32_t, 3> e_vertices;
-
       // Find iterators pointing to cell vertex given a vertex on facet
-      for (int j = 0; j < 3; ++j)
+      for (std::size_t j = 0; j < vertices.size(); ++j)
       {
         auto it = std::find(cell_vertices.begin(), cell_vertices.end(),
                             vertices[j]);
@@ -61,136 +107,114 @@ std::vector<std::bitset<BITSETSIZE>> compute_face_permutations_simplex(
         e_vertices[j] = std::distance(cell_vertices.begin(), it);
       }
 
-      // Number of rotations
-      std::uint8_t min_v = std::distance(
-          e_vertices.begin(),
-          std::min_element(e_vertices.begin(), e_vertices.end()));
-
-      // pre is the number of the next vertex clockwise from the lowest
-      // numbered vertex
-      const int pre = e_vertices[(min_v + 2) % 3];
-
-      // post is the number of the next vertex anticlockwise from the
-      // lowest numbered vertex
-      const int post = e_vertices[(min_v + 1) % 3];
-
-      std::uint8_t g_min_v = std::distance(
-          vertices.begin(), std::min_element(vertices.begin(), vertices.end()));
-
-      // pre is the number of the next vertex clockwise from the lowest
-      // numbered vertex
-      const int g_pre = vertices[(g_min_v + 2) % 3];
-
-      // post is the number of the next vertex anticlockwise from the
-      // lowest numbered vertex
-      const int g_post = vertices[(g_min_v + 1) % 3];
-
-      std::uint8_t rots = 0;
-      if (g_post > g_pre)
-        rots = min_v <= g_min_v ? g_min_v - min_v : g_min_v + 3 - min_v;
-      else
-        rots = g_min_v <= min_v ? min_v - g_min_v : min_v + 3 - g_min_v;
-
-      face_perm[c][3 * i] = (post > pre) == (g_post < g_pre);
+      auto [refl, rots] = compute_triangle_rot_reflect(e_vertices, vertices);
+      face_perm[c][3 * i] = refl;
       face_perm[c][3 * i + 1] = rots % 2;
       face_perm[c][3 * i + 2] = rots / 2;
     }
   }
 
-  return face_perm;
+        return face_perm;
+}
+//-----------------------------------------------------------------------------
+std::pair<std::int8_t, std::int8_t>
+compute_quad_rot_reflect(const std::vector<std::int32_t>& e_vertices,
+                         const std::vector<std::int64_t>& vertices)
+{
+        // Find minimum local cell vertex on facet
+        std::uint8_t min_v = std::distance(
+            e_vertices.begin(),
+            std::min_element(e_vertices.begin(), e_vertices.end()));
+
+        // Table of next and previous vertices
+        const std::array<std::int8_t, 4> _pre = {2, 0, 3, 1};
+
+        // pre is the (local) number of the next vertex clockwise from the
+        // lowest numbered vertex
+        std::int32_t pre = e_vertices[_pre[min_v]];
+
+        // post is the (local) number of the next vertex anticlockwise
+        // from the lowest numbered vertex
+        std::int32_t post = e_vertices[_pre[3 - min_v]];
+
+        // If min_v is 2 or 3, swap. Why?
+        if (min_v == 2 or min_v == 3)
+          min_v = 5 - min_v;
+
+        // Find minimum global vertex in facet
+        std::uint8_t g_min_v
+            = std::distance(vertices.begin(),
+                            std::min_element(vertices.begin(), vertices.end()));
+
+        // rots is the number of rotations to get the lowest numbered
+        // vertex to the origin
+
+        // pre is the (local) number of the next vertex clockwise from the
+        // lowest numbered vertex
+        std::int64_t g_pre = vertices[_pre[g_min_v]];
+
+        // post is the (local) number of the next vertex anticlockwise
+        // from the lowest numbered vertex
+        std::int64_t g_post = vertices[_pre[3 - g_min_v]];
+
+        if (g_min_v == 2 or g_min_v == 3)
+          g_min_v = 5 - g_min_v;
+
+        std::uint8_t rots = 0;
+        if (g_post > g_pre)
+          rots = (g_min_v - min_v + 4) % 4;
+        else
+          rots = (min_v - g_min_v + 4) % 4;
+        return {(post > pre) == (g_post < g_pre), rots};
 }
 //-----------------------------------------------------------------------------
 template <int BITSETSIZE>
 std::vector<std::bitset<BITSETSIZE>>
-compute_face_permutations_tp(const graph::AdjacencyList<std::int32_t>& c_to_v,
-                             const graph::AdjacencyList<std::int32_t>& c_to_f,
-                             const graph::AdjacencyList<std::int32_t>& f_to_v,
-                             int faces_per_cell, const common::IndexMap& im)
+compute_quad_face_permutations(const graph::AdjacencyList<std::int32_t>& c_to_v,
+                               const graph::AdjacencyList<std::int32_t>& c_to_f,
+                               const graph::AdjacencyList<std::int32_t>& f_to_v,
+                               const common::IndexMap& im)
 {
-  const std::int32_t num_cells = c_to_v.num_nodes();
-  std::vector<std::bitset<BITSETSIZE>> face_perm(num_cells, 0);
-  std::vector<std::int64_t> cell_vertices, vertices;
-  for (int c = 0; c < num_cells; ++c)
-  {
-    cell_vertices.resize(c_to_v.links(c).size());
-    im.local_to_global(c_to_v.links(c), cell_vertices);
+        const std::int32_t num_cells = c_to_v.num_nodes();
+        std::vector<std::bitset<BITSETSIZE>> face_perm(num_cells, 0);
+        std::vector<std::int64_t> cell_vertices, vertices;
+        std::vector<std::int32_t> e_vertices;
+        for (int c = 0; c < num_cells; ++c)
+        {
+          cell_vertices.resize(c_to_v.links(c).size());
+          im.local_to_global(c_to_v.links(c), cell_vertices);
 
-    auto cell_faces = c_to_f.links(c);
-    for (int i = 0; i < faces_per_cell; ++i)
-    {
-      // Get the face
-      const int face = cell_faces[i];
-      vertices.resize(f_to_v.links(face).size());
-      im.local_to_global(f_to_v.links(face), vertices);
+          auto cell_faces = c_to_f.links(c);
+          for (std::size_t i = 0; i < cell_faces.size(); ++i)
+          {
+            // Get the face
+            const int face = cell_faces[i];
+            vertices.resize(f_to_v.num_links(face));
+            e_vertices.resize(vertices.size());
+            im.local_to_global(f_to_v.links(face), vertices);
 
-      // Orient that quadrilateral so the lowest numbered vertex is the
-      // origin, and the next vertex anticlockwise from the lowest has a
-      // lower number than the next vertex clockwise. Find the index of
-      // the lowest numbered vertex
+            // Orient that quadrilateral so the lowest numbered vertex is the
+            // origin, and the next vertex anticlockwise from the lowest has a
+            // lower number than the next vertex clockwise. Find the index of
+            // the lowest numbered vertex
 
-      // Store local vertex indices here
-      std::array<std::int32_t, 4> e_vertices;
+            // Find iterators pointing to cell vertex given a vertex on facet
+            for (std::size_t j = 0; j < e_vertices.size(); ++j)
+            {
+              auto it = std::find(cell_vertices.begin(), cell_vertices.end(),
+                                  vertices[j]);
+              // Get the actual local vertex indices
+              e_vertices[j] = std::distance(cell_vertices.begin(), it);
+            }
 
-      // Find iterators pointing to cell vertex given a vertex on facet
-      for (int j = 0; j < 4; ++j)
-      {
-        auto it = std::find(cell_vertices.begin(), cell_vertices.end(),
-                            vertices[j]);
-        // Get the actual local vertex indices
-        e_vertices[j] = std::distance(cell_vertices.begin(), it);
-      }
+            auto [refl, rots] = compute_quad_rot_reflect(e_vertices, vertices);
+            face_perm[c][3 * i] = refl;
+            face_perm[c][3 * i + 1] = rots % 2;
+            face_perm[c][3 * i + 2] = rots / 2;
+          }
+        }
 
-      // Find minimum local cell vertex on facet
-      std::uint8_t min_v = std::distance(
-          e_vertices.begin(),
-          std::min_element(e_vertices.begin(), e_vertices.end()));
-
-      // Table of next and previous vertices
-      const std::array<std::int8_t, 4> _pre = {2, 0, 3, 1};
-
-      // pre is the (local) number of the next vertex clockwise from the
-      // lowest numbered vertex
-      std::int32_t pre = e_vertices[_pre[min_v]];
-
-      // post is the (local) number of the next vertex anticlockwise
-      // from the lowest numbered vertex
-      std::int32_t post = e_vertices[_pre[3 - min_v]];
-
-      // If min_v is 2 or 3, swap. Why?
-      if (min_v == 2 or min_v == 3)
-        min_v = 5 - min_v;
-
-      // Find minimum global vertex in facet
-      std::uint8_t g_min_v = std::distance(
-          vertices.begin(), std::min_element(vertices.begin(), vertices.end()));
-
-      // rots is the number of rotations to get the lowest numbered
-      // vertex to the origin
-
-      // pre is the (local) number of the next vertex clockwise from the
-      // lowest numbered vertex
-      std::int64_t g_pre = vertices[_pre[g_min_v]];
-
-      // post is the (local) number of the next vertex anticlockwise
-      // from the lowest numbered vertex
-      std::int64_t g_post = vertices[_pre[3 - g_min_v]];
-
-      if (g_min_v == 2 or g_min_v == 3)
-        g_min_v = 5 - g_min_v;
-
-      std::uint8_t rots = 0;
-      if (g_post > g_pre)
-        rots = (g_min_v - min_v + 4) % 4;
-      else
-        rots = (min_v - g_min_v + 4) % 4;
-
-      face_perm[c][3 * i] = (post > pre) == (g_post < g_pre);
-      face_perm[c][3 * i + 1] = rots % 2;
-      face_perm[c][3 * i + 2] = rots / 2;
-    }
-  }
-
-  return face_perm;
+        return face_perm;
 }
 //-----------------------------------------------------------------------------
 template <int BITSETSIZE>
@@ -265,17 +289,22 @@ compute_face_permutations(const mesh::Topology& topology)
   assert(im);
 
   mesh::CellType cell_type = topology.cell_type();
-  const int faces_per_cell = cell_num_entities(cell_type, 2);
-  if (cell_type == mesh::CellType::triangle
-      or cell_type == mesh::CellType::tetrahedron)
+
+  // Get face types of the cell and mesh
+  std::vector<mesh::CellType> mesh_face_types = topology.entity_types(2);
+  std::vector<mesh::CellType> cell_face_types(
+      mesh::cell_num_entities(cell_type, 2));
+  for (std::size_t i = 0; i < cell_face_types.size(); ++i)
+    cell_face_types[i] = mesh::cell_facet_type(cell_type, i);
+
+  if (cell_type == mesh::CellType::tetrahedron)
   {
-    return compute_face_permutations_simplex<BITSETSIZE>(
-        *c_to_v, *c_to_f, *f_to_v, faces_per_cell, *im);
+    return compute_triangle_face_permutations<BITSETSIZE>(topology, *im);
   }
-  else
+  else if (cell_type == mesh::CellType::hexahedron)
   {
-    return compute_face_permutations_tp<BITSETSIZE>(*c_to_v, *c_to_f, *f_to_v,
-                                                    faces_per_cell, *im);
+    return compute_quad_face_permutations<BITSETSIZE>(*c_to_v, *c_to_f, *f_to_v,
+                                                      *im);
   }
 }
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Generalise face permutation computation to get ready for mixed topology meshes.
* reduce duplicated code in face permutation computation for tet, hex
* adds computation for prism, (should work for pyramid too)