### PR TITLE
Use dtype in vtkhdf test

### DIFF
--- a/python/test/unit/io/test_vtkhdf.py
+++ b/python/test/unit/io/test_vtkhdf.py
@@ -136,12 +136,12 @@ def test_read_write_higher_order_mesh(order):
     gmsh.finalize()
 
     ref_volume_form = dolfinx.fem.form(
-        1 * ufl.dx(domain=ref_mesh), form_compiler_options={"scalar_type": mesh.geometry.x.dtype}
+        1 * ufl.dx(domain=ref_mesh), form_compiler_options={"scalar_type": ref_mesh.geometry.x.dtype}
     )
     ref_volume = comm.allreduce(dolfinx.fem.assemble_scalar(ref_volume_form), op=MPI.SUM)
 
     ref_surface_form = dolfinx.fem.form(
-        1 * ufl.ds(domain=ref_mesh), form_compiler_options={"scalar_type": mesh.geometry.x.dtype}
+        1 * ufl.ds(domain=ref_mesh), form_compiler_options={"scalar_type": ref_mesh.geometry.x.dtype}
     )
     ref_surface = comm.allreduce(dolfinx.fem.assemble_scalar(ref_surface_form), op=MPI.SUM)
 
@@ -155,13 +155,13 @@ def test_read_write_higher_order_mesh(order):
 
     # Compare surface and volume metrics
     volume_form = dolfinx.fem.form(
-        1 * ufl.dx(domain=mesh), form_compiler_options={"scalar_type": mesh.geometry.x.dtype}
+        1 * ufl.dx(domain=mesh), form_compiler_options={"scalar_type": ref_mesh.geometry.x.dtype}
     )
     volume = comm.allreduce(dolfinx.fem.assemble_scalar(volume_form), op=MPI.SUM)
     assert np.isclose(ref_volume, volume)
 
     surface_form = dolfinx.fem.form(
-        1 * ufl.ds(domain=mesh), form_compiler_options={"scalar_type": mesh.geometry.x.dtype}
+        1 * ufl.ds(domain=mesh), form_compiler_options={"scalar_type": ref_mesh.geometry.x.dtype}
     )
     surface = comm.allreduce(dolfinx.fem.assemble_scalar(surface_form), op=MPI.SUM)
     assert np.isclose(ref_surface, surface)

--- a/python/test/unit/io/test_vtkhdf.py
+++ b/python/test/unit/io/test_vtkhdf.py
@@ -157,13 +157,13 @@ def test_read_write_higher_order_mesh(order):
 
     # Compare surface and volume metrics
     volume_form = dolfinx.fem.form(
-        1 * ufl.dx(domain=mesh), form_compiler_options={"scalar_type": ref_mesh.geometry.x.dtype}
+        1 * ufl.dx(domain=mesh), form_compiler_options={"scalar_type": mesh.geometry.x.dtype}
     )
     volume = comm.allreduce(dolfinx.fem.assemble_scalar(volume_form), op=MPI.SUM)
     assert np.isclose(ref_volume, volume)
 
     surface_form = dolfinx.fem.form(
-        1 * ufl.ds(domain=mesh), form_compiler_options={"scalar_type": ref_mesh.geometry.x.dtype}
+        1 * ufl.ds(domain=mesh), form_compiler_options={"scalar_type": mesh.geometry.x.dtype}
     )
     surface = comm.allreduce(dolfinx.fem.assemble_scalar(surface_form), op=MPI.SUM)
     assert np.isclose(ref_surface, surface)

--- a/python/test/unit/io/test_vtkhdf.py
+++ b/python/test/unit/io/test_vtkhdf.py
@@ -137,13 +137,13 @@ def test_read_write_higher_order_mesh(order):
 
     ref_volume_form = dolfinx.fem.form(
         1 * ufl.dx(domain=ref_mesh),
-        form_compiler_options={"scalar_type": ref_mesh.geometry.x.dtype},
+        dtype=ref_mesh.geometry.x.dtype,
     )
     ref_volume = comm.allreduce(dolfinx.fem.assemble_scalar(ref_volume_form), op=MPI.SUM)
 
     ref_surface_form = dolfinx.fem.form(
         1 * ufl.ds(domain=ref_mesh),
-        form_compiler_options={"scalar_type": ref_mesh.geometry.x.dtype},
+        dtype=ref_mesh.geometry.x.dtype,
     )
     ref_surface = comm.allreduce(dolfinx.fem.assemble_scalar(ref_surface_form), op=MPI.SUM)
 
@@ -156,14 +156,10 @@ def test_read_write_higher_order_mesh(order):
     mesh = read_mesh(comm, filename)
 
     # Compare surface and volume metrics
