### PR TITLE
Unpin Sphinx version.

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -36,7 +36,7 @@ docs = [
       "matplotlib",
       "myst_parser",
       "pyyaml",
-      "sphinx==8.2.1",
+      "sphinx",
       "sphinx_rtd_theme",
 ]
 lint = ["ruff>=0.2.0"]


### PR DESCRIPTION
This was pinned pending an update to Breathe. A new Breathe version has since been released.