### PR TITLE
nls ksp/pc choice

### DIFF
--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -674,6 +674,23 @@ petsc::KrylovSolver& petsc::KrylovSolver::operator=(KrylovSolver&& solver)
   return *this;
 }
 //-----------------------------------------------------------------------------
+void petsc::KrylovSolver::set_as_direct_solver() 
+{ 
+  assert(_ksp);
+  // remove iterative resolution: only use preconditioner pass
+  PetscErrorCode ierr = KSPSetType(_ksp, KSPPREONLY);
+  CHECK_ERROR("KSPSetType");
+
+  PC pc;
+  ierr = KSPGetPC(_ksp, &pc);
+  CHECK_ERROR("KSPGetPC");
+
+  // set preconditioner as a direct solver using LU factorization
+  ierr = PCSetType(pc, PCLU);
+  CHECK_ERROR("PCSetType");
+   
+}
+//-----------------------------------------------------------------------------
 void petsc::KrylovSolver::set_operator(const Mat A) { set_operators(A, A); }
 //-----------------------------------------------------------------------------
 void petsc::KrylovSolver::set_operators(const Mat A, const Mat P)

--- a/cpp/dolfinx/la/petsc.h
+++ b/cpp/dolfinx/la/petsc.h
@@ -496,6 +496,9 @@ public:
   /// Set options from PETSc options database
   void set_from_options() const;
 
+  /// Transform Krylov solver into a direct solver using LU factorization
+  void set_as_direct_solver();
+
   /// Return PETSc KSP pointer
   KSP ksp() const;
 

--- a/cpp/dolfinx/nls/NewtonSolver.cpp
+++ b/cpp/dolfinx/nls/NewtonSolver.cpp
@@ -71,10 +71,10 @@ nls::petsc::NewtonSolver::NewtonSolver(MPI_Comm comm)
       _krylov_iterations(0), _iteration(0), _residual(0.0), _residual0(0.0),
       _solver(comm), _dx(nullptr), _comm(comm)
 {
-  // Create linear solver if not already created. Default to LU.
+  // Tune linear solver:  
+  //     Default to LU and let the user options change this default
   _solver.set_options_prefix("nls_solve_");
-  la::petsc::options::set("nls_solve_ksp_type", "preonly");
-  la::petsc::options::set("nls_solve_pc_type", "lu");
+  _solver.set_as_direct_solver();
   _solver.set_from_options();
 }
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Hello
If the original intention was to force the NewtonSolver ksp/pc object to be set as a direct solver and only give the user the ability to tune the LU solver options with command line arguments, this PR is not going in the right direction. 

Anyway user, after NewtonSolver instantiation, can grab ksp pointer and reset the way he want  ksp/pc by either using KSPSetType, PCSetType, PetscOptionsSetValue and/or KSPSetFromOptions. For a newbie like me, it takes some time to figure out why adding :
`-nls_solve_ksp_type cg -nls_solve_pc_type hypre -nls_solve_pc_hypre_type boomeramg -nls_solve_pc_hypre_boomeramg_max_levels 15 `
options to my program did not work, and how to change my code so that this setting is taken into account.

This PR replace the hard-coded option setting by a call to KSPSetType, PCSetType so that KSPSetFromOptions woks. Now to avoid "polluting"  NewtonSolver class by direct use of KSPSetType, PCSetType,... some extra warper for these functions could have been implemented...but I prefer to add a function to KrylovSolver class ...

Regards

P.S. Won't be available before the 19th of August for any exchange ... if any ...