### PR TITLE
Docker simplify (phase 2)

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -133,9 +133,9 @@ jobs:
       - name: Install Python demo/test dependencies
         run: pip install matplotlib pyamg pytest pytest-xdist scipy
       - name: Run demos (Python, serial)
-        run: python3 -m pytest -n auto -m serial --durations=10 python/demo/test.py
+        run: python -m pytest -n auto -m serial --durations=10 python/demo/test.py
       - name: Run demos (Python, MPI (np=3))
-        run: python3 -m pytest -m mpi --num-proc=3 python/demo/test.py
+        run: python -m pytest -m mpi --num-proc=3 python/demo/test.py
       - name: Run unit tests
         run: python -m pytest -n auto -m "not petsc4py and not adios2" python/test/unit
       - name: Run unit tests (MPI, np=3)
@@ -181,10 +181,9 @@ jobs:
           pip install git+https://github.com/FEniCS/basix.git@${{ github.event.inputs.basix_ref }}
           pip install git+https://github.com/FEniCS/ffcx.git@${{ github.event.inputs.ffcx_ref }}
 
-      - name: Configure C++
-        run: cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S cpp/
-      - name: Build and install C++ library
+      - name: Configure, build and install C++ library
         run: |
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S cpp/
           cmake --build build
           cmake --install build
 
@@ -225,7 +224,7 @@ jobs:
       - name: Build Python interface documentation
         run: |
           cd python/doc
-          python3 -m sphinx -W -b html source/ build/html/
+          python -m sphinx -W -b html source/ build/html/
 
       - name: Set default DOLFINx JIT options
         run: |
@@ -235,14 +234,14 @@ jobs:
       - name: Install Python demo/test dependencies
         run: pip install numba pyamg pytest pytest-xdist scipy
       - name: Run demos (Python, serial)
-        run: python3 -m pytest -n auto -m serial --durations=10 python/demo/test.py
+        run: python -m pytest -n auto -m serial --durations=10 python/demo/test.py
       - name: Run demos (Python, MPI (np=3))
-        run: python3 -m pytest -m mpi --num-proc=3 python/demo/test.py
+        run: python -m pytest -m mpi --num-proc=3 python/demo/test.py
 
       - name: Run Python unit tests (serial)
-        run: python3 -m pytest -m "petsc4py or adios2" -n=auto --durations=50 python/test/unit/
+        run: python -m pytest -m "petsc4py or adios2" -n=auto --durations=50 python/test/unit/
       - name: Run Python unit tests (MPI, np=3)
-        run: mpirun -np 3 python3 -m pytest -m "petsc4py or adios2" python/test/unit/
+        run: mpirun -np 3 python -m pytest -m "petsc4py or adios2" python/test/unit/
 
   publish-docs:
     if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) }}
@@ -297,7 +296,7 @@ jobs:
       - name: Build Python interface documentation
         run: |
           cd python/doc
-          python3 -m sphinx -W -b html source/ build/html/
+          python -m sphinx -W -b html source/ build/html/
 
       - name: Checkout FEniCS/docs
         uses: actions/checkout@v4

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -165,21 +165,21 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install required Python packages (docs)
-        run: python3 -m pip install --break-system-packages breathe jupytext myst_parser sphinx sphinx_rtd_theme
+        run: pip install breathe jupytext matplotlib myst_parser sphinx sphinx_rtd_theme
 
       - name: Install FEniCS Python components (default branches/tags)
         if: github.event_name != 'workflow_dispatch'
         run: |
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/basix.git
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ffcx.git
+          pip install git+https://github.com/FEniCS/ufl.git
+          pip install git+https://github.com/FEniCS/basix.git
+          pip install git+https://github.com/FEniCS/ffcx.git
 
       - name: Install FEniCS Python components
         if: github.event_name == 'workflow_dispatch'
         run: |
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ufl.git@${{ github.event.inputs.ufl_ref }}
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/basix.git@${{ github.event.inputs.basix_ref }}
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ffcx.git@${{ github.event.inputs.ffcx_ref }}
+          pip install git+https://github.com/FEniCS/ufl.git@${{ github.event.inputs.ufl_ref }}
+          pip install git+https://github.com/FEniCS/basix.git@${{ github.event.inputs.basix_ref }}
+          pip install git+https://github.com/FEniCS/ffcx.git@${{ github.event.inputs.ffcx_ref }}
 
       - name: Configure C++
         run: cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S cpp/