-    volume_form = dolfinx.fem.form(
-        1 * ufl.dx(domain=mesh), form_compiler_options={"scalar_type": mesh.geometry.x.dtype}
-    )
+    volume_form = dolfinx.fem.form(1 * ufl.dx(domain=mesh), dtype=mesh.geometry.x.dtype)
     volume = comm.allreduce(dolfinx.fem.assemble_scalar(volume_form), op=MPI.SUM)
     assert np.isclose(ref_volume, volume)
 
-    surface_form = dolfinx.fem.form(
-        1 * ufl.ds(domain=mesh), form_compiler_options={"scalar_type": mesh.geometry.x.dtype}
-    )
+    surface_form = dolfinx.fem.form(1 * ufl.ds(domain=mesh), dtype=mesh.geometry.x.dtype)
     surface = comm.allreduce(dolfinx.fem.assemble_scalar(surface_form), op=MPI.SUM)
     assert np.isclose(ref_surface, surface)

--- a/python/test/unit/io/test_vtkhdf.py
+++ b/python/test/unit/io/test_vtkhdf.py
@@ -135,10 +135,14 @@ def test_read_write_higher_order_mesh(order):
     ref_mesh = dolfinx.io.gmshio.model_to_mesh(gmsh.model, comm, rank).mesh
     gmsh.finalize()
 
-    ref_volume_form = dolfinx.fem.form(1 * ufl.dx(domain=ref_mesh))
+    ref_volume_form = dolfinx.fem.form(
+        1 * ufl.dx(domain=ref_mesh), form_compiler_options={"scalar_type": mesh.geometry.x.dtype}
+    )
     ref_volume = comm.allreduce(dolfinx.fem.assemble_scalar(ref_volume_form), op=MPI.SUM)
 
-    ref_surface_form = dolfinx.fem.form(1 * ufl.ds(domain=ref_mesh))
+    ref_surface_form = dolfinx.fem.form(
+        1 * ufl.ds(domain=ref_mesh), form_compiler_options={"scalar_type": mesh.geometry.x.dtype}
+    )
     ref_surface = comm.allreduce(dolfinx.fem.assemble_scalar(ref_surface_form), op=MPI.SUM)
 
     # Write to file
@@ -150,10 +154,14 @@ def test_read_write_higher_order_mesh(order):
     mesh = read_mesh(comm, filename)
 
     # Compare surface and volume metrics
-    volume_form = dolfinx.fem.form(1 * ufl.dx(domain=mesh))
+    volume_form = dolfinx.fem.form(
+        1 * ufl.dx(domain=mesh), form_compiler_options={"scalar_type": mesh.geometry.x.dtype}
+    )
     volume = comm.allreduce(dolfinx.fem.assemble_scalar(volume_form), op=MPI.SUM)
     assert np.isclose(ref_volume, volume)
 
-    surface_form = dolfinx.fem.form(1 * ufl.ds(domain=mesh))
+    surface_form = dolfinx.fem.form(
+        1 * ufl.ds(domain=mesh), form_compiler_options={"scalar_type": mesh.geometry.x.dtype}
+    )
     surface = comm.allreduce(dolfinx.fem.assemble_scalar(surface_form), op=MPI.SUM)
     assert np.isclose(ref_surface, surface)

--- a/python/test/unit/io/test_vtkhdf.py
+++ b/python/test/unit/io/test_vtkhdf.py
@@ -136,12 +136,14 @@ def test_read_write_higher_order_mesh(order):
     gmsh.finalize()
 
     ref_volume_form = dolfinx.fem.form(
-        1 * ufl.dx(domain=ref_mesh), form_compiler_options={"scalar_type": ref_mesh.geometry.x.dtype}
+        1 * ufl.dx(domain=ref_mesh),
+        form_compiler_options={"scalar_type": ref_mesh.geometry.x.dtype},
     )
     ref_volume = comm.allreduce(dolfinx.fem.assemble_scalar(ref_volume_form), op=MPI.SUM)
 
     ref_surface_form = dolfinx.fem.form(
-        1 * ufl.ds(domain=ref_mesh), form_compiler_options={"scalar_type": ref_mesh.geometry.x.dtype}
+        1 * ufl.ds(domain=ref_mesh),
+        form_compiler_options={"scalar_type": ref_mesh.geometry.x.dtype},
     )
     ref_surface = comm.allreduce(dolfinx.fem.assemble_scalar(ref_surface_form), op=MPI.SUM)
 


### PR DESCRIPTION
Fixing failing Basix CI.

eg in https://github.com/FEniCS/basix/pull/918, CI is failing with DOLFINx main (https://github.com/FEniCS/basix/actions/runs/14664578518/job/41156277652) and pass with this DOLFINx branch (https://github.com/FEniCS/basix/actions/runs/14665033516/job/41158949036).