### PR TITLE
General tidy and restrict cffi < 1.17 due to static condensation demo issue

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -187,14 +187,6 @@ jobs:
           cmake --build build
           cmake --install build
 
-      - name: Build C++ interface documentation
-        run: |
-          export DOLFINX_VERSION=`cmake -L build | grep DOXYGEN_DOLFINX_VERSION | cut -f2 -d "="`
-          echo $DOLFINX_VERSION
-          cd cpp/doc
-          doxygen Doxyfile
-          make html
-
       - name: Build C++ unit tests
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build/test/ -S cpp/test/
@@ -220,11 +212,7 @@ jobs:
 
       - name: Build Python interface
         run: |
-          pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" 'python/[test,docs]'
-      - name: Build Python interface documentation
-        run: |
-          cd python/doc
-          python -m sphinx -W -b html source/ build/html/
+          pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" 'python/[test]'
 
       - name: Set default DOLFINx JIT options
         run: |
@@ -243,9 +231,7 @@ jobs:
       - name: Run Python unit tests (MPI, np=3)
         run: mpirun -np 3 python -m pytest -m "petsc4py or adios2" python/test/unit/
 
-  publish-docs:
-    if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) }}
-    needs: build-with-petsc
+  build-and-publish-docs:
     runs-on: ubuntu-latest
     container: "ghcr.io/fenics/test-env:current-openmpi"
     env:
@@ -254,7 +240,7 @@ jobs:
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
       PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
-    name: Publish docs
+    name: Build and publish docs
     steps:
       - uses: actions/checkout@v4
 
@@ -277,6 +263,11 @@ jobs:
           cmake --build build
           cmake --install build
 
+      - name: Build Python interface
+        run: |
+          pip install -r python/build-requirements.txt
+          pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" 'python/[docs]'
+
       - name: Build C++ interface documentation
         run: |
           export DOLFINX_VERSION=`cmake -L build | grep DOXYGEN_DOLFINX_VERSION | cut -f2 -d "="`
@@ -284,26 +275,24 @@ jobs:
           cd cpp/doc
           doxygen Doxyfile
           make html
-
-      - name: Build Python interface
-        run: |
-          pip install -r python/build-requirements.txt
-          pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" 'python/[docs]'
       - name: Build Python interface documentation
         run: |
           cd python/doc
           python -m sphinx -W -b html source/ build/html/
 
       - name: Checkout FEniCS/docs
+        if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) }}
         uses: actions/checkout@v4
         with:
           repository: "FEniCS/docs"
           path: "docs"
           ssh-key: "${{ secrets.SSH_GITHUB_DOCS_PRIVATE_KEY }}"
       - name: Set version name
+        if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) }}
         run: |
           echo "VERSION_NAME=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Copy documentation into repository
+        if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) }}
         run: |
           cd docs
           git rm -r --ignore-unmatch dolfinx/${{ env.VERSION_NAME }}/cpp
