### PR TITLE
Fix cffi_utils for abscence of petsc4py

### DIFF
--- a/python/dolfinx/utils.py
+++ b/python/dolfinx/utils.py
@@ -211,7 +211,10 @@ class cffi_utils:
     except KeyError:
         pass
     except ImportError:
-        warnings.warn("Could not import numba, so cffi/numba complex types were not registered.", ImportWarning)
+        warnings.warn(
+            "Could not import numba, so cffi/numba complex types were not registered.",
+            ImportWarning,
+        )
 
     try:
         from petsc4py import PETSc as _PETSc
@@ -254,5 +257,6 @@ class cffi_utils:
         pass
     except ImportError:
         warnings.warn(
-            "Could not import petsc4py, so cffi/PETSc ABI mode interface was not created.", ImportWarning
+            "Could not import petsc4py, so cffi/PETSc ABI mode interface was not created.",
+            ImportWarning,
         )

--- a/python/dolfinx/utils.py
+++ b/python/dolfinx/utils.py
@@ -211,7 +211,7 @@ class cffi_utils:
     except KeyError:
         pass
     except ImportError:
-        warnings.warn("Could not import numba, so complex types are not registered!", ImportWarning)
+        warnings.warn("Could not import numba, so cffi/numba complex types were not registered.", ImportWarning)
 
     try:
         from petsc4py import PETSc as _PETSc
@@ -254,5 +254,5 @@ class cffi_utils:
         pass
     except ImportError:
         warnings.warn(
-            "Could not import petsc4py, so numba petsc overloads are not available!", ImportWarning
+            "Could not import petsc4py, so cffi/PETSc ABI mode interface was not created.", ImportWarning
         )

--- a/python/dolfinx/utils.py
+++ b/python/dolfinx/utils.py
@@ -208,6 +208,8 @@ class cffi_utils:
         _cffi_support.register_type(_ffi.typeof("float _Complex"), _numba.types.complex64)
         _cffi_support.register_type(_ffi.typeof("double _Complex"), _numba.types.complex128)
 
+    except KeyError:
+        pass
     except ImportError:
         warnings.warn("Could not import numba, so complex types are not registered!", ImportWarning)
 
@@ -248,6 +250,8 @@ class cffi_utils:
         """See PETSc `MatSetValuesBlockedLocal
         <https://petsc.org/release/manualpages/Mat/MatSetValuesBlockedLocal>`_
         documentation."""
+    except KeyError:
+        pass
     except ImportError:
         warnings.warn(
             "Could not import petsc4py, so numba petsc overloads are not available!", ImportWarning


### PR DESCRIPTION
Make `cffi` type registry also work when `pets4py` is not available.