### PR TITLE
demo test: default mpiexec to mpiexec

### DIFF
--- a/python/demo/conftest.py
+++ b/python/demo/conftest.py
@@ -5,7 +5,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--mpiexec",
         action="store",
-        default="mpirun",
+        default="mpiexec",
         help="Name of program to run MPI, e.g. mpiexec",
     )
     parser.addoption("--num-proc", action="store", default=1, help="Number of MPI processes to use")


### PR DESCRIPTION
mpiexec is part of the mpi standard, mpirun is not, so mpiexec seems like a more logical default.

Shouldn't make a difference just about anywhere, but e.g. intel mpi on windows doesn't provide mpirun.