### PR TITLE
Require `clang-format` CI checks to pass

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -62,12 +62,12 @@ jobs:
           mypy dolfinx
           mypy demo
           mypy test
-      - name: clang-format C++ checks (non-blocking)
+      - name: clang-format C++ checks
         run: |
           cd cpp
           clang-format --version
           find . -type f \( -name "*.cpp" -o -name "*.h" \) | xargs clang-format --dry-run --Werror
-      - name: clang-format Python binding checks (non-blocking)
+      - name: clang-format Python binding checks
         run: |
           cd python/dolfinx/wrappers
           clang-format --version

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -63,13 +63,11 @@ jobs:
           mypy demo
           mypy test
       - name: clang-format C++ checks (non-blocking)
-        continue-on-error: true
         run: |
           cd cpp
           clang-format --version
           find . -type f \( -name "*.cpp" -o -name "*.h" \) | xargs clang-format --dry-run --Werror
       - name: clang-format Python binding checks (non-blocking)
-        continue-on-error: true
         run: |
           cd python/dolfinx/wrappers
           clang-format --version

--- a/cpp/demo/custom_kernel/main.cpp
+++ b/cpp/demo/custom_kernel/main.cpp
@@ -236,9 +236,9 @@ void assemble(MPI_Comm comm)
 
   // Finite element mass matrix kernel function
   std::array<T, 9> A_hat_b = A_ref<T>(phi, weights);
-  auto kernel_a
-      = [A_hat = mdspan2_t<T, 3, 3>(A_hat_b.data()),
-         detJ](T* A, const T*, const T*, const T* x, const int*, const uint8_t*, void*)
+  auto kernel_a = [A_hat = mdspan2_t<T, 3, 3>(A_hat_b.data()),
+                   detJ](T* A, const T*, const T*, const T* x, const int*,
+                         const uint8_t*, void*)
   {
     T scale = detJ(mdspan2_t<const T, 3, 3>(x));
     mdspan2_t<T, 3, 3> _A(A);
@@ -248,9 +248,9 @@ void assemble(MPI_Comm comm)
   };
 
   // Finite element RHS (f=1) kernel function
