### PR TITLE
Add python wrapper for `FiniteElement.basix_element`

### DIFF
--- a/python/dolfinx/fem/element.py
+++ b/python/dolfinx/fem/element.py
@@ -6,7 +6,7 @@
 """Finite elements."""
 
 import typing
-from functools import singledispatch
+from functools import cached_property, singledispatch
 
 import numpy as np
 import numpy.typing as npt
@@ -189,14 +189,14 @@ class FiniteElement:
         """Geometry type of the Mesh that the FunctionSpace is defined on."""
         return self._cpp_object.dtype
 
-    @property
+    @cached_property
     def basix_element(self) -> basix.finite_element.FiniteElement:
         """Return underlying Basix C++ element (if it exists).
 
         Raises:
             Runtime error if Basix element does not exist.
         """
-        return self._cpp_object.basix_element
+        return basix.finite_element.FiniteElement(self._cpp_object.basix_element)
 
     @property
     def num_sub_elements(self) -> int:

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -250,14 +250,11 @@ def test_cell_mismatch(mesh):
 @pytest.mark.skipif(default_real_type != np.float64, reason="float32 not supported yet")
 def test_basix_element(V, W, Q, V2):
     for V_ in (V, W, V2):
-        e = V_.element.basix_element
-        assert isinstance(
-            e, (basix._basixcpp.FiniteElement_float64, basix._basixcpp.FiniteElement_float32)
-        )
+        assert isinstance(V_.element.basix_element, basix.finite_element.FiniteElement)
 
     # Mixed spaces do not yet return a basix element
     with pytest.raises(RuntimeError):
-        e = Q.element.basix_element
+        Q.element.basix_element
 
 
 @pytest.mark.skip_in_parallel


### PR DESCRIPTION
Switches to use the Basix type for the returned element.

Ping https://github.com/FEniCS/dolfinx/issues/3553