### PR TITLE
Simplify interface to `nanobind::ndarray`

### DIFF
--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -72,7 +72,7 @@ public:
       std::function<void(scalar_type*, const scalar_type*, const scalar_type*,
                          const geometry_type*, const int*, const uint8_t*)>
           fn,
-      const std::vector<int>& value_shape,
+      const std::vector<std::size_t>& value_shape,
       std::shared_ptr<const FunctionSpace<geometry_type>>
           argument_function_space
       = nullptr)
@@ -269,7 +269,7 @@ public:
 
   /// @brief Get value shape.
   /// @return The value shape.
-  const std::vector<int>& value_shape() const { return _value_shape; }
+  const std::vector<std::size_t>& value_shape() const { return _value_shape; }
 
   /// @brief Evaluation points on the reference cell.
   /// @return Evaluation points.
@@ -295,7 +295,7 @@ private:
       _fn;
 
   // Shape of the evaluated expression
-  std::vector<int> _value_shape;
+  std::vector<std::size_t> _value_shape;
 
   // Evaluation points on reference cell. Synonymous with X in public
   // interface.

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -1204,7 +1204,8 @@ Expression<T, U> create_expression(
   std::array<std::size_t, 2> Xshape
       = {static_cast<std::size_t>(e.num_points),
          static_cast<std::size_t>(e.entity_dimension)};
-  std::vector<int> value_shape(e.value_shape, e.value_shape + e.num_components);
+  std::vector<std::size_t> value_shape(e.value_shape,
+                                       e.value_shape + e.num_components);
   std::function<void(T*, const T*, const T*,
                      const typename scalar_value_type<T>::value_type*,
                      const int*, const std::uint8_t*)>

--- a/python/dolfinx/geometry.py
+++ b/python/dolfinx/geometry.py
@@ -45,19 +45,19 @@ class PointOwnershipData:
         self._cpp_object = ownership_data
 
     def src_owner(self) -> npt.NDArray[np.int32]:
-        """Ranks owning each point sent into ownership determination for current process"""
+        """Ranks owning each point sent into ownership determination for current process."""
         return self._cpp_object.src_owner
 
     def dest_owner(self) -> npt.NDArray[np.int32]:
-        """Ranks that sent `dest_points` to current process"""
+        """Ranks that sent ``dest_points`` to current process."""
         return self._cpp_object.dest_owners
 
     def dest_points(self) -> npt.NDArray[np.floating]:
-        """Points owned by current rank"""
+        """Points owned by current rank."""
         return self._cpp_object.dest_points
 
     def dest_cells(self) -> npt.NDArray[np.int32]:
-        """Cell indices (local to process) where each entry of `dest_points` is located"""
+        """Cell indices (local to process) where each entry of ``dest_points`` is located."""
         return self._cpp_object.dest_cells
 
 

--- a/python/dolfinx/wrappers/array.h
+++ b/python/dolfinx/wrappers/array.h
@@ -38,8 +38,10 @@ auto as_nbarray_copy(const V& x, const std::initializer_list<std::size_t> shape)
 }
 
 /// Create an n-dimensional nb::ndarray that shares data with a
-/// std::vector. The std::vector owns the data, and the nb::ndarray
-/// object keeps the std::vector alive.
+/// std::vector.
+///
+/// The std::vector owns the data, and the nb::ndarray object keeps the
+/// std::vector alive.
 template <typename V>
 auto as_nbarray(V&& x, std::size_t ndim, const std::size_t* shape)
 {
@@ -50,14 +52,20 @@ auto as_nbarray(V&& x, std::size_t ndim, const std::size_t* shape)
       nb::capsule(ptr, [](void* p) noexcept { delete (_V*)p; }));
 }
 
+/// Create an n-dimensional nb::ndarray that shares data with a
+/// std::vector.
+///
+/// The std::vector owns the data, and the nb::ndarray object keeps the
+/// std::vector alive.
 template <typename V>
 auto as_nbarray(V&& x, const std::initializer_list<std::size_t> shape)
 {
   return as_nbarray(x, shape.size(), shape.begin());
 }
 
-/// Create a nb::ndarray that shares data with a std::vector. The
-/// std::vector owns the data, and the nb::ndarray object keeps the
+/// Create a 1D nb::ndarray that shares data with a std::vector.
+///
+/// The std::vector owns the data, and the nb::ndarray object keeps the
 /// std::vector alive.
 template <typename V>
 auto as_nbarray(V&& x)

--- a/python/dolfinx/wrappers/array.h
+++ b/python/dolfinx/wrappers/array.h
@@ -6,13 +6,11 @@
 
 #pragma once
 
-#include <algorithm>
-#include <array>
 #include <concepts>
 #include <initializer_list>
-#include <memory>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
+#include <utility>
 #include <vector>
 
 namespace nb = nanobind;

--- a/python/dolfinx/wrappers/array.h
+++ b/python/dolfinx/wrappers/array.h
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <array>
+#include <concepts>
 #include <initializer_list>
 #include <memory>
 #include <nanobind/nanobind.h>
