### PR TITLE
Remove workarounds following upstream updates for CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,13 +36,6 @@ jobs:
           export PATH="$(brew --prefix bison)/bin:$PATH"
           git clone -b release https://gitlab.com/petsc/petsc.git petsc
           cd petsc
-          patch config/BuildSystem/config/packages/MUMPS.py << EOF
-          @@ -178,3 +178,4 @@ class Configure(config.package.Package):
-                 if self.avoid_mpi_in_place:
-                   g.write('CDEFS += -DAVOID_MPI_IN_PLACE') # only take effect since mumps-5.6.2
-          +        g.write('\nOPTF += -DAVOID_MPI_IN_PLACE\n')
-                   self.addDefine('HAVE_MUMPS_AVOID_MPI_IN_PLACE', 1)
-          EOF
           python ./configure \
             --with-64-bit-indices=no \
             --with-debugging=no \

--- a/python/demo/test.py
+++ b/python/demo/test.py
@@ -23,8 +23,6 @@ for f in demo_files:
 @pytest.mark.serial
 @pytest.mark.parametrize("path,name", demos)
 def test_demos(path, name):
-    if "pyamg" in name:
-        pytest.xfail("pyamg needs updating for latest numpy and scipy")
     ret = subprocess.run([sys.executable, name], cwd=str(path), check=True)
     assert ret.returncode == 0
 

--- a/python/test/unit/mesh/test_ghost_mesh.py
+++ b/python/test/unit/mesh/test_ghost_mesh.py
@@ -100,7 +100,8 @@ def test_ghost_connectivities(mode):
     facet_mp = compute_midpoints(meshR, tdim - 1, np.arange(num_facets))
     meshR.topology.create_connectivity(tdim, tdim)
     cell_mp = compute_midpoints(meshR, tdim, np.arange(num_cells))
-    reference = dict.fromkeys([tuple(row) for row in facet_mp], [])
+    reference = {tuple(row): [] for row in facet_mp}
+
     for i in range(num_facets):
         for cidx in meshR.topology.connectivity(1, 2).links(i):
             reference[tuple(facet_mp[i])].append(cell_mp[cidx].tolist())


### PR DESCRIPTION
Fixes for pyamg and petsc are now available.