### PR TITLE
Improve check for facet->cell connectivity

### DIFF
--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -60,9 +60,10 @@ std::vector<std::int32_t> mesh::exterior_facet_indices(const Topology& topology)
   const int tdim = topology.dim();
   auto f_to_c = topology.connectivity(tdim - 1, tdim);
   if (!f_to_c)
+  {
     throw std::runtime_error(
         "Facet to cell connectivity has not been computed.");
-
+  }
   // Find all owned facets (not ghost) with only one attached cell
   auto facet_map = topology.index_map(tdim - 1);
   const int num_facets = facet_map->size_local();

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -58,14 +58,14 @@ mesh::extract_topology(CellType cell_type, const fem::ElementDofLayout& layout,
 std::vector<std::int32_t> mesh::exterior_facet_indices(const Topology& topology)
 {
   const int tdim = topology.dim();
-  auto facet_map = topology.index_map(tdim - 1);
-  if (!facet_map)
-    throw std::runtime_error("Facets have not been computed.");
+  auto f_to_c = topology.connectivity(tdim - 1, tdim);
+  if (!f_to_c)
+    throw std::runtime_error(
+        "Facet to cell connectivity has not been computed.");
 
   // Find all owned facets (not ghost) with only one attached cell
+  auto facet_map = topology.index_map(tdim - 1);
   const int num_facets = facet_map->size_local();
-  auto f_to_c = topology.connectivity(tdim - 1, tdim);
-  assert(f_to_c);
   std::vector<std::int32_t> facets;
   for (std::int32_t f = 0; f < num_facets; ++f)
   {


### PR DESCRIPTION

Currently `exterior_facet_indices()` only checks that the facet index map exists, which is insufficient.

* add a check for facet->cell connectivity instead