@@ -18,31 +19,13 @@ namespace nb = nanobind;
 
 namespace dolfinx_wrappers
 {
-
-template <typename V>
-auto as_nbarray_copy(const V& x, std::size_t ndim, const std::size_t* shape)
-{
-  using _V = std::decay_t<V>;
-  using T = typename _V::value_type;
-  T* ptr = new T[x.size()];
-  std::ranges::copy(x, ptr);
-  return nb::ndarray<T, nb::numpy>(
-      ptr, ndim, shape,
-      nb::capsule(ptr, [](void* p) noexcept { delete[] (T*)p; }));
-}
-
-template <typename V>
-auto as_nbarray_copy(const V& x, const std::initializer_list<std::size_t> shape)
-{
-  return as_nbarray_copy(x, shape.size(), shape.begin());
-}
-
 /// Create an n-dimensional nb::ndarray that shares data with a
 /// std::vector.
 ///
 /// The std::vector owns the data, and the nb::ndarray object keeps the
 /// std::vector alive.
 template <typename V>
+  requires std::movable<V>
 auto as_nbarray(V&& x, std::size_t ndim, const std::size_t* shape)
 {
   using _V = std::decay_t<V>;
@@ -58,9 +41,10 @@ auto as_nbarray(V&& x, std::size_t ndim, const std::size_t* shape)
 /// The std::vector owns the data, and the nb::ndarray object keeps the
 /// std::vector alive.
 template <typename V>
+  requires std::movable<V>
 auto as_nbarray(V&& x, const std::initializer_list<std::size_t> shape)
 {
-  return as_nbarray(x, shape.size(), shape.begin());
+  return as_nbarray(std::forward<V>(x), shape.size(), shape.begin());
 }
 
 /// Create a 1D nb::ndarray that shares data with a std::vector.
@@ -68,9 +52,10 @@ auto as_nbarray(V&& x, const std::initializer_list<std::size_t> shape)
 /// The std::vector owns the data, and the nb::ndarray object keeps the
 /// std::vector alive.
 template <typename V>
+  requires std::movable<V>
 auto as_nbarray(V&& x)
 {
-  return as_nbarray(std::move(x), {x.size()});
+  return as_nbarray(std::forward<V>(x), {x.size()});
 }
 
 } // namespace dolfinx_wrappers

--- a/python/dolfinx/wrappers/array.h
+++ b/python/dolfinx/wrappers/array.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Garth N. Wells
+// Copyright (C) 2021-2024 Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -12,8 +12,6 @@
 #include <nanobind/ndarray.h>
 #include <utility>
 #include <vector>
-
-#include <iostream>
 
 namespace nb = nanobind;
 

--- a/python/dolfinx/wrappers/array.h
+++ b/python/dolfinx/wrappers/array.h
@@ -13,6 +13,8 @@
 #include <utility>
 #include <vector>
 
+#include <iostream>
+
 namespace nb = nanobind;
 
 namespace dolfinx_wrappers
@@ -27,7 +29,7 @@ template <typename V>
 auto as_nbarray(V&& x, std::size_t ndim, const std::size_t* shape)
 {
   using _V = std::decay_t<V>;
-  _V* ptr = new _V(std::move(x));
+  _V* ptr = new _V(std::forward<V>(x));
   return nb::ndarray<typename _V::value_type, nb::numpy>(
       ptr->data(), ndim, shape,
       nb::capsule(ptr, [](void* p) noexcept { delete (_V*)p; }));

--- a/python/dolfinx/wrappers/assemble.cpp
+++ b/python/dolfinx/wrappers/assemble.cpp
@@ -254,8 +254,10 @@ void declare_assembly_functions(nb::module_& m)
                a.function_spaces().at(1)->dofmap()->index_map_bs()};
 
         if (data_bs[0] != data_bs[1])
+        {
           throw std::runtime_error(
               "Non-square blocksize unsupported in Python");
+        }
 
         if (data_bs[0] == 1)
         {

--- a/python/dolfinx/wrappers/assemble.cpp
+++ b/python/dolfinx/wrappers/assemble.cpp
@@ -364,13 +364,12 @@ void declare_assembly_functions(nb::module_& m)
                         std::span<const std::int32_t> cols,
                         std::span<const T> data)
         {
-          return fin(
-              nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig,
-                          nb::numpy>(rows.data(), {rows.size()}, nb::handle()),
-              nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig,
-                          nb::numpy>(cols.data(), {cols.size()}, nb::handle()),
-              nb::ndarray<const T, nb::ndim<2>, nb::c_contig, nb::numpy>(
-                  data.data(), {data.size()}, nb::handle()));
+          return fin(nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig,
+                                 nb::numpy>(rows.data(), {rows.size()}),
+                     nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig,
+                                 nb::numpy>(cols.data(), {cols.size()}),
+                     nb::ndarray<const T, nb::ndim<2>, nb::c_contig, nb::numpy>(
+                         data.data(), {data.size()}));
         };
         dolfinx::fem::assemble_matrix(f, form, bcs);
       },

--- a/python/dolfinx/wrappers/assemble.cpp
+++ b/python/dolfinx/wrappers/assemble.cpp
@@ -369,7 +369,7 @@ void declare_assembly_functions(nb::module_& m)
                      nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig,
                                  nb::numpy>(cols.data(), {cols.size()}),
                      nb::ndarray<const T, nb::ndim<2>, nb::c_contig, nb::numpy>(
-                         data.data(), {data.size()}));
+                         data.data(), {rows.size(), cols.size()}));
         };
         dolfinx::fem::assemble_matrix(f, form, bcs);
       },

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -137,7 +137,7 @@ void common(nb::module_& m)
           [](const dolfinx::common::IndexMap& self)
           {
             std::span owners = self.owners();
-            return nb::ndarray<nb::numpy, const int, nb::ndim<1>>(
+            return nb::ndarray<const int, nb::ndim<1>, nb::numpy>(
                 owners.data(), {owners.size()});
           },
           nb::rv_policy::reference_internal)

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -128,8 +128,8 @@ void common(nb::module_& m)
           [](const dolfinx::common::IndexMap& self)
           {
             std::span ghosts = self.ghosts();
-            return nb::ndarray<const std::int64_t, nb::numpy>(
-                ghosts.data(), {ghosts.size()}, nb::handle());
+            return nb::ndarray<const std::int64_t, nb::numpy>(ghosts.data(),
+                                                              {ghosts.size()});
           },
           nb::rv_policy::reference_internal, "Return list of ghost indices")
       .def_prop_ro(
@@ -138,7 +138,7 @@ void common(nb::module_& m)
           {
             std::span owners = self.owners();
             return nb::ndarray<nb::numpy, const int, nb::ndim<1>>(
-                owners.data(), {owners.size()}, nb::handle());
+                owners.data(), {owners.size()});
           },
           nb::rv_policy::reference_internal)
       .def(

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -88,8 +88,8 @@ void declare_function_space(nb::module_& m, std::string type)
             [](const dolfinx::fem::FunctionSpace<T>& self)
             {
               std::span<const std::size_t> vshape = self.value_shape();
-              return nb::ndarray<const std::size_t, nb::numpy>(
-                  vshape.data(), {vshape.size()}, nb::handle());
+              return nb::ndarray<const std::size_t, nb::numpy>(vshape.data(),
+                                                               {vshape.size()});
             },
             nb::rv_policy::reference_internal)
         .def("sub", &dolfinx::fem::FunctionSpace<T>::sub, nb::arg("component"))
