### PR TITLE
Fix signed version of radix_sort

### DIFF
--- a/cpp/dolfinx/common/sort.h
+++ b/cpp/dolfinx/common/sort.h
@@ -63,41 +63,32 @@ struct __radix_sort
     using I = std::remove_cvref_t<std::invoke_result_t<P, T>>;
     using uI = std::make_unsigned_t<I>;
 
+    // Assert binary structure for bit shift in _proj
+    if constexpr (!std::is_same_v<uI, I>)
+    {
+      static_assert(static_cast<uI>(std::numeric_limits<I>::min())
+                        + static_cast<uI>(std::numeric_limits<I>::max())
+                    == static_cast<uI>(I(-1)));
+      static_assert(std::numeric_limits<uI>::digits
+                    == std::numeric_limits<I>::digits + 1);
+      static_assert(std::bit_cast<uI>(std::numeric_limits<I>::min())
+                    == (uI(1) << (sizeof(I) * 8 - 1)));
+    }
+
     if (range.size() <= 1)
       return;
 
-    // Transforms the projected value to an unsigned int while maintaining
-    // relative order by
-    //    x |-> x + |std::numeric_limits<I>::min()|
-    //        = x -  std::numeric_limits<I>::min()
-    // However, since
-    //    |std::numeric_limits<I>::min()| > |std::numeric_limits<I>::max()|
-    // this needs to be done carefully to avoid an overflow. A solution is the
-    // following:
-    //    x = static_cast<uI>(x) +
-    //    static_cast<uI>(-(std::numeric_limits<I>::min() + 1)) + uI(1);
-    // Given the underlying binary strucutre of integers and the difference
-    // between in unsigned and singed integral being the leading sign bit for
-    // same overall width this can also be expressed as a flip of the most
-    // significant bit in binary representation.
+    // Transforms the projected value to an unsigned int (if signed), while
+    // maintaining relative order by
+    //    x ↦ x + |std::numeric_limits<I>::min()|
     auto _proj = [&](auto&& e) -> uI
     {
-      I projected = proj(e);
+      I projected = proj(std::forward<decltype(e)>(e));
 
       if constexpr (std::is_same_v<uI, I>)
         return projected;
       else
-      {
-        static_assert(static_cast<uI>(std::numeric_limits<I>::min())
-                          + static_cast<uI>(std::numeric_limits<I>::max())
-                      == static_cast<uI>(I(-1)));
-        static_assert(std::numeric_limits<uI>::digits
-                      == std::numeric_limits<I>::digits + 1);
-        static_assert(std::bit_cast<uI>(std::numeric_limits<I>::min())
-                      == (uI(1) << (sizeof(I) * 8 - 1)));
-
         return std::bit_cast<uI>(projected) ^ (uI(1) << (sizeof(I) * 8 - 1));
-      }
     };
 
     uI max_value = _proj(*std::ranges::max_element(range, std::less{}, proj));

--- a/cpp/dolfinx/common/sort.h
+++ b/cpp/dolfinx/common/sort.h
@@ -46,10 +46,11 @@ struct __radix_sort
   /// @tparam BITS The number of bits to sort at a time.
   /// @param[in, out] range The range to sort.
   /// @param[in] P Element projection.
-  template <
-      std::ranges::random_access_range R, typename P = std::identity,
-      std::remove_cvref_t<std::invoke_result_t<P, std::iter_value_t<R>>> BITS
-      = 8>
+  template <std::ranges::random_access_range R, typename P = std::identity,
+            std::make_unsigned_t<std::remove_cvref_t<
+                std::invoke_result_t<P, std::iter_value_t<R>>>>
+                BITS
+            = 8>
     requires std::integral<decltype(BITS)>
   constexpr void operator()(R&& range, P proj = {}) const
   {
@@ -65,13 +66,15 @@ struct __radix_sort
 
     auto _proj = [&](auto&& e) -> uI
     {
-      auto&& projected = proj(e);
+      I projected = proj(e);
 
       if constexpr (std::is_same_v<uI, I>)
         return projected;
-
-      return static_cast<uI>(projected)
-             + std::abs(std::numeric_limits<I>::min());
+      else
+      {
+        return static_cast<uI>(projected)
+               + std::abs(std::numeric_limits<I>::min());
+      }
     };
 
     uI max_value = _proj(*std::ranges::max_element(range, std::less{}, proj));

--- a/cpp/dolfinx/common/sort.h
+++ b/cpp/dolfinx/common/sort.h
@@ -70,14 +70,15 @@ struct __radix_sort
       if constexpr (std::is_same_v<uI, I>)
         return projected;
 
-      return static_cast<uI>(projected) + std::numeric_limits<I>::min();
+      return static_cast<uI>(projected)
+             + std::abs(std::numeric_limits<I>::min());
     };
 
     uI max_value = _proj(*std::ranges::max_element(range, std::less{}, proj));
 
     // Sort N bits at a time
     constexpr uI bucket_size = 1 << BITS;
