### PR TITLE
Introduce `sort_unique`

### DIFF
--- a/cpp/demo/mixed_topology/main.cpp
+++ b/cpp/demo/mixed_topology/main.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/MPI.h>
+#include <dolfinx/common/utils.h>
 #include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/mesh/Geometry.h>
 #include <dolfinx/mesh/Mesh.h>
@@ -98,10 +99,7 @@ int main(int argc, char* argv[])
     boundary_vertices.push_back(ny + (ny + 1) * i);
   }
 
-  std::ranges::sort(boundary_vertices);
-  boundary_vertices.erase(
-      std::unique(boundary_vertices.begin(), boundary_vertices.end()),
-      boundary_vertices.end());
+  common::sort_unique(boundary_vertices);
 
   std::vector<mesh::CellType> cell_types{mesh::CellType::quadrilateral,
                                          mesh::CellType::triangle};

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "IndexMap.h"
+#include "dolfinx/common/utils.h"
 #include "sort.h"
 #include <algorithm>
 #include <cstdint>
@@ -36,8 +37,8 @@ std::array<std::vector<int>, 2> build_src_dest(MPI_Comm comm,
   }
 
   std::vector<int> src(owners.begin(), owners.end());
-  std::ranges::sort(src);
-  src.erase(std::unique(src.begin(), src.end()), src.end());
+  sort_unique(src);
+
   src.shrink_to_fit();
   std::vector<int> dest = dolfinx::MPI::compute_graph_edges_nbx(comm, src);
   std::ranges::sort(dest);
@@ -337,9 +338,7 @@ compute_submap_indices(const IndexMap& imap,
   // Get submap source ranks
   std::vector<int> submap_src(submap_ghost_owners.begin(),
                               submap_ghost_owners.end());
-  std::ranges::sort(submap_src);
-  submap_src.erase(std::unique(submap_src.begin(), submap_src.end()),
-                   submap_src.end());
+  common::sort_unique(submap_src);
   submap_src.shrink_to_fit();
 
   // If required, preserve the order of the ghost indices
@@ -551,9 +550,7 @@ common::compute_owned_indices(std::span<const std::int32_t> indices,
   dolfinx::MPI::check_error(map.comm(), ierr);
 
   // Remove duplicates from received indices
-  std::ranges::sort(recv_buffer);
-  recv_buffer.erase(std::unique(recv_buffer.begin(), recv_buffer.end()),
-                    recv_buffer.end());
+  common::sort_unique(recv_buffer);
 
   // Copy owned and ghost indices into return array
   std::vector<std::int32_t> owned;
@@ -567,9 +564,7 @@ common::compute_owned_indices(std::span<const std::int32_t> indices,
                            return idx - range[0];
                          });
 
-  std::ranges::sort(owned);
-  owned.erase(std::unique(owned.begin(), owned.end()), owned.end());
-
+  common::sort_unique(owned);
   return owned;
 }
 //-----------------------------------------------------------------------------
@@ -939,8 +934,7 @@ graph::AdjacencyList<int> IndexMap::index_to_dest_ranks() const
 
   // Build lists of src and dest ranks
   std::vector<int> src = _owners;
-  std::ranges::sort(src);
-  src.erase(std::unique(src.begin(), src.end()), src.end());
+  common::sort_unique(src);
   auto dest = dolfinx::MPI::compute_graph_edges_nbx(_comm.comm(), src);
   std::ranges::sort(dest);
 
@@ -1217,9 +1211,7 @@ std::vector<std::int32_t> IndexMap::shared_indices() const
                          });
 
   // Sort and remove duplicates
-  std::ranges::sort(shared);
-  shared.erase(std::unique(shared.begin(), shared.end()), shared.end());
-
+  common::sort_unique(shared);
   return shared;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/sort.h
+++ b/cpp/dolfinx/common/sort.h
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <bitset>
 #include <cstdint>
+#include <iterator>
 #include <numeric>
 #include <span>
 #include <type_traits>
@@ -23,9 +24,10 @@ namespace dolfinx
 /// @tparam T Integral type
 /// @tparam BITS The number of bits to sort at a time.
 /// @param[in, out] array The array to sort.
