### PR TITLE
Build spdlog from source in Dockerfile.test-env

### DIFF
--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -24,6 +24,7 @@ ARG KAHIP_VERSION=3.18
 ARG NUMPY_VERSION=2.1.3
 ARG PETSC_VERSION=3.22.3
 ARG SLEPC_VERSION=3.22.2
+ARG SPDLOG_VERSION=1.15.1
 
 ARG MPICH_VERSION=4.2.3
 ARG OPENMPI_SERIES=5.0
@@ -35,13 +36,14 @@ FROM ubuntu:24.04 AS dev-env
 LABEL maintainer="FEniCS Steering Council <fenics-steering-council@googlegroups.com>"
 LABEL description="FEniCS testing and development environment with PETSc real, complex, 32-bit and 64-bit modes"
 
+ARG ADIOS2_VERSION
 ARG DOXYGEN_VERSION
 ARG GMSH_VERSION
 ARG HDF5_VERSION
+ARG KAHIP_VERSION
 ARG PETSC_VERSION
 ARG SLEPC_VERSION
-ARG ADIOS2_VERSION
-ARG KAHIP_VERSION
+ARG SPDLOG_VERSION
 ARG NUMPY_VERSION
 ARG MPICH_VERSION
 ARG OPENMPI_SERIES
@@ -83,7 +85,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     liblapack-dev \
     libopenblas-dev \
     libpugixml-dev \
-    libspdlog-dev \
     ninja-build \
     pkg-config \
     python3-dev \
@@ -111,6 +112,15 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Install spdlog from source - Ubuntu version is incompatible with CUDA 12.
+RUN wget -nc --quiet https://github.com/gabime/spdlog/archive/refs/tags/v${SPDLOG_VERSION}.tar.gz && \
+    tar xfz v${SPDLOG_VERSION}.tar.gz && \
+    cd spdlog-${SPDLOG_VERSION} && \
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -B build-dir . && \
+    cmake --build build-dir && \
+    cmake --install build-dir && \
+    rm -rf /tmp/*
+
 # Install Doxygen
 RUN apt-get -qq update && \
     apt-get -y install bison flex && \
@@ -118,7 +128,7 @@ RUN apt-get -qq update && \
     tar xfz Release_${DOXYGEN_VERSION}.tar.gz && \
     cd doxygen-Release_${DOXYGEN_VERSION} && \
     cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -B build-dir . && \
-    cmake --build build-dir  -j 2 && \
+    cmake --build build-dir && \
     cmake --install build-dir && \
     apt-get -y purge bison flex && \
     apt-get -y autoremove && \


### PR DESCRIPTION
The Ubuntu packaged version of spdlog/fmt cannot be built by CUDA compilers. This builds spdlog from source.﻿ The outcome of this is that our containers can easily be used for CUDA development.