-    T mask = (T(1) << BITS) - 1;
+    uI mask = (uI(1) << BITS) - 1;
 
     // Compute number of iterations, most significant digit (N bits) of
     // maxvalue
@@ -111,8 +112,8 @@ struct __radix_sort
                        std::next(offset.begin()));
       for (const auto& c : current_perm)
       {
-        I bucket = (_proj(c) & mask) >> mask_offset;
-        I new_pos = offset[bucket + 1] - counter[bucket];
+        uI bucket = (_proj(c) & mask) >> mask_offset;
+        uI new_pos = offset[bucket + 1] - counter[bucket];
         next_perm[new_pos] = c;
         counter[bucket]--;
       }

--- a/cpp/dolfinx/common/sort.h
+++ b/cpp/dolfinx/common/sort.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <algorithm>
+#include <bit>
 #include <cassert>
 #include <concepts>
 #include <cstdint>
@@ -109,6 +110,15 @@ struct __radix_sort
     // Compute number of iterations, most significant digit (N bits) of
     // maxvalue
     I its = 0;
+
+    // optimize for case where all first bits are set - then order will not
+    // depend on it
+    bool all_first_bit = std::ranges::all_of(
+        range, [&](const auto& e)
+        { return proj(e) & (uI(1) << (sizeof(uI) * 8 - 1)); });
+    if (all_first_bit)
+      max_value = max_value & ~(uI(1) << (sizeof(uI) * 8 - 1));
+
     while (max_value)
     {
       max_value >>= BITS;

--- a/cpp/dolfinx/common/sort.h
+++ b/cpp/dolfinx/common/sort.h
@@ -20,6 +20,18 @@
 
 namespace dolfinx
 {
+// namespace impl
+// {
+
+// template <std::integral T> requires std::is_signed_v<T>
+// std::make_unsigned_t<T> _shift_to_unsigned(T a)
+// {
+//   using uT = std::make_unsigned_t<T>;
+//   return static_cast<uT>(a) +
+//   static_cast<uT>(-(std::numeric_limits<T>::min()+1)) + 1;
+// }
+// } // namespace impl
+
 struct __radix_sort
 {
   /// @brief Sort a range with radix sorting algorithm. The bucket size
@@ -72,8 +84,9 @@ struct __radix_sort
         return projected;
       else
       {
+        // return impl::_shift_to_unsigned(projected);
         return static_cast<uI>(projected)
-               + std::abs(std::numeric_limits<I>::min());
+               + static_cast<uI>(-(std::numeric_limits<I>::min() + 1)) + 1;
       }
     };
 

--- a/cpp/dolfinx/common/sort.h
+++ b/cpp/dolfinx/common/sort.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Igor Baratta
+// Copyright (C) 2021-2025 Igor Baratta and Paul T. Kühner
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -58,14 +58,25 @@ struct __radix_sort
 
     // index type (if no projection is provided it holds I == T)
     using I = std::remove_cvref_t<std::invoke_result_t<P, T>>;
+    using uI = std::make_unsigned_t<I>;
 
     if (range.size() <= 1)
       return;
 
-    T max_value = proj(*std::ranges::max_element(range, std::less{}, proj));
+    auto _proj = [&](auto&& e) -> uI
+    {
+      auto&& projected = proj(e);
+
+      if constexpr (std::is_same_v<uI, I>)
+        return projected;
+
+      return static_cast<uI>(projected - std::numeric_limits<I>::min());
+    };
+
+    uI max_value = _proj(*std::ranges::max_element(range, std::less{}, proj));
 
     // Sort N bits at a time
-    constexpr I bucket_size = 1 << BITS;
+    constexpr uI bucket_size = 1 << BITS;
     T mask = (T(1) << BITS) - 1;
 
     // Compute number of iterations, most significant digit (N bits) of
@@ -81,7 +92,7 @@ struct __radix_sort
     std::array<I, bucket_size> counter;
     std::array<I, bucket_size + 1> offset;
 
-    I mask_offset = 0;
+    uI mask_offset = 0;
     std::vector<T> buffer(range.size());
     std::span<T> current_perm = range;
     std::span<T> next_perm = buffer;
@@ -92,7 +103,7 @@ struct __radix_sort
 
       // Count number of elements per bucket
       for (const auto& c : current_perm)
-        counter[(proj(c) & mask) >> mask_offset]++;
+        counter[(_proj(c) & mask) >> mask_offset]++;
 
       // Prefix sum to get the inserting position
       offset[0] = 0;
@@ -100,7 +111,7 @@ struct __radix_sort
                        std::next(offset.begin()));
       for (const auto& c : current_perm)
       {
-        I bucket = (proj(c) & mask) >> mask_offset;
+        I bucket = (_proj(c) & mask) >> mask_offset;
         I new_pos = offset[bucket + 1] - counter[bucket];
         next_perm[new_pos] = c;
         counter[bucket]--;

--- a/cpp/dolfinx/common/sort.h
+++ b/cpp/dolfinx/common/sort.h
@@ -70,7 +70,7 @@ struct __radix_sort
       if constexpr (std::is_same_v<uI, I>)
         return projected;
 
-      return static_cast<uI>(projected - std::numeric_limits<I>::min());
+      return static_cast<uI>(projected) + std::numeric_limits<I>::min();
     };
 
     uI max_value = _proj(*std::ranges::max_element(range, std::less{}, proj));

--- a/cpp/test/common/sort.cpp
+++ b/cpp/test/common/sort.cpp
@@ -118,6 +118,6 @@ TEST_CASE("bug")
   {
     auto P = [&cells](auto index) { return cells[index]; };
     dolfinx::radix_sort(perm, P);
-    REQUIRE(std::ranges::is_sorted(cells, std::less{}, P));
+    REQUIRE(std::ranges::is_sorted(perm, std::less{}, P));
   }
 }