@@ -315,6 +304,7 @@ jobs:
           cp -r ../cpp/doc/html/* dolfinx/${{ env.VERSION_NAME }}/cpp/doxygen
           cp -r ../python/doc/build/html/* dolfinx/${{ env.VERSION_NAME }}/python
       - name: Commit and push documentation to FEniCS/docs
+        if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) }}
         run: |
           cd docs
           git config --global user.email "fenics@github.com"

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -278,11 +278,13 @@ jobs:
       - name: Upload C++ Doxygen documentation artifact
         uses: actions/upload-artifact@v4
         with:
+          name: docs-cpp-doxygen
           path: cpp/doc/html 
           retention-days: 2 
       - name: Upload C++ Sphinx documentation artifact
         uses: actions/upload-artifact@v4
         with:
+          name: docs-cpp-sphinx
           path: cpp/doc/build/html 
           retention-days: 2 
       
@@ -293,6 +295,7 @@ jobs:
       - name: Upload Python documentation artifact
         uses: actions/upload-artifact@v4
         with:
+          name: docs-python
           path: python/doc/build/html 
           retention-days: 2 
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -96,7 +96,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install Python build dependencies
-        run: pip install --no-build-isolation --upgrade -r python/build-requirements.txt
+        run: |
+          pip install --upgrade pip setuptools wheel
+          pip install --no-build-isolation --upgrade -r python/build-requirements.txt
 
       - name: Install FEniCS Python components (default branches/tags)
         if: github.event_name != 'workflow_dispatch'

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -97,8 +97,7 @@ jobs:
 
       - name: Install Python build dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
-          pip install --no-build-isolation --upgrade -r python/build-requirements.txt
+          pip install --upgrade -r python/build-requirements.txt
 
       - name: Install FEniCS Python components (default branches/tags)
         if: github.event_name != 'workflow_dispatch'
@@ -216,12 +215,12 @@ jobs:
           ctest -V -R demo -R serial
           ctest -V -R demo -R mpi_2
 
-      - name: Install required Python (build Python interface)
-        run: pip install --no-build-isolation -r python/build-requirements.txt 
+      - name: Install Python build dependencies 
+        run: pip install -r python/build-requirements.txt 
 
       - name: Build Python interface
         run: |
-          pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" 'python/[test]'
+          pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" 'python/[test,docs]'
       - name: Build Python interface documentation
         run: |
           cd python/doc
@@ -288,7 +287,7 @@ jobs:
 
       - name: Build Python interface
         run: |
-          pip install -r --no-build-isolation python/build-requirements.txt
+          pip install -r python/build-requirements.txt
           pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" 'python/[docs]'
       - name: Build Python interface documentation
         run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           cd cpp
           clang-format --version
-          find . -type f \( -name "*.cpp" -o -name "*.h" \) ! -name "loguru.cpp" | xargs clang-format --dry-run --Werror
+          find . -type f \( -name "*.cpp" -o -name "*.h" \) | xargs clang-format --dry-run --Werror
       - name: clang-format Python binding checks (non-blocking)
         continue-on-error: true
         run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -276,13 +276,13 @@ jobs:
           doxygen Doxyfile
           make html
       - name: Upload C++ Doxygen documentation artifact
+        uses: actions/upload-artifact@v4
         with:
-          uses: actions/upload-artifact@v4
           path: cpp/doc/html 
           retention-days: 2 
       - name: Upload C++ Sphinx documentation artifact
+        uses: actions/upload-artifact@v4
         with:
-          uses: actions/upload-artifact@v4
           path: cpp/doc/build/html 
           retention-days: 2 
       
@@ -291,8 +291,8 @@ jobs:
           cd python/doc
           python -m sphinx -W -b html source/ build/html/
       - name: Upload Python documentation artifact
+        uses: actions/upload-artifact@v4
         with:
-          uses: actions/upload-artifact@v4
           path: python/doc/build/html 
           retention-days: 2 
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -93,7 +93,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Python build dependencies
-        run: pip install mpi4py nanobind scikit-build-core[pyproject] --upgrade
+        run: pip install --no-build-isolation --upgrade -r python/build-requirements.txt
 
       - name: Install FEniCS Python components (default branches/tags)
         if: github.event_name != 'workflow_dispatch'
@@ -129,12 +129,12 @@ jobs:
           mpirun -n 3 ctest -V --output-on-failure -R unittests
 
       - name: Build Python interface
-        run: pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" python/
+        run: pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" 'python/[test]'
 
-      - name: Install Python demo/test dependencies
-        run: pip install matplotlib pyamg pytest pytest-xdist scipy
       - name: Run demos (Python, serial)
-        run: python -m pytest -n auto -m serial --durations=10 python/demo/test.py
+        run: |
+          pip install pytest-xdist
+          python -m pytest -n auto -m serial --durations=10 python/demo/test.py
       - name: Run demos (Python, MPI (np=3))
         run: python -m pytest -m mpi --num-proc=3 python/demo/test.py
       - name: Run unit tests
@@ -164,9 +164,6 @@ jobs:
     name: Build and test (${{ matrix.petsc_arch }}, ${{ matrix.docker_image }})
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install required Python packages (docs)
-        run: pip install breathe jupytext matplotlib myst_parser sphinx sphinx_rtd_theme
 
       - name: Install FEniCS Python components (default branches/tags)
         if: github.event_name != 'workflow_dispatch'
@@ -217,11 +214,11 @@ jobs:
           ctest -V -R demo -R mpi_2
 
       - name: Install required Python (build Python interface)
-        run: pip install nanobind scikit-build-core[pyproject]
+        run: pip install --no-build-isolation -r python/build-requirements.txt 
 
       - name: Build Python interface
         run: |
-          pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" python/
+          pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" 'python/[test]'
       - name: Build Python interface documentation
         run: |
           cd python/doc
@@ -232,10 +229,10 @@ jobs:
           mkdir -p ~/.config/dolfinx
           echo '{ "cffi_extra_compile_args": ["-g0", "-O0" ] }' > ~/.config/dolfinx/dolfinx_jit_options.json
 
-      - name: Install Python demo/test dependencies
-        run: pip install numba pyamg pytest pytest-xdist scipy
       - name: Run demos (Python, serial)
-        run: python -m pytest -n auto -m serial --durations=10 python/demo/test.py
+        run: |
+          pip install pytest-xdist
+          python -m pytest -n auto -m serial --durations=10 python/demo/test.py
       - name: Run demos (Python, MPI (np=3))
         run: python -m pytest -m mpi --num-proc=3 python/demo/test.py
 
@@ -258,9 +255,6 @@ jobs:
     name: Publish docs
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install required Python packages (docs)
-        run: pip install breathe jupytext matplotlib myst_parser sphinx sphinx_rtd_theme
 
       - name: Install FEniCS Python components (default branches/tags)
         if: github.event_name != 'workflow_dispatch'
@@ -293,7 +287,7 @@ jobs:
         run: pip install nanobind scikit-build-core[pyproject]
 
       - name: Build Python interface
-        run: pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" python/
+        run: pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" 'python/[docs]'
       - name: Build Python interface documentation
         run: |
           cd python/doc

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -276,22 +276,25 @@ jobs:
           doxygen Doxyfile
           make html
       - name: Upload C++ Doxygen documentation artifact
-        uses: actions/upload-artifact@v4
-        path: cpp/doc/html 
-        retention-days: 2 
+        with:
+          uses: actions/upload-artifact@v4
+          path: cpp/doc/html 
+          retention-days: 2 
       - name: Upload C++ Sphinx documentation artifact
-        uses: actions/upload-artifact@v4
-        path: cpp/doc/build/html 
-        retention-days: 2 
+        with:
+          uses: actions/upload-artifact@v4
+          path: cpp/doc/build/html 
+          retention-days: 2 
       
       - name: Build Python interface documentation
         run: |
           cd python/doc
           python -m sphinx -W -b html source/ build/html/
       - name: Upload Python documentation artifact
-        uses: actions/upload-artifact@v4
-        path: python/doc/build/html 
-        retention-days: 2 
+        with:
+          uses: actions/upload-artifact@v4
+          path: python/doc/build/html 
+          retention-days: 2 
 
       - name: Checkout FEniCS/docs
         if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) }}

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -275,10 +275,23 @@ jobs:
           cd cpp/doc
           doxygen Doxyfile
           make html
+      - name: Upload C++ Doxygen documentation artifact
+        uses: actions/upload-artifact@v4
+        path: cpp/doc/html 
+        retention-days: 2 
+      - name: Upload C++ Sphinx documentation artifact
+        uses: actions/upload-artifact@v4
+        path: cpp/doc/build/html 
+        retention-days: 2 
+      
       - name: Build Python interface documentation
         run: |
           cd python/doc
           python -m sphinx -W -b html source/ build/html/
+      - name: Upload Python documentation artifact
+        uses: actions/upload-artifact@v4
+        path: python/doc/build/html 
+        retention-days: 2 
 
       - name: Checkout FEniCS/docs
         if: ${{ github.repository == 'FEniCS/dolfinx' && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') ) }}

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -33,6 +33,7 @@ jobs:
     name: Lint
     steps:
       - uses: actions/checkout@v4
+      
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -83,6 +84,8 @@ jobs:
 
     name: Build and test
     steps:
+      - uses: actions/checkout@v4
+      
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -107,8 +110,6 @@ jobs:
           pip install git+https://github.com/FEniCS/ufl.git@${{ github.event.inputs.ufl_ref }}
           pip install git+https://github.com/FEniCS/basix.git@${{ github.event.inputs.basix_ref }}
           pip install git+https://github.com/FEniCS/ffcx.git@${{ github.event.inputs.ffcx_ref }}
-
-      - uses: actions/checkout@v4
 
       - name: Configure and install C++
         run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -283,11 +283,10 @@ jobs:
           doxygen Doxyfile
           make html
 
-      - name: Install required Python (build Python interface)
-        run: pip install nanobind scikit-build-core[pyproject]
-
       - name: Build Python interface
-        run: pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" 'python/[docs]'
+        run: |
+          pip install -r --no-build-isolation python/build-requirements.txt
+          pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Debug" 'python/[docs]'
       - name: Build Python interface documentation
         run: |
           cd python/doc

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,8 +27,7 @@ jobs:
 
       - name: Install Python dependencies (petsc4py)
         run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --no-build-isolation mpi4py
+          python -m pip install mpi4py
           python -m pip install cython
 
       - name: Install minimal PETSc and petsc4py

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --no-build-isolation mpi4py
+          python -m pip install cython
 
       - name: Install minimal PETSc and petsc4py
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Python dependencies (petsc4py)
         run: |
           python -m pip install mpi4py
-          python -m pip install cython
+          python -m pip install cython setuptools wheel
 
       - name: Install minimal PETSc and petsc4py
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,10 +25,9 @@ jobs:
           brew install adios2 boost cmake hdf5-mpi make ninja open-mpi pkg-config pugixml spdlog # FEniCS
           brew install bison flex gfortran # PETSc
 
-      - name: Install Python dependencies
+      - name: Install Python dependencies (petsc4py)
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install cffi cppimport cython numba numpy pytest pytest-xdist scipy
           python -m pip install --no-build-isolation mpi4py
 
       - name: Install minimal PETSc and petsc4py
@@ -91,7 +90,7 @@ jobs:
         working-directory: dolfinx
         run: |
           python -m pip install -r python/build-requirements.txt
-          python -m pip install --check-build-dependencies --no-build-isolation python/
+          python -m pip install --check-build-dependencies --no-build-isolation 'python/[test]'
 
       - name: Basic test
         run: |
@@ -100,7 +99,10 @@ jobs:
 
       - name: Run Python unit tests (serial)
         working-directory: dolfinx
-        run: python3 -m pytest -n=auto --durations=50 python/test/unit/
+        run: |
+          python -m pip install pytest-xdist
+          python3 -m pytest -n=auto --durations=50 python/test/unit/
       - name: Run Python unit tests (MPI, np=3)
         working-directory: dolfinx
-        run: mpirun -np 3 python3 -m pytest python/test/unit/
+        run: |
+          mpirun -np 3 python3 -m pytest python/test/unit/

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install Python dependencies (petsc4py)
         run: |
-          python -m pip install mpi4py
+          python -m pip install mpi4py numpy
           python -m pip install cython setuptools wheel
 
       - name: Install minimal PETSc and petsc4py

--- a/.github/workflows/pyvista.yml
+++ b/.github/workflows/pyvista.yml
@@ -38,15 +38,15 @@ jobs:
 
       - name: Install FEniCS Python components
         run: |
-          python3 -m pip install git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install git+https://github.com/FEniCS/basix.git
-          python3 -m pip install git+https://github.com/FEniCS/ffcx.git
+          pip install git+https://github.com/FEniCS/ufl.git
+          pip install git+https://github.com/FEniCS/basix.git
+          pip install git+https://github.com/FEniCS/ffcx.git
           apt-get update
           apt-get install -y --no-install-recommends libgl1-mesa-dev xvfb  # pyvista
           apt-get install -y --no-install-recommends libqt5gui5t64 libgl1 # pyvistaqt
-          python3 -m pip install pyvista==${PYVISTA_VERSION}
-          python3 -m pip install pyqt5 pyvistaqt==${PYVISTA_QT_VERSION}
-          python3 -m pip install matplotlib ipython nanobind scikit-build-core[pyproject] pytest pytest-xdist scipy numba
+          pip install pyvista==${PYVISTA_VERSION}
+          pip install pyqt5 pyvistaqt==${PYVISTA_QT_VERSION}
+          pip install --no-build-isolation -r python/build-requirements.txt
 
       - name: Configure C++
         run: cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S cpp/
@@ -56,10 +56,12 @@ jobs:
           cmake --install build
 
       - name: Build Python interface
-        run: pip -v install --check-build-dependencies --config-settings=build-dir="build" --config-settings=cmake.build-type="Debug" --no-build-isolation python/
+        run: pip -v install --check-build-dependencies --config-settings=build-dir="build" --config-settings=cmake.build-type="Debug" --no-build-isolation 'python/[test]'
 
       - name: Run pyvista demos (Python, serial)
-        run: python3 -m pytest -v -n 2 -m serial --durations=10 python/demo/test.py
+        run: |
+          pip install pytest-xdist
+          python3 -m pytest -v -n 2 -m serial --durations=10 python/demo/test.py
 
       - name: Run pyvista demos (Python, MPI (np=2))
         run: python3 -m pytest -v -m mpi --num-proc=2 python/demo/test.py

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -24,13 +24,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Python dependencies
+      - name: Install Python build dependencies
         run: |
-          python3 -m pip install mpi4py nanobind scikit-build-core[pyproject] --upgrade
+          python3 -m pip install --no-cache-dir --upgrade pip setuptools
 
       - name: Install FEniCS Python components
         run: |
-          python3 -m pip install --no-cache-dir --upgrade pip setuptools
           python3 -m pip install git+https://github.com/FEniCS/ufl.git
           python3 -m pip install git+https://github.com/FEniCS/basix.git
           python3 -m pip install git+https://github.com/FEniCS/ffcx.git
@@ -64,9 +63,9 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python3 -m pip install cffi==1.16.0 numba scikit-build-core[pyproject] pytest pytest-xdist scipy matplotlib
       - name: Build Python interface (editable install)
         run: |
+          python3 -m pip install --upgrade -r python/build-requirements.txt
           python3 -m pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type=Debug --config-settings=build-dir="build" -e python/
 
       - name: Set default DOLFINx JIT options

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install Python build dependencies
         run: |
-          python3 -m pip install --no-cache-dir --upgrade pip setuptools
+          python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel
 
       - name: Install FEniCS Python components
         run: |
@@ -74,7 +74,9 @@ jobs:
           echo '{ "cffi_extra_compile_args": ["-g0", "-O0" ] }' > ~/.config/dolfinx/dolfinx_jit_options.json
 
       - name: Run demos (Python, serial)
-        run: python3 -m pytest -n auto -m serial --durations=10 python/demo/test.py
+        run: |
+          python3 -m pip install pytest-xdist
+          python3 -m pytest -n auto -m serial --durations=10 python/demo/test.py
       - name: Run demos (Python, MPI (np=2))
         run: python3 -m pytest -m mpi --num-proc=2 python/demo/test.py
 

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -66,15 +66,12 @@ jobs:
       - name: Build Python interface (editable install)
         run: |
           python3 -m pip install --upgrade -r python/build-requirements.txt
-          python3 -m pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type=Debug --config-settings=build-dir="build" -e python/
+          python3 -m pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type=Debug --config-settings=build-dir="build" -e 'python/[test]'
 
       - name: Set default DOLFINx JIT options
         run: |
           mkdir -p ~/.config/dolfinx
           echo '{ "cffi_extra_compile_args": ["-g0", "-O0" ] }' > ~/.config/dolfinx/dolfinx_jit_options.json
-
-      - name: Install test Python dependencies
-        run: python3 -m pip install matplotlib numba pytest pytest-xdist scipy
 
       - name: Run demos (Python, serial)
         run: python3 -m pytest -n auto -m serial --durations=10 python/demo/test.py

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -58,9 +58,9 @@ jobs:
           echo "$HOME/.sonar/build-wrapper-linux-x86" >> $GITHUB_PATH
       - name: Install FEniCS Python components
         run: |
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/basix.git
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ffcx.git
+          python3 -m pip install git+https://github.com/FEniCS/ufl.git
+          python3 -m pip install git+https://github.com/FEniCS/basix.git
+          python3 -m pip install git+https://github.com/FEniCS/ffcx.git
       - name: Run build-wrapper
         run: |
           mkdir build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install build dependencies (workaround)
         run: |
           python -m pip install git+https://github.com/jhale/nanobind.git@jhale/msvc2022-workaround
-          python -m pip install scikit-build-core[pyproject]
+          python -m pip install scikit-build-core[pyproject] setuptools wheel
       - name: Install Basix (Python)
         working-directory: basix
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,12 +60,13 @@ jobs:
 
       - name: Install build dependencies (workaround)
         run: |
-          python -m pip install scikit-build-core[pyproject] git+https://github.com/jhale/nanobind.git@jhale/msvc2022-workaround setuptools wheel
+          python -m pip install git+https://github.com/jhale/nanobind.git@jhale/msvc2022-workaround
+          python -m pip install scikit-build-core[pyproject]
       - name: Install Basix (Python)
         working-directory: basix
         run: |
           cd python
-          python -m pip -v install --no-build-isolation --no-cache-dir .[ci] --config-settings=cmake.args=-DBasix_DIR=D:/a/basix/install/lib/cmake/basix
+          python -m pip -v install --check-build-dependencies --no-build-isolation --no-cache-dir .[ci] --config-settings=cmake.args=-DBasix_DIR=D:/a/basix/install/lib/cmake/basix
           cd ../
 
       - name: Checkout FFCx

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -140,6 +140,7 @@ jobs:
       - name: Run units tests (Python, serial)
         working-directory: dolfinx
         run: |
+          pip install pytest-xdist
           python -m pytest -n auto -m "not petsc4py and not adios2" python/test/unit
       - name: Run units tests (Python, MPI, np=3)
         working-directory: dolfinx
@@ -149,7 +150,6 @@ jobs:
       - name: Run Python demos (serial)
         working-directory: dolfinx
         run: |
-          pip install pyamg matplotlib numba scipy # TO REMOVE
           cd python/demo
           python3 -m pytest -n auto -m serial --durations=10 test.py
       - name: Run Python demos (MPI, np=3)

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -148,8 +148,8 @@ ENV PATH /dolfinx-env/bin:$PATH
 RUN python3 -m venv ${VIRTUAL_ENV}
 
 # Install Python packages (via pip)
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir cffi numpy==${NUMPY_VERSION} setuptools wheel && \
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    pip install --no-cache-dir numpy==${NUMPY_VERSION} && \
     pip install --no-cache-dir --no-build-isolation mpi4py
 
 # Install KaHIP
@@ -316,9 +316,9 @@ RUN apt-get -qq update && \
     make PETSC_ARCH=linux-gnu-complex128-64 ${MAKEFLAGS} all && \
     # Install petsc4py
     cd src/binding/petsc4py && \
-    pip install --no-cache-dir cython wheel && \
+    pip install --no-cache-dir cython && \
     PETSC_ARCH=linux-gnu-real32-32:linux-gnu-complex64-32:linux-gnu-real64-32:linux-gnu-complex128-32:linux-gnu-real64-64:linux-gnu-complex128-64 pip -v install --no-cache-dir --no-build-isolation . && \
-    # pip3 uninstall --yes cython wheel && \
+    pip3 uninstall --yes cython && \
     # Cleanup
     apt-get -y purge bison flex && \
     apt-get -y autoremove && \
@@ -359,9 +359,9 @@ RUN git clone --depth=1 -b v${SLEPC_VERSION} https://gitlab.com/slepc/slepc.git 
     make && \
     # Install slepc4py
     cd src/binding/slepc4py && \
-    # pip3 install --break-system-packages --no-cache-dir cython wheel && \
+    pip3 install --no-cache-dir cython && \
     PETSC_ARCH=linux-gnu-real32-32:linux-gnu-complex64-32:linux-gnu-real64-32:linux-gnu-complex128-32:linux-gnu-real64-64:linux-gnu-complex128-64 pip -v install --no-cache-dir --no-build-isolation . && \
-    # pip3 uninstall --yes cython wheel && \
+    pip3 uninstall --yes cython && \
     rm -rf ${SLEPC_DIR}/CTAGS ${SLEPC_DIR}/TAGS ${SLEPC_DIR}/docs ${SLEPC_DIR}/src/ ${SLEPC_DIR}/**/obj/ ${SLEPC_DIR}/**/test/ && \
     rm -rf /tmp/*
 

--- a/python/dolfinx/utils.py
+++ b/python/dolfinx/utils.py
@@ -170,15 +170,16 @@ class ctypes_utils:
 
 
 class cffi_utils:
-    """Utility attributes for working with CFFI (ABI mode) and PETSc.
+    """Utility attributes for working with CFFI (ABI mode) and Numba.
 
-    These attributes are convenience functions for calling PETSc C
+    This will register Numba complex types with CFFI.
+
+    If PETSc is available CFFI convenience functions for calling PETSc C
     functions, typically from within Numba functions.
 
     Note:
         `CFFI <https://cffi.readthedocs.io/>`_ and  `Numba
-        <https://numba.pydata.org/>`_ must be available to use these
-        utilities.
+        <https://numba.pydata.org/>`_ must be available to use these utilities.
 
     Examples:
         A typical use of these utility functions is::
@@ -188,23 +189,30 @@ class cffi_utils:
             def set_vals(A: int,
                          m: int, rows: npt.NDArray[PETSc.IntType],
                          n: int, cols: npt.NDArray[PETSc.IntType],
-                         data: npt.NDArray[PETSc.ScalarTYpe], mode: int):
+                         data: npt.NDArray[PETSc.ScalarType], mode: int):
                 MatSetValuesLocal(A, m, ffi.from_buffer(rows), n, ffi.from_buffer(cols),
                                 ffi.from_buffer(rows(data), mode)
     """
 
+    # Register numba complex types with cffi
     try:
-        from petsc4py import PETSc as _PETSc
-
         import cffi as _cffi
         import numba as _numba
         import numba.core.typing.cffi_utils as _cffi_support
 
-        # Register complex types
         _ffi = _cffi.FFI()
         _cffi_support.register_type(_ffi.typeof("float _Complex"), _numba.types.complex64)
         _cffi_support.register_type(_ffi.typeof("double _Complex"), _numba.types.complex128)
+    except (ImportError, KeyError):
+        pass
 
+    # Define CFFI ABI functions for PETSc calls.
+    try:
+        from petsc4py import PETSc as _PETSc
+
+        import cffi as _cffi
+
+        _ffi = _cffi.FFI()
         _lib_cffi = _ffi.dlopen(str(get_petsc_lib()))
 
         _CTYPES = {
@@ -216,6 +224,7 @@ class cffi_utils:
             np.complex128: "double _Complex",
             np.longlong: "long long",
         }
+
         _c_int_t = _CTYPES[_PETSc.IntType]  # type: ignore
         _c_scalar_t = _CTYPES[_PETSc.ScalarType]  # type: ignore
         _ffi.cdef(

--- a/python/dolfinx/utils.py
+++ b/python/dolfinx/utils.py
@@ -172,10 +172,11 @@ class ctypes_utils:
 class cffi_utils:
     """Utility attributes for working with CFFI (ABI mode) and Numba.
 
-    This will register Numba complex types with CFFI.
+    Registers Numba's complex types with CFFI.
 
-    If PETSc is available CFFI convenience functions for calling PETSc C
-    functions, typically from within Numba functions.
+    If PETSc is available, CFFI convenience functions for calling PETSc C
+    functions are also created. These are typically called from within Numba
+    functions.
 
     Note:
         `CFFI <https://cffi.readthedocs.io/>`_ and  `Numba

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,7 +25,7 @@ authors = [
 ]
 dependencies = [
       "numpy>=1.21",
-      "cffi<1.17",
+      "cffi",
       "mpi4py",
       "fenics-basix>=0.9.0.dev0,<0.10.0",
       "fenics-ffcx>=0.9.0.dev0,<0.10.0",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,7 +25,7 @@ authors = [
 ]
 dependencies = [
       "numpy>=1.21",
-      "cffi",
+      "cffi<1.17",
       "mpi4py",
       "fenics-basix>=0.9.0.dev0,<0.10.0",
       "fenics-ffcx>=0.9.0.dev0,<0.10.0",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,7 +37,7 @@ docs = ["breathe", "jupytext", "markdown", "matplotlib", "myst_parser", "pyyaml"
 lint = ["ruff>=0.2.0"]
 optional = ["numba", "pyamg"]
 petsc4py = ["petsc4py"]
-test = ["cffi", "pytest", "scipy", "matplotlib", "fenics-dolfinx[optional]"]
+test = ["pytest", "scipy", "matplotlib", "fenics-dolfinx[optional]"]
 ci = [
       "mypy",
       "pytest-xdist",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,7 +37,7 @@ docs = ["breathe", "jupytext", "markdown", "matplotlib", "myst_parser", "pyyaml"
 lint = ["ruff>=0.2.0"]
 optional = ["numba", "pyamg"]
 petsc4py = ["petsc4py"]
-test = ["pytest", "scipy", "matplotlib", "fenics-dolfinx[optional]"]
+test = ["cffi", "pytest", "scipy", "matplotlib", "fenics-dolfinx[optional]"]
 ci = [
       "mypy",
       "pytest-xdist",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -33,9 +33,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-docs = ["markdown", "pyyaml", "sphinx", "sphinx_rtd_theme"]
+docs = ["breathe", "jupytext", "markdown", "matplotlib", "myst_parser", "pyyaml", "sphinx", "sphinx_rtd_theme"]
 lint = ["ruff>=0.2.0"]
-optional = ["numba"]
+optional = ["numba", "pyamg"]
 petsc4py = ["petsc4py"]
 test = ["pytest", "scipy", "matplotlib", "fenics-dolfinx[optional]"]
 ci = [


### PR DESCRIPTION
Not totally clear why but there is an issue with the static condensation demo, numba and a new version of cffi. @michalhabera you can reproduce this by branching and removing the `cffi<1.17` restriction from `pyproject.toml`.

This PR also tidies up all of the CI pipelines; I would like to ask again, please do not put `pip install x y z` into pipelines. Please use the optional dependencies feature within `pyproject.toml`.

I have also split apart cffi registering Numba's complex types and creating cffi PETSc wrappers - you can now use cffi with numba complex numbers without having PETSc installed. This was causing a test failure.