### PR TITLE
Use `enabled_coefficients` to restrict packing of coefficients

### DIFF
--- a/cpp/demo/custom_kernel/main.cpp
+++ b/cpp/demo/custom_kernel/main.cpp
@@ -76,7 +76,7 @@ double assemble_matrix0(std::shared_ptr<fem::FunctionSpace<T>> V, auto kernel,
                         std::span<const std::int32_t> cells)
 {
   // Kernel data (ID, kernel function, cell indices to execute over)
-  std::vector kernel_data{fem::integral_data<T>(-1, kernel, cells)};
+  std::vector kernel_data{fem::integral_data<T>(-1, kernel, cells, {})};
 
   // Associate kernel with cells (as opposed to facets, etc)
   std::map integrals{std::pair{fem::IntegralType::cell, kernel_data}};
@@ -107,7 +107,7 @@ double assemble_vector0(std::shared_ptr<fem::FunctionSpace<T>> V, auto kernel,
                         std::span<const std::int32_t> cells)
 {
   auto mesh = V->mesh();
-  std::vector kernal_data{fem::integral_data<T>(-1, kernel, cells)};
+  std::vector kernal_data{fem::integral_data<T>(-1, kernel, cells, {})};
   std::map integrals{std::pair{fem::IntegralType::cell, kernal_data}};
   fem::Form<T> L({V}, integrals, {}, {}, false, {}, mesh);
   auto dofmap = V->dofmap();

--- a/cpp/demo/custom_kernel/main.cpp
+++ b/cpp/demo/custom_kernel/main.cpp
@@ -76,7 +76,8 @@ double assemble_matrix0(std::shared_ptr<fem::FunctionSpace<T>> V, auto kernel,
                         std::span<const std::int32_t> cells)
 {
   // Kernel data (ID, kernel function, cell indices to execute over)
-  std::vector kernel_data{fem::integral_data<T>(-1, kernel, cells, {})};
+  std::vector kernel_data{
+      fem::integral_data<T>(-1, kernel, cells, std::vector<std::int8_t>{})};
 
   // Associate kernel with cells (as opposed to facets, etc)
   std::map integrals{std::pair{fem::IntegralType::cell, kernel_data}};
@@ -107,7 +108,8 @@ double assemble_vector0(std::shared_ptr<fem::FunctionSpace<T>> V, auto kernel,
                         std::span<const std::int32_t> cells)
 {
   auto mesh = V->mesh();
-  std::vector kernal_data{fem::integral_data<T>(-1, kernel, cells, {})};
+  std::vector kernal_data{
+      fem::integral_data<T>(-1, kernel, cells, std::vector<std::int8_t>{})};
   std::map integrals{std::pair{fem::IntegralType::cell, kernal_data}};
   fem::Form<T> L({V}, integrals, {}, {}, false, {}, mesh);
   auto dofmap = V->dofmap();

--- a/cpp/demo/custom_kernel/main.cpp
+++ b/cpp/demo/custom_kernel/main.cpp
@@ -77,7 +77,7 @@ double assemble_matrix0(std::shared_ptr<fem::FunctionSpace<T>> V, auto kernel,
 {
   // Kernel data (ID, kernel function, cell indices to execute over)
   std::vector kernel_data{
-      fem::integral_data<T>(-1, kernel, cells, std::vector<std::int8_t>{})};
+      fem::integral_data<T>(-1, kernel, cells, std::vector<int>{})};
 
   // Associate kernel with cells (as opposed to facets, etc)
   std::map integrals{std::pair{fem::IntegralType::cell, kernel_data}};
@@ -109,7 +109,7 @@ double assemble_vector0(std::shared_ptr<fem::FunctionSpace<T>> V, auto kernel,
 {
   auto mesh = V->mesh();
   std::vector kernal_data{
-      fem::integral_data<T>(-1, kernel, cells, std::vector<std::int8_t>{})};
+      fem::integral_data<T>(-1, kernel, cells, std::vector<int>{})};
   std::map integrals{std::pair{fem::IntegralType::cell, kernal_data}};
   fem::Form<T> L({V}, integrals, {}, {}, false, {}, mesh);
   auto dofmap = V->dofmap();

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -49,8 +49,8 @@ struct integral_data
   /// @param id Domain ID.
   /// @param kernel Integration kernel.
   /// @param entities Entities to integrate over.
-  /// @param enabled_coefficients Coefficients in form that are enabled in this
-  /// integral
+  /// @param enabled_coefficients An array of booleans that signifies which
+  /// coefficients that are present in the kernel.
   template <typename K, typename V, typename Q>
     requires std::is_convertible_v<
                  std::remove_cvref_t<K>,
@@ -63,7 +63,7 @@ struct integral_data
   integral_data(int id, K&& kernel, V&& entities, Q&& enabled_coefficients)
       : id(id), kernel(std::forward<K>(kernel)),
         entities(std::forward<V>(entities)),
-        enabled_coefficients(std::move(enabled_coefficients))
+        enabled_coefficients(std::forward<Q>(enabled_coefficients))
   {
   }
 
@@ -71,8 +71,8 @@ struct integral_data
   /// @param id Domain ID
   /// @param kernel Integration kernel.
   /// @param e Entities to integrate over.
-  /// @param c Coefficients in form that are enabled in this
-  /// integral
+  /// @param c An array of booleans that signifies which coefficients that are
+  /// present in the kernel.
   template <typename K>
     requires std::is_convertible_v<
                  std::remove_cvref_t<K>,

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -71,7 +71,7 @@ struct integral_data
   /// @param id Domain ID
   /// @param kernel Integration kernel.
   /// @param e Entities to integrate over.
-  /// @param enabled_coefficients Coefficients in form that are enabled in this
+  /// @param c Coefficients in form that are enabled in this
   /// integral
   template <typename K>
     requires std::is_convertible_v<

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -295,6 +295,12 @@ public:
 
   /// @brief Indicator of which coefficient is enabled for a given integral
   /// (kernel).
+  ///
+  /// A form is split into multipe integrals (kernels) and each integral might
+  /// container only a subset of all coefficients in the form. This function
+  /// returns an indicator array for a given integral kernel that signifies
+  /// which coefficients are present.
+  ///
   /// @param[in] type Integral type.
   /// @param[in] i The index of the integral.
   std::span<const std::int8_t> enabled_coefficients(IntegralType type,

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -51,19 +51,19 @@ struct integral_data
   /// @param entities Entities to integrate over.
   /// @param enabled_coefficients An array of booleans that signifies which
   /// coefficients that are present in the kernel.
-  template <typename K, typename V, typename Q>
+  template <typename K, typename V>
     requires std::is_convertible_v<
                  std::remove_cvref_t<K>,
                  std::function<void(T*, const T*, const T*, const U*,
                                     const int*, const uint8_t*)>>
                  and std::is_convertible_v<std::remove_cvref_t<V>,
                                            std::vector<std::int32_t>>
-                 and std::is_convertible_v<std::remove_cvref_t<Q>,
-                                           std::vector<std::int8_t>>
-  integral_data(int id, K&& kernel, V&& entities, Q&& enabled_coefficients)
+  integral_data(int id, K&& kernel, V&& entities,
+                const std::vector<std::int8_t>& enabled_coefficients)
       : id(id), kernel(std::forward<K>(kernel)),
         entities(std::forward<V>(entities)),
-        enabled_coefficients(std::forward<Q>(enabled_coefficients))
+        enabled_coefficients(enabled_coefficients.begin(),
+                             enabled_coefficients.end())
   {
   }
 
@@ -303,14 +303,14 @@ public:
   ///
   /// @param[in] type Integral type.
   /// @param[in] i The index of the integral.
-  std::span<const std::int8_t> enabled_coefficients(IntegralType type,
-                                                    std::size_t i) const
+  std::vector<std::int8_t> enabled_coefficients(IntegralType type,
+                                                std::size_t i) const
   {
     assert(i < _integrals[static_cast<std::size_t>(type)].size());
     const std::vector<std::int8_t>& enabled_coeffs
         = _integrals[static_cast<std::size_t>(type)][i].enabled_coefficients;
-    return std::span<const std::int8_t>(enabled_coeffs.data(),
-                                        enabled_coeffs.size());
+    return std::vector<std::int8_t>(enabled_coeffs.begin(),
+                                    enabled_coeffs.end());
   }
   /// @brief Get the IDs for integrals (kernels) for given integral type.
   ///

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -48,10 +48,8 @@ struct integral_data
   /// @param[in] id Domain ID.
   /// @param[in] kernel Integration kernel.
   /// @param[in] entities Indices of entities to integrate over.
-  /// @param[in] enabled_coefficients Indicator array for which
-  /// coefficients are present in the kernel. If
-  /// `enabled_coefficients[i] == 1` coefficient `i` is used in
-  /// `kernel`. Otherwise coefficient `i` is not used in `kernel`.
+  /// @param[in] coeffs Indicies of the coefficients are present in the
+  /// kernel.
   template <typename K, typename V, typename W>
     requires std::is_convertible_v<
                  std::remove_cvref_t<K>,
@@ -61,10 +59,9 @@ struct integral_data
                                            std::vector<std::int32_t>>
                  and std::is_convertible_v<std::remove_cvref_t<W>,
                                            std::vector<std::int8_t>>
-  integral_data(int id, K&& kernel, V&& entities, W&& enabled_coefficients)
+  integral_data(int id, K&& kernel, V&& entities, W&& coeffs)
       : id(id), kernel(std::forward<K>(kernel)),
-        entities(std::forward<V>(entities)),
-        enabled_coefficients(std::forward<W>(enabled_coefficients))
+        entities(std::forward<V>(entities)), coeffs(std::forward<W>(coeffs))
   {
   }
 
@@ -73,10 +70,8 @@ struct integral_data
   /// @param[in] id Domain ID.
   /// @param[in] kernel Integration kernel.
   /// @param[in] entities Indices of entities to integrate over.
-  /// @param[in] enabled_coefficients Indicator array for which
-  /// coefficients are present in the kernel. If
-  /// `enabled_coefficients[i] == 1` coefficient `i` is used in
-  /// `kernel`. Otherwise coefficient `i` is not used in `kernel`.
+  /// @param[in] coeffs Indicies of the coefficients are present in the
+  /// kernel.
   ///
   /// @note This version allows `entities` to be passed as a std::span,
   /// which is then copied.
@@ -88,10 +83,10 @@ struct integral_data
                  and std::is_convertible_v<std::remove_cvref_t<W>,
                                            std::vector<std::int8_t>>
   integral_data(int id, K&& kernel, std::span<const std::int32_t> entities,
-                W&& enabled_coefficients)
+                W&& coeffs)
       : id(id), kernel(std::forward<K>(kernel)),
         entities(entities.begin(), entities.end()),
-        enabled_coefficients(std::forward<W>(enabled_coefficients))
+        coeffs(std::forward<W>(coeffs))
   {
   }
 
@@ -106,12 +101,9 @@ struct integral_data
   /// @brief The entities to integrate over.
   std::vector<std::int32_t> entities;
 
-  /// @brief Indicator of which coefficients (from the form) that is in
-  /// this integral.
-  ///
-  /// If `enabled_coefficients[i] == 1`, coefficient `i` is used form
-  /// kernel. Otherwise coefficient `i` is not used in kernel.
-  std::vector<std::int8_t> enabled_coefficients;
+  /// @brief Indices of coefficients (from the form) that are in this
+  /// integral.
+  std::vector<std::int8_t> coeffs;
 };
 
 /// @brief A representation of finite element variational forms.
@@ -307,7 +299,7 @@ public:
     return _integrals[static_cast<std::size_t>(type)].size();
   }
 
-  /// @brief Indicator of which coefficient is enabled for a given
+  /// @brief Indices of coefficients that are active for a given
   /// integral (kernel).
   ///
   /// A form is split into multiple integrals (kernels) and each
@@ -321,7 +313,7 @@ public:
                                                 std::size_t i) const
   {
     assert(i < _integrals[static_cast<std::size_t>(type)].size());
-    return _integrals[static_cast<std::size_t>(type)][i].enabled_coefficients;
+    return _integrals[static_cast<std::size_t>(type)][i].coeffs;
   }
 
   /// @brief Get the IDs for integrals (kernels) for given integral type.

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -71,6 +71,8 @@ struct integral_data
   /// @param id Domain ID
   /// @param kernel Integration kernel.
   /// @param e Entities to integrate over.
+  /// @param enabled_coefficients Coefficients in form that are enabled in this
+  /// integral
   template <typename K>
     requires std::is_convertible_v<
                  std::remove_cvref_t<K>,

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -48,8 +48,8 @@ struct integral_data
   /// @param[in] id Domain ID.
   /// @param[in] kernel Integration kernel.
   /// @param[in] entities Indices of entities to integrate over.
-  /// @param[in] coeffs Indicies of the coefficients are present in the
-  /// kernel.
+  /// @param[in] coeffs Indicies of the coefficients are present
+  /// (active) in `kernel`.
   template <typename K, typename V, typename W>
     requires std::is_convertible_v<
                  std::remove_cvref_t<K>,
@@ -58,7 +58,7 @@ struct integral_data
                  and std::is_convertible_v<std::remove_cvref_t<V>,
                                            std::vector<std::int32_t>>
                  and std::is_convertible_v<std::remove_cvref_t<W>,
-                                           std::vector<std::int8_t>>
+                                           std::vector<int>>
   integral_data(int id, K&& kernel, V&& entities, W&& coeffs)
       : id(id), kernel(std::forward<K>(kernel)),
         entities(std::forward<V>(entities)), coeffs(std::forward<W>(coeffs))
@@ -71,7 +71,6 @@ struct integral_data
   /// @param[in] kernel Integration kernel.
   /// @param[in] entities Indices of entities to integrate over.
   /// @param[in] coeffs Indicies of the coefficients are present in the
-  /// kernel.
   ///
   /// @note This version allows `entities` to be passed as a std::span,
   /// which is then copied.
@@ -81,7 +80,7 @@ struct integral_data
                  std::function<void(T*, const T*, const T*, const U*,
                                     const int*, const uint8_t*)>>
                  and std::is_convertible_v<std::remove_cvref_t<W>,
-                                           std::vector<std::int8_t>>
+                                           std::vector<int>>
   integral_data(int id, K&& kernel, std::span<const std::int32_t> entities,
                 W&& coeffs)
       : id(id), kernel(std::forward<K>(kernel)),
@@ -103,7 +102,7 @@ struct integral_data
 
   /// @brief Indices of coefficients (from the form) that are in this
   /// integral.
-  std::vector<std::int8_t> coeffs;
+  std::vector<int> coeffs;
 };
 
 /// @brief A representation of finite element variational forms.
@@ -309,8 +308,7 @@ public:
   ///
   /// @param[in] type Integral type.
   /// @param[in] i Index of the integral.
-  std::vector<std::int8_t> enabled_coeffs(IntegralType type,
-                                          std::size_t i) const
+  std::vector<int> active_coeffs(IntegralType type, std::size_t i) const
   {
     assert(i < _integrals[static_cast<std::size_t>(type)].size());
     return _integrals[static_cast<std::size_t>(type)][i].coeffs;

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -70,7 +70,8 @@ struct integral_data
   /// @param[in] id Domain ID.
   /// @param[in] kernel Integration kernel.
   /// @param[in] entities Indices of entities to integrate over.
-  /// @param[in] coeffs Indicies of the coefficients are present in the
+  /// @param[in] coeffs Indicies of the coefficients that are active in
+  /// the `kernel`.
   ///
   /// @note This version allows `entities` to be passed as a std::span,
   /// which is then copied.

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -309,8 +309,8 @@ public:
   ///
   /// @param[in] type Integral type.
   /// @param[in] i Index of the integral.
-  std::vector<std::int8_t> enabled_coefficients(IntegralType type,
-                                                std::size_t i) const
+  std::vector<std::int8_t> enabled_coeffs(IntegralType type,
+                                          std::size_t i) const
   {
     assert(i < _integrals[static_cast<std::size_t>(type)].size());
     return _integrals[static_cast<std::size_t>(type)][i].coeffs;

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -1020,14 +1020,17 @@ void pack_coefficients(const Form<T, U>& form, IntegralType integral_type,
     {
     case IntegralType::cell:
     {
-      // Get indicator for all coefficients that are active in cell integrals
+      // Get indicator for all coefficients that are active in cell
+      // integrals
       for (std::size_t i = 0; i < form.num_integrals(IntegralType::cell); ++i)
       {
-        const std::vector<std::int8_t> enabled_coefficients
+        std::vector<std::int8_t> enabled_coefficients
             = form.enabled_coefficients(IntegralType::cell, i);
         for (std::size_t j = 0; j < coefficients.size(); ++j)
+        {
           if (enabled_coefficients[j])
             active_coefficients[j] = 1;
+        }
       }
 
       // Iterate over coefficients

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -1023,7 +1023,7 @@ void pack_coefficients(const Form<T, U>& form, IntegralType integral_type,
       // Get indicator for all coefficients that are active in cell integrals
       for (std::size_t i = 0; i < form.num_integrals(IntegralType::cell); ++i)
       {
-        std::span<const std::int8_t> enabled_coefficients
+        const std::vector<std::int8_t> enabled_coefficients
             = form.enabled_coefficients(IntegralType::cell, i);
         for (std::size_t j = 0; j < coefficients.size(); ++j)
           if (enabled_coefficients[j])
@@ -1066,7 +1066,7 @@ void pack_coefficients(const Form<T, U>& form, IntegralType integral_type,
       for (std::size_t i = 0;
            i < form.num_integrals(IntegralType::exterior_facet); ++i)
       {
-        std::span<const std::int8_t> enabled_coefficients
+        const std::vector<std::int8_t> enabled_coefficients
             = form.enabled_coefficients(IntegralType::exterior_facet, i);
         for (std::size_t j = 0; j < coefficients.size(); ++j)
           if (enabled_coefficients[j])
@@ -1096,7 +1096,7 @@ void pack_coefficients(const Form<T, U>& form, IntegralType integral_type,
       for (std::size_t i = 0;
            i < form.num_integrals(IntegralType::interior_facet); ++i)
       {
-        std::span<const std::int8_t> enabled_coefficients
+        const std::vector<std::int8_t> enabled_coefficients
             = form.enabled_coefficients(IntegralType::interior_facet, i);
         for (std::size_t j = 0; j < coefficients.size(); ++j)
           if (enabled_coefficients[j])

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -420,10 +420,9 @@ Form<T, U> create_form_factory(
       assert(integral);
       const bool* _enabled_coefficients = integral->enabled_coefficients;
       // Get list of enabled coefficients
-      std::vector<std::int8_t> enabled_coefficients(ufcx_form.num_coefficients);
-      for (std::size_t i = 0; i < enabled_coefficients.size(); ++i)
-        enabled_coefficients[i] = _enabled_coefficients[i];
-
+      std::vector<std::int8_t> enabled_coefficients(
+          integral->enabled_coefficients,
+          integral->enabled_coefficients + ufcx_form.num_coefficients);
       kern_t k = nullptr;
       if constexpr (std::is_same_v<T, float>)
         k = integral->tabulate_tensor_float32;
@@ -496,10 +495,9 @@ Form<T, U> create_form_factory(
       assert(integral);
 
       const bool* _enabled_coefficients = integral->enabled_coefficients;
-      std::vector<std::int8_t> enabled_coefficients(ufcx_form.num_coefficients);
-      for (std::size_t i = 0; i < enabled_coefficients.size(); ++i)
-        enabled_coefficients[i] = _enabled_coefficients[i];
-
+      std::vector<std::int8_t> enabled_coefficients(
+          integral->enabled_coefficients,
+          integral->enabled_coefficients + ufcx_form.num_coefficients);
       kern_t k = nullptr;
       if constexpr (std::is_same_v<T, float>)
         k = integral->tabulate_tensor_float32;
@@ -578,10 +576,9 @@ Form<T, U> create_form_factory(
       assert(integral);
 
       const bool* _enabled_coefficients = integral->enabled_coefficients;
-      std::vector<std::int8_t> enabled_coefficients(ufcx_form.num_coefficients);
-      for (std::size_t i = 0; i < enabled_coefficients.size(); ++i)
-        enabled_coefficients[i] = _enabled_coefficients[i];
-
+      std::vector<std::int8_t> enabled_coefficients(
+          integral->enabled_coefficients,
+          integral->enabled_coefficients + ufcx_form.num_coefficients);
       kern_t k = nullptr;
       if constexpr (std::is_same_v<T, float>)
         k = integral->tabulate_tensor_float32;

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -419,16 +419,12 @@ Form<T, U> create_form_factory(
           = ufcx_form.form_integrals[integral_offsets[cell] + i];
       assert(integral);
 
-      // Get list of enabled coefficients
-      // std::vector<std::int8_t> enabled_coefficients(
-      //     integral->enabled_coefficients,
-      //     integral->enabled_coefficients + ufcx_form.num_coefficients);
-
-      std::vector<std::int8_t> enabled_coefficients;
+      // Build list of enabled coefficients
+      std::vector<std::int8_t> enabled_coeffs;
       for (int j = 0; j < ufcx_form.num_coefficients; ++j)
       {
-        if (integral->enabled_coefficients[j] == 1)
-          enabled_coefficients.push_back(j);
+        if (integral->enabled_coefficients[j])
+          enabled_coeffs.push_back(j);
       }
 
       kern_t k = nullptr;
@@ -468,8 +464,7 @@ Form<T, U> create_form_factory(
         assert(topology->index_map(tdim));
         default_cells.resize(topology->index_map(tdim)->size_local(), 0);
         std::iota(default_cells.begin(), default_cells.end(), 0);
-        itg.first->second.emplace_back(id, k, default_cells,
-                                       enabled_coefficients);
+        itg.first->second.emplace_back(id, k, default_cells, enabled_coeffs);
       }
       else if (sd != subdomains.end())
       {
@@ -478,8 +473,7 @@ Form<T, U> create_form_factory(
                                    [](auto& pair, auto val)
                                    { return pair.first < val; });
         if (it != sd->second.end() and it->first == id)
-          itg.first->second.emplace_back(id, k, it->second,
-                                         enabled_coefficients);
+          itg.first->second.emplace_back(id, k, it->second, enabled_coeffs);
       }
 
       if (integral->needs_facet_permutations)
@@ -501,15 +495,11 @@ Form<T, U> create_form_factory(
       ufcx_integral* integral
           = ufcx_form.form_integrals[integral_offsets[exterior_facet] + i];
       assert(integral);
-
-      // std::vector<std::int8_t> enabled_coefficients(
-      //     integral->enabled_coefficients,
-      //     integral->enabled_coefficients + ufcx_form.num_coefficients);
-      std::vector<std::int8_t> enabled_coefficients;
+      std::vector<std::int8_t> enabled_coeffs;
       for (int j = 0; j < ufcx_form.num_coefficients; ++j)
       {
-        if (integral->enabled_coefficients[j] == 1)
-          enabled_coefficients.push_back(j);
+        if (integral->enabled_coefficients[j])
+          enabled_coeffs.push_back(j);
       }
 
       kern_t k = nullptr;
@@ -556,7 +546,7 @@ Form<T, U> create_form_factory(
                                     pair.end());
         }
         itg.first->second.emplace_back(id, k, default_facets_ext,
-                                       enabled_coefficients);
+                                       enabled_coeffs);
       }
       else if (sd != subdomains.end())
       {
@@ -565,8 +555,7 @@ Form<T, U> create_form_factory(
                                    [](auto& pair, auto val)
                                    { return pair.first < val; });
         if (it != sd->second.end() and it->first == id)
-          itg.first->second.emplace_back(id, k, it->second,
-                                         enabled_coefficients);
+          itg.first->second.emplace_back(id, k, it->second, enabled_coeffs);
       }
 
       if (integral->needs_facet_permutations)
@@ -588,15 +577,11 @@ Form<T, U> create_form_factory(
       ufcx_integral* integral
           = ufcx_form.form_integrals[integral_offsets[interior_facet] + i];
       assert(integral);
-
-      // std::vector<std::int8_t> enabled_coefficients(
-      //     integral->enabled_coefficients,
-      //     integral->enabled_coefficients + ufcx_form.num_coefficients);
-      std::vector<std::int8_t> enabled_coefficients;
+      std::vector<std::int8_t> enabled_coeffs;
       for (int j = 0; j < ufcx_form.num_coefficients; ++j)
       {
-        if (integral->enabled_coefficients[j] == 1)
-          enabled_coefficients.push_back(j);
+        if (integral->enabled_coefficients[j])
+          enabled_coeffs.push_back(j);
       }
 
       kern_t k = nullptr;
@@ -646,7 +631,7 @@ Form<T, U> create_form_factory(
           }
         }
         itg.first->second.emplace_back(id, k, default_facets_int,
-                                       enabled_coefficients);
+                                       enabled_coeffs);
       }
       else if (sd != subdomains.end())
       {
@@ -654,8 +639,7 @@ Form<T, U> create_form_factory(
                                    [](auto& pair, auto val)
                                    { return pair.first < val; });
         if (it != sd->second.end() and it->first == id)
-          itg.first->second.emplace_back(id, k, it->second,
-                                         enabled_coefficients);
+          itg.first->second.emplace_back(id, k, it->second, enabled_coeffs);
       }
 
       if (integral->needs_facet_permutations)
@@ -1047,7 +1031,7 @@ void pack_coefficients(const Form<T, U>& form, IntegralType integral_type,
       // integrals
       for (std::size_t i = 0; i < form.num_integrals(IntegralType::cell); ++i)
       {
-        for (auto idx : form.enabled_coefficients(IntegralType::cell, i))
+        for (auto idx : form.enabled_coeffs(IntegralType::cell, i))
           active_coefficients[idx] = 1;
       }
 
@@ -1089,8 +1073,7 @@ void pack_coefficients(const Form<T, U>& form, IntegralType integral_type,
       for (std::size_t i = 0;
            i < form.num_integrals(IntegralType::exterior_facet); ++i)
       {
-        for (auto idx :
-             form.enabled_coefficients(IntegralType::exterior_facet, i))
+        for (auto idx : form.enabled_coeffs(IntegralType::exterior_facet, i))
           active_coefficients[idx] = 1;
       }
 
@@ -1118,8 +1101,7 @@ void pack_coefficients(const Form<T, U>& form, IntegralType integral_type,
       for (std::size_t i = 0;
            i < form.num_integrals(IntegralType::interior_facet); ++i)
       {
-        for (auto idx :
-             form.enabled_coefficients(IntegralType::interior_facet, i))
+        for (auto idx : form.enabled_coeffs(IntegralType::interior_facet, i))
           active_coefficients[idx] = 1;
       }
 

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -418,7 +418,6 @@ Form<T, U> create_form_factory(
       ufcx_integral* integral
           = ufcx_form.form_integrals[integral_offsets[cell] + i];
       assert(integral);
-      const bool* _enabled_coefficients = integral->enabled_coefficients;
       // Get list of enabled coefficients
       std::vector<std::int8_t> enabled_coefficients(
           integral->enabled_coefficients,
@@ -494,7 +493,6 @@ Form<T, U> create_form_factory(
           = ufcx_form.form_integrals[integral_offsets[exterior_facet] + i];
       assert(integral);
 
-      const bool* _enabled_coefficients = integral->enabled_coefficients;
       std::vector<std::int8_t> enabled_coefficients(
           integral->enabled_coefficients,
           integral->enabled_coefficients + ufcx_form.num_coefficients);
@@ -575,7 +573,6 @@ Form<T, U> create_form_factory(
           = ufcx_form.form_integrals[integral_offsets[interior_facet] + i];
       assert(integral);
 
-      const bool* _enabled_coefficients = integral->enabled_coefficients;
       std::vector<std::int8_t> enabled_coefficients(
           integral->enabled_coefficients,
           integral->enabled_coefficients + ufcx_form.num_coefficients);

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -419,12 +419,12 @@ Form<T, U> create_form_factory(
           = ufcx_form.form_integrals[integral_offsets[cell] + i];
       assert(integral);
 
-      // Build list of enabled coefficients
-      std::vector<std::int8_t> enabled_coeffs;
+      // Build list of active coefficients
+      std::vector<int> active_coeffs;
       for (int j = 0; j < ufcx_form.num_coefficients; ++j)
       {
         if (integral->enabled_coefficients[j])
-          enabled_coeffs.push_back(j);
+          active_coeffs.push_back(j);
       }
 
       kern_t k = nullptr;
@@ -464,7 +464,7 @@ Form<T, U> create_form_factory(
         assert(topology->index_map(tdim));
         default_cells.resize(topology->index_map(tdim)->size_local(), 0);
         std::iota(default_cells.begin(), default_cells.end(), 0);
-        itg.first->second.emplace_back(id, k, default_cells, enabled_coeffs);
+        itg.first->second.emplace_back(id, k, default_cells, active_coeffs);
       }
       else if (sd != subdomains.end())
       {
@@ -473,7 +473,7 @@ Form<T, U> create_form_factory(
                                    [](auto& pair, auto val)
                                    { return pair.first < val; });
         if (it != sd->second.end() and it->first == id)
-          itg.first->second.emplace_back(id, k, it->second, enabled_coeffs);
+          itg.first->second.emplace_back(id, k, it->second, active_coeffs);
       }
 
       if (integral->needs_facet_permutations)
@@ -495,11 +495,11 @@ Form<T, U> create_form_factory(
       ufcx_integral* integral
           = ufcx_form.form_integrals[integral_offsets[exterior_facet] + i];
       assert(integral);
-      std::vector<std::int8_t> enabled_coeffs;
+      std::vector<int> active_coeffs;
       for (int j = 0; j < ufcx_form.num_coefficients; ++j)
       {
         if (integral->enabled_coefficients[j])
-          enabled_coeffs.push_back(j);
+          active_coeffs.push_back(j);
       }
 
       kern_t k = nullptr;
@@ -546,7 +546,7 @@ Form<T, U> create_form_factory(
                                     pair.end());
         }
         itg.first->second.emplace_back(id, k, default_facets_ext,
-                                       enabled_coeffs);
+                                       active_coeffs);
       }
       else if (sd != subdomains.end())
       {
@@ -555,7 +555,7 @@ Form<T, U> create_form_factory(
                                    [](auto& pair, auto val)
                                    { return pair.first < val; });
         if (it != sd->second.end() and it->first == id)
-          itg.first->second.emplace_back(id, k, it->second, enabled_coeffs);
+          itg.first->second.emplace_back(id, k, it->second, active_coeffs);
       }
 
       if (integral->needs_facet_permutations)
@@ -577,11 +577,11 @@ Form<T, U> create_form_factory(
       ufcx_integral* integral
           = ufcx_form.form_integrals[integral_offsets[interior_facet] + i];
       assert(integral);
-      std::vector<std::int8_t> enabled_coeffs;
+      std::vector<int> active_coeffs;
       for (int j = 0; j < ufcx_form.num_coefficients; ++j)
       {
         if (integral->enabled_coefficients[j])
-          enabled_coeffs.push_back(j);
+          active_coeffs.push_back(j);
       }
 
       kern_t k = nullptr;
@@ -631,7 +631,7 @@ Form<T, U> create_form_factory(
           }
         }
         itg.first->second.emplace_back(id, k, default_facets_int,
-                                       enabled_coeffs);
+                                       active_coeffs);
       }
       else if (sd != subdomains.end())
       {
@@ -639,7 +639,7 @@ Form<T, U> create_form_factory(
                                    [](auto& pair, auto val)
                                    { return pair.first < val; });
         if (it != sd->second.end() and it->first == id)
-          itg.first->second.emplace_back(id, k, it->second, enabled_coeffs);
+          itg.first->second.emplace_back(id, k, it->second, active_coeffs);
       }
 
       if (integral->needs_facet_permutations)
@@ -1020,7 +1020,7 @@ void pack_coefficients(const Form<T, U>& form, IntegralType integral_type,
   const std::vector<int> offsets = form.coefficient_offsets();
 
   // Indicator for packing coefficients
-  std::vector<std::int8_t> active_coefficients(coefficients.size(), 0);
+  std::vector<int> active_coefficients(coefficients.size(), 0);
   if (!coefficients.empty())
   {
     switch (integral_type)
@@ -1031,7 +1031,7 @@ void pack_coefficients(const Form<T, U>& form, IntegralType integral_type,
       // integrals
       for (std::size_t i = 0; i < form.num_integrals(IntegralType::cell); ++i)
       {
-        for (auto idx : form.enabled_coeffs(IntegralType::cell, i))
+        for (auto idx : form.active_coeffs(IntegralType::cell, i))
           active_coefficients[idx] = 1;
       }
 
@@ -1073,7 +1073,7 @@ void pack_coefficients(const Form<T, U>& form, IntegralType integral_type,
       for (std::size_t i = 0;
            i < form.num_integrals(IntegralType::exterior_facet); ++i)
       {
-        for (auto idx : form.enabled_coeffs(IntegralType::exterior_facet, i))
+        for (auto idx : form.active_coeffs(IntegralType::exterior_facet, i))
           active_coefficients[idx] = 1;
       }
 
@@ -1101,7 +1101,7 @@ void pack_coefficients(const Form<T, U>& form, IntegralType integral_type,
       for (std::size_t i = 0;
            i < form.num_integrals(IntegralType::interior_facet); ++i)
       {
-        for (auto idx : form.enabled_coeffs(IntegralType::interior_facet, i))
+        for (auto idx : form.active_coeffs(IntegralType::interior_facet, i))
           active_coefficients[idx] = 1;
       }
 

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -162,7 +162,7 @@ def tabulate_A(A_, w_, c_, coords_, entity_local_index, permutation=ffi.NULL):
 # Prepare a Form with a condensed tabulation kernel
 formtype = form_cpp_class(PETSc.ScalarType)  # type: ignore
 cells = np.arange(msh.topology.index_map(msh.topology.dim).size_local)
-integrals = {IntegralType.cell: [(-1, tabulate_A.address, cells)]}
+integrals = {IntegralType.cell: [(-1, tabulate_A.address, cells, np.array([],dtype=np.int8))]}
 a_cond = Form(formtype([U._cpp_object, U._cpp_object], integrals, [], [], False, {}, None))
 
 A_cond = assemble_matrix(a_cond, bcs=[bc])

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -162,7 +162,7 @@ def tabulate_A(A_, w_, c_, coords_, entity_local_index, permutation=ffi.NULL):
 # Prepare a Form with a condensed tabulation kernel
 formtype = form_cpp_class(PETSc.ScalarType)  # type: ignore
 cells = np.arange(msh.topology.index_map(msh.topology.dim).size_local)
-integrals = {IntegralType.cell: [(-1, tabulate_A.address, cells, np.array([],dtype=np.int8))]}
+integrals = {IntegralType.cell: [(-1, tabulate_A.address, cells, np.array([], dtype=np.int8))]}
 a_cond = Form(formtype([U._cpp_object, U._cpp_object], integrals, [], [], False, {}, None))
 
 A_cond = assemble_matrix(a_cond, bcs=[bc])

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -607,11 +607,13 @@ void declare_form(nb::module_& m, std::string type)
           [](dolfinx::fem::Form<T, U>* fp,
              const std::vector<
                  std::shared_ptr<const dolfinx::fem::FunctionSpace<U>>>& spaces,
-             const std::map<dolfinx::fem::IntegralType,
-                            std::vector<std::tuple<
-                                int, std::uintptr_t,
-                                nb::ndarray<const std::int32_t, nb::ndim<1>,
-                                            nb::c_contig>>>>& integrals,
+             const std::map<
+                 dolfinx::fem::IntegralType,
+                 std::vector<std::tuple<
+                     int, std::uintptr_t,
+                     nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>,
+                     nb::ndarray<const std::int8_t, nb::ndim<1>,
+                                 nb::c_contig>>>>& integrals,
              const std::vector<std::shared_ptr<
                  const dolfinx::fem::Function<T, U>>>& coefficients,
              const std::vector<
@@ -629,7 +631,7 @@ void declare_form(nb::module_& m, std::string type)
             // Loop over kernel for each entity type
             for (auto& [type, kernels] : integrals)
             {
-              for (auto& [id, ptr, e] : kernels)
+              for (auto& [id, ptr, e, c] : kernels)
               {
                 auto kn_ptr
                     = (void (*)(T*, const T*, const T*,
@@ -637,7 +639,8 @@ void declare_form(nb::module_& m, std::string type)
                                 const int*, const std::uint8_t*))ptr;
                 _integrals[type].emplace_back(
                     id, kn_ptr,
-                    std::span<const std::int32_t>(e.data(), e.size()));
+                    std::span<const std::int32_t>(e.data(), e.size()),
+                    std::span<const std::int8_t>(c.data(), c.size()));
               }
             }
 

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -640,7 +640,7 @@ void declare_form(nb::module_& m, std::string type)
                 _integrals[type].emplace_back(
                     id, kn_ptr,
                     std::span<const std::int32_t>(e.data(), e.size()),
-                    std::vector<std::int8_t>(c.data(), c.data() + c.size()));
+                    std::vector<int>(c.data(), c.data() + c.size()));
               }
             }
 

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -640,7 +640,7 @@ void declare_form(nb::module_& m, std::string type)
                 _integrals[type].emplace_back(
                     id, kn_ptr,
                     std::span<const std::int32_t>(e.data(), e.size()),
-                    std::span<const std::int8_t>(c.data(), c.size()));
+                    std::vector<std::int8_t>(c.data(), c.data() + c.size()));
               }
             }
 

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -129,7 +129,7 @@ def test_coefficient(dtype):
 
     tdim = mesh.topology.dim
     num_cells = mesh.topology.index_map(tdim).size_local + mesh.topology.index_map(tdim).num_ghosts
-    active_coeffs = np.array([1], dtype=np.int8)
+    active_coeffs = np.array([0], dtype=np.int8)
     integrals = {
         IntegralType.cell: [(1, k1.address, np.arange(num_cells, dtype=np.int32), active_coeffs)]
     }

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -90,16 +90,17 @@ def test_numba_assembly(dtype):
     mesh = create_unit_square(MPI.COMM_WORLD, 13, 13, dtype=xdtype)
     V = functionspace(mesh, ("Lagrange", 1))
     cells = np.arange(mesh.topology.index_map(mesh.topology.dim).size_local, dtype=np.int32)
+    active_coeffs = np.array([],dtype=np.int8)
     integrals = {
         IntegralType.cell: [
-            (-1, k2.address, cells),
-            (2, k2.address, np.arange(0)),
-            (12, k2.address, np.arange(0)),
+            (-1, k2.address, cells, active_coeffs),
+            (2, k2.address, np.arange(0), active_coeffs),
+            (12, k2.address, np.arange(0), active_coeffs),
         ]
     }
     formtype = form_cpp_class(dtype)
     a = Form(formtype([V._cpp_object, V._cpp_object], integrals, [], [], False, {}, None))
-    integrals = {IntegralType.cell: [(-1, k1.address, cells)]}
+    integrals = {IntegralType.cell: [(-1, k1.address, cells, active_coeffs)]}
     L = Form(formtype([V._cpp_object], integrals, [], [], False, {}, None))
 
     A = dolfinx.fem.assemble_matrix(a)
@@ -128,7 +129,9 @@ def test_coefficient(dtype):
 
     tdim = mesh.topology.dim
     num_cells = mesh.topology.index_map(tdim).size_local + mesh.topology.index_map(tdim).num_ghosts
-    integrals = {IntegralType.cell: [(1, k1.address, np.arange(num_cells, dtype=np.int32))]}
+    active_coeffs = np.array([1], dtype=np.int8)
+    integrals = {IntegralType.cell: [(1, k1.address, np.arange(num_cells, dtype=np.int32),
+                                      active_coeffs)]}
     formtype = form_cpp_class(dtype)
     L = Form(formtype([V._cpp_object], integrals, [vals._cpp_object], [], False, {}, None))
 
@@ -258,13 +261,14 @@ def test_cffi_assembly():
     cells = np.arange(mesh.topology.index_map(mesh.topology.dim).size_local, dtype=np.int32)
 
     ptrA = ffi.cast("intptr_t", ffi.addressof(lib, "tabulate_tensor_poissonA"))
-    integrals = {IntegralType.cell: [(-1, ptrA, cells)]}
+    active_coeffs = np.array([],dtype=np.int8)
+    integrals = {IntegralType.cell: [(-1, ptrA, cells, active_coeffs)]}
     a = Form(
         _cpp.fem.Form_float64([V._cpp_object, V._cpp_object], integrals, [], [], False, {}, None)
     )
 
     ptrL = ffi.cast("intptr_t", ffi.addressof(lib, "tabulate_tensor_poissonL"))
-    integrals = {IntegralType.cell: [(-1, ptrL, cells)]}
+    integrals = {IntegralType.cell: [(-1, ptrL, cells, active_coeffs)]}
     L = Form(_cpp.fem.Form_float64([V._cpp_object], integrals, [], [], False, {}, None))
 
     A = fem.assemble_matrix(a)

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -90,7 +90,7 @@ def test_numba_assembly(dtype):
     mesh = create_unit_square(MPI.COMM_WORLD, 13, 13, dtype=xdtype)
     V = functionspace(mesh, ("Lagrange", 1))
     cells = np.arange(mesh.topology.index_map(mesh.topology.dim).size_local, dtype=np.int32)
-    active_coeffs = np.array([],dtype=np.int8)
+    active_coeffs = np.array([], dtype=np.int8)
     integrals = {
         IntegralType.cell: [
             (-1, k2.address, cells, active_coeffs),
@@ -130,8 +130,9 @@ def test_coefficient(dtype):
     tdim = mesh.topology.dim
     num_cells = mesh.topology.index_map(tdim).size_local + mesh.topology.index_map(tdim).num_ghosts
     active_coeffs = np.array([1], dtype=np.int8)
-    integrals = {IntegralType.cell: [(1, k1.address, np.arange(num_cells, dtype=np.int32),
-                                      active_coeffs)]}
+    integrals = {
+        IntegralType.cell: [(1, k1.address, np.arange(num_cells, dtype=np.int32), active_coeffs)]
+    }
     formtype = form_cpp_class(dtype)
     L = Form(formtype([V._cpp_object], integrals, [vals._cpp_object], [], False, {}, None))
 
@@ -261,7 +262,7 @@ def test_cffi_assembly():
     cells = np.arange(mesh.topology.index_map(mesh.topology.dim).size_local, dtype=np.int32)
 
     ptrA = ffi.cast("intptr_t", ffi.addressof(lib, "tabulate_tensor_poissonA"))
-    active_coeffs = np.array([],dtype=np.int8)
+    active_coeffs = np.array([], dtype=np.int8)
     integrals = {IntegralType.cell: [(-1, ptrA, cells, active_coeffs)]}
     a = Form(
         _cpp.fem.Form_float64([V._cpp_object, V._cpp_object], integrals, [], [], False, {}, None)


### PR DESCRIPTION
Pack only entities used in integral type:
MWE:
```python
from mpi4py import MPI
import dolfinx
import ufl

mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, 50, 50, 50)
V = dolfinx.fem.functionspace(mesh, ("Lagrange", 3))
N = 50
us = [dolfinx.fem.Function(V) for _ in range(N)]
for i,u in enumerate(us):
    u.x.array[:] = i + 1
    u.name=f"u_{i}"

volume_form = us[0] * ufl.dx
surface_form = sum(us[i] * ufl.ds for i in range(N))

combined_form = volume_form + surface_form
compiled_form = dolfinx.fem.form(combined_form)

import time
start = time.perf_counter()
coeffs = dolfinx.fem.assemble.pack_coefficients(compiled_form._cpp_object)
end =time.perf_counter()
print(f"{dolfinx.common.git_commit_hash=} {end-start=:.5e}")
print(coeffs[(dolfinx.fem.IntegralType.cell, -1)])
```
On the main branch, all coefficients are packed for the cell integral, even if only the first coefficient is used in that integral.
Runtime on this branch:
```bash
dolfinx.common.git_commit_hash='002e1fa9360995f9c71414a683e7ce618d6101e9' end-start=1.70250e+00
```
on main
```bash
dolfinx.common.git_commit_hash='64e35310085683f4f61804e70b8b58b9bb8653ae' end-start=2.89335e+00
```
It would also resolve #3256 and simplify some logic in: #3224