-  auto kernel_L
-      = [b_hat = b_ref<T>(phi, weights),
-         detJ](T* b, const T*, const T*, const T* x, const int*, const uint8_t*, void*)
+  auto kernel_L = [b_hat = b_ref<T>(phi, weights),
+                   detJ](T* b, const T*, const T*, const T* x, const int*,
+                         const uint8_t*, void*)
   {
     T scale = detJ(mdspan2_t<const T, 3, 3>(x));
     for (std::size_t i = 0; i < 3; ++i)

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -145,7 +145,8 @@ public:
 
     // Scale sizes and displacements by block size
     {
-      auto rescale = [](auto& x, int bs) {
+      auto rescale = [](auto& x, int bs)
+      {
         std::ranges::transform(x, x.begin(), [bs](auto e) { return e *= bs; });
       };
       rescale(_sizes_local, bs);

--- a/cpp/dolfinx/common/types.h
+++ b/cpp/dolfinx/common/types.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <basix/mdspan.hpp>
 #include <complex>
 #include <concepts>
 #include <type_traits>
-#include <basix/mdspan.hpp>
 
 namespace dolfinx
 {

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -250,8 +250,7 @@ std::array<std::vector<std::int32_t>, 2> locate_dofs_geometrical(
 /// A DirichletBC is specified by the function \f$g\f$, the function
 /// space (trial space) and degrees of freedom to which the boundary
 /// condition applies.
-template <dolfinx::scalar T,
-          std::floating_point U = dolfinx::scalar_value_t<T>>
+template <dolfinx::scalar T, std::floating_point U = dolfinx::scalar_value_t<T>>
 class DirichletBC
 {
 private:

--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -36,8 +36,7 @@ class Function;
 ///
 /// @tparam T The scalar type.
 /// @tparam U The mesh geometry scalar type.
-template <dolfinx::scalar T,
-          std::floating_point U = dolfinx::scalar_value_t<T>>
+template <dolfinx::scalar T, std::floating_point U = dolfinx::scalar_value_t<T>>
 class Expression
 {
 public:
@@ -67,18 +66,19 @@ public:
   /// computed a 1-form expression, e.g. can be used to create a matrix
   /// that when applied to a degree-of-freedom vector gives the
   /// expression values at the evaluation points.
-  Expression(
-      const std::vector<std::shared_ptr<
-          const Function<scalar_type, geometry_type>>>& coefficients,
-      const std::vector<std::shared_ptr<const Constant<scalar_type>>>&
-          constants,
-      std::span<const geometry_type> X, std::array<std::size_t, 2> Xshape,
-      std::function<void(scalar_type*, const scalar_type*, const scalar_type*,
-                         const geometry_type*, const int*, const uint8_t*, void*)>
-          fn,
-      const std::vector<std::size_t>& value_shape,
-      std::shared_ptr<const FunctionSpace<geometry_type>> argument_space
-      = nullptr)
+  Expression(const std::vector<std::shared_ptr<
+                 const Function<scalar_type, geometry_type>>>& coefficients,
+             const std::vector<std::shared_ptr<const Constant<scalar_type>>>&
+                 constants,
+             std::span<const geometry_type> X,
+             std::array<std::size_t, 2> Xshape,
+             std::function<void(scalar_type*, const scalar_type*,
+                                const scalar_type*, const geometry_type*,
+                                const int*, const uint8_t*, void*)>
+                 fn,
+             const std::vector<std::size_t>& value_shape,
+             std::shared_ptr<const FunctionSpace<geometry_type>> argument_space
+             = nullptr)
       : _coefficients(coefficients), _constants(constants),
         _x_ref(std::vector<geometry_type>(X.begin(), X.end()), Xshape), _fn(fn),
         _value_shape(value_shape), _argument_space(argument_space)
@@ -144,7 +144,8 @@ public:
 
   /// @brief Function for tabulating the Expression.
   const std::function<void(scalar_type*, const scalar_type*, const scalar_type*,
-                           const geometry_type*, const int*, const uint8_t*, void*)>&
+                           const geometry_type*, const int*, const uint8_t*,
+                           void*)>&
   kernel() const
   {
     return _fn;

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -42,8 +42,7 @@ class Expression;
 ///
 /// @tparam T The function scalar type.
 /// @tparam U The mesh geometry scalar type.
-template <dolfinx::scalar T,
-          std::floating_point U = dolfinx::scalar_value_t<T>>
+template <dolfinx::scalar T, std::floating_point U = dolfinx::scalar_value_t<T>>
 class Function
 {
 public:

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -134,10 +134,10 @@ make_coefficients_span(const std::map<std::pair<IntegralType, int>,
 {
   using Key = typename std::remove_reference_t<decltype(coeffs)>::key_type;
   std::map<Key, std::pair<std::span<const T>, int>> c;
-  std::ranges::transform(coeffs, std::inserter(c, c.end()),
-                         [](auto& e) -> typename decltype(c)::value_type {
-                           return {e.first, {e.second.first, e.second.second}};
-                         });
+  std::ranges::transform(
+      coeffs, std::inserter(c, c.end()),
+      [](auto& e) -> typename decltype(c)::value_type
+      { return {e.first, {e.second.first, e.second.second}}; });
   return c;
 }
 

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -309,8 +309,7 @@ void discrete_curl(const FunctionSpace<T>& V0, const FunctionSpace<T>& V1,
 /// @param[in] V1 Nédélec (first kind) element and dofmap for
 /// corresponding space to interpolate into.
 /// @param[in] mat_set A functor that sets values in a matrix
-template <dolfinx::scalar T,
-          std::floating_point U = dolfinx::scalar_value_t<T>>
+template <dolfinx::scalar T, std::floating_point U = dolfinx::scalar_value_t<T>>
 void discrete_gradient(mesh::Topology& topology,
                        std::pair<std::reference_wrapper<const FiniteElement<U>>,
                                  std::reference_wrapper<const DofMap>>

--- a/cpp/dolfinx/fem/traits.h
+++ b/cpp/dolfinx/fem/traits.h
@@ -26,9 +26,9 @@ concept DofTransformKernel
 /// Kernel functions that can be passed to an assembler for execution
 /// must satisfy this concept.
 template <class U, class T>
-concept FEkernel = std::is_invocable_v<U, T*, const T*, const T*,
-                                       const scalar_value_t<T>*,
-                                       const int*, const std::uint8_t*, void*>;
+concept FEkernel
+    = std::is_invocable_v<U, T*, const T*, const T*, const scalar_value_t<T>*,
+                          const int*, const std::uint8_t*, void*>;
 
 /// @brief Concept for mdspan of rank 1 or 2.
 template <class T>

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -496,9 +496,10 @@ Form<T, U> create_form_factory(
 #ifndef DOLFINX_NO_STDC_COMPLEX_KERNELS
         else if constexpr (std::is_same_v<T, std::complex<float>>)
         {
-          k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
-              const unsigned char*, void*)>(integral->tabulate_tensor_complex64);
+          k = reinterpret_cast<void (*)(T*, const T*, const T*,
+                                        const scalar_value_t<T>*, const int*,
+                                        const unsigned char*, void*)>(
+              integral->tabulate_tensor_complex64);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
         else if constexpr (std::is_same_v<T, double>)
@@ -506,9 +507,10 @@ Form<T, U> create_form_factory(
 #ifndef DOLFINX_NO_STDC_COMPLEX_KERNELS
         else if constexpr (std::is_same_v<T, std::complex<double>>)
         {
-          k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
-              const unsigned char*, void*)>(integral->tabulate_tensor_complex128);
+          k = reinterpret_cast<void (*)(T*, const T*, const T*,
+                                        const scalar_value_t<T>*, const int*,
+                                        const unsigned char*, void*)>(
+              integral->tabulate_tensor_complex128);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
 
@@ -581,9 +583,10 @@ Form<T, U> create_form_factory(
 #ifndef DOLFINX_NO_STDC_COMPLEX_KERNELS
         else if constexpr (std::is_same_v<T, std::complex<float>>)
         {
-          k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
-              const unsigned char*, void*)>(integral->tabulate_tensor_complex64);
+          k = reinterpret_cast<void (*)(T*, const T*, const T*,
+                                        const scalar_value_t<T>*, const int*,
+                                        const unsigned char*, void*)>(
+              integral->tabulate_tensor_complex64);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
         else if constexpr (std::is_same_v<T, double>)
@@ -591,9 +594,10 @@ Form<T, U> create_form_factory(
 #ifndef DOLFINX_NO_STDC_COMPLEX_KERNELS
         else if constexpr (std::is_same_v<T, std::complex<double>>)
         {
-          k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
-              const unsigned char*, void*)>(integral->tabulate_tensor_complex128);
+          k = reinterpret_cast<void (*)(T*, const T*, const T*,
+                                        const scalar_value_t<T>*, const int*,
+                                        const unsigned char*, void*)>(
+              integral->tabulate_tensor_complex128);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
         assert(k);
@@ -687,9 +691,10 @@ Form<T, U> create_form_factory(
 #ifndef DOLFINX_NO_STDC_COMPLEX_KERNELS
         else if constexpr (std::is_same_v<T, std::complex<float>>)
         {
-          k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
-              const unsigned char*, void*)>(integral->tabulate_tensor_complex64);
+          k = reinterpret_cast<void (*)(T*, const T*, const T*,
+                                        const scalar_value_t<T>*, const int*,
+                                        const unsigned char*, void*)>(
+              integral->tabulate_tensor_complex64);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
         else if constexpr (std::is_same_v<T, double>)
@@ -697,9 +702,10 @@ Form<T, U> create_form_factory(
 #ifndef DOLFINX_NO_STDC_COMPLEX_KERNELS
         else if constexpr (std::is_same_v<T, std::complex<double>>)
         {
-          k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
-              const unsigned char*, void*)>(integral->tabulate_tensor_complex128);
+          k = reinterpret_cast<void (*)(T*, const T*, const T*,
+                                        const scalar_value_t<T>*, const int*,
+                                        const unsigned char*, void*)>(
+              integral->tabulate_tensor_complex128);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
         assert(k);

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -293,8 +293,8 @@ auto norm(const V& x, Norm type = Norm::l2)
         data, [](T a, T b) { return std::norm(a) < std::norm(b); });
     auto local_linf = std::abs(*max_pos);
     decltype(local_linf) linf = 0;
-    MPI_Allreduce(&local_linf, &linf, 1, MPI::mpi_t<decltype(linf)>,
-                  MPI_MAX, x.index_map()->comm());
+    MPI_Allreduce(&local_linf, &linf, 1, MPI::mpi_t<decltype(linf)>, MPI_MAX,
+                  x.index_map()->comm());
     return linf;
   }
   default:
@@ -353,15 +353,14 @@ void orthonormalize(std::vector<std::reference_wrapper<V>> basis)
 template <class V>
 bool is_orthonormal(
     std::vector<std::reference_wrapper<const V>> basis,
-    dolfinx::scalar_value_t<typename V::value_type> eps
-    = std::numeric_limits<
+    dolfinx::scalar_value_t<typename V::value_type> eps = std::numeric_limits<
         dolfinx::scalar_value_t<typename V::value_type>>::epsilon())
 {
   using T = typename V::value_type;
   for (std::size_t i = 0; i < basis.size(); i++)
   {
     for (std::size_t j = i; j < basis.size(); j++)
-  {
+    {
       T delta_ij = (i == j) ? T(1) : T(0);
       auto dot_ij = inner_product(basis[i].get(), basis[j].get());
       if (std::norm(delta_ij - dot_ij) > eps)

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -198,7 +198,7 @@ public:
   /// existed.
   bool create_entities(int dim);
 
-    /// @brief Create connectivity between given pair of dimensions, `d0
+  /// @brief Create connectivity between given pair of dimensions, `d0
   /// -> d1`.
   /// @param[in] d0 Topological dimension.
   /// @param[in] d1 Topological dimension.

--- a/cpp/test/mesh/read_named_meshtags.cpp
+++ b/cpp/test/mesh/read_named_meshtags.cpp
@@ -49,7 +49,8 @@ void test_read_named_meshtags()
                                             material_values);
   mt_materials.name = "material";
 
-  io::XDMFFile file(mesh->comm(), mesh_file_name, "w", io::XDMFFile::Encoding::HDF5);
+  io::XDMFFile file(mesh->comm(), mesh_file_name, "w",
+                    io::XDMFFile::Encoding::HDF5);
   file.write_mesh(*mesh);
   file.write_meshtags(mt_domains, mesh->geometry(),
                       "/Xdmf/Domain/mesh/Geometry");
@@ -58,7 +59,7 @@ void test_read_named_meshtags()
   file.close();
 
   io::XDMFFile mesh_file(MPI_COMM_WORLD, mesh_file_name, "r",
-                        io::XDMFFile::Encoding::HDF5);
+                         io::XDMFFile::Encoding::HDF5);
   mesh = std::make_shared<mesh::Mesh<double>>(mesh_file.read_mesh(
       fem::CoordinateElement<double>(mesh::CellType::triangle, 1),
       mesh::GhostMode::none, "mesh"));

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -481,7 +481,8 @@ void declare_objects(nb::module_& m, const std::string& type)
             std::array<std::size_t, 2> shape{value_size, x.size() / 3};
             std::vector<T> values(shape[0] * shape[1]);
             std::function<void(T*, int, int, const U*, void*)> f
-                = reinterpret_cast<void (*)(T*, int, int, const U*, void*)>(addr);
+                = reinterpret_cast<void (*)(T*, int, int, const U*, void*)>(
+                    addr);
             f(values.data(), shape[1], shape[0], x.data(), nullptr);
             dolfinx::fem::interpolate(self, std::span<const T>(values), shape,
                                       std::span(cells.data(), cells.size()));


### PR DESCRIPTION
This change requires `clang-format` checks to pass for CI to be green . `clang-format`  checks were previously 'non-blocking', which didn't really help anything.