### PR TITLE
Mixed topology: find dS cells

### DIFF
--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -346,17 +346,19 @@ entities_to_index(const Topology& topology, int dim,
 /// in the topology which have the same connecting facet type.
 /// @param topology A mesh topology
 /// @param facet_type Type of facet connection between cells
-/// @return List of cell index pairs, for each cell-cell possibility, arranged
-/// as a flattened 2D array in the ordering given by `cell_types()` in the
-/// topology. i.e. if the cell types are tet, prism, hex, and the facet_type is
-/// quadrilateral, then the lists returned are: tet-tet (empty), tet-prism
-/// (empty), tet-hex (empty), prism-tet (empty), prism-prism, prism-hex, hex-tet
-/// (empty), hex-prism, hex-hex. Note there are empty lists for the invalid
-/// cases, and also that there is currently redundant data, since the transpose
-/// is also computed, i.e. prism-hex as well as hex-prism.
-/// @note All facet-cell connectivity must be computed beforehand.
-/// @todo Remove redundant data
-
+/// @return A list for each possible cell-cell connection, arranged
+/// in the ordering given by `cell_types()` in the topology. i.e. if the cell
+/// types are tet, prism, hex, and the facet_type is quadrilateral, then the
+/// lists returned are: tet-tet (empty), tet-prism (empty), tet-hex (empty),
+/// prism-tet (empty), prism-prism, prism-hex, hex-tet (empty), hex-prism,
+/// hex-hex. Note there are empty lists for the invalid cases, and also that
+/// there is currently redundant data, since the transpose is also computed,
+/// i.e. prism-hex as well as hex-prism.
+/// Each list contains a flattened array with data in the order (cell0, local
+/// facet0, cell1, local facet1) for each connection between cells.
+/// @note All facet-cell connectivity and cell-facet connectivity must be
+/// computed beforehand in the topology.
+/// @todo Remove redundant data.
 std::vector<std::vector<std::int32_t>>
 compute_mixed_cell_pairs(const Topology& topology, mesh::CellType facet_type);
 

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -357,7 +357,7 @@ entities_to_index(const Topology& topology, int dim,
 /// @note All facet-cell connectivity must be computed beforehand.
 /// @todo Remove redundant data
 
-std::vector<std::vector<std::pair<std::int32_t, std::int32_t>>>
+std::vector<std::vector<std::int32_t>>
 compute_mixed_cell_pairs(const Topology& topology, mesh::CellType facet_type);
 
 } // namespace dolfinx::mesh

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -341,4 +341,23 @@ create_subtopology(const Topology& topology, int dim,
 std::vector<std::int32_t>
 entities_to_index(const Topology& topology, int dim,
                   std::span<const std::int32_t> entities);
+
+/// @brief Compute a list of cell-cell connections for each possible combination
+/// in the topology which have the same connecting facet type.
+/// @param topology A mesh topology
+/// @param facet_type Type of facet connection between cells
+/// @return List of cell index pairs, for each cell-cell possibility, arranged
+/// as a flattened 2D array in the ordering given by `cell_types()` in the
+/// topology. i.e. if the cell types are tet, prism, hex, and the facet_type is
+/// quadrilateral, then the lists returned are: tet-tet (empty), tet-prism
+/// (empty), tet-hex (empty), prism-tet (empty), prism-prism, prism-hex, hex-tet
+/// (empty), hex-prism, hex-hex. Note there are empty lists for the invalid
+/// cases, and also that there is currently redundant data, since the transpose
+/// is also computed, i.e. prism-hex as well as hex-prism.
+/// @note All facet-cell connectivity must be computed beforehand.
+/// @todo Remove redundant data
+
+std::vector<std::vector<std::pair<std::int32_t, std::int32_t>>>
+compute_mixed_cell_pairs(const Topology& topology, mesh::CellType facet_type);
+
 } // namespace dolfinx::mesh

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -696,6 +696,8 @@ void mesh(nb::module_& m)
               ghost_owners_span, boundary_vertices_span);
         });
 
+  m.def("compute_mixed_cell_pairs", &dolfinx::mesh::compute_mixed_cell_pairs);
+
   declare_meshtags<std::int8_t>(m, "int8");
   declare_meshtags<std::int32_t>(m, "int32");
   declare_meshtags<std::int64_t>(m, "int64");

--- a/python/test/unit/mesh/test_mixed_topology.py
+++ b/python/test/unit/mesh/test_mixed_topology.py
@@ -3,10 +3,15 @@ from mpi4py import MPI
 import numpy as np
 
 from dolfinx.cpp.log import set_thread_name
-from dolfinx.cpp.mesh import Mesh_float64, create_geometry, create_topology
+from dolfinx.cpp.mesh import (
+    Mesh_float64,
+    compute_mixed_cell_pairs,
+    create_geometry,
+    create_topology,
+)
 from dolfinx.fem import coordinate_element
 from dolfinx.log import LogLevel, set_log_level
-from dolfinx.mesh import CellType, GhostMode, create_unit_cube
+from dolfinx.mesh import CellType, GhostMode, Mesh, create_unit_cube
 
 
 def test_mixed_topology_mesh():
@@ -271,3 +276,27 @@ def test_create_entities():
 
     # Triangle and quad to prism (facet->cell)
     mesh.topology.create_connectivity(2, 3)
+
+
+def test_mixed_cell_pairs(mixed_topology_mesh):
+    mesh = Mesh(mixed_topology_mesh, None)
+    mesh.topology.create_entities(2)
+    mesh.topology.create_connectivity(2, 3)
+    cell_types = mesh.topology.entity_types[3]
+    facet_types = mesh.topology.entity_types[2]
+    print(cell_types, facet_types)
+
+    # For each facet type
+    for f, ft in enumerate(facet_types):
+        cell_pairs = compute_mixed_cell_pairs(mesh.topology._cpp_object, ft)
+        for i, cti in enumerate(cell_types):
+            for j, ctj in enumerate(cell_types):
+                idx = i * len(cell_types) + j
+                num_conns = len(cell_pairs[idx]) // 4
+                print(f"Connectivity ({ft}) from {cti} to {ctj} : {num_conns}")
+                if len(cell_pairs[idx]) > 0:
+                    connection = np.array(cell_pairs[idx]).reshape((num_conns, -1))
+                    f0 = mesh.topology.connectivity((3, i), (2, f))
+                    f1 = mesh.topology.connectivity((3, j), (2, f))
+                    for row in connection:
+                        assert f0.links(row[0])[row[1]] == f1.links(row[2])[row[3]]


### PR DESCRIPTION
Adds a utility to compute the lists of pairs of cells for `dS` integrals, in the mixed-topology case.

`mesh::compute_mixed_cell_pairs(const Topology& topology, mesh::CellType facet_type)`

returns a list for each possible combination of cells, containing the cell indices and local facet indices for each pair.