### PR TITLE
Re-enable Windows CI.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,17 @@
 name: Windows build
 
 on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -47,11 +58,14 @@ jobs:
           cmake --install build-dir --config Release --prefix D:/a/dolfinx/basix-install
           echo "D:/a/dolfinx/basix-install/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
+      - name: Install build dependencies (workaround)
+        run: |
+          python -m pip install scikit-build-core[pyproject] git+https://github.com/jhale/nanobind.git@jhale/msvc2022-workaround setuptools wheel
       - name: Install Basix (Python)
         working-directory: basix
         run: |
           cd python
-          python -m pip -v install --no-cache-dir .[ci] --config-settings=cmake.args=-DBasix_DIR=D:/a/basix/install/lib/cmake/basix
+          python -m pip -v install --no-build-isolation --no-cache-dir .[ci] --config-settings=cmake.args=-DBasix_DIR=D:/a/basix/install/lib/cmake/basix
           cd ../
 
       - name: Checkout FFCx


### PR DESCRIPTION
This uses a fork of nanobind created from tag v2.0.0 with a patch applied from https://github.com/wjakob/nanobind/issues/613#issuecomment-2239868209

This isn't a long term solution but it at least ensures that the work done towards to the Windows port is not slowly reversed.