### PR TITLE
Correct usage of input coefficients for `apply_lifting` of blocked operators.

### DIFF
--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -658,8 +658,8 @@ def apply_lifting(
                     pass
                 offset0, offset1 = b.getAttr("_blocks")
                 with b.localForm() as b_l:
-                    for i, (a_, off0, off1, offg0, offg1) in enumerate(zip(
-                        a, offset0, offset0[1:], offset1, offset1[1:])
+                    for i, (a_, off0, off1, offg0, offg1) in enumerate(
+                        zip(a, offset0, offset0[1:], offset1, offset1[1:])
                     ):
                         const = pack_constants(a_) if constants is None else constants[i]
                         coeff = pack_coefficients(a_) if coeffs is None else coeffs[i]

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -658,11 +658,11 @@ def apply_lifting(
                     pass
                 offset0, offset1 = b.getAttr("_blocks")
                 with b.localForm() as b_l:
-                    for a_, off0, off1, offg0, offg1 in zip(
-                        a, offset0, offset0[1:], offset1, offset1[1:]
+                    for i, (a_, off0, off1, offg0, offg1) in enumerate(zip(
+                        a, offset0, offset0[1:], offset1, offset1[1:])
                     ):
-                        const = pack_constants(a_) if constants is None else constants
-                        coeff = pack_coefficients(a_) if coeffs is None else coeffs
+                        const = pack_constants(a_) if constants is None else constants[i]
+                        coeff = pack_coefficients(a_) if coeffs is None else coeffs[i]
                         const_ = [
                             np.empty(0, dtype=PETSc.ScalarType) if val is None else val
                             for val in const

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -17,7 +17,7 @@ import basix
 import ufl
 from basix.ufl import element, mixed_element
 from dolfinx import cpp as _cpp
-from dolfinx import default_real_type, fem, graph, la
+from dolfinx import default_real_type, default_scalar_type, fem, graph, la
 from dolfinx.fem import (
     Constant,
     Function,
@@ -1091,7 +1091,7 @@ class TestPETScAssemblers:
         mesh.topology.create_connectivity(mesh.topology.dim - 1, mesh.topology.dim)
         bndry_facets = exterior_facet_indices(mesh.topology)
         bndry_dofs = locate_dofs_topological(V, mesh.topology.dim - 1, bndry_facets)
-        bcs = [dirichletbc(2.0, bndry_dofs, V)]
+        bcs = [dirichletbc(default_scalar_type(2.0), bndry_dofs, V)]
 
         if kind == "mpi":
             bcs1 = bcs_by_block(extract_function_spaces(J, 1), bcs)


### PR DESCRIPTION
Patch for #3668.
Also generalizes the assembly checks to different kinds of matrices.