@@ -358,14 +358,16 @@ void declare_objects(nb::module_& m, const std::string& type)
           nb::arg("V").noconvert())
       .def_prop_ro("dtype", [](const dolfinx::fem::Function<T, U>&)
                    { return dolfinx_wrappers::numpy_dtype<T>(); })
-      .def("dof_indices",
-           [](const dolfinx::fem::DirichletBC<T, U>& self)
-           {
-             auto [dofs, owned] = self.dof_indices();
-             return std::pair(nb::ndarray<const std::int32_t, nb::numpy>(
-                                  dofs.data(), {dofs.size()}, nb::handle()),
-                              owned);
-           })
+      .def(
+          "dof_indices",
+          [](const dolfinx::fem::DirichletBC<T, U>& self)
+          {
+            auto [dofs, owned] = self.dof_indices();
+            return std::pair(nb::ndarray<const std::int32_t, nb::numpy>(
+                                 dofs.data(), {dofs.size()}),
+                             owned);
+          },
+          nb::rv_policy::reference_internal)
       .def(
           "set",
           [](const dolfinx::fem::DirichletBC<T, U>& self,
@@ -533,9 +535,8 @@ void declare_objects(nb::module_& m, const std::string& type)
           "value",
           [](dolfinx::fem::Constant<T>& self)
           {
-            return nb::ndarray<T, nb::numpy>(self.value.data(),
-                                             self.shape.size(),
-                                             self.shape.data(), nb::handle());
+            return nb::ndarray<T, nb::numpy>(
+                self.value.data(), self.shape.size(), self.shape.data());
           },
           nb::rv_policy::reference_internal);
 
@@ -751,17 +752,17 @@ void declare_form(nb::module_& m, std::string type)
             switch (type)
             {
             case dolfinx::fem::IntegralType::cell:
-              return nb::ndarray<const std::int32_t, nb::numpy>(
-                  _d.data(), {_d.size()}, nb::handle());
+              return nb::ndarray<const std::int32_t, nb::numpy>(_d.data(),
+                                                                {_d.size()});
             case dolfinx::fem::IntegralType::exterior_facet:
             {
               return nb::ndarray<const std::int32_t, nb::numpy>(
-                  _d.data(), {_d.size() / 2, 2}, nb::handle());
+                  _d.data(), {_d.size() / 2, 2});
             }
             case dolfinx::fem::IntegralType::interior_facet:
             {
               return nb::ndarray<const std::int32_t, nb::numpy>(
-                  _d.data(), {_d.size() / 4, 2, 2}, nb::handle());
+                  _d.data(), {_d.size() / 4, 2, 2});
             }
             default:
               throw ::std::runtime_error("Integral type unsupported.");
@@ -1248,8 +1249,8 @@ void fem(nb::module_& m)
           [](const dolfinx::fem::DofMap& self, int cell)
           {
             std::span<const std::int32_t> dofs = self.cell_dofs(cell);
-            return nb::ndarray<const std::int32_t, nb::numpy>(
-                dofs.data(), {dofs.size()}, nb::handle());
+            return nb::ndarray<const std::int32_t, nb::numpy>(dofs.data(),
+                                                              {dofs.size()});
           },
           nb::rv_policy::reference_internal, nb::arg("cell"))
       .def_prop_ro("bs", &dolfinx::fem::DofMap::bs)
@@ -1259,8 +1260,7 @@ void fem(nb::module_& m)
           {
             auto dofs = self.map();
             return nb::ndarray<const std::int32_t, nb::numpy>(
-                dofs.data_handle(), {dofs.extent(0), dofs.extent(1)},
-                nb::handle());
+                dofs.data_handle(), {dofs.extent(0), dofs.extent(1)});
           },
           nb::rv_policy::reference_internal);
 

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -735,10 +735,7 @@ void declare_form(nb::module_& m, std::string type)
           "integral_ids",
           [](const dolfinx::fem::Form<T, U>& self,
              dolfinx::fem::IntegralType type)
-          {
-            auto ids = self.integral_ids(type);
-            return dolfinx_wrappers::as_nbarray(std::move(ids));
-          },
+          { return dolfinx_wrappers::as_nbarray(self.integral_ids(type)); },
           nb::arg("type"))
       .def_prop_ro("integral_types", &dolfinx::fem::Form<T, U>::integral_types)
       .def_prop_ro("needs_facet_permutations",
@@ -916,7 +913,6 @@ void declare_cmap(nb::module_& m, std::string type)
                 mdspan2_t(xb.data(), shape),
                 cmdspan2_t(cell_x.data(), cell_x.shape(0), cell_x.shape(1)),
                 phi);
-
             return dolfinx_wrappers::as_nbarray(std::move(xb),
                                                 {X.shape(0), cell_x.shape(1)});
           },
