### PR TITLE
Changes to type system

### DIFF
--- a/cpp/demo/biharmonic/main.cpp
+++ b/cpp/demo/biharmonic/main.cpp
@@ -141,7 +141,7 @@
 
 using namespace dolfinx;
 using T = PetscScalar;
-using U = typename dolfinx::scalar_value_type_t<T>;
+using U = typename dolfinx::scalar_value_t<T>;
 
 // Inside the `main` function, we begin by defining a mesh of the
 // domain. As the unit square is a very standard domain, we can use a

--- a/cpp/demo/codim_0_assembly/main.cpp
+++ b/cpp/demo/codim_0_assembly/main.cpp
@@ -22,7 +22,7 @@
 
 using namespace dolfinx;
 using T = PetscScalar;
-using U = typename dolfinx::scalar_value_type_t<T>;
+using U = typename dolfinx::scalar_value_t<T>;
 
 int main(int argc, char* argv[])
 {

--- a/cpp/demo/custom_kernel/main.cpp
+++ b/cpp/demo/custom_kernel/main.cpp
@@ -25,7 +25,6 @@
 #include <vector>
 
 using namespace dolfinx;
-namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
 template <typename T, std::size_t ndim>
 using mdspand_t = md::mdspan<T, md::dextents<std::size_t, ndim>>;
 template <typename T, std::size_t n0, std::size_t n1>

--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -36,7 +36,7 @@
 
 using namespace dolfinx;
 using T = PetscScalar;
-using U = typename dolfinx::scalar_value_type_t<T>;
+using U = typename dolfinx::scalar_value_t<T>;
 
 /// Hyperelastic problem class
 class HyperElasticProblem

--- a/cpp/demo/mixed_poisson/main.cpp
+++ b/cpp/demo/mixed_poisson/main.cpp
@@ -110,7 +110,7 @@
 
 using namespace dolfinx;
 using T = PetscScalar;
-using U = typename dolfinx::scalar_value_type_t<T>;
+using U = typename dolfinx::scalar_value_t<T>;
 
 int main(int argc, char* argv[])
 {

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -94,7 +94,7 @@
 
 using namespace dolfinx;
 using T = PetscScalar;
-using U = typename dolfinx::scalar_value_type_t<T>;
+using U = typename dolfinx::scalar_value_t<T>;
 
 // Then follows the definition of the coefficient functions (for $f$ and
 // $g$), which are derived from the {cpp:class}`Expression` class in

--- a/cpp/demo/poisson_matrix_free/main.cpp
+++ b/cpp/demo/poisson_matrix_free/main.cpp
@@ -245,7 +245,7 @@ void solver(MPI_Comm comm)
 int main(int argc, char* argv[])
 {
   using T = PetscScalar;
-  using U = typename dolfinx::scalar_value_type_t<T>;
+  using U = typename dolfinx::scalar_value_t<T>;
   init_logging(argc, argv);
   MPI_Init(&argc, &argv);
   solver<T, U>(MPI_COMM_WORLD);

--- a/cpp/dolfinx/common/types.h
+++ b/cpp/dolfinx/common/types.h
@@ -16,7 +16,7 @@ namespace dolfinx
 /// point real or complex types. Note that this concept is different to
 /// std::floating_point which does not include std::complex.
 template <class T>
-concept scalar = std::is_floating_point_v<T>
+concept scalar = std::floating_point<T>
                  || std::is_same_v<T, std::complex<typename T::value_type>>;
 
 /// @private These structs are used to get the float/value type from a

--- a/cpp/dolfinx/common/types.h
+++ b/cpp/dolfinx/common/types.h
@@ -10,6 +10,8 @@
 #include <concepts>
 #include <type_traits>
 
+#include <basix/mdspan.hpp>
+
 namespace dolfinx
 {
 /// @private This concept is used to constrain the a template type to floating
@@ -36,4 +38,8 @@ struct scalar_value<T, std::void_t<typename T::value_type>>
 /// @private Convenience typedef
 template <scalar T>
 using scalar_value_t = typename scalar_value<T>::type;
+
+/// @private mdspan/mdarray namespace
+namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
+
 } // namespace dolfinx

--- a/cpp/dolfinx/common/types.h
+++ b/cpp/dolfinx/common/types.h
@@ -9,7 +9,6 @@
 #include <complex>
 #include <concepts>
 #include <type_traits>
-
 #include <basix/mdspan.hpp>
 
 namespace dolfinx

--- a/cpp/dolfinx/common/types.h
+++ b/cpp/dolfinx/common/types.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Garth N. Wells
+// Copyright (C) 2023-2025 Garth N. Wells and Paul T. Kühner
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //

--- a/cpp/dolfinx/common/types.h
+++ b/cpp/dolfinx/common/types.h
@@ -19,22 +19,21 @@ template <class T>
 concept scalar = std::is_floating_point_v<T>
                  || std::is_same_v<T, std::complex<typename T::value_type>>;
 
-
 /// @private These structs are used to get the float/value type from a
 /// template argument, including support for complex types.
 template <scalar T, typename = void>
-struct scalar_value_type
+struct scalar_value
 {
   /// @internal
-  typedef T value_type;
+  typedef T type;
 };
 /// @private
 template <scalar T>
-struct scalar_value_type<T, std::void_t<typename T::value_type>>
+struct scalar_value<T, std::void_t<typename T::value_type>>
 {
-  typedef typename T::value_type value_type;
+  typedef typename T::value_type type;
 };
 /// @private Convenience typedef
 template <scalar T>
-using scalar_value_type_t = typename scalar_value_type<T>::value_type;
+using scalar_value_type_t = typename scalar_value<T>::type;
 } // namespace dolfinx

--- a/cpp/dolfinx/common/types.h
+++ b/cpp/dolfinx/common/types.h
@@ -35,5 +35,5 @@ struct scalar_value<T, std::void_t<typename T::value_type>>
 };
 /// @private Convenience typedef
 template <scalar T>
-using scalar_value_type_t = typename scalar_value<T>::type;
+using scalar_value_t = typename scalar_value<T>::type;
 } // namespace dolfinx

