### PR TITLE
Fix refine constructor (currently overwriting ufl_cargo)

### DIFF
--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -331,7 +331,8 @@ def refine(
         mesh1 = _cpp.refinement.refine(mesh._cpp_object, redistribute)
     else:
         mesh1 = _cpp.refinement.refine(mesh._cpp_object, edges, redistribute)
-    return Mesh(mesh1, ufl.Mesh(mesh._ufl_domain.ufl_coordinate_element()))
+    ufl_domain = ufl.Mesh(mesh._ufl_domain.ufl_coordinate_element())  # type: ignore
+    return Mesh(mesh1, ufl_domain)
 
 
 def refine_interval(

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -330,8 +330,8 @@ def refine(
     if edges is None:
         mesh1 = _cpp.refinement.refine(mesh._cpp_object, redistribute)
     else:
-        mesh1 = _cpp.refinement.refine(mesh._cpp_object, edges, redistribute)
-    return Mesh(mesh1, mesh._ufl_domain)
+        mesh1 = _cpp.refinement.refine(mesh._cpp_object, edges, redistribute)    
+    return Mesh(mesh1, ufl.Mesh(mesh._ufl_domain.ufl_coordinate_element()))
 
 
 def refine_interval(

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -330,7 +330,7 @@ def refine(
     if edges is None:
         mesh1 = _cpp.refinement.refine(mesh._cpp_object, redistribute)
     else:
-        mesh1 = _cpp.refinement.refine(mesh._cpp_object, edges, redistribute)    
+        mesh1 = _cpp.refinement.refine(mesh._cpp_object, edges, redistribute)
     return Mesh(mesh1, ufl.Mesh(mesh._ufl_domain.ufl_coordinate_element()))
 
 


### PR DESCRIPTION
Create new ufl mesh as ufl mesh carries ufl_cargo which references the e latest mesh added through the mesh constructor.

This might be relevant for you as well @schnellerhase.