### PR TITLE
Windows CI on dispatch only

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,17 +1,17 @@
 name: Windows build
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "v*"
-  pull_request:
-    branches:
-      - main
-  merge_group:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
+  #   tags:
+  #     - "v*"
+  # pull_request:
+  #   branches:
+  #     - main
+  # merge_group:
+  #   branches:
+  #     - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Windows CI is failing at the moment. Can be re-enabled for PRs once issue is resolved.