### PR TITLE
Require `nanobind>=2.2.0`

### DIFF
--- a/python/build-requirements.txt
+++ b/python/build-requirements.txt
@@ -1,3 +1,3 @@
-nanobind>=2.0.0
+nanobind>=2.2.0
 scikit-build-core[pyproject]>=0.10
 mpi4py

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@
 # list it here.
 # pip install -r build-requirements.txt
 [build-system]
-requires = ["scikit-build-core[pyproject]>=0.10", "nanobind>=2.0.0", "mpi4py"]
+requires = ["scikit-build-core[pyproject]>=0.10", "nanobind>=2.2.0", "mpi4py"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
Failed CI runs with
- `2.0.0` at https://github.com/FEniCS/dolfinx/actions/runs/11834818465
- `2.1.0` at https://github.com/FEniCS/dolfinx/actions/runs/11834895735

#3496 seems to be the one that contains backward incompatible changes.