### PR TITLE
Change solver in mixed Poisson

### DIFF
--- a/python/demo/demo_mixed-poisson.py
+++ b/python/demo/demo_mixed-poisson.py
@@ -176,7 +176,7 @@ problem = LinearProblem(
     petsc_options={
         "ksp_type": "preonly",
         "pc_type": "lu",
-        "pc_factor_mat_solver_type": "superlu_dist",
+        "pc_factor_mat_solver_type": "mumps",
         "ksp_error_if_not_converged": True,
     },
 )

--- a/python/demo/demo_mixed-poisson.py
+++ b/python/demo/demo_mixed-poisson.py
@@ -177,6 +177,7 @@ problem = LinearProblem(
         "ksp_type": "preonly",
         "pc_type": "lu",
         "pc_factor_mat_solver_type": "superlu_dist",
+        "ksp_error_if_not_converged": True,
     },
 )
 try:


### PR DESCRIPTION
"superlu_dist" fails with 
```bash
Traceback (most recent call last):
  File "/root/shared/demo/demo_mixed-poisson.py", line 196, in <module>
    raise e
  File "/root/shared/demo/demo_mixed-poisson.py", line 189, in <module>
    w_h = problem.solve()
          ^^^^^^^^^^^^^^^
  File "/usr/local/dolfinx-real/lib/python3.12/dist-packages/dolfinx/fem/petsc.py", line 906, in solve
    self._solver.solve(self._b, self._x)
  File "petsc4py/PETSc/KSP.pyx", line 1782, in petsc4py.PETSc.KSP.solve
petsc4py.PETSc.Error: error code 71
[0] KSPSolve() at /usr/local/petsc/src/ksp/ksp/interface/itfunc.c:1075
[0] KSPSolve_Private() at /usr/local/petsc/src/ksp/ksp/interface/itfunc.c:826
[0] KSPSetUp() at /usr/local/petsc/src/ksp/ksp/interface/itfunc.c:415
[0] PCSetUp() at /usr/local/petsc/src/ksp/pc/interface/precon.c:1071
[0] PCSetUp_LU() at /usr/local/petsc/src/ksp/pc/impls/factor/lu/lu.c:121
[0] MatLUFactorNumeric() at /usr/local/petsc/src/mat/interface/matrix.c:3307
[0] MatLUFactorNumeric_SuperLU_DIST() at /usr/local/petsc/src/mat/impls/aij/mpi/superlu_dist/superlu_dist.c:561
[0] Zero pivot in LU factorization: https://petsc.org/release/faq/#zeropivot
[0] Zero pivot in row 1862
```
Changing to "mumps" resolves the issue.
Also adding assertion if ksp fails to demo to avoid this slipping in at a future release of mumps.