### PR TITLE
Export missing compile time constants to python

### DIFF
--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -4,19 +4,12 @@
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
-#include "MPICommWrapper.h"
-#include "array.h"
-#include "caster_mpi.h"
 #include <complex>
-#include <dolfinx/common/IndexMap.h>
-#include <dolfinx/common/Scatterer.h>
-#include <dolfinx/common/Table.h>
-#include <dolfinx/common/Timer.h>
-#include <dolfinx/common/defines.h>
-#include <dolfinx/common/log.h>
-#include <dolfinx/common/timing.h>
-#include <dolfinx/common/utils.h>
 #include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/array.h>
@@ -24,9 +17,20 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
-#include <span>
-#include <string>
-#include <vector>
+
+#include <dolfinx/common/defines.h>
+#include <dolfinx/common/defines.h>
+#include <dolfinx/common/IndexMap.h>
+#include <dolfinx/common/log.h>
+#include <dolfinx/common/Scatterer.h>
+#include <dolfinx/common/Table.h>
+#include <dolfinx/common/Timer.h>
+#include <dolfinx/common/timing.h>
+#include <dolfinx/common/utils.h>
+
+#include "MPICommWrapper.h"
+#include "array.h"
+#include "caster_mpi.h"
 
 namespace nb = nanobind;
 
@@ -36,13 +40,17 @@ namespace dolfinx_wrappers
 void common(nb::module_& m)
 {
   // From dolfinx/common/defines.h
-  m.attr("has_debug") = dolfinx::has_debug();
-  m.attr("has_parmetis") = dolfinx::has_parmetis();
-  m.attr("has_kahip") = dolfinx::has_kahip();
-  m.attr("has_petsc") = dolfinx::has_petsc();
-  m.attr("has_slepc") = dolfinx::has_slepc();
-  m.attr("has_adios2") = dolfinx::has_adios2();
   m.attr("git_commit_hash") = dolfinx::git_commit_hash();
+  m.attr("has_adios2") = dolfinx::has_adios2();
+  m.attr("has_complex_ufcx_kernels") = dolfinx::has_complex_ufcx_kernels();
+  m.attr("has_debug") = dolfinx::has_debug();
+  m.attr("has_kahip") = dolfinx::has_kahip();
+  m.attr("has_parmetis") = dolfinx::has_parmetis();
+  m.attr("has_petsc") = dolfinx::has_petsc();
+  m.attr("has_ptscotch") = dolfinx::has_ptscotch();
+  m.attr("has_slepc") = dolfinx::has_slepc();
+  m.attr("ufcx_signature") = dolfinx::ufcx_signature();
+  m.attr("version") = dolfinx::version();
 
   nb::enum_<dolfinx::Table::Reduction>(m, "Reduction")
       .value("max", dolfinx::Table::Reduction::max)


### PR DESCRIPTION
In addition to https://github.com/FEniCS/dolfinx/pull/3246 - as pointed out by @jhale this contains the corresponding exports to the python module.