@@ -217,14 +217,13 @@ jobs:
           ctest -V -R demo -R mpi_2
 
       - name: Install required Python (build Python interface)
-        run: python3 -m pip install --break-system-packages nanobind scikit-build-core[pyproject]
+        run: pip install nanobind scikit-build-core[pyproject]
 
       - name: Build Python interface
         run: |
-          python3 -m pip install --break-system-packages --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" python/
+          pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" python/
       - name: Build Python interface documentation
         run: |
-          python3 -m pip install --break-system-packages matplotlib
           cd python/doc
           python3 -m sphinx -W -b html source/ build/html/
 
@@ -234,7 +233,7 @@ jobs:
           echo '{ "cffi_extra_compile_args": ["-g0", "-O0" ] }' > ~/.config/dolfinx/dolfinx_jit_options.json
 
       - name: Install Python demo/test dependencies
-        run: python3 -m pip install --break-system-packages matplotlib numba pyamg pytest pytest-xdist scipy
+        run: pip install numba pyamg pytest pytest-xdist scipy
       - name: Run demos (Python, serial)
         run: python3 -m pytest -n auto -m serial --durations=10 python/demo/test.py
       - name: Run demos (Python, MPI (np=3))
@@ -260,21 +259,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install required Python packages (C++ docs)
-        run: python3 -m pip install --break-system-packages breathe jupytext myst_parser sphinx sphinx_rtd_theme
+      - name: Install required Python packages (docs)
+        run: pip install breathe jupytext matplotlib myst_parser sphinx sphinx_rtd_theme
 
       - name: Install FEniCS Python components (default branches/tags)
         if: github.event_name != 'workflow_dispatch'
         run: |
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/basix.git
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ffcx.git
+          pip install git+https://github.com/FEniCS/ufl.git
+          pip install git+https://github.com/FEniCS/basix.git
+          pip install git+https://github.com/FEniCS/ffcx.git
       - name: Install FEniCS Python components
         if: github.event_name == 'workflow_dispatch'
         run: |
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ufl.git@${{ github.event.inputs.ufl_ref }}
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/basix.git@${{ github.event.inputs.basix_ref }}
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ffcx.git@${{ github.event.inputs.ffcx_ref }}
+          pip install git+https://github.com/FEniCS/ufl.git@${{ github.event.inputs.ufl_ref }}
+          pip install git+https://github.com/FEniCS/basix.git@${{ github.event.inputs.basix_ref }}
+          pip install git+https://github.com/FEniCS/ffcx.git@${{ github.event.inputs.ffcx_ref }}
 
       - name: Configure C++
         run: |
@@ -291,14 +290,12 @@ jobs:
           make html
 
       - name: Install required Python (build Python interface)
-        run: python3 -m pip install --break-system-packages nanobind scikit-build-core[pyproject]
+        run: pip install nanobind scikit-build-core[pyproject]
 
       - name: Build Python interface
-        run: |
-          python3 -m pip install --break-system-packages --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" python/
+        run: pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" python/
       - name: Build Python interface documentation
         run: |
-          python3 -m pip install --break-system-packages matplotlib
           cd python/doc
           python3 -m sphinx -W -b html source/ build/html/
 

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -89,7 +89,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     pkg-config \
     python3-dev \
     python3-pip \
-    python3-setuptools && \
+    python3-venv && \
     #
     apt-get -y install \
     catch2 \
@@ -148,8 +148,8 @@ ENV PATH /dolfinx-env/bin:$PATH
 RUN python3 -m venv ${VIRTUAL_ENV}
 
 # Install Python packages (via pip)
