### PR TITLE
Extract edge tags and vertex tags from gmsh and return a NamedTuple

### DIFF
--- a/python/demo/demo_axis.py
+++ b/python/demo/demo_axis.py
@@ -458,9 +458,7 @@ if MPI.COMM_WORLD.rank == 0:
 
 model = MPI.COMM_WORLD.bcast(model, root=0)
 partitioner = dolfinx.cpp.mesh.create_cell_partitioner(dolfinx.mesh.GhostMode.shared_facet)
-msh, cell_tags, facet_tags, _, _ = io.gmshio.model_to_mesh(
-    model, MPI.COMM_WORLD, 0, gdim=2, partitioner=partitioner
-)
+gmsh_model = io.gmshio.model_to_mesh(model, MPI.COMM_WORLD, 0, gdim=2, partitioner=partitioner)
 
 gmsh.finalize()
 MPI.COMM_WORLD.barrier()
@@ -468,13 +466,15 @@ MPI.COMM_WORLD.barrier()
 
 # Visually check of the mesh and of the subdomains using PyVista:
 
-tdim = msh.topology.dim
+tdim = gmsh_model.mesh.topology.dim
 if have_pyvista:
-    topology, cell_types, geometry = plot.vtk_mesh(msh, 2)
+    topology, cell_types, geometry = plot.vtk_mesh(gmsh_model.mesh, 2)
     grid = pyvista.UnstructuredGrid(topology, cell_types, geometry)
     plotter = pyvista.Plotter()
-    num_local_cells = msh.topology.index_map(tdim).size_local
-    grid.cell_data["Marker"] = cell_tags.values[cell_tags.indices < num_local_cells]
+    num_local_cells = gmsh_model.mesh.topology.index_map(tdim).size_local
+    grid.cell_data["Marker"] = gmsh_model.cell_tags.values[
+        gmsh_model.cell_tags.indices < num_local_cells
+    ]
     grid.set_active_scalars("Marker")
     plotter.add_mesh(grid, show_edges=True)
     plotter.view_xy()
@@ -489,15 +489,17 @@ if have_pyvista:
 # will use Lagrange elements:
 
 degree = 3
-curl_el = element("N1curl", msh.basix_cell(), degree, dtype=real_type)
-lagr_el = element("Lagrange", msh.basix_cell(), degree, dtype=real_type)
-V = fem.functionspace(msh, mixed_element([curl_el, lagr_el]))
+curl_el = element("N1curl", gmsh_model.mesh.basix_cell(), degree, dtype=real_type)
+lagr_el = element("Lagrange", gmsh_model.mesh.basix_cell(), degree, dtype=real_type)
+V = fem.functionspace(gmsh_model.mesh, mixed_element([curl_el, lagr_el]))
 
 # The integration domains of our problem are the following:
 
 # +
 # Measures for subdomains
-dx = ufl.Measure("dx", msh, subdomain_data=cell_tags, metadata={"quadrature_degree": 5})
+dx = ufl.Measure(
+    "dx", gmsh_model.mesh, subdomain_data=gmsh_model.cell_tags, metadata={"quadrature_degree": 5}
+)
 dDom = dx((au_tag, bkg_tag))
 dPml = dx(pml_tag)
 # -
@@ -509,10 +511,10 @@ n_bkg = 1  # Background refractive index
 eps_bkg = n_bkg**2  # Background relative permittivity
 eps_au = -1.0782 + 1j * 5.8089
 
-D = fem.functionspace(msh, ("DG", 0))
+D = fem.functionspace(gmsh_model.mesh, ("DG", 0))
 eps = fem.Function(D)
-au_cells = cell_tags.find(au_tag)
-bkg_cells = cell_tags.find(bkg_tag)
+au_cells = gmsh_model.cell_tags.find(au_tag)
+bkg_cells = gmsh_model.cell_tags.find(bkg_tag)
 eps.x.array[au_cells] = np.full_like(au_cells, eps_au, dtype=eps.x.array.dtype)
 eps.x.array[bkg_cells] = np.full_like(bkg_cells, eps_bkg, dtype=eps.x.array.dtype)
 eps.x.scatter_forward()
@@ -556,7 +558,7 @@ I0 = 0.5 * n_bkg / Z0  # Intensity
 # We now now define `eps_pml` and `mu_pml`:
 
 # +
-rho, z = ufl.SpatialCoordinate(msh)
+rho, z = ufl.SpatialCoordinate(gmsh_model.mesh)
 alpha = 5
 r = ufl.sqrt(rho**2 + z**2)
 
@@ -577,7 +579,7 @@ eps_pml, mu_pml = create_eps_mu(pml_coords, rho, eps_bkg, 1)
 Eh_m = fem.Function(V)
 Esh = fem.Function(V)
 
-n = ufl.FacetNormal(msh)
+n = ufl.FacetNormal(gmsh_model.mesh)
 n_3d = ufl.as_vector((n[0], n[1], 0))
 
 # Geometrical cross section of the sphere, for efficiency calculation
@@ -585,10 +587,12 @@ gcs = np.pi * radius_sph**2
 
 # Marker functions for the scattering efficiency integral
 marker = fem.Function(D)
-scatt_facets = facet_tags.find(scatt_tag)
-incident_cells = mesh.compute_incident_entities(msh.topology, scatt_facets, tdim - 1, tdim)
-msh.topology.create_connectivity(tdim, tdim)
-midpoints = mesh.compute_midpoints(msh, tdim, incident_cells)
+scatt_facets = gmsh_model.facet_tags.find(scatt_tag)
+incident_cells = mesh.compute_incident_entities(
+    gmsh_model.mesh.topology, scatt_facets, tdim - 1, tdim
+)
+gmsh_model.mesh.topology.create_connectivity(tdim, tdim)
+midpoints = mesh.compute_midpoints(gmsh_model.mesh, tdim, incident_cells)
 inner_cells = incident_cells[(midpoints[:, 0] ** 2 + midpoints[:, 1] ** 2) < (radius_scatt) ** 2]
 marker.x.array[inner_cells] = 1
 
@@ -596,7 +600,7 @@ marker.x.array[inner_cells] = 1
 dAu = dx(au_tag)
 
 # Define integration facet for the scattering efficiency
-dS = ufl.Measure("dS", msh, subdomain_data=facet_tags)
+dS = ufl.Measure("dS", gmsh_model.mesh, subdomain_data=gmsh_model.facet_tags)
 # -
 
 # We also specify a variable `phi`, corresponding to the $\phi$ angle of
@@ -620,7 +624,7 @@ dS = ufl.Measure("dS", msh, subdomain_data=facet_tags)
 phi = np.pi / 4
 
 # Initialize phase term
-phase = fem.Constant(msh, scalar_type(np.exp(1j * 0 * phi)))
+phase = fem.Constant(gmsh_model.mesh, scalar_type(np.exp(1j * 0 * phi)))
 # -
 
 # We now solve the problem:
@@ -655,7 +659,7 @@ for m in m_list:
     elif sys.hasExternalPackage("superlu_dist"):  # type: ignore
         mat_factor_backend = "superlu_dist"
     else:
-        if msh.comm.size > 1:
+        if gmsh_model.mesh.comm.size > 1:
             raise RuntimeError("This demo requires a parallel linear algebra backend.")
         else:
             mat_factor_backend = "petsc"
@@ -705,8 +709,8 @@ for m in m_list:
         q_sca_fenics_proc = (
             fem.assemble_scalar(fem.form((P("+") + P("-")) * rho * dS(scatt_tag))) / gcs / I0
         ).real
-        q_abs_fenics = msh.comm.allreduce(q_abs_fenics_proc, op=MPI.SUM)
-        q_sca_fenics = msh.comm.allreduce(q_sca_fenics_proc, op=MPI.SUM)
+        q_abs_fenics = gmsh_model.mesh.comm.allreduce(q_abs_fenics_proc, op=MPI.SUM)
+        q_sca_fenics = gmsh_model.mesh.comm.allreduce(q_sca_fenics_proc, op=MPI.SUM)
     elif m == m_list[0]:  # initialize and add 2 factor
         P = 2 * np.pi * ufl.inner(-ufl.cross(Esh_m, ufl.conj(Hsh_m)), n_3d) * marker
         Q = 2 * np.pi * eps_au.imag * k0 * (ufl.inner(Eh_m, Eh_m)) / Z0 / n_bkg
