### PR TITLE
New NewtonSolver._residual0 initialisation (residual)

### DIFF
--- a/cpp/dolfinx/nls/NewtonSolver.cpp
+++ b/cpp/dolfinx/nls/NewtonSolver.cpp
@@ -228,9 +228,9 @@ std::pair<int, bool> nls::petsc::NewtonSolver::solve(Vec x)
       // set.
       if (_iteration == 1)
       {
-         PetscReal _r = 0.0;
-         VecNorm(_dx, NORM_2, &_r);
-         _residual0 = _r;
+        PetscReal _r = 0.0;
+        VecNorm(_dx, NORM_2, &_r);
+        _residual0 = _r;
         _residual = 1.0;
         newton_converged = false;
       }

--- a/cpp/dolfinx/nls/NewtonSolver.cpp
+++ b/cpp/dolfinx/nls/NewtonSolver.cpp
@@ -169,7 +169,10 @@ std::pair<int, bool> nls::petsc::NewtonSolver::solve(Vec x)
   // Check convergence
   bool newton_converged = false;
   if (convergence_criterion == "residual")
+  {
     std::tie(_residual, newton_converged) = this->_converged(*this, _b);
+    _residual0 = _residual;
+  }
   else if (convergence_criterion == "incremental")
   {
     // We need to do at least one Newton step with the ||dx||-stopping
@@ -215,13 +218,6 @@ std::pair<int, bool> nls::petsc::NewtonSolver::solve(Vec x)
     if (_system)
       _system(x);
     _fnF(x, _b);
-    // Initialize _residual0
-    if (_iteration == 1)
-    {
-      PetscReal _r = 0.0;
-      VecNorm(_dx, NORM_2, &_r);
-      _residual0 = _r;
-    }
 
     // Test for convergence
     if (convergence_criterion == "residual")
@@ -232,6 +228,9 @@ std::pair<int, bool> nls::petsc::NewtonSolver::solve(Vec x)
       // set.
       if (_iteration == 1)
       {
+         PetscReal _r = 0.0;
+         VecNorm(_dx, NORM_2, &_r);
+         _residual0 = _r;
         _residual = 1.0;
         newton_converged = false;
       }


### PR DESCRIPTION
Hello,
just in case ...  It's almost my first PR, so I hope I'm not too far away from how these things should be done.

The origins:
============
In making comparisons with another library, I saw that FENICSX needed more iterations to solve the same non-linear test case in order to converge to the same atol/rtol.
And it wasn't possible (due to non-convergence) to reduce the rtol as much as in the other library.
It was the same with either the Python API or the C++ API.
After investigation, both libraries use the same test (with convergence_criterion==‘residual’), but in FENICSX _residual0 is set to the norm of the first variation of the solution, whereas in the other library it is set to the norm of the initial residual vector.
In FENICSX it is not adimentional, which explains why in my case, with my units and settings, I got |dx| far less than |r0| and the relative convergence criterion was really not the same as in the other code.  
In https://fenicsproject.discourse.group/t/finite-relative-residuals-for-0th-newton-iteration-in-time-dependent-problem/15214 they seem to have made a similar observation about the _residual0 setting, plus some other questions about using the solve method in a time-dependent context.

How:
====
This PR now forces _residual0 to be set to |r0| when convergence_criterion=="residual". If convergence_criterion=="incremental", this PR does not change anything.

Now regarding the multiple call to solve (time-dependent context), the assignment of _residual0 is placed just after the test for:
1) Using the calculation of the residual vector returned by the _converged method.
2) As with the incremental criterion for repeated calls to the solver, where the previous _residual0 is retained between calls, it is possible that convergence will occur immediately if the problem does not change too much.

Tests:
======
For my test case (a crude  elasto-damaged asymmetric tension/compression  constitutive law), I run the solve method twice, with a 'small' or 'large' variation in the volume load imposed between the two runs.
Only relative convergence is observed (i.e. atol is set to a very small value).
The results (see [asym.txt](https://github.com/user-attachments/files/18605747/asym.txt)) show that with the PR, the first resolution uses fewer iterations (in agreement with the other library) and the second iterates little or converges immediately.
With the original version of the code, for this specific test, |dx| is well below |r0|, so there are convergence problems.

This PR does not change the cpp/demo/hyperelastic behaviour.  
It pass the python unit test.

With the test case demo_cahn-hilliard.py, the analysis of the system resolution at the first time step is shown in [ch.pdf](https://github.com/user-attachments/files/18605873/ch.pdf).
So with PR and convergence_criterion=="residual" there is one more iteration compared to the original code version (but less than with convergence_criterion=="incremental").
In this case |dx|>>|r0| and the PR look more conservative.
Counting all non-linear iterations of all 50 timesteps, we have 266 iterations for convergence_criterion=="incremental", 189 iterations for convergence_criterion=="residual" with original code and 205 iterations with PR.

With https://jsdokken.com/dolfinx-tutorial/chapter2/hyperelasticity.html, using solver.convergence_criterion = "residual", the PR gives a slightly modified number of iterations (61) over the 10 time steps compared to the original code (59).
In any case (PR or original) we have 69 iterations with solver.convergence_criterion = "incremental". 
Some runs are given in  [hyperelastic_tuto.zip](https://github.com/user-attachments/files/18605945/hyperelastic_tuto.zip) and in particular "ir" runs where an iregular load has been tuned to have a variation at a time step small enough that the "residual" relative convergence criterion is less than rtol with the original code and conservatively greater with PR, with an absolute convergence criterion greater than atol. 

Future:
======
It is certainly possible to find cases where this initial test with the previous _residual0 value disturbs the simulation.
And it is still possible to assign _residual0 before the test, but as this requires an extra norm calculation and leads to at least one iteration, it may be at the user's discretion.
This means an API change that goes far beyond the original intent of this PR, which was to address the one solve case.


