### PR TITLE
Fix: interval refinement assertion ignores optional type

### DIFF
--- a/cpp/dolfinx/refinement/interval.h
+++ b/cpp/dolfinx/refinement/interval.h
@@ -176,7 +176,7 @@ compute_refinement_data(const mesh::Mesh<T>& mesh,
   }
 
   assert(cell_topology.size() == 2 * refined_cell_count);
-  assert(parent_cell->size() == (compute_parent_cell ? refined_cell_count : 0));
+  assert((!compute_parent_cell) || (parent_cell->size() == refined_cell_count));
 
   std::vector<std::int32_t> offsets(refined_cell_count + 1);
   std::ranges::generate(offsets, [i = 0]() mutable { return 2 * i++; });

--- a/cpp/dolfinx/refinement/interval.h
+++ b/cpp/dolfinx/refinement/interval.h
@@ -176,7 +176,7 @@ compute_refinement_data(const mesh::Mesh<T>& mesh,
   }
 
   assert(cell_topology.size() == 2 * refined_cell_count);
-  assert((!compute_parent_cell) || (parent_cell->size() == refined_cell_count));
+  assert(!compute_parent_cell or parent_cell->size() == refined_cell_count);
 
   std::vector<std::int32_t> offsets(refined_cell_count + 1);
   std::ranges::generate(offsets, [i = 0]() mutable { return 2 * i++; });

--- a/cpp/test/mesh/generation.cpp
+++ b/cpp/test/mesh/generation.cpp
@@ -112,7 +112,7 @@ TEMPLATE_TEST_CASE("Interval mesh (parallel)", "[mesh][interval]", float,
               {2}, {2}, {2, 0}, {0, 2}, {0},    {0},    {0}};
     }
     else
-      FAIL("Test only supports <= 3 processes");
+      SKIP("Test only supports <= 3 processes");
 
     return graph::AdjacencyList<std::int32_t>(std::move(data));
   };

--- a/cpp/test/mesh/refinement/interval.cpp
+++ b/cpp/test/mesh/refinement/interval.cpp
@@ -247,5 +247,5 @@ TEMPLATE_TEST_CASE("Interval uniform refinement", "[refinement][interva]",
                                                            {0.0, 1.0});
   auto [refined, parent_edge, parent_facet]
       = dolfinx::refinement::refine(interval, std::nullopt);
-  CHECK(refined.topology()->index_map(0)->size_global() == 5);
+  CHECK(refined.topology()->index_map(0)->size_global() == 41);
 }

--- a/cpp/test/mesh/refinement/interval.cpp
+++ b/cpp/test/mesh/refinement/interval.cpp
@@ -243,8 +243,8 @@ TEMPLATE_TEST_CASE("Interval Refinement (parallel)",
 TEMPLATE_TEST_CASE("Interval uniform refinement", "[refinement][interva]",
                    double, float)
 {
-  auto interval
-      = dolfinx::mesh::create_interval<TestType>(MPI_COMM_WORLD, 2, {0.0, 1.0});
+  auto interval = dolfinx::mesh::create_interval<TestType>(MPI_COMM_WORLD, 20,
+                                                           {0.0, 1.0});
   auto [refined, parent_edge, parent_facet]
       = dolfinx::refinement::refine(interval, std::nullopt);
   CHECK(refined.topology()->index_map(0)->size_global() == 5);

--- a/cpp/test/mesh/refinement/interval.cpp
+++ b/cpp/test/mesh/refinement/interval.cpp
@@ -239,3 +239,13 @@ TEMPLATE_TEST_CASE("Interval Refinement (parallel)",
           != v_to_e->links((center_index + 2) % 3)[0]);
   }
 }
+
+TEMPLATE_TEST_CASE("Interval uniform refinement", "[refinement][interva]",
+                   double, float)
+{
+  auto interval
+      = dolfinx::mesh::create_interval<TestType>(MPI_COMM_WORLD, 2, {0.0, 1.0});
+  auto [refined, parent_edge, parent_facet]
+      = dolfinx::refinement::refine(interval, std::nullopt);
+  CHECK(refined.topology()->index_map(0)->size_global() == 5);
+}


### PR DESCRIPTION
The interval refinement routine falsely ignores the `std::optional` data type of the underlying checked object, causing undefined behavior in the case of it being unassigned. 

Introduces a fix to the assertion and a (previously failing) test case. 

Fixes https://github.com/FEniCS/dolfinx/issues/3583