### PR TITLE
Sparsity pattern insert

### DIFF
--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -143,16 +143,20 @@ SparsityPattern::SparsityPattern(
 void SparsityPattern::insert(std::int32_t row, std::int32_t col)
 {
   if (!_offsets.empty())
+  {
     throw std::runtime_error(
         "Cannot insert into sparsity pattern. It has already been finalized");
+  }
 
   assert(_index_maps[0]);
   const std::int32_t max_row
       = _index_maps[0]->size_local() + _index_maps[0]->num_ghosts() - 1;
 
   if (row > max_row or row < 0)
+  {
     throw std::runtime_error(
         "Cannot insert rows that do not exist in the IndexMap.");
+  }
 
   _row_cache[row].push_back(col);
 }
@@ -161,8 +165,10 @@ void SparsityPattern::insert(std::span<const std::int32_t> rows,
                              std::span<const std::int32_t> cols)
 {
   if (!_offsets.empty())
+  {
     throw std::runtime_error(
         "Cannot insert into sparsity pattern. It has already been finalized");
+  }
 
   assert(_index_maps[0]);
   const std::int32_t max_row
@@ -181,8 +187,10 @@ void SparsityPattern::insert(std::span<const std::int32_t> rows,
 void SparsityPattern::insert_diagonal(std::span<const std::int32_t> rows)
 {
   if (!_offsets.empty())
+  {
     throw std::runtime_error(
         "Cannot insert into sparsity pattern. It has already been finalized");
+  }
 
   assert(_index_maps[0]);
   const std::int32_t max_row

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -140,6 +140,23 @@ SparsityPattern::SparsityPattern(
   }
 }
 //-----------------------------------------------------------------------------
+void SparsityPattern::insert(std::int32_t row, std::int32_t col)
+{
+  if (!_offsets.empty())
+    throw std::runtime_error(
+        "Cannot insert into sparsity pattern. It has already been finalized");
+
+  assert(_index_maps[0]);
+  const std::int32_t max_row
+      = _index_maps[0]->size_local() + _index_maps[0]->num_ghosts() - 1;
+
+  if (row > max_row or row < 0)
+    throw std::runtime_error(
+        "Cannot insert rows that do not exist in the IndexMap.");
+
+  _row_cache[row].push_back(col);
+}
+//-----------------------------------------------------------------------------
 void SparsityPattern::insert(std::span<const std::int32_t> rows,
                              std::span<const std::int32_t> cols)
 {

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -177,9 +177,10 @@ void SparsityPattern::insert(std::span<const std::int32_t> rows,
   for (std::int32_t row : rows)
   {
     if (row > max_row or row < 0)
+    {
       throw std::runtime_error(
           "Cannot insert rows that do not exist in the IndexMap.");
-
+    }
     _row_cache[row].insert(_row_cache[row].end(), cols.begin(), cols.end());
   }
 }
@@ -199,8 +200,10 @@ void SparsityPattern::insert_diagonal(std::span<const std::int32_t> rows)
   for (std::int32_t row : rows)
   {
     if (row > max_row or row < 0)
+    {
       throw std::runtime_error(
           "Cannot insert rows that do not exist in the IndexMap.");
+    }
 
     _row_cache[row].push_back(row);
   }

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -161,10 +161,8 @@ void SparsityPattern::insert(std::span<const std::int32_t> rows,
                              std::span<const std::int32_t> cols)
 {
   if (!_offsets.empty())
-  {
     throw std::runtime_error(
         "Cannot insert into sparsity pattern. It has already been finalized");
-  }
 
   assert(_index_maps[0]);
   const std::int32_t max_row
@@ -173,10 +171,8 @@ void SparsityPattern::insert(std::span<const std::int32_t> rows,
   for (std::int32_t row : rows)
   {
     if (row > max_row or row < 0)
-    {
       throw std::runtime_error(
           "Cannot insert rows that do not exist in the IndexMap.");
-    }
 
     _row_cache[row].insert(_row_cache[row].end(), cols.begin(), cols.end());
   }
@@ -185,10 +181,8 @@ void SparsityPattern::insert(std::span<const std::int32_t> rows,
 void SparsityPattern::insert_diagonal(std::span<const std::int32_t> rows)
 {
   if (!_offsets.empty())
-  {
     throw std::runtime_error(
         "Cannot insert into sparsity pattern. It has already been finalized");
-  }
 
   assert(_index_maps[0]);
   const std::int32_t max_row
@@ -197,10 +191,8 @@ void SparsityPattern::insert_diagonal(std::span<const std::int32_t> rows)
   for (std::int32_t row : rows)
   {
     if (row > max_row or row < 0)
-    {
       throw std::runtime_error(
           "Cannot insert rows that do not exist in the IndexMap.");
-    }
 
     _row_cache[row].push_back(row);
   }

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -67,6 +67,10 @@ public:
 
   /// @brief Insert non-zero locations using local (process-wise)
   /// indices.
+  void insert(std::int32_t row, std::int32_t col);
+
+  /// @brief Insert non-zero locations using local (process-wise)
+  /// indices.
   void insert(std::span<const std::int32_t> rows,
               std::span<const std::int32_t> cols);
 

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -67,6 +67,8 @@ public:
 
   /// @brief Insert non-zero locations using local (process-wise)
   /// indices.
+  /// @param[in] row local row index
+  /// @param[in] col local column index
   void insert(std::int32_t row, std::int32_t col);
 
   /// @brief Insert non-zero locations using local (process-wise)
@@ -75,6 +77,9 @@ public:
   /// This routine inserts non-zero locations at the outer product of rows and
   /// cols into the sparsity pattern, i.e. adds the matrix entries at
   ///   A[row[i], col[j]] for all i, j.
+  ///
+  /// @param[in] rows list of the local row indices 
+  /// @param[in] cols list of the local column indices
   void insert(std::span<const std::int32_t> rows,
               std::span<const std::int32_t> cols);
 

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -72,14 +72,17 @@ public:
   /// @brief Insert non-zero locations using local (process-wise)
   /// indices.
   ///
-  /// This inserts for every row in rows the columns (listed in cols) to the
-  /// sparsity pattern. This allows for easy setting of dense sub-blocks, for
-  /// example sp.insert({0, 1, 2}, {1, 2, 3}) creates a 3x3 block in the
-  /// sparsity pattern with top left corner at (0, 1).
+  /// This routine inserts non-zero locations at the outer product of rows and
+  /// cols to the sparsity pattern, i.e. adds the matrix entries at
+  ///   A[row[i], col[j]] for all i, j
+  /// Enabling easy setting of dense sub-blocks, for example
+  ///   sp.insert({0, 1, 2}, {1, 2, 3})
+  /// creates a 3x3 block in the sparsity pattern with top left corner at (0,
+  /// 1).
   ///
   /// Note: Especially this operation does not perform a pairwise insertion to
-  /// the sparsity pattern, i.e. the above call does not introduce the entries
-  /// at locations (0, 1), (1, 2) and (2, 3)!
+  /// the sparsity pattern, i.e. the above call creates more then (9 in total)
+  /// entries and not only entries at the locations (0,1), (1,2) and (2,3)!
   void insert(std::span<const std::int32_t> rows,
               std::span<const std::int32_t> cols);
 

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -74,12 +74,7 @@ public:
   ///
   /// This routine inserts non-zero locations at the outer product of rows and
   /// cols into the sparsity pattern, i.e. adds the matrix entries at
-  ///   A[row[i], col[j]] for all i, j
-  /// Enabling easy setting of dense sub-blocks, for example
-  ///   sp.insert({0, 1, 2}, {1, 2, 3})
-  /// creates a 3x3 block in the sparsity pattern with top left corner at (0,
-  /// 1).
-  ///
+  ///   A[row[i], col[j]] for all i, j.
   void insert(std::span<const std::int32_t> rows,
               std::span<const std::int32_t> cols);
 

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -71,6 +71,15 @@ public:
 
   /// @brief Insert non-zero locations using local (process-wise)
   /// indices.
+  ///
+  /// This inserts for every row in rows the columns (listed in cols) to the
+  /// sparsity pattern. This allows for easy setting of dense sub-blocks, for
+  /// example sp.insert({0, 1, 2}, {1, 2, 3}) creates a 3x3 block in the
+  /// sparsity pattern with top left corner at (0, 1).
+  ///
+  /// Note: Especially this operation does not perform a pairwise insertion to
+  /// the sparsity pattern, i.e. the above call does not introduce the entries
+  /// at locations (0, 1), (1, 2) and (2, 3)!
   void insert(std::span<const std::int32_t> rows,
               std::span<const std::int32_t> cols);
 

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -73,7 +73,7 @@ public:
   /// indices.
   ///
   /// This routine inserts non-zero locations at the outer product of rows and
-  /// cols to the sparsity pattern, i.e. adds the matrix entries at
+  /// cols into the sparsity pattern, i.e. adds the matrix entries at
   ///   A[row[i], col[j]] for all i, j
   /// Enabling easy setting of dense sub-blocks, for example
   ///   sp.insert({0, 1, 2}, {1, 2, 3})

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -80,9 +80,6 @@ public:
   /// creates a 3x3 block in the sparsity pattern with top left corner at (0,
   /// 1).
   ///
-  /// Note: Especially this operation does not perform a pairwise insertion to
-  /// the sparsity pattern, i.e. the above call creates more then (9 in total)
-  /// entries and not only entries at the locations (0,1), (1,2) and (2,3)!
   void insert(std::span<const std::int32_t> rows,
               std::span<const std::int32_t> cols);
 

--- a/cpp/test/matrix.cpp
+++ b/cpp/test/matrix.cpp
@@ -201,9 +201,9 @@ void test_matrix()
 {
   auto map0 = std::make_shared<common::IndexMap>(MPI_COMM_SELF, 8);
   la::SparsityPattern p(MPI_COMM_SELF, {map0, map0}, {1, 1});
-  p.insert(std::vector{0}, std::vector{0});
-  p.insert(std::vector{4}, std::vector{5});
-  p.insert(std::vector{5}, std::vector{4});
+  p.insert(0, 0);
+  p.insert(4, 5);
+  p.insert(5, 4);
   p.finalize();
 
   using T = float;

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -8,6 +8,7 @@
 #include "caster_mpi.h"
 #include "numpy_dtype.h"
 #include <complex>
+#include <cstdint>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/la/MatrixCSR.h>
 #include <dolfinx/la/SparsityPattern.h>
@@ -265,6 +266,10 @@ void la(nb::module_& m)
                         std::span(cols.data(), cols.size()));
           },
           nb::arg("rows"), nb::arg("cols"))
+      .def("insert",
+           nb::overload_cast<int32_t, int32_t>(
+               &dolfinx::la::SparsityPattern::insert),
+           nb::arg("row"), nb::arg("col"))
       .def(
           "insert_diagonal",
           [](dolfinx::la::SparsityPattern& self,

--- a/python/test/unit/la/test_matrix_csr.py
+++ b/python/test/unit/la/test_matrix_csr.py
@@ -25,9 +25,9 @@ def create_test_sparsity(n, bs):
     if bs == 1:
         for i in range(2):
             for j in range(2):
-                sp.insert(np.array([2 + i]), np.array([4 + j]))
+                sp.insert(2 + i, 4 + j)
     elif bs == 2:
-        sp.insert(np.array([1]), np.array([2]))
+        sp.insert(1, 2)
     sp.finalize()
     return sp
 
@@ -126,10 +126,10 @@ def test_distributed_csr(dtype):
     sp = SparsityPattern(MPI.COMM_WORLD, [im, im], [1, 1])
     for i in range(n):
         for j in range(n + nghost):
-            sp.insert(np.array([i]), np.array([j]))
+            sp.insert(i, j)
     for i in range(n, n + nghost):
         for j in range(n, n + nghost):
-            sp.insert(np.array([i]), np.array([j]))
+            sp.insert(i, j)
     sp.finalize()
 
     mat = matrix_csr(sp, dtype=dtype)


### PR DESCRIPTION
Introduces a new sparsity pattern insert functionality for a single entry - which is the method of choice used in multiple locations of the code base.

Additionally the documentation of the `insert(span<>, span<>)` call on a  sparsity pattern  is extended to make clear how the inputs work together, and now hints that the interpretation of a pairwise operation is not correct to the caller.