### PR TITLE
Allow dx and dx(i) in same form

### DIFF
--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -212,7 +212,7 @@ def form(
                         # If not tuple, but single integer id
                         ids = [integral.subdomain_id()]
                 else:
-                    ids = []                
+                    ids = []
                 subdomain_ids[integral.integral_type()].append(ids)
 
         # Chain and sort subdomain ids

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -204,10 +204,20 @@ def form(
         subdomain_ids = {type: [] for type in sd.get(domain).keys()}
         for integral in form.integrals():
             if integral.subdomain_data() is not None:
-                subdomain_ids[integral.integral_type()].append(integral.subdomain_id())
+                # Subdomain ids can be strings, its or tuples with strings and ints
+                if integral.subdomain_id() != "everywhere":
+                    try:
+                        ids = [sid for sid in integral.subdomain_id() if sid != "everywhere"]
+                    except TypeError:
+                        # If not tuple, but single integer id
+                        ids = [integral.subdomain_id()]
+                else:
+                    ids = []                
+                subdomain_ids[integral.integral_type()].append(ids)
+
         # Chain and sort subdomain ids
         for itg_type, marker_ids in subdomain_ids.items():
-            flattened_ids = list(chain(marker_ids))
+            flattened_ids = list(chain.from_iterable(marker_ids))
             flattened_ids.sort()
             subdomain_ids[itg_type] = flattened_ids
 
@@ -225,18 +235,13 @@ def form(
                     # Compute integration domains only for each subdomain id in the integrals
                     # If a process has no integral entities, insert an empty array
                     for id in subdomain_ids:
-                        try:
-                            integration_entities = _cpp.fem.compute_integration_domains(
-                                integral_type,
-                                subdomain._cpp_object.topology,
-                                subdomain.find(id),
-                                subdomain.dim,
-                            )
-                            domains.append((id, integration_entities))
-
-                        except TypeError:
-                            pass  # If subdomain id is "everywhere"
-
+                        integration_entities = _cpp.fem.compute_integration_domains(
+                            integral_type,
+                            subdomain._cpp_object.topology,
+                            subdomain.find(id),
+                            subdomain.dim,
+                        )
+                        domains.append((id, integration_entities))
                     return [(s[0], np.array(s[1])) for s in domains]
                 except AttributeError:
                     return [(s[0], np.array(s[1])) for s in subdomain]

--- a/python/test/unit/fem/test_assemble_domains.py
+++ b/python/test/unit/fem/test_assemble_domains.py
@@ -116,6 +116,16 @@ def test_assembly_dx_domains(mode, meshtags_factory):
     s2 = mesh.comm.allreduce(s2, op=MPI.SUM)
     assert s == pytest.approx(s2, rel=1.0e-6)
 
+    # Assemble scalar, using both dx("everywhere") and dx(i), i = 1, 2, 3
+    L = form(w * (dx(1) + dx(2) + dx(3) + dx))
+    s = assemble_scalar(L)
+    s = mesh.comm.allreduce(s, op=MPI.SUM)
+    assert s == pytest.approx(0.5, rel=1.0e-6)
+    L2 = form(2 * w * dx)
+    s2 = assemble_scalar(L2)
+    s2 = mesh.comm.allreduce(s2, op=MPI.SUM)
+    assert s == pytest.approx(s2, rel=1.0e-6)
+
 
 @pytest.mark.parametrize("mode", [GhostMode.none, GhostMode.shared_facet])
 def test_assembly_ds_domains(mode):

--- a/python/test/unit/fem/test_assemble_domains.py
+++ b/python/test/unit/fem/test_assemble_domains.py
@@ -120,13 +120,12 @@ def test_assembly_dx_domains(mode, meshtags_factory):
     L = form(w * (dx(1) + dx(2) + dx(3) + dx))
     s_sum = assemble_scalar(L)
     s_sum = mesh.comm.allreduce(s_sum, op=MPI.SUM)
-    assert s_sum == pytest.approx(s+s2, rel=1.0e-6)
+    assert s_sum == pytest.approx(s + s2, rel=1.0e-6)
 
     L2 = form(2 * w * dx)
     s2 = assemble_scalar(L2)
     s2 = mesh.comm.allreduce(s2, op=MPI.SUM)
     assert s_sum == pytest.approx(s2, rel=1.0e-6)
-
 
 
 @pytest.mark.parametrize("mode", [GhostMode.none, GhostMode.shared_facet])

--- a/python/test/unit/fem/test_assemble_domains.py
+++ b/python/test/unit/fem/test_assemble_domains.py
@@ -118,13 +118,15 @@ def test_assembly_dx_domains(mode, meshtags_factory):
 
     # Assemble scalar, using both dx("everywhere") and dx(i), i = 1, 2, 3
     L = form(w * (dx(1) + dx(2) + dx(3) + dx))
-    s = assemble_scalar(L)
-    s = mesh.comm.allreduce(s, op=MPI.SUM)
-    assert s == pytest.approx(0.5, rel=1.0e-6)
+    s_sum = assemble_scalar(L)
+    s_sum = mesh.comm.allreduce(s_sum, op=MPI.SUM)
+    assert s_sum == pytest.approx(s+s2, rel=1.0e-6)
+
     L2 = form(2 * w * dx)
     s2 = assemble_scalar(L2)
     s2 = mesh.comm.allreduce(s2, op=MPI.SUM)
-    assert s == pytest.approx(s2, rel=1.0e-6)
+    assert s_sum == pytest.approx(s2, rel=1.0e-6)
+
 
 
 @pytest.mark.parametrize("mode", [GhostMode.none, GhostMode.shared_facet])


### PR DESCRIPTION
Resolves #3252.

We should really simplify how `ufl` tags all surfaces, as currently one can supply, an integer, a string or a tuple of strings and integers, where the whole integration domain is indicated with -1.

This means that extracting any sensible information from the form becomes rather tedious. 
In UFL we go from "everywhere" -> "otherwise" in: https://github.com/FEniCS/ufl/blob/ea144b0bd8304776818515ec2b2e6033c63c1d87/ufl/algorithms/domain_analysis.py#L175-L206
which to me indicates that things are overcomplicated at the source.