@@ -1196,9 +1192,10 @@ void fem(nb::module_& m)
              entities,
          int dim)
       {
-        auto integration_entities = dolfinx::fem::compute_integration_domains(
-            type, topology, std::span(entities.data(), entities.size()), dim);
-        return dolfinx_wrappers::as_nbarray(std::move(integration_entities));
+        return dolfinx_wrappers::as_nbarray(
+            dolfinx::fem::compute_integration_domains(
+                type, topology, std::span(entities.data(), entities.size()),
+                dim));
       },
       nb::arg("integral_type"), nb::arg("topology"), nb::arg("entities"),
       nb::arg("dim"));

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -1078,7 +1078,7 @@ void declare_real_functions(nb::module_& m)
         auto _marker = [&marker](auto x)
         {
           nb::ndarray<const T, nb::ndim<2>, nb::numpy> x_view(
-              x.data_handle(), {x.extent(0), x.extent(1)}, nb::handle());
+              x.data_handle(), {x.extent(0), x.extent(1)});
           auto marked = marker(x_view);
           return std::vector<std::int8_t>(marked.data(),
                                           marked.data() + marked.size());
@@ -1101,7 +1101,7 @@ void declare_real_functions(nb::module_& m)
         auto _marker = [&marker](auto x)
         {
           nb::ndarray<const T, nb::ndim<2>, nb::numpy> x_view(
-              x.data_handle(), {x.extent(0), x.extent(1)}, nb::handle());
+              x.data_handle(), {x.extent(0), x.extent(1)});
           auto marked = marker(x_view);
           return std::vector<std::int8_t>(marked.data(),
                                           marked.data() + marked.size());

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -552,7 +552,8 @@ void declare_objects(nb::module_& m, const std::string& type)
              const std::vector<
                  std::shared_ptr<const dolfinx::fem::Constant<T>>>& constants,
              nb::ndarray<const U, nb::ndim<2>, nb::c_contig> X,
-             std::uintptr_t fn_addr, const std::vector<int>& value_shape,
+             std::uintptr_t fn_addr,
+             const std::vector<std::size_t>& value_shape,
              std::shared_ptr<const dolfinx::fem::FunctionSpace<U>>
                  argument_function_space)
           {
@@ -590,7 +591,15 @@ void declare_objects(nb::module_& m, const std::string& type)
       .def_prop_ro("dtype", [](const dolfinx::fem::Expression<T, U>&)
                    { return dolfinx_wrappers::numpy_dtype<T>(); })
       .def_prop_ro("value_size", &dolfinx::fem::Expression<T, U>::value_size)
-      .def_prop_ro("value_shape", &dolfinx::fem::Expression<T, U>::value_shape);
+      .def_prop_ro(
+          "value_shape",
+          [](const dolfinx::fem::Expression<T, U>& self)
+          {
+            const std::vector<std::size_t>& vshape = self.value_shape();
+            return nb::ndarray<const std::size_t, nb::numpy>(vshape.data(),
+                                                             {vshape.size()});
+          },
+          nb::rv_policy::reference_internal);
 
   std::string pymethod_create_expression
       = std::string("create_expression_") + type;

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -1188,8 +1188,7 @@ void fem(nb::module_& m)
       "compute_integration_domains",
       [](dolfinx::fem::IntegralType type,
          const dolfinx::mesh::Topology& topology,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>
-             entities,
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities,
          int dim)
       {
         return dolfinx_wrappers::as_nbarray(

--- a/python/dolfinx/wrappers/geometry.cpp
+++ b/python/dolfinx/wrappers/geometry.cpp
@@ -216,34 +216,38 @@ void declare_bbtree(nb::module_& m, std::string type)
           },
           nb::arg("src_owner"), nb::arg("dest_owners"), nb::arg("dest_points"),
           nb::arg("dest_cells"))
-      .def_prop_ro("src_owner",
-                   [](const dolfinx::geometry::PointOwnershipData<T>& self)
-                   {
-                     return nb::ndarray<const int, nb::numpy>(
-                         self.src_owner.data(), {self.src_owner.size()},
-                         nb::handle());
-                   })
-      .def_prop_ro("dest_owners",
-                   [](const dolfinx::geometry::PointOwnershipData<T>& self)
-                   {
-                     return nb::ndarray<const int, nb::numpy>(
-                         self.dest_owners.data(), {self.dest_owners.size()},
-                         nb::handle());
-                   })
-      .def_prop_ro("dest_points",
-                   [](const dolfinx::geometry::PointOwnershipData<T>& self)
-                   {
-                     return nb::ndarray<const T, nb::numpy>(
-                         self.dest_points.data(),
-                         {self.dest_points.size() / 3, 3}, nb::handle());
-                   })
-      .def_prop_ro("dest_cells",
-                   [](const dolfinx::geometry::PointOwnershipData<T>& self)
-                   {
-                     return nb::ndarray<const std::int32_t, nb::numpy>(
-                         self.dest_cells.data(), {self.dest_cells.size()},
-                         nb::handle());
-                   });
+      .def_prop_ro(
+          "src_owner",
+          [](const dolfinx::geometry::PointOwnershipData<T>& self)
+          {
+            return nb::ndarray<const int, nb::numpy>(self.src_owner.data(),
+                                                     {self.src_owner.size()});
+          },
+          nb::rv_policy::reference_internal)
+      .def_prop_ro(
+          "dest_owners",
+          [](const dolfinx::geometry::PointOwnershipData<T>& self)
+          {
+            return nb::ndarray<const int, nb::numpy>(self.dest_owners.data(),
+                                                     {self.dest_owners.size()});
+          },
+          nb::rv_policy::reference_internal)
+      .def_prop_ro(
+          "dest_points",
+          [](const dolfinx::geometry::PointOwnershipData<T>& self)
+          {
+            return nb::ndarray<const T, nb::numpy>(
+                self.dest_points.data(), {self.dest_points.size() / 3, 3});
+          },
+          nb::rv_policy::reference_internal)
+      .def_prop_ro(
+          "dest_cells",
+          [](const dolfinx::geometry::PointOwnershipData<T>& self)
+          {
+            return nb::ndarray<const std::int32_t, nb::numpy>(
+                self.dest_cells.data(), {self.dest_cells.size()});
+          },
+          nb::rv_policy::reference_internal);
 }
 } // namespace
 

