### PR TITLE
Unify and fix BoundingBoxtree constructor (C++)

### DIFF
--- a/cpp/dolfinx/geometry/BoundingBoxTree.h
+++ b/cpp/dolfinx/geometry/BoundingBoxTree.h
@@ -227,7 +227,7 @@ public:
   /// build the bounding box tree for.
   /// @param[in] entities List of entity indices (local to process) to
   /// compute the bounding box for. If `std::nullopt`, the bounding box tree is
-  /// computed for all local entiteis (including ghosts) of the given `tdim`.
+  /// computed for all local entities (including ghosts) of the given `tdim`.
   /// @param[in] padding Value to pad (extend) the the bounding box of
   /// each entity by.
   BoundingBoxTree(const mesh::Mesh<T>& mesh, int tdim,

--- a/python/dolfinx/geometry.py
+++ b/python/dolfinx/geometry.py
@@ -121,8 +121,6 @@ def bb_tree(
     map = mesh.topology.index_map(dim)
     if map is None:
         raise RuntimeError(f"Mesh entities of dimension {dim} have not been created.")
-    if entities is None:
-        entities = np.arange(map.size_local + map.num_ghosts, dtype=np.int32)
 
     dtype = mesh.geometry.x.dtype
     if np.issubdtype(dtype, np.float32):

--- a/python/dolfinx/wrappers/geometry.cpp
+++ b/python/dolfinx/wrappers/geometry.cpp
@@ -51,7 +51,7 @@ void declare_bbtree(nb::module_& m, std::string type)
             new (bbt)
                 dolfinx::geometry::BoundingBoxTree<T>(mesh, dim, ents, padding);
           },
-          nb::arg("mesh"), nb::arg("dim"), nb::arg("entities"),
+          nb::arg("mesh"), nb::arg("dim"), nb::arg("entities").none(),
           nb::arg("padding") = 0.0)
       .def_prop_ro("num_bboxes",
                    &dolfinx::geometry::BoundingBoxTree<T>::num_bboxes)

--- a/python/dolfinx/wrappers/geometry.cpp
+++ b/python/dolfinx/wrappers/geometry.cpp
@@ -16,8 +16,10 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/array.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
+#include <optional>
 #include <span>
 
 namespace nb = nanobind;
@@ -34,14 +36,20 @@ void declare_bbtree(nb::module_& m, std::string type)
           "__init__",
           [](dolfinx::geometry::BoundingBoxTree<T>* bbt,
              const dolfinx::mesh::Mesh<T>& mesh, int dim,
-             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>
+             std::optional<
+                 nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>>
                  entities,
              double padding)
           {
-            new (bbt) dolfinx::geometry::BoundingBoxTree<T>(
-                mesh, dim,
-                std::span<const std::int32_t>(entities.data(), entities.size()),
-                padding);
+            std::optional<std::span<const std::int32_t>> ents
+                = entities ? std::span<const std::int32_t>(
+                                 entities->data(),
+                                 entities->data() + entities->size())
+                           : std::optional<std::span<const std::int32_t>>(
+                                 std::nullopt);
+
+            new (bbt)
+                dolfinx::geometry::BoundingBoxTree<T>(mesh, dim, ents, padding);
           },
           nb::arg("mesh"), nb::arg("dim"), nb::arg("entities"),
           nb::arg("padding") = 0.0)


### PR DESCRIPTION
Reported by @adeebkor.

The constructor:
```c++
 /// Constructor
  /// @param[in] mesh The mesh for building the bounding box tree
  /// @param[in] tdim The topological dimension of the mesh entities to
  /// build the bounding box tree for
  /// @param[in] padding Value to pad (extend) the the bounding box of
  /// each entity by.
  BoundingBoxTree(const mesh::Mesh<T>& mesh, int tdim, T padding = 0)
      : BoundingBoxTree::BoundingBoxTree(
            mesh, tdim, range(mesh.topology_mutable(), tdim), padding)
  {
```
does not work at the moment (and is never tested), as `range` takes in a reference, not a shared pointer.

To fix this, and follow the rest of DOLFINx, I've unified the constructors using `std::optional`.

This also removes the None-conversion in the Python layer.