### PR TITLE
Fix SNES NonlinearPDE class when using line search

### DIFF
--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -612,7 +612,7 @@ void mesh(nb::module_& m)
           nb::rv_policy::reference_internal)
       .def_prop_ro("dim", &dolfinx::mesh::Topology::dim,
                    "Topological dimension")
-      .def_prop_ro(
+      .def_prop_rw(
           "original_cell_index",
           [](const dolfinx::mesh::Topology& self)
           {
@@ -623,7 +623,16 @@ void mesh(nb::module_& m)
             return nb::ndarray<const std::int64_t, nb::numpy>(idx[0].data(),
                                                               {idx[0].size()});
           },
-          nb::rv_policy::reference_internal)
+          [](dolfinx::mesh::Topology& self,
+             const nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>&
+                 original_cell_indices)
+          {
+            self.original_cell_index.resize(1);
+            self.original_cell_index[0].assign(
+                original_cell_indices.data(),
+                original_cell_indices.data() + original_cell_indices.size());
+          },
+          nb::arg("original_cell_indices"))
       .def("connectivity",
            nb::overload_cast<int, int>(&dolfinx::mesh::Topology::connectivity,
                                        nb::const_),

--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -11,7 +11,6 @@ import numpy as np
 import pytest
 
 import ufl
-from dolfinx import cpp as _cpp
 from dolfinx import default_real_type
 from dolfinx.fem import Function, dirichletbc, form, functionspace, locate_dofs_geometrical
 from dolfinx.mesh import create_unit_square
@@ -106,6 +105,7 @@ class TestNLS:
     def test_linear_pde(self):
         """Test Newton solver for a linear PDE."""
         from petsc4py import PETSc
+
         from dolfinx.nls.petsc import NewtonSolver
 
         # Create mesh and function space
@@ -154,6 +154,7 @@ class TestNLS:
     def test_nonlinear_pde(self):
         """Test Newton solver for a simple nonlinear PDE"""
         from petsc4py import PETSc
+
         from dolfinx.nls.petsc import NewtonSolver
 
         mesh = create_unit_square(MPI.COMM_WORLD, 12, 5)

--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -76,7 +76,7 @@ class NonlinearPDE_SNESProblem:
         self._F, self._J = None, None
         self.u = u
 
-    def F(self, snes: PETSc.SNES, x_: PETSc.Vec, b_: PETSc.Vec):
+    def F(self, snes, x_, b_):
         """Assemble residual vector."""
         from dolfinx.fem.petsc import apply_lifting, assemble_vector, set_bc
 
@@ -98,7 +98,7 @@ class NonlinearPDE_SNESProblem:
             # Restore the state of the SNES solver
             x0_local.copy(u_local)
 
-    def J(self, snes: PETSc.SNES, x_: PETSc.Vec, J: PETSc.Mat, P: PETSc.Mat):
+    def J(self, snes, x_, J, P):
         """Assemble Jacobian matrix."""
         from dolfinx.fem.petsc import assemble_matrix
 

--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -239,8 +239,6 @@ class TestNLS:
         snes.solve(None, u.x.petsc_vec)
         assert snes.getConvergedReason() > 0
         assert snes.getIterationNumber() < 6
-        # print(snes.getIterationNumber())
-        # print(snes.getFunctionNorm())
 
         snes.destroy()
         b.destroy()


### PR DESCRIPTION
Thanks to @jonas-heinzmann for clearly identifying and explaining this issue and @michalhabera for help creating this fix.

When using a linesearch routine SNES needs to calculate (multiple times) the norm of the residual evaluated at a vector `w` equal to the current solution plus some proposed scaling factor times the Newton increment. To do this SNES calls the user-defined residual evaluation routine passing `w`. Our current implementation of the residual evaluation routine overwrites the residual form state `u` with `w` but does not *replace* `u` with the current solution `x` before returning. This leads to a failure of the linesearch.

This patch fixes this behaviour by preserving the internal state of the residual.