### PR TITLE
Add more PETSc destruction notes to assembly functionality that creates PETSc.Mat/Vec objects

### DIFF
--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -245,7 +245,7 @@ def assemble_vector(L: typing.Any, constants=None, coeffs=None) -> PETSc.Vec:
         and the Python garbage collector, it is recommended that the method ``PETSc.Vec.destroy()``
         is called on the returned object once the object is no longer required. Note that
         ``PETSc.Vec.destroy()`` is collective over the object's MPI communicator.
-        
+
     Args:
         L: A linear form.
 
@@ -342,7 +342,7 @@ def assemble_vector_block(
         and the Python garbage collector, it is recommended that the method ``PETSc.Vec.destroy()``
         is called on the returned object once the object is no longer required. Note that
         ``PETSc.Vec.destroy()`` is collective over the object's MPI communicator.
-    
+
     The vector is not finalised, i.e. ghost values are not accumulated.
     """
     maps = [
@@ -464,7 +464,7 @@ def assemble_matrix(
         and the Python garbage collector, it is recommended that the method ``PETSc.Mat.destroy()``
         is called on the returned object once the object is no longer required. Note that
         ``PETSc.Mat.destroy()`` is collective over the object's MPI communicator.
-        
+
     Args:
         a: Bilinear form to assembled into a matrix.
         bc: Dirichlet boundary conditions applied to the system.
@@ -613,7 +613,7 @@ def assemble_matrix_block(
     coeffs=None,
 ) -> PETSc.Mat:  # type: ignore
     """Assemble bilinear forms into a blocked matrix.
-    
+
     Note:
         Due to subtle issues in the interaction between petsc4py memory management
         and the Python garbage collector, it is recommended that the method ``PETSc.Mat.destroy()``

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -103,6 +103,12 @@ def _extract_function_spaces(a: list[list[Form]]):
 def create_vector(L: Form) -> PETSc.Vec:
     """Create a PETSc vector that is compatible with a linear form.
 
+    Note:
+        Due to subtle issues in the interaction between petsc4py memory management
+        and the Python garbage collector, it is recommended that the method ``PETSc.Vec.destroy()``
+        is called on the returned object once the object is no longer required. Note that
+        ``PETSc.Vec.destroy()`` is collective over the object's MPI communicator.
+
     Args:
         L: A linear form.
 
@@ -234,6 +240,12 @@ def assemble_vector(L: typing.Any, constants=None, coeffs=None) -> PETSc.Vec:
         The returned vector is not finalised, i.e. ghost values are not
         accumulated on the owning processes.
 
+    Note:
+        Due to subtle issues in the interaction between petsc4py memory management
+        and the Python garbage collector, it is recommended that the method ``PETSc.Vec.destroy()``
+        is called on the returned object once the object is no longer required. Note that
+        ``PETSc.Vec.destroy()`` is collective over the object's MPI communicator.
+        
     Args:
         L: A linear form.
 
@@ -272,6 +284,12 @@ def _assemble_vector_vec(b: PETSc.Vec, L: Form, constants=None, coeffs=None) -> 
 @functools.singledispatch
 def assemble_vector_nest(L: typing.Any, constants=None, coeffs=None) -> PETSc.Vec:
     """Assemble linear forms into a new nested PETSc (``VecNest``) vector.
+
+    Note:
+        Due to subtle issues in the interaction between petsc4py memory management
+        and the Python garbage collector, it is recommended that the method ``PETSc.Vec.destroy()``
+        is called on the returned object once the object is no longer required. Note that
+        ``PETSc.Vec.destroy()`` is collective over the object's MPI communicator.
 
     The returned vector is not finalised, i.e. ghost values are not
     accumulated on the owning processes.
@@ -319,6 +337,12 @@ def assemble_vector_block(
 ) -> PETSc.Vec:
     """Assemble linear forms into a monolithic vector.
 
+    Note:
+        Due to subtle issues in the interaction between petsc4py memory management
+        and the Python garbage collector, it is recommended that the method ``PETSc.Vec.destroy()``
+        is called on the returned object once the object is no longer required. Note that
+        ``PETSc.Vec.destroy()`` is collective over the object's MPI communicator.
+    
     The vector is not finalised, i.e. ghost values are not accumulated.
     """
     maps = [
@@ -435,6 +459,12 @@ def assemble_matrix(
         The returned matrix is not 'assembled', i.e. ghost contributions
         have not been communicated.
 
+    Note:
+        Due to subtle issues in the interaction between petsc4py memory management
+        and the Python garbage collector, it is recommended that the method ``PETSc.Mat.destroy()``
+        is called on the returned object once the object is no longer required. Note that
+        ``PETSc.Mat.destroy()`` is collective over the object's MPI communicator.
+        
     Args:
         a: Bilinear form to assembled into a matrix.
         bc: Dirichlet boundary conditions applied to the system.
@@ -488,6 +518,12 @@ def assemble_matrix_nest(
     coeffs=None,
 ) -> PETSc.Mat:
     """Create a nested matrix and assemble bilinear forms into the matrix.
+
+    Note:
+        Due to subtle issues in the interaction between petsc4py memory management
+        and the Python garbage collector, it is recommended that the method ``PETSc.Mat.destroy()``
+        is called on the returned object once the object is no longer required. Note that
+        ``PETSc.Mat.destroy()`` is collective over the object's MPI communicator.
 
     Args:
         a: Rectangular (list-of-lists) array for bilinear forms.
@@ -576,7 +612,15 @@ def assemble_matrix_block(
     constants=None,
     coeffs=None,
 ) -> PETSc.Mat:  # type: ignore
-    """Assemble bilinear forms into a blocked matrix."""
+    """Assemble bilinear forms into a blocked matrix.
+    
+    Note:
+        Due to subtle issues in the interaction between petsc4py memory management
+        and the Python garbage collector, it is recommended that the method ``PETSc.Mat.destroy()``
+        is called on the returned object once the object is no longer required. Note that
+        ``PETSc.Mat.destroy()`` is collective over the object's MPI communicator.
+
+    """
     _a = [[None if form is None else form._cpp_object for form in arow] for arow in a]
     A = _cpp.fem.petsc.create_matrix_block(_a)
     return _assemble_matrix_block_mat(A, a, bcs, diagonal, constants, coeffs)


### PR DESCRIPTION
Continuation of: https://github.com/FEniCS/dolfinx/pull/3329
Uncovered in: https://github.com/FEniCS/dolfinx/issues/3522#issuecomment-2488679142