-template <typename T, int BITS = 8>
-void radix_sort(std::span<T> array)
+template <std::ranges::random_access_range R, int BITS = 8>
+void radix_sort(R&& array)
 {
+  using T = std::iter_value_t<R>;
   static_assert(std::is_integral<T>(), "This function only sorts integers.");
 
   if (array.size() <= 1)

--- a/cpp/dolfinx/common/sort.h
+++ b/cpp/dolfinx/common/sort.h
@@ -20,13 +20,14 @@
 namespace dolfinx
 {
 
-/// Sort a vector of integers with radix sorting algorithm. The bucket
-/// size is determined by the number of bits to sort at a time (2^BITS).
-/// @tparam T Integral type
-/// @tparam BITS The number of bits to sort at a time.
-/// @param[in, out] array The array to sort.
+/// std::ranges compatible struct for radix sort.
 struct __radix_sort
 {
+  /// Sort a vector of integers with radix sorting algorithm. The bucket
+  /// size is determined by the number of bits to sort at a time (2^BITS).
+  /// @tparam T Integral type
+  /// @tparam BITS The number of bits to sort at a time.
+  /// @param[in, out] array The array to sort.
   template <std::ranges::random_access_range R, int BITS = 8>
   constexpr void operator()(R&& array) const
   {
@@ -92,6 +93,7 @@ struct __radix_sort
   }
 };
 
+/// Radix sort.
 inline constexpr __radix_sort radix_sort{};
 
 /// Returns the indices that would sort (lexicographic) a vector of

--- a/cpp/dolfinx/common/utils.h
+++ b/cpp/dolfinx/common/utils.h
@@ -19,14 +19,22 @@
 namespace dolfinx::common
 {
 
-template <std::ranges::random_access_range R, std::invocable<R> F = std::ranges::__sort_fn>
+/// @brief Sorts and uniquifies a (random access) range.
+///
+/// Any duplicates are therefore removed and the range is transformed into an
+/// ordered state.
+///
+/// @param[in] range Range to be sorted and uniquified
+/// @param[in] sort Sorting algorithm to be used, defaults to std::ranges::sort
+/// but dolfinx::radix_sort is also supported
+template <std::ranges::random_access_range R,
+          std::invocable<R> F = std::ranges::__sort_fn>
 void sort_unique(R&& range, F sort = std::ranges::sort)
 {
   sort(range);
   auto [end_unique, range_end] = std::ranges::unique(range);
   range.erase(end_unique, range_end);
 }
-
 
 ///@brief Sort two arrays based on the values in array `indices`.
 ///

--- a/cpp/dolfinx/common/utils.h
+++ b/cpp/dolfinx/common/utils.h
@@ -8,7 +8,9 @@
 
 #include "MPI.h"
 #include <algorithm>
+#include <bits/ranges_algo.h>
 #include <boost/functional/hash.hpp>
+#include <concepts>
 #include <mpi.h>
 #include <utility>
 #include <vector>
@@ -17,10 +19,10 @@
 namespace dolfinx::common
 {
 
-template <std::ranges::random_access_range R>
-void sort_unique(R&& range)
+template <std::ranges::random_access_range R, std::invocable<R> F = std::ranges::__sort_fn>
+void sort_unique(R&& range, F sort = std::ranges::sort)
 {
-  std::ranges::sort(range);
+  sort(range);
   auto [end_unique, range_end] = std::ranges::unique(range);
   range.erase(end_unique, range_end);
 }

--- a/cpp/dolfinx/common/utils.h
+++ b/cpp/dolfinx/common/utils.h
@@ -16,6 +16,16 @@
 /// Generic tools
 namespace dolfinx::common
 {
+
+template <std::ranges::random_access_range R>
+void sort_unique(R&& range)
+{
+  std::ranges::sort(range);
+  auto [end_unique, range_end] = std::ranges::unique(range);
+  range.erase(end_unique, range_end);
+}
+
+
 ///@brief Sort two arrays based on the values in array `indices`.
 ///
 /// Any duplicate indices and the corresponding value are removed. In

--- a/cpp/dolfinx/fem/DirichletBC.cpp
+++ b/cpp/dolfinx/fem/DirichletBC.cpp
@@ -11,6 +11,7 @@
 #include <array>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/sort.h>
+#include <dolfinx/common/utils.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/Topology.h>
 #include <dolfinx/mesh/cell_types.h>
@@ -248,8 +249,7 @@ std::vector<std::int32_t> fem::locate_dofs_topological(
 
   // TODO: is removing duplicates at this point worth the effort?
   // Remove duplicates
-  std::ranges::sort(dofs);
-  dofs.erase(std::unique(dofs.begin(), dofs.end()), dofs.end());
+  common::sort_unique(dofs);
 
   if (remote)
   {
@@ -283,8 +283,7 @@ std::vector<std::int32_t> fem::locate_dofs_topological(
     // Add received bc indices to dofs_local, sort, and remove
     // duplicates
     dofs.insert(dofs.end(), dofs_remote.begin(), dofs_remote.end());
-    std::ranges::sort(dofs);
-    dofs.erase(std::unique(dofs.begin(), dofs.end()), dofs.end());
+    common::sort_unique(dofs);
   }
 
   return dofs;

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -230,8 +230,7 @@ std::array<std::vector<std::int32_t>, 2> locate_dofs_geometrical(
   }
 
   // Remove duplicates
-  std::ranges::sort(bc_dofs);
-  bc_dofs.erase(std::unique(bc_dofs.begin(), bc_dofs.end()), bc_dofs.end());
+  common::sort_unique(bc_dofs);
 
   // Copy to separate array
   std::array dofs = {std::vector<std::int32_t>(bc_dofs.size()),

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -6,6 +6,7 @@
 
 #include "DofMap.h"
 #include "ElementDofLayout.h"
+#include "common/utils.h"
 #include "dofmapbuilder.h"
 #include "utils.h"
 #include <cstdint>
@@ -46,9 +47,7 @@ fem::DofMap build_collapsed_dofmap(const DofMap& dofmap_view,
   std::vector<std::int32_t> dofs_view(dofs_view_md.data_handle(),
                                       dofs_view_md.data_handle()
                                           + dofs_view_md.size());
-  dolfinx::radix_sort(std::span(dofs_view));
-  dofs_view.erase(std::unique(dofs_view.begin(), dofs_view.end()),
-                  dofs_view.end());
+  common::sort_unique(dofs_view, dolfinx::radix_sort);
 
   // Get block size
   int bs_view = dofmap_view.index_map_bs();

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -16,6 +16,7 @@
 #include <concepts>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/types.h>
+#include <dolfinx/common/utils.h>
 #include <dolfinx/geometry/utils.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <functional>
@@ -175,8 +176,7 @@ void scatter_values(MPI_Comm comm, std::span<const std::int32_t> src_ranks,
                [](auto rank) { return rank >= 0; });
 
   // Create unique set of sorted in-ranks
-  std::ranges::sort(in_ranks);
-  in_ranks.erase(std::unique(in_ranks.begin(), in_ranks.end()), in_ranks.end());
+  common::sort_unique(in_ranks);
   in_ranks.reserve(in_ranks.size() + 1);
 
   // Create neighborhood communicator

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -706,9 +706,8 @@ PointOwnershipData<T> determine_point_ownership(const mesh::Mesh<T>& mesh,
 
   // Get unique list of outgoing ranks
   std::vector<std::int32_t> out_ranks = collisions.array();
-  std::ranges::sort(out_ranks);
-  out_ranks.erase(std::unique(out_ranks.begin(), out_ranks.end()),
-                  out_ranks.end());
+  common::sort_unique(out_ranks);
+
   // Compute incoming edges (source processes)
   std::vector in_ranks = dolfinx::MPI::compute_graph_edges_nbx(comm, out_ranks);
   std::ranges::sort(in_ranks);

--- a/cpp/dolfinx/graph/partitioners.cpp
+++ b/cpp/dolfinx/graph/partitioners.cpp
@@ -10,6 +10,7 @@
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/common/log.h>
+#include <dolfinx/common/utils.h>
 #include <map>
 #include <numeric>
 #include <set>
@@ -81,9 +82,7 @@ graph::AdjacencyList<int> compute_destination_ranks(
             {rank, node1, static_cast<std::int64_t>(part[node0])});
     }
   }
-  std::ranges::sort(node_to_dest);
-  node_to_dest.erase(std::unique(node_to_dest.begin(), node_to_dest.end()),
-                     node_to_dest.end());
+  common::sort_unique(node_to_dest);
 
   // Build send data and buffer
   std::vector<int> dest, send_sizes;
@@ -164,10 +163,8 @@ graph::AdjacencyList<int> compute_destination_ranks(
     std::int32_t idx_local = idx - range0;
     local_node_to_dest.push_back({idx_local, d});
   }
-  std::ranges::sort(local_node_to_dest);
-  local_node_to_dest.erase(
-      std::unique(local_node_to_dest.begin(), local_node_to_dest.end()),
-      local_node_to_dest.end());
+
+  common::sort_unique(local_node_to_dest);
 
   // Compute offsets
   std::vector<std::int32_t> offsets(graph.num_nodes() + 1, 0);

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -15,6 +15,7 @@
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/common/log.h>
 #include <dolfinx/common/sort.h>
+#include <dolfinx/common/utils.h>
 #include <dolfinx/graph/AdjacencyList.h>
 #include <memory>
 #include <numeric>
@@ -39,8 +40,7 @@ namespace
 template <typename U>
 graph::AdjacencyList<int> create_adj_list(U& data, std::int32_t size)
 {
-  std::ranges::sort(data);
-  data.erase(std::unique(data.begin(), data.end()), data.end());
+  common::sort_unique(data);
 
   std::vector<int> array;
   array.reserve(data.size());
@@ -129,8 +129,8 @@ get_local_indexing(MPI_Comm comm, const common::IndexMap& vertex_map,
   // Create unique list of ranks that share vertices (owners of)
   std::vector<int> ranks(vertex_ranks.array().begin(),
                          vertex_ranks.array().end());
-  std::ranges::sort(ranks);
-  ranks.erase(std::unique(ranks.begin(), ranks.end()), ranks.end());
+
+  common::sort_unique(ranks);
 
   MPI_Comm neighbor_comm;
   MPI_Dist_graph_create_adjacent(

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -137,9 +137,7 @@ mesh::compute_incident_entities(const Topology& topology,
     entities1.insert(entities1.end(), e.begin(), e.end());
   }
 
-  std::ranges::sort(entities1);
-  entities1.erase(std::unique(entities1.begin(), entities1.end()),
-                  entities1.end());
+  common::sort_unique(entities1);
   return entities1;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <basix/mdspan.hpp>
 #include <concepts>
+#include <dolfinx/common/utils.h>
 #include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/graph/ordering.h>
 #include <dolfinx/graph/partition.h>
@@ -104,12 +105,8 @@ compute_vertex_coords_boundary(const mesh::Mesh<T>& mesh, int dim,
     }
 
     // Build vector of boundary vertices
-    std::ranges::sort(vertices);
-    vertices.erase(std::unique(vertices.begin(), vertices.end()),
-                   vertices.end());
-    std::ranges::sort(entities);
-    entities.erase(std::unique(entities.begin(), entities.end()),
-                   entities.end());
+    common::sort_unique(vertices);
+    common::sort_unique(entities);
   }
 
   // Get geometry data
@@ -869,9 +866,7 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
 
     // Boundary vertices are marked as 'unknown'
     boundary_v = unmatched_facets;
-    std::ranges::sort(boundary_v);
-    boundary_v.erase(std::unique(boundary_v.begin(), boundary_v.end()),
-                     boundary_v.end());
+    common::sort_unique(boundary_v);
 
     // Remove -1 if it occurs in boundary vertices (may occur in mixed
     // topology)
@@ -894,8 +889,8 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
   // Build list of unique (global) node indices from cells1 and
   // distribute coordinate data
   std::vector<std::int64_t> nodes1 = cells1;
-  dolfinx::radix_sort(std::span(nodes1));
-  nodes1.erase(std::unique(nodes1.begin(), nodes1.end()), nodes1.end());
+    common::sort_unique(nodes1, dolfinx::radix_sort);
+
   std::vector coords
       = dolfinx::MPI::distribute_data(comm, nodes1, commg, x, xshape[1]);
 
@@ -1073,9 +1068,7 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
 
     // Boundary vertices are marked as 'unknown'
     boundary_v = unmatched_facets;
-    std::ranges::sort(boundary_v);
-    boundary_v.erase(std::unique(boundary_v.begin(), boundary_v.end()),
-                     boundary_v.end());
+    common::sort_unique(boundary_v);
 
     // Remove -1 if it occurs in boundary vertices (may occur in mixed
     // topology)
@@ -1120,8 +1113,7 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
   for (std::vector<std::int64_t>& c : cells1)
     nodes2.insert(nodes2.end(), c.begin(), c.end());
 
-  dolfinx::radix_sort(std::span(nodes1));
-  nodes1.erase(std::unique(nodes1.begin(), nodes1.end()), nodes1.end());
+  common::sort_unique(nodes1, dolfinx::radix_sort);
   std::vector coords
       = dolfinx::MPI::distribute_data(comm, nodes1, commg, x, xshape[1]);
 
@@ -1193,9 +1185,7 @@ create_subgeometry(const Mesh<T>& mesh, int dim,
       = entities_to_geometry(mesh, dim, subentity_to_entity, true);
 
   std::vector<std::int32_t> sub_x_dofs = x_indices;
-  std::ranges::sort(sub_x_dofs);
-  sub_x_dofs.erase(std::unique(sub_x_dofs.begin(), sub_x_dofs.end()),
-                   sub_x_dofs.end());
+  common::sort_unique(sub_x_dofs);
 
   // Get the sub-geometry dofs owned by this process
   auto x_index_map = geometry.index_map();

--- a/cpp/dolfinx/refinement/plaza.h
+++ b/cpp/dolfinx/refinement/plaza.h
@@ -581,8 +581,7 @@ compute_refinement_data(const mesh::Mesh<T>& mesh, Option option)
   // Create unique list of ranks that share edges (owners of ghosts
   // plus ranks that ghost owned indices)
   std::vector<int> ranks(edge_ranks.array().begin(), edge_ranks.array().end());
-  std::ranges::sort(ranks);
-  ranks.erase(std::unique(ranks.begin(), ranks.end()), ranks.end());
+  common::sort_unique(ranks);
 
   // Convert edge_ranks from global rank to to neighbourhood ranks
   std::ranges::transform(edge_ranks.array(), edge_ranks.array().begin(),
@@ -647,8 +646,7 @@ compute_refinement_data(const mesh::Mesh<T>& mesh,
   // Create unique list of ranks that share edges (owners of ghosts plus
   // ranks that ghost owned indices)
   std::vector<int> ranks(edge_ranks.array().begin(), edge_ranks.array().end());
-  std::ranges::sort(ranks);
-  ranks.erase(std::unique(ranks.begin(), ranks.end()), ranks.end());
+  common::sort_unique(ranks);
 
   // Convert edge_ranks from global rank to to neighbourhood ranks
   std::ranges::transform(edge_ranks.array(), edge_ranks.array().begin(),

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -10,6 +10,7 @@
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/Scatterer.h>
+#include <dolfinx/common/utils.h>
 #include <numeric>
 #include <set>
 #include <vector>
@@ -144,9 +145,8 @@ void test_consensus_exchange()
 
   // Create an IndexMap
   std::vector<int> src_ranks = global_ghost_owner;
+  common::sort_unique(src_ranks);
   std::ranges::sort(src_ranks);
-  src_ranks.erase(std::unique(src_ranks.begin(), src_ranks.end()),
-                  src_ranks.end());
 
   auto dest_ranks0
       = dolfinx::MPI::compute_graph_edges_nbx(MPI_COMM_WORLD, src_ranks);


### PR DESCRIPTION
While working on https://github.com/FEniCS/dolfinx/pull/3293, noticed that a lot of the use cases of `sort` are coupled with a following `unique` call to produce a sorted and unique range.

Introduces `common::sort_unique` which sorts and uniquifies a range, given a custom sort routine. To allow for the passing of `radix_sort` its interface is made `std::ranges` compatible, i.e. functionality is exposed by `opeartor()` of a struct.
