### PR TITLE
Bump pyvista version

### DIFF
--- a/.github/workflows/pyvista.yml
+++ b/.github/workflows/pyvista.yml
@@ -24,7 +24,7 @@ jobs:
       DISPLAY: ":99.0"
       PYVISTA_OFF_SCREEN: true
       PYVISTA_QT_VERSION: 0.11.1
-      PYVISTA_VERSION: 0.44.1
+      PYVISTA_VERSION: 0.44.2
       QT_DEBUG_PLUGINS: 1
 
       PETSC_ARCH: ${{ matrix.petsc_arch }}

--- a/docker/Dockerfile.end-user
+++ b/docker/Dockerfile.end-user
@@ -34,7 +34,7 @@
 #    echo "FROM dolfinx/dolfinx-onbuild:nightly" | docker build -f- .
 #
 
-ARG PYVISTA_VERSION=0.44.1
+ARG PYVISTA_VERSION=0.44.2
 
 # Used to set the correct PYTHONPATH for the real and complex install of
 # DOLFINx
@@ -172,11 +172,11 @@ RUN apt-get -qq update && \
 RUN dpkgArch="$(dpkg --print-architecture)"; \
     pip install matplotlib; \
     case "$dpkgArch" in amd64) \
-      pip install --no-cache-dir pyvista[trame]==${PYVISTA_VERSION} ;; \
+      pip install --no-cache-dir pyvista[jupyter]==${PYVISTA_VERSION} ;; \
     esac; \
     case "$dpkgArch" in arm64) \
       pip install --no-cache-dir https://github.com/finsberg/vtk-aarch64/releases/download/vtk-9.3.0-cp312/vtk-9.3.0.dev0-cp312-cp312-linux_aarch64.whl && \
-      pip install --no-cache-dir pyvista[trame]==${PYVISTA_VERSION} ;; \
+      pip install --no-cache-dir pyvista[jupyter]==${PYVISTA_VERSION} ;; \
     esac; \
     pip cache purge
 


### PR DESCRIPTION
https://github.com/pyvista/pyvista/releases/tag/v0.44.2

and fix optional dependencies (previously called trame explicitly, now just called jupyter)