### PR TITLE
Update Install instructions

### DIFF
--- a/python/doc/source/installation.rst
+++ b/python/doc/source/installation.rst
@@ -24,7 +24,7 @@ Dependencies
 C++ core
 ********
 
-The C++ core can be installed without Python.
+The C++ core can be installed without Python as a dependency.
 
 .. rubric:: Required
 

--- a/python/doc/source/installation.rst
+++ b/python/doc/source/installation.rst
@@ -41,14 +41,14 @@ The C++ core can be installed without Python.
 - `pkg-config <https://www.freedesktop.org/wiki/Software/pkg-config/>`_
 - `pugixml <https://pugixml.org/>`_
 - `spdlog <https://github.com/gabime/spdlog/>`_
-- UFCx [``ufcx.h``, provided by FFCx or UFCx C++ at ``ffcx/cmake/*``]
+- UFCx [``ufcx.h``, provided by FFCx Python package or UFCx CMake install at ``ffcx/cmake/*``]
 - At least one of ParMETIS [2]_, KaHIP or PT-SCOTCH [2]_
 
 From ParMETIS, KaHIP or PT-SCOTCH, ParMETIS is recommended.
 
 .. rubric:: Optional
 
-- `FFCx`
+- FFCx
 - `ADIOS2 <https://github.com/ornladios/ADIOS2/>`_ (additional parallel
   IO support)
 - `PETSc <https://petsc.org/>`_ [1]_

--- a/python/doc/source/installation.rst
+++ b/python/doc/source/installation.rst
@@ -18,6 +18,12 @@ Source
 Installation of DOLFINx requires installation of the C++ core. Most
 users will also want the Python interface.
 
+We do not provide step-by-step instructions for a complete source install as
+these often do not work consistently between different environments. Instead,
+we recommend consulting our `RedHat Dockerfile <https://github.com/FEniCS/dolfinx/blob/main/docker/Dockerfile.redhat>`_
+and `RedHat GitHub Actions workflow <https://github.com/FEniCS/dolfinx/blob/main/.github/workflows/redhat.yml>`_
+for a minimal set of tested steps that can be adapted to suit most Unix-like systems.
+
 Dependencies
 ^^^^^^^^^^^^
 
@@ -41,7 +47,7 @@ The C++ core can be installed without Python as a dependency.
 - `pkg-config <https://www.freedesktop.org/wiki/Software/pkg-config/>`_
 - `pugixml <https://pugixml.org/>`_
 - `spdlog <https://github.com/gabime/spdlog/>`_
-- UFCx [``ufcx.h``, provided by FFCx Python package or UFCx CMake install at ``ffcx/cmake/*``]
+- UFCx [``ufcx.h``, provided by FFCx package or FFCx UFCx CMake install at ``ffcx/cmake/*``]
 - At least one of ParMETIS [2]_, KaHIP or PT-SCOTCH [2]_
 
 From ParMETIS, KaHIP or PT-SCOTCH, ParMETIS is recommended.

--- a/python/doc/source/installation.rst
+++ b/python/doc/source/installation.rst
@@ -18,11 +18,13 @@ Source
 Installation of DOLFINx requires installation of the C++ core. Most
 users will also want the Python interface.
 
-We do not provide step-by-step instructions for a complete source install as
-these often do not work consistently between different environments. Instead,
-we recommend consulting our `RedHat Dockerfile <https://github.com/FEniCS/dolfinx/blob/main/docker/Dockerfile.redhat>`_
-and `RedHat GitHub Actions workflow <https://github.com/FEniCS/dolfinx/blob/main/.github/workflows/redhat.yml>`_
-for a minimal set of tested steps that can be adapted to suit most Unix-like systems.
+An example of how to build DOLFINx and its dependencies can be found in
+our `RedHat Dockerfile
+<https://github.com/FEniCS/dolfinx/blob/main/docker/Dockerfile.redhat>`_
+and `RedHat GitHub Actions workflow
+<https://github.com/FEniCS/dolfinx/blob/main/.github/workflows/redhat.yml>`_
+for a minimal set of tested steps that can be adapted to suit most
+Unix-like systems.
 
 Dependencies
 ^^^^^^^^^^^^
@@ -54,33 +56,40 @@ From ParMETIS, KaHIP or PT-SCOTCH, ParMETIS is recommended.
 
 .. rubric:: Optional
 
-- FFCx
 - `ADIOS2 <https://github.com/ornladios/ADIOS2/>`_ (additional parallel
   IO support)
 - `PETSc <https://petsc.org/>`_ [1]_
 - `SLEPc <https://slepc.upv.es/>`_ (eigenvalue computations)
+
+.. rubric:: Optional for demos
+
+- FFCx
 
 PETSc and FFCx are optional but still recommended.
 
 Python interface
 ****************
 
-Below are additional requirements for the Python interface to the C++ core.
+Below are additional requirements for the Python interface to the C++
+core.
 
 .. rubric:: Required
 
 - Python
-- Python cffi
+- Python cffi (https://cffi.readthedocs.io/)
 - FFCx, UFL and Basix Python interface.
-- mpi4py
+- mpi4py (https://mpi4py.readthedocs.io/)
 - nanobind (https://github.com/wjakob/nanobind)
 - NumPy (https://www.numpy.org)
 - scikit-build-core[pyproject] (https://scikit-build-core.readthedocs.io)
 
 .. rubric:: Optional
 
-- Numba
 - petsc4py (recommended)
+
+.. rubric:: Optional for demos
+
+- Numba
 - pyamg
 - pyvista (for plotting)
 - slepc4py
@@ -118,8 +127,8 @@ Python interface can be installed using::
 .. [1] Its is recommended to configure with ParMETIS, PT-SCOTCH,
        MUMPS and Hypre using
        ``--download-parmetis --download-ptscotch --download-suitesparse
-       --download-mumps --download-hypre``. macOS users should 
-       additionally configure MUMPS via PETSc with 
+       --download-mumps --download-hypre``. macOS users should
+       additionally configure MUMPS via PETSc with
        ``--download-mumps-avoid-mpi-in-place``.
 
 .. [2] PETSc can download and configure and build these libraries.

--- a/python/doc/source/installation.rst
+++ b/python/doc/source/installation.rst
@@ -24,10 +24,12 @@ Dependencies
 C++ core
 ********
 
+The C++ core can be installed without Python.
+
 .. rubric:: Required
 
 - C++ compiler (supporting the C++20 standard)
-- `Basix <https://github.com/FEniCS/basix>`_
+- `Basix C++ core <https://github.com/FEniCS/basix>`_
 - `Boost <https://www.boost.org>`_, with the following compiled Boost
   components
 
@@ -35,33 +37,35 @@ C++ core
 
 - `CMake <https://cmake.org>`_ [build dependency]
 - HDF5 (with MPI support enabled)
-- MPI supporting MPI version 3 or above.
+- MPI supporting MPI standard version 3 or above.
 - `pkg-config <https://www.freedesktop.org/wiki/Software/pkg-config/>`_
 - `pugixml <https://pugixml.org/>`_
 - `spdlog <https://github.com/gabime/spdlog/>`_
-- UFCx [``ufcx.h``, provided by FFCx]
+- UFCx [``ufcx.h``, provided by FFCx or UFCx C++ at ``ffcx/cmake/*``]
 - At least one of ParMETIS [2]_, KaHIP or PT-SCOTCH [2]_
 
 From ParMETIS, KaHIP or PT-SCOTCH, ParMETIS is recommended.
 
 .. rubric:: Optional
 
+- `FFCx`
 - `ADIOS2 <https://github.com/ornladios/ADIOS2/>`_ (additional parallel
   IO support)
 - `PETSc <https://petsc.org/>`_ [1]_
 - `SLEPc <https://slepc.upv.es/>`_ (eigenvalue computations)
 
-PETSc is optional but still recommended.
+PETSc and FFCx are optional but still recommended.
 
 Python interface
 ****************
 
-Below are additional requirements for the Python interface.
+Below are additional requirements for the Python interface to the C++ core.
 
 .. rubric:: Required
 
 - Python
-- FFCx, UFL and Basix (https://github.com/FEniCS/).
+- Python cffi
+- FFCx, UFL and Basix Python interface.
 - mpi4py
 - nanobind (https://github.com/wjakob/nanobind)
 - NumPy (https://www.numpy.org)

--- a/python/doc/source/installation.rst
+++ b/python/doc/source/installation.rst
@@ -6,22 +6,17 @@ Installation
 DOLFINx can be installed using various packages managers, run using
 containers, or built manually from source.
 
-`Spack <https://spack.io/>`_ is the recommended installation tool for
-high performance computers.
-
-
 Binaries
 --------
 
 See the `README.md <https://github.com/FEniCS/dolfinx/blob/main/README.md#installation>`_
-for instructions.
+for recommendations and instructions.
 
 Source
 ------
 
 Installation of DOLFINx requires installation of the C++ core. Most
 users will also want the Python interface.
-
 
 Dependencies
 ^^^^^^^^^^^^
@@ -40,8 +35,7 @@ C++ core
 
 - `CMake <https://cmake.org>`_ [build dependency]
 - HDF5 (with MPI support enabled)
-- MPI
-- `PETSc <https://petsc.org/>`_ [1]_
+- MPI supporting MPI version 3 or above.
 - `pkg-config <https://www.freedesktop.org/wiki/Software/pkg-config/>`_
 - `pugixml <https://pugixml.org/>`_
 - `spdlog <https://github.com/gabime/spdlog/>`_
@@ -54,8 +48,10 @@ From ParMETIS, KaHIP or PT-SCOTCH, ParMETIS is recommended.
 
 - `ADIOS2 <https://github.com/ornladios/ADIOS2/>`_ (additional parallel
   IO support)
+- `PETSc <https://petsc.org/>`_ [1]_
 - `SLEPc <https://slepc.upv.es/>`_ (eigenvalue computations)
 
+PETSc is optional but still recommended.
 
 Python interface
 ****************
@@ -69,15 +65,15 @@ Below are additional requirements for the Python interface.
 - mpi4py
 - nanobind (https://github.com/wjakob/nanobind)
 - NumPy (https://www.numpy.org)
-- petsc4py
 - scikit-build-core[pyproject] (https://scikit-build-core.readthedocs.io)
 
-.. rubric:: Suggested
+.. rubric:: Optional
 
-- pyvista (for plotting)
 - Numba
+- petsc4py (recommended)
+- pyamg
+- pyvista (for plotting)
 - slepc4py
-
 
 Building and installing
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -112,6 +108,8 @@ Python interface can be installed using::
 .. [1] Its is recommended to configure with ParMETIS, PT-SCOTCH,
        MUMPS and Hypre using
        ``--download-parmetis --download-ptscotch --download-suitesparse
-       --download-mumps --download-hypre``
+       --download-mumps --download-hypre``. macOS users should 
+       additionally configure MUMPS via PETSc with 
+       ``--download-mumps-avoid-mpi-in-place``.
 
 .. [2] PETSc can download and configure and build these libraries.


### PR DESCRIPTION
PETSc and petsc4py is now optional but recommended, pyamg now supported.