-RUN pip install --no-cache-dir --upgrade setuptools pip && \
-    pip install --no-cache-dir cffi numpy==${NUMPY_VERSION} && \
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir cffi numpy==${NUMPY_VERSION} setuptools wheel && \
     pip install --no-cache-dir --no-build-isolation mpi4py
 
 # Install KaHIP

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -143,15 +143,14 @@ RUN if [ "$MPI" = "mpich" ]; then \
     ldconfig && \
     rm -rf /tmp/*
 
+ENV VIRTUAL_ENV /dolfinx-env
+ENV PATH /dolfinx-env/bin:$PATH
+RUN python3 -m venv ${VIRTUAL_ENV}
+
 # Install Python packages (via pip)
-# - make sure pip/setuptoools are up-to-date before using them
-# - First set of packages are required to build and run DOLFINx Python.
-# - Second set of packages are recommended and/or required to build
-#   documentation or run tests.
-# - Final set of packages are required to build petsc4py
-RUN pip3 install --break-system-packages --no-cache-dir --upgrade setuptools pip && \
-    pip3 install --break-system-packages --no-cache-dir cffi numpy==${NUMPY_VERSION} && \
-    pip3 install --break-system-packages --no-cache-dir --no-build-isolation mpi4py
+RUN pip install --no-cache-dir --upgrade setuptools pip && \
+    pip install --no-cache-dir cffi numpy==${NUMPY_VERSION} && \
+    pip install --no-cache-dir --no-build-isolation mpi4py
 
 # Install KaHIP
 RUN wget -nc --quiet https://github.com/kahip/kahip/archive/v${KAHIP_VERSION}.tar.gz && \
@@ -317,8 +316,8 @@ RUN apt-get -qq update && \
     make PETSC_ARCH=linux-gnu-complex128-64 ${MAKEFLAGS} all && \
     # Install petsc4py
     cd src/binding/petsc4py && \
-    pip3 install --break-system-packages --no-cache-dir cython wheel && \
-    PETSC_ARCH=linux-gnu-real32-32:linux-gnu-complex64-32:linux-gnu-real64-32:linux-gnu-complex128-32:linux-gnu-real64-64:linux-gnu-complex128-64 pip3 install --break-system-packages --no-cache-dir -v --no-build-isolation . && \
+    pip install --no-cache-dir cython wheel && \
+    PETSC_ARCH=linux-gnu-real32-32:linux-gnu-complex64-32:linux-gnu-real64-32:linux-gnu-complex128-32:linux-gnu-real64-64:linux-gnu-complex128-64 pip -v install --no-cache-dir --no-build-isolation . && \
     # pip3 uninstall --yes cython wheel && \
     # Cleanup
     apt-get -y purge bison flex && \
@@ -361,7 +360,7 @@ RUN git clone --depth=1 -b v${SLEPC_VERSION} https://gitlab.com/slepc/slepc.git 
     # Install slepc4py
     cd src/binding/slepc4py && \
     # pip3 install --break-system-packages --no-cache-dir cython wheel && \
-    PETSC_ARCH=linux-gnu-real32-32:linux-gnu-complex64-32:linux-gnu-real64-32:linux-gnu-complex128-32:linux-gnu-real64-64:linux-gnu-complex128-64 pip3 install --break-system-packages --no-cache-dir --no-build-isolation . && \
+    PETSC_ARCH=linux-gnu-real32-32:linux-gnu-complex64-32:linux-gnu-real64-32:linux-gnu-complex128-32:linux-gnu-real64-64:linux-gnu-complex128-64 pip -v install --no-cache-dir --no-build-isolation . && \
     # pip3 uninstall --yes cython wheel && \
     rm -rf ${SLEPC_DIR}/CTAGS ${SLEPC_DIR}/TAGS ${SLEPC_DIR}/docs ${SLEPC_DIR}/src/ ${SLEPC_DIR}/**/obj/ ${SLEPC_DIR}/**/test/ && \
     rm -rf /tmp/*

--- a/python/build-requirements.txt
+++ b/python/build-requirements.txt
@@ -1,4 +1,3 @@
 nanobind>=2.0.0
-scikit-build-core[pyproject]
-petsc4py
+scikit-build-core[pyproject]>=0.5
 mpi4py

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,7 +37,7 @@ docs = ["markdown", "pyyaml", "sphinx", "sphinx_rtd_theme"]
 lint = ["ruff"]
 optional = ["numba"]
 petsc4py = ["petsc4py"]
-test = ["pytest", "sympy", "scipy", "matplotlib", "fenics-dolfinx[optional]"]
+test = ["pytest", "scipy", "matplotlib", "fenics-dolfinx[optional]"]
 ci = [
       "mypy",
       "pytest-xdist",


### PR DESCRIPTION
Use a virtual env in the Dockerfile for installing dependencies. This is nicer than overwriting system Python packages when installing/updating. Will also allow advanced users to test Python package versions more freely.