@@ -714,8 +718,8 @@ for m in m_list:
         q_sca_fenics_proc = (
             fem.assemble_scalar(fem.form((P("+") + P("-")) * rho * dS(scatt_tag))) / gcs / I0
         ).real
-        q_abs_fenics = msh.comm.allreduce(q_abs_fenics_proc, op=MPI.SUM)
-        q_sca_fenics = msh.comm.allreduce(q_sca_fenics_proc, op=MPI.SUM)
+        q_abs_fenics = gmsh_model.mesh.comm.allreduce(q_abs_fenics_proc, op=MPI.SUM)
+        q_sca_fenics = gmsh_model.mesh.comm.allreduce(q_sca_fenics_proc, op=MPI.SUM)
     else:  # do not initialize and add 2 factor
         P = 2 * np.pi * ufl.inner(-ufl.cross(Esh_m, ufl.conj(Hsh_m)), n_3d) * marker
         Q = 2 * np.pi * eps_au.imag * k0 * (ufl.inner(Eh_m, Eh_m)) / Z0 / n_bkg
@@ -723,8 +727,8 @@ for m in m_list:
         q_sca_fenics_proc = (
             fem.assemble_scalar(fem.form((P("+") + P("-")) * rho * dS(scatt_tag))) / gcs / I0
         ).real
-        q_abs_fenics += msh.comm.allreduce(q_abs_fenics_proc, op=MPI.SUM)
-        q_sca_fenics += msh.comm.allreduce(q_sca_fenics_proc, op=MPI.SUM)
+        q_abs_fenics += gmsh_model.mesh.comm.allreduce(q_abs_fenics_proc, op=MPI.SUM)
+        q_sca_fenics += gmsh_model.mesh.comm.allreduce(q_sca_fenics_proc, op=MPI.SUM)
 
 q_ext_fenics = q_abs_fenics + q_sca_fenics
 # -
@@ -783,11 +787,11 @@ if MPI.COMM_WORLD.rank == 0:
 # assert err_ext < 0.01
 
 if has_vtx:
-    v_dg_el = element("DG", msh.basix_cell(), degree, shape=(3,), dtype=real_type)
-    W = fem.functionspace(msh, v_dg_el)
+    v_dg_el = element("DG", gmsh_model.mesh.basix_cell(), degree, shape=(3,), dtype=real_type)
+    W = fem.functionspace(gmsh_model.mesh, v_dg_el)
     Es_dg = fem.Function(W)
     Es_expr = fem.Expression(Esh, W.element.interpolation_points())
     Es_dg.interpolate(Es_expr)
-    with VTXWriter(msh.comm, "sols/Es.bp", Es_dg) as f:
+    with VTXWriter(gmsh_model.mesh.comm, "sols/Es.bp", Es_dg) as f:
         f.write(0.0)
 # -

--- a/python/demo/demo_axis.py
+++ b/python/demo/demo_axis.py
@@ -458,7 +458,7 @@ if MPI.COMM_WORLD.rank == 0:
 
 model = MPI.COMM_WORLD.bcast(model, root=0)
 partitioner = dolfinx.cpp.mesh.create_cell_partitioner(dolfinx.mesh.GhostMode.shared_facet)
-gmsh_model = io.gmshio.model_to_mesh(model, MPI.COMM_WORLD, 0, gdim=2, partitioner=partitioner)
+mesh_data = io.gmshio.model_to_mesh(model, MPI.COMM_WORLD, 0, gdim=2, partitioner=partitioner)
 
 gmsh.finalize()
 MPI.COMM_WORLD.barrier()
@@ -466,14 +466,14 @@ MPI.COMM_WORLD.barrier()
 
 # Visually check of the mesh and of the subdomains using PyVista:
 
-tdim = gmsh_model.mesh.topology.dim
+tdim = mesh_data.mesh.topology.dim
 if have_pyvista:
-    topology, cell_types, geometry = plot.vtk_mesh(gmsh_model.mesh, 2)
+    topology, cell_types, geometry = plot.vtk_mesh(mesh_data.mesh, 2)
     grid = pyvista.UnstructuredGrid(topology, cell_types, geometry)
     plotter = pyvista.Plotter()
