### PR TITLE
Fix finite relative-residual at 0th iteration

### DIFF
--- a/cpp/dolfinx/nls/NewtonSolver.cpp
+++ b/cpp/dolfinx/nls/NewtonSolver.cpp
@@ -148,6 +148,7 @@ std::pair<int, bool> nls::petsc::NewtonSolver::solve(Vec x)
   _iteration = 0;
   _krylov_iterations = 0;
   _residual = -1;
+  _residual0 = 0.0;
 
   if (!_fnF)
   {


### PR DESCRIPTION
For what it's worth, this is my attempt at fixing the issue described [here](https://fenicsproject.discourse.group/t/finite-relative-residuals-for-0th-newton-iteration-in-time-dependent-problem/15214) by @mcjbo 

In legacy-fenics, at the 0th Newton iteration of each timestep, the relative residual was `inf`. This is no-longer the case in dolfinx and it makes a bunch of our use cases extremely tricky to solve as the step sometimes solves in zero iterations (ie. doesn't solve) when it should.

@jorgensd told me the plan was to replace the NewtonSolver altogether but I thought this could be a quick fix in the meantime