### PR TITLE
Copy x into u inside SNES Solver during Jacobian computation

### DIFF
--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -93,7 +93,13 @@ class NonlinearPDE_SNESProblem:
 
     def J(self, snes, x, J, P):
         """Assemble Jacobian matrix."""
-        from dolfinx.fem.petsc import assemble_matrix
+        from petsc4py import PETSc
+        
+        from dolfinx.fem.petsc import assemble_matrix  
+
+        x.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+        x.copy(self.u.x.petsc_vec)
+        self.u.x.petsc_vec.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
 
         J.zeroEntries()
         assemble_matrix(J, self.a, bcs=[self.bc])


### PR DESCRIPTION
SNES requires J to be evaluated at x - it is only by chance that this was the same x as updated immediately prior in the call to F, but there is no guarantee that this is the case.

