### PR TITLE
Block assembly with no DirichletBC and None on diagonal

### DIFF
--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -479,7 +479,7 @@ def _assemble_matrix_block_mat(
                 )
                 A.restoreLocalSubMatrix(is0[i], is1[j], Asub)
             elif i == j:
-                for bc in bcs:
+                for bc in _bcs:
                     row_forms = [row_form for row_form in a_row if row_form is not None]
                     assert len(row_forms) > 0
                     if row_forms[0].function_spaces[0].contains(bc.function_space):

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -1271,6 +1271,19 @@ class TestPETScAssemblers:
         b = assemble_vector(L, kind=PETSc.Vec.Type.MPI)
         b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
 
+    def test_zero_diagonal_block_no_bcs(self):
+        from dolfinx.fem.petsc import assemble_matrix
+        msh = create_unit_square(MPI.COMM_WORLD, 2, 2)
+        V = functionspace(msh, ("Lagrange", 1))
+        W = functionspace(msh, ("Lagrange", 2))
+        u, p = ufl.TrialFunction(V), ufl.TrialFunction(W)
+        v, q = ufl.TestFunction(V), ufl.TestFunction(W)
+        a = form([[ufl.inner(u, v) * ufl.dx, ufl.inner(p, v)*ufl.dx], [ufl.inner(u, q) * ufl.dx, None]])
+        A = assemble_matrix(a, kind="mpi")
+        A.assemble()
+
+
+
 
 @pytest.mark.parametrize("mode", [GhostMode.none, GhostMode.shared_facet])
 @dtype_parametrize

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -1273,16 +1273,17 @@ class TestPETScAssemblers:
 
     def test_zero_diagonal_block_no_bcs(self):
         from dolfinx.fem.petsc import assemble_matrix
+
         msh = create_unit_square(MPI.COMM_WORLD, 2, 2)
         V = functionspace(msh, ("Lagrange", 1))
         W = functionspace(msh, ("Lagrange", 2))
         u, p = ufl.TrialFunction(V), ufl.TrialFunction(W)
         v, q = ufl.TestFunction(V), ufl.TestFunction(W)
-        a = form([[ufl.inner(u, v) * ufl.dx, ufl.inner(p, v)*ufl.dx], [ufl.inner(u, q) * ufl.dx, None]])
+        a = form(
+            [[ufl.inner(u, v) * ufl.dx, ufl.inner(p, v) * ufl.dx], [ufl.inner(u, q) * ufl.dx, None]]
+        )
         A = assemble_matrix(a, kind="mpi")
         A.assemble()
-
-
 
 
 @pytest.mark.parametrize("mode", [GhostMode.none, GhostMode.shared_facet])


### PR DESCRIPTION
Corner-case that happens for instance for solving singular Poisson using the real function space:
- There is no diagonal block in the blocked `A` matrix.
- There are no DirichletBCs

Currently the code then tries to iterate a `None`-object, instead of going through the C++ wrapped list that is empty.
Uncovered in: https://github.com/scientificcomputing/scifem/pull/106