### PR TITLE
Fix ubuntu CI

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -85,6 +85,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install catch2 cmake g++ libboost-dev libboost-timer-dev libhdf5-mpi-dev libparmetis-dev libpugixml-dev libspdlog-dev mpi-default-dev ninja-build pkg-config
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python3 -m pip install cffi numba scikit-build-core[pyproject] pytest pytest-xdist scipy matplotlib
+          python3 -m pip install cffi==1.16.0 numba scikit-build-core[pyproject] pytest pytest-xdist scipy matplotlib
       - name: Build Python interface (editable install)
         run: |
           python3 -m pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type=Debug --config-settings=build-dir="build" -e python/


### PR DESCRIPTION
Runs a prior `apt-get update` call before running the installs. This is also the recommended setup by github https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/customizing-github-hosted-runners.