--- a/python/dolfinx/wrappers/geometry.cpp
+++ b/python/dolfinx/wrappers/geometry.cpp
@@ -6,6 +6,7 @@
 
 #include "array.h"
 #include "caster_mpi.h"
+#include <array>
 #include <dolfinx/common/utils.h>
 #include <dolfinx/geometry/BoundingBoxTree.h>
 #include <dolfinx/geometry/gjk.h>
@@ -52,7 +53,8 @@ void declare_bbtree(nb::module_& m, std::string type)
              const std::size_t i)
           {
             std::array<T, 6> bbox = self.get_bbox(i);
-            return nb::ndarray<T, nb::numpy>(bbox.data(), {2, 3}).cast();
+            return nb::ndarray<T, nb::shape<2, 3>, nb::numpy>(bbox.data())
+                .cast();
           },
           nb::arg("i"))
       .def("__repr__", &dolfinx::geometry::BoundingBoxTree<T>::str)

--- a/python/dolfinx/wrappers/geometry.cpp
+++ b/python/dolfinx/wrappers/geometry.cpp
@@ -52,7 +52,7 @@ void declare_bbtree(nb::module_& m, std::string type)
              const std::size_t i)
           {
             std::array<T, 6> bbox = self.get_bbox(i);
-            return nb::ndarray<T, nb::numpy>(bbox.data(), {2, 3});
+            return nb::ndarray<T, nb::numpy>(bbox.data(), {2, 3}).cast();
           },
           nb::arg("i"))
       .def("__repr__", &dolfinx::geometry::BoundingBoxTree<T>::str)
@@ -160,7 +160,7 @@ void declare_bbtree(nb::module_& m, std::string type)
         std::size_t q_s0 = q.ndim() == 1 ? 1 : q.shape(0);
         std::span<const T> _p(p.data(), 3 * p_s0), _q(q.data(), 3 * q_s0);
         std::array<T, 3> d = dolfinx::geometry::compute_distance_gjk<T>(_p, _q);
-        return nb::ndarray<T, nb::numpy>(d.data(), {d.size()});
+        return nb::ndarray<T, nb::numpy>(d.data(), {d.size()}).cast();
       },
       //   nb::rv_policy::copy,
       nb::arg("p"), nb::arg("q"));
@@ -171,7 +171,7 @@ void declare_bbtree(nb::module_& m, std::string type)
          nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> indices,
          nb::ndarray<const T, nb::c_contig> points)
       {
-        const std::size_t p_s0 = points.ndim() == 1 ? 1 : points.shape(0);
+        std::size_t p_s0 = points.ndim() == 1 ? 1 : points.shape(0);
         std::span<const T> _p(points.data(), 3 * p_s0);
         return dolfinx_wrappers::as_nbarray(
             dolfinx::geometry::squared_distance<T>(
@@ -182,7 +182,7 @@ void declare_bbtree(nb::module_& m, std::string type)
         [](const dolfinx::mesh::Mesh<T>& mesh,
            nb::ndarray<const T, nb::c_contig> points, const T padding)
         {
-          const std::size_t p_s0 = points.ndim() == 1 ? 1 : points.shape(0);
+          std::size_t p_s0 = points.ndim() == 1 ? 1 : points.shape(0);
           std::span<const T> _p(points.data(), 3 * p_s0);
           return dolfinx::geometry::determine_point_ownership<T>(mesh, _p,
                                                                  padding);

--- a/python/dolfinx/wrappers/geometry.cpp
+++ b/python/dolfinx/wrappers/geometry.cpp
@@ -238,7 +238,7 @@ void declare_bbtree(nb::module_& m, std::string type)
           "dest_points",
           [](const dolfinx::geometry::PointOwnershipData<T>& self)
           {
-            return nb::ndarray<const T, nb::numpy>(
+            return nb::ndarray<const T, nb::shape<-1, 3>, nb::numpy>(
                 self.dest_points.data(), {self.dest_points.size() / 3, 3});
           },
           nb::rv_policy::reference_internal)

--- a/python/dolfinx/wrappers/geometry.cpp
+++ b/python/dolfinx/wrappers/geometry.cpp
@@ -241,7 +241,7 @@ void declare_bbtree(nb::module_& m, std::string type)
             return nb::ndarray<const T, nb::shape<-1, 3>, nb::numpy>(
                 self.dest_points.data(), {self.dest_points.size() / 3, 3});
           },
-          nb::rv_policy::reference_internal)
+          nb::rv_policy::reference_internal, "Destination point")
       .def_prop_ro(
           "dest_cells",
           [](const dolfinx::geometry::PointOwnershipData<T>& self)

--- a/python/dolfinx/wrappers/geometry.cpp
+++ b/python/dolfinx/wrappers/geometry.cpp
@@ -52,7 +52,7 @@ void declare_bbtree(nb::module_& m, std::string type)
              const std::size_t i)
           {
             std::array<T, 6> bbox = self.get_bbox(i);
-            return dolfinx_wrappers::as_nbarray_copy(bbox, {2, 3});
+            return nb::ndarray<T, nb::numpy>(bbox.data(), {2, 3});
           },
           nb::arg("i"))
       .def("__repr__", &dolfinx::geometry::BoundingBoxTree<T>::str)
@@ -160,7 +160,7 @@ void declare_bbtree(nb::module_& m, std::string type)
         std::size_t q_s0 = q.ndim() == 1 ? 1 : q.shape(0);
         std::span<const T> _p(p.data(), 3 * p_s0), _q(q.data(), 3 * q_s0);
         std::array<T, 3> d = dolfinx::geometry::compute_distance_gjk<T>(_p, _q);
