### PR TITLE
Unify PETSc matrix and vector factory functions

### DIFF
--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -16,6 +16,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <petscmat.h>
 #include <petscvec.h>
 #include <span>
@@ -43,7 +44,7 @@ namespace petsc
 /// object.
 template <std::floating_point T>
 Mat create_matrix(const Form<PetscScalar, T>& a,
-                  std::string type = std::string())
+                  std::optional<std::string> type = std::nullopt)
 {
   la::SparsityPattern pattern = fem::create_sparsity_pattern(a);
   pattern.finalize();
@@ -62,7 +63,7 @@ Mat create_matrix(const Form<PetscScalar, T>& a,
 template <std::floating_point T>
 Mat create_matrix_block(
     const std::vector<std::vector<const Form<PetscScalar, T>*>>& a,
-    std::string type = std::string())
+    std::optional<std::string> type = std::nullopt)
 {
   // Extract and check row/column ranges
   std::array<std::vector<std::shared_ptr<const FunctionSpace<T>>>, 2> V
@@ -191,15 +192,15 @@ Mat create_matrix_block(
 template <std::floating_point T>
 Mat create_matrix_nest(
     const std::vector<std::vector<const Form<PetscScalar, T>*>>& a,
-    const std::vector<std::vector<std::string>>& types)
+    std::optional<std::vector<std::vector<std::string>>> types)
 {
   // Extract and check row/column ranges
   auto V = fem::common_function_spaces(extract_function_spaces(a));
 
   std::vector<std::vector<std::string>> _types(
       a.size(), std::vector<std::string>(a.front().size()));
-  if (!types.empty())
-    _types = types;
+  if (types)
+    _types = *types;
 
   // Loop over each form and create matrix
   int rows = a.size();
@@ -462,7 +463,8 @@ void apply_lifting(
 template <std::floating_point T>
 void set_bc(
     Vec b,
-    const std::vector<std::reference_wrapper<const DirichletBC<PetscScalar, T>>> bcs,
+    const std::vector<std::reference_wrapper<const DirichletBC<PetscScalar, T>>>
+        bcs,
     const Vec x0, PetscScalar alpha = 1)
 {
   PetscInt n = 0;

--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -193,7 +193,7 @@ Mat create_matrix_block(
 template <std::floating_point T>
 Mat create_matrix_nest(
     const std::vector<std::vector<const Form<PetscScalar, T>*>>& a,
-    std::optional<std::vector<std::vector<std::string>>> types)
+    std::optional<std::vector<std::vector<std::optional<std::string>>>> types)
 {
   // Extract and check row/column ranges
   auto V = fem::common_function_spaces(extract_function_spaces(a));
@@ -286,7 +286,7 @@ void assemble_vector(
 /// @brief Assemble linear form into an already allocated PETSc vector.
 ///
 /// Ghost contributions are not accumulated (not sent to owner). Caller
-/// is responsible for calling `VecGhostUpdateBegin/End`.
+/// is responsible for calling `VecGhostUpdateBegin`/`End`.
 ///
 /// @param[in,out] b Vector to assemble the form into. The vector must
 /// already be initialised with the correct size. The process-local

--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -231,7 +231,7 @@ void la::petsc::scatter_local_vectors(
 }
 //-----------------------------------------------------------------------------
 Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
-                             std::string type)
+                             std::optional<std::string> type)
 {
   PetscErrorCode ierr;
   Mat A;
@@ -243,8 +243,8 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   std::array maps = {sp.index_map(0), sp.index_map(1)};
   const std::array bs = {sp.block_size(0), sp.block_size(1)};
 
-  if (!type.empty())
-    MatSetType(A, type.c_str());
+  if (type)
+    MatSetType(A, type->c_str());
 
   // Get global and local dimensions
   const std::int64_t M = bs[0] * maps[0]->size_global();
@@ -561,7 +561,7 @@ Mat petsc::Operator::mat() const { return _matA; }
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 petsc::Matrix::Matrix(MPI_Comm comm, const SparsityPattern& sp,
-                      std::string type)
+                      std::optional<std::string> type)
     : Operator(petsc::create_matrix(comm, sp, type), false)
 {
   // Do nothing

--- a/cpp/dolfinx/la/petsc.h
+++ b/cpp/dolfinx/la/petsc.h
@@ -13,6 +13,7 @@
 #include "utils.h"
 #include <boost/lexical_cast.hpp>
 #include <functional>
+#include <optional>
 #include <petscksp.h>
 #include <petscmat.h>
 #include <petscoptions.h>
@@ -118,7 +119,7 @@ void scatter_local_vectors(
 /// Create a PETSc Mat. Caller is responsible for destroying the
 /// returned object.
 Mat create_matrix(MPI_Comm comm, const SparsityPattern& sp,
-                  std::string type = std::string());
+                  std::optional<std::string> type = std::nullopt);
 
 /// Create PETSc MatNullSpace. Caller is responsible for destruction
 /// returned object.
@@ -390,7 +391,7 @@ public:
 
   /// Create holder for a PETSc Mat object from a sparsity pattern
   Matrix(MPI_Comm comm, const SparsityPattern& sp,
-         std::string type = std::string());
+         std::optional<std::string> type = std::nullopt);
 
   /// Create holder of a PETSc Mat object/pointer. The Mat A object
   /// should already be created. If inc_ref_count is true, the reference

--- a/python/demo/demo_stokes.py
+++ b/python/demo/demo_stokes.py
@@ -249,7 +249,7 @@ def nested_iterative_solver():
     # a vector that spans the nullspace to the solver, and any component
     # of the solution in this direction will be eliminated during the
     # solution process.
-    null_vec = fem.petsc.create_vector_nest(L)
+    null_vec = fem.petsc.create_vector(L, "nest")
 
     # Set velocity part to zero and the pressure part to a non-zero
     # constant

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -138,7 +138,7 @@ def create_vector(
         ]
         if kind == PETSc.Vec.Type.NEST:
             return _cpp.fem.petsc.create_vector_nest(maps)
-        elif kind in (None, PETSc.Vec.Type.NEST, PETSc.Vec.Type.MPI):
+        elif kind in (None, PETSc.Vec.Type.MPI):
             return _cpp.fem.petsc.create_vector_block(maps)
         else:
             raise NotImplementedError(f"Vector type '{kind}' not supported.")

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -417,7 +417,7 @@ def assemble_matrix(
     Returns:
         Matrix representing the bilinear form.
     """
-    A = _cpp.fem.petsc.create_matrix(a._cpp_object)
+    A = _cpp.fem.petsc.create_matrix(a._cpp_object, None)
     assemble_matrix_mat(A, a, bcs, diagonal, constants, coeffs)
     return A
 
@@ -548,7 +548,7 @@ def assemble_matrix_block(
 ) -> PETSc.Mat:
     """Assemble bilinear forms into a blocked matrix."""
     _a = [[None if form is None else form._cpp_object for form in arow] for arow in a]
-    A = _cpp.fem.petsc.create_matrix_block(_a)
+    A = _cpp.fem.petsc.create_matrix_block(_a, None)
     return _assemble_matrix_block_mat(A, a, bcs, diagonal, constants, coeffs)
 
 

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -119,8 +119,8 @@ def create_vector(
     Returns:
         A PETSc vector with a layout that is compatible with ``L``.
     """
-    # Try normal vector creation
     try:
+        # Non-blocked vector creation
         dofmap = L.function_spaces[0].dofmaps(0)
         return dolfinx.la.petsc.create_vector(dofmap.index_map, dofmap.index_map_bs)
     except AttributeError:
@@ -136,6 +136,7 @@ def create_vector(
             # Create block vector
             return _cpp.fem.petsc.create_vector_block(maps)
         elif vec_type == PETSc.Vec.Type.NEST or vec_type == "nest":
+            # Create nest vector
             return _cpp.fem.petsc.create_vector_nest(maps)
         else:
             raise NotImplementedError(f"Vector type '{vec_type}' not supported.")

--- a/python/dolfinx/wrappers/petsc.cpp
+++ b/python/dolfinx/wrappers/petsc.cpp
@@ -292,17 +292,15 @@ void petsc_fem_module(nb::module_& m)
       nb::rv_policy::take_ownership, nb::arg("maps"),
       "Create nested vector for multiple (stacked) linear forms.");
   m.def("create_matrix", dolfinx::fem::petsc::create_matrix<PetscReal>,
-        nb::rv_policy::take_ownership, nb::arg("a"),
-        nb::arg("type") = nb::none(), "Create a PETSc Mat for bilinear form.");
+        nb::rv_policy::take_ownership, nb::arg("a"), nb::arg("type").none(),
+        "Create a PETSc Mat for bilinear form.");
   m.def("create_matrix_block",
         &dolfinx::fem::petsc::create_matrix_block<PetscReal>,
-        nb::rv_policy::take_ownership, nb::arg("a"),
-        nb::arg("type") = nb::none(),
+        nb::rv_policy::take_ownership, nb::arg("a"), nb::arg("type").none(),
         "Create monolithic sparse matrix for stacked bilinear forms.");
   m.def("create_matrix_nest",
         &dolfinx::fem::petsc::create_matrix_nest<PetscReal>,
-        nb::rv_policy::take_ownership, nb::arg("a"),
-        nb::arg("types") = nb::none(),
+        nb::rv_policy::take_ownership, nb::arg("a"), nb::arg("types").none(),
         "Create nested sparse matrix for bilinear forms.");
 
   // PETSc Matrices

--- a/python/dolfinx/wrappers/petsc.cpp
+++ b/python/dolfinx/wrappers/petsc.cpp
@@ -31,6 +31,7 @@
 #include <nanobind/stl/complex.h>
 #include <nanobind/stl/function.h>
 #include <nanobind/stl/map.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
@@ -174,14 +175,14 @@ void petsc_la_module(nb::module_& m)
   m.def(
       "create_matrix",
       [](dolfinx_wrappers::MPICommWrapper comm,
-         const dolfinx::la::SparsityPattern& p, const std::string& type)
+         const dolfinx::la::SparsityPattern& p, std::optional<std::string> type)
       {
         Mat A = dolfinx::la::petsc::create_matrix(comm.get(), p, type);
         PyObject* obj = PyPetscMat_New(A);
         PetscObjectDereference((PetscObject)A);
         return nb::borrow(obj);
       },
-      nb::arg("comm"), nb::arg("p"), nb::arg("type") = std::string(),
+      nb::arg("comm"), nb::arg("p"), nb::arg("type") = nb::none(),
       "Create a PETSc Mat from sparsity pattern.");
 
   m.def(
@@ -292,17 +293,16 @@ void petsc_fem_module(nb::module_& m)
       "Create nested vector for multiple (stacked) linear forms.");
   m.def("create_matrix", dolfinx::fem::petsc::create_matrix<PetscReal>,
         nb::rv_policy::take_ownership, nb::arg("a"),
-        nb::arg("type") = std::string(),
-        "Create a PETSc Mat for bilinear form.");
+        nb::arg("type") = nb::none(), "Create a PETSc Mat for bilinear form.");
   m.def("create_matrix_block",
         &dolfinx::fem::petsc::create_matrix_block<PetscReal>,
         nb::rv_policy::take_ownership, nb::arg("a"),
-        nb::arg("type") = std::string(),
+        nb::arg("type") = nb::none(),
         "Create monolithic sparse matrix for stacked bilinear forms.");
   m.def("create_matrix_nest",
         &dolfinx::fem::petsc::create_matrix_nest<PetscReal>,
         nb::rv_policy::take_ownership, nb::arg("a"),
-        nb::arg("types") = std::vector<std::vector<std::string>>(),
+        nb::arg("types") = nb::none(),
         "Create nested sparse matrix for bilinear forms.");
 
   // PETSc Matrices

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -373,7 +373,7 @@ class TestPETScAssemblers:
             A = petsc_assemble_matrix_nest(
                 a_block,
                 bcs=[bc],
-                mat_types=[["baij", "aij", "aij"], ["aij", "", "aij"], ["aij", "aij", "aij"]],
+                kind=[["baij", "aij", "aij"], ["aij", "", "aij"], ["aij", "aij", "aij"]],
             )
             A.assemble()
             with pytest.raises(RuntimeError):
@@ -659,15 +659,11 @@ class TestPETScAssemblers:
         def nested_solve():
             """Nested solver"""
             A = petsc_assemble_matrix_nest(
-                form([[a00, a01], [a10, a11]]),
-                bcs=[bc0, bc1],
-                mat_types=[["baij", "aij"], ["aij", ""]],
+                form([[a00, a01], [a10, a11]]), bcs=[bc0, bc1], kind=[["baij", "aij"], ["aij", ""]]
             )
             A.assemble()
             P = petsc_assemble_matrix_nest(
-                form([[p00, p01], [p10, p11]]),
-                bcs=[bc0, bc1],
-                mat_types=[["aij", "aij"], ["aij", ""]],
+                form([[p00, p01], [p10, p11]]), bcs=[bc0, bc1], kind=[["aij", "aij"], ["aij", ""]]
             )
             P.assemble()
             b = petsc_assemble_vector_nest(form([L0, L1]))

--- a/python/test/unit/fem/test_petsc_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_petsc_nonlinear_assembler.py
@@ -165,8 +165,7 @@ class TestNLSPETSc:
             assemble_vector_block,
             assemble_vector_nest,
             assign,
-            create_vector_block,
-            create_vector_nest,
+            create_vector,
             set_bc,
             set_bc_nest,
         )
@@ -221,7 +220,7 @@ class TestNLSPETSc:
 
         def blocked():
             """Monolithic blocked"""
-            x = create_vector_block(L_block)
+            x = create_vector(L_block)
 
             assign((u, p), x)
 
@@ -240,7 +239,7 @@ class TestNLSPETSc:
         # Nested (MatNest)
         def nested():
             """Nested (MatNest)"""
-            x = create_vector_nest(L_block)
+            x = create_vector(L_block, vec_type=PETSc.Vec.Type.NEST)
 
             assign((u, p), x)
 
@@ -316,11 +315,7 @@ class TestNLSPETSc:
         from dolfinx.fem.petsc import (
             assign,
             create_matrix,
-            create_matrix_block,
-            create_matrix_nest,
             create_vector,
-            create_vector_block,
-            create_vector_nest,
         )
 
         mesh = create_unit_square(MPI.COMM_WORLD, 12, 11)
@@ -372,8 +367,8 @@ class TestNLSPETSc:
 
         def blocked_solve():
             """Blocked version"""
-            Jmat = create_matrix_block(J)
-            Fvec = create_vector_block(F)
+            Jmat = create_matrix(J)
+            Fvec = create_vector(F)
             snes = PETSc.SNES().create(MPI.COMM_WORLD)
             snes.setTolerances(rtol=1.0e-15, max_it=10)
             problem = NonlinearPDE_SNESProblem(F, J, [u, p], bcs)
@@ -383,7 +378,7 @@ class TestNLSPETSc:
             u.interpolate(initial_guess_u)
             p.interpolate(initial_guess_p)
 
-            x = create_vector_block(F)
+            x = create_vector(F)
 
             assign((u, p), x)
 
@@ -399,9 +394,9 @@ class TestNLSPETSc:
 
         def nested_solve():
             """Nested version"""
-            Jmat = create_matrix_nest(J)
+            Jmat = create_matrix(J, mat_type=[["baij", "aij"], ["aij", "baij"]])
             assert Jmat.getType() == "nest"
-            Fvec = create_vector_nest(F)
+            Fvec = create_vector(F, vec_type="nest")
             assert Fvec.getType() == "nest"
 
             snes = PETSc.SNES().create(MPI.COMM_WORLD)
@@ -418,7 +413,7 @@ class TestNLSPETSc:
 
             u.interpolate(initial_guess_u)
             p.interpolate(initial_guess_p)
-            x = create_vector_nest(F)
+            x = create_vector(F, vec_type=PETSc.Vec.Type.NEST)
             assert x.getType() == "nest"
 
             assign((u, p), x)
@@ -516,11 +511,7 @@ class TestNLSPETSc:
         from dolfinx.fem.petsc import (
             assign,
             create_matrix,
-            create_matrix_block,
-            create_matrix_nest,
             create_vector,
-            create_vector_block,
-            create_vector_nest,
         )
 
         gdim = mesh.geometry.dim
@@ -576,9 +567,9 @@ class TestNLSPETSc:
 
         def blocked():
             """Blocked and monolithic"""
-            Jmat = create_matrix_block(J)
-            Pmat = create_matrix_block(P)
-            Fvec = create_vector_block(F)
+            Jmat = create_matrix(J)
+            Pmat = create_matrix(P)
+            Fvec = create_vector(F)
 
             snes = PETSc.SNES().create(MPI.COMM_WORLD)
             snes.setTolerances(rtol=1.0e-15, max_it=20)
@@ -590,7 +581,7 @@ class TestNLSPETSc:
 
             u.interpolate(initial_guess_u)
             p.interpolate(initial_guess_p)
-            x = create_vector_block(F)
+            x = create_vector(F)
 
             assign((u, p), x)
 
@@ -607,9 +598,9 @@ class TestNLSPETSc:
 
         def nested():
             """Blocked and nested"""
-            Jmat = create_matrix_nest(J)
-            Pmat = create_matrix_nest(P)
-            Fvec = create_vector_nest(F)
+            Jmat = create_matrix(J, mat_type=PETSc.Mat.Type.NEST)
+            Pmat = create_matrix(P, mat_type=PETSc.Mat.Type.NEST)
+            Fvec = create_vector(F, vec_type=PETSc.Vec.Type.NEST)
 
             snes = PETSc.SNES().create(MPI.COMM_WORLD)
             snes.setTolerances(rtol=1.0e-15, max_it=20)
@@ -625,7 +616,7 @@ class TestNLSPETSc:
 
             u.interpolate(initial_guess_u)
             p.interpolate(initial_guess_p)
-            x = create_vector_nest(F)
+            x = create_vector(F, "nest")
 
             assign((u, p), x)
 

--- a/python/test/unit/fem/test_petsc_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_petsc_nonlinear_assembler.py
@@ -239,7 +239,7 @@ class TestNLSPETSc:
         # Nested (MatNest)
         def nested():
             """Nested (MatNest)"""
-            x = create_vector(L_block, vec_type=PETSc.Vec.Type.NEST)
+            x = create_vector(L_block, kind=PETSc.Vec.Type.NEST)
 
             assign((u, p), x)
 
@@ -394,9 +394,9 @@ class TestNLSPETSc:
 
         def nested_solve():
             """Nested version"""
-            Jmat = create_matrix(J, mat_type=[["baij", "aij"], ["aij", "baij"]])
+            Jmat = create_matrix(J, kind=[["baij", "aij"], ["aij", "baij"]])
             assert Jmat.getType() == "nest"
-            Fvec = create_vector(F, vec_type="nest")
+            Fvec = create_vector(F, kind="nest")
             assert Fvec.getType() == "nest"
 
             snes = PETSc.SNES().create(MPI.COMM_WORLD)
@@ -413,7 +413,7 @@ class TestNLSPETSc:
 
             u.interpolate(initial_guess_u)
             p.interpolate(initial_guess_p)
-            x = create_vector(F, vec_type=PETSc.Vec.Type.NEST)
+            x = create_vector(F, kind=PETSc.Vec.Type.NEST)
             assert x.getType() == "nest"
 
             assign((u, p), x)
@@ -598,9 +598,9 @@ class TestNLSPETSc:
 
         def nested():
             """Blocked and nested"""
-            Jmat = create_matrix(J, mat_type=PETSc.Mat.Type.NEST)
-            Pmat = create_matrix(P, mat_type=PETSc.Mat.Type.NEST)
-            Fvec = create_vector(F, vec_type=PETSc.Vec.Type.NEST)
+            Jmat = create_matrix(J, kind=PETSc.Mat.Type.NEST)
+            Pmat = create_matrix(P, kind=PETSc.Mat.Type.NEST)
+            Fvec = create_vector(F, kind=PETSc.Vec.Type.NEST)
 
             snes = PETSc.SNES().create(MPI.COMM_WORLD)
             snes.setTolerances(rtol=1.0e-15, max_it=20)


### PR DESCRIPTION
Stemming from discussions in #3648, here is an attempt at unifying the PETSc matrix and vector constructors.

It avoids docs duplication, and very small wrapper function mapping Python <-> C++ one to one.