--- a/cpp/test/common/sort.cpp
+++ b/cpp/test/common/sort.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Igor A. Baratta
+// Copyright (C) 2021-2025 Igor A. Baratta and Paul T. Kühner
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -6,11 +6,14 @@
 
 #include <algorithm>
 #include <array>
+#include <bitset>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <cstdint>
 #include <dolfinx/common/sort.h>
 #include <functional>
+#include <iostream>
 #include <numeric>
 #include <random>
 #include <vector>
@@ -99,5 +102,22 @@ TEST_CASE("Test argsort bitset")
     REQUIRE(std::equal(arr.data() + shape1 * perm[i],
                        arr.data() + shape1 * perm[i] + shape1,
                        arr.data() + shape1 * index[i]));
+  }
+}
+
+TEST_CASE("bug")
+{
+  std::vector<std::int32_t> cells = {-1, 2, -3};
+  std::vector<std::int32_t> perm = {0, 1, 2};
+
+  {
+    dolfinx::radix_sort(cells);
+    REQUIRE(std::ranges::is_sorted(cells));
+  }
+
+  {
+    auto P = [&cells](auto index) { return cells[index]; };
+    dolfinx::radix_sort(perm, P);
+    REQUIRE(std::ranges::is_sorted(cells, std::less{}, P));
   }
 }

--- a/cpp/test/common/sort.cpp
+++ b/cpp/test/common/sort.cpp
@@ -14,6 +14,7 @@
 #include <dolfinx/common/sort.h>
 #include <functional>
 #include <iostream>
+#include <limits>
 #include <numeric>
 #include <random>
 #include <type_traits>
@@ -38,6 +39,19 @@ TEMPLATE_TEST_CASE("Test radix sort", "[vector][template]", std::int16_t,
 
   // Check if vector is sorted
   REQUIRE(std::ranges::is_sorted(vec));
+}
+
+TEMPLATE_TEST_CASE("Test radix sort (limits)", "[vector][template]",
+                   std::int16_t, std::int32_t, std::int64_t, std::uint16_t,
+                   std::uint32_t, std::uint64_t)
+{
+  std::vector<TestType> vec{0, std::numeric_limits<TestType>::max(),
+                            std::numeric_limits<TestType>::min()};
+  dolfinx::radix_sort(vec);
+  REQUIRE(std::ranges::is_sorted(vec));
+  REQUIRE(std::ranges::equal(
+      vec, std::vector<TestType>{std::numeric_limits<TestType>::min(), 0,
+                                 std::numeric_limits<TestType>::max()}));
 }
 
 TEMPLATE_TEST_CASE("Test radix sort (projection)", "[radix]", std::int16_t,

--- a/cpp/test/common/sort.cpp
+++ b/cpp/test/common/sort.cpp
@@ -19,14 +19,14 @@
 #include <vector>
 
 TEMPLATE_TEST_CASE("Test radix sort", "[vector][template]", std::int32_t,
-                   std::int64_t)
+                   std::int64_t, std::uint32_t, std::uint64_t)
 {
   auto vec_size = GENERATE(100, 1000, 10000);
   std::vector<TestType> vec;
   vec.reserve(vec_size);
 
   // Generate a vector of ints with a Uniform Int distribution
-  std::uniform_int_distribution<TestType> distribution(0, 10000);
+  std::uniform_int_distribution<TestType> distribution(-10000, 10000);
   std::mt19937 engine;
   auto generator = std::bind(distribution, engine);
   std::generate_n(std::back_inserter(vec), vec_size, generator);


### PR DESCRIPTION
Fixes bug in `radix_sort`, reported by @jorgensd,  for signed integers where bitwise comparison failed and resulted in either infinite loops or unsorted result.

Fixes it by radix sort only working on unsigned ints internally and inputs with signed getting shifted to corresponding unsigned int ranges.