-        return dolfinx_wrappers::as_nbarray_copy(d, {d.size()});
+        return nb::ndarray<T, nb::numpy>(d.data(), {d.size()});
       },
       //   nb::rv_policy::copy,
       nb::arg("p"), nb::arg("q"));

--- a/python/dolfinx/wrappers/graph.cpp
+++ b/python/dolfinx/wrappers/graph.cpp
@@ -82,8 +82,7 @@ void declare_adjacency_list(nb::module_& m, std::string type)
           [](const dolfinx::graph::AdjacencyList<T>& self, int i)
           {
             std::span<const T> link = self.links(i);
-            return nb::ndarray<const T, nb::numpy>(link.data(), {link.size()},
-                                                   nb::handle());
+            return nb::ndarray<const T, nb::numpy>(link.data(), {link.size()});
           },
           nb::rv_policy::reference_internal, nb::arg("i"),
           "Links (edges) of a node")
@@ -91,8 +90,8 @@ void declare_adjacency_list(nb::module_& m, std::string type)
           "array",
           [](const dolfinx::graph::AdjacencyList<T>& self)
           {
-            return nb::ndarray<const T, nb::numpy>(
-                self.array().data(), {self.array().size()}, nb::handle());
+            return nb::ndarray<const T, nb::numpy>(self.array().data(),
+                                                   {self.array().size()});
           },
           nb::rv_policy::reference_internal)
       .def_prop_ro(
@@ -100,7 +99,7 @@ void declare_adjacency_list(nb::module_& m, std::string type)
           [](const dolfinx::graph::AdjacencyList<T>& self)
           {
             return nb::ndarray<const std::int32_t, nb::numpy>(
-                self.offsets().data(), {self.offsets().size()}, nb::handle());
+                self.offsets().data(), {self.offsets().size()});
           },
           nb::rv_policy::reference_internal)
       .def_prop_ro("num_nodes", &dolfinx::graph::AdjacencyList<T>::num_nodes)

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -56,8 +56,7 @@ void declare_objects(nb::module_& m, const std::string& type)
           [](dolfinx::la::Vector<T>& self)
           {
             return nb::ndarray<T, nb::numpy>(self.mutable_array().data(),
-                                             {self.array().size()},
-                                             nb::handle());
+                                             {self.array().size()});
           },
           nb::rv_policy::reference_internal)
       .def("scatter_forward", &dolfinx::la::Vector<T>::scatter_fwd)
@@ -146,8 +145,8 @@ void declare_objects(nb::module_& m, const std::string& type)
           "data",
           [](dolfinx::la::MatrixCSR<T>& self)
           {
-            return nb::ndarray<T, nb::numpy>(
-                self.values().data(), {self.values().size()}, nb::handle());
+            return nb::ndarray<T, nb::numpy>(self.values().data(),
+                                             {self.values().size()});
           },
           nb::rv_policy::reference_internal)
       .def_prop_ro(
@@ -155,7 +154,7 @@ void declare_objects(nb::module_& m, const std::string& type)
           [](dolfinx::la::MatrixCSR<T>& self)
           {
             return nb::ndarray<const std::int32_t, nb::numpy>(
-                self.cols().data(), {self.cols().size()}, nb::handle());
+                self.cols().data(), {self.cols().size()});
           },
           nb::rv_policy::reference_internal)
       .def_prop_ro(
@@ -163,8 +162,8 @@ void declare_objects(nb::module_& m, const std::string& type)
           [](dolfinx::la::MatrixCSR<T>& self)
           {
             std::span<const std::int64_t> array = self.row_ptr();
-            return nb::ndarray<const std::int64_t, nb::numpy>(
-                array.data(), {array.size()}, nb::handle());
+            return nb::ndarray<const std::int64_t, nb::numpy>(array.data(),
+                                                              {array.size()});
           },
           nb::rv_policy::reference_internal)
       .def("scatter_rev_begin", &dolfinx::la::MatrixCSR<T>::scatter_rev_begin)
@@ -246,7 +245,8 @@ void la(nb::module_& m)
                      std::reference_wrapper<const dolfinx::common::IndexMap>,
                      int>>,
                  2>& maps,
-             const std::array<std::vector<int>, 2>& bs) {
+             const std::array<std::vector<int>, 2>& bs)
+          {
             new (sp)
                 dolfinx::la::SparsityPattern(comm.get(), patterns, maps, bs);
           },
@@ -282,9 +282,9 @@ void la(nb::module_& m)
           {
             auto [edges, ptr] = self.graph();
             return std::pair(nb::ndarray<const std::int32_t, nb::numpy>(
-                                 edges.data(), {edges.size()}, nb::handle()),
+                                 edges.data(), {edges.size()}),
                              nb::ndarray<const std::int64_t, nb::numpy>(
-                                 ptr.data(), {ptr.size()}, nb::handle()));
+                                 ptr.data(), {ptr.size()}));
           },
           nb::rv_policy::reference_internal);
 

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -133,12 +133,12 @@ void declare_objects(nb::module_& m, const std::string& type)
       .def("to_dense",
            [](const dolfinx::la::MatrixCSR<T>& self)
            {
-             const std::array<int, 2> bs = self.block_size();
+             std::array<int, 2> bs = self.block_size();
              std::size_t nrows = self.num_all_rows() * bs[0];
              std::size_t ncols = self.index_map(1)->size_global() * bs[1];
-             auto dense = self.to_dense();
+             std::vector<T> dense = self.to_dense();
              assert(nrows * ncols == dense.size());
-             return dolfinx_wrappers::as_nbarray(std::move(self.to_dense()),
+             return dolfinx_wrappers::as_nbarray(std::move(dense),
                                                  {nrows, ncols});
            })
       .def_prop_ro(

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -616,9 +616,11 @@ void mesh(nb::module_& m)
           {
             if (self.original_cell_index.size() != 1)
               throw std::runtime_error("Mixed topology unsupported");
-            return nb::ndarray<const std::int64_t, nb::numpy>(
-                self.original_cell_index[0].data(),
-                {self.original_cell_index[0].size()});
+
+            const std::vector<std::vector<std::int64_t>>& idx
+                = self.original_cell_index;
+            return nb::ndarray<const std::int64_t, nb::numpy>(idx[0].data(),
+                                                              {idx[0].size()});
           },
           nb::rv_policy::reference_internal)
       .def("connectivity",

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -53,10 +53,9 @@ create_cell_partitioner_cpp(const PythonCellPartitionFunction& p)
           cells, std::back_inserter(cells_nb),
           [](auto c)
           {
-            return nb::ndarray<const std::int64_t, nb::numpy>(
-                c.data(), {c.size()}, nb::handle());
+            return nb::ndarray<const std::int64_t, nb::numpy>(c.data(),
+                                                              {c.size()});
           });
-
       return p(dolfinx_wrappers::MPICommWrapper(comm), n, cell_types, cells_nb);
     };
   }
