### PR TITLE
Expose geometry constructor in Python

### DIFF
--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -209,8 +209,7 @@ void declare_mesh(nb::module_& m, std::string type)
                 nb::handle());
           },
           nb::rv_policy::reference_internal, nb::arg("i"),
-          "Get the geometry dofmap associated with coordinate element i "
-          "(mixed "
+          "Get the geometry dofmap associated with coordinate element i (mixed "
           "topology)")
       .def("index_map", &dolfinx::mesh::Geometry<T>::index_map)
       .def_prop_ro(

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -171,20 +171,24 @@ void declare_mesh(nb::module_& m, std::string type)
           "__init__",
           [](dolfinx::mesh::Geometry<T>* self,
              std::shared_ptr<const dolfinx::common::IndexMap> index_map,
-             nb::ndarray<std::int32_t, nb::ndim<2>, nb::c_contig> dofmap,
+             nb::ndarray<const std::int32_t, nb::ndim<2>, nb::c_contig> dofmap,
              const dolfinx::fem::CoordinateElement<T>& element,
-             nb::ndarray<T, nb::ndim<2>, nb::c_contig> x,
-             nb::ndarray<std::int64_t, nb::ndim<1>, nb::c_contig>
+             nb::ndarray<const T, nb::ndim<2>> x,
+             nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>
                  input_global_indices)
           {
-            // Pad geometry to be 3D
-            std::size_t shape0 = x.shape(0);
             int shape1 = x.shape(1);
-            std::vector<T> x_vec(3 * shape0, 0);
-            for (std::size_t i = 0; i < shape0; ++i)
+            std::vector<T> x_vec;
+            if (shape1 == 3 and x.stride(0) == 3 and x.stride(1) == 1)
+              x_vec.assign(x.data(), x.data() + x.size());
+            else
             {
-              std::copy_n(std::next(x.data(), shape1 * i), shape1,
-                          std::next(x_vec.begin(), 3 * i));
+              // Pad geometry to be 3D
+              x_vec.assign(3 * x.shape(0), 0);
+              auto _x = x.view();
+              for (std::size_t i = 0; i < x.shape(0); ++i)
+                for (int j = 0; j < shape1; ++j)
+                  x_vec[3 * i + j] = _x(i, j);
             }
 
             new (self) dolfinx::mesh::Geometry<T>(

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -171,21 +171,19 @@ void declare_mesh(nb::module_& m, std::string type)
           "__init__",
           [](dolfinx::mesh::Geometry<T>* self,
              std::shared_ptr<const dolfinx::common::IndexMap> index_map,
-             nb::ndarray<std::int32_t, nb::ndim<1>, nb::c_contig> dofmap,
+             nb::ndarray<std::int32_t, nb::ndim<2>, nb::c_contig> dofmap,
              const dolfinx::fem::CoordinateElement<T>& element,
-             nb::ndarray<T, nb::ndim<1>, nb::c_contig> x, int dim,
+             nb::ndarray<T, nb::ndim<2>, nb::c_contig> x, int dim,
              nb::ndarray<std::int64_t, nb::ndim<1>, nb::c_contig>
                  input_global_indices)
           {
-            std::vector<std::int32_t> dofmap_vec(dofmap.data(),
-                                                 dofmap.data() + dofmap.size());
-            std::vector<T> x_vec(x.data(), x.data() + x.size());
-            std::vector<std::int64_t> igi_vec(
-                input_global_indices.data(),
-                input_global_indices.data() + input_global_indices.size());
             new (self) dolfinx::mesh::Geometry<T>(
-                std::move(index_map), std::move(dofmap_vec), element,
-                std::move(x_vec), dim, std::move(igi_vec));
+                index_map,
+                std::vector(dofmap.data(), dofmap.data() + dofmap.size()),
+                element, std::vector(x.data(), x.data() + x.size()), dim,
+                std::vector(input_global_indices.data(),
+                            input_global_indices.data()
+                                + input_global_indices.size()));
           },
           nb::arg("index_map"), nb::arg("dofmap"), nb::arg("element"),
           nb::arg("x"), nb::arg("dim"), nb::arg("input_global_indices"))

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -167,6 +167,28 @@ void declare_mesh(nb::module_& m, std::string type)
   std::string pyclass_geometry_name = std::string("Geometry_") + type;
   nb::class_<dolfinx::mesh::Geometry<T>>(m, pyclass_geometry_name.c_str(),
                                          "Geometry object")
+      .def(
+          "__init__",
+          [](dolfinx::mesh::Geometry<T>* self,
+             std::shared_ptr<const dolfinx::common::IndexMap> index_map,
+             nb::ndarray<std::int32_t, nb::ndim<1>, nb::c_contig> dofmap,
+             const dolfinx::fem::CoordinateElement<T>& element,
+             nb::ndarray<T, nb::ndim<1>, nb::c_contig> x, int dim,
+             nb::ndarray<std::int64_t, nb::ndim<1>, nb::c_contig>
+                 input_global_indices)
+          {
+            std::vector<std::int32_t> dofmap_vec(dofmap.data(),
+                                                 dofmap.data() + dofmap.size());
+            std::vector<T> x_vec(x.data(), x.data() + x.size());
+            std::vector<std::int64_t> igi_vec(
+                input_global_indices.data(),
+                input_global_indices.data() + input_global_indices.size());
+            new (self) dolfinx::mesh::Geometry<T>(
+                std::move(index_map), std::move(dofmap_vec), element,
+                std::move(x_vec), dim, std::move(igi_vec));
+          },
+          nb::arg("index_map"), nb::arg("dofmap"), nb::arg("element"),
+          nb::arg("x"), nb::arg("dim"), nb::arg("input_global_indices"))
       .def_prop_ro("dim", &dolfinx::mesh::Geometry<T>::dim,
                    "Geometric dimension")
       .def_prop_ro(
@@ -189,7 +211,8 @@ void declare_mesh(nb::module_& m, std::string type)
                 nb::handle());
           },
           nb::rv_policy::reference_internal, nb::arg("i"),
-          "Get the geometry dofmap associated with coordinate element i (mixed "
+          "Get the geometry dofmap associated with coordinate element i "
+          "(mixed "
           "topology)")
       .def("index_map", &dolfinx::mesh::Geometry<T>::index_map)
       .def_prop_ro(


### PR DESCRIPTION
Resolve #2978.

Illustrative use-case:
```python
from mpi4py import MPI
from dolfinx import cpp, mesh

msh = mesh.create_unit_square(MPI.COMM_WORLD, 10, 10, cpp.mesh.CellType.triangle)

dofmap = msh.geometry.dofmap.reshape(-1).copy()
igi = msh.geometry.input_global_indices.copy()
nodes =  msh.geometry.x.reshape(-1).copy()
new_geom = cpp.mesh.Geometry_float64(msh.geometry.index_map(), 
                                     dofmap, msh.geometry.cmap,nodes, 2, igi)

```