### PR TITLE
Fix bug in coefficient packing

### DIFF
--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -324,19 +324,6 @@ public:
 
   /// @brief Indices of coefficients that are active for a given
   /// integral (kernel).
-  std::vector<int> active_coeffs_new(IntegralType type, int id) const
-  {
-    for (auto& integral : _integrals[static_cast<std::size_t>(type)])
-    {
-      if (integral.id == id)
-        return integral.coeffs;
-    }
-
-    throw std::runtime_error("No active coeffs for integral/domain.");
-  }
-
-  /// @brief Indices of coefficients that are active for a given
-  /// integral (kernel).
   ///
   /// A form is split into multiple integrals (kernels) and each
   /// integral might container only a subset of all coefficients in the
@@ -344,10 +331,14 @@ public:
   /// integral kernel that signifies which coefficients are present.
   ///
   /// @param[in] type Integral type.
-  /// @param[in] i Index of the integral.
-  std::vector<int> active_coeffs(IntegralType type, std::size_t i) const
+  /// @param[in] id Domain index (identifier) of the integral.
+  std::vector<int> active_coeffs(IntegralType type, int id) const
   {
-    return _integrals[static_cast<std::size_t>(type)].at(i).coeffs;
+    auto it = std::ranges::find_if(_integrals[static_cast<std::size_t>(type)],
+                                   [id](auto& x) { return x.id == id; });
+    if (it == _integrals[static_cast<std::size_t>(type)].end())
+      throw std::runtime_error("No active coeffs for integral/domain.");
+    return it->coeffs;
   }
 
   /// @brief Get the IDs for integrals (kernels) for given integral type.

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -324,6 +324,19 @@ public:
 
   /// @brief Indices of coefficients that are active for a given
   /// integral (kernel).
+  std::vector<int> active_coeffs_new(IntegralType type, int id) const
+  {
+    for (auto& integral : _integrals[static_cast<std::size_t>(type)])
+    {
+      if (integral.id == id)
+        return integral.coeffs;
+    }
+
+    throw std::runtime_error("No active coeffs for integral/domain.");
+  }
+
+  /// @brief Indices of coefficients that are active for a given
+  /// integral (kernel).
   ///
   /// A form is split into multiple integrals (kernels) and each
   /// integral might container only a subset of all coefficients in the

--- a/cpp/dolfinx/fem/pack.h
+++ b/cpp/dolfinx/fem/pack.h
@@ -252,13 +252,7 @@ void pack_coefficients(const Form<T, U>& form,
       {
         // Get indicator for all coefficients that are active in cell
         // integrals
-        // for (std::size_t i = 0; i < form.num_integrals(IntegralType::cell);
-        // ++i)
-        // {
-        //   for (auto idx : form.active_coeffs(IntegralType::cell, i))
-        //     active_coefficient[idx] = 1;
-        // }
-        for (auto idx : form.active_coeffs_new(IntegralType::cell, id))
+        for (auto idx : form.active_coeffs(IntegralType::cell, id))
           active_coefficient[idx] = 1;
 
         // Iterate over coefficients
@@ -297,18 +291,8 @@ void pack_coefficients(const Form<T, U>& form,
       {
         // Get indicator for all coefficients that are active in
         // exterior facet integrals
-        // for (std::size_t i = 0;
-        //      i < form.num_integrals(IntegralType::exterior_facet); ++i)
-        // {
-        //   for (auto idx : form.active_coeffs(IntegralType::exterior_facet,
-        //   i))
-        //     active_coefficient[idx] = 1;
-        // }
-        for (auto idx :
-             form.active_coeffs_new(IntegralType::exterior_facet, id))
-        {
+        for (auto idx : form.active_coeffs(IntegralType::exterior_facet, id))
           active_coefficient[idx] = 1;
-        }
 
         // Iterate over coefficients
         for (std::size_t coeff = 0; coeff < coefficients.size(); ++coeff)
@@ -336,19 +320,8 @@ void pack_coefficients(const Form<T, U>& form,
       {
         // Get indicator for all coefficients that are active in interior
         // facet integrals
-        // for (std::size_t i = 0;
-        //      i < form.num_integrals(IntegralType::interior_facet); ++i)
-        // {
-        //   for (auto idx : form.active_coeffs(IntegralType::interior_facet,
-        //   i))
-        //     active_coefficient[idx] = 1;
-        // }
-
-        for (auto idx :
-             form.active_coeffs_new(IntegralType::interior_facet, id))
-        {
+        for (auto idx : form.active_coeffs(IntegralType::interior_facet, id))
           active_coefficient[idx] = 1;
-        }
 
         // Iterate over coefficients
         for (std::size_t coeff = 0; coeff < coefficients.size(); ++coeff)

--- a/cpp/dolfinx/fem/pack.h
+++ b/cpp/dolfinx/fem/pack.h
@@ -252,11 +252,14 @@ void pack_coefficients(const Form<T, U>& form,
       {
         // Get indicator for all coefficients that are active in cell
         // integrals
-        for (std::size_t i = 0; i < form.num_integrals(IntegralType::cell); ++i)
-        {
-          for (auto idx : form.active_coeffs(IntegralType::cell, i))
-            active_coefficient[idx] = 1;
-        }
+        // for (std::size_t i = 0; i < form.num_integrals(IntegralType::cell);
+        // ++i)
+        // {
+        //   for (auto idx : form.active_coeffs(IntegralType::cell, i))
+        //     active_coefficient[idx] = 1;
+        // }
+        for (auto idx : form.active_coeffs_new(IntegralType::cell, id))
+          active_coefficient[idx] = 1;
 
         // Iterate over coefficients
         for (std::size_t coeff = 0; coeff < coefficients.size(); ++coeff)
@@ -294,11 +297,17 @@ void pack_coefficients(const Form<T, U>& form,
       {
         // Get indicator for all coefficients that are active in
         // exterior facet integrals
-        for (std::size_t i = 0;
-             i < form.num_integrals(IntegralType::exterior_facet); ++i)
+        // for (std::size_t i = 0;
+        //      i < form.num_integrals(IntegralType::exterior_facet); ++i)
+        // {
+        //   for (auto idx : form.active_coeffs(IntegralType::exterior_facet,
+        //   i))
+        //     active_coefficient[idx] = 1;
+        // }
+        for (auto idx :
+             form.active_coeffs_new(IntegralType::exterior_facet, id))
         {
-          for (auto idx : form.active_coeffs(IntegralType::exterior_facet, i))
-            active_coefficient[idx] = 1;
+          active_coefficient[idx] = 1;
         }
 
         // Iterate over coefficients
@@ -327,11 +336,18 @@ void pack_coefficients(const Form<T, U>& form,
       {
         // Get indicator for all coefficients that are active in interior
         // facet integrals
-        for (std::size_t i = 0;
-             i < form.num_integrals(IntegralType::interior_facet); ++i)
+        // for (std::size_t i = 0;
+        //      i < form.num_integrals(IntegralType::interior_facet); ++i)
+        // {
+        //   for (auto idx : form.active_coeffs(IntegralType::interior_facet,
+        //   i))
+        //     active_coefficient[idx] = 1;
+        // }
+
+        for (auto idx :
+             form.active_coeffs_new(IntegralType::interior_facet, id))
         {
-          for (auto idx : form.active_coeffs(IntegralType::interior_facet, i))
-            active_coefficient[idx] = 1;
+          active_coefficient[idx] = 1;
         }
 
         // Iterate over coefficients


### PR DESCRIPTION
Packing got all coefficients for an integral (domain) type, rather than just  coefficients that a present in an integral over a subdomain (i.e., an integral with an ID).