### PR TITLE
Fixes for mypy

### DIFF
--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -528,7 +528,8 @@ def compile_form(
     p_ffcx = ffcx.get_options(form_compiler_options)
     p_jit = jit.get_options(jit_options)
     ufcx_form, module, code = jit.ffcx_jit(comm, form, p_ffcx, p_jit)
-    return CompiledForm(form, ufcx_form, module, code, p_ffcx["scalar_type"])
+    scalar_type: npt.DTypeLike = p_ffcx["scalar_type"]  # type: ignore
+    return CompiledForm(form, ufcx_form, module, code, scalar_type)
 
 
 def form_cpp_creator(

--- a/python/dolfinx/jit.py
+++ b/python/dolfinx/jit.py
@@ -210,8 +210,6 @@ def ffcx_jit(
     # Switch on type and compile, returning cffi object
     if isinstance(ufl_object, ufl.Form):
         r = ffcx.codegeneration.jit.compile_forms([ufl_object], options=p_ffcx, **p_jit)
-    elif isinstance(ufl_object, ufl.Mesh):
-        r = ffcx.codegeneration.jit.compile_coordinate_maps([ufl_object], options=p_ffcx, **p_jit)
     elif isinstance(ufl_object, tuple) and isinstance(ufl_object[0], ufl.core.expr.Expr):
         r = ffcx.codegeneration.jit.compile_expressions([ufl_object], options=p_ffcx, **p_jit)
     else:


### PR DESCRIPTION
https://github.com/FEniCS/ffcx/pull/757 exposes two typing issues in DOLFINx (https://github.com/FEniCS/basix/actions/runs/14327628553/job/40156132123)

1. Typing of scalar type from options
2. Call to non-existing function `compile_coordinate_maps`, that was removed with https://github.com/FEniCS/ffcx/pull/327