### PR TITLE
Remove note about FFCx generated elements

### DIFF
--- a/cpp/demo/interpolation-io/main.cpp
+++ b/cpp/demo/interpolation-io/main.cpp
@@ -29,8 +29,6 @@ using namespace dolfinx;
 /// and outputs the finite element function to a VTX file for
 /// visualisation.
 ///
-/// Also shows how to create a finite element using Basix.
-///
 /// @tparam T Scalar type of the finite element function.
 /// @tparam U Float type for the finite element basis and the mesh.
 /// @param mesh Mesh.
@@ -190,8 +188,8 @@ void interpolate_nedelec(std::shared_ptr<mesh::Mesh<U>> mesh,
 #endif
 }
 
-/// @brief This program shows how to create finite element spaces without FFCx
-/// generated code.
+/// @brief This program shows how to interpolate functions into different types
+/// of finite element spaces and output the result to file for visualisation.
 int main(int argc, char* argv[])
 {
   dolfinx::init_logging(argc, argv);


### PR DESCRIPTION
In C++ all demos now create elements using basix, after we removed UFCx_element, so these comments where outdated.