### PR TITLE
Fix symmetric value shape

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,7 +20,7 @@ on:
         type: string
       basix_ref:
         description: "Basix branch or tag"
-        default: "main"
+        default: "michal/symmetry-value-shape"
         type: string
       ufl_ref:
         description: "UFL branch or tag"

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -302,30 +302,11 @@ int FiniteElement<T>::space_dimension() const noexcept
 template <std::floating_point T>
 int FiniteElement<T>::value_size() const
 {
-  if (_value_shape)
-  {
-    int vs = std::accumulate(_value_shape->begin(), _value_shape->end(), 1,
-                             std::multiplies{});
-
-    // See comments in constructor on why special handling for the
-    // symmetric case is required.
-    if (_symmetric)
-    {
-      if (vs == 3)
-        return 4;
-      else if (vs == 6)
-        return 9;
-      else
-      {
-        throw std::runtime_error(
-            "Inconsistent size for symmetric rank-2 tensor.");
-      }
-    }
-    else
-      return vs;
-  }
-  else
+  if (!_value_shape)
     throw std::runtime_error("Element does not have a value_shape.");
+
+  return std::accumulate(_value_shape->begin(), _value_shape->end(), 1,
+                         std::multiplies{});
 }
 //-----------------------------------------------------------------------------
 template <std::floating_point T>

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -109,9 +109,8 @@ FiniteElement<T>::FiniteElement(
                              "from scalar base elements.");
   }
 
-  if (symmetric)
-  {
-    if (!value_shape || _value_shape->size() != 2
+  if (symmetric && value_shape){
+    if (_value_shape->size() != 2
         || (_value_shape.value()[0] != _value_shape.value()[1]))
     {
       throw std::runtime_error(
@@ -123,10 +122,14 @@ FiniteElement<T>::FiniteElement(
     const int dim = _value_shape.value()[0];
     _bs = dim * (dim + 1) / 2;
   }
-  else
+  else if (value_shape)
   {
     _bs = std::accumulate(_value_shape->begin(), _value_shape->end(), 1,
                           std::multiplies{});
+  }
+  else
+  {
+    _bs = 1;
   }
 
   _space_dim = _bs * element.dim();

--- a/python/test/unit/fem/test_symmetric_tensor.py
+++ b/python/test/unit/fem/test_symmetric_tensor.py
@@ -22,7 +22,7 @@ def test_transpose(degree, symmetry):
     )
     space = dolfinx.fem.functionspace(mesh, e)
     f = dolfinx.fem.Function(space)
-    f.interpolate(lambda x: (x[0], x[1], x[0] ** 3, x[0]))
+    f.interpolate(lambda x: [x[0], x[1], 2 * x[1], x[0] ** 3])
 
     form = dolfinx.fem.form(ufl.inner(f - ufl.transpose(f), f - ufl.transpose(f)) * ufl.dx)
     assert np.isclose(dolfinx.fem.assemble_scalar(form), 0) == symmetry


### PR DESCRIPTION
Attempt to fix https://github.com/FEniCS/dolfinx/issues/3516.

This PR makes symmetric rank-2 elements have `block size == dim*(dim + 1) / 2` but keeps `value_shape == (dim, dim)`.

