### PR TITLE
Remove brew unlink

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,7 +30,6 @@ jobs:
 
       - name: Install Homebrew dependencies
         run: |
-          brew unlink pkg-config@0.29.2 # Can be removed once - https://github.com/actions/runner-images/pull/11015
           brew install adios2 boost cmake hdf5-mpi make ninja open-mpi pkgconf pugixml spdlog # FEniCS
           brew install bison flex gfortran # PETSc
 


### PR DESCRIPTION
Reverts https://github.com/FEniCS/dolfinx/pull/3530 since the `macos-14-arm64` has now been updated, see https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20241125.556.