### PR TITLE
Switch to GitHub native runners

### DIFF
--- a/.github/workflows/docker-dev-test-env.yml
+++ b/.github/workflows/docker-dev-test-env.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         variant: ["test-env", "dev-env"]
         mpi: ["openmpi", "mpich"]
-        os: ["ubuntu-latest", "buildjet-4vcpu-ubuntu-2204-arm"]
+        os: ["ubuntu-latest", "ubuntu-24.04-arm"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/docker-end-user.yml
+++ b/.github/workflows/docker-end-user.yml
@@ -64,7 +64,7 @@ jobs:
           - arch_tag: amd64
             os: ubuntu-latest
           - arch_tag: arm64
-            os: buildjet-8vcpu-ubuntu-2204-arm
+            os: ubuntu-24.04-arm
     runs-on: ${{ matrix.os }}
     steps:
       - name: Create tag without image name


### PR DESCRIPTION
This switches our ARM docker builds to the new GitHub native runners, removing BuildJet.
