### PR TITLE
Turns search for KaHiP on by default.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -224,7 +224,7 @@ else()
       CACHE BOOL "Is KaHIP REQUIRED?"
   )
 endif()
-option(DOLFINX_ENABLE_KAHIP "Compile with support for KaHIP." OFF)
+option(DOLFINX_ENABLE_KAHIP "Compile with support for KaHIP." ON)
 set_package_properties(
   KaHIP PROPERTIES
   TYPE OPTIONAL


### PR DESCRIPTION
This matches the behaviour of our other optional dependencies.