@@ -94,8 +93,8 @@ void declare_meshtags(nb::module_& m, std::string type)
           "values",
           [](dolfinx::mesh::MeshTags<T>& self)
           {
-            return nb::ndarray<const T, nb::numpy>(
-                self.values().data(), {self.values().size()}, nb::handle());
+            return nb::ndarray<const T, nb::numpy>(self.values().data(),
+                                                   {self.values().size()});
           },
           nb::rv_policy::reference_internal)
       .def_prop_ro(
@@ -103,7 +102,7 @@ void declare_meshtags(nb::module_& m, std::string type)
           [](dolfinx::mesh::MeshTags<T>& self)
           {
             return nb::ndarray<const std::int32_t, nb::numpy>(
-                self.indices().data(), {self.indices().size()}, nb::handle());
+                self.indices().data(), {self.indices().size()});
           },
           nb::rv_policy::reference_internal)
       .def("find", [](dolfinx::mesh::MeshTags<T>& self, T value)
@@ -167,8 +166,7 @@ void declare_mesh(nb::module_& m, std::string type)
           {
             auto dofs = self.dofmap();
             return nb::ndarray<const std::int32_t, nb::numpy>(
-                dofs.data_handle(), {dofs.extent(0), dofs.extent(1)},
-                nb::handle());
+                dofs.data_handle(), {dofs.extent(0), dofs.extent(1)});
           },
           nb::rv_policy::reference_internal)
       .def(
@@ -177,8 +175,7 @@ void declare_mesh(nb::module_& m, std::string type)
           {
             auto dofs = self.dofmap(i);
             return nb::ndarray<const std::int32_t, nb::numpy>(
-                dofs.data_handle(), {dofs.extent(0), dofs.extent(1)},
-                nb::handle());
+                dofs.data_handle(), {dofs.extent(0), dofs.extent(1)});
           },
           nb::rv_policy::reference_internal, nb::arg("i"),
           "Get the geometry dofmap associated with coordinate element i (mixed "
@@ -188,8 +185,8 @@ void declare_mesh(nb::module_& m, std::string type)
           "x",
           [](dolfinx::mesh::Geometry<T>& self)
           {
-            return nb::ndarray<T, nb::numpy>(
-                self.x().data(), {self.x().size() / 3, 3}, nb::handle());
+            return nb::ndarray<T, nb::numpy>(self.x().data(),
+                                             {self.x().size() / 3, 3});
           },
           nb::rv_policy::reference_internal,
           "Return coordinates of all geometry points. Each row is the "
@@ -207,7 +204,7 @@ void declare_mesh(nb::module_& m, std::string type)
             const std::vector<std::int64_t>& id_to_global
                 = self.input_global_indices();
             return nb::ndarray<const std::int64_t, nb::numpy>(
-                id_to_global.data(), {id_to_global.size()}, nb::handle());
+                id_to_global.data(), {id_to_global.size()});
           },
           nb::rv_policy::reference_internal);
 
@@ -306,7 +303,7 @@ void declare_mesh(nb::module_& m, std::string type)
                   [](auto c)
                   {
                     return nb::ndarray<const std::int64_t, nb::numpy>(
-                        c.data(), {c.size()}, nb::handle());
+                        c.data(), {c.size()});
                   });
               return p(MPICommWrapper(comm), n, cell_types, cells_nb);
             };
@@ -341,8 +338,8 @@ void declare_mesh(nb::module_& m, std::string type)
                 cells, std::back_inserter(cells_nb),
                 [](auto c)
                 {
-                  return nb::ndarray<const std::int64_t, nb::numpy>(
-                      c.data(), {c.size()}, nb::handle());
+                  return nb::ndarray<const std::int64_t, nb::numpy>(c.data(),
+                                                                    {c.size()});
                 });
             return p(MPICommWrapper(comm), n, cell_types, cells_nb);
           };
@@ -418,7 +415,7 @@ void declare_mesh(nb::module_& m, std::string type)
         auto cpp_marker = [&marker](auto x)
         {
           nb::ndarray<const T, nb::ndim<2>, nb::numpy> x_view(
-              x.data_handle(), {x.extent(0), x.extent(1)}, nb::handle());
+              x.data_handle(), {x.extent(0), x.extent(1)});
           auto marked = marker(x_view);
           return std::vector<std::int8_t>(marked.data(),
                                           marked.data() + marked.size());
@@ -439,7 +436,7 @@ void declare_mesh(nb::module_& m, std::string type)
         auto cpp_marker = [&marker](auto x)
         {
           nb::ndarray<const T, nb::ndim<2>, nb::numpy> x_view(
-              x.data_handle(), {x.extent(0), x.extent(1)}, nb::handle());
+              x.data_handle(), {x.extent(0), x.extent(1)});
           auto marked = marker(x_view);
           return std::vector<std::int8_t>(marked.data(),
                                           marked.data() + marked.size());
