### PR TITLE
Allow a custom cell reorder function to be passed to `create_mesh`

### DIFF
--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -839,9 +839,10 @@ compute_incident_entities(const Topology& topology,
 /// @param[in] partitioner Graph partitioner that computes the owning
 /// rank for each cell in `cells`. If not callable, cells are not
 /// redistributed.
-/// @param[in] reorder_fn A function that reorders cells in the mesh.
-/// It should take the mesh dual graph as input and return a list whose
-/// ith entry is the new index of cell i.
+/// @param[in] reorder_fn A function that reorders local cells that are
+/// owned by this process. The function should take the mesh (local)
+/// dual graph as input and return a list whose ith entry is the new index
+/// of cell i.
 /// @return A mesh distributed on the communicator `comm`.
 template <typename U>
 Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -839,6 +839,9 @@ compute_incident_entities(const Topology& topology,
 /// @param[in] partitioner Graph partitioner that computes the owning
 /// rank for each cell in `cells`. If not callable, cells are not
 /// redistributed.
+/// @param[in] reorder_fn A function that reorders cells in the mesh.
+/// It should take the mesh dual graph as input and return a list whose
+/// ith entry is the new index of cell i.
 /// @return A mesh distributed on the communicator `comm`.
 template <typename U>
 Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -958,15 +958,15 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
   // Build local dual graph for owned cells to (i) get list of vertices
   // on the process boundary and (ii) apply re-ordering to cells for
   // locality
-  auto boundary_v_fn = [](const std::vector<CellType>& celltypes,
-                          const std::vector<fem::ElementDofLayout>& doflayouts,
-                          const std::vector<std::vector<int>>& ghost_owners,
-                          std::vector<std::vector<std::int64_t>>& cells1,
-                          std::vector<std::vector<std::int64_t>>& cells1_v,
-                          std::vector<std::vector<std::int64_t>>& original_idx1,
-                          std::function<std::vector<std::int32_t>(
-                              const graph::AdjacencyList<std::int32_t>&)>
-                              reorder_fn)
+  auto boundary_v_fn
+      = [](const std::vector<CellType>& celltypes,
+           const std::vector<fem::ElementDofLayout>& doflayouts,
+           const std::vector<std::vector<int>>& ghost_owners,
+           std::vector<std::vector<std::int64_t>>& cells1,
+           std::vector<std::vector<std::int64_t>>& cells1_v,
+           std::vector<std::vector<std::int64_t>>& original_idx1,
+           const std::function<std::vector<std::int32_t>(
+               const graph::AdjacencyList<std::int32_t>&)>& reorder_fn)
   {
     spdlog::info("Build local dual graphs, re-order cells, and compute process "
                  "boundary vertices.");

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -848,9 +848,8 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
         typename std::remove_reference_t<typename U::value_type>>>& elements,
     MPI_Comm commg, const U& x, std::array<std::size_t, 2> xshape,
     const CellPartitionFunction& partitioner,
-    const std::function<
-        std::vector<std::int32_t>(const graph::AdjacencyList<std::int32_t>&)>&
-        reorder_fn
+    const std::function<std::vector<std::int32_t>(
+        const graph::AdjacencyList<std::int32_t>&)>& reorder_fn
     = graph::reorder_gps)
 {
   assert(cells.size() == elements.size());

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -839,10 +839,10 @@ compute_incident_entities(const Topology& topology,
 /// @param[in] partitioner Graph partitioner that computes the owning
 /// rank for each cell in `cells`. If not callable, cells are not
 /// redistributed.
-/// @param[in] reorder_fn A function that reorders local cells that are
-/// owned by this process. The function should take the mesh (local)
-/// dual graph as input and return a list whose ith entry is the new index
-/// of cell i.
+/// @param[in] reorder_fn Function that reorders (locally) cells that
+/// are owned by this process. It takes the local mesh dual graph as an
+/// argument and return a list whose `i`th entry is the new index of
+/// cell `i`.
 /// @return A mesh distributed on the communicator `comm`.
 template <typename U>
 Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
@@ -1163,6 +1163,10 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
 /// not callable, i.e. it does not store a callable function, no
 /// re-distribution of cells is done.
 ///
+/// This constructor provides a simplified interface to the more general
+/// ::create_mesh constructor, which supports meshes with more than one
+/// cell type.
+///
 /// @param[in] comm Communicator to build the mesh on.
 /// @param[in] commt Communicator that the topology data (`cells`) is
 /// distributed on. This should be `MPI_COMM_NULL` for ranks that should
@@ -1182,11 +1186,11 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
 /// @param[in] xshape Shape of the `x` data.
 /// @param[in] partitioner Graph partitioner that computes the owning
 /// rank for each cell. If not callable, cells are not redistributed.
+/// @param[in] reorder_fn Function that reorders (locally) cells that
+/// are owned by this process. It takes the local mesh dual graph as an
+/// argument and return a list whose `i`th entry is the new index of
+/// cell `i`.
 /// @return A mesh distributed on the communicator `comm`.
-///
-/// This constructor provides a simplified interface to the more general
-/// ::create_mesh constructor, which supports meshes with more than one
-/// cell type.
 template <typename U>
 Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
     MPI_Comm comm, MPI_Comm commt, std::span<const std::int64_t> cells,

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -848,8 +848,8 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
         typename std::remove_reference_t<typename U::value_type>>>& elements,
     MPI_Comm commg, const U& x, std::array<std::size_t, 2> xshape,
     const CellPartitionFunction& partitioner,
-    std::function<
-        std::vector<std::int32_t>(const graph::AdjacencyList<std::int32_t>&)>
+    const std::function<
+        std::vector<std::int32_t>(const graph::AdjacencyList<std::int32_t>&)>&
         reorder_fn
     = graph::reorder_gps)
 {

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -1192,10 +1192,13 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
     const fem::CoordinateElement<
         typename std::remove_reference_t<typename U::value_type>>& element,
     MPI_Comm commg, const U& x, std::array<std::size_t, 2> xshape,
-    const CellPartitionFunction& partitioner)
+    const CellPartitionFunction& partitioner,
+    const std::function<std::vector<std::int32_t>(
+        const graph::AdjacencyList<std::int32_t>&)>& reorder_fn
+    = graph::reorder_gps)
 {
   return create_mesh(comm, commt, std::vector{cells}, std::vector{element},
-                     commg, x, xshape, partitioner);
+                     commg, x, xshape, partitioner, reorder_fn);
 }
 
 /// @brief Create a distributed mesh from mesh data using the default


### PR DESCRIPTION
I wasn't sure whether to also allow this to be passed to all of the built-in mesh functions or not. It could also be exposed to Python. Let me know what is preferred.