### PR TITLE
Some updates for mesh generation

### DIFF
--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -6,16 +6,23 @@
 
 #pragma once
 
+#include <algorithm>
+#include <array>
+#include <cfloat>
+#include <cmath>
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include <mpi.h>
+
 #include "Mesh.h"
 #include "cell_types.h"
 #include "utils.h"
-#include <array>
-#include <cfloat>
-#include <concepts>
-#include <cstddef>
-#include <limits>
-#include <mpi.h>
-#include <vector>
 
 namespace dolfinx::mesh
 {
@@ -93,6 +100,15 @@ Mesh<T> create_box(MPI_Comm comm, MPI_Comm subcomm,
                    std::array<std::int64_t, 3> n, CellType celltype,
                    CellPartitionFunction partitioner = nullptr)
 {
+  if (std::ranges::any_of(n, [](auto e) { return e < 1; }))
+    throw std::runtime_error("At least one element per dimension is required");
+
+  for (int32_t i = 0; i < 3; i++)
+  {
+    if (p[0][i] >= p[1][i])
+      throw std::runtime_error("It must hold p[0] < p[1]");
+  }
+
   if (!partitioner and dolfinx::MPI::size(comm) > 1)
     partitioner = create_cell_partitioner();
 
@@ -155,6 +171,15 @@ Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<double, 2>, 2> p,
                          CellPartitionFunction partitioner,
                          DiagonalType diagonal = DiagonalType::right)
 {
+  if (std::ranges::any_of(n, [](auto e) { return e < 1; }))
+    throw std::runtime_error("At least one element per dimension is required");
+
+  for (int32_t i = 0; i < 2; i++)
+  {
+    if (p[0][i] >= p[1][i])
+      throw std::runtime_error("It must hold p[0] < p[1]");
+  }
+
   if (!partitioner and dolfinx::MPI::size(comm) > 1)
     partitioner = create_cell_partitioner();
 
@@ -207,53 +232,46 @@ template <std::floating_point T = double>
 Mesh<T> create_interval(MPI_Comm comm, std::int64_t n, std::array<double, 2> p,
                         CellPartitionFunction partitioner = nullptr)
 {
+  if (n < 1)
+    throw std::runtime_error("At least one element is required");
+
+  const auto [a, b] = p;
+  if (a >= b)
+    throw std::runtime_error("It must hold p[0] < p[1]");
+
   if (!partitioner and dolfinx::MPI::size(comm) > 1)
     partitioner = create_cell_partitioner();
 
   fem::CoordinateElement<T> element(CellType::interval, 1);
   std::vector<T> x;
   std::vector<std::int64_t> cells;
-  if (dolfinx::MPI::rank(comm) == 0)
-  {
-    const T a = p[0];
-    const T b = p[1];
-    const T ab = (b - a) / static_cast<T>(n);
 
-    if (std::abs(a - b) < std::numeric_limits<double>::epsilon())
-    {
-      throw std::runtime_error(
-          "Length of interval is zero. Check your dimensions.");
-    }
-
-    if (b < a)
-    {
-      throw std::runtime_error(
-          "Interval length is negative. Check order of arguments.");
-    }
-
-    if (n < 1)
-      throw std::runtime_error(
-          "Number of points on interval must be at least 1");
-
-    // Create vertices
-    x.resize(n + 1);
-    for (std::int64_t ix = 0; ix <= n; ix++)
-      x[ix] = a + ab * static_cast<T>(ix);
-
-    // Create intervals
-    cells.resize(n * 2);
-    for (std::int64_t ix = 0; ix < n; ++ix)
-      for (std::int64_t j = 0; j < 2; ++j)
-        cells[2 * ix + j] = ix + j;
-
-    return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
-                       {x.size(), 1}, partitioner);
-  }
-  else
+  if (dolfinx::MPI::rank(comm) != 0)
   {
     return create_mesh(comm, MPI_COMM_NULL, {}, element, MPI_COMM_NULL, x,
                        {x.size(), 1}, partitioner);
   }
+
+  const T h = (b - a) / static_cast<T>(n);
+
+  if (std::abs(a - b) < std::numeric_limits<double>::epsilon())
+  {
+    throw std::runtime_error(
+        "Length of interval is zero. Check your dimensions.");
+  }
+
+  // Create vertices
+  x.reserve(n + 1);
+  for (std::int64_t idx = 0; idx < n + 1; idx++)
+    x.emplace_back(a + h * static_cast<T>(idx));
+
+  // Create intervals -> cells=[0,1,1,...,n-1,n-1,n]
+  cells.reserve(n * 2);
+  for (std::int64_t idx = 0; idx < n * 2; idx++)
+    cells.emplace_back(std::floor(idx / 2) + idx % 2);
+
+  return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
+                     {x.size(), 1}, partitioner);
 }
 
 namespace impl
