### PR TITLE
Simplify assembler implementation interfaces

### DIFF
--- a/cpp/demo/custom_kernel/main.cpp
+++ b/cpp/demo/custom_kernel/main.cpp
@@ -140,9 +140,11 @@ double assemble_matrix1(const mesh::Geometry<T>& g, const fem::DofMap& dofmap,
   la::MatrixCSR<T> A(sp);
   auto ident = [](auto, auto, auto, auto) {}; // DOF permutation not required
   common::Timer timer("Assembler1 lambda (matrix)");
+  md::mdspan<const T, md::extents<std::size_t, md::dynamic_extent, 3>> x(
+      g.x().data(), g.x().size() / 3, 3);
   fem::impl::assemble_cells<T>(
-      A.mat_add_values(), g.dofmap(), g.x(), cells, {dofmap.map(), 1, cells},
-      ident, {dofmap.map(), 1, cells}, ident, {}, {}, kernel, {}, {}, {}, {});
+      A.mat_add_values(), g.dofmap(), x, cells, {dofmap.map(), 1, cells}, ident,
+      {dofmap.map(), 1, cells}, ident, {}, {}, kernel, {}, {}, {}, {});
   A.scatter_rev();
   return A.squared_norm();
 }
@@ -163,9 +165,11 @@ double assemble_vector1(const mesh::Geometry<T>& g, const fem::DofMap& dofmap,
                         auto kernel, const std::vector<std::int32_t>& cells)
 {
   la::Vector<T> b(dofmap.index_map, 1);
+  md::mdspan<const T, md::extents<std::size_t, md::dynamic_extent, 3>> x(
+      g.x().data(), g.x().size() / 3, 3);
   common::Timer timer("Assembler1 lambda (vector)");
   fem::impl::assemble_cells<T, 1>([](auto, auto, auto, auto) {},
-                                  b.mutable_array(), g.dofmap(), g.x(), cells,
+                                  b.mutable_array(), g.dofmap(), x, cells,
                                   {dofmap.map(), 1, cells}, kernel, {}, {}, {});
   b.scatter_rev(std::plus<T>());
   return la::squared_norm(b);

--- a/cpp/demo/custom_kernel/main.cpp
+++ b/cpp/demo/custom_kernel/main.cpp
@@ -140,10 +140,9 @@ double assemble_matrix1(const mesh::Geometry<T>& g, const fem::DofMap& dofmap,
   la::MatrixCSR<T> A(sp);
   auto ident = [](auto, auto, auto, auto) {}; // DOF permutation not required
   common::Timer timer("Assembler1 lambda (matrix)");
-  fem::impl::assemble_cells(A.mat_add_values(), g.dofmap(), g.x(), cells,
-                            {dofmap.map(), 1, cells}, ident,
-                            {dofmap.map(), 1, cells}, ident, {}, {}, kernel,
-                            std::span<const T>(), 0, {}, {}, {});
+  fem::impl::assemble_cells<T>(
+      A.mat_add_values(), g.dofmap(), g.x(), cells, {dofmap.map(), 1, cells},
+      ident, {dofmap.map(), 1, cells}, ident, {}, {}, kernel, {}, {}, {}, {});
   A.scatter_rev();
   return A.squared_norm();
 }

--- a/cpp/demo/custom_kernel/main.cpp
+++ b/cpp/demo/custom_kernel/main.cpp
@@ -165,9 +165,9 @@ double assemble_vector1(const mesh::Geometry<T>& g, const fem::DofMap& dofmap,
 {
   la::Vector<T> b(dofmap.index_map, 1);
   common::Timer timer("Assembler1 lambda (vector)");
-  fem::impl::assemble_cells<T, 1>(
-      [](auto, auto, auto, auto) {}, b.mutable_array(), g.dofmap(), g.x(),
-      cells, {dofmap.map(), 1, cells}, kernel, {}, {}, 0, {});
+  fem::impl::assemble_cells<T, 1>([](auto, auto, auto, auto) {},
+                                  b.mutable_array(), g.dofmap(), g.x(), cells,
+                                  {dofmap.map(), 1, cells}, kernel, {}, {}, {});
   b.scatter_rev(std::plus<T>());
   return la::squared_norm(b);
 }

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -29,31 +29,34 @@ namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
 /// @brief Typedef
 using mdspan2_t = md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>;
 
-/// @brief Execute kernel over cells and accumulate result in matrix.
+/// @brief Execute kernel over cells and accumulate result in a matrix.
+///
 /// @tparam T Matrix/form scalar type.
 /// @param mat_set Function that accumulates computed entries into a
 /// matrix.
-/// @param x_dofmap Dofmap for the mesh geometry.
-/// @param x Mesh geometry (coordinates).
-/// @param cells Cell indices (in the integration domain mesh) to
-/// execute the kernel over. These are the indices into the geometry
-/// dofmap.
-/// @param dofmap0 Test function (row) degree-of-freedom data holding
-/// the (0) dofmap, (1) dofmap block size and (2) dofmap cell indices.
-/// @param P0 Function that applies transformation P_0 A in-place to
-/// transform test degrees-of-freedom.
-/// @param dofmap1 Trial function (column) degree-of-freedom data
+/// @param[in] x_dofmap Degree-of-freedom map for the mesh geometry.
+/// @param[in] x Mesh geometry (coordinates).
+/// @param[in] cells Cell indices to execute the kernel over. These are
+/// the indices into the geometry dofmap `x_dofmap`.
+/// @param[in] dofmap0 Test function (row) degree-of-freedom data
 /// holding the (0) dofmap, (1) dofmap block size and (2) dofmap cell
 /// indices.
-/// @param P1T Function that applies transformation A P_1^T in-place to
-/// transform trial degrees-of-freedom.
+/// @param[in] P0 Function that applies transformation `P_0 A` in-place
+/// to the computed tensor `A` to transform its test degrees-of-freedom.
+/// @param[in] dofmap1 Trial function (column) degree-of-freedom data
+/// holding the (0) dofmap, (1) dofmap block size and (2) dofmap cell
+/// indices.
+/// @param[in] P1T Function that applies transformation `A P_1^T`
+/// in-place to to the computed tensor `A` to transform trial
+/// degrees-of-freedom.
 /// @param bc0 Marker for rows with Dirichlet boundary conditions
 /// applied.
 /// @param bc1 Marker for columns with Dirichlet boundary conditions
 /// applied.
 /// @param kernel Kernel function to execute over each cell.
-/// @param coeffs Coefficient data array of shape (cells.size(),
-/// cstride).
+/// @param[in] coeffs Coefficient data in the kernel. It has shape
+/// `(cells.size(), num_cell_coeffs)`. `coeffs(i, j)` is the `j`th
+/// coefficient for cell `i`.
 /// @param constants Constant data.
 /// @param cell_info0 Cell permutation information for the test
 /// function mesh.
@@ -159,6 +162,7 @@ void assemble_cells(
 
 /// @brief Execute kernel over exterior facets and accumulate result in
 /// a matrix.
+///
 /// @tparam T Matrix/form scalar type.
 /// @param[in] mat_set Function that accumulates computed entries into a
 /// matrix.
@@ -299,6 +303,7 @@ void assemble_exterior_facets(
 
 /// @brief Execute kernel over interior facets and accumulate result in
 /// a matrix.
+///
 /// @tparam T Matrix/form scalar type.
 /// @param mat_set Function that accumulates computed entries into a
 /// matrix.
@@ -493,6 +498,25 @@ void assemble_interior_facets(
 /// local indices. Rows (bc0) and columns (bc1) with Dirichlet
 /// conditions are zeroed. Markers (bc0 and bc1) can be empty if no bcs
 /// are applied. Matrix is not finalised.
+
+/// @brief Assemble (accumulate) into a matrix.
+///
+/// Rows (bc0) and columns (bc1) with Dirichlet conditions are zeroed.
+/// Markers (bc0 and bc1) can be empty if no Dirichlet conditions are
+/// applied.
+///
+/// @tparam T Scalar type.
+/// @tparam U Geometry type.
+/// @param[in] mat_set Function that accumulates computed entries into a
+/// matrix.
+/// @param[in] a Bilinear form to assemble.
+/// @param[in] x Mesh geometry (coordinates).
+/// @param[in] constants Constants that appear in `a`.
+/// @param[in] coefficients Coefficients that appear in `a`.
+/// @param bc0 Marker for rows with Dirichlet boundary conditions
+/// applied.
+/// @param bc1 Marker for columns with Dirichlet boundary conditions
+/// applied.
 template <dolfinx::scalar T, std::floating_point U>
 void assemble_matrix(
     la::MatSet<T> auto mat_set, const Form<T, U>& a,

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -117,15 +117,14 @@ T assemble_interior_facets(
   if (facets.empty())
     return value;
 
+  assert(offsets.back() == cstride);
+
   // Create data structures used in assembly
   using X = scalar_value_type_t<T>;
   std::vector<X> coordinate_dofs(2 * x_dofmap.extent(1) * 3);
   std::span<X> cdofs0(coordinate_dofs.data(), x_dofmap.extent(1) * 3);
   std::span<X> cdofs1(coordinate_dofs.data() + x_dofmap.extent(1) * 3,
                       x_dofmap.extent(1) * 3);
-
-  std::vector<T> coeff_array(2 * offsets.back());
-  assert(offsets.back() == cstride);
 
   // Iterate over all facets
   for (std::size_t f = 0; f < facets.extent(0); ++f)
@@ -200,13 +199,12 @@ T assemble_scalar(
     auto& [coeffs, cstride]
         = coefficients.at({IntegralType::exterior_facet, i});
 
+    using Ext2 = md::extents<std::size_t, md::dynamic_extent, 2>;
     std::span facets = M.domain(IntegralType::exterior_facet, i, 0);
     value += impl::assemble_exterior_facets(
         x_dofmap, x, num_facets_per_cell,
-        /// M.domain(IntegralType::exterior_facet, i, 0),
-        md::mdspan<const std::int32_t,
-                   md::extents<std::size_t, md::dynamic_extent, 2>>(
-            facets.data(), facets.size() / 2, 2),
+        md::mdspan<const std::int32_t, Ext2>(facets.data(), facets.size() / 2,
+                                             2),
         fn, constants,
         md::mdspan(coeffs.data(), coeffs.size() / cstride, cstride), perms);
   }

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -110,14 +110,14 @@ T assemble_interior_facets(
                md::extents<std::size_t, md::dynamic_extent, 4>>
         facets,
     FEkernel<T> auto fn, std::span<const T> constants,
-    std::span<const T> coeffs, int cstride, std::span<const int> offsets,
+    md::mdspan<const T, md::extents<std::size_t, md::dynamic_extent, 2,
+                                    md::dynamic_extent>>
+        coeffs,
     std::span<const std::uint8_t> perms)
 {
   T value(0);
   if (facets.empty())
     return value;
-
-  assert(offsets.back() == cstride);
 
   // Create data structures used in assembly
   using X = scalar_value_type_t<T>;
@@ -152,8 +152,8 @@ T assemble_interior_facets(
               : std::array{
                     perms[cells[0] * num_facets_per_cell + local_facet[0]],
                     perms[cells[1] * num_facets_per_cell + local_facet[1]]};
-    fn(&value, coeffs.data() + 2 * f * cstride, constants.data(),
-       coordinate_dofs.data(), local_facet.data(), perm.data());
+    fn(&value, &coeffs(f, 0, 0), constants.data(), coordinate_dofs.data(),
+       local_facet.data(), perm.data());
   }
 
   return value;
@@ -213,20 +213,22 @@ T assemble_scalar(
 
   for (int i : M.integral_ids(IntegralType::interior_facet))
   {
-    const std::vector<int> c_offsets = M.coefficient_offsets();
     auto fn = M.kernel(IntegralType::interior_facet, i, 0);
     assert(fn);
     auto& [coeffs, cstride]
         = coefficients.at({IntegralType::interior_facet, i});
-
     std::span facets = M.domain(IntegralType::interior_facet, i, 0);
-
+    assert((facets.size() / 4) * 2 * cstride == coeffs.size());
     value += impl::assemble_interior_facets(
         x_dofmap, x, num_facets_per_cell,
         md::mdspan<const std::int32_t,
                    md::extents<std::size_t, md::dynamic_extent, 4>>(
             facets.data(), facets.size() / 4, 4),
-        fn, constants, coeffs, cstride, c_offsets, perms);
+        fn, constants,
+        md::mdspan<const T, md::extents<std::size_t, md::dynamic_extent, 2,
+                                        md::dynamic_extent>>(
+            coeffs.data(), facets.size() / 4, 2, cstride),
+        perms);
   }
 
   return value;

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -1041,7 +1041,7 @@ void lift_bc(std::span<T> b, const Form<T, U>& a, mdspan2_t x_dofmap,
     mdspanx2_t facets1(f1.data(), f1.size() / 2, 2);
     _lift_bc_exterior_facets(b, x_dofmap, x, num_facets_per_cell, kernel,
                              facets, {dofmap0, bs0, facets0}, P0,
-                             {dofmap1, bs1, facets0}, P1T, constants, coeffs,
+                             {dofmap1, bs1, facets1}, P1T, constants, coeffs,
                              cstride, cell_info0, cell_info1, bc_values1,
                              bc_markers1, x0, alpha, perms);
   }

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -479,10 +479,10 @@ void _lift_bc_interior_facets(
     // Get cell geometry
     auto x_dofs0 = md::submdspan(x_dofmap, cells[0], md::full_extent);
     for (std::size_t i = 0; i < x_dofs0.size(); ++i)
-      std::copy_n(&x(x_dofs0[i], 3), 3, std::next(cdofs0.begin(), 3 * i));
+      std::copy_n(&x(x_dofs0[i], 0), 3, std::next(cdofs0.begin(), 3 * i));
     auto x_dofs1 = md::submdspan(x_dofmap, cells[1], md::full_extent);
     for (std::size_t i = 0; i < x_dofs1.size(); ++i)
-      std::copy_n(&x(x_dofs1[i], 3), 3, std::next(cdofs1.begin(), 3 * i));
+      std::copy_n(&x(x_dofs1[i], 0), 3, std::next(cdofs1.begin(), 3 * i));
 
     // Get dof maps for cells and pack
     std::span dmap0_cell0(dmap0.data_handle() + cells0[0] * num_dofs0,

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -809,9 +809,8 @@ void assemble_exterior_facets(
 /// the (0) dofmap, (1) dofmap block size and (2) dofmap cell indices.
 /// @param[in] fn Kernel function to execute over each cell.
 /// @param[in] constants The constant data
-/// @param[in] coeffs The coefficient data array of shape (cells.size(),
-/// cstride), flattened into row-major format.
-/// @param[in] cstride The coefficient stride
+/// @param[in] coeffs Coefficient data array, withshape (cells.size(),
+/// cstride).
 /// @param[in] cell_info0 The cell permutation information for the test
 /// function mesh.
 /// @param[in] perms Facet permutation integer. Empty if facet

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -1252,8 +1252,7 @@ void assemble_vector(
       assert(fn);
       auto& [coeffs, cstride]
           = coefficients.at({IntegralType::exterior_facet, i});
-      std::span<const std::int32_t> f
-          = L.domain(IntegralType::exterior_facet, i, 0);
+      std::span f = L.domain(IntegralType::exterior_facet, i, 0);
       mdspanx2_t facets(f.data(), f.size() / 2, 2);
       std::span f1 = L.domain_arg(IntegralType::exterior_facet, 0, i, 0);
       mdspanx2_t facets1(f1.data(), f1.size() / 2, 2);

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -191,8 +191,11 @@ template <dolfinx::scalar T, std::floating_point U>
 T assemble_scalar(const Form<T, U>& M)
 {
   const std::vector<T> constants = pack_constants(M);
+  std::cout << "Allocate storage" << std::endl;
   auto coefficients = allocate_coefficient_storage(M);
+  std::cout << "Pack coefss" << std::endl;
   pack_coefficients(M, coefficients);
+  std::cout << "End Pack coefss" << std::endl;
   return assemble_scalar(M, std::span(constants),
                          make_coefficients_span(coefficients));
 }

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -350,19 +350,24 @@ void assemble_matrix(
     std::span<const std::int8_t> dof_marker1)
 
 {
+  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
+  using mdspanx3_t
+      = md::mdspan<const scalar_value_type_t<T>,
+                   md::extents<std::size_t, md::dynamic_extent, 3>>;
+
   std::shared_ptr<const mesh::Mesh<U>> mesh = a.mesh();
   assert(mesh);
+  std::span x = mesh->geometry().x();
   if constexpr (std::is_same_v<U, scalar_value_type_t<T>>)
   {
-    impl::assemble_matrix(mat_add, a, mesh->geometry().x(), constants,
-                          coefficients, dof_marker0, dof_marker1);
+    impl::assemble_matrix(mat_add, a, mdspanx3_t(x.data(), x.size() / 3, 3),
+                          constants, coefficients, dof_marker0, dof_marker1);
   }
   else
   {
-    auto x = mesh->geometry().x();
     std::vector<scalar_value_type_t<T>> _x(x.begin(), x.end());
-    impl::assemble_matrix(mat_add, a, _x, constants, coefficients, dof_marker0,
-                          dof_marker1);
+    impl::assemble_matrix(mat_add, a, mdspanx3_t(_x.data(), _x.size() / 3, 3),
+                          constants, coefficients, dof_marker0, dof_marker1);
   }
 }
 

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -191,11 +191,8 @@ template <dolfinx::scalar T, std::floating_point U>
 T assemble_scalar(const Form<T, U>& M)
 {
   const std::vector<T> constants = pack_constants(M);
-  std::cout << "Allocate storage" << std::endl;
   auto coefficients = allocate_coefficient_storage(M);
-  std::cout << "Pack coefss" << std::endl;
   pack_coefficients(M, coefficients);
-  std::cout << "End Pack coefss" << std::endl;
   return assemble_scalar(M, std::span(constants),
                          make_coefficients_span(coefficients));
 }

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -164,19 +164,26 @@ T assemble_scalar(
     const std::map<std::pair<IntegralType, int>,
                    std::pair<std::span<const T>, int>>& coefficients)
 {
+  namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
+  using mdspanx3_t
+      = md::mdspan<const scalar_value_type_t<T>,
+                   md::extents<std::size_t, md::dynamic_extent, 3>>;
+
   std::shared_ptr<const mesh::Mesh<U>> mesh = M.mesh();
   assert(mesh);
+  std::span x = mesh->geometry().x();
   if constexpr (std::is_same_v<U, scalar_value_type_t<T>>)
   {
     return impl::assemble_scalar(M, mesh->geometry().dofmap(),
-                                 mesh->geometry().x(), constants, coefficients);
+                                 mdspanx3_t(x.data(), x.size() / 3, 3),
+                                 constants, coefficients);
   }
   else
   {
-    auto x = mesh->geometry().x();
     std::vector<scalar_value_type_t<T>> _x(x.begin(), x.end());
-    return impl::assemble_scalar(M, mesh->geometry().dofmap(), _x, constants,
-                                 coefficients);
+    return impl::assemble_scalar(M, mesh->geometry().dofmap(),
+                                 mdspanx3_t(_x.data(), _x.size() / 3, 3),
+                                 constants, coefficients);
   }
 }
 

--- a/python/dolfinx/wrappers/dolfinx_wrappers/pycoeff.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/pycoeff.h
@@ -25,10 +25,10 @@ py_to_cpp_coeffs(
       coeffs, std::inserter(c, c.end()),
       [](auto& e) -> typename decltype(c)::value_type
       {
-        return {e.first,
-                {std::span(static_cast<const T*>(e.second.data()),
-                           e.second.shape(0)),
-                 e.second.shape(1)}};
+        return {
+            e.first,
+            {std::span(static_cast<const T*>(e.second.data()), e.second.size()),
+             e.second.shape(1)}};
       });
   return c;
 }

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -17,8 +17,6 @@ from dolfinx import fem, la
 from dolfinx.fem import Constant, Expression, Function, form, functionspace
 from dolfinx.mesh import create_unit_square
 
-dolfinx.cpp.log.set_log_level(dolfinx.cpp.log.LogLevel.DEBUG)
-
 
 @pytest.mark.parametrize(
     "dtype",


### PR DESCRIPTION
Use `mdspan` for multi-dimensional arrays in the (private) assembler implementations. `mdspan` has crept into the interface in other places, so we might as well use it where it makes things simpler. This change:
- Reduces the number of arguments to assembly interfaces, which improves readability. 
- Exposed an error in the Python interface for wrapping 2D arrays
- Removes code lint where data was passed that was not used.
- Has documentation improvements (still more to do).
- In simplifying the code exposed sub-performant code, which has been fixed (#3645).