### PR TITLE
Fix DofMap::collapse() on rank with no dofs

### DIFF
--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -78,7 +78,8 @@ fem::DofMap build_collapsed_dofmap(const DofMap& dofmap_view,
   }
 
   // Create a map from old dofs to new dofs
-  std::vector<std::int32_t> old_to_new(dofs_view.back() + bs_view, -1);
+  std::size_t array_size = dofs_view.empty() ? 0 : dofs_view.back() + bs_view;
+  std::vector<std::int32_t> old_to_new(array_size, -1);
   for (std::size_t new_idx = 0; new_idx < sub_imap_to_imap.size(); ++new_idx)
   {
     for (int k = 0; k < bs_view; ++k)
@@ -215,7 +216,6 @@ std::pair<DofMap, std::vector<std::int32_t>> DofMap::collapse(
     reorder_fn = [](const graph::AdjacencyList<std::int32_t>& g)
     { return graph::reorder_gps(g); };
   }
-
   // Create new dofmap
   auto create_subdofmap = [](MPI_Comm comm, auto index_map_bs, auto& layout,
                              auto& topology, auto& reorder_fn, auto& dmap)
@@ -227,7 +227,6 @@ std::pair<DofMap, std::vector<std::int32_t>> DofMap::collapse(
 
       // Create new element dof layout and reset parent
       ElementDofLayout collapsed_dof_layout = layout.copy();
-
       auto [_index_map, bs, dofmaps] = build_dofmap_data(
           comm, topology, {collapsed_dof_layout}, reorder_fn);
       auto index_map


### PR DESCRIPTION
Currently, collapsing a dofmap with no dofs on the process segfaults due to unsafe access of `dofs_view.back()`, as it might be empty.

This is unlikely to happen to "standard" meshes, but very likely to happen for sub-meshes.

Thanks to @RemDelaporteMathurin for providing me with a segfaulting code that I could distill down.