### PR TITLE
Enforce linting in CI for C++ and CMake files

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -38,18 +38,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
       - name: Install linting tools
         run: pip install clang-format cmake-format[YAML] mypy ruff
-      - name: ruff .py files in C++ code
-        run: |
-          cd cpp/
-          ruff check .
-          ruff format --check .
-      - name: ruff Python interface checks
-        run: |
-          cd python/
-          ruff check .
-          ruff format --check .
+
+      - name: Run ruff
+        run: ruff check python/ cpp/
+
       - name: mypy checks
         run: |
           cd python/

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -53,14 +53,10 @@ jobs:
           mypy test
 
       - name: Run clang-format
-        run: |
-          clang-format --version
-          find cpp/ python/dolfinx/wrappers/ -type f \( -name "*.cpp" -o -name "*.h" \) | xargs clang-format --dry-run --Werror
+        run: find cpp/ python/dolfinx/wrappers/ -type f \( -name "*.cpp" -o -name "*.h" \) | xargs clang-format --dry-run --Werror
 
-      - name: cmake-format (non-blocking)
-        continue-on-error: true
-        run: |
-          find . -type f \( -name "*.cmake" -o -name "*.cmake.in" -o -name "CMakeLists.txt" \) | xargs cmake-format --check
+      - name: Run cmake-format
+        run: find . -type f \( -name "*.cmake" -o -name "*.cmake.in" -o -name "CMakeLists.txt" \) | xargs cmake-format --check
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -52,17 +52,10 @@ jobs:
           mypy demo
           mypy test
 
-      - name: clang-format cpp/
-        working-directory: cpp
+      - name: Run clang-format
         run: |
           clang-format --version
-          find . -type f \( -name "*.cpp" -o -name "*.h" \) | xargs clang-format --dry-run --Werror
-
-      - name: clang-format Python bindings
-        working-directory: python/dolfinx/wrappers
-        run: |
-          clang-format --version
-          find . -type f \( -name "*.cpp" -o -name "*.h" \) | xargs clang-format --dry-run --Werror
+          find cpp/ python/dolfinx/wrappers/ -type f \( -name "*.cpp" -o -name "*.h" \) | xargs clang-format --dry-run --Werror
 
       - name: cmake-format (non-blocking)
         continue-on-error: true

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -50,11 +50,11 @@ jobs:
         run: mypy dolfinx/ demo/ test/
 
       - name: clang-format C++ checks (non-blocking)
-        continue-on-error: true
+        working-directory: cpp
         run: |
-          cd cpp
           clang-format --version
           find . -type f \( -name "*.cpp" -o -name "*.h" \) | xargs clang-format --dry-run --Werror
+
       - name: clang-format Python binding checks (non-blocking)
         continue-on-error: true
         run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -47,7 +47,10 @@ jobs:
 
       - name: Run mypy
         working-directory: python/
-        run: mypy dolfinx/ demo/ test/
+        run: |
+          mypy dolfinx
+          mypy demo
+          mypy test
 
       - name: clang-format C++ checks (non-blocking)
         working-directory: cpp

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -45,12 +45,10 @@ jobs:
       - name: Run ruff
         run: ruff check python/ cpp/
 
-      - name: mypy checks
-        run: |
-          cd python/
-          mypy dolfinx
-          mypy demo
-          mypy test
+      - name: Run mypy
+        working-directory: python/
+        run: mypy dolfinx/ demo/ test/
+
       - name: clang-format C++ checks (non-blocking)
         continue-on-error: true
         run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -52,18 +52,18 @@ jobs:
           mypy demo
           mypy test
 
-      - name: clang-format C++ checks (non-blocking)
+      - name: clang-format cpp/
         working-directory: cpp
         run: |
           clang-format --version
           find . -type f \( -name "*.cpp" -o -name "*.h" \) | xargs clang-format --dry-run --Werror
 
-      - name: clang-format Python binding checks (non-blocking)
-        continue-on-error: true
+      - name: clang-format Python bindings
+        working-directory: python/dolfinx/wrappers
         run: |
-          cd python/dolfinx/wrappers
           clang-format --version
           find . -type f \( -name "*.cpp" -o -name "*.h" \) | xargs clang-format --dry-run --Werror
+
       - name: cmake-format (non-blocking)
         continue-on-error: true
         run: |

--- a/cpp/.vcpkg-overlay/intel-mpi/portfile.cmake
+++ b/cpp/.vcpkg-overlay/intel-mpi/portfile.cmake
@@ -69,9 +69,8 @@ file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/mpi-wrapper.cmake"
 )
 
 # Handle copyright
-file(
-  COPY "${SDK_SOURCE_DIR}/licensing/2024.1/licensing/2024.1/license.htm"
-  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+file(COPY "${SDK_SOURCE_DIR}/licensing/2024.1/licensing/2024.1/license.htm"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
 )
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright"
      "See the licence.htm file in this directory."

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 if(POLICY CMP0167)
-  cmake_policy(SET CMP0167 NEW)  # Boost CONFIG mode
+  cmake_policy(SET CMP0167 NEW) # Boost CONFIG mode
 endif()
 
 # ------------------------------------------------------------------------------
@@ -285,9 +285,11 @@ endif()
 # library
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
    AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "11.4"
-   AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14.0")
+   AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14.0"
+)
   list(APPEND DOLFINX_CXX_DEVELOPER_FLAGS
-       -Wno-array-bounds;-Wno-stringop-overflow)
+       -Wno-array-bounds;-Wno-stringop-overflow
+  )
 endif()
 
 # ------------------------------------------------------------------------------

