### PR TITLE
Fix for mixed topology when mixing cells with different facet types

### DIFF
--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -279,6 +279,10 @@ build_basic_dofmaps(
 
         const std::vector<std::vector<int>>& e_dofs_d = entity_dofs[d];
 
+        // Skip over undefined topology, e.g. quad facets of tetrahedra
+        if (d < D and !topology.connectivity({D, i}, {d, et}))
+          continue;
+
         // Iterate over each entity of current dimension d and type et
         std::span<const std::int32_t> c_to_e
             = d < D ? topology.connectivity({D, i}, {d, et})->links(c)


### PR DESCRIPTION

When a mesh contains cells with different facet types, e.g. tetrahedra and pyramids, cells try to loop over all facet types, (in this case triangle and quadrilateral). However, tets do not have any quadrilateral facets, so it will fail.

This only comes up with higher order dofmaps (since facets are not required at P1).

