### PR TITLE
Use earlier NumPy version in Dockerfile

### DIFF
--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -17,7 +17,11 @@ ARG DOXYGEN_VERSION=1_12_0
 ARG GMSH_VERSION=4_13_1
 ARG HDF5_VERSION=1.14.4.3
 ARG KAHIP_VERSION=3.16
-ARG NUMPY_VERSION=2.1.1
+# NOTE: The NumPy version (https://pypi.org/project/numpy/#history)
+# should be pinned to the most recent NumPy release that is supported by
+# the most recent Numba release, see
+# https://numba.readthedocs.io/en/stable/user/installing.html#version-support-information
+ARG NUMPY_VERSION=2.0.1
 ARG PETSC_VERSION=3.22.0
 ARG SLEPC_VERSION=3.22.0
 

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -21,7 +21,7 @@ ARG KAHIP_VERSION=3.16
 # should be pinned to the most recent NumPy release that is supported by
 # the most recent Numba release, see
 # https://numba.readthedocs.io/en/stable/user/installing.html#version-support-information
-ARG NUMPY_VERSION=2.0.1
+ARG NUMPY_VERSION=2.0.2
 ARG PETSC_VERSION=3.22.0
 ARG SLEPC_VERSION=3.22.0
 


### PR DESCRIPTION
Fall back to NumPy version that is supported by Numba. Otherwise Numba uninstalls NumPy to then install an earlier version. This could breaks libraries, e.g. petsc4py, that are built with a non-compatible NumPy version.

Add notes in Dockerfile that NumPy version should be latest version that is compatible with Numba.