@@ -599,8 +596,8 @@ void mesh(nb::module_& m)
           [](const dolfinx::mesh::Topology& self)
           {
             const std::vector<std::uint8_t>& p = self.get_facet_permutations();
-            return nb::ndarray<const std::uint8_t, nb::numpy>(
-                p.data(), {p.size()}, nb::handle());
+            return nb::ndarray<const std::uint8_t, nb::numpy>(p.data(),
+                                                              {p.size()});
           },
           nb::rv_policy::reference_internal)
       .def(
@@ -609,8 +606,8 @@ void mesh(nb::module_& m)
           {
             const std::vector<std::uint32_t>& p
                 = self.get_cell_permutation_info();
-            return nb::ndarray<const std::uint32_t, nb::numpy>(
-                p.data(), {p.size()}, nb::handle());
+            return nb::ndarray<const std::uint32_t, nb::numpy>(p.data(),
+                                                               {p.size()});
           },
           nb::rv_policy::reference_internal)
       .def_prop_ro("dim", &dolfinx::mesh::Topology::dim,
@@ -623,7 +620,7 @@ void mesh(nb::module_& m)
               throw std::runtime_error("Mixed topology unsupported");
             return nb::ndarray<const std::int64_t, nb::numpy>(
                 self.original_cell_index[0].data(),
-                {self.original_cell_index[0].size()}, nb::handle());
+                {self.original_cell_index[0].size()});
           },
           nb::rv_policy::reference_internal)
       .def("connectivity",
@@ -653,8 +650,8 @@ void mesh(nb::module_& m)
           {
             const std::vector<std::int32_t>& facets
                 = self.interprocess_facets();
-            return nb::ndarray<const std::int32_t, nb::numpy>(
-                facets.data(), {facets.size()}, nb::handle());
+            return nb::ndarray<const std::int32_t, nb::numpy>(facets.data(),
+                                                              {facets.size()});
           },
           nb::rv_policy::reference_internal)
       .def_prop_ro(

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -618,7 +618,6 @@ void mesh(nb::module_& m)
           {
             if (self.original_cell_index.size() != 1)
               throw std::runtime_error("Mixed topology unsupported");
-
             const std::vector<std::vector<std::int64_t>>& idx
                 = self.original_cell_index;
             return nb::ndarray<const std::int64_t, nb::numpy>(idx[0].data(),

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -364,8 +364,10 @@ void declare_mesh(nb::module_& m, std::string type)
       [](const dolfinx::mesh::Mesh<T>& mesh, int dim,
          nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities)
       {
-        auto submesh = dolfinx::mesh::create_submesh(
-            mesh, dim, std::span(entities.data(), entities.size()));
+        std::tuple<dolfinx::mesh::Mesh<T>, std::vector<std::int32_t>,
+                   std::vector<std::int32_t>, std::vector<std::int32_t>>
+            submesh = dolfinx::mesh::create_submesh(
+                mesh, dim, std::span(entities.data(), entities.size()));
         auto _e_map = as_nbarray(std::move(std::get<1>(submesh)));
         auto _v_map = as_nbarray(std::move(std::get<2>(submesh)));
         auto _g_map = as_nbarray(std::move(std::get<3>(submesh)));
@@ -454,10 +456,6 @@ void declare_mesh(nb::module_& m, std::string type)
       {
         std::vector<std::int32_t> idx = dolfinx::mesh::entities_to_geometry(
             mesh, dim, std::span(entities.data(), entities.size()), permute);
-
-        auto topology = mesh.topology();
-        assert(topology);
-        dolfinx::mesh::CellType cell_type = topology->cell_type();
         return as_nbarray(std::move(idx),
                           {entities.size(), idx.size() / entities.size()});
       },

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -91,18 +91,19 @@ void declare_meshtags(nb::module_& m, std::string type)
       .def_prop_ro("topology", &dolfinx::mesh::MeshTags<T>::topology)
       .def_prop_ro(
           "values",
-          [](dolfinx::mesh::MeshTags<T>& self)
+          [](const dolfinx::mesh::MeshTags<T>& self)
           {
-            return nb::ndarray<const T, nb::numpy>(self.values().data(),
-                                                   {self.values().size()});
+            std::span<const T> v = self.values();
+            return nb::ndarray<const T, nb::numpy>(v.data(), {v.size()});
           },
           nb::rv_policy::reference_internal)
       .def_prop_ro(
           "indices",
-          [](dolfinx::mesh::MeshTags<T>& self)
+          [](const dolfinx::mesh::MeshTags<T>& self)
           {
-            return nb::ndarray<const std::int32_t, nb::numpy>(
-                self.indices().data(), {self.indices().size()});
+            std::span<const std::int32_t> idx = self.indices();
+            return nb::ndarray<const std::int32_t, nb::numpy>(idx.data(),
+                                                              {idx.size()});
           },
           nb::rv_policy::reference_internal)
       .def("find", [](dolfinx::mesh::MeshTags<T>& self, T value)
@@ -185,8 +186,9 @@ void declare_mesh(nb::module_& m, std::string type)
           "x",
           [](dolfinx::mesh::Geometry<T>& self)
           {
-            return nb::ndarray<T, nb::numpy>(self.x().data(),
-                                             {self.x().size() / 3, 3});
+            std::span<T> x = self.x();
+            return nb::ndarray<T, nb::shape<-1, 3>, nb::numpy>(
+                x.data(), {x.size() / 3, 3});
           },
           nb::rv_policy::reference_internal,
           "Return coordinates of all geometry points. Each row is the "


### PR DESCRIPTION
`nanobind` [docs](https://nanobind.readthedocs.io/en/latest/ndarray.html) for `nanobind::ndarray` have improved lot recently, which has helped with these changes to simplify code.