### PR TITLE
Require `nanobind>=2.5.0`

### DIFF
--- a/python/build-requirements.txt
+++ b/python/build-requirements.txt
@@ -1,3 +1,3 @@
-nanobind>=2.2.0
+nanobind>=2.5.0
 scikit-build-core[pyproject]>=0.10
 mpi4py

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@
 # list it here.
 # pip install -r build-requirements.txt
 [build-system]
-requires = ["scikit-build-core[pyproject]>=0.10", "nanobind>=2.2.0", "mpi4py"]
+requires = ["scikit-build-core[pyproject]>=0.10", "nanobind>=2.5.0", "mpi4py"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
Needed due to #3617. Otherwise the user may get odd errors like

```
#23 127.3       CMake Error at /usr/local/lib/python3.12/site-packages/nanobind/cmake/nanobind-config.cmake:316 (add_library):
#23 127.3         Cannot find source file:
#23 127.3       
#23 127.3           NB_SUPPRESS_WARNINGS
#23 127.3       Call Stack (most recent call first):
#23 127.3         CMakeLists.txt:34 (nanobind_add_module)
#23 127.3       
#23 127.3       
#23 127.3       CMake Error at /usr/local/lib/python3.12/site-packages/nanobind/cmake/nanobind-config.cmake:316 (add_library):
#23 127.3         No SOURCES given to target: cpp
#23 127.3       Call Stack (most recent call first):
#23 127.3         CMakeLists.txt:34 (nanobind_add_module)
#23 127.3       
#23 127.3       
#23 127.3       CMake Generate step failed.  Build files cannot be regenerated correctly.
```