--- a/cpp/cmake/modules/FindSCOTCH.cmake
+++ b/cpp/cmake/modules/FindSCOTCH.cmake
@@ -386,7 +386,12 @@ find_package_handle_standard_args(
 
 if(SCOTCH_FOUND AND NOT TARGET SCOTCH::ptscotch)
   add_library(SCOTCH::ptscotch INTERFACE IMPORTED)
-  set_property(TARGET SCOTCH::ptscotch PROPERTY INTERFACE_LINK_LIBRARIES "${SCOTCH_LIBRARIES}")
-  set_property(TARGET SCOTCH::ptscotch PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${SCOTCH_INCLUDE_DIRS}")
+  set_property(
+    TARGET SCOTCH::ptscotch PROPERTY INTERFACE_LINK_LIBRARIES
+                                     "${SCOTCH_LIBRARIES}"
+  )
+  set_property(
+    TARGET SCOTCH::ptscotch PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                                     "${SCOTCH_INCLUDE_DIRS}"
+  )
 endif()
-

--- a/cpp/cmake/modules/FindUFCx.cmake
+++ b/cpp/cmake/modules/FindUFCx.cmake
@@ -42,10 +42,7 @@ find_package(
   REQUIRED
 )
 
-message(
-  STATUS
-    "Asking Python module FFCx for location of ufcx.h..."
-)
+message(STATUS "Asking Python module FFCx for location of ufcx.h...")
 
 # Get include path
 execute_process(

--- a/cpp/demo/biharmonic/CMakeLists.txt
+++ b/cpp/demo/biharmonic/CMakeLists.txt
@@ -45,7 +45,9 @@ add_custom_command(
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-add_executable(${PROJECT_NAME} main.cpp ${CMAKE_CURRENT_BINARY_DIR}/biharmonic.c)
+add_executable(
+  ${PROJECT_NAME} main.cpp ${CMAKE_CURRENT_BINARY_DIR}/biharmonic.c
+)
 target_link_libraries(${PROJECT_NAME} dolfinx)
 
 # Do not throw error for 'multi-line comments' (these are typical in rst which

--- a/cpp/demo/hyperelasticity/CMakeLists.txt
+++ b/cpp/demo/hyperelasticity/CMakeLists.txt
@@ -40,7 +40,9 @@ else()
 
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-  add_executable(${PROJECT_NAME} main.cpp ${CMAKE_CURRENT_BINARY_DIR}/hyperelasticity.c)
+  add_executable(
+    ${PROJECT_NAME} main.cpp ${CMAKE_CURRENT_BINARY_DIR}/hyperelasticity.c
+  )
   target_link_libraries(${PROJECT_NAME} dolfinx)
 
   # Do not throw error for 'multi-line comments' (these are typical in rst which

--- a/cpp/demo/mixed_topology/main.cpp
+++ b/cpp/demo/mixed_topology/main.cpp
@@ -120,7 +120,7 @@ int main(int argc, char* argv[])
       std::cout << i << " [";
       for (auto q : topo_cells->links(i))
         std::cout << q << " ";
-      std::cout << "]" << std::endl;;
+      std::cout << "]" << std::endl;
     }
 
     topo->create_connectivity(1, 0);

--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -276,8 +276,8 @@ foreach(_target ${PKGCONFIG_DOLFINX_TARGET_LINK_LIBRARIES})
       list(APPEND PKGCONFIG_DOLFINX_LIBS ${_target})
     endif()
 
-    # Special handling to extract data for compiled Boost imported
-    # targets to use in generate pkg-config file
+    # Special handling to extract data for compiled Boost imported targets to
+    # use in generate pkg-config file
     if(("${_target}" MATCHES "^.*Boost::.*$") AND NOT "${_target}" STREQUAL
                                                   "Boost::headers"
     )

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -637,7 +637,7 @@ MatrixCSR<U, V, W, X>::to_dense() const
       for (int i0 = 0; i0 < _bs[0]; ++i0)
         for (int i1 = 0; i1 < _bs[1]; ++i1)
         {
-          std::array<std::int32_t, 1> local_col {_cols[j]};
+          std::array<std::int32_t, 1> local_col{_cols[j]};
           std::array<std::int64_t, 1> global_col{0};
           _index_maps[1]->local_to_global(local_col, global_col);
           A[(r * _bs[1] + i0) * ncols * _bs[0] + global_col[0] * _bs[1] + i1]

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -78,7 +78,7 @@ public:
   /// cols into the sparsity pattern, i.e. adds the matrix entries at
   ///   A[row[i], col[j]] for all i, j.
   ///
-  /// @param[in] rows list of the local row indices 
+  /// @param[in] rows list of the local row indices
   /// @param[in] cols list of the local column indices
   void insert(std::span<const std::int32_t> rows,
               std::span<const std::int32_t> cols);

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -205,7 +205,8 @@ Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<double, 2>, 2> p,
 /// across MPI ranks.
 /// @return A mesh.
 template <std::floating_point T = double>
-Mesh<T> create_interval(MPI_Comm comm, std::int64_t n, std::array<double, 2> p, mesh::GhostMode ghost_mode = mesh::GhostMode::none,
+Mesh<T> create_interval(MPI_Comm comm, std::int64_t n, std::array<double, 2> p,
+                        mesh::GhostMode ghost_mode = mesh::GhostMode::none,
                         CellPartitionFunction partitioner = nullptr)
 {
   if (!partitioner and dolfinx::MPI::size(comm) > 1)

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -1256,8 +1256,7 @@ create_subgeometry(const Mesh<T>& mesh, int dim,
   std::vector<std::int64_t> sub_igi;
   sub_igi.reserve(subx_to_x_dofmap.size());
   std::ranges::transform(subx_to_x_dofmap, std::back_inserter(sub_igi),
-                         [&igi](auto sub_x_dof)
-                         { return igi[sub_x_dof]; });
+                         [&igi](auto sub_x_dof) { return igi[sub_x_dof]; });
 
   // Create geometry
   return {Geometry(sub_x_dof_index_map, std::move(sub_x_dofmap), {sub_cmap},

--- a/cpp/dolfinx/refinement/CMakeLists.txt
+++ b/cpp/dolfinx/refinement/CMakeLists.txt
@@ -1,9 +1,7 @@
 set(HEADERS_refinement
     ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_refinement.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/interval.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/plaza.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/refine.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/interval.h ${CMAKE_CURRENT_SOURCE_DIR}/plaza.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/refine.h ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
     PARENT_SCOPE
 )
 

--- a/cpp/dolfinx/refinement/dolfinx_refinement.h
+++ b/cpp/dolfinx/refinement/dolfinx_refinement.h
@@ -10,5 +10,5 @@ namespace dolfinx::refinement
 
 // DOLFINx refinement interface
 
-#include <dolfinx/refinement/refine.h>
 #include <dolfinx/refinement/interval.h>
+#include <dolfinx/refinement/refine.h>

--- a/cpp/dolfinx/refinement/interval.h
+++ b/cpp/dolfinx/refinement/interval.h
@@ -121,8 +121,8 @@ compute_interval_refinement(const mesh::Mesh<T>& mesh,
       = adjust_indices(*mesh.topology()->index_map(0), number_of_refined_cells);
 
   // Build the topology on the new vertices
-  const auto refined_cell_count = mesh.topology()->index_map(1)->size_local()
-                                  + number_of_refined_cells;
+  const auto refined_cell_count
+      = mesh.topology()->index_map(1)->size_local() + number_of_refined_cells;
 
   std::vector<std::int64_t> cell_topology;
   cell_topology.reserve(refined_cell_count * 2);

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -18,13 +18,12 @@
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
 
-#include <dolfinx/common/defines.h>
-#include <dolfinx/common/defines.h>
 #include <dolfinx/common/IndexMap.h>
-#include <dolfinx/common/log.h>
 #include <dolfinx/common/Scatterer.h>
 #include <dolfinx/common/Table.h>
 #include <dolfinx/common/Timer.h>
+#include <dolfinx/common/defines.h>
+#include <dolfinx/common/log.h>
 #include <dolfinx/common/timing.h>
 #include <dolfinx/common/utils.h>
 

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -138,7 +138,7 @@ void declare_objects(nb::module_& m, const std::string& type)
              std::size_t nrows = self.num_all_rows() * bs[0];
              std::size_t ncols = self.index_map(1)->size_global() * bs[1];
              auto dense = self.to_dense();
-             assert(nrows*ncols == dense.size());
+             assert(nrows * ncols == dense.size());
              return dolfinx_wrappers::as_nbarray(std::move(self.to_dense()),
                                                  {nrows, ncols});
            })

--- a/python/dolfinx/wrappers/refinement.cpp
+++ b/python/dolfinx/wrappers/refinement.cpp
@@ -47,8 +47,9 @@ void export_refinement_with_variable_mesh_type(nb::module_& m)
       [](const dolfinx::mesh::Mesh<T>& mesh, bool redistribute,
          dolfinx::mesh::GhostMode ghost_mode)
       {
-        auto [mesh_refined, parent_cells] = dolfinx::refinement::refine_interval(
-            mesh, std::nullopt, redistribute, ghost_mode);
+        auto [mesh_refined, parent_cells]
+            = dolfinx::refinement::refine_interval(mesh, std::nullopt,
+                                                   redistribute, ghost_mode);
         return std::tuple(std::move(mesh_refined),
                           as_nbarray(std::move(parent_cells)));
       },


### PR DESCRIPTION
Changes to CI:
- `ruff` combined to a single call
- `clang-format` combined to a single call and no longer allowed to fail
- `cmake-format` no longer allowed to fail

Additionally this contains the necessary format changes that were previously missed due to allowed failure.