### PR TITLE
Fix element name in mixed Poisson demo

### DIFF
--- a/python/demo/demo_mixed-poisson.py
+++ b/python/demo/demo_mixed-poisson.py
@@ -76,7 +76,7 @@
 # To discretize the above formulation, two discrete function spaces $\Sigma_h
 # \subset \Sigma$ and $V_h \subset V$ are needed to form a mixed function space
 # $\Sigma_h \times V_h$. A stable choice of finite element spaces is to let
-# $\Sigma_h$ be the Brezzi-Douglas-Fortin-Marini elements of polynomial order
+# $\Sigma_h$ be the Brezzi-Douglas-Marini elements of polynomial order
 # $k$ and let $V_h$ be discontinuous elements of polynomial order $k-1$.
 #
 # We will use the same definitions of functions and boundaries as in the


### PR DESCRIPTION
The mixed Poisson demo says it uses the Brezzi-Douglas-Fortin-Marini element in the docs, but it's actually using the BDMCF element, which is (as far as I'm aware) just a Brezzi-Douglas-Marini element defined on a quad (the CF stands for cubical face, not Fortin). This PR fixes the name.

@mscroggs please correct me if this is wrong.