### PR TITLE
Fix oneapi CI

### DIFF
--- a/.github/workflows/oneapi.yml
+++ b/.github/workflows/oneapi.yml
@@ -27,6 +27,7 @@ jobs:
       I_MPI_OFI_LIBRARY_INTERNAL: 0
       OMP_NUM_THREADS: 1
       OPENBLAS_NUM_THREADS: 1
+      KMP_DUPLICATE_LIB_OK: 1 # Silences error on multiple openMP installs found
 
     name: oneAPI build and test
 


### PR DESCRIPTION
The presence of both `llvm-openmp` and `intel-openmp` causes an error in the intel CI - warning for possible performance implications.

We can not avoid this presence of both: `llvm-openmp` will be pulled in in by the `llvm` tooling which `numba` builds on and `intel-openmp` is what we would like to use for testing here.

Deactivates the warning by setting `KMP_DUPLICATE_LIB_OK`.