-    num_local_cells = gmsh_model.mesh.topology.index_map(tdim).size_local
-    grid.cell_data["Marker"] = gmsh_model.cell_tags.values[
-        gmsh_model.cell_tags.indices < num_local_cells
+    num_local_cells = mesh_data.mesh.topology.index_map(tdim).size_local
+    grid.cell_data["Marker"] = mesh_data.cell_tags.values[
+        mesh_data.cell_tags.indices < num_local_cells
     ]
     grid.set_active_scalars("Marker")
     plotter.add_mesh(grid, show_edges=True)
@@ -489,16 +489,16 @@ if have_pyvista:
 # will use Lagrange elements:
 
 degree = 3
-curl_el = element("N1curl", gmsh_model.mesh.basix_cell(), degree, dtype=real_type)
-lagr_el = element("Lagrange", gmsh_model.mesh.basix_cell(), degree, dtype=real_type)
-V = fem.functionspace(gmsh_model.mesh, mixed_element([curl_el, lagr_el]))
+curl_el = element("N1curl", mesh_data.mesh.basix_cell(), degree, dtype=real_type)
+lagr_el = element("Lagrange", mesh_data.mesh.basix_cell(), degree, dtype=real_type)
+V = fem.functionspace(mesh_data.mesh, mixed_element([curl_el, lagr_el]))
 
 # The integration domains of our problem are the following:
 
 # +
 # Measures for subdomains
 dx = ufl.Measure(
-    "dx", gmsh_model.mesh, subdomain_data=gmsh_model.cell_tags, metadata={"quadrature_degree": 5}
+    "dx", mesh_data.mesh, subdomain_data=mesh_data.cell_tags, metadata={"quadrature_degree": 5}
 )
 dDom = dx((au_tag, bkg_tag))
 dPml = dx(pml_tag)
@@ -511,10 +511,10 @@ n_bkg = 1  # Background refractive index
 eps_bkg = n_bkg**2  # Background relative permittivity
 eps_au = -1.0782 + 1j * 5.8089
 
-D = fem.functionspace(gmsh_model.mesh, ("DG", 0))
+D = fem.functionspace(mesh_data.mesh, ("DG", 0))
 eps = fem.Function(D)
-au_cells = gmsh_model.cell_tags.find(au_tag)
-bkg_cells = gmsh_model.cell_tags.find(bkg_tag)
+au_cells = mesh_data.cell_tags.find(au_tag)
+bkg_cells = mesh_data.cell_tags.find(bkg_tag)
 eps.x.array[au_cells] = np.full_like(au_cells, eps_au, dtype=eps.x.array.dtype)
 eps.x.array[bkg_cells] = np.full_like(bkg_cells, eps_bkg, dtype=eps.x.array.dtype)
 eps.x.scatter_forward()
@@ -558,7 +558,7 @@ I0 = 0.5 * n_bkg / Z0  # Intensity
 # We now now define `eps_pml` and `mu_pml`:
 
 # +
-rho, z = ufl.SpatialCoordinate(gmsh_model.mesh)
+rho, z = ufl.SpatialCoordinate(mesh_data.mesh)
 alpha = 5
 r = ufl.sqrt(rho**2 + z**2)
 
@@ -579,7 +579,7 @@ eps_pml, mu_pml = create_eps_mu(pml_coords, rho, eps_bkg, 1)
 Eh_m = fem.Function(V)
 Esh = fem.Function(V)
 
-n = ufl.FacetNormal(gmsh_model.mesh)
+n = ufl.FacetNormal(mesh_data.mesh)
 n_3d = ufl.as_vector((n[0], n[1], 0))
 
 # Geometrical cross section of the sphere, for efficiency calculation
@@ -587,12 +587,12 @@ gcs = np.pi * radius_sph**2
 
 # Marker functions for the scattering efficiency integral
 marker = fem.Function(D)
-scatt_facets = gmsh_model.facet_tags.find(scatt_tag)
+scatt_facets = mesh_data.facet_tags.find(scatt_tag)
 incident_cells = mesh.compute_incident_entities(
-    gmsh_model.mesh.topology, scatt_facets, tdim - 1, tdim
+    mesh_data.mesh.topology, scatt_facets, tdim - 1, tdim
 )
-gmsh_model.mesh.topology.create_connectivity(tdim, tdim)
-midpoints = mesh.compute_midpoints(gmsh_model.mesh, tdim, incident_cells)
+mesh_data.mesh.topology.create_connectivity(tdim, tdim)
+midpoints = mesh.compute_midpoints(mesh_data.mesh, tdim, incident_cells)
 inner_cells = incident_cells[(midpoints[:, 0] ** 2 + midpoints[:, 1] ** 2) < (radius_scatt) ** 2]
 marker.x.array[inner_cells] = 1
 
@@ -600,7 +600,7 @@ marker.x.array[inner_cells] = 1
 dAu = dx(au_tag)
 
 # Define integration facet for the scattering efficiency
-dS = ufl.Measure("dS", gmsh_model.mesh, subdomain_data=gmsh_model.facet_tags)
+dS = ufl.Measure("dS", mesh_data.mesh, subdomain_data=mesh_data.facet_tags)
 # -
 
 # We also specify a variable `phi`, corresponding to the $\phi$ angle of
@@ -624,7 +624,7 @@ dS = ufl.Measure("dS", gmsh_model.mesh, subdomain_data=gmsh_model.facet_tags)
 phi = np.pi / 4
 
 # Initialize phase term
-phase = fem.Constant(gmsh_model.mesh, scalar_type(np.exp(1j * 0 * phi)))
+phase = fem.Constant(mesh_data.mesh, scalar_type(np.exp(1j * 0 * phi)))
 # -
 
 # We now solve the problem:
@@ -659,7 +659,7 @@ for m in m_list:
     elif sys.hasExternalPackage("superlu_dist"):  # type: ignore
         mat_factor_backend = "superlu_dist"
     else:
-        if gmsh_model.mesh.comm.size > 1:
+        if mesh_data.mesh.comm.size > 1:
             raise RuntimeError("This demo requires a parallel linear algebra backend.")
         else:
             mat_factor_backend = "petsc"
@@ -709,8 +709,8 @@ for m in m_list:
         q_sca_fenics_proc = (
             fem.assemble_scalar(fem.form((P("+") + P("-")) * rho * dS(scatt_tag))) / gcs / I0
         ).real
-        q_abs_fenics = gmsh_model.mesh.comm.allreduce(q_abs_fenics_proc, op=MPI.SUM)
-        q_sca_fenics = gmsh_model.mesh.comm.allreduce(q_sca_fenics_proc, op=MPI.SUM)
+        q_abs_fenics = mesh_data.mesh.comm.allreduce(q_abs_fenics_proc, op=MPI.SUM)
+        q_sca_fenics = mesh_data.mesh.comm.allreduce(q_sca_fenics_proc, op=MPI.SUM)
     elif m == m_list[0]:  # initialize and add 2 factor
         P = 2 * np.pi * ufl.inner(-ufl.cross(Esh_m, ufl.conj(Hsh_m)), n_3d) * marker
         Q = 2 * np.pi * eps_au.imag * k0 * (ufl.inner(Eh_m, Eh_m)) / Z0 / n_bkg
@@ -718,8 +718,8 @@ for m in m_list:
         q_sca_fenics_proc = (
             fem.assemble_scalar(fem.form((P("+") + P("-")) * rho * dS(scatt_tag))) / gcs / I0
         ).real
-        q_abs_fenics = gmsh_model.mesh.comm.allreduce(q_abs_fenics_proc, op=MPI.SUM)
-        q_sca_fenics = gmsh_model.mesh.comm.allreduce(q_sca_fenics_proc, op=MPI.SUM)
+        q_abs_fenics = mesh_data.mesh.comm.allreduce(q_abs_fenics_proc, op=MPI.SUM)
+        q_sca_fenics = mesh_data.mesh.comm.allreduce(q_sca_fenics_proc, op=MPI.SUM)
     else:  # do not initialize and add 2 factor
         P = 2 * np.pi * ufl.inner(-ufl.cross(Esh_m, ufl.conj(Hsh_m)), n_3d) * marker
         Q = 2 * np.pi * eps_au.imag * k0 * (ufl.inner(Eh_m, Eh_m)) / Z0 / n_bkg
@@ -727,8 +727,8 @@ for m in m_list:
         q_sca_fenics_proc = (
             fem.assemble_scalar(fem.form((P("+") + P("-")) * rho * dS(scatt_tag))) / gcs / I0
         ).real
-        q_abs_fenics += gmsh_model.mesh.comm.allreduce(q_abs_fenics_proc, op=MPI.SUM)
-        q_sca_fenics += gmsh_model.mesh.comm.allreduce(q_sca_fenics_proc, op=MPI.SUM)
+        q_abs_fenics += mesh_data.mesh.comm.allreduce(q_abs_fenics_proc, op=MPI.SUM)
+        q_sca_fenics += mesh_data.mesh.comm.allreduce(q_sca_fenics_proc, op=MPI.SUM)
 
 q_ext_fenics = q_abs_fenics + q_sca_fenics
 # -
@@ -787,11 +787,11 @@ if MPI.COMM_WORLD.rank == 0:
 # assert err_ext < 0.01
 
 if has_vtx:
-    v_dg_el = element("DG", gmsh_model.mesh.basix_cell(), degree, shape=(3,), dtype=real_type)
-    W = fem.functionspace(gmsh_model.mesh, v_dg_el)
+    v_dg_el = element("DG", mesh_data.mesh.basix_cell(), degree, shape=(3,), dtype=real_type)
+    W = fem.functionspace(mesh_data.mesh, v_dg_el)
     Es_dg = fem.Function(W)
     Es_expr = fem.Expression(Esh, W.element.interpolation_points())
     Es_dg.interpolate(Es_expr)
-    with VTXWriter(gmsh_model.mesh.comm, "sols/Es.bp", Es_dg) as f:
+    with VTXWriter(mesh_data.mesh.comm, "sols/Es.bp", Es_dg) as f:
         f.write(0.0)
 # -

--- a/python/demo/demo_axis.py
+++ b/python/demo/demo_axis.py
@@ -458,7 +458,7 @@ if MPI.COMM_WORLD.rank == 0:
 
 model = MPI.COMM_WORLD.bcast(model, root=0)
 partitioner = dolfinx.cpp.mesh.create_cell_partitioner(dolfinx.mesh.GhostMode.shared_facet)
-msh, cell_tags, facet_tags = io.gmshio.model_to_mesh(
+msh, cell_tags, facet_tags, _, _ = io.gmshio.model_to_mesh(
     model, MPI.COMM_WORLD, 0, gdim=2, partitioner=partitioner
 )
 

--- a/python/demo/demo_axis.py
+++ b/python/demo/demo_axis.py
@@ -459,6 +459,8 @@ if MPI.COMM_WORLD.rank == 0:
 model = MPI.COMM_WORLD.bcast(model, root=0)
 partitioner = dolfinx.cpp.mesh.create_cell_partitioner(dolfinx.mesh.GhostMode.shared_facet)
 mesh_data = io.gmshio.model_to_mesh(model, MPI.COMM_WORLD, 0, gdim=2, partitioner=partitioner)
+assert mesh_data.cell_tags is not None, "Cell tags are missing"
+assert mesh_data.facet_tags is not None, "Facet tags are missing"
 
 gmsh.finalize()
 MPI.COMM_WORLD.barrier()

--- a/python/demo/demo_gmsh.py
+++ b/python/demo/demo_gmsh.py
@@ -35,6 +35,29 @@ except ImportError:
 
 
 # +
+def gmsh_sphere_no_physical_groups(model: gmsh.model, name: str) -> gmsh.model:
+    """Create a Gmsh model of a sphere.
+
+    Args:
+        model: Gmsh model to add the mesh to.
+        name: Name (identifier) of the mesh to add.
+
+    Returns:
+        Gmsh model with a sphere mesh added.
+
+    """
+    model.add(name)
+    model.setCurrent(name)
+    model.occ.addSphere(0, 0, 0, 1, tag=1)
+
+    # Synchronize OpenCascade representation with gmsh model
+    model.occ.synchronize()
+
+    # Generate the mesh
+    model.mesh.generate(dim=3)
+    return model
+
+
 def gmsh_sphere(model: gmsh.model, name: str) -> gmsh.model:
     """Create a Gmsh model of a sphere.
 
@@ -212,7 +235,16 @@ model = gmsh.model()
 # First, we create a Gmsh model of a sphere using tetrahedral cells
 # (linear geometry), then create independent meshes on each MPI rank and
 # write each mesh to an XDMF file. The MPI rank is appended to the
-# filename since the meshes are not distributed.
+# filename since the meshes are not distributed. We can first create
+# a sphere without physical groups.
+
+# +
+model = gmsh_sphere_no_physical_groups(model, "Sphere")
+model.setCurrent("Sphere")
+create_mesh(MPI.COMM_SELF, model, "sphere", f"out_gmsh/mesh_rank_{MPI.COMM_WORLD.rank}.xdmf", "w")
+# -
+
+# Next, we create a sphere with physical groups.
 
 # +
 model = gmsh_sphere(model, "Sphere")

--- a/python/demo/demo_gmsh.py
+++ b/python/demo/demo_gmsh.py
@@ -169,6 +169,8 @@ def create_mesh(comm: MPI.Comm, model: gmsh.model, name: str, filename: str, mod
     msh.vertex_tags.name = f"{name}_vertices"
     with XDMFFile(msh.mesh.comm, filename, mode) as file:
         msh.mesh.topology.create_connectivity(2, 3)
+        msh.mesh.topology.create_connectivity(1, 3)
+        msh.mesh.topology.create_connectivity(0, 3)
         file.write_mesh(msh.mesh)
         file.write_meshtags(
             msh.cell_tags,

--- a/python/demo/demo_gmsh.py
+++ b/python/demo/demo_gmsh.py
@@ -161,35 +161,35 @@ def create_mesh(comm: MPI.Comm, model: gmsh.model, name: str, filename: str, mod
         filename: XDMF filename.
         mode: XDMF file mode. "w" (write) or "a" (append).
     """
-    msh = gmshio.model_to_mesh(model, comm, rank=0)
-    msh.mesh.name = name
-    msh.cell_tags.name = f"{name}_cells"
-    msh.facet_tags.name = f"{name}_facets"
-    msh.edge_tags.name = f"{name}_edges"
-    msh.vertex_tags.name = f"{name}_vertices"
-    with XDMFFile(msh.mesh.comm, filename, mode) as file:
-        msh.mesh.topology.create_connectivity(2, 3)
-        msh.mesh.topology.create_connectivity(1, 3)
-        msh.mesh.topology.create_connectivity(0, 3)
-        file.write_mesh(msh.mesh)
+    mesh_data = gmshio.model_to_mesh(model, comm, rank=0)
+    mesh_data.mesh.name = name
+    mesh_data.cell_tags.name = f"{name}_cells"
+    mesh_data.facet_tags.name = f"{name}_facets"
+    mesh_data.edge_tags.name = f"{name}_edges"
+    mesh_data.vertex_tags.name = f"{name}_vertices"
+    with XDMFFile(mesh_data.mesh.comm, filename, mode) as file:
+        mesh_data.mesh.topology.create_connectivity(2, 3)
+        mesh_data.mesh.topology.create_connectivity(1, 3)
+        mesh_data.mesh.topology.create_connectivity(0, 3)
+        file.write_mesh(mesh_data.mesh)
         file.write_meshtags(
-            msh.cell_tags,
-            msh.mesh.geometry,
+            mesh_data.cell_tags,
+            mesh_data.mesh.geometry,
             geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
         )
         file.write_meshtags(
-            msh.facet_tags,
-            msh.mesh.geometry,
+            mesh_data.facet_tags,
+            mesh_data.mesh.geometry,
             geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
         )
         file.write_meshtags(
-            msh.edge_tags,
-            msh.mesh.geometry,
+            mesh_data.edge_tags,
+            mesh_data.mesh.geometry,
             geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
         )
         file.write_meshtags(
-            msh.vertex_tags,
-            msh.mesh.geometry,
+            mesh_data.vertex_tags,
+            mesh_data.mesh.geometry,
             geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
         )
 

--- a/python/demo/demo_gmsh.py
+++ b/python/demo/demo_gmsh.py
@@ -35,29 +35,6 @@ except ImportError:
 
 
 # +
-def gmsh_sphere_no_physical_groups(model: gmsh.model, name: str) -> gmsh.model:
-    """Create a Gmsh model of a sphere.
-
-    Args:
-        model: Gmsh model to add the mesh to.
-        name: Name (identifier) of the mesh to add.
-
-    Returns:
-        Gmsh model with a sphere mesh added.
-
-    """
-    model.add(name)
-    model.setCurrent(name)
-    model.occ.addSphere(0, 0, 0, 1, tag=1)
-
-    # Synchronize OpenCascade representation with gmsh model
-    model.occ.synchronize()
-
-    # Generate the mesh
-    model.mesh.generate(dim=3)
-    return model
-
-
 def gmsh_sphere(model: gmsh.model, name: str) -> gmsh.model:
     """Create a Gmsh model of a sphere.
 
@@ -235,16 +212,7 @@ model = gmsh.model()
 # First, we create a Gmsh model of a sphere using tetrahedral cells
 # (linear geometry), then create independent meshes on each MPI rank and
 # write each mesh to an XDMF file. The MPI rank is appended to the
-# filename since the meshes are not distributed. We can first create
-# a sphere without physical groups.
-
-# +
-model = gmsh_sphere_no_physical_groups(model, "Sphere")
-model.setCurrent("Sphere")
-create_mesh(MPI.COMM_SELF, model, "sphere", f"out_gmsh/mesh_rank_{MPI.COMM_WORLD.rank}.xdmf", "w")
-# -
-
-# Next, we create a sphere with physical groups.
+# filename since the meshes are not distributed.
 
 # +
 model = gmsh_sphere(model, "Sphere")

--- a/python/demo/demo_gmsh.py
+++ b/python/demo/demo_gmsh.py
@@ -163,35 +163,43 @@ def create_mesh(comm: MPI.Comm, model: gmsh.model, name: str, filename: str, mod
     """
     mesh_data = gmshio.model_to_mesh(model, comm, rank=0)
     mesh_data.mesh.name = name
-    mesh_data.cell_tags.name = f"{name}_cells"
-    mesh_data.facet_tags.name = f"{name}_facets"
-    mesh_data.edge_tags.name = f"{name}_edges"
-    mesh_data.vertex_tags.name = f"{name}_vertices"
+    if mesh_data.cell_tags is not None:
+        mesh_data.cell_tags.name = f"{name}_cells"
+    if mesh_data.facet_tags is not None:
+        mesh_data.facet_tags.name = f"{name}_facets"
+    if mesh_data.edge_tags is not None:
+        mesh_data.edge_tags.name = f"{name}_edges"
+    if mesh_data.vertex_tags is not None:
+        mesh_data.vertex_tags.name = f"{name}_vertices"
     with XDMFFile(mesh_data.mesh.comm, filename, mode) as file:
         mesh_data.mesh.topology.create_connectivity(2, 3)
         mesh_data.mesh.topology.create_connectivity(1, 3)
         mesh_data.mesh.topology.create_connectivity(0, 3)
         file.write_mesh(mesh_data.mesh)
-        file.write_meshtags(
-            mesh_data.cell_tags,
-            mesh_data.mesh.geometry,
-            geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
-        )
-        file.write_meshtags(
-            mesh_data.facet_tags,
-            mesh_data.mesh.geometry,
-            geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
-        )
-        file.write_meshtags(
-            mesh_data.edge_tags,
-            mesh_data.mesh.geometry,
-            geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
-        )
-        file.write_meshtags(
-            mesh_data.vertex_tags,
-            mesh_data.mesh.geometry,
-            geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
-        )
+        if mesh_data.cell_tags is not None:
+            file.write_meshtags(
+                mesh_data.cell_tags,
+                mesh_data.mesh.geometry,
+                geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
+            )
+        if mesh_data.facet_tags is not None:
+            file.write_meshtags(
+                mesh_data.facet_tags,
+                mesh_data.mesh.geometry,
+                geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
+            )
+        if mesh_data.edge_tags is not None:
+            file.write_meshtags(
+                mesh_data.edge_tags,
+                mesh_data.mesh.geometry,
+                geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
+            )
+        if mesh_data.vertex_tags is not None:
+            file.write_meshtags(
+                mesh_data.vertex_tags,
+                mesh_data.mesh.geometry,
+                geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
+            )
 
 
 # -

--- a/python/demo/demo_gmsh.py
+++ b/python/demo/demo_gmsh.py
@@ -161,18 +161,34 @@ def create_mesh(comm: MPI.Comm, model: gmsh.model, name: str, filename: str, mod
         filename: XDMF filename.
         mode: XDMF file mode. "w" (write) or "a" (append).
     """
-    msh, ct, ft = gmshio.model_to_mesh(model, comm, rank=0)
-    msh.name = name
-    ct.name = f"{msh.name}_cells"
-    ft.name = f"{msh.name}_facets"
-    with XDMFFile(msh.comm, filename, mode) as file:
-        msh.topology.create_connectivity(2, 3)
-        file.write_mesh(msh)
+    msh = gmshio.model_to_mesh(model, comm, rank=0)
+    msh.mesh.name = name
+    msh.cell_tags.name = f"{name}_cells"
+    msh.facet_tags.name = f"{name}_facets"
+    msh.edge_tags.name = f"{name}_edges"
+    msh.vertex_tags.name = f"{name}_vertices"
+    with XDMFFile(msh.mesh.comm, filename, mode) as file:
+        msh.mesh.topology.create_connectivity(2, 3)
+        file.write_mesh(msh.mesh)
         file.write_meshtags(
-            ct, msh.geometry, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry"
+            msh.cell_tags,
+            msh.mesh.geometry,
+            geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
         )
         file.write_meshtags(
-            ft, msh.geometry, geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{msh.name}']/Geometry"
+            msh.facet_tags,
+            msh.mesh.geometry,
+            geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
+        )
+        file.write_meshtags(
+            msh.edge_tags,
+            msh.mesh.geometry,
+            geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
+        )
+        file.write_meshtags(
+            msh.vertex_tags,
+            msh.mesh.geometry,
+            geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
         )
 
 

--- a/python/demo/demo_pml.py
+++ b/python/demo/demo_pml.py
@@ -451,7 +451,7 @@ if MPI.COMM_WORLD.rank == 0:
 model = MPI.COMM_WORLD.bcast(model, root=0)
 partitioner = dolfinx.cpp.mesh.create_cell_partitioner(dolfinx.mesh.GhostMode.shared_facet)
 
-msh, cell_tags, facet_tags = gmshio.model_to_mesh(
+msh, cell_tags, facet_tags, _, _ = gmshio.model_to_mesh(
     model, MPI.COMM_WORLD, 0, gdim=2, partitioner=partitioner
 )
 

--- a/python/demo/demo_pml.py
+++ b/python/demo/demo_pml.py
@@ -451,9 +451,7 @@ if MPI.COMM_WORLD.rank == 0:
 model = MPI.COMM_WORLD.bcast(model, root=0)
 partitioner = dolfinx.cpp.mesh.create_cell_partitioner(dolfinx.mesh.GhostMode.shared_facet)
 
-msh, cell_tags, facet_tags, _, _ = gmshio.model_to_mesh(
-    model, MPI.COMM_WORLD, 0, gdim=2, partitioner=partitioner
-)
+gmsh_model = gmshio.model_to_mesh(model, MPI.COMM_WORLD, 0, gdim=2, partitioner=partitioner)
 
 gmsh.finalize()
 MPI.COMM_WORLD.barrier()
@@ -462,13 +460,15 @@ MPI.COMM_WORLD.barrier()
 # We visualize the mesh and subdomains with
 # [PyVista](https://docs.pyvista.org/)
 
-tdim = msh.topology.dim
+tdim = gmsh_model.mesh.topology.dim
 if have_pyvista:
-    topology, cell_types, geometry = plot.vtk_mesh(msh, 2)
+    topology, cell_types, geometry = plot.vtk_mesh(gmsh_model.mesh, 2)
     grid = pyvista.UnstructuredGrid(topology, cell_types, geometry)
     plotter = pyvista.Plotter()
-    num_local_cells = msh.topology.index_map(tdim).size_local
-    grid.cell_data["Marker"] = cell_tags.values[cell_tags.indices < num_local_cells]
+    num_local_cells = gmsh_model.mesh.topology.index_map(tdim).size_local
+    grid.cell_data["Marker"] = gmsh_model.cell_tags.values[
+        gmsh_model.cell_tags.indices < num_local_cells
+    ]
     grid.set_active_scalars("Marker")
     plotter.add_mesh(grid, show_edges=True)
     plotter.view_xy()
@@ -508,8 +508,8 @@ theta = 0  # Angle of incidence of the background field
 # element to represent the electric field:
 
 degree = 3
-curl_el = element("N1curl", msh.basix_cell(), degree, dtype=default_real_type)
-V = fem.functionspace(msh, curl_el)
+curl_el = element("N1curl", gmsh_model.mesh.basix_cell(), degree, dtype=default_real_type)
+V = fem.functionspace(gmsh_model.mesh, curl_el)
 
 # Next, we interpolate $\mathbf{E}_b$ into the function space $V$,
 # define our trial and test function, and the integration domains:
@@ -528,7 +528,7 @@ Es_3d = ufl.as_vector((Es[0], Es[1], 0))
 v_3d = ufl.as_vector((v[0], v[1], 0))
 
 # Measures for subdomains
-dx = ufl.Measure("dx", msh, subdomain_data=cell_tags)
+dx = ufl.Measure("dx", gmsh_model.mesh, subdomain_data=gmsh_model.cell_tags)
 dDom = dx((au_tag, bkg_tag))
 dPml_xy = dx(pml_tag)
 dPml_x = dx(pml_tag + 1)
@@ -550,10 +550,10 @@ eps_au = -1.0782 + 1j * 5.8089
 # it takes the value of the background permittivity $\varepsilon_b$ in
 # the background region:
 
-D = fem.functionspace(msh, ("DG", 0))
+D = fem.functionspace(gmsh_model.mesh, ("DG", 0))
 eps = fem.Function(D)
-au_cells = cell_tags.find(au_tag)
-bkg_cells = cell_tags.find(bkg_tag)
+au_cells = gmsh_model.cell_tags.find(au_tag)
+bkg_cells = gmsh_model.cell_tags.find(bkg_tag)
 eps.x.array[au_cells] = np.full_like(au_cells, eps_au, dtype=eps.x.array.dtype)
 eps.x.array[bkg_cells] = np.full_like(bkg_cells, eps_bkg, dtype=eps.x.array.dtype)
 eps.x.scatter_forward()
@@ -563,7 +563,7 @@ eps.x.scatter_forward()
 # coordinates as:
 
 # +
-x = ufl.SpatialCoordinate(msh)
+x = ufl.SpatialCoordinate(gmsh_model.mesh)
 alpha = 1
 
 # PML corners
@@ -703,7 +703,7 @@ if sys.hasExternalPackage("mumps") and not use_superlu:  # type: ignore
 elif sys.hasExternalPackage("superlu_dist"):  # type: ignore
     mat_factor_backend = "superlu_dist"
 else:
-    if msh.comm > 1:
+    if gmsh_model.mesh.comm > 1:
         raise RuntimeError("This demo requires a parallel LU solver.")
     else:
         mat_factor_backend = "petsc"
@@ -727,12 +727,12 @@ assert problem.solver.getConvergedReason() > 0, "Solver did not converge!"
 # compatible discontinuous Lagrange space.
 
 # +
-gdim = msh.geometry.dim
-V_dg = fem.functionspace(msh, ("DG", degree, (gdim,)))
+gdim = gmsh_model.mesh.geometry.dim
+V_dg = fem.functionspace(gmsh_model.mesh, ("DG", degree, (gdim,)))
 Esh_dg = fem.Function(V_dg)
 Esh_dg.interpolate(Esh)
 
-with VTXWriter(msh.comm, "Esh.bp", Esh_dg) as vtx:
+with VTXWriter(gmsh_model.mesh.comm, "Esh.bp", Esh_dg) as vtx:
     vtx.write(0.0)
 # -
 
@@ -770,7 +770,7 @@ E.x.array[:] = Eb.x.array[:] + Esh.x.array[:]
 E_dg = fem.Function(V_dg)
 E_dg.interpolate(E)
 
-with VTXWriter(msh.comm, "E.bp", E_dg) as vtx:
+with VTXWriter(gmsh_model.mesh.comm, "E.bp", E_dg) as vtx:
     vtx.write(0.0)
 # -
 
@@ -809,17 +809,19 @@ I0 = 0.5 / Z0
 # Geometrical cross section of the wire
 gcs = 2 * radius_wire
 
-n = ufl.FacetNormal(msh)
+n = ufl.FacetNormal(gmsh_model.mesh)
 n_3d = ufl.as_vector((n[0], n[1], 0))
 
 # Create a marker for the integration boundary for the scattering
 # efficiency
 marker = fem.Function(D)
-scatt_facets = facet_tags.find(scatt_tag)
-incident_cells = mesh.compute_incident_entities(msh.topology, scatt_facets, tdim - 1, tdim)
+scatt_facets = gmsh_model.facet_tags.find(scatt_tag)
+incident_cells = mesh.compute_incident_entities(
+    gmsh_model.mesh.topology, scatt_facets, tdim - 1, tdim
+)
 
-msh.topology.create_connectivity(tdim, tdim)
-midpoints = mesh.compute_midpoints(msh, tdim, incident_cells)
+gmsh_model.mesh.topology.create_connectivity(tdim, tdim)
+midpoints = mesh.compute_midpoints(gmsh_model.mesh, tdim, incident_cells)
 inner_cells = incident_cells[(midpoints[:, 0] ** 2 + midpoints[:, 1] ** 2) < (radius_scatt) ** 2]
 
 marker.x.array[inner_cells] = 1
@@ -832,12 +834,12 @@ Q = 0.5 * eps_au.imag * k0 * (ufl.inner(E_3d, E_3d)) / (Z0 * n_bkg)
 dAu = dx(au_tag)
 
 # Define integration facet for the scattering efficiency
-dS = ufl.Measure("dS", msh, subdomain_data=facet_tags)
+dS = ufl.Measure("dS", gmsh_model.mesh, subdomain_data=gmsh_model.facet_tags)
 
 # Normalized absorption efficiency
 q_abs_fenics_proc = (fem.assemble_scalar(fem.form(Q * dAu)) / (gcs * I0)).real
 # Sum results from all MPI processes
-q_abs_fenics = msh.comm.allreduce(q_abs_fenics_proc, op=MPI.SUM)
+q_abs_fenics = gmsh_model.mesh.comm.allreduce(q_abs_fenics_proc, op=MPI.SUM)
 
 # Normalized scattering efficiency
 q_sca_fenics_proc = (
@@ -845,7 +847,7 @@ q_sca_fenics_proc = (
 ).real
 
 # Sum results from all MPI processes
-q_sca_fenics = msh.comm.allreduce(q_sca_fenics_proc, op=MPI.SUM)
+q_sca_fenics = gmsh_model.mesh.comm.allreduce(q_sca_fenics_proc, op=MPI.SUM)
 
 # Extinction efficiency
 q_ext_fenics = q_abs_fenics + q_sca_fenics
@@ -855,7 +857,7 @@ err_abs = np.abs(q_abs_analyt - q_abs_fenics) / q_abs_analyt
 err_sca = np.abs(q_sca_analyt - q_sca_fenics) / q_sca_analyt
 err_ext = np.abs(q_ext_analyt - q_ext_fenics) / q_ext_analyt
 
-if msh.comm.rank == 0:
+if gmsh_model.mesh.comm.rank == 0:
     print()
     print(f"The analytical absorption efficiency is {q_abs_analyt}")
     print(f"The numerical absorption efficiency is {q_abs_fenics}")

--- a/python/demo/demo_pml.py
+++ b/python/demo/demo_pml.py
@@ -452,6 +452,8 @@ model = MPI.COMM_WORLD.bcast(model, root=0)
 partitioner = dolfinx.cpp.mesh.create_cell_partitioner(dolfinx.mesh.GhostMode.shared_facet)
 
 mesh_data = gmshio.model_to_mesh(model, MPI.COMM_WORLD, 0, gdim=2, partitioner=partitioner)
+assert mesh_data.cell_tags is not None, "Cell tags are missing"
+assert mesh_data.facet_tags is not None, "Facet tags are missing"
 
 gmsh.finalize()
 MPI.COMM_WORLD.barrier()

--- a/python/demo/demo_scattering_boundary_conditions.py
+++ b/python/demo/demo_scattering_boundary_conditions.py
@@ -442,7 +442,7 @@ if MPI.COMM_WORLD.rank == 0:
     )
 
 model = MPI.COMM_WORLD.bcast(model, root=0)
-domain, cell_tags, facet_tags = io.gmshio.model_to_mesh(model, MPI.COMM_WORLD, 0, gdim=2)
+domain, cell_tags, facet_tags, _, _ = io.gmshio.model_to_mesh(model, MPI.COMM_WORLD, 0, gdim=2)
 
 gmsh.finalize()
 MPI.COMM_WORLD.barrier()

--- a/python/demo/demo_scattering_boundary_conditions.py
+++ b/python/demo/demo_scattering_boundary_conditions.py
@@ -443,6 +443,8 @@ if MPI.COMM_WORLD.rank == 0:
 
 model = MPI.COMM_WORLD.bcast(model, root=0)
 mesh_data = io.gmshio.model_to_mesh(model, MPI.COMM_WORLD, 0, gdim=2)
+assert mesh_data.cell_tags is not None, "Cell tags are missing"
+assert mesh_data.facet_tags is not None, "Facet tags are missing"
 
 gmsh.finalize()
 MPI.COMM_WORLD.barrier()

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -130,11 +130,11 @@ def extract_topology_and_markers(
             model will be used.
 
     Returns:
-        A tuple ``(topologies, groups)``, where ``topologies`` is a
+        A tuple ``(topologies, physical_groups)``, where ``topologies`` is a
         nested dictionary where each key corresponds to a gmsh cell
         type. Each cell type found in the mesh has a 2D array containing
         the topology of the marked cell and a list with the
-        corresponding markers. ``groups`` is a dictionary where the key
+        corresponding markers. ``physical_groups`` is a dictionary where the key
         is the physical name and the value is a tuple with the dimension
         and tag.
 
@@ -148,7 +148,7 @@ def extract_topology_and_markers(
     topologies: dict[int, TopologyDict] = {}
     # Create a dictionary with the physical groups where the key is the
     # physical name and the value is a tuple with the dimension and tag
-    groups: dict[str, tuple[int, int]] = {}
+    physical_groups: dict[str, tuple[int, int]] = {}
     for dim, tag in phys_grps:
         # Get the entities of dimension `dim`, dim=0 -> Points, dim=1 -
         # >Lines, dim=2 -> Triangles/Quadrilaterals, etc.
@@ -187,9 +187,9 @@ def extract_topology_and_markers(
             else:
                 topologies[entity_type] = {"topology": topology, "cell_data": marker}
 
-        groups[model.getPhysicalName(dim, tag)] = (dim, tag)
+        physical_groups[model.getPhysicalName(dim, tag)] = (dim, tag)
 
-    return topologies, groups
+    return topologies, physical_groups
 
 
 def extract_geometry(model, name: typing.Optional[str] = None) -> npt.NDArray[np.float64]:

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -55,7 +55,7 @@ _gmsh_to_cells = {
 }
 
 
-class GMSHModel(typing.NamedTuple):
+class GmshModel(typing.NamedTuple):
     mesh: Mesh
     cell_tags: MeshTags
     facet_tags: MeshTags
@@ -219,7 +219,7 @@ def model_to_mesh(
         typing.Callable[[_MPI.Comm, int, int, AdjacencyList_int32], AdjacencyList_int32]
     ] = None,
     dtype=default_real_type,
-) -> GMSHModel:
+) -> GmshModel:
     """Create a Mesh from a Gmsh model.
 
     Creates a :class:`dolfinx.mesh.Mesh` from the physical entities of
@@ -409,7 +409,7 @@ def model_to_mesh(
     else:
         vt = meshtags(mesh, tdim - 3, np.empty(0, dtype=np.int32), np.empty(0, dtype=np.int32))
 
-    return GMSHModel(mesh, ct, ft, et, vt)
+    return GmshModel(mesh, ct, ft, et, vt)
 
 
 def read_from_msh(
@@ -420,7 +420,7 @@ def read_from_msh(
     partitioner: typing.Optional[
         typing.Callable[[_MPI.Comm, int, int, AdjacencyList], AdjacencyList_int32]
     ] = None,
-) -> GMSHModel:
+) -> GmshModel:
     """Read a Gmsh .msh file and return a :class:`dolfinx.mesh.Mesh` and cell facet markers.
 
     Note:

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -60,7 +60,17 @@ _gmsh_to_cells = {
 }
 
 
-class GmshModel(typing.NamedTuple):
+class MeshData(typing.NamedTuple):
+    """A NamedTuple ``(mesh, cell_tags, facet_tags,
+    edge_tags, vertex_tags, physical_groups)``, where
+    cell_tags hold markers for the cells, facet tags holds markers
+    for facets (if tags are found), edge_tags holds markers
+    for edges (if tags are found), and vertex_tags holds
+    markers for vertices (if tags are found).
+    Physical groups is a dictionary where the key is the physical
+    name and the value is a tuple with the dimension and tag.
+    """
+
     mesh: Mesh
     cell_tags: MeshTags
     facet_tags: MeshTags
@@ -235,7 +245,7 @@ def model_to_mesh(
         typing.Callable[[_MPI.Comm, int, int, AdjacencyList_int32], AdjacencyList_int32]
     ] = None,
     dtype=default_real_type,
-) -> GmshModel:
+) -> MeshData:
     """Create a Mesh from a Gmsh model.
 
     Creates a :class:`dolfinx.mesh.Mesh` from the physical entities of
@@ -252,11 +262,8 @@ def model_to_mesh(
             distribution of cells across MPI ranks.
 
     Returns:
-        A NamedTuple ``(mesh, cell_tags, facet_tags, edge_tags, vertex_tags)``,
-        where cell_tags hold markers for the cells, facet tags holds markers
-        for facets (if tags are found in Gmsh model), edge_tags holds markers
-        for edges (if tags are found in Gmsh model), and vertex_tags holds
-        markers for vertices (if tags are found in Gmsh model).
+        MeshData with mesh, cell tags, facet tags, edge tags,
+        vertex tags and physical groups.
 
     Note:
         For performance, this function should only be called once for
@@ -428,7 +435,7 @@ def model_to_mesh(
     else:
         vt = meshtags(mesh, tdim - 3, np.empty(0, dtype=np.int32), np.empty(0, dtype=np.int32))
 
-    return GmshModel(mesh, ct, ft, et, vt, physical_groups)
+    return MeshData(mesh, ct, ft, et, vt, physical_groups)
 
 
 def read_from_msh(
@@ -439,7 +446,7 @@ def read_from_msh(
     partitioner: typing.Optional[
         typing.Callable[[_MPI.Comm, int, int, AdjacencyList], AdjacencyList_int32]
     ] = None,
-) -> GmshModel:
+) -> MeshData:
     """Read a Gmsh .msh file and return a :class:`dolfinx.mesh.Mesh` and cell facet markers.
 
     Note:
@@ -453,8 +460,8 @@ def read_from_msh(
         gdim: Geometric dimension of the mesh
 
     Returns:
-        A NamedTuple ``(mesh, cell_tags, facet_tags, edge_tags, vertex_tags)``
-        with meshtags for associated physical groups for cells and facets.
+        Meshdata with mesh, cell tags, facet tags, edge tags,
+        vertex tags and physical groups.
 
     """
     try:

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -21,7 +21,7 @@ from dolfinx import default_real_type
 from dolfinx.cpp.graph import AdjacencyList_int32
 from dolfinx.graph import AdjacencyList, adjacencylist
 from dolfinx.io.utils import distribute_entity_data
-from dolfinx.mesh import CellType, Mesh, create_mesh, meshtags, meshtags_from_entities, MeshTags
+from dolfinx.mesh import CellType, Mesh, MeshTags, create_mesh, meshtags, meshtags_from_entities
 
 __all__ = [
     "cell_perm_array",

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -324,6 +324,7 @@ def model_to_mesh(
 
         cells = np.asarray(topologies[cell_id]["topology"], dtype=np.int64)
         cell_values = np.asarray(topologies[cell_id]["cell_data"], dtype=np.int32)
+        physical_groups = comm.bcast(physical_groups, root=rank)
     else:
         cell_id, num_nodes = comm.bcast([None, None], root=rank)
         cells, x = np.empty([0, num_nodes], dtype=np.int32), np.empty([0, gdim], dtype=dtype)
@@ -346,6 +347,8 @@ def model_to_mesh(
             num_vertex_nodes = comm.bcast(None, root=rank)
             marked_vertices = np.empty((0, num_vertex_nodes), dtype=np.int32)
             vertex_values = np.empty((0,), dtype=np.int32)
+
+        physical_groups = comm.bcast(None, root=rank)
 
     # Create distributed mesh
     ufl_domain = ufl_mesh(cell_id, gdim, dtype=dtype)

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -21,7 +21,7 @@ from dolfinx import default_real_type
 from dolfinx.cpp.graph import AdjacencyList_int32
 from dolfinx.graph import AdjacencyList, adjacencylist
 from dolfinx.io.utils import distribute_entity_data
-from dolfinx.mesh import CellType, Mesh, MeshTags, create_mesh, meshtags, meshtags_from_entities
+from dolfinx.mesh import CellType, Mesh, MeshTags, create_mesh, meshtags_from_entities
 
 __all__ = [
     "cell_perm_array",
@@ -72,10 +72,10 @@ class MeshData(typing.NamedTuple):
     """
 
     mesh: Mesh
-    cell_tags: MeshTags
-    facet_tags: MeshTags
-    edge_tags: MeshTags
-    vertex_tags: MeshTags
+    cell_tags: typing.Optional[MeshTags]
+    facet_tags: typing.Optional[MeshTags]
+    edge_tags: typing.Optional[MeshTags]
+    vertex_tags: typing.Optional[MeshTags]
     physical_groups: dict[str, tuple[int, int]]
 
 
@@ -391,7 +391,7 @@ def model_to_mesh(
         ft = meshtags_from_entities(mesh, tdim - 1, adj, local_values.astype(np.int32, copy=False))
         ft.name = "Facet tags"
     else:
-        ft = meshtags(mesh, tdim - 1, np.empty(0, dtype=np.int32), np.empty(0, dtype=np.int32))
+        ft = None
 
     if has_edge_data:
         # Permute edges from MSH to DOLFINx ordering
@@ -409,7 +409,7 @@ def model_to_mesh(
         et = meshtags_from_entities(mesh, tdim - 2, adj, local_values.astype(np.int32, copy=False))
         et.name = "Edge tags"
     else:
-        et = meshtags(mesh, tdim - 2, np.empty(0, dtype=np.int32), np.empty(0, dtype=np.int32))
+        et = None
 
     if has_vertex_data:
         # Permute vertices from MSH to DOLFINx ordering
@@ -427,7 +427,7 @@ def model_to_mesh(
         vt = meshtags_from_entities(mesh, tdim - 3, adj, local_values.astype(np.int32, copy=False))
         vt.name = "Vertex tags"
     else:
-        vt = meshtags(mesh, tdim - 3, np.empty(0, dtype=np.int32), np.empty(0, dtype=np.int32))
+        vt = None
 
     return MeshData(mesh, ct, ft, et, vt, physical_groups)
 

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -34,16 +34,16 @@ __all__ = [
 
 
 class TopologyDict(typing.TypedDict):
-    """
-    TopologyDict is a TypedDict where the key is the gmsh cell type
-    and the value is a dictionary with the keys "topology" and
-    "cell_data". The value of "topology" is a 2D array containing
-    the topology of the marked cell and the value of "cell_data"
-    is a list with the corresponding markers.
+    """TopologyDict is a TypedDict for storing the topology of the marked cell.
 
-    The TypedDict is only used for type hinting, and does not
-    enforce the structure of the dictionary, but rather provides
-    a hint to the user and the type checker.
+    Args:
+        topology: 2D array containing the topology of the marked cell.
+        cell_data: List with the corresponding markers.
+
+    Note:
+        The TypedDict is only used for type hinting, and does not
+        enforce the structure of the dictionary, but rather provides
+        a hint to the user and the type checker.
     """
 
     topology: npt.NDArray[typing.Any]
@@ -75,14 +75,15 @@ _gmsh_to_cells = {
 class MeshData(typing.NamedTuple):
     """Data for representing a mesh and associated tags.
 
-    :param mesh: Mesh.
-    :param cell_tags: MeshTags for cells.
-    :param facet_tags: MeshTags for facets.
-    :param edge_tags: MeshTags for edges.
-    :param vertex_tags: MeshTags for vertices.
-    :param physical_groups: Physical groups in the mesh, where the key
-        is the physical name and the value is a tuple with the
-        dimension and tag.
+    Args:
+        mesh: Mesh.
+        cell_tags: MeshTags for cells.
+        facet_tags: MeshTags for facets.
+        edge_tags: MeshTags for edges.
+        vertex_tags: MeshTags for vertices.
+        physical_groups: Physical groups in the mesh, where the key
+            is the physical name and the value is a tuple with the
+            dimension and tag.
     """
 
     mesh: Mesh

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -34,6 +34,18 @@ __all__ = [
 
 
 class TopologyDict(typing.TypedDict):
+    """
+    TopologyDict is a TypedDict where the key is the gmsh cell type
+    and the value is a dictionary with the keys "topology" and
+    "cell_data". The value of "topology" is a 2D array containing
+    the topology of the marked cell and the value of "cell_data"
+    is a list with the corresponding markers.
+
+    The TypedDict is only used for type hinting, and does not
+    enforce the structure of the dictionary, but rather provides
+    a hint to the user and the type checker.
+    """
+
     topology: npt.NDArray[typing.Any]
     cell_data: npt.NDArray[typing.Any]
 

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -21,7 +21,7 @@ from dolfinx import default_real_type
 from dolfinx.cpp.graph import AdjacencyList_int32
 from dolfinx.graph import AdjacencyList, adjacencylist
 from dolfinx.io.utils import distribute_entity_data
-from dolfinx.mesh import CellType, Mesh, create_mesh, meshtags, meshtags_from_entities
+from dolfinx.mesh import CellType, Mesh, create_mesh, meshtags, meshtags_from_entities, MeshTags
 
 __all__ = [
     "cell_perm_array",
@@ -57,10 +57,10 @@ _gmsh_to_cells = {
 
 class GMSHModel(typing.NamedTuple):
     mesh: Mesh
-    cell_tags: _cpp.mesh.MeshTags_int32
-    facet_tags: _cpp.mesh.MeshTags_int32
-    edge_tags: _cpp.mesh.MeshTags_int32
-    vertex_tags: _cpp.mesh.MeshTags_int32
+    cell_tags: MeshTags
+    facet_tags: MeshTags
+    edge_tags: MeshTags
+    vertex_tags: MeshTags
 
 
 def ufl_mesh(gmsh_cell: int, gdim: int, dtype: npt.DTypeLike) -> ufl.Mesh:

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -298,15 +298,9 @@ def model_to_mesh(
         cell_id, num_nodes = comm.bcast([cell_id, num_nodes], root=rank)
 
         # Check for facet, edge and vertex data and broadcast relevant info if True
-        has_facet_data = False
-        if tdim - 1 in cell_dimensions:
-            has_facet_data = True
-        has_edge_data = False
-        if tdim - 2 in cell_dimensions:
-            has_edge_data = True
-        has_vertex_data = False
-        if tdim - 3 in cell_dimensions:
-            has_vertex_data = True
+        has_facet_data = (tdim - 1) in cell_dimensions
+        has_edge_data = (tdim - 2) in cell_dimensions
+        has_vertex_data = (tdim - 3) in cell_dimensions
 
         has_facet_data = comm.bcast(has_facet_data, root=rank)
         if has_facet_data:

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -73,14 +73,16 @@ _gmsh_to_cells = {
 
 
 class MeshData(typing.NamedTuple):
-    """A NamedTuple ``(mesh, cell_tags, facet_tags,
-    edge_tags, vertex_tags, physical_groups)``, where
-    cell_tags hold markers for the cells, facet tags holds markers
-    for facets (if tags are found), edge_tags holds markers
-    for edges (if tags are found), and vertex_tags holds
-    markers for vertices (if tags are found).
-    Physical groups is a dictionary where the key is the physical
-    name and the value is a tuple with the dimension and tag.
+    """Data for representing a mesh and associated tags.
+
+    :param mesh: Mesh.
+    :param cell_tags: MeshTags for cells.
+    :param facet_tags: MeshTags for facets.
+    :param edge_tags: MeshTags for edges.
+    :param vertex_tags: MeshTags for vertices.
+    :param physical_groups: Physical groups in the mesh, where the key
+        is the physical name and the value is a tuple with the
+        dimension and tag.
     """
 
     mesh: Mesh


### PR DESCRIPTION
Fix https://github.com/FEniCS/dolfinx/issues/3482

Extract `edge_tags` and `vertex_tags` from gmsh if exists and return a `NamedTuple` with mesh and meshtags rather than a regular tuple. 

Another thing I also find very useful is to the extract the physical groups from gmsh. This can be done as follows
```python
if comm.rank == rank:
    gmsh.initialize()
    gmsh.model.add("Mesh from file")
    gmsh.merge(str(msh_file))
    mesh, ct, ft, et, vt = model_to_mesh(gmsh.model, comm, 0)
    markers = {
        gmsh.model.getPhysicalName(*v): tuple(reversed(v))
        for v in gmsh.model.getPhysicalGroups()
    }
    gmsh.finalize()
else:
    mesh, ct, ft, et, vt = model_to_mesh(gmsh.model, comm, 0)
    markers = {}
 markers = comm.bcast(markers, root=rank)
```
However, since we here return a `NamedTuple` we could also add these markers as another item to the `NamedTuple`. Let me know if you think it is a good idea, and I can add this as well.