@@ -264,61 +282,48 @@ std::vector<T> create_geom(MPI_Comm comm,
                            std::array<std::int64_t, 3> n)
 {
   // Extract data
-  const std::array<double, 3> p0 = p[0];
-  const std::array<double, 3> p1 = p[1];
-  std::int64_t nx = n[0];
-  std::int64_t ny = n[1];
-  std::int64_t nz = n[2];
+  auto& [p0, p1] = p;
+  const auto [nx, ny, nz] = n;
 
-  const std::int64_t n_points = (nx + 1) * (ny + 1) * (nz + 1);
-  std::array range_p = dolfinx::MPI::local_range(
-      dolfinx::MPI::rank(comm), n_points, dolfinx::MPI::size(comm));
+  assert(std::ranges::all_of(n, [](auto e) { return e >= 1; }));
+  for (std::int64_t i = 0; i < 3; i++)
+    assert(p0[i] < p1[i]);
 
-  // Extract minimum and maximum coordinates
-  const double x0 = std::min(p0[0], p1[0]);
-  const double x1 = std::max(p0[0], p1[0]);
-  const double y0 = std::min(p0[1], p1[1]);
-  const double y1 = std::max(p0[1], p1[1]);
-  const double z0 = std::min(p0[2], p1[2]);
-  const double z1 = std::max(p0[2], p1[2]);
+  // structured grid cuboid extents
+  const std::array<T, 3> extents = {
+      (p1[0] - p0[0]) / static_cast<T>(nx),
+      (p1[1] - p0[1]) / static_cast<T>(ny),
+      (p1[2] - p0[2]) / static_cast<T>(nz),
+  };
 
-  const T a = x0;
-  const T b = x1;
-  const T ab = (b - a) / static_cast<T>(nx);
-  const T c = y0;
-  const T d = y1;
-  const T cd = (d - c) / static_cast<T>(ny);
-  const T e = z0;
-  const T f = z1;
-  const T ef = (f - e) / static_cast<T>(nz);
-
-  if (std::abs(x0 - x1) < 2.0 * std::numeric_limits<double>::epsilon()
-      or std::abs(y0 - y1) < 2.0 * std::numeric_limits<double>::epsilon()
-      or std::abs(z0 - z1) < 2.0 * std::numeric_limits<double>::epsilon())
+  if (std::ranges::any_of(
+          extents,
+          [](auto e) {
+            return std::abs(e) < 2.0 * std::numeric_limits<double>::epsilon();
+          }))
   {
     throw std::runtime_error(
         "Box seems to have zero width, height or depth. Check dimensions");
   }
 
-  if (nx < 1 or ny < 1 or nz < 1)
-  {
-    throw std::runtime_error(
-        "BoxMesh has non-positive number of vertices in some dimension");
-  }
+  const std::int64_t n_points = (nx + 1) * (ny + 1) * (nz + 1);
+  const auto [range_begin, range_end] = dolfinx::MPI::local_range(
+      dolfinx::MPI::rank(comm), n_points, dolfinx::MPI::size(comm));
 
   std::vector<T> geom;
-  geom.reserve((range_p[1] - range_p[0]) * 3);
+  geom.reserve((range_end - range_begin) * 3);
   const std::int64_t sqxy = (nx + 1) * (ny + 1);
-  for (std::int64_t v = range_p[0]; v < range_p[1]; ++v)
+  for (std::int64_t v = range_begin; v < range_end; ++v)
   {
-    const std::int64_t iz = v / sqxy;
+    // lexiographic index to spacial index
     const std::int64_t p = v % sqxy;
-    const std::int64_t iy = p / (nx + 1);
-    const std::int64_t ix = p % (nx + 1);
-    const T z = e + ef * static_cast<T>(iz);
-    const T y = c + cd * static_cast<T>(iy);
-    const T x = a + ab * static_cast<T>(ix);
-    geom.insert(geom.end(), {x, y, z});
+    std::array<std::int64_t, 3> idx{v / sqxy, p / (nx + 1), p % (nx + 1)};
+
+    // vertex = p0 + idx * extents (elementwise)
+    for (std::size_t i = 0; i < idx.size(); i++)
+    {
+      geom.emplace_back(p0[i] + static_cast<T>(idx[i]) * extents[i]);
+    }
   }
 
   return geom;
@@ -333,43 +338,42 @@ Mesh<T> build_tet(MPI_Comm comm, MPI_Comm subcomm,
   common::Timer timer("Build BoxMesh (tetrahedra)");
   std::vector<T> x;
   std::vector<std::int64_t> cells;
-  if (subcomm != MPI_COMM_NULL)
+  fem::CoordinateElement<T> element(CellType::tetrahedron, 1);
+
+  if (subcomm == MPI_COMM_NULL)
+    return create_mesh(comm, subcomm, cells, element, subcomm, x,
+                       {x.size() / 3, 3}, partitioner);
+
+  x = create_geom<T>(subcomm, p, n);
+
+  const auto [nx, ny, nz] = n;
+  const std::int64_t n_cells = nx * ny * nz;
+
+  std::array range_c = dolfinx::MPI::local_range(
+      dolfinx::MPI::rank(subcomm), n_cells, dolfinx::MPI::size(subcomm));
+  cells.reserve(6 * (range_c[1] - range_c[0]) * 4);
+
+  // Create tetrahedra
+  for (std::int64_t i = range_c[0]; i < range_c[1]; ++i)
   {
-    x = create_geom<T>(subcomm, p, n);
+    const std::int64_t iz = i / (nx * ny);
+    const std::int64_t j = i % (nx * ny);
+    const std::int64_t iy = j / nx;
+    const std::int64_t ix = j % nx;
+    const std::int64_t v0 = iz * (nx + 1) * (ny + 1) + iy * (nx + 1) + ix;
+    const std::int64_t v1 = v0 + 1;
+    const std::int64_t v2 = v0 + (nx + 1);
+    const std::int64_t v3 = v1 + (nx + 1);
+    const std::int64_t v4 = v0 + (nx + 1) * (ny + 1);
+    const std::int64_t v5 = v1 + (nx + 1) * (ny + 1);
+    const std::int64_t v6 = v2 + (nx + 1) * (ny + 1);
+    const std::int64_t v7 = v3 + (nx + 1) * (ny + 1);
 
-    const std::int64_t nx = n[0];
-    const std::int64_t ny = n[1];
-    const std::int64_t nz = n[2];
-    const std::int64_t n_cells = nx * ny * nz;
-
-    std::array range_c = dolfinx::MPI::local_range(
-        dolfinx::MPI::rank(subcomm), n_cells, dolfinx::MPI::size(subcomm));
-    cells.reserve(6 * (range_c[1] - range_c[0]) * 4);
-
-    // Create tetrahedra
-    for (std::int64_t i = range_c[0]; i < range_c[1]; ++i)
-    {
-      const std::int64_t iz = i / (nx * ny);
-      const std::int64_t j = i % (nx * ny);
-      const std::int64_t iy = j / nx;
-      const std::int64_t ix = j % nx;
-      const std::int64_t v0 = iz * (nx + 1) * (ny + 1) + iy * (nx + 1) + ix;
-      const std::int64_t v1 = v0 + 1;
-      const std::int64_t v2 = v0 + (nx + 1);
-      const std::int64_t v3 = v1 + (nx + 1);
-      const std::int64_t v4 = v0 + (nx + 1) * (ny + 1);
-      const std::int64_t v5 = v1 + (nx + 1) * (ny + 1);
-      const std::int64_t v6 = v2 + (nx + 1) * (ny + 1);
-      const std::int64_t v7 = v3 + (nx + 1) * (ny + 1);
-
-      // Note that v0 < v1 < v2 < v3 < vmid
-      cells.insert(cells.end(),
-                   {v0, v1, v3, v7, v0, v1, v7, v5, v0, v5, v7, v4,
-                    v0, v3, v2, v7, v0, v6, v4, v7, v0, v2, v6, v7});
-    }
+    // Note that v0 < v1 < v2 < v3 < vmid
+    cells.insert(cells.end(), {v0, v1, v3, v7, v0, v1, v7, v5, v0, v5, v7, v4,
+                               v0, v3, v2, v7, v0, v6, v4, v7, v0, v2, v6, v7});
   }
 
-  fem::CoordinateElement<T> element(CellType::tetrahedron, 1);
   return create_mesh(comm, subcomm, cells, element, subcomm, x,
                      {x.size() / 3, 3}, partitioner);
 }
@@ -383,38 +387,38 @@ mesh::Mesh<T> build_hex(MPI_Comm comm, MPI_Comm subcomm,
   common::Timer timer("Build BoxMesh (hexahedra)");
   std::vector<T> x;
   std::vector<std::int64_t> cells;
-  if (subcomm != MPI_COMM_NULL)
+  fem::CoordinateElement<T> element(CellType::hexahedron, 1);
+
+  if (subcomm == MPI_COMM_NULL)
+    return create_mesh(comm, subcomm, cells, element, subcomm, x,
+                       {x.size() / 3, 3}, partitioner);
+
+  x = create_geom<T>(subcomm, p, n);
+
+  // Create cuboids
+  const auto [nx, ny, nz] = n;
+  const std::int64_t n_cells = nx * ny * nz;
+  std::array range_c = dolfinx::MPI::local_range(
+      dolfinx::MPI::rank(subcomm), n_cells, dolfinx::MPI::size(subcomm));
+  cells.reserve((range_c[1] - range_c[0]) * 8);
+  for (std::int64_t i = range_c[0]; i < range_c[1]; ++i)
   {
-    x = create_geom<T>(subcomm, p, n);
+    const std::int64_t iz = i / (nx * ny);
+    const std::int64_t j = i % (nx * ny);
+    const std::int64_t iy = j / nx;
+    const std::int64_t ix = j % nx;
 
-    // Create cuboids
-    const std::int64_t nx = n[0];
-    const std::int64_t ny = n[1];
-    const std::int64_t nz = n[2];
-    const std::int64_t n_cells = nx * ny * nz;
-    std::array range_c = dolfinx::MPI::local_range(
-        dolfinx::MPI::rank(subcomm), n_cells, dolfinx::MPI::size(subcomm));
-    cells.reserve((range_c[1] - range_c[0]) * 8);
-    for (std::int64_t i = range_c[0]; i < range_c[1]; ++i)
-    {
-      const std::int64_t iz = i / (nx * ny);
-      const std::int64_t j = i % (nx * ny);
-      const std::int64_t iy = j / nx;
-      const std::int64_t ix = j % nx;
-
-      const std::int64_t v0 = (iz * (ny + 1) + iy) * (nx + 1) + ix;
-      const std::int64_t v1 = v0 + 1;
-      const std::int64_t v2 = v0 + (nx + 1);
-      const std::int64_t v3 = v1 + (nx + 1);
-      const std::int64_t v4 = v0 + (nx + 1) * (ny + 1);
-      const std::int64_t v5 = v1 + (nx + 1) * (ny + 1);
-      const std::int64_t v6 = v2 + (nx + 1) * (ny + 1);
-      const std::int64_t v7 = v3 + (nx + 1) * (ny + 1);
-      cells.insert(cells.end(), {v0, v1, v2, v3, v4, v5, v6, v7});
-    }
+    const std::int64_t v0 = (iz * (ny + 1) + iy) * (nx + 1) + ix;
+    const std::int64_t v1 = v0 + 1;
+    const std::int64_t v2 = v0 + (nx + 1);
+    const std::int64_t v3 = v1 + (nx + 1);
+    const std::int64_t v4 = v0 + (nx + 1) * (ny + 1);
+    const std::int64_t v5 = v1 + (nx + 1) * (ny + 1);
+    const std::int64_t v6 = v2 + (nx + 1) * (ny + 1);
+    const std::int64_t v7 = v3 + (nx + 1) * (ny + 1);
+    cells.insert(cells.end(), {v0, v1, v2, v3, v4, v5, v6, v7});
   }
 
-  fem::CoordinateElement<T> element(CellType::hexahedron, 1);
   return create_mesh(comm, subcomm, cells, element, subcomm, x,
                      {x.size() / 3, 3}, partitioner);
 }
@@ -427,42 +431,44 @@ Mesh<T> build_prism(MPI_Comm comm, MPI_Comm subcomm,
 {
   std::vector<T> x;
   std::vector<std::int64_t> cells;
-  if (subcomm != MPI_COMM_NULL)
+  fem::CoordinateElement<T> element(CellType::prism, 1);
+
+  if (subcomm == MPI_COMM_NULL)
+    return create_mesh(comm, subcomm, cells, element, subcomm, x,
+                       {x.size() / 3, 3}, partitioner);
+
+  x = create_geom<T>(subcomm, p, n);
+
+  const std::int64_t nx = n[0];
+  const std::int64_t ny = n[1];
+  const std::int64_t nz = n[2];
+  const std::int64_t n_cells = nx * ny * nz;
+  std::array range_c = dolfinx::MPI::local_range(
+      dolfinx::MPI::rank(comm), n_cells, dolfinx::MPI::size(comm));
+  const std::int64_t cell_range = range_c[1] - range_c[0];
+
+  // Create cuboids
+
+  cells.reserve(2 * cell_range * 6);
+  for (std::int64_t i = range_c[0]; i < range_c[1]; ++i)
   {
-    x = create_geom<T>(subcomm, p, n);
+    const std::int64_t iz = i / (nx * ny);
+    const std::int64_t j = i % (nx * ny);
+    const std::int64_t iy = j / nx;
+    const std::int64_t ix = j % nx;
 
-    const std::int64_t nx = n[0];
-    const std::int64_t ny = n[1];
-    const std::int64_t nz = n[2];
-    const std::int64_t n_cells = nx * ny * nz;
-    std::array range_c = dolfinx::MPI::local_range(
-        dolfinx::MPI::rank(comm), n_cells, dolfinx::MPI::size(comm));
-    const std::int64_t cell_range = range_c[1] - range_c[0];
-
-    // Create cuboids
-
-    cells.reserve(2 * cell_range * 6);
-    for (std::int64_t i = range_c[0]; i < range_c[1]; ++i)
-    {
-      const std::int64_t iz = i / (nx * ny);
-      const std::int64_t j = i % (nx * ny);
-      const std::int64_t iy = j / nx;
-      const std::int64_t ix = j % nx;
-
-      const std::int64_t v0 = (iz * (ny + 1) + iy) * (nx + 1) + ix;
-      const std::int64_t v1 = v0 + 1;
-      const std::int64_t v2 = v0 + (nx + 1);
-      const std::int64_t v3 = v1 + (nx + 1);
-      const std::int64_t v4 = v0 + (nx + 1) * (ny + 1);
-      const std::int64_t v5 = v1 + (nx + 1) * (ny + 1);
-      const std::int64_t v6 = v2 + (nx + 1) * (ny + 1);
-      const std::int64_t v7 = v3 + (nx + 1) * (ny + 1);
-      cells.insert(cells.end(), {v0, v1, v2, v4, v5, v6});
-      cells.insert(cells.end(), {v1, v2, v3, v5, v6, v7});
-    }
+    const std::int64_t v0 = (iz * (ny + 1) + iy) * (nx + 1) + ix;
+    const std::int64_t v1 = v0 + 1;
+    const std::int64_t v2 = v0 + (nx + 1);
+    const std::int64_t v3 = v1 + (nx + 1);
+    const std::int64_t v4 = v0 + (nx + 1) * (ny + 1);
+    const std::int64_t v5 = v1 + (nx + 1) * (ny + 1);
+    const std::int64_t v6 = v2 + (nx + 1) * (ny + 1);
+    const std::int64_t v7 = v3 + (nx + 1) * (ny + 1);
+    cells.insert(cells.end(), {v0, v1, v2, v4, v5, v6});
+    cells.insert(cells.end(), {v1, v2, v3, v5, v6, v7});
   }
 
-  fem::CoordinateElement<T> element(CellType::prism, 1);
   return create_mesh(comm, subcomm, cells, element, subcomm, x,
                      {x.size() / 3, 3}, partitioner);
 }
@@ -476,171 +482,151 @@ Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<double, 2>, 2> p,
   fem::CoordinateElement<T> element(CellType::triangle, 1);
   std::vector<T> x;
   std::vector<std::int64_t> cells;
-  if (dolfinx::MPI::rank(comm) == 0)
-  {
-    const std::array<double, 2> p0 = p[0];
-    const std::array<double, 2> p1 = p[1];
 
-    const std::int64_t nx = n[0];
-    const std::int64_t ny = n[1];
-
-    // Extract minimum and maximum coordinates
-    const T x0 = std::min(p0[0], p1[0]);
-    const T x1 = std::max(p0[0], p1[0]);
-    const T y0 = std::min(p0[1], p1[1]);
-    const T y1 = std::max(p0[1], p1[1]);
-
-    const T a = x0;
-    const T b = x1;
-    const T ab = (b - a) / static_cast<T>(nx);
-    const T c = y0;
-    const T d = y1;
-    const T cd = (d - c) / static_cast<T>(ny);
-
-    if (std::abs(x0 - x1) < std::numeric_limits<double>::epsilon()
-        or std::abs(y0 - y1) < std::numeric_limits<double>::epsilon())
-    {
-      throw std::runtime_error("Rectangle seems to have zero width, height or "
-                               "depth. Check dimensions");
-    }
-
-    if (nx < 1 or ny < 1)
-    {
-      throw std::runtime_error(
-          "Rectangle has non-positive number of vertices in some dimension: "
-          "number of vertices must be at least 1 in each dimension");
-    }
-
-    // Create vertices and cells
-    std::int64_t nv, nc;
-    switch (diagonal)
-    {
-    case DiagonalType::crossed:
-      nv = (nx + 1) * (ny + 1) + nx * ny;
-      nc = 4 * nx * ny;
-      break;
-    default:
-      nv = (nx + 1) * (ny + 1);
-      nc = 2 * nx * ny;
-    }
-
-    x.reserve(nv * 2);
-    cells.reserve(nc * 3);
-
-    // Create main vertices
-    std::int64_t vertex = 0;
-    for (std::int64_t iy = 0; iy <= ny; iy++)
-    {
-      const T x1 = c + cd * static_cast<T>(iy);
-      for (std::int64_t ix = 0; ix <= nx; ix++)
-        x.insert(x.end(), {a + ab * static_cast<T>(ix), x1});
-    }
-
-    // Create midpoint vertices if the mesh type is crossed
-    switch (diagonal)
-    {
-    case DiagonalType::crossed:
-      for (std::int64_t iy = 0; iy < ny; iy++)
-      {
-        const T x1 = c + cd * (static_cast<T>(iy) + 0.5);
-        for (std::int64_t ix = 0; ix < nx; ix++)
-        {
-          const T x0 = a + ab * (static_cast<T>(ix) + 0.5);
-          x.insert(x.end(), {x0, x1});
-        }
-      }
-      break;
-    default:
-      break;
-    }
-
-    // Create triangles
-    switch (diagonal)
-    {
-    case DiagonalType::crossed:
-    {
-      for (std::int64_t iy = 0; iy < ny; iy++)
-      {
-        for (std::int64_t ix = 0; ix < nx; ix++)
-        {
-          const std::int64_t v0 = iy * (nx + 1) + ix;
-          const std::int64_t v1 = v0 + 1;
-          const std::int64_t v2 = v0 + (nx + 1);
-          const std::int64_t v3 = v1 + (nx + 1);
-          const std::int64_t vmid = (nx + 1) * (ny + 1) + iy * nx + ix;
-
-          // Note that v0 < v1 < v2 < v3 < vmid
-          cells.insert(cells.end(), {v0, v1, vmid, v0, v2, vmid, v1, v3, vmid,
-                                     v2, v3, vmid});
-        }
-      }
-      break;
-    }
-    default:
-    {
-      DiagonalType local_diagonal = diagonal;
-      for (std::int64_t iy = 0; iy < ny; iy++)
-      {
-        // Set up alternating diagonal
-        switch (diagonal)
-        {
-        case DiagonalType::right_left:
-          if (iy % 2)
-            local_diagonal = DiagonalType::right;
-          else
-            local_diagonal = DiagonalType::left;
-          break;
-        case DiagonalType::left_right:
-          if (iy % 2)
-            local_diagonal = DiagonalType::left;
-          else
-            local_diagonal = DiagonalType::right;
-          break;
-        default:
-          break;
-        }
-        for (std::int64_t ix = 0; ix < nx; ix++)
-        {
-          const std::int64_t v0 = iy * (nx + 1) + ix;
-          const std::int64_t v1 = v0 + 1;
-          const std::int64_t v2 = v0 + (nx + 1);
-          const std::int64_t v3 = v1 + (nx + 1);
-
-          switch (local_diagonal)
-          {
-          case DiagonalType::left:
-          {
-            cells.insert(cells.end(), {v0, v1, v2, v1, v2, v3});
-            if (diagonal == DiagonalType::right_left
-                or diagonal == DiagonalType::left_right)
-            {
-              local_diagonal = DiagonalType::right;
-            }
-            break;
-          }
-          default:
-          {
-            cells.insert(cells.end(), {v0, v1, v3, v0, v2, v3});
-            if (diagonal == DiagonalType::right_left
-                or diagonal == DiagonalType::left_right)
-            {
-              local_diagonal = DiagonalType::left;
-            }
-          }
-          }
-        }
-      }
-    }
-    }
-
-    return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
-                       {x.size() / 2, 2}, partitioner);
-  }
-  else
-  {
+  if (dolfinx::MPI::rank(comm) != 0)
     return create_mesh(comm, MPI_COMM_NULL, cells, element, MPI_COMM_NULL, x,
                        {x.size() / 2, 2}, partitioner);
+
+  const auto [p0, p1] = p;
+  const auto [nx, ny] = n;
+  
+  const auto [a, c] = p0;
+  const auto [b, d] = p1;
+
+  const T ab = (b - a) / static_cast<T>(nx);
+  const T cd = (d - c) / static_cast<T>(ny);
+
+  if (std::abs(b - a) < std::numeric_limits<double>::epsilon()
+      or std::abs(d - c) < std::numeric_limits<double>::epsilon())
+  {
+    throw std::runtime_error("Rectangle seems to have zero width, height or "
+                             "depth. Check dimensions");
   }
+
+  // Create vertices and cells
+  std::int64_t nv, nc;
+  switch (diagonal)
+  {
+  case DiagonalType::crossed:
+    nv = (nx + 1) * (ny + 1) + nx * ny;
+    nc = 4 * nx * ny;
+    break;
+  default:
+    nv = (nx + 1) * (ny + 1);
+    nc = 2 * nx * ny;
+  }
+
+  x.reserve(nv * 2);
+  cells.reserve(nc * 3);
+
+  // Create main vertices
+  std::int64_t vertex = 0;
+  for (std::int64_t iy = 0; iy <= ny; iy++)
+  {
+    const T x1 = c + cd * static_cast<T>(iy);
+    for (std::int64_t ix = 0; ix <= nx; ix++)
+      x.insert(x.end(), {a + ab * static_cast<T>(ix), x1});
+  }
+
+  // Create midpoint vertices if the mesh type is crossed
+  switch (diagonal)
+  {
+  case DiagonalType::crossed:
+    for (std::int64_t iy = 0; iy < ny; iy++)
+    {
+      const T x1 = c + cd * (static_cast<T>(iy) + 0.5);
+      for (std::int64_t ix = 0; ix < nx; ix++)
+      {
+        const T x0 = a + ab * (static_cast<T>(ix) + 0.5);
+        x.insert(x.end(), {x0, x1});
+      }
+    }
+    break;
+  default:
+    break;
+  }
+
+  // Create triangles
+  switch (diagonal)
+  {
+  case DiagonalType::crossed:
+  {
+    for (std::int64_t iy = 0; iy < ny; iy++)
+    {
+      for (std::int64_t ix = 0; ix < nx; ix++)
+      {
+        const std::int64_t v0 = iy * (nx + 1) + ix;
+        const std::int64_t v1 = v0 + 1;
+        const std::int64_t v2 = v0 + (nx + 1);
+        const std::int64_t v3 = v1 + (nx + 1);
+        const std::int64_t vmid = (nx + 1) * (ny + 1) + iy * nx + ix;
+
+        // Note that v0 < v1 < v2 < v3 < vmid
+        cells.insert(cells.end(),
+                     {v0, v1, vmid, v0, v2, vmid, v1, v3, vmid, v2, v3, vmid});
+      }
+    }
+    break;
+  }
+  default:
+  {
+    DiagonalType local_diagonal = diagonal;
+    for (std::int64_t iy = 0; iy < ny; iy++)
+    {
+      // Set up alternating diagonal
+      switch (diagonal)
+      {
+      case DiagonalType::right_left:
+        if (iy % 2)
+          local_diagonal = DiagonalType::right;
+        else
+          local_diagonal = DiagonalType::left;
+        break;
+      case DiagonalType::left_right:
+        if (iy % 2)
+          local_diagonal = DiagonalType::left;
+        else
+          local_diagonal = DiagonalType::right;
+        break;
+      default:
+        break;
+      }
+      for (std::int64_t ix = 0; ix < nx; ix++)
+      {
+        const std::int64_t v0 = iy * (nx + 1) + ix;
+        const std::int64_t v1 = v0 + 1;
+        const std::int64_t v2 = v0 + (nx + 1);
+        const std::int64_t v3 = v1 + (nx + 1);
+
+        switch (local_diagonal)
+        {
+        case DiagonalType::left:
+        {
+          cells.insert(cells.end(), {v0, v1, v2, v1, v2, v3});
+          if (diagonal == DiagonalType::right_left
+              or diagonal == DiagonalType::left_right)
+          {
+            local_diagonal = DiagonalType::right;
+          }
+          break;
+        }
+        default:
+        {
+          cells.insert(cells.end(), {v0, v1, v3, v0, v2, v3});
+          if (diagonal == DiagonalType::right_left
+              or diagonal == DiagonalType::left_right)
+          {
+            local_diagonal = DiagonalType::left;
+          }
+        }
+        }
+      }
+    }
+  }
+  }
+
+  return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
+                     {x.size() / 2, 2}, partitioner);
 }
 
 template <std::floating_point T>