--- a/cpp/dolfinx/common/types.h
+++ b/cpp/dolfinx/common/types.h
@@ -16,9 +16,10 @@ namespace dolfinx
 /// point real or complex types. Note that this concept is different to
 /// std::floating_point which does not include std::complex.
 template <class T>
-concept scalar
-    = std::is_floating_point_v<T> || std::is_same_v<T, std::complex<double>>
-      || std::is_same_v<T, std::complex<float>>;
+concept scalar = std::is_floating_point_v<T>
+                 || std::is_same_v<T, std::complex<typename T::value_type>>;
+
+
 /// @private These structs are used to get the float/value type from a
 /// template argument, including support for complex types.
 template <scalar T, typename = void>

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -255,7 +255,7 @@ std::array<std::vector<std::int32_t>, 2> locate_dofs_geometrical(
 /// space (trial space) and degrees of freedom to which the boundary
 /// condition applies.
 template <dolfinx::scalar T,
-          std::floating_point U = dolfinx::scalar_value_type_t<T>>
+          std::floating_point U = dolfinx::scalar_value_t<T>>
 class DirichletBC
 {
 private:

--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -37,7 +37,7 @@ class Function;
 /// @tparam T The scalar type.
 /// @tparam U The mesh geometry scalar type.
 template <dolfinx::scalar T,
-          std::floating_point U = dolfinx::scalar_value_type_t<T>>
+          std::floating_point U = dolfinx::scalar_value_t<T>>
 class Expression
 {
 public:

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -105,7 +105,7 @@ std::vector<std::int32_t> compute_domain(
 /// @brief Represents integral data, containing the kernel, and a list
 /// of entities to integrate over and the indicies of the coefficient
 /// functions (relative to the Form) active for this integral.
-template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
 struct integral_data
 {
   /// @brief Create a structure to hold integral data.
@@ -170,8 +170,7 @@ struct integral_data
 /// @tparam U Float (real) type used for the finite element and
 /// geometry.
 /// @tparam Kern Element kernel.
-template <dolfinx::scalar T,
-          std::floating_point U = dolfinx::scalar_value_type_t<T>>
+template <dolfinx::scalar T, std::floating_point U = dolfinx::scalar_value_t<T>>
 class Form
 {
 public:

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -227,7 +227,6 @@ public:
         _mesh(mesh), _coefficients(coefficients), _constants(constants),
         _needs_facet_permutations(needs_facet_permutations)
   {
-    namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
     if (!_mesh)
       throw std::runtime_error("Form Mesh is null.");
 

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -43,7 +43,7 @@ class Expression;
 /// @tparam T The function scalar type.
 /// @tparam U The mesh geometry scalar type.
 template <dolfinx::scalar T,
-          std::floating_point U = dolfinx::scalar_value_type_t<T>>
+          std::floating_point U = dolfinx::scalar_value_t<T>>
 class Function
 {
 public:

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -317,8 +317,6 @@ public:
                    std::span<const std::int32_t> cells0,
                    std::span<const std::int32_t> cells1 = {})
   {
-    namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
     // Extract mesh
     const mesh::Mesh<geometry_type>* mesh0 = nullptr;
     for (auto& c : e0.coefficients())

--- a/cpp/dolfinx/fem/assemble_expression_impl.h
+++ b/cpp/dolfinx/fem/assemble_expression_impl.h
@@ -75,7 +75,6 @@ void tabulate_expression(
     std::span<const std::uint32_t> cell_info,
     fem::DofTransformKernel<T> auto P0)
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
   static_assert(entities.rank() == 1 or entities.rank() == 2);
 
   // Create data structures used in evaluation
@@ -164,8 +163,6 @@ void tabulate_expression(
         std::pair<std::reference_wrapper<const FiniteElement<U>>, std::size_t>>
         element)
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
   std::function<void(std::span<T>, std::span<const std::uint32_t>, std::int32_t,
                      int)>
       post_dof_transform

--- a/cpp/dolfinx/fem/assemble_expression_impl.h
+++ b/cpp/dolfinx/fem/assemble_expression_impl.h
@@ -67,7 +67,7 @@ void tabulate_expression(
         const std::int32_t,
         MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
         x_dofmap,
-    std::span<const scalar_value_type_t<T>> x,
+    std::span<const scalar_value_t<T>> x,
     MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
         const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
         coeffs,

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -65,7 +65,7 @@ using mdspan2_t = md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>;
 template <dolfinx::scalar T>
 void assemble_cells(
     la::MatSet<T> auto mat_set, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_type_t<T>,
+    md::mdspan<const scalar_value_t<T>,
                md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     std::span<const std::int32_t> cells,
@@ -91,7 +91,7 @@ void assemble_cells(
   const int ndim1 = bs1 * num_dofs1;
   std::vector<T> Ae(ndim0 * ndim1);
   std::span<T> _Ae(Ae);
-  std::vector<scalar_value_type_t<T>> cdofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> cdofs(3 * x_dofmap.extent(1));
 
   // Iterate over active cells
   assert(cells0.size() == cells.size());
@@ -196,7 +196,7 @@ void assemble_cells(
 template <dolfinx::scalar T>
 void assemble_exterior_facets(
     la::MatSet<T> auto mat_set, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_type_t<T>,
+    md::mdspan<const scalar_value_t<T>,
                md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     md::mdspan<const std::int32_t,
@@ -225,7 +225,7 @@ void assemble_exterior_facets(
   const auto [dmap1, bs1, facets1] = dofmap1;
 
   // Data structures used in assembly
-  std::vector<scalar_value_type_t<T>> cdofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> cdofs(3 * x_dofmap.extent(1));
   const int num_dofs0 = dmap0.extent(1);
   const int num_dofs1 = dmap1.extent(1);
   const int ndim0 = bs0 * num_dofs0;
@@ -336,7 +336,7 @@ void assemble_exterior_facets(
 template <dolfinx::scalar T>
 void assemble_interior_facets(
     la::MatSet<T> auto mat_set, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_type_t<T>,
+    md::mdspan<const scalar_value_t<T>,
                md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     md::mdspan<const std::int32_t,
@@ -367,7 +367,7 @@ void assemble_interior_facets(
   const auto [dmap1, bs1, facets1] = dofmap1;
 
   // Data structures used in assembly
-  using X = scalar_value_type_t<T>;
+  using X = scalar_value_t<T>;
   std::vector<X> cdofs(2 * x_dofmap.extent(1) * 3);
   std::span<X> cdofs0(cdofs.data(), x_dofmap.extent(1) * 3);
   std::span<X> cdofs1(cdofs.data() + x_dofmap.extent(1) * 3,
@@ -514,7 +514,7 @@ void assemble_interior_facets(
 template <dolfinx::scalar T, std::floating_point U>
 void assemble_matrix(
     la::MatSet<T> auto mat_set, const Form<T, U>& a,
-    md::mdspan<const scalar_value_type_t<T>,
+    md::mdspan<const scalar_value_t<T>,
                md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     std::span<const T> constants,

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -24,8 +24,6 @@
 
 namespace dolfinx::fem::impl
 {
-namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
 /// @brief Typedef
 using mdspan2_t = md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>;
 

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -21,8 +21,6 @@
 
 namespace dolfinx::fem::impl
 {
-namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
 /// Assemble functional over cells
 template <dolfinx::scalar T>
 T assemble_cells(mdspan2_t x_dofmap,

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -26,7 +26,7 @@ namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
 /// Assemble functional over cells
 template <dolfinx::scalar T>
 T assemble_cells(mdspan2_t x_dofmap,
-                 md::mdspan<const scalar_value_type_t<T>,
+                 md::mdspan<const scalar_value_t<T>,
                             md::extents<std::size_t, md::dynamic_extent, 3>>
                      x,
                  std::span<const std::int32_t> cells, FEkernel<T> auto fn,
@@ -38,7 +38,7 @@ T assemble_cells(mdspan2_t x_dofmap,
     return value;
 
   // Create data structures used in assembly
-  std::vector<scalar_value_type_t<T>> cdofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> cdofs(3 * x_dofmap.extent(1));
 
   // Iterate over all cells
   for (std::size_t index = 0; index < cells.size(); ++index)
@@ -63,7 +63,7 @@ T assemble_cells(mdspan2_t x_dofmap,
 template <dolfinx::scalar T>
 T assemble_exterior_facets(
     mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_type_t<T>,
+    md::mdspan<const scalar_value_t<T>,
                md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     md::mdspan<const std::int32_t,
@@ -78,7 +78,7 @@ T assemble_exterior_facets(
     return value;
 
   // Create data structures used in assembly
-  std::vector<scalar_value_type_t<T>> cdofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> cdofs(3 * x_dofmap.extent(1));
 
   // Iterate over all facets
   for (std::size_t f = 0; f < facets.extent(0); ++f)
@@ -104,7 +104,7 @@ T assemble_exterior_facets(
 template <dolfinx::scalar T>
 T assemble_interior_facets(
     mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_type_t<T>,
+    md::mdspan<const scalar_value_t<T>,
                md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     md::mdspan<const std::int32_t,
@@ -121,7 +121,7 @@ T assemble_interior_facets(
     return value;
 
   // Create data structures used in assembly
-  using X = scalar_value_type_t<T>;
+  using X = scalar_value_t<T>;
   std::vector<X> cdofs(2 * x_dofmap.extent(1) * 3);
   std::span<X> cdofs0(cdofs.data(), x_dofmap.extent(1) * 3);
   std::span<X> cdofs1(cdofs.data() + x_dofmap.extent(1) * 3,
@@ -156,7 +156,7 @@ T assemble_interior_facets(
 template <dolfinx::scalar T, std::floating_point U>
 T assemble_scalar(
     const fem::Form<T, U>& M, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_type_t<T>,
+    md::mdspan<const scalar_value_t<T>,
                md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     std::span<const T> constants,

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -33,8 +33,6 @@ class DirichletBC;
 }
 namespace dolfinx::fem::impl
 {
-namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
 /// @cond
 using mdspan2_t = md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>;
 /// @endcond
@@ -1357,7 +1355,6 @@ void assemble_vector(
     const std::map<std::pair<IntegralType, int>,
                    std::pair<std::span<const T>, int>>& coefficients)
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
   using mdspanx3_t
       = md::mdspan<const scalar_value_t<T>,
                    md::extents<std::size_t, md::dynamic_extent, 3>>;

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -81,7 +81,7 @@ using mdspan2_t = md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>;
 template <dolfinx::scalar T, int _bs0 = -1, int _bs1 = -1>
 void _lift_bc_cells(
     std::span<T> b, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_type_t<T>,
+    md::mdspan<const scalar_value_t<T>,
                md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     FEkernel<T> auto kernel, std::span<const std::int32_t> cells,
@@ -103,7 +103,7 @@ void _lift_bc_cells(
   assert(_bs1 < 0 or _bs1 == bs1);
 
   // Data structures used in bc application
-  std::vector<scalar_value_type_t<T>> cdofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> cdofs(3 * x_dofmap.extent(1));
   std::vector<T> Ae, be;
   assert(cells0.size() == cells.size());
   assert(cells1.size() == cells.size());
@@ -265,7 +265,7 @@ void _lift_bc_cells(
 template <dolfinx::scalar T>
 void _lift_bc_exterior_facets(
     std::span<T> b, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_type_t<T>,
+    md::mdspan<const scalar_value_t<T>,
                md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     FEkernel<T> auto kernel,
@@ -295,7 +295,7 @@ void _lift_bc_exterior_facets(
   const auto [dmap1, bs1, facets1] = dofmap1;
 
   // Data structures used in bc application
-  std::vector<scalar_value_type_t<T>> cdofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> cdofs(3 * x_dofmap.extent(1));
   std::vector<T> Ae, be;
   assert(facets0.size() == facets.size());
   assert(facets1.size() == facets.size());
@@ -419,7 +419,7 @@ void _lift_bc_exterior_facets(
 template <dolfinx::scalar T>
 void _lift_bc_interior_facets(
     std::span<T> b, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_type_t<T>,
+    md::mdspan<const scalar_value_t<T>,
                md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     FEkernel<T> auto kernel,
@@ -451,7 +451,7 @@ void _lift_bc_interior_facets(
   const auto [dmap1, bs1, facets1] = dofmap1;
 
   // Data structures used in assembly
-  using X = scalar_value_type_t<T>;
+  using X = scalar_value_t<T>;
   std::vector<X> cdofs(2 * x_dofmap.extent(1) * 3);
   std::span<X> cdofs0(cdofs.data(), x_dofmap.extent(1) * 3);
   std::span<X> cdofs1(cdofs.data() + x_dofmap.extent(1) * 3,
@@ -643,7 +643,7 @@ void _lift_bc_interior_facets(
 template <dolfinx::scalar T, int _bs = -1>
 void assemble_cells(
     fem::DofTransformKernel<T> auto P0, std::span<T> b, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_type_t<T>,
+    md::mdspan<const scalar_value_t<T>,
                md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     std::span<const std::int32_t> cells,
@@ -659,7 +659,7 @@ void assemble_cells(
   assert(_bs < 0 or _bs == bs);
 
   // Create data structures used in assembly
-  std::vector<scalar_value_type_t<T>> cdofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> cdofs(3 * x_dofmap.extent(1));
   std::vector<T> be(bs * dmap.extent(1));
   std::span<T> _be(be);
 
@@ -725,7 +725,7 @@ void assemble_cells(
 template <dolfinx::scalar T, int _bs = -1>
 void assemble_exterior_facets(
     fem::DofTransformKernel<T> auto P0, std::span<T> b, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_type_t<T>,
+    md::mdspan<const scalar_value_t<T>,
                md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     md::mdspan<const std::int32_t,
@@ -748,7 +748,7 @@ void assemble_exterior_facets(
 
   // Create data structures used in assembly
   const int num_dofs = dmap.extent(1);
-  std::vector<scalar_value_type_t<T>> cdofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> cdofs(3 * x_dofmap.extent(1));
   std::vector<T> be(bs * num_dofs);
   std::span<T> _be(be);
   assert(facets0.size() == facets.size());
@@ -818,7 +818,7 @@ void assemble_exterior_facets(
 template <dolfinx::scalar T, int _bs = -1>
 void assemble_interior_facets(
     fem::DofTransformKernel<T> auto P0, std::span<T> b, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_type_t<T>,
+    md::mdspan<const scalar_value_t<T>,
                md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     md::mdspan<const std::int32_t,
@@ -842,7 +842,7 @@ void assemble_interior_facets(
   assert(_bs < 0 or _bs == bs);
 
   // Create data structures used in assembly
-  using X = scalar_value_type_t<T>;
+  using X = scalar_value_t<T>;
   std::vector<X> cdofs(2 * x_dofmap.extent(1) * 3);
   std::span<X> cdofs0(cdofs.data(), x_dofmap.extent(1) * 3);
   std::span<X> cdofs1(cdofs.data() + x_dofmap.extent(1) * 3,
@@ -927,7 +927,7 @@ void assemble_interior_facets(
 /// @param[in] alpha Scaling to apply
 template <dolfinx::scalar T, std::floating_point U>
 void lift_bc(std::span<T> b, const Form<T, U>& a, mdspan2_t x_dofmap,
-             md::mdspan<const scalar_value_type_t<T>,
+             md::mdspan<const scalar_value_t<T>,
                         md::extents<std::size_t, md::dynamic_extent, 3>>
                  x,
              std::span<const T> constants,
@@ -1129,7 +1129,7 @@ void apply_lifting(
         throw std::runtime_error("Unable to extract a mesh.");
       mdspan2_t x_dofmap = mesh->geometry().dofmap();
       std::span _x = mesh->geometry().x();
-      md::mdspan<const scalar_value_type_t<T>,
+      md::mdspan<const scalar_value_t<T>,
                  md::extents<std::size_t, md::dynamic_extent, 3>>
           x(_x.data(), _x.size() / 3, 3);
 
@@ -1172,7 +1172,7 @@ void apply_lifting(
 template <dolfinx::scalar T, std::floating_point U>
 void assemble_vector(
     std::span<T> b, const Form<T, U>& L,
-    md::mdspan<const scalar_value_type_t<T>,
+    md::mdspan<const scalar_value_t<T>,
                md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     std::span<const T> constants,
@@ -1359,20 +1359,20 @@ void assemble_vector(
 {
   namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
   using mdspanx3_t
-      = md::mdspan<const scalar_value_type_t<T>,
+      = md::mdspan<const scalar_value_t<T>,
                    md::extents<std::size_t, md::dynamic_extent, 3>>;
 
   std::shared_ptr<const mesh::Mesh<U>> mesh = L.mesh();
   assert(mesh);
   auto x = mesh->geometry().x();
-  if constexpr (std::is_same_v<U, scalar_value_type_t<T>>)
+  if constexpr (std::is_same_v<U, scalar_value_t<T>>)
   {
     assemble_vector(b, L, mdspanx3_t(x.data(), x.size() / 3, 3), constants,
                     coefficients);
   }
   else
   {
-    std::vector<scalar_value_type_t<T>> _x(x.begin(), x.end());
+    std::vector<scalar_value_t<T>> _x(x.begin(), x.end());
     assemble_vector(b, L, mdspanx3_t(_x.data(), _x.size() / 3, 3), constants,
                     coefficients);
   }

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -97,8 +97,6 @@ template <dolfinx::scalar T, std::floating_point U>
 void tabulate_expression(std::span<T> values, const fem::Expression<T, U>& e,
                          const mesh::Mesh<U>& mesh, fem::MDSpan2 auto entities)
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
   std::optional<
       std::pair<std::reference_wrapper<const FiniteElement<U>>, std::size_t>>
       element = std::nullopt;
@@ -164,7 +162,6 @@ T assemble_scalar(
     const std::map<std::pair<IntegralType, int>,
                    std::pair<std::span<const T>, int>>& coefficients)
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
   using mdspanx3_t
       = md::mdspan<const scalar_value_t<T>,
                    md::extents<std::size_t, md::dynamic_extent, 3>>;
@@ -350,7 +347,6 @@ void assemble_matrix(
     std::span<const std::int8_t> dof_marker1)
 
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
   using mdspanx3_t
       = md::mdspan<const scalar_value_t<T>,
                    md::extents<std::size_t, md::dynamic_extent, 3>>;

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -138,10 +138,10 @@ make_coefficients_span(const std::map<std::pair<IntegralType, int>,
 {
   using Key = typename std::remove_reference_t<decltype(coeffs)>::key_type;
   std::map<Key, std::pair<std::span<const T>, int>> c;
-  std::ranges::transform(
-      coeffs, std::inserter(c, c.end()),
-      [](auto& e) -> typename decltype(c)::value_type
-      { return {e.first, {e.second.first, e.second.second}}; });
+  std::ranges::transform(coeffs, std::inserter(c, c.end()),
+                         [](auto& e) -> typename decltype(c)::value_type {
+                           return {e.first, {e.second.first, e.second.second}};
+                         });
   return c;
 }
 
@@ -166,13 +166,13 @@ T assemble_scalar(
 {
   namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
   using mdspanx3_t
-      = md::mdspan<const scalar_value_type_t<T>,
+      = md::mdspan<const scalar_value_t<T>,
                    md::extents<std::size_t, md::dynamic_extent, 3>>;
 
   std::shared_ptr<const mesh::Mesh<U>> mesh = M.mesh();
   assert(mesh);
   std::span x = mesh->geometry().x();
-  if constexpr (std::is_same_v<U, scalar_value_type_t<T>>)
+  if constexpr (std::is_same_v<U, scalar_value_t<T>>)
   {
     return impl::assemble_scalar(M, mesh->geometry().dofmap(),
                                  mdspanx3_t(x.data(), x.size() / 3, 3),
@@ -180,7 +180,7 @@ T assemble_scalar(
   }
   else
   {
-    std::vector<scalar_value_type_t<T>> _x(x.begin(), x.end());
+    std::vector<scalar_value_t<T>> _x(x.begin(), x.end());
     return impl::assemble_scalar(M, mesh->geometry().dofmap(),
                                  mdspanx3_t(_x.data(), _x.size() / 3, 3),
                                  constants, coefficients);
@@ -352,20 +352,20 @@ void assemble_matrix(
 {
   namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
   using mdspanx3_t
-      = md::mdspan<const scalar_value_type_t<T>,
+      = md::mdspan<const scalar_value_t<T>,
                    md::extents<std::size_t, md::dynamic_extent, 3>>;
 
   std::shared_ptr<const mesh::Mesh<U>> mesh = a.mesh();
   assert(mesh);
   std::span x = mesh->geometry().x();
-  if constexpr (std::is_same_v<U, scalar_value_type_t<T>>)
+  if constexpr (std::is_same_v<U, scalar_value_t<T>>)
   {
     impl::assemble_matrix(mat_add, a, mdspanx3_t(x.data(), x.size() / 3, 3),
                           constants, coefficients, dof_marker0, dof_marker1);
   }
   else
   {
-    std::vector<scalar_value_type_t<T>> _x(x.begin(), x.end());
+    std::vector<scalar_value_t<T>> _x(x.begin(), x.end());
     impl::assemble_matrix(mat_add, a, mdspanx3_t(_x.data(), _x.size() / 3, 3),
                           constants, coefficients, dof_marker0, dof_marker1);
   }

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -86,8 +86,6 @@ template <std::floating_point T, dolfinx::scalar U = T>
 void discrete_curl(const FunctionSpace<T>& V0, const FunctionSpace<T>& V1,
                    la::MatSet<U> auto&& mat_set)
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
   // Get mesh
   auto mesh = V0.mesh();
   assert(mesh);
@@ -322,8 +320,6 @@ void discrete_gradient(mesh::Topology& topology,
                            V1,
                        auto&& mat_set)
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
   auto& e0 = V0.first.get();
   const DofMap& dofmap0 = V0.second.get();
   auto& e1 = V1.first.get();
@@ -416,8 +412,6 @@ template <dolfinx::scalar T, std::floating_point U>
 void interpolation_matrix(const FunctionSpace<U>& V0,
                           const FunctionSpace<U>& V1, auto&& mat_set)
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
   // Get mesh
   auto mesh = V0.mesh();
   assert(mesh);

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -312,7 +312,7 @@ void discrete_curl(const FunctionSpace<T>& V0, const FunctionSpace<T>& V1,
 /// corresponding space to interpolate into.
 /// @param[in] mat_set A functor that sets values in a matrix
 template <dolfinx::scalar T,
-          std::floating_point U = dolfinx::scalar_value_type_t<T>>
+          std::floating_point U = dolfinx::scalar_value_t<T>>
 void discrete_gradient(mesh::Topology& topology,
                        std::pair<std::reference_wrapper<const FiniteElement<U>>,
                                  std::reference_wrapper<const DofMap>>

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -52,8 +52,6 @@ std::vector<T> interpolation_coords(const fem::FiniteElement<T>& element,
                                     const mesh::Geometry<T>& geometry,
                                     std::span<const std::int32_t> cells)
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
   // Get geometry data and the element coordinate map
   const std::size_t gdim = geometry.dim();
   auto x_dofmap = geometry.dofmap();
@@ -459,8 +457,6 @@ void interpolate_nonmatching_maps(Function<T, U>& u1,
                                   const Function<T, U>& u0,
                                   std::span<const std::int32_t> cells0)
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
   // Get mesh
   auto V0 = u0.function_space();
   assert(V0);
@@ -700,8 +696,6 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
                  std::array<std::size_t, 2> fshape,
                  std::span<const std::int32_t> cells)
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
   auto element = u.function_space()->element();
   assert(element);
   const int element_bs = element->block_size();
@@ -1086,8 +1080,6 @@ void interpolate(Function<T, U>& u, const Function<T, U>& v,
                  std::span<const std::int32_t> cells,
                  const geometry::PointOwnershipData<U>& interpolation_data)
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
   auto mesh = u.function_space()->mesh();
   assert(mesh);
   MPI_Comm comm = mesh->comm();

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -301,7 +301,7 @@ void scatter_values(MPI_Comm comm, std::span<const std::int32_t> src_ranks,
 template <MDSpan U, MDSpan V, dolfinx::scalar T>
 void interpolation_apply(U&& Pi, V&& data, std::span<T> coeffs, int bs)
 {
-  using X = typename dolfinx::scalar_value_type_t<T>;
+  using X = typename dolfinx::scalar_value_t<T>;
 
   // Compute coefficients = Pi * x (matrix-vector multiply)
   if (bs == 1)
@@ -413,7 +413,7 @@ void interpolate_same_map(Function<T, U>& u1, const Function<T, U>& u0,
       = element1->create_interpolation_operator(*element0);
 
   // Iterate over mesh and interpolate on each cell
-  using X = typename dolfinx::scalar_value_type_t<T>;
+  using X = typename dolfinx::scalar_value_t<T>;
   for (std::size_t c = 0; c < cells0.size(); c++)
   {
     // Pack and transform cell dofs to reference ordering
@@ -652,7 +652,7 @@ void interpolate_nonmatching_maps(Function<T, U>& u1,
         coeffs0[dof_bs0 * i + k] = array0[dof_bs0 * dofs0[i] + k];
 
     // Evaluate v at the interpolation points (physical space values)
-    using X = typename dolfinx::scalar_value_type_t<T>;
+    using X = typename dolfinx::scalar_value_t<T>;
     for (std::size_t p = 0; p < Xshape[0]; ++p)
     {
       for (int k = 0; k < bs0; ++k)

--- a/cpp/dolfinx/fem/pack.h
+++ b/cpp/dolfinx/fem/pack.h
@@ -226,8 +226,6 @@ void pack_coefficients(const Form<T, U>& form,
                        std::map<std::pair<IntegralType, int>,
                                 std::pair<std::vector<T>, int>>& coeffs)
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
   const std::vector<std::shared_ptr<const Function<T, U>>>& coefficients
       = form.coefficients();
   const std::vector<int> offsets = form.coefficient_offsets();
@@ -346,8 +344,6 @@ void pack_coefficients(
     std::vector<std::reference_wrapper<const Function<T, U>>> coeffs,
     std::span<const int> offsets, fem::MDSpan2 auto entities, std::span<T> c)
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
   assert(!offsets.empty());
   const int cstride = offsets.back();
 

--- a/cpp/dolfinx/fem/traits.h
+++ b/cpp/dolfinx/fem/traits.h
@@ -27,7 +27,7 @@ concept DofTransformKernel
 /// must satisfy this concept.
 template <class U, class T>
 concept FEkernel = std::is_invocable_v<U, T*, const T*, const T*,
-                                       const scalar_value_type_t<T>*,
+                                       const scalar_value_t<T>*,
                                        const int*, const std::uint8_t*>;
 
 /// @brief Concept for mdspan of rank 1 or 2.

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -360,7 +360,7 @@ std::vector<std::string> get_constant_names(const ufcx_form& ufcx_form);
 /// @param[in] mesh The mesh of the domain.
 ///
 /// @pre Each value in `subdomains` must be sorted by domain id.
-template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
 Form<T, U> create_form_factory(
     const std::vector<std::reference_wrapper<const ufcx_form>>& ufcx_forms,
     const std::vector<std::shared_ptr<const FunctionSpace<U>>>& spaces,
@@ -497,7 +497,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<float>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex64);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -507,7 +507,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<double>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex128);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -582,7 +582,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<float>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex64);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -592,7 +592,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<double>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex128);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -688,7 +688,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<float>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex64);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -698,7 +698,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<double>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex128);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -773,7 +773,7 @@ Form<T, U> create_form_factory(
 /// @param[in] mesh Mesh of the domain. This is required if the form has
 /// no arguments, e.g. a functional.
 /// @return A Form
-template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
 Form<T, U> create_form(
     const ufcx_form& ufcx_form,
     const std::vector<std::shared_ptr<const FunctionSpace<U>>>& spaces,
@@ -833,7 +833,7 @@ Form<T, U> create_form(
 /// @param[in] mesh Mesh of the domain. This is required if the form has
 /// no arguments, e.g. a functional.
 /// @return A Form
-template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
 Form<T, U> create_form(
     ufcx_form* (*fptr)(),
     const std::vector<std::shared_ptr<const FunctionSpace<U>>>& spaces,
@@ -885,7 +885,7 @@ FunctionSpace<T> create_functionspace(
 }
 
 /// @brief Create Expression from UFC
-template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
 Expression<T, U> create_expression(
     const ufcx_expression& e,
     const std::vector<std::shared_ptr<const Function<T, U>>>& coefficients,
@@ -917,7 +917,7 @@ Expression<T, U> create_expression(
          static_cast<std::size_t>(e.entity_dimension)};
   std::vector<std::size_t> value_shape(e.value_shape,
                                        e.value_shape + e.num_components);
-  std::function<void(T*, const T*, const T*, const scalar_value_type_t<T>*,
+  std::function<void(T*, const T*, const T*, const scalar_value_t<T>*,
                      const int*, const std::uint8_t*)>
       tabulate_tensor = nullptr;
   if constexpr (std::is_same_v<T, float>)
@@ -926,7 +926,7 @@ Expression<T, U> create_expression(
   else if constexpr (std::is_same_v<T, std::complex<float>>)
   {
     tabulate_tensor = reinterpret_cast<void (*)(
-        T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+        T*, const T*, const T*, const scalar_value_t<T>*, const int*,
         const unsigned char*)>(e.tabulate_tensor_complex64);
   }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -936,7 +936,7 @@ Expression<T, U> create_expression(
   else if constexpr (std::is_same_v<T, std::complex<double>>)
   {
     tabulate_tensor = reinterpret_cast<void (*)(
-        T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+        T*, const T*, const T*, const scalar_value_t<T>*, const int*,
         const unsigned char*)>(e.tabulate_tensor_complex128);
   }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -950,7 +950,7 @@ Expression<T, U> create_expression(
 
 /// @brief Create Expression from UFC input (with named coefficients and
 /// constants).
-template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
 Expression<T, U> create_expression(
     const ufcx_expression& e,
     const std::map<std::string, std::shared_ptr<const Function<T, U>>>&

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -497,8 +497,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<float>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*,
-              const typename scalar_value_type<T>::value_type*, const int*,
+              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex64);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -508,8 +507,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<double>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*,
-              const typename scalar_value_type<T>::value_type*, const int*,
+              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex128);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -584,8 +582,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<float>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*,
-              const typename scalar_value_type<T>::value_type*, const int*,
+              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex64);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -595,8 +592,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<double>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*,
-              const typename scalar_value_type<T>::value_type*, const int*,
+              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex128);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -692,8 +688,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<float>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*,
-              const typename scalar_value_type<T>::value_type*, const int*,
+              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex64);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -703,8 +698,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<double>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*,
-              const typename scalar_value_type<T>::value_type*, const int*,
+              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex128);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -923,8 +917,7 @@ Expression<T, U> create_expression(
          static_cast<std::size_t>(e.entity_dimension)};
   std::vector<std::size_t> value_shape(e.value_shape,
                                        e.value_shape + e.num_components);
-  std::function<void(T*, const T*, const T*,
-                     const typename scalar_value_type<T>::value_type*,
+  std::function<void(T*, const T*, const T*, const scalar_value_type_t<T>*,
                      const int*, const std::uint8_t*)>
       tabulate_tensor = nullptr;
   if constexpr (std::is_same_v<T, float>)
@@ -933,8 +926,7 @@ Expression<T, U> create_expression(
   else if constexpr (std::is_same_v<T, std::complex<float>>)
   {
     tabulate_tensor = reinterpret_cast<void (*)(
-        T*, const T*, const T*,
-        const typename scalar_value_type<T>::value_type*, const int*,
+        T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
         const unsigned char*)>(e.tabulate_tensor_complex64);
   }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -944,8 +936,7 @@ Expression<T, U> create_expression(
   else if constexpr (std::is_same_v<T, std::complex<double>>)
   {
     tabulate_tensor = reinterpret_cast<void (*)(
-        T*, const T*, const T*,
-        const typename scalar_value_type<T>::value_type*, const int*,
+        T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
         const unsigned char*)>(e.tabulate_tensor_complex128);
   }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS

--- a/cpp/dolfinx/io/VTKFile.h
+++ b/cpp/dolfinx/io/VTKFile.h
@@ -80,7 +80,7 @@ public:
   /// @param[in] u List of functions to write to file
   /// @param[in] t Time parameter to associate with @p u
   /// @pre All Functions in `u` must share the same mesh
-  template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+  template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
   void
   write(const std::vector<std::reference_wrapper<const fem::Function<T, U>>>& u,
         double t);

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -147,7 +147,7 @@ public:
   /// @param[in] t Time stamp to associate with `u`.
   /// @param[in] mesh_xpath XPath for a Grid under which `u` will be
   /// inserted.
-  template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+  template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
   void write_function(const fem::Function<T, U>& u, double t,
                       std::string mesh_xpath
                       = "/Xdmf/Domain/Grid[@GridType='Uniform'][1]");

--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -184,8 +184,8 @@ void xdmf_function::add_function(MPI_Comm comm, const fem::Function<T, U>& u,
         = shape_to_string(value_shape).c_str();
     attr_node.append_attribute("Center") = cell_centred ? "Cell" : "Node";
 
-    std::span<const scalar_value_type_t<T>> u;
-    std::vector<scalar_value_type_t<T>> _data;
+    std::span<const scalar_value_t<T>> u;
+    std::vector<scalar_value_t<T>> _data;
     if constexpr (!std::is_scalar_v<T>)
     {
       // Complex-valued case
@@ -200,7 +200,7 @@ void xdmf_function::add_function(MPI_Comm comm, const fem::Function<T, U>& u,
         std::ranges::transform(data_values, _data.begin(),
                                [](auto x) { return x.imag(); });
       }
-      u = std::span<const scalar_value_type_t<T>>(_data);
+      u = std::span<const scalar_value_t<T>>(_data);
     }
     else
       u = std::span<const T>(data_values);

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -274,7 +274,7 @@ auto norm(const V& x, Norm type = Norm::l2)
   {
     std::int32_t size_local = x.bs() * x.index_map()->size_local();
     std::span<const T> data = x.array().subspan(0, size_local);
-    using U = typename dolfinx::scalar_value_type_t<T>;
+    using U = typename dolfinx::scalar_value_t<T>;
     U local_l1
         = std::accumulate(data.begin(), data.end(), U(0),
                           [](auto norm, auto x) { return norm + std::abs(x); });
@@ -311,7 +311,7 @@ template <class V>
 void orthonormalize(std::vector<std::reference_wrapper<V>> basis)
 {
   using T = typename V::value_type;
-  using U = typename dolfinx::scalar_value_type_t<T>;
+  using U = typename dolfinx::scalar_value_t<T>;
 
   // Loop over each vector in basis
   for (std::size_t i = 0; i < basis.size(); ++i)
@@ -353,9 +353,9 @@ void orthonormalize(std::vector<std::reference_wrapper<V>> basis)
 template <class V>
 bool is_orthonormal(
     std::vector<std::reference_wrapper<const V>> basis,
-    dolfinx::scalar_value_type_t<typename V::value_type> eps
+    dolfinx::scalar_value_t<typename V::value_type> eps
     = std::numeric_limits<
-        dolfinx::scalar_value_type_t<typename V::value_type>>::epsilon())
+        dolfinx::scalar_value_t<typename V::value_type>>::epsilon())
 {
   using T = typename V::value_type;
   for (std::size_t i = 0; i < basis.size(); i++)

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -442,8 +442,6 @@ template <std::floating_point T>
 std::pair<std::vector<T>, std::array<std::size_t, 2>>
 compute_vertex_coords(const mesh::Mesh<T>& mesh)
 {
-  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
   auto topology = mesh.topology();
   assert(topology);
   const int tdim = topology->dim();

--- a/cpp/test/fem/form.cpp
+++ b/cpp/test/fem/form.cpp
@@ -16,7 +16,6 @@
 #include <dolfinx/mesh/generation.h>
 
 using namespace dolfinx;
-namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
 
 namespace
 {

--- a/python/dolfinx/wrappers/assemble.cpp
+++ b/python/dolfinx/wrappers/assemble.cpp
@@ -213,8 +213,6 @@ void declare_assembly_functions(nb::module_& m)
       [](const dolfinx::fem::Expression<T, U>& e,
          nb::ndarray<const std::int32_t, nb::c_contig> entities)
       {
-        namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
         std::vector<int> coffsets = e.coefficient_offsets();
         const std::vector<std::shared_ptr<const dolfinx::fem::Function<T, U>>>&
             coefficients
@@ -269,8 +267,6 @@ void declare_assembly_functions(nb::module_& m)
          const dolfinx::mesh::Mesh<U>& mesh,
          nb::ndarray<const std::int32_t, nb::c_contig> entities)
       {
-        namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
-
         std::optional<std::pair<
             std::reference_wrapper<const dolfinx::fem::FiniteElement<U>>,
             std::size_t>>

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -302,7 +302,7 @@ void declare_function_space(nb::module_& m, std::string type)
 template <typename T>
 void declare_objects(nb::module_& m, const std::string& type)
 {
-  using U = typename dolfinx::scalar_value_type_t<T>;
+  using U = typename dolfinx::scalar_value_t<T>;
 
   // dolfinx::fem::DirichletBC
   std::string pyclass_name = std::string("DirichletBC_") + type;
@@ -620,7 +620,7 @@ void declare_objects(nb::module_& m, const std::string& type)
 template <typename T>
 void declare_form(nb::module_& m, std::string type)
 {
-  using U = typename dolfinx::scalar_value_type_t<T>;
+  using U = typename dolfinx::scalar_value_t<T>;
 
   // dolfinx::fem::Form
   std::string pyclass_name_form = std::string("Form_") + type;

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -196,7 +196,7 @@ void declare_functions(nb::module_& m)
   m.def(
       "is_orthonormal",
       [](std::vector<const dolfinx::la::Vector<T>*> basis,
-         dolfinx::scalar_value_type_t<T> eps)
+         dolfinx::scalar_value_t<T> eps)
       {
         std::vector<std::reference_wrapper<const dolfinx::la::Vector<T>>>
             _basis;


### PR DESCRIPTION
Contains multiple changes to the type system.

1. Generalizes `dolfinx::scalar` concept to allow for general `std::complex<T>` types (before only `float` and `double` supported).
2. Renames trait `dolfinx::scalar_value_type` to `dolfinx::scalar_value` and its short notation `scalar_value_type_t` to `scalar_value_t` (removes duplicate 'type'). Also renames internal trait variable from `value_type` to `type` to highlight different implications. Also, switches to usage of short notation when feasible.
3. ~Introduces `DofMapSpan` type in `types.h` in favor of multiple definitions of `mdspan2_t` types. (This caused undefined definition errors when including assembler implementation files)~
4. Introduce namespace alias `md` for `MDSPAN_IMPL_STANDARD_NAMESPACE` - following style chosen in https://github.com/FEniCS/basix/pull/902  (should one globally rename `MDSPAN_IMPL_STANDARD_NAMESPACE` to `md` with this?)