### PR TITLE
A form can be empty and should return None

### DIFF
--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -302,6 +302,8 @@ def form(
         """Recursively convert ufl.Forms to dolfinx.fem.Form, otherwise
         return form argument"""
         if isinstance(form, ufl.Form):
+            if form.empty():
+                return None
             return _form(form)
         elif isinstance(form, collections.abc.Iterable):
             return list(map(lambda sub_form: _create_form(sub_form), form))


### PR DESCRIPTION
Relevant for block models, if one wants to use `ufl.MixedFunctionSpace`, where `ufl.extract_block(a, i, j)` can return None or an empty form.
https://github.com/FEniCS/ufl/blob/main/ufl/form.py#L311