### PR TITLE
Unpin cffi version (fixes tests for Python 3.13)

### DIFF
--- a/python/conda-oneapi-test-env.yml
+++ b/python/conda-oneapi-test-env.yml
@@ -6,7 +6,7 @@ channels:
   - defaults
 dependencies:
   - intelpython3_core
-  - python=3.12
+  - python=3.11
   - dpcpp_linux-64
   - mkl
   - libblas=*=*mkl

--- a/python/conda-oneapi-test-env.yml
+++ b/python/conda-oneapi-test-env.yml
@@ -6,7 +6,7 @@ channels:
   - defaults
 dependencies:
   - intelpython3_core
-  - python=3.11
+  - python=3.12
   - dpcpp_linux-64
   - mkl
   - libblas=*=*mkl
@@ -21,6 +21,7 @@ dependencies:
   - petsc
   - petsc4py
   - kahip
+  - cffi
   - catch2
   - pytest
   - pytest-xdist

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -133,7 +133,9 @@ kernel10 = getattr(ufcx10.form_integrals[0], f"tabulate_tensor_{np.dtype(PETSc.S
 ffi = cffi.FFI()
 if np.issubdtype(PETSc.ScalarType, np.complexfloating):
     if cffi.__version_info__ > (1, 16, 99) and cffi.__version_info__ <= (1, 17, 1):
-        print("CFFI 1.17.0 and 1.17.1 has a bug for complex type. Exiting.")
+        print(
+            "CFFI 1.17.0 and 1.17.1 has a bug for complex type. See https://github.com/FEniCS/dolfinx/pull/3635. Exiting."
+        )
         exit(0)
     cffi_support.register_type(ffi.typeof("double _Complex"), numba.types.complex128)
 

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -130,11 +130,11 @@ ufcx10, _, _ = ffcx_jit(msh.comm, a10, form_compiler_options={"scalar_type": PET
 kernel10 = getattr(ufcx10.form_integrals[0], f"tabulate_tensor_{np.dtype(PETSc.ScalarType).name}")  # type: ignore
 
 
-if np.issubdtype(PETSc.ScalarType, np.complexfloating) and cffi.__version_info__ == (1, 17, 1):
-    print("CFFI 1.17.1 has a bug for complex type.")
-    exit(0)
-else:
-    ffi = cffi.FFI()
+ffi = cffi.FFI()
+if np.issubdtype(PETSc.ScalarType, np.complexfloating):
+    if cffi.__version_info__ == (1, 17, 1):
+        print("CFFI 1.17.1 has a bug for complex type. Exiting.")
+        exit(0)
     cffi_support.register_type(ffi.typeof("double _Complex"), numba.types.complex128)
 
 # Get local dofmap sizes for later local tensor tabulations

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -65,7 +65,6 @@ if np.issubdtype(PETSc.RealType, np.float32):  # type: ignore
     print("float32 not yet supported for this demo.")
     exit(0)
 
-
 infile = XDMFFile(
     MPI.COMM_WORLD,
     Path(Path(__file__).parent, "data", "cooks_tri_mesh.xdmf"),
@@ -130,8 +129,13 @@ kernel01 = getattr(ufcx01.form_integrals[0], f"tabulate_tensor_{np.dtype(PETSc.S
 ufcx10, _, _ = ffcx_jit(msh.comm, a10, form_compiler_options={"scalar_type": PETSc.ScalarType})  # type: ignore
 kernel10 = getattr(ufcx10.form_integrals[0], f"tabulate_tensor_{np.dtype(PETSc.ScalarType).name}")  # type: ignore
 
-ffi = cffi.FFI()
-cffi_support.register_type(ffi.typeof("double _Complex"), numba.types.complex128)
+
+if np.issubdtype(PETSc.ScalarType, np.complexfloating) and cffi.__version_info__ == (1, 17, 1):
+    print("CFFI 1.17.1 has a bug for complex type.")
+    exit(0)
+else:
+    ffi = cffi.FFI()
+    cffi_support.register_type(ffi.typeof("double _Complex"), numba.types.complex128)
 
 # Get local dofmap sizes for later local tensor tabulations
 Ssize = S.element.space_dimension

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -132,8 +132,8 @@ kernel10 = getattr(ufcx10.form_integrals[0], f"tabulate_tensor_{np.dtype(PETSc.S
 
 ffi = cffi.FFI()
 if np.issubdtype(PETSc.ScalarType, np.complexfloating):
-    if cffi.__version_info__ == (1, 17, 1):
-        print("CFFI 1.17.1 has a bug for complex type. Exiting.")
+    if cffi.__version_info__ > (1, 16, 99) and cffi.__version_info__ <= (1, 17, 1):
+        print("CFFI 1.17.0 and 1.17.1 has a bug for complex type. Exiting.")
         exit(0)
     cffi_support.register_type(ffi.typeof("double _Complex"), numba.types.complex128)
 

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -134,7 +134,8 @@ ffi = cffi.FFI()
 if np.issubdtype(PETSc.ScalarType, np.complexfloating):
     if cffi.__version_info__ > (1, 16, 99) and cffi.__version_info__ <= (1, 17, 1):
         print(
-            "CFFI 1.17.0 and 1.17.1 has a bug for complex type. See https://github.com/FEniCS/dolfinx/pull/3635. Exiting."
+            "CFFI 1.17.0 and 1.17.1 has a bug for complex type."
+            "See https://github.com/FEniCS/dolfinx/pull/3635. Exiting."
         )
         exit(0)
     cffi_support.register_type(ffi.typeof("double _Complex"), numba.types.complex128)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,7 +21,7 @@ authors = [
 ]
 dependencies = [
       "numpy>=1.21",
-      "cffi<1.17",                           # See https://github.com/FEniCS/dolfinx/issues/3340
+      "cffi",
       "mpi4py",
       "fenics-basix>=0.10.0.dev0,<0.11.0",
       "fenics-ffcx>=0.10.0.dev0,<0.11.0",

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -235,8 +235,24 @@ def assemble_petsc_matrix(A, mesh, dofmap, num_cells, set_vals, mode):
     [
         np.float32,
         np.float64,
-        pytest.param(np.complex64, marks=pytest.mark.xfail_win32_complex),
-        pytest.param(np.complex128, marks=pytest.mark.xfail_win32_complex),
+        pytest.param(
+            np.complex64,
+            marks=[
+                pytest.mark.xfail_win32_complex,
+                pytest.mark.skipif(
+                    cffi.__version_info__ == (1, 17, 1), reason="bug in cffi 1.17.1 for complex"
+                ),
+            ],
+        ),
+        pytest.param(
+            np.complex128,
+            marks=[
+                pytest.mark.xfail_win32_complex,
+                pytest.mark.skipif(
+                    cffi.__version_info__ == (1, 17, 1), reason="bug in cffi 1.17.1 for complex"
+                ),
+            ],
+        ),
     ],
 )
 def test_custom_mesh_loop_rank1(dtype):

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -332,6 +332,7 @@ def test_custom_mesh_loop_rank1(dtype):
     assert np.linalg.norm(b3.x.array - b0.x.array) == pytest.approx(0.0, abs=1e-8)
 
 
+@pytest.mark.skipif(cffi.__version_info__ == (1, 17, 1), reason="bug in cffi 1.17.1 for complex")
 @pytest.mark.petsc4py
 @pytest.mark.parametrize(
     "set_vals,backend",

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -240,7 +240,8 @@ def assemble_petsc_matrix(A, mesh, dofmap, num_cells, set_vals, mode):
             marks=[
                 pytest.mark.xfail_win32_complex,
                 pytest.mark.skipif(
-                    cffi.__version_info__ == (1, 17, 1), reason="bug in cffi 1.17.1 for complex"
+                    cffi.__version_info__ > (1, 16, 99) and cffi.__version_info__ <= (1, 17, 1),
+                    reason="bug in cffi 1.17.0/1 for complex",
                 ),
             ],
         ),
@@ -249,7 +250,8 @@ def assemble_petsc_matrix(A, mesh, dofmap, num_cells, set_vals, mode):
             marks=[
                 pytest.mark.xfail_win32_complex,
                 pytest.mark.skipif(
-                    cffi.__version_info__ == (1, 17, 1), reason="bug in cffi 1.17.1 for complex"
+                    cffi.__version_info__ > (1, 16, 99) and cffi.__version_info__ <= (1, 17, 1),
+                    reason="bug in cffi 1.17.0/1 for complex",
                 ),
             ],
         ),


### PR DESCRIPTION
The CFFI version was pinned to <1.17 due to the bug https://github.com/python-cffi/cffi/issues/110, which hasn't made its way into a CFFI release. However, older CFFI releases do not support Python 3.13.

This changes removes the CFFI version pin, and for CFFI version 1.17.0/1 adds skips to tests that fail due to the CFFI bug. 

Resolves #3340.