### PR TITLE
Simplify: `MDSPAN_IMPL_STANDARD_NAMESPACE` -> `md`

### DIFF
--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -198,11 +198,8 @@ int main(int argc, char* argv[])
 
           // New coordinates
           std::vector<U> fdata(3 * x.extent(1), 0.0);
-          MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-              U, MDSPAN_IMPL_STANDARD_NAMESPACE::extents<
-                     std::size_t, 3,
-                     MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent>>
-              f(fdata.data(), 3, x.extent(1));
+          md::mdspan<U, md::extents<std::size_t, 3, md::dynamic_extent>> f(
+              fdata.data(), 3, x.extent(1));
           for (std::size_t p = 0; p < x.extent(1); ++p)
           {
             U x1 = x(1, p);

--- a/cpp/demo/interpolation_different_meshes/main.cpp
+++ b/cpp/demo/interpolation_different_meshes/main.cpp
@@ -54,9 +54,8 @@ int main(int argc, char* argv[])
     auto fun = [](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
     {
       std::vector<T> fdata(3 * x.extent(1), 0.0);
-      using dextent = MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>;
-      MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<double, dextent> f(fdata.data(), 3,
-                                                                x.extent(1));
+      using dextent = md::dextents<std::size_t, 2>;
+      md::mdspan<double, dextent> f(fdata.data(), 3, x.extent(1));
       for (std::size_t i = 0; i < x.extent(1); ++i)
       {
         f(0, i) = std::cos(10 * x(0, i)) * std::sin(10 * x(2, i));

--- a/cpp/demo/mixed_poisson/main.cpp
+++ b/cpp/demo/mixed_poisson/main.cpp
@@ -180,10 +180,8 @@ int main(int argc, char* argv[])
     g->interpolate(
         [](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
         {
-          using mspan_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-              T, MDSPAN_IMPL_STANDARD_NAMESPACE::extents<
-                     std::size_t, 2,
-                     MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent>>;
+          using mspan_t
+              = md::mdspan<T, md::extents<std::size_t, 2, md::dynamic_extent>>;
 
           std::vector<T> fdata(2 * x.extent(1), 0);
           mspan_t f(fdata.data(), 2, x.extent(1));

--- a/cpp/dolfinx/common/math.h
+++ b/cpp/dolfinx/common/math.h
@@ -222,15 +222,9 @@ void pinv(U A, V P)
   {
     std::array<T, 6> ATb;
     std::array<T, 4> ATAb, Invb;
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        T, MDSPAN_IMPL_STANDARD_NAMESPACE::extents<std::size_t, 2, 3>>
-        AT(ATb.data(), 2, 3);
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        T, MDSPAN_IMPL_STANDARD_NAMESPACE::extents<std::size_t, 2, 2>>
-        ATA(ATAb.data(), 2, 2);
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        T, MDSPAN_IMPL_STANDARD_NAMESPACE::extents<std::size_t, 2, 2>>
-        Inv(Invb.data(), 2, 2);
+    md::mdspan<T, md::extents<std::size_t, 2, 3>> AT(ATb.data(), 2, 3);
+    md::mdspan<T, md::extents<std::size_t, 2, 2>> ATA(ATAb.data(), 2, 2);
+    md::mdspan<T, md::extents<std::size_t, 2, 2>> Inv(Invb.data(), 2, 2);
 
     for (std::size_t i = 0; i < AT.extent(0); ++i)
       for (std::size_t j = 0; j < AT.extent(1); ++j)

--- a/cpp/dolfinx/fem/CoordinateElement.cpp
+++ b/cpp/dolfinx/fem/CoordinateElement.cpp
@@ -110,8 +110,7 @@ void CoordinateElement<T>::pull_back_nonaffine(mdspan2_t<T> X,
   std::vector<T> K_b(tdim * gdim);
   mdspan2_t<T> K(K_b.data(), tdim, gdim);
 
-  using mdspan4_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 4>>;
+  using mdspan4_t = md::mdspan<T, md::dextents<std::size_t, 4>>;
 
   const std::array<std::size_t, 4> bsize = _element->tabulate_shape(1, 1);
   std::vector<T> basis_b(

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -165,8 +165,7 @@ public:
     {
       assert(w.size() >= 2 * J.extent(0) * J.extent(1));
       using X = typename U::element_type;
-      using mdspan2_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-          X, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>;
+      using mdspan2_t = md::mdspan<X, md::dextents<std::size_t, 2>>;
       mdspan2_t B(w.data(), J.extent(1), J.extent(0));
       mdspan2_t BA(w.data() + J.extent(0) * J.extent(1), B.extent(0),
                    J.extent(1));
@@ -232,8 +231,7 @@ public:
 
   /// mdspan typedef
   template <typename X>
-  using mdspan2_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      X, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>;
+  using mdspan2_t = md::mdspan<X, md::dextents<std::size_t, 2>>;
 
   /// @brief Compute reference coordinates `X` for physical coordinates
   /// `x` for a non-affine map.

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -117,10 +117,8 @@ std::vector<std::int32_t> locate_dofs_geometrical(const FunctionSpace<T>& V,
   // Compute dof coordinates
   const std::vector<T> dof_coordinates = V.tabulate_dof_coordinates(true);
 
-  using cmdspan3x_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      const T,
-      MDSPAN_IMPL_STANDARD_NAMESPACE::extents<
-          std::size_t, 3, MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent>>;
+  using cmdspan3x_t
+      = md::mdspan<const T, md::extents<std::size_t, 3, md::dynamic_extent>>;
 
   // Compute marker for each dof coordinate
   cmdspan3x_t x(dof_coordinates.data(), 3, dof_coordinates.size() / 3);
@@ -179,10 +177,8 @@ std::array<std::vector<std::int32_t>, 2> locate_dofs_geometrical(
   // Compute dof coordinates
   const std::vector<T> dof_coordinates = V1.tabulate_dof_coordinates(true);
 
-  using cmdspan3x_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      const T,
-      MDSPAN_IMPL_STANDARD_NAMESPACE::extents<
-          std::size_t, 3, MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent>>;
+  using cmdspan3x_t
+      = md::mdspan<const T, md::extents<std::size_t, 3, md::dynamic_extent>>;
 
   // Evaluate marker for each dof coordinate
   cmdspan3x_t x(dof_coordinates.data(), 3, dof_coordinates.size() / 3);

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -116,10 +116,7 @@ fem::DofMap build_collapsed_dofmap(const DofMap& dofmap_view,
 
 //-----------------------------------------------------------------------------
 graph::AdjacencyList<std::int32_t> fem::transpose_dofmap(
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int32_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        dofmap,
+    md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> dofmap,
     std::int32_t num_cells)
 {
   // Count number of cell contributions to each global index
@@ -130,8 +127,7 @@ graph::AdjacencyList<std::int32_t> fem::transpose_dofmap(
   std::vector<int> num_local_contributions(max_index + 1, 0);
   for (std::int32_t c = 0; c < num_cells; ++c)
   {
-    auto dofs = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-        dofmap, c, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+    auto dofs = md::submdspan(dofmap, c, md::full_extent);
     for (std::size_t d = 0; d < dofmap.extent(1); ++d)
       num_local_contributions[dofs[d]]++;
   }
@@ -146,8 +142,7 @@ graph::AdjacencyList<std::int32_t> fem::transpose_dofmap(
   int cell_offset = 0;
   for (std::int32_t c = 0; c < num_cells; ++c)
   {
-    auto dofs = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-        dofmap, c, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+    auto dofs = md::submdspan(dofmap, c, md::full_extent);
     for (std::size_t d = 0; d < dofmap.extent(1); ++d)
       data[pos[dofs[d]]++] = cell_offset++;
   }
@@ -272,14 +267,9 @@ std::pair<DofMap, std::vector<std::int32_t>> DofMap::collapse(
   return {std::move(dofmap_new), std::move(collapsed_map)};
 }
 //-----------------------------------------------------------------------------
-MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-    const std::int32_t,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-DofMap::map() const
+md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> DofMap::map() const
 {
-  return MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      const std::int32_t,
-      MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>(
+  return md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>(
       _dofmap.data(), _dofmap.size() / _shape1, _shape1);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/DofMap.h
+++ b/cpp/dolfinx/fem/DofMap.h
@@ -59,12 +59,9 @@ namespace dolfinx::fem
 /// typically used to exclude ghost cell contributions.
 /// @return Map from global (process-wise) index to positions in an
 /// unaassembled array. The links for each node are sorted.
-graph::AdjacencyList<std::int32_t>
-transpose_dofmap(MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-                     const std::int32_t,
-                     MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-                     dofmap,
-                 std::int32_t num_cells);
+graph::AdjacencyList<std::int32_t> transpose_dofmap(
+    md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> dofmap,
+    std::int32_t num_cells);
 
 /// @brief Degree-of-freedom map.
 ///
@@ -154,10 +151,7 @@ public:
 
   /// @brief Get dofmap data
   /// @return The adjacency list with dof indices for each cell
-  MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      const std::int32_t,
-      MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-  map() const;
+  md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> map() const;
 
   /// Layout of dofs on an element
   const ElementDofLayout& element_dof_layout() const

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -155,14 +155,11 @@ public:
 
   /// @brief Interpolate an expression f(x) on the whole domain.
   /// @param[in] f Expression to be interpolated.
-  void
-  interpolate(const std::function<
-              std::pair<std::vector<value_type>, std::vector<std::size_t>>(
-                  MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-                      const geometry_type,
-                      MDSPAN_IMPL_STANDARD_NAMESPACE::extents<
-                          std::size_t, 3,
-                          MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent>>)>& f)
+  void interpolate(
+      const std::function<
+          std::pair<std::vector<value_type>, std::vector<std::size_t>>(
+              md::mdspan<const geometry_type,
+                         md::extents<std::size_t, 3, md::dynamic_extent>>)>& f)
   {
     assert(_function_space);
     assert(_function_space->mesh());
@@ -180,11 +177,8 @@ public:
   void interpolate(
       const std::function<
           std::pair<std::vector<value_type>, std::vector<std::size_t>>(
-              MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-                  const geometry_type,
-                  MDSPAN_IMPL_STANDARD_NAMESPACE::extents<
-                      std::size_t, 3,
-                      MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent>>)>& f,
+              md::mdspan<const geometry_type,
+                         md::extents<std::size_t, 3, md::dynamic_extent>>)>& f,
       std::span<const std::int32_t> cells)
   {
     assert(_function_space);
@@ -194,10 +188,8 @@ public:
         = fem::interpolation_coords<geometry_type>(
             *_function_space->element(), _function_space->mesh()->geometry(),
             cells);
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const geometry_type,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::extents<
-            std::size_t, 3, MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent>>
+    md::mdspan<const geometry_type,
+               md::extents<std::size_t, 3, md::dynamic_extent>>
         _x(x.data(), 3, x.size() / 3);
 
     const auto [fx, fshape] = f(_x);
@@ -387,10 +379,8 @@ public:
     std::size_t num_cells = cells0.size();
     std::size_t num_points = e0.X().second[0];
     std::vector<value_type> fdata(num_cells * num_points * value_size);
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const value_type,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 3>>
-        f(fdata.data(), num_cells, num_points, value_size);
+    md::mdspan<const value_type, md::dextents<std::size_t, 3>> f(
+        fdata.data(), num_cells, num_points, value_size);
 
     // Evaluate Expression at points
     tabulate_expression(std::span(fdata), e0, *mesh0,
@@ -402,9 +392,8 @@ public:
     // point. The interpolation uses xxyyzz input, ordered for all
     // points of each cell, i.e. (value_size, num_cells*num_points).
     std::vector<value_type> fdata1(num_cells * num_points * value_size);
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        value_type, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 3>>
-        f1(fdata1.data(), value_size, num_cells, num_points);
+    md::mdspan<value_type, md::dextents<std::size_t, 3>> f1(
+        fdata1.data(), value_size, num_cells, num_points);
     for (std::size_t i = 0; i < f.extent(0); ++i)
       for (std::size_t j = 0; j < f.extent(1); ++j)
         for (std::size_t k = 0; k < f.extent(2); ++k)
@@ -535,9 +524,8 @@ public:
         phi0_shape.begin(), phi0_shape.end(), 1, std::multiplies{}));
     impl::mdspan_t<const geometry_type, 4> phi0(phi0_b.data(), phi0_shape);
     cmap.tabulate(1, std::vector<geometry_type>(tdim), {1, tdim}, phi0_b);
-    auto dphi0 = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-        phi0, std::pair(1, tdim + 1), 0,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent, 0);
+    auto dphi0
+        = md::submdspan(phi0, std::pair(1, tdim + 1), 0, md::full_extent, 0);
 
     // Data structure for evaluating geometry basis at specific points.
     // Used in non-affine case.
@@ -545,9 +533,8 @@ public:
     std::vector<geometry_type> phi_b(
         std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
     impl::mdspan_t<const geometry_type, 4> phi(phi_b.data(), phi_shape);
-    auto dphi = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-        phi, std::pair(1, tdim + 1), 0,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent, 0);
+    auto dphi
+        = md::submdspan(phi, std::pair(1, tdim + 1), 0, md::full_extent, 0);
 
     // Reference coordinates for each point
     std::vector<geometry_type> Xb(xshape[0] * tdim);
@@ -571,8 +558,7 @@ public:
         continue;
 
       // Get cell geometry (coordinate dofs)
-      auto x_dofs = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-          x_dofmap, cell_index, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+      auto x_dofs = md::submdspan(x_dofmap, cell_index, md::full_extent);
       assert(x_dofs.size() == num_dofs_g);
       for (std::size_t i = 0; i < num_dofs_g; ++i)
       {
@@ -584,18 +570,11 @@ public:
       for (std::size_t j = 0; j < gdim; ++j)
         xp(0, j) = x[p * xshape[1] + j];
 
-      auto _J = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-          J, p, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent,
-          MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
-      auto _K = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-          K, p, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent,
-          MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+      auto _J = md::submdspan(J, p, md::full_extent, md::full_extent);
+      auto _K = md::submdspan(K, p, md::full_extent, md::full_extent);
 
       std::array<geometry_type, 3> Xpb = {0, 0, 0};
-      MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-          geometry_type,
-          MDSPAN_IMPL_STANDARD_NAMESPACE::extents<
-              std::size_t, 1, MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent>>
+      md::mdspan<geometry_type, md::extents<std::size_t, 1, md::dynamic_extent>>
           Xp(Xpb.data(), 1, tdim);
 
       // Compute reference coordinates X, and J, detJ and K
@@ -681,16 +660,10 @@ public:
           cell_info, cell_index, reference_value_size);
 
       {
-        auto _U = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-            basis_derivatives_reference_values, 0, p,
-            MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent,
-            MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
-        auto _J = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-            J, p, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent,
-            MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
-        auto _K = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-            K, p, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent,
-            MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+        auto _U = md::submdspan(basis_derivatives_reference_values, 0, p,
+                                md::full_extent, md::full_extent);
+        auto _J = md::submdspan(J, p, md::full_extent, md::full_extent);
+        auto _K = md::submdspan(K, p, md::full_extent, md::full_extent);
         push_forward_fn(basis_values, _U, _J, detJ[p], _K);
       }
 

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -262,12 +262,9 @@ public:
     const std::size_t shape_c1 = transpose ? num_dofs : 3;
     std::vector<geometry_type> coords(shape_c0 * shape_c1, 0);
 
-    using mdspan2_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        geometry_type,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>;
-    using cmdspan4_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const geometry_type,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 4>>;
+    using mdspan2_t = md::mdspan<geometry_type, md::dextents<std::size_t, 2>>;
+    using cmdspan4_t
+        = md::mdspan<const geometry_type, md::dextents<std::size_t, 4>>;
 
     // Loop over cells and tabulate dofs
     std::vector<geometry_type> x_b(scalar_dofs * gdim);
@@ -293,9 +290,7 @@ public:
         std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
     cmdspan4_t phi_full(phi_b.data(), phi_shape);
     cmap.tabulate(0, X, Xshape, phi_b);
-    auto phi = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-        phi_full, 0, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent, 0);
+    auto phi = md::submdspan(phi_full, 0, md::full_extent, md::full_extent, 0);
 
     // TODO: Check transform
     // Basis function reference-to-conforming transformation function
@@ -306,8 +301,7 @@ public:
     for (int c = 0; c < num_cells; ++c)
     {
       // Extract cell geometry 'dofs'
-      auto x_dofs = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-          x_dofmap, c, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+      auto x_dofs = md::submdspan(x_dofmap, c, md::full_extent);
       for (std::size_t i = 0; i < x_dofs.size(); ++i)
         for (std::size_t j = 0; j < gdim; ++j)
           coordinate_dofs(i, j) = x_g[3 * x_dofs[i] + j];

--- a/cpp/dolfinx/fem/assemble_expression_impl.h
+++ b/cpp/dolfinx/fem/assemble_expression_impl.h
@@ -63,14 +63,9 @@ void tabulate_expression(
     std::span<T> values, fem::FEkernel<T> auto fn,
     std::array<std::size_t, 2> Xshape, std::size_t value_size,
     std::size_t num_argument_dofs,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int32_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        x_dofmap,
+    md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> x_dofmap,
     std::span<const scalar_value_t<T>> x,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        coeffs,
+    md::mdspan<const T, md::dextents<std::size_t, 2>> coeffs,
     std::span<const T> constants, fem::MDSpan2 auto entities,
     std::span<const std::uint32_t> cell_info,
     fem::DofTransformKernel<T> auto P0)
@@ -154,9 +149,7 @@ template <dolfinx::scalar T, std::floating_point U>
 void tabulate_expression(
     std::span<T> values, fem::FEkernel<T> auto fn,
     std::array<std::size_t, 2> Xshape, std::size_t value_size,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        coeffs,
+    md::mdspan<const T, md::dextents<std::size_t, 2>> coeffs,
     std::span<const T> constants, const mesh::Mesh<U>& mesh,
     fem::MDSpan2 auto entities,
     std::optional<

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -63,9 +63,7 @@ class FunctionSpace;
 template <dolfinx::scalar T, std::floating_point U>
 void tabulate_expression(
     std::span<T> values, const fem::Expression<T, U>& e,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        coeffs,
+    md::mdspan<const T, md::dextents<std::size_t, 2>> coeffs,
     std::span<const T> constants, const mesh::Mesh<U>& mesh,
     fem::MDSpan2 auto entities,
     std::optional<

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -128,8 +128,7 @@ namespace impl
 {
 /// @brief Convenience typedef
 template <typename T, std::size_t D>
-using mdspan_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-    T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, D>>;
+using mdspan_t = md::mdspan<T, md::dextents<std::size_t, D>>;
 
 /// @brief Scatter data into non-contiguous memory.
 ///

--- a/cpp/dolfinx/fem/traits.h
+++ b/cpp/dolfinx/fem/traits.h
@@ -35,13 +35,9 @@ template <class T>
 concept MDSpan2
     = std::is_convertible_v<
           std::remove_cvref_t<T>,
-          MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-              const std::int32_t,
-              MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>>
+          md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>>
       or std::is_convertible_v<
           std::remove_cvref_t<T>,
-          MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-              const std::int32_t,
-              MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 1>>>;
+          md::mdspan<const std::int32_t, md::dextents<std::size_t, 1>>>;
 
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -67,8 +67,7 @@ std::vector<T> shortest_vector(const mesh::Mesh<T>& mesh, int dim,
       // Check that we have sent in valid entities, i.e. that they exist in the
       // local dofmap. One gets a cryptical memory segfault if entities is -1
       assert(entities[e] >= 0);
-      auto dofs = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-          x_dofmap, entities[e], MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+      auto dofs = md::submdspan(x_dofmap, entities[e], md::full_extent);
       std::vector<T> nodes(3 * dofs.size());
       for (std::size_t i = 0; i < dofs.size(); ++i)
       {
@@ -105,8 +104,7 @@ std::vector<T> shortest_vector(const mesh::Mesh<T>& mesh, int dim,
       const int local_cell_entity = std::distance(cell_entities.begin(), it0);
 
       // Tabulate geometry dofs for the entity
-      auto dofs = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-          x_dofmap, c, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+      auto dofs = md::submdspan(x_dofmap, c, md::full_extent);
       const std::vector<int> entity_dofs
           = geometry.cmap().create_dof_layout().entity_closure_dofs(
               dim, local_cell_entity);
@@ -535,8 +533,7 @@ std::int32_t compute_first_colliding_cell(const mesh::Mesh<T>& mesh,
     std::vector<T> coordinate_dofs(num_nodes * 3);
     for (auto cell : cells)
     {
-      auto dofs = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-          x_dofmap, cell, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+      auto dofs = md::submdspan(x_dofmap, cell, md::full_extent);
       for (std::size_t i = 0; i < num_nodes; ++i)
       {
         std::copy_n(std::next(geom_dofs.begin(), 3 * dofs[i]), 3,
@@ -878,8 +875,7 @@ PointOwnershipData<T> determine_point_ownership(const mesh::Mesh<T>& mesh,
       std::int32_t closest_cell = -1;
       for (auto cell : candidate_collisions.links(i))
       {
-        auto dofs = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-            x_dofmap, cell, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+        auto dofs = md::submdspan(x_dofmap, cell, md::full_extent);
         std::vector<T> nodes(3 * dofs.size());
         for (std::size_t j = 0; j < dofs.size(); ++j)
         {

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -376,10 +376,8 @@ XDMFFile::read_meshtags(const mesh::Mesh<double>& mesh, std::string name,
   std::vector<std::int64_t> entities1 = io::cells::apply_permutation(
       entities, eshape, io::cells::perm_vtk(cell_type, eshape[1]));
 
-  MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      const std::int64_t,
-      MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-      entities_span(entities1.data(), eshape);
+  md::mdspan<const std::int64_t, md::dextents<std::size_t, 2>> entities_span(
+      entities1.data(), eshape);
   std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
       entities_values = xdmf_utils::distribute_entity_data<std::int32_t>(
           *mesh.topology(), mesh.geometry().input_global_indices(),

--- a/cpp/dolfinx/io/vtk_utils.cpp
+++ b/cpp/dolfinx/io/vtk_utils.cpp
@@ -21,10 +21,7 @@ using namespace dolfinx;
 //-----------------------------------------------------------------------------
 std::pair<std::vector<std::int64_t>, std::array<std::size_t, 2>>
 io::extract_vtk_connectivity(
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int32_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        dofmap_x,
+    md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> dofmap_x,
     mesh::CellType cell_type)
 {
   // Get DOLFINx to VTK permutation

--- a/cpp/dolfinx/io/vtk_utils.h
+++ b/cpp/dolfinx/io/vtk_utils.h
@@ -105,10 +105,8 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace<T>& V)
   auto apply_dof_transformation
       = element->template dof_transformation_fn<T>(fem::doftransform::standard);
 
-  using mdspan2_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>;
-  using cmdspan4_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 4>>;
+  using mdspan2_t = md::mdspan<T, md::dextents<std::size_t, 2>>;
+  using cmdspan4_t = md::mdspan<T, md::dextents<std::size_t, 4>>;
 
   // Tabulate basis functions at node reference coordinates
   const std::array<std::size_t, 4> phi_shape
@@ -117,9 +115,7 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace<T>& V)
       std::reduce(phi_shape.begin(), phi_shape.end(), 1, std::multiplies{}));
   cmdspan4_t phi_full(phi_b.data(), phi_shape);
   cmap.tabulate(0, X, Xshape, phi_b);
-  auto phi = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-      phi_full, 0, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent,
-      MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent, 0);
+  auto phi = md::submdspan(phi_full, 0, md::full_extent, md::full_extent, 0);
 
   // Loop over cells and tabulate dofs
   auto map = topology->index_map(tdim);
@@ -250,10 +246,7 @@ vtk_mesh_from_space(const fem::FunctionSpace<T>& V)
 /// local input.
 std::pair<std::vector<std::int64_t>, std::array<std::size_t, 2>>
 extract_vtk_connectivity(
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int32_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        dofmap_x,
+    md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> dofmap_x,
     mesh::CellType cell_type);
 } // namespace io
 } // namespace dolfinx

--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -141,8 +141,7 @@ void xdmf_function::add_function(MPI_Comm comm, const fem::Function<T, U>& u,
     for (std::int32_t c = 0; c < num_cells; ++c)
     {
       auto dofs = dofmap->cell_dofs(c);
-      auto dofs_x = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-          dofmap_x, c, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+      auto dofs_x = md::submdspan(dofmap_x, c, md::full_extent);
       assert(dofs.size() == dofs_x.size());
       for (std::size_t i = 0; i < dofs.size(); ++i)
       {

--- a/cpp/dolfinx/io/xdmf_mesh.cpp
+++ b/cpp/dolfinx/io/xdmf_mesh.cpp
@@ -73,8 +73,7 @@ void xdmf_mesh::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
     for (std::int32_t c : entities)
     {
       assert(c < (std::int32_t)x_dofmap.extent(0));
-      auto xdofs = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-          x_dofmap, c, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+      auto xdofs = md::submdspan(x_dofmap, c, md::full_extent);
       for (std::size_t i = 0; i < x_dofmap.extent(1); ++i)
       {
         std::int64_t global_index = xdofs[vtk_map[i]];
@@ -116,8 +115,7 @@ void xdmf_mesh::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
       // Get geometry dofs for the entity
       const std::vector<int>& entity_dofs_e = entity_dofs[local_cell_entity];
 
-      auto xdofs = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-          x_dofmap, c, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+      auto xdofs = md::submdspan(x_dofmap, c, md::full_extent);
       for (std::size_t i = 0; i < entity_dofs_e.size(); ++i)
       {
         std::int64_t global_index = xdofs[entity_dofs_e[vtk_map[i]]];

--- a/cpp/dolfinx/io/xdmf_utils.cpp
+++ b/cpp/dolfinx/io/xdmf_utils.cpp
@@ -33,8 +33,7 @@ using namespace dolfinx::io;
 namespace
 {
 template <typename T, std::size_t ndim>
-using mdspan_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-    T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, ndim>>;
+using mdspan_t = md::mdspan<T, md::dextents<std::size_t, ndim>>;
 } // namespace
 
 //----------------------------------------------------------------------------
@@ -217,15 +216,9 @@ std::pair<std::vector<std::int32_t>, std::vector<T>>
 xdmf_utils::distribute_entity_data(
     const mesh::Topology& topology, std::span<const std::int64_t> nodes_g,
     std::int64_t num_nodes_g, const fem::ElementDofLayout& cmap_dof_layout,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int32_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        xdofmap,
+    md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> xdofmap,
     int entity_dim,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int64_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        entities,
+    md::mdspan<const std::int64_t, md::dextents<std::size_t, 2>> entities,
     std::span<const T> data)
 {
   assert(entities.extent(0) == data.size());
@@ -641,61 +634,36 @@ template std::pair<std::vector<std::int32_t>, std::vector<double>>
 xdmf_utils::distribute_entity_data(
     const mesh::Topology&, std::span<const std::int64_t>, std::int64_t,
     const fem::ElementDofLayout&,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int32_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>,
-    int,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int64_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>,
+    md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>, int,
+    md::mdspan<const std::int64_t, md::dextents<std::size_t, 2>>,
     std::span<const double>);
 template std::pair<std::vector<std::int32_t>, std::vector<float>>
 xdmf_utils::distribute_entity_data(
     const mesh::Topology&, std::span<const std::int64_t>, std::int64_t,
     const fem::ElementDofLayout&,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int32_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>,
-    int,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int64_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>,
+    md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>, int,
+    md::mdspan<const std::int64_t, md::dextents<std::size_t, 2>>,
     std::span<const float>);
 template std::pair<std::vector<std::int32_t>, std::vector<std::int32_t>>
 xdmf_utils::distribute_entity_data(
     const mesh::Topology&, std::span<const std::int64_t>, std::int64_t,
     const fem::ElementDofLayout&,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int32_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>,
-    int,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int64_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>,
+    md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>, int,
+    md::mdspan<const std::int64_t, md::dextents<std::size_t, 2>>,
     std::span<const std::int32_t>);
 template std::pair<std::vector<std::int32_t>, std::vector<std::complex<double>>>
 xdmf_utils::distribute_entity_data(
     const mesh::Topology&, std::span<const std::int64_t>, std::int64_t,
     const fem::ElementDofLayout&,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int32_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>,
-    int,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int64_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>,
+    md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>, int,
+    md::mdspan<const std::int64_t, md::dextents<std::size_t, 2>>,
     std::span<const std::complex<double>>);
 template std::pair<std::vector<std::int32_t>, std::vector<std::complex<float>>>
 xdmf_utils::distribute_entity_data(
     const mesh::Topology&, std::span<const std::int64_t>, std::int64_t,
     const fem::ElementDofLayout&,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int32_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>,
-    int,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int64_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>,
+    md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>, int,
+    md::mdspan<const std::int64_t, md::dextents<std::size_t, 2>>,
     std::span<const std::complex<float>>);
 
 /// @endcond

--- a/cpp/dolfinx/io/xdmf_utils.h
+++ b/cpp/dolfinx/io/xdmf_utils.h
@@ -107,15 +107,9 @@ template <typename T>
 std::pair<std::vector<std::int32_t>, std::vector<T>> distribute_entity_data(
     const mesh::Topology& topology, std::span<const std::int64_t> nodes_g,
     std::int64_t num_nodes_g, const fem::ElementDofLayout& cmap_dof_layout,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int32_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        xdofmap,
+    md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> xdofmap,
     int entity_dim,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int64_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-        entities,
+    md::mdspan<const std::int64_t, md::dextents<std::size_t, 2>> entities,
     std::span<const T> data);
 
 /// TODO: Document

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -108,10 +108,7 @@ public:
 
   /// @brief DofMap for the geometry.
   /// @return A 2D array with shape `(num_cells, dofs_per_cell)`.
-  MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      const std::int32_t,
-      MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-  dofmap() const
+  md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> dofmap() const
   {
     if (_dofmaps.size() != 1)
       throw std::runtime_error("Multiple dofmaps");
@@ -124,15 +121,11 @@ public:
   /// degree-of-freedom map corresponds to the geometry element
   /// `cmaps()[i]`.
   /// @return A dofmap array, with shape `(num_cells, dofs_per_cell)`.
-  MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      const std::int32_t,
-      MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
+  md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>
   dofmap(std::size_t i) const
   {
     std::size_t ndofs = _cmaps.at(i).dim();
-    return MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const std::int32_t,
-        MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>(
+    return md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>(
         _dofmaps.at(i).data(), _dofmaps.at(i).size() / ndofs, ndofs);
   }
 

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -146,8 +146,7 @@ compute_vertex_coords_boundary(const mesh::Mesh<T>& mesh, int dim,
     assert(it != cell_vertices.end());
     const std::size_t local_pos = std::distance(cell_vertices.begin(), it);
 
-    auto dofs = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-        x_dofmap, c, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+    auto dofs = md::submdspan(x_dofmap, c, md::full_extent);
     for (std::size_t j = 0; j < 3; ++j)
       x_vertices[j * vertices.size() + i] = x_nodes[3 * dofs[local_pos] + j];
     vertex_to_pos[v] = i;
@@ -488,10 +487,8 @@ compute_vertex_coords(const mesh::Mesh<T>& mesh)
 template <typename Fn, typename T>
 concept MarkerFn = std::is_invocable_r<
     std::vector<std::int8_t>, Fn,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-        const T, MDSPAN_IMPL_STANDARD_NAMESPACE::extents<
-                     std::size_t, 3,
-                     MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent>>>::value;
+    md::mdspan<const T,
+               md::extents<std::size_t, 3, md::dynamic_extent>>>::value;
 
 /// @brief Compute indices of all mesh entities that evaluate to true
 /// for the provided geometric marking function.
@@ -513,10 +510,8 @@ std::vector<std::int32_t> locate_entities(const Mesh<T>& mesh, int dim,
                                           U marker, int entity_type_idx)
 {
 
-  using cmdspan3x_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      const T,
-      MDSPAN_IMPL_STANDARD_NAMESPACE::extents<
-          std::size_t, 3, MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent>>;
+  using cmdspan3x_t
+      = md::mdspan<const T, md::extents<std::size_t, 3, md::dynamic_extent>>;
 
   // Run marker function on vertex coordinates
   const auto [xdata, xshape] = impl::compute_vertex_coords(mesh);
@@ -627,10 +622,8 @@ std::vector<std::int32_t> locate_entities_boundary(const Mesh<T>& mesh, int dim,
   mesh.topology_mutable()->create_connectivity(tdim - 1, tdim);
   std::vector<std::int32_t> boundary_facets = exterior_facet_indices(*topology);
 
-  using cmdspan3x_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      const T,
-      MDSPAN_IMPL_STANDARD_NAMESPACE::extents<
-          std::size_t, 3, MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent>>;
+  using cmdspan3x_t
+      = md::mdspan<const T, md::extents<std::size_t, 3, md::dynamic_extent>>;
 
   // Run marker function on the vertex coordinates
   auto [facet_entities, xdata, vertex_to_pos]
@@ -722,8 +715,7 @@ entities_to_geometry(const Mesh<T>& mesh, int dim,
     {
       const std::int32_t c = entities[i];
       // Extract degrees of freedom
-      auto x_c = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-          xdofs, c, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+      auto x_c = md::submdspan(xdofs, c, md::full_extent);
       for (std::int32_t entity_dof : closure_dofs_all[tdim][0])
         entity_xdofs.push_back(x_c[entity_dof]);
     }
@@ -780,8 +772,7 @@ entities_to_geometry(const Mesh<T>& mesh, int dim,
     }
 
     // Extract degrees of freedom
-    auto x_c = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-        xdofs, c, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+    auto x_c = md::submdspan(xdofs, c, md::full_extent);
     for (std::int32_t entity_dof : closure_dofs)
       entity_xdofs.push_back(x_c[entity_dof]);
   }

--- a/cpp/dolfinx/refinement/plaza.h
+++ b/cpp/dolfinx/refinement/plaza.h
@@ -198,8 +198,7 @@ face_long_edge(const mesh::Mesh<T>& mesh)
     assert(it1 != cell_vertices.end());
     const std::size_t local1 = std::distance(cell_vertices.begin(), it1);
 
-    auto x_dofs = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-        x_dofmap, cells.front(), MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+    auto x_dofs = md::submdspan(x_dofmap, cells.front(), md::full_extent);
     std::span<const T, 3> x0(mesh.geometry().x().data() + 3 * x_dofs[local0],
                              3);
     std::span<const T, 3> x1(mesh.geometry().x().data() + 3 * x_dofs[local1],

--- a/cpp/dolfinx/refinement/utils.h
+++ b/cpp/dolfinx/refinement/utils.h
@@ -72,8 +72,7 @@ std::pair<std::vector<T>, std::array<std::size_t, 2>> create_new_geometry(
   for (int c = 0; c < map_c->size_local() + map_c->num_ghosts(); ++c)
   {
     auto vertices = c_to_v->links(c);
-    auto dofs = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-        x_dofmap, c, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent);
+    auto dofs = md::submdspan(x_dofmap, c, md::full_extent);
     for (std::size_t i = 0; i < vertices.size(); ++i)
     {
       auto vertex_pos = entity_dofs_all[0][i][0];

--- a/cpp/test/matrix.cpp
+++ b/cpp/test/matrix.cpp
@@ -140,17 +140,12 @@ void test_matrix()
   // Note: we cut off the ghost rows by intent here! But therefore we are not
   // able to work with the dimensions of Adense0 to compute indices, these
   // contain the ghost rows, which also vary between processes.
-  MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      const T,
-      MDSPAN_IMPL_STANDARD_NAMESPACE::extents<
-          std::size_t, 8, MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent>>
-      Adense(Adense0.data(), 8, A.index_map(1)->size_global());
+  md::mdspan<const T, md::extents<std::size_t, 8, md::dynamic_extent>> Adense(
+      Adense0.data(), 8, A.index_map(1)->size_global());
 
   std::vector<T> Aref_data(8 * A.index_map(1)->size_global(), 0);
-  MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-      T, MDSPAN_IMPL_STANDARD_NAMESPACE::extents<
-             std::size_t, 8, MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent>>
-      Aref(Aref_data.data(), 8, A.index_map(1)->size_global());
+  md::mdspan<T, md::extents<std::size_t, 8, md::dynamic_extent>> Aref(
+      Aref_data.data(), 8, A.index_map(1)->size_global());
 
   auto to_global_col = [&](auto col)
   {

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -896,14 +896,11 @@ void declare_cmap(nb::module_& m, std::string type)
              nb::ndarray<const T, nb::ndim<2>, nb::c_contig> X,
              nb::ndarray<const T, nb::ndim<2>, nb::c_contig> cell_x)
           {
-            using mdspan2_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-                T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>;
-            using cmdspan2_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-                const T,
-                MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>;
-            using cmdspan4_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-                const T,
-                MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 4>>;
+            using mdspan2_t = md::mdspan<T, md::dextents<std::size_t, 2>>;
+            using cmdspan2_t
+                = md::mdspan<const T, md::dextents<std::size_t, 2>>;
+            using cmdspan4_t
+                = md::mdspan<const T, md::dextents<std::size_t, 4>>;
 
             std::array<std::size_t, 2> Xshape{X.shape(0), X.shape(1)};
             std::array<std::size_t, 4> phi_shape
@@ -912,9 +909,8 @@ void declare_cmap(nb::module_& m, std::string type)
                                              1, std::multiplies{}));
             cmdspan4_t phi_full(phi_b.data(), phi_shape);
             self.tabulate(0, std::span(X.data(), X.size()), Xshape, phi_b);
-            auto phi = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-                phi_full, 0, MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent,
-                MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent, 0);
+            auto phi = md::submdspan(phi_full, 0, md::full_extent,
+                                     md::full_extent, 0);
 
             std::array<std::size_t, 2> shape = {X.shape(0), cell_x.shape(1)};
             std::vector<T> xb(shape[0] * shape[1]);
@@ -936,14 +932,11 @@ void declare_cmap(nb::module_& m, std::string type)
             std::size_t gdim = x.shape(1);
             std::size_t tdim = dolfinx::mesh::cell_dim(self.cell_shape());
 
-            using mdspan2_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-                T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>;
-            using cmdspan2_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-                const T,
-                MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>;
-            using cmdspan4_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-                const T,
-                MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 4>>;
+            using mdspan2_t = md::mdspan<T, md::dextents<std::size_t, 2>>;
+            using cmdspan2_t
+                = md::mdspan<const T, md::dextents<std::size_t, 2>>;
+            using cmdspan4_t
+                = md::mdspan<const T, md::dextents<std::size_t, 4>>;
 
             std::vector<T> Xb(num_points * tdim);
             mdspan2_t X(Xb.data(), num_points, tdim);
@@ -964,9 +957,8 @@ void declare_cmap(nb::module_& m, std::string type)
               cmdspan4_t phi(phi_b.data(), phi_shape);
 
               self.tabulate(1, std::vector<T>(tdim), {1, tdim}, phi_b);
-              auto dphi = MDSPAN_IMPL_STANDARD_NAMESPACE::submdspan(
-                  phi, std::pair(1, tdim + 1), 0,
-                  MDSPAN_IMPL_STANDARD_NAMESPACE::full_extent, 0);
+              auto dphi = md::submdspan(phi, std::pair(1, tdim + 1), 0,
+                                        md::full_extent, 0);
 
               self.compute_jacobian(dphi, g, J);
               self.compute_jacobian_inverse(J, K);
@@ -1184,10 +1176,8 @@ void fem(nb::module_& m)
       [](nb::ndarray<const std::int32_t, nb::ndim<2>, nb::c_contig> dofmap,
          int num_cells)
       {
-        MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-            const std::int32_t,
-            MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>
-            _dofmap(dofmap.data(), dofmap.shape(0), dofmap.shape(1));
+        md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> _dofmap(
+            dofmap.data(), dofmap.shape(0), dofmap.shape(1));
         return dolfinx::fem::transpose_dofmap(_dofmap, num_cells);
       },
       "Build the index to (cell, local index) map from a dofmap ((cell, local "

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -41,8 +41,7 @@ namespace dolfinx_wrappers
 namespace
 {
 template <typename T, std::size_t ndim>
-using mdspan_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-    const T, MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, ndim>>;
+using mdspan_t = md::mdspan<const T, md::dextents<std::size_t, ndim>>;
 
 template <typename T>
 void xdmf_real_fn(auto&& m)


### PR DESCRIPTION
Following changes in https://github.com/FEniCS/dolfinx/pull/3642 we can remove the usage of `MDSPAN_IMPL_STANDARD_NAMESPACE`, besides the one time definition in `types.h`. Resulting in notably easier to read type declarations. 