@@ -651,47 +637,42 @@ Mesh<T> build_quad(MPI_Comm comm, const std::array<std::array<double, 2>, 2> p,
   fem::CoordinateElement<T> element(CellType::quadrilateral, 1);
   std::vector<std::int64_t> cells;
   std::vector<T> x;
-  if (dolfinx::MPI::rank(comm) == 0)
-  {
-    const std::int64_t nx = n[0];
-    const std::int64_t ny = n[1];
-    const T a = p[0][0];
-    const T b = p[1][0];
-    const T ab = (b - a) / static_cast<T>(nx);
-    const T c = p[0][1];
-    const T d = p[1][1];
-    const T cd = (d - c) / static_cast<T>(ny);
 
-    // Create vertices
-    x.reserve((nx + 1) * (ny + 1) * 2);
-    std::int64_t vertex = 0;
-    for (std::int64_t ix = 0; ix <= nx; ix++)
-    {
-      T x0 = a + ab * static_cast<T>(ix);
-      for (std::int64_t iy = 0; iy <= ny; iy++)
-        x.insert(x.end(), {x0, c + cd * static_cast<T>(iy)});
-    }
-
-    // Create rectangles
-    cells.reserve(nx * ny * 4);
-    for (std::int64_t ix = 0; ix < nx; ix++)
-    {
-      for (std::int64_t iy = 0; iy < ny; iy++)
-      {
-        std::int64_t i0 = ix * (ny + 1);
-        cells.insert(cells.end(), {i0 + iy, i0 + iy + 1, i0 + iy + ny + 1,
-                                   i0 + iy + ny + 2});
-      }
-    }
-
-    return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
-                       {x.size() / 2, 2}, partitioner);
-  }
-  else
-  {
+  if ((dolfinx::MPI::rank(comm) != 0))
     return create_mesh(comm, MPI_COMM_NULL, cells, element, MPI_COMM_NULL, x,
                        {x.size() / 2, 2}, partitioner);
+
+  const auto [nx, ny] = n;
+  const auto [a, c] = p[0];
+  const auto [b, d] = p[1];
+
+  const T ab = (b - a) / static_cast<T>(nx);
+  const T cd = (d - c) / static_cast<T>(ny);
+
+  // Create vertices
+  x.reserve((nx + 1) * (ny + 1) * 2);
+  std::int64_t vertex = 0;
+  for (std::int64_t ix = 0; ix <= nx; ix++)
+  {
+    T x0 = a + ab * static_cast<T>(ix);
+    for (std::int64_t iy = 0; iy <= ny; iy++)
+      x.insert(x.end(), {x0, c + cd * static_cast<T>(iy)});
   }
+
+  // Create rectangles
+  cells.reserve(nx * ny * 4);
+  for (std::int64_t ix = 0; ix < nx; ix++)
+  {
+    for (std::int64_t iy = 0; iy < ny; iy++)
+    {
+      std::int64_t i0 = ix * (ny + 1);
+      cells.insert(cells.end(),
+                   {i0 + iy, i0 + iy + 1, i0 + iy + ny + 1, i0 + iy + ny + 2});
+    }
+  }
+
+  return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
+                     {x.size() / 2, 2}, partitioner);
 }
 } // namespace impl
 } // namespace dolfinx::mesh

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(
   common/index_map.cpp
   common/sort.cpp
   mesh/distributed_mesh.cpp
+  mesh/generation.cpp
   common/CIFailure.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/poisson.c
 )

