### PR TITLE
Remove overflow issue in pybinding for `entities_to_geometry`

### DIFF
--- a/cpp/dolfinx/geometry/BoundingBoxTree.h
+++ b/cpp/dolfinx/geometry/BoundingBoxTree.h
@@ -34,7 +34,7 @@ std::array<T, 6> compute_bbox_of_entity(const mesh::Mesh<T>& mesh, int dim,
 
   // FIXME: return of small dynamic array is expensive
   std::span<const std::int32_t> entity(&index, 1);
-  const std::vector<std::int32_t> vertex_indices
+  [[maybe_unused]] const auto [vertex_indices, vertex_shape]
       = mesh::entities_to_geometry(mesh, dim, entity, false);
 
   std::array<T, 6> b;

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -245,10 +245,9 @@ std::vector<T> h(const Mesh<T>& mesh, std::span<const std::int32_t> entities,
     return std::vector<T>(entities.size(), 0);
 
   // Get the geometry dofs for the vertices of each entity
-  const std::vector<std::int32_t> vertex_xdofs
+  const auto [vertex_xdofs, xdof_shape]
       = entities_to_geometry(mesh, dim, entities, false);
-  assert(!entities.empty());
-  const std::size_t num_vertices = vertex_xdofs.size() / entities.size();
+  const std::size_t num_vertices = xdof_shape[1];
 
   // Get the  geometry coordinate
   std::span<const T> x = mesh.geometry().x();
@@ -309,10 +308,10 @@ std::vector<T> cell_normals(const Mesh<T>& mesh, int dim,
 
   // Find geometry nodes for topology entities
   std::span<const T> x = mesh.geometry().x();
-  std::vector<std::int32_t> geometry_entities
+  const auto [geometry_entities, eshape]
       = entities_to_geometry(mesh, dim, entities, false);
 
-  const std::size_t shape1 = geometry_entities.size() / entities.size();
+  const std::size_t shape1 = eshape[1];
   std::vector<T> n(entities.size() * 3);
   switch (type)
   {
@@ -417,9 +416,9 @@ std::vector<T> compute_midpoints(const Mesh<T>& mesh, int dim,
   std::span<const T> x = mesh.geometry().x();
 
   // Build map from entity -> geometry dof
-  const std::vector<std::int32_t> e_to_g
+  const auto [e_to_g, eshape]
       = entities_to_geometry(mesh, dim, entities, false);
-  std::size_t shape1 = e_to_g.size() / entities.size();
+  std::size_t shape1 = eshape[1];
 
   std::vector<T> x_mid(entities.size() * 3, 0);
   for (std::size_t e = 0; e < entities.size(); ++e)
@@ -676,17 +675,17 @@ std::vector<std::int32_t> locate_entities_boundary(const Mesh<T>& mesh, int dim,
 /// @param[in] permute If `true`, permute the DOFs such that they are
 /// consistent with the orientation of `dim`-dimensional mesh entities.
 /// This requires `create_entity_permutations` to be called first.
-/// @return The geometry DOFs associated with the closure of each entity
-/// in `entities`. The shape is `(num_entities, num_xdofs_per_entity)`
-/// and the storage is row-major. The index `indices[i, j]` is the
-/// position in the geometry array of the `j`-th vertex of the
+/// @return Returns The geometry DOFs associated with the closure of each entity
+/// in `entities` and the shape. The shape is `(num_entities,
+/// num_xdofs_per_entity)` and the storage is row-major. The index `indices[i,
+/// j]` is the position in the geometry array of the `j`-th vertex of the
 /// `entity[i]`.
 ///
 /// @pre The mesh connectivities `dim -> mesh.topology().dim()` and
 /// `mesh.topology().dim() -> dim` must have been computed. Otherwise an
 /// exception is thrown.
 template <std::floating_point T>
-std::vector<std::int32_t>
+std::pair<std::vector<std::int32_t>, std::array<std::size_t, 2>>
 entities_to_geometry(const Mesh<T>& mesh, int dim,
                      std::span<const std::int32_t> entities,
                      bool permute = false)
@@ -710,6 +709,7 @@ entities_to_geometry(const Mesh<T>& mesh, int dim,
   const std::size_t num_entity_dofs = layout.num_entity_closure_dofs(dim);
   std::vector<std::int32_t> entity_xdofs;
   entity_xdofs.reserve(entities.size() * num_entity_dofs);
+  std::array<std::size_t, 2> eshape{entities.size(), num_entity_dofs};
 
   // Get the element's closure DOFs
   const std::vector<std::vector<std::vector<int>>>& closure_dofs_all
@@ -726,7 +726,7 @@ entities_to_geometry(const Mesh<T>& mesh, int dim,
       for (std::int32_t entity_dof : closure_dofs_all[tdim][0])
         entity_xdofs.push_back(x_c[entity_dof]);
     }
-    return entity_xdofs;
+    return {entity_xdofs, eshape};
   }
 
   assert(dim != tdim);
@@ -783,8 +783,7 @@ entities_to_geometry(const Mesh<T>& mesh, int dim,
     for (std::int32_t entity_dof : closure_dofs)
       entity_xdofs.push_back(x_c[entity_dof]);
   }
-
-  return entity_xdofs;
+  return {entity_xdofs, eshape};
 }
 
 /// @brief Create a function that computes destination rank for mesh
@@ -1262,7 +1261,7 @@ create_subgeometry(const Mesh<T>& mesh, int dim,
   // sub-geometry
   const fem::ElementDofLayout layout = geometry.cmap().create_dof_layout();
 
-  std::vector<std::int32_t> x_indices
+  [[maybe_unused]] const auto [x_indices, xshape]
       = entities_to_geometry(mesh, dim, subentity_to_entity, true);
 
   std::vector<std::int32_t> sub_x_dofs = x_indices;

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -482,10 +482,13 @@ void declare_mesh(nb::module_& m, std::string type)
          nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities,
          bool permute)
       {
-        std::vector<std::int32_t> idx = dolfinx::mesh::entities_to_geometry(
-            mesh, dim, std::span(entities.data(), entities.size()), permute);
-        return as_nbarray(std::move(idx),
-                          {entities.size(), idx.size() / entities.size()});
+        std::pair<std::vector<std::int32_t>, std::array<std::size_t, 2>>
+            geom_entities = dolfinx::mesh::entities_to_geometry(
+                mesh, dim, std::span(entities.data(), entities.size()),
+                permute);
+        const auto& idx_shape = geom_entities.second;
+        return as_nbarray(std::move(geom_entities.first),
+                          {idx_shape[0], idx_shape[1]});
       },
       nb::arg("mesh"), nb::arg("dim"), nb::arg("entities"), nb::arg("permute"));
 

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -91,6 +91,19 @@ def submesh_geometry_test(mesh, submesh, entity_map, geom_map, entity_dim):
                 )
 
 
+@pytest.mark.parametrize("cell_type", [_mesh.CellType.triangle, _mesh.CellType.quadrilateral])
+def test_empty_entities_to_geometry(cell_type):
+    """Test entities_to_geometry with empty entity list"""
+    mesh = _mesh.create_unit_square(MPI.COMM_WORLD, 10, 12, cell_type=cell_type)
+
+    mesh.topology.create_connectivity(0, mesh.topology.dim)
+    mesh.topology.create_entity_permutations()
+    e_to_g = entities_to_geometry(mesh, 0, np.array([], dtype=np.int32), True)
+    assert e_to_g.shape == (0, 1)
+    e_to_g = entities_to_geometry(mesh, mesh.topology.dim, np.array([], dtype=np.int32), True)
+    assert e_to_g.shape == (0, _cpp.mesh.cell_num_vertices(cell_type))
+
+
 def mesh_1d(dtype):
     """Create 1D mesh with degenerate cell"""
     mesh1d = create_unit_interval(MPI.COMM_WORLD, 4, dtype=dtype)


### PR DESCRIPTION
The current logic in `entities_to_geometry` (nanobind layer), causes a division by 0/overflow error when one supplies no entities on a process.

This PR rewrites `entities_to_geometry` so that it also returns the shape of the 2D array.

Exposed with using a non-scotch partitioner in ADIOS4DOLFINx: https://github.com/jorgensd/adios4dolfinx/actions/runs/14352168908/job/40234091707