### PR TITLE
Remove error/warning when running macOS with OpenMPI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -102,15 +102,15 @@ jobs:
 
       - name: Basic test
         run: |
-          python -c "import dolfinx; from mpi4py import MPI; dolfinx.mesh.create_rectangle(comm=MPI.COMM_WORLD, points=((0, 0), (2, 1)), n=(32, 16))"
-          mpirun -np 2 python -c "import dolfinx; from mpi4py import MPI; dolfinx.mesh.create_rectangle(comm=MPI.COMM_WORLD, points=((0, 0), (2, 1)), n=(32, 16))"
+          mpiexec -np 1 python -c "import dolfinx; from mpi4py import MPI; dolfinx.mesh.create_rectangle(comm=MPI.COMM_WORLD, points=((0, 0), (2, 1)), n=(32, 16))"
+          mpiexec -np 2 python -c "import dolfinx; from mpi4py import MPI; dolfinx.mesh.create_rectangle(comm=MPI.COMM_WORLD, points=((0, 0), (2, 1)), n=(32, 16))"
 
       - name: Run Python unit tests (serial)
         working-directory: dolfinx
         run: |
           python -m pip install pytest-xdist
-          python3 -m pytest -n=auto --durations=50 python/test/unit/
+          mpiexec -np 1 python3 -m pytest -n=auto --durations=50 python/test/unit/
       - name: Run Python unit tests (MPI, np=3)
         working-directory: dolfinx
         run: |
-          mpirun -np 3 python3 -m pytest python/test/unit/
+          mpiexec -np 3 python3 -m pytest python/test/unit/

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,7 +87,7 @@ jobs:
         working-directory: dolfinx
         run: |
           cd build/test
-          ctest -V --output-on-failure -R unittests
+          mpiexec -np 1 ctest -V --output-on-failure -R unittests
       - name: Run C++ unit tests (MPI)
         working-directory: dolfinx
         run: |


### PR DESCRIPTION
Homebrew OpenMPI requires `mpiexec` when executing an MPI binary otherwise it prints a scary-looking warning