### PR TITLE
Start simplification and consistency fixes for `fem::FiniteElement`

### DIFF
--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -302,7 +302,7 @@ int FiniteElement<T>::num_sub_elements() const noexcept
 template <std::floating_point T>
 bool FiniteElement<T>::is_mixed() const noexcept
 {
-  return !_reference_value_shape.has_value();
+  return !_reference_value_shape;
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -143,7 +143,7 @@ FiniteElement<T>::FiniteElement(
       _reference_value_shape(std::nullopt), _bs(1), _symmetric(false),
       _needs_dof_permutations(false), _needs_dof_transformations(false)
 {
-  if (elements.size() > 1)
+  if (elements.size() < 2)
   {
     throw std::runtime_error("FiniteElement constructor for mixed elements "
                              "called with a single element.");

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -71,9 +71,11 @@ FiniteElement<T>::FiniteElement(mesh::CellType cell_type,
                                 std::size_t block_size, bool symmetric)
     : _signature("Quadrature element " + std::to_string(pshape[0]) + " "
                  + std::to_string(block_size)),
-      _space_dim(pshape[0] * block_size), _reference_value_shape({}),
-      _bs(block_size), _is_mixed(false), _symmetric(symmetric),
-      _needs_dof_permutations(false), _needs_dof_transformations(false),
+      _space_dim(pshape[0] * block_size), _reference_value_shape(std::nullopt),
+      _bs(block_size),
+      /*_is_mixed(false), */
+      _symmetric(symmetric), _needs_dof_permutations(false),
+      _needs_dof_transformations(false),
       _entity_dofs(mesh::cell_dim(cell_type) + 1),
       _entity_closure_dofs(mesh::cell_dim(cell_type) + 1),
       _points(std::vector<T>(points.begin(), points.end()), pshape)
@@ -98,7 +100,6 @@ FiniteElement<T>::FiniteElement(const basix::FiniteElement<T>& element,
                                 std::size_t block_size, bool symmetric)
     : _space_dim(block_size * element.dim()),
       _reference_value_shape(element.value_shape()), _bs(block_size),
-      _is_mixed(false),
       _element(std::make_unique<basix::FiniteElement<T>>(element)),
       _symmetric(symmetric),
       _needs_dof_permutations(
@@ -139,9 +140,9 @@ FiniteElement<T>::FiniteElement(const basix::FiniteElement<T>& element,
 template <std::floating_point T>
 FiniteElement<T>::FiniteElement(
     const std::vector<std::shared_ptr<const FiniteElement<T>>>& elements)
-    : _space_dim(0), _sub_elements(elements), _bs(1), _is_mixed(true),
-      _symmetric(false), _needs_dof_permutations(false),
-      _needs_dof_transformations(false)
+    : _space_dim(0), _sub_elements(elements),
+      _reference_value_shape(std::nullopt), _bs(1), _symmetric(false),
+      _needs_dof_permutations(false), _needs_dof_transformations(false)
 {
   std::size_t vsize = 0;
   _signature = "Mixed element (";
@@ -191,7 +192,7 @@ FiniteElement<T>::FiniteElement(
   }
 
   _space_dim = dof_offset;
-  _reference_value_shape = {vsize};
+  // _reference_value_shape = {vsize};
   _signature += ")";
 }
 //-----------------------------------------------------------------------------
@@ -226,10 +227,12 @@ int FiniteElement<T>::space_dimension() const noexcept
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
-std::span<const std::size_t>
-FiniteElement<T>::reference_value_shape() const noexcept
+std::span<const std::size_t> FiniteElement<T>::reference_value_shape() const
 {
-  return _reference_value_shape;
+  if (_reference_value_shape.has_value())
+    return *_reference_value_shape;
+  else
+    throw std::runtime_error("Element does not have a reference_value_shape.");
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
@@ -255,8 +258,13 @@ bool FiniteElement<T>::symmetric() const
 template <std::floating_point T>
 int FiniteElement<T>::reference_value_size() const
 {
-  return std::accumulate(_reference_value_shape.begin(),
-                         _reference_value_shape.end(), 1, std::multiplies{});
+  if (_reference_value_shape.has_value())
+  {
+    return std::accumulate(_reference_value_shape->begin(),
+                           _reference_value_shape->end(), 1, std::multiplies{});
+  }
+  else
+    throw std::runtime_error("Element does not have a reference_value_shape.");
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>
@@ -292,7 +300,7 @@ int FiniteElement<T>::num_sub_elements() const noexcept
 template <std::floating_point T>
 bool FiniteElement<T>::is_mixed() const noexcept
 {
-  return _is_mixed;
+  return !_reference_value_shape.has_value();
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -144,7 +144,7 @@ FiniteElement<T>::FiniteElement(
       _reference_value_shape(std::nullopt), _bs(1), _symmetric(false),
       _needs_dof_permutations(false), _needs_dof_transformations(false)
 {
-  std::size_t vsize = 0;
+  // std::size_t vsize = 0;
   _signature = "Mixed element (";
 
   const std::vector<std::vector<std::vector<int>>>& ed
@@ -160,7 +160,7 @@ FiniteElement<T>::FiniteElement(
   int dof_offset = 0;
   for (auto& e : elements)
   {
-    vsize += e->reference_value_size();
+    // vsize += e->reference_value_size();
     _signature += e->signature() + ", ";
 
     if (e->needs_dof_permutations())

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -14,6 +14,7 @@
 #include <dolfinx/mesh/cell_types.h>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <span>
 #include <utility>
 #include <vector>
@@ -115,7 +116,7 @@ public:
   int reference_value_size() const;
 
   /// The reference value shape
-  std::span<const std::size_t> reference_value_shape() const noexcept;
+  std::span<const std::size_t> reference_value_shape() const;
 
   /// The local DOFs associated with each subentity of the cell
   const std::vector<std::vector<std::vector<int>>>&
@@ -324,7 +325,7 @@ public:
 
     if (!_sub_elements.empty())
     {
-      if (_is_mixed)
+      if (!_reference_value_shape.has_value())
       {
         // Mixed element
         std::vector<std::function<void(
@@ -426,9 +427,9 @@ public:
         // Do nothing
       };
     }
-    else if (_sub_elements.size() != 0)
+    else if (!_sub_elements.empty())
     {
-      if (_is_mixed)
+      if (!_reference_value_shape.has_value())
       {
         // Mixed element
         std::vector<std::function<void(
@@ -725,14 +726,12 @@ private:
       _sub_elements;
 
   // Dimension of each value space
-  std::vector<std::size_t> _reference_value_shape;
+  // std::vector<std::size_t> _reference_value_shape;
+  std::optional<std::vector<std::size_t>> _reference_value_shape;
 
   // Block size for BlockedElements. This gives the number of DOFs
   // co-located at each dof 'point'.
   int _bs;
-
-  // Indicate whether this is a mixed element
-  bool _is_mixed;
 
   // Basix Element (nullptr for mixed elements)
   std::unique_ptr<basix::FiniteElement<geometry_type>> _element;

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -723,7 +723,8 @@ private:
   std::vector<std::shared_ptr<const FiniteElement<geometry_type>>>
       _sub_elements;
 
-  // Value space shape, e.g. {} for a scalar, {3, 3} for a tensor in 3D
+  // Value space shape, e.g. {} for a scalar, {3, 3} for a tensor in 3D.
+  // For a mixed element it is std::nullopt.
   std::optional<std::vector<std::size_t>> _reference_value_shape;
 
   // Block size for BlockedElements. This gives the number of DOFs

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -325,9 +325,8 @@ public:
 
     if (!_sub_elements.empty())
     {
-      if (!_reference_value_shape.has_value())
+      if (!_reference_value_shape) // Mixed element
       {
-        // Mixed element
         std::vector<std::function<void(
             std::span<U>, std::span<const std::uint32_t>, std::int32_t, int)>>
             sub_element_fns;
@@ -429,9 +428,8 @@ public:
     }
     else if (!_sub_elements.empty())
     {
-      if (!_reference_value_shape.has_value())
+      if (!_reference_value_shape) // Mixed element
       {
-        // Mixed element
         std::vector<std::function<void(
             std::span<U>, std::span<const std::uint32_t>, std::int32_t, int)>>
             sub_element_fns;

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -104,18 +104,31 @@ public:
   /// @return Dimension of the finite element space
   int space_dimension() const noexcept;
 
-  /// Block size of the finite element function space. For
-  /// BlockedElements, this is the number of DOFs
-  /// colocated at each DOF point. For other elements, this is always 1.
+  /// @brief Block size of the finite element function space.
+  ///
+  /// For BlockedElements, this is the number of DOFs colocated at each
+  /// DOF point. For other elements, this is always 1.
   /// @return Block size of the finite element space
   int block_size() const noexcept;
 
-  /// The value size, e.g. 1 for a scalar function, 2 for a 2D vector, 9
-  /// for a second-order tensor in 3D, for the reference element
-  /// @return The value size for the reference element
+  /// @brief Value size.
+  ///
+  /// The value size is the product of the value shape, e.g. is is  1
+  /// for a scalar function, 2 for a 2D vector, 9 for a second-order
+  /// tensor in 3D.
+  /// @throws Exception is thrown for a mixed element as mixed elements
+  /// do not have a value shape.
+  /// @return The value size.
   int reference_value_size() const;
 
-  /// The reference value shape
+  /// @brief Value shape.
+  ///
+  /// The value shape described the shape of the finite element field,
+  /// e.g. {} for a scalar, {3, 3} for a tensor in 3D. Mixed elements do
+  /// not have a value shape.
+  /// @throws Exception is thrown for a mixed element as mixed elements
+  /// do not have a value shape.
+  /// @return The value shape.
   std::span<const std::size_t> reference_value_shape() const;
 
   /// The local DOFs associated with each subentity of the cell

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -725,8 +725,7 @@ private:
   std::vector<std::shared_ptr<const FiniteElement<geometry_type>>>
       _sub_elements;
 
-  // Dimension of each value space
-  // std::vector<std::size_t> _reference_value_shape;
+  // Value space shape, e.g. {} for a scalar, {3, 3} for a tensor in 3D
   std::optional<std::vector<std::size_t>> _reference_value_shape;
 
   // Block size for BlockedElements. This gives the number of DOFs

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -1197,13 +1197,16 @@ void fem(nb::module_& m)
       "compute_integration_domains",
       [](dolfinx::fem::IntegralType type,
          const dolfinx::mesh::Topology& topology,
-         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities)
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities,
+         int dim)
       {
         return dolfinx_wrappers::as_nbarray(
             dolfinx::fem::compute_integration_domains(
-                type, topology, std::span(entities.data(), entities.size())));
+                type, topology, std::span(entities.data(), entities.size()),
+                dim));
       },
-      nb::arg("integral_type"), nb::arg("topology"), nb::arg("entities"));
+      nb::arg("integral_type"), nb::arg("topology"), nb::arg("entities"),
+      nb::arg("dim"));
 
   // dolfinx::fem::ElementDofLayout
   nb::class_<dolfinx::fem::ElementDofLayout>(

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -1197,16 +1197,13 @@ void fem(nb::module_& m)
       "compute_integration_domains",
       [](dolfinx::fem::IntegralType type,
          const dolfinx::mesh::Topology& topology,
-         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities,
-         int dim)
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities)
       {
         return dolfinx_wrappers::as_nbarray(
             dolfinx::fem::compute_integration_domains(
-                type, topology, std::span(entities.data(), entities.size()),
-                dim));
+                type, topology, std::span(entities.data(), entities.size())));
       },
-      nb::arg("integral_type"), nb::arg("topology"), nb::arg("entities"),
-      nb::arg("dim"));
+      nb::arg("integral_type"), nb::arg("topology"), nb::arg("entities"));
 
   // dolfinx::fem::ElementDofLayout
   nb::class_<dolfinx::fem::ElementDofLayout>(

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -171,7 +171,7 @@ def test_block_size():
         V = functionspace(mesh, mixed_element([P2, P2]))
         assert V.dofmap.index_map_bs == 1
 
-        for i in range(1, 6):
+        for i in range(2, 6):
             W = functionspace(mesh, mixed_element(i * [P2]))
             assert W.dofmap.index_map_bs == 1
 

--- a/python/test/unit/fem/test_mixed_element.py
+++ b/python/test/unit/fem/test_mixed_element.py
@@ -44,8 +44,6 @@ def test_mixed_element(rank, family, cell, degree):
         A.scatter_reverse()
         norms.append(A.squared_norm())
 
-        U_el = mixed_element([U_el])
-
     for i in norms[1:]:
         assert np.isclose(norms[0], i)
 


### PR DESCRIPTION
`fem::FiniteElement` and `fem::FunctionSpace` are in a bit of a mess with respect to block size, value_shape and mixed elements. It's all a bit muddled. This is a first step of several to straighten things out. This change makes `fem::FiniteElement::_reference_value_shape` optional - it takes on a value only when it makes sense and when needed, i.e. not for mixed elements.