### PR TITLE
Prepare for release of numpy 2.0 by using ruff ruleset

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -8,7 +8,7 @@
 requires = [
       "scikit-build-core[pyproject]>=0.5",
       "nanobind>=2.0.0",
-      "mpi4py"
+      "mpi4py",
 ]
 build-backend = "scikit_build_core.build"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -8,7 +8,7 @@
 requires = [
       "scikit-build-core[pyproject]>=0.5",
       "nanobind>=2.0.0",
-      "mpi4py",
+      "mpi4py"
 ]
 build-backend = "scikit_build_core.build"
 
@@ -34,7 +34,7 @@ dependencies = [
 
 [project.optional-dependencies]
 docs = ["markdown", "pyyaml", "sphinx", "sphinx_rtd_theme"]
-lint = ["ruff"]
+lint = ["ruff>=0.2.0"]
 optional = ["numba"]
 petsc4py = ["petsc4py"]
 test = ["pytest", "scipy", "matplotlib", "fenics-dolfinx[optional]"]
@@ -87,15 +87,16 @@ indent-width = 4
 
 [tool.ruff.lint]
 select = [
-      "E", # pycodestyle
-      "W", # pycodestyle
-      "F", # pyflakes
-      "I",   # isort - use standalone isort
-      "RUF", # Ruff-specific rules
-      "UP",  # pyupgrade
-      "ICN", # flake8-import-conventions
-      "NPY", # numpy-specific rules
-      "FLY", # use f-string not static joins
+      "E",      # pycodestyle
+      "W",      # pycodestyle
+      "F",      # pyflakes
+      "I",      # isort - use standalone isort
+      "RUF",    # Ruff-specific rules
+      "UP",     # pyupgrade
+      "ICN",    # flake8-import-conventions
+      "NPY",    # numpy-specific rules
+      "FLY",    # use f-string not static joins
+      "NPY201", # numpy 2.x ruleset
 ]
 ignore = ["UP007", "RUF012"]
 allowed-confusables = ["σ"]


### PR DESCRIPTION
Ref:  https://numpy.org/devdocs/numpy_2_0_migration_guide.html#ruff-plugin