### PR TITLE
Make `meshtags_from_entities` backward compatible

### DIFF
--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -736,7 +736,10 @@ def meshtags(
 
 
 def meshtags_from_entities(
-    msh: Mesh, dim: int, entities: AdjacencyList, values: npt.NDArray[typing.Any]
+    msh: Mesh,
+    dim: int,
+    entities: AdjacencyList | _cpp.graph.AdjacencyList_int32,
+    values: npt.NDArray[typing.Any],
 ):
     """Create a :class:dolfinx.mesh.MeshTags` object that associates
     data with a subset of mesh entities, where the entities are defined
@@ -763,8 +766,14 @@ def meshtags_from_entities(
     elif isinstance(values, float):
         values = np.full(entities.num_nodes, values, dtype=np.double)
     values = np.asarray(values)
+
+    if isinstance(entities, AdjacencyList):
+        entities_cpp_object = entities._cpp_object
+    else:
+        entities_cpp_object = entities
+
     return MeshTags(
-        _cpp.mesh.create_meshtags(msh.topology._cpp_object, dim, entities._cpp_object, values)
+        _cpp.mesh.create_meshtags(msh.topology._cpp_object, dim, entities_cpp_object, values)
     )
 
 


### PR DESCRIPTION
PR https://github.com/FEniCS/dolfinx/pull/3509 introduced some regressions in ``meshtags_from_entities``, see also https://github.com/jorgensd/adios4dolfinx/pull/144 and https://github.com/ComputationalPhysiology/cardiac-geometriesx/actions/runs/12137079934/job/33839521797?pr=47

Here I am trying here to make it backward compatible by allowing user to pass an object of type `_cpp.graph.AdjacencyList_int32` which used to be the case.