--- a/cpp/test/mesh/generation.cpp
+++ b/cpp/test/mesh/generation.cpp
@@ -1,0 +1,43 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <mpi.h>
+
+#include "dolfinx/mesh/generation.h"
+
+using namespace dolfinx;
+
+TEST_CASE("Generation", "create_interval")
+{
+    auto mesh = mesh::create_interval(MPI_COMM_SELF, 4, {0., 1.});
+
+    // TODO: CHECK(mesh.comm() == MPI_COMM_SELF);
+    CHECK(mesh.geometry().dim() == 1);
+    auto vertices = mesh.geometry().x();
+    CHECK(vertices[0*3] == 0.0);
+    CHECK(vertices[1*3] == 0.25);
+    CHECK(vertices[2*3] == 0.5);
+    CHECK(vertices[3*3] == 0.75);
+    CHECK(vertices[4*3] == 1.0);
+
+    mesh.topology()->create_connectivity(0, 1);
+    auto point_conn = mesh.topology()->connectivity(0, 1);
+
+    CHECK(point_conn->num_nodes() == 5);
+
+    CHECK(point_conn->num_links(0) == 1);
+    CHECK(point_conn->num_links(1) == 2);
+    CHECK(point_conn->num_links(2) == 2);
+    CHECK(point_conn->num_links(3) == 2);
+    CHECK(point_conn->num_links(4) == 1);
+
+    CHECK(point_conn->links(0)[0] == 0);
+    CHECK(point_conn->links(1)[0] == 0);
+    CHECK(point_conn->links(1)[1] == 1);
+    CHECK(point_conn->links(2)[0] == 1);
+    CHECK(point_conn->links(2)[1] == 2);
+    CHECK(point_conn->links(3)[0] == 2);
+    CHECK(point_conn->links(3)[1] == 3);
+    CHECK(point_conn->links(4)[0] == 3);
+}
+
+// TODO extend for further mesh types.


### PR DESCRIPTION
While reading up on the mesh generation I had quite a hard time to understand what was going on in `generation.h`. This contains some tidying up of the code and relocation of input checks to more central positions.

What this PR does not change but should be done in the future is (if PR gets accepted I'll make this a new issue)

- [ ] unify interface of box based mesh generation, i.e. combine `create_interval`, `create_rectangle` and `create_box`
    - the checks for valid parameters can then be performed in one central location
    - the geometries that are created are already in 3D space, but we do not make use of this. For example an interval mesh is currently only to be generated along the $x$-axis and not along an arbitrary line segment in 3D space. Same holds for the rectangle interface. Changing this, also allows for common data types, i.e. we will no longer need to handle point types of different dimensions.
- [ ] extend testing -> currently a lot of the provided functionality is not tested thoroughly .