### PR TITLE
Support assembly of linear forms with cell integrals on mixed-topology meshes

### DIFF
--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -1300,8 +1300,6 @@ void assemble_vector(
     const std::map<std::pair<IntegralType, int>,
                    std::pair<std::span<const T>, int>>& coefficients)
 {
-  std::cout << "IN ASSEMBLE VEC\n";
-
   std::shared_ptr<const mesh::Mesh<U>> mesh = L.mesh();
   assert(mesh);
   if constexpr (std::is_same_v<U, scalar_value_type_t<T>>)

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -1146,7 +1146,7 @@ void apply_lifting(
 /// @param[in] coefficients Packed coefficients that appear in `L`.
 template <dolfinx::scalar T, std::floating_point U>
 void assemble_vector(
-    std::span<T> b, const Form<T, U>& L, mdspan2_t x_dofmap,
+    std::span<T> b, const Form<T, U>& L,
     std::span<const scalar_value_type_t<T>> x, std::span<const T> constants,
     const std::map<std::pair<IntegralType, int>,
                    std::pair<std::span<const T>, int>>& coefficients)
@@ -1159,123 +1159,131 @@ void assemble_vector(
   auto mesh0 = L.function_spaces().at(0)->mesh();
   assert(mesh0);
 
-  // Get dofmap data
-  assert(L.function_spaces().at(0));
-  auto element = L.function_spaces().at(0)->element();
-  assert(element);
-  std::shared_ptr<const fem::DofMap> dofmap
-      = L.function_spaces().at(0)->dofmap();
-  assert(dofmap);
-  auto dofs = dofmap->map();
-  const int bs = dofmap->bs();
-
-  fem::DofTransformKernel<T> auto P0
-      = element->template dof_transformation_fn<T>(doftransform::standard);
-
-  std::span<const std::uint32_t> cell_info0;
-  if (element->needs_dof_transformations() or L.needs_facet_permutations())
+  const int num_cell_types = mesh->topology()->cell_types().size();
+  for (int cell_type_idx = 0; cell_type_idx < num_cell_types; ++cell_type_idx)
   {
-    mesh0->topology_mutable()->create_entity_permutations();
-    cell_info0 = std::span(mesh0->topology()->get_cell_permutation_info());
-  }
+    // Geometry dofmap and data
+    mdspan2_t x_dofmap = mesh->geometry().dofmap(cell_type_idx);
 
-  for (int i : L.integral_ids(IntegralType::cell))
-  {
-    auto fn = L.kernel(IntegralType::cell, i);
-    assert(fn);
-    auto& [coeffs, cstride] = coefficients.at({IntegralType::cell, i});
-    std::span<const std::int32_t> cells = L.domain(IntegralType::cell, i);
-    if (bs == 1)
-    {
-      impl::assemble_cells<T, 1>(
-          P0, b, x_dofmap, x, cells,
-          {dofs, bs, L.domain(IntegralType::cell, i, *mesh0)}, fn, constants,
-          coeffs, cstride, cell_info0);
-    }
-    else if (bs == 3)
-    {
-      impl::assemble_cells<T, 3>(
-          P0, b, x_dofmap, x, cells,
-          {dofs, bs, L.domain(IntegralType::cell, i, *mesh0)}, fn, constants,
-          coeffs, cstride, cell_info0);
-    }
-    else
-    {
-      impl::assemble_cells(P0, b, x_dofmap, x, cells,
-                           {dofs, bs, L.domain(IntegralType::cell, i, *mesh0)},
-                           fn, constants, coeffs, cstride, cell_info0);
-    }
-  }
+    // Get dofmap data
+    assert(L.function_spaces().at(0));
+    auto element = L.function_spaces().at(0)->elements(cell_type_idx);
+    assert(element);
+    std::shared_ptr<const fem::DofMap> dofmap
+        = L.function_spaces().at(0)->dofmaps(cell_type_idx);
+    assert(dofmap);
+    auto dofs = dofmap->map();
+    const int bs = dofmap->bs();
 
-  std::span<const std::uint8_t> perms;
-  if (L.needs_facet_permutations())
-  {
-    mesh->topology_mutable()->create_entity_permutations();
-    perms = std::span(mesh->topology()->get_facet_permutations());
-  }
+    fem::DofTransformKernel<T> auto P0
+        = element->template dof_transformation_fn<T>(doftransform::standard);
 
-  mesh::CellType cell_type = mesh->topology()->cell_type();
-  int num_facets_per_cell
-      = mesh::cell_num_entities(cell_type, mesh->topology()->dim() - 1);
-  for (int i : L.integral_ids(IntegralType::exterior_facet))
-  {
-    auto fn = L.kernel(IntegralType::exterior_facet, i);
-    assert(fn);
-    auto& [coeffs, cstride]
-        = coefficients.at({IntegralType::exterior_facet, i});
-    std::span<const std::int32_t> facets
-        = L.domain(IntegralType::exterior_facet, i);
-    if (bs == 1)
+    std::span<const std::uint32_t> cell_info0;
+    if (element->needs_dof_transformations() or L.needs_facet_permutations())
     {
-      impl::assemble_exterior_facets<T, 1>(
-          P0, b, x_dofmap, x, num_facets_per_cell, facets,
-          {dofs, bs, L.domain(IntegralType::exterior_facet, i, *mesh0)}, fn,
-          constants, coeffs, cstride, cell_info0, perms);
+      mesh0->topology_mutable()->create_entity_permutations();
+      cell_info0 = std::span(mesh0->topology()->get_cell_permutation_info());
     }
-    else if (bs == 3)
-    {
-      impl::assemble_exterior_facets<T, 3>(
-          P0, b, x_dofmap, x, num_facets_per_cell, facets,
-          {dofs, bs, L.domain(IntegralType::exterior_facet, i, *mesh0)}, fn,
-          constants, coeffs, cstride, cell_info0, perms);
-    }
-    else
-    {
-      impl::assemble_exterior_facets(
-          P0, b, x_dofmap, x, num_facets_per_cell, facets,
-          {dofs, bs, L.domain(IntegralType::exterior_facet, i, *mesh0)}, fn,
-          constants, coeffs, cstride, cell_info0, perms);
-    }
-  }
 
-  for (int i : L.integral_ids(IntegralType::interior_facet))
-  {
-    auto fn = L.kernel(IntegralType::interior_facet, i);
-    assert(fn);
-    auto& [coeffs, cstride]
-        = coefficients.at({IntegralType::interior_facet, i});
-    std::span<const std::int32_t> facets
-        = L.domain(IntegralType::interior_facet, i);
-    if (bs == 1)
+    for (int i : L.integral_ids(IntegralType::cell))
     {
-      impl::assemble_interior_facets<T, 1>(
-          P0, b, x_dofmap, x, num_facets_per_cell, facets,
-          {*dofmap, bs, L.domain(IntegralType::interior_facet, i, *mesh0)}, fn,
-          constants, coeffs, cstride, cell_info0, perms);
+      auto fn = L.kernel(IntegralType::cell, i, cell_type_idx);
+      assert(fn);
+      auto& [coeffs, cstride] = coefficients.at({IntegralType::cell, i});
+      std::span<const std::int32_t> cells = L.domain(IntegralType::cell, i);
+      if (bs == 1)
+      {
+        impl::assemble_cells<T, 1>(
+            P0, b, x_dofmap, x, cells,
+            {dofs, bs, L.domain(IntegralType::cell, i, cell_type_idx, *mesh0)}, fn, constants,
+            coeffs, cstride, cell_info0);
+      }
+      else if (bs == 3)
+      {
+        impl::assemble_cells<T, 3>(
+            P0, b, x_dofmap, x, cells,
+            {dofs, bs, L.domain(IntegralType::cell, i, cell_type_idx, *mesh0)}, fn, constants,
+            coeffs, cstride, cell_info0);
+      }
+      else
+      {
+        impl::assemble_cells(
+            P0, b, x_dofmap, x, cells,
+            {dofs, bs, L.domain(IntegralType::cell, i, cell_type_idx, *mesh0)}, fn, constants,
+            coeffs, cstride, cell_info0);
+      }
     }
-    else if (bs == 3)
+
+    std::span<const std::uint8_t> perms;
+    if (L.needs_facet_permutations())
     {
-      impl::assemble_interior_facets<T, 3>(
-          P0, b, x_dofmap, x, num_facets_per_cell, facets,
-          {*dofmap, bs, L.domain(IntegralType::interior_facet, i, *mesh0)}, fn,
-          constants, coeffs, cstride, cell_info0, perms);
+      mesh->topology_mutable()->create_entity_permutations();
+      perms = std::span(mesh->topology()->get_facet_permutations());
     }
-    else
+
+    mesh::CellType cell_type = mesh->topology()->cell_types()[cell_type_idx];
+    int num_facets_per_cell
+        = mesh::cell_num_entities(cell_type, mesh->topology()->dim() - 1);
+    for (int i : L.integral_ids(IntegralType::exterior_facet))
     {
-      impl::assemble_interior_facets(
-          P0, b, x_dofmap, x, num_facets_per_cell, facets,
-          {*dofmap, bs, L.domain(IntegralType::interior_facet, i, *mesh0)}, fn,
-          constants, coeffs, cstride, cell_info0, perms);
+      auto fn = L.kernel(IntegralType::exterior_facet, i);
+      assert(fn);
+      auto& [coeffs, cstride]
+          = coefficients.at({IntegralType::exterior_facet, i});
+      std::span<const std::int32_t> facets
+          = L.domain(IntegralType::exterior_facet, i);
+      if (bs == 1)
+      {
+        impl::assemble_exterior_facets<T, 1>(
+            P0, b, x_dofmap, x, num_facets_per_cell, facets,
+            {dofs, bs, L.domain(IntegralType::exterior_facet, i, *mesh0)}, fn,
+            constants, coeffs, cstride, cell_info0, perms);
+      }
+      else if (bs == 3)
+      {
+        impl::assemble_exterior_facets<T, 3>(
+            P0, b, x_dofmap, x, num_facets_per_cell, facets,
+            {dofs, bs, L.domain(IntegralType::exterior_facet, i, *mesh0)}, fn,
+            constants, coeffs, cstride, cell_info0, perms);
+      }
+      else
+      {
+        impl::assemble_exterior_facets(
+            P0, b, x_dofmap, x, num_facets_per_cell, facets,
+            {dofs, bs, L.domain(IntegralType::exterior_facet, i, *mesh0)}, fn,
+            constants, coeffs, cstride, cell_info0, perms);
+      }
+    }
+
+    for (int i : L.integral_ids(IntegralType::interior_facet))
+    {
+      auto fn = L.kernel(IntegralType::interior_facet, i);
+      assert(fn);
+      auto& [coeffs, cstride]
+          = coefficients.at({IntegralType::interior_facet, i});
+      std::span<const std::int32_t> facets
+          = L.domain(IntegralType::interior_facet, i);
+      if (bs == 1)
+      {
+        impl::assemble_interior_facets<T, 1>(
+            P0, b, x_dofmap, x, num_facets_per_cell, facets,
+            {*dofmap, bs, L.domain(IntegralType::interior_facet, i, *mesh0)},
+            fn, constants, coeffs, cstride, cell_info0, perms);
+      }
+      else if (bs == 3)
+      {
+        impl::assemble_interior_facets<T, 3>(
+            P0, b, x_dofmap, x, num_facets_per_cell, facets,
+            {*dofmap, bs, L.domain(IntegralType::interior_facet, i, *mesh0)},
+            fn, constants, coeffs, cstride, cell_info0, perms);
+      }
+      else
+      {
+        impl::assemble_interior_facets(
+            P0, b, x_dofmap, x, num_facets_per_cell, facets,
+            {*dofmap, bs, L.domain(IntegralType::interior_facet, i, *mesh0)},
+            fn, constants, coeffs, cstride, cell_info0, perms);
+      }
     }
   }
 }
@@ -1292,19 +1300,19 @@ void assemble_vector(
     const std::map<std::pair<IntegralType, int>,
                    std::pair<std::span<const T>, int>>& coefficients)
 {
+  std::cout << "IN ASSEMBLE VEC\n";
+
   std::shared_ptr<const mesh::Mesh<U>> mesh = L.mesh();
   assert(mesh);
   if constexpr (std::is_same_v<U, scalar_value_type_t<T>>)
   {
-    assemble_vector(b, L, mesh->geometry().dofmap(), mesh->geometry().x(),
-                    constants, coefficients);
+    assemble_vector(b, L, mesh->geometry().x(), constants, coefficients);
   }
   else
   {
     auto x = mesh->geometry().x();
     std::vector<scalar_value_type_t<T>> _x(x.begin(), x.end());
-    assemble_vector(b, L, mesh->geometry().dofmap(), _x, constants,
-                    coefficients);
+    assemble_vector(b, L, _x, constants, coefficients);
   }
 }
 } // namespace dolfinx::fem::impl

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -1190,7 +1190,7 @@ void assemble_vector(
       auto fn = L.kernel(IntegralType::cell, i, cell_type_idx);
       assert(fn);
       auto& [coeffs, cstride] = coefficients.at({IntegralType::cell, i});
-      std::span<const std::int32_t> cells = L.domain(IntegralType::cell, i);
+      std::vector<std::int32_t> cells = L.domain(IntegralType::cell, i, cell_type_idx);
       if (bs == 1)
       {
         impl::assemble_cells<T, 1>(

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -1140,7 +1140,6 @@ void apply_lifting(
 /// @param[in,out] b The vector to be assembled. It will not be zeroed
 /// before assembly.
 /// @param[in] L Linear forms to assemble into b.
-/// @param[in] x_dofmap Mesh geometry dofmap.
 /// @param[in] x Mesh coordinates.
 /// @param[in] constants Packed constants that appear in `L`.
 /// @param[in] coefficients Packed coefficients that appear in `L`.

--- a/python/demo/demo_mixed-topology.py
+++ b/python/demo/demo_mixed-topology.py
@@ -124,8 +124,10 @@ for i, cell_name in enumerate(["hexahedron", "prism"]):
     V = FunctionSpace(Mesh(mesh, domain), element, V_cpp)
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
     k = 12.0
+    x = ufl.SpatialCoordinate(domain)
     a += [(ufl.inner(ufl.grad(u), ufl.grad(v)) - k**2 * u * v) * ufl.dx]
-    L += [ufl.inner(1.0, v) * ufl.dx]
+    f = ufl.sin(ufl.pi * x[0]) * ufl.sin(ufl.pi * x[1])
+    L += [f * v * ufl.dx]
 
 # Compile the form
 # FIXME: For the time being, since UFL doesn't understand mixed topology meshes,
@@ -139,9 +141,13 @@ b = assemble_vector(L_form)
 
 # Solve
 A_scipy = A.to_scipy()
-b_scipy = np.ones(A_scipy.shape[1])
+b_scipy = b.array
+
+print(b_scipy)
 
 x = spsolve(A_scipy, b_scipy)
+
+print(np.min(x), np.max(x))
 print(f"Solution vector norm {np.linalg.norm(x)}")
 
 # I/O

--- a/python/demo/demo_mixed-topology.py
+++ b/python/demo/demo_mixed-topology.py
@@ -143,11 +143,8 @@ b = assemble_vector(L_form)
 A_scipy = A.to_scipy()
 b_scipy = b.array
 
-print(b_scipy)
-
 x = spsolve(A_scipy, b_scipy)
 
-print(np.min(x), np.max(x))
 print(f"Solution vector norm {np.linalg.norm(x)}")
 
 # I/O

--- a/python/demo/demo_mixed-topology.py
+++ b/python/demo/demo_mixed-topology.py
@@ -94,8 +94,7 @@ prism = coordinate_element(CellType.prism, 1)
 
 part = create_cell_partitioner(GhostMode.none)
 mesh = create_mesh(
-    MPI.COMM_WORLD, cells_np, [
-        hexahedron._cpp_object, prism._cpp_object], geomx, part
+    MPI.COMM_WORLD, cells_np, [hexahedron._cpp_object, prism._cpp_object], geomx, part
 )
 
 # Create elements and dofmaps for each cell type
@@ -103,8 +102,7 @@ elements = [
     basix.create_element(basix.ElementFamily.P, basix.CellType.hexahedron, 1),
     basix.create_element(basix.ElementFamily.P, basix.CellType.prism, 1),
 ]
-elements_cpp = [_cpp.fem.FiniteElement_float64(
-    e._e, None, True) for e in elements]
+elements_cpp = [_cpp.fem.FiniteElement_float64(e._e, None, True) for e in elements]
 # NOTE: Both dofmaps have the same IndexMap, but different cell_dofs
 dofmaps = _cpp.fem.create_dofmaps(mesh.comm, mesh.topology, elements_cpp)
 
@@ -156,8 +154,7 @@ xdmf = """<?xml version="1.0"?>
 
 """
 
-perm = [cell_perm_vtk(CellType.hexahedron, 8),
-        cell_perm_vtk(CellType.prism, 6)]
+perm = [cell_perm_vtk(CellType.hexahedron, 8), cell_perm_vtk(CellType.prism, 6)]
 topologies = ["Hexahedron", "Wedge"]
 
 for j in range(2):

--- a/python/demo/demo_mixed-topology.py
+++ b/python/demo/demo_mixed-topology.py
@@ -31,7 +31,6 @@ from dolfinx.fem import (
     assemble_vector,
     coordinate_element,
     mixed_topology_form,
-    Constant,
 )
 from dolfinx.io.utils import cell_perm_vtk
 from dolfinx.mesh import CellType, Mesh

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -89,7 +89,7 @@ def pack_coefficients(form: typing.Union[Form, typing.Sequence[Form]]):
 
 def create_vector(L: Form) -> la.Vector:
     """Create a Vector that is compatible with a given linear form"""
-    dofmap = L.function_spaces[0].dofmap
+    dofmap = L.function_spaces[0].dofmaps(0)
     return la.vector(dofmap.index_map, dofmap.index_map_bs, dtype=L.dtype)
 
 

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -89,6 +89,8 @@ def pack_coefficients(form: typing.Union[Form, typing.Sequence[Form]]):
 
 def create_vector(L: Form) -> la.Vector:
     """Create a Vector that is compatible with a given linear form"""
+    # Can just take the first dofmap here, since all dof maps have the same
+    # index map in mixed-topology meshes
     dofmap = L.function_spaces[0].dofmaps(0)
     return la.vector(dofmap.index_map, dofmap.index_map_bs, dtype=L.dtype)
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -316,9 +316,9 @@ class Function(ufl.Coefficient):
             if dtype is None:
                 dtype = default_scalar_type
 
-        assert np.issubdtype(
-            V.element.dtype, np.dtype(dtype).type(0).real.dtype
-        ), "Incompatible FunctionSpace dtype and requested dtype."
+        assert np.issubdtype(V.element.dtype, np.dtype(dtype).type(0).real.dtype), (
+            "Incompatible FunctionSpace dtype and requested dtype."
+        )
 
         # Create cpp Function
         def functiontype(dtype):
@@ -592,9 +592,9 @@ def functionspace(
     element = finiteelement(mesh.topology.cell_type, ufl_e, dtype)
     cpp_dofmap = _cpp.fem.create_dofmap(mesh.comm, mesh.topology._cpp_object, element._cpp_object)
 
-    assert np.issubdtype(
-        mesh.geometry.x.dtype, element.dtype
-    ), "Mesh and element dtype are not compatible."
+    assert np.issubdtype(mesh.geometry.x.dtype, element.dtype), (
+        "Mesh and element dtype are not compatible."
+    )
 
     # Initialize the cpp.FunctionSpace
     try:

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -316,9 +316,9 @@ class Function(ufl.Coefficient):
             if dtype is None:
                 dtype = default_scalar_type
 
-        assert np.issubdtype(V.element.dtype, np.dtype(dtype).type(0).real.dtype), (
-            "Incompatible FunctionSpace dtype and requested dtype."
-        )
+        assert np.issubdtype(
+            V.element.dtype, np.dtype(dtype).type(0).real.dtype
+        ), "Incompatible FunctionSpace dtype and requested dtype."
 
         # Create cpp Function
         def functiontype(dtype):
@@ -592,9 +592,9 @@ def functionspace(
     element = finiteelement(mesh.topology.cell_type, ufl_e, dtype)
     cpp_dofmap = _cpp.fem.create_dofmap(mesh.comm, mesh.topology._cpp_object, element._cpp_object)
 
-    assert np.issubdtype(mesh.geometry.x.dtype, element.dtype), (
-        "Mesh and element dtype are not compatible."
-    )
+    assert np.issubdtype(
+        mesh.geometry.x.dtype, element.dtype
+    ), "Mesh and element dtype are not compatible."
 
     # Initialize the cpp.FunctionSpace
     try:

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -85,6 +85,7 @@ void declare_function_space(nb::module_& m, std::string type)
         .def_prop_ro("element", &dolfinx::fem::FunctionSpace<T>::element)
         .def_prop_ro("mesh", &dolfinx::fem::FunctionSpace<T>::mesh)
         .def_prop_ro("dofmap", &dolfinx::fem::FunctionSpace<T>::dofmap)
+        .def("dofmaps", &dolfinx::fem::FunctionSpace<T>::dofmaps, nb::arg("cell_type_index"))
         .def("sub", &dolfinx::fem::FunctionSpace<T>::sub, nb::arg("component"))
         .def("tabulate_dof_coordinates",
              [](const dolfinx::fem::FunctionSpace<T>& self)


### PR DESCRIPTION
This PR adds support for the assembly of linear forms with cell integrals on mixed-topology meshes.

There is still a lot of work to be done to allow, for example, other integral types and the application of boundary conditions etc. 