### PR TITLE
allow larger tolerance in timing test

### DIFF
--- a/python/test/unit/common/test_timer.py
+++ b/python/test/unit/common/test_timer.py
@@ -14,6 +14,9 @@ from dolfinx import common
 # Seed random generator for determinism
 random.seed(0)
 
+# resolution of the Timer is not precise,
+# need to allow some tolerance
+timing_resolution = 0.015
 
 def get_random_task_name():
     """Get pseudo-random string"""
@@ -26,8 +29,8 @@ def test_context_manager_named():
 
     # Execute task in the context manager
     t = common.Timer(task)
-    sleep(0.05)
-    assert t.elapsed()[0] >= 0.05
+    sleep(0.1)
+    assert t.elapsed()[0] >= 0.1 - timing_resolution
     del t
 
     # Check timing
@@ -39,5 +42,5 @@ def test_context_manager_named():
 def test_context_manager_anonymous():
     """Test that anonymous Timer works as context manager"""
     with common.Timer() as t:
-        sleep(0.05)
-        assert t.elapsed()[0] >= 0.05
+        sleep(0.1)
+        assert t.elapsed()[0] >= 0.1 - timing_resolution


### PR DESCRIPTION
sleep(0.05) may obtain t.elapsed()[0] = 0.04, causing the timing test to fail. So tolerance in the timing precision should be a little larger than 0.01 (this patch uses 0.015).

Also increases sleep time from 0.05s to 0.1 sec for more reliable timing.

Adapted from debian patch
https://salsa.debian.org/science-team/fenics/fenics-dolfinx/-/blob/9206e6b14aad2d487f1fec692dbe81c7f47467de/debian/patches/test_timing_precision.patch

Closes: #2946 