### PR TITLE
Expose `Scatterer` in Python layer

### DIFF
--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -50,24 +50,28 @@ consteval bool has_petsc4py()
 template <typename T>
 void add_scatter_functions(nb::class_<dolfinx::common::Scatterer<>>& sc)
 {
-  sc.def("scatter_fwd",
-         [](dolfinx::common::Scatterer<>& self,
-            nb::ndarray<const T, nb::ndim<1>, nb::c_contig> local_data,
-            nb::ndarray<T, nb::ndim<1>, nb::c_contig> remote_data)
-         {
-           self.scatter_fwd(std::span(local_data.data(), local_data.size()),
-                            std::span(remote_data.data(), remote_data.size()));
-         });
+  sc.def(
+      "scatter_fwd",
+      [](dolfinx::common::Scatterer<>& self,
+         nb::ndarray<const T, nb::ndim<1>, nb::c_contig> local_data,
+         nb::ndarray<T, nb::ndim<1>, nb::c_contig> remote_data)
+      {
+        self.scatter_fwd(std::span(local_data.data(), local_data.size()),
+                         std::span(remote_data.data(), remote_data.size()));
+      },
+      nb::arg("local_data"), nb::arg("remote_data"));
 
-  sc.def("scatter_rev",
-         [](dolfinx::common::Scatterer<>& self,
-            nb::ndarray<T, nb::ndim<1>, nb::c_contig> local_data,
-            nb::ndarray<const T, nb::ndim<1>, nb::c_contig> remote_data)
-         {
-           self.scatter_rev(std::span(local_data.data(), local_data.size()),
-                            std::span(remote_data.data(), remote_data.size()),
-                            std::plus<T>());
-         });
+  sc.def(
+      "scatter_rev",
+      [](dolfinx::common::Scatterer<>& self,
+         nb::ndarray<T, nb::ndim<1>, nb::c_contig> local_data,
+         nb::ndarray<const T, nb::ndim<1>, nb::c_contig> remote_data)
+      {
+        self.scatter_rev(std::span(local_data.data(), local_data.size()),
+                         std::span(remote_data.data(), remote_data.size()),
+                         std::plus<T>());
+      },
+      nb::arg("local_data"), nb::arg("remote_data"));
 }
 
 // Interface for dolfinx/common
@@ -93,7 +97,8 @@ void common(nb::module_& m)
       .value("average", dolfinx::Table::Reduction::average);
 
   auto sc = nb::class_<dolfinx::common::Scatterer<>>(m, "Scatterer")
-                .def(nb::init<dolfinx::common::IndexMap&, int>());
+                .def(nb::init<dolfinx::common::IndexMap&, int>(),
+                     nb::arg("index_map"), nb::arg("block_size"));
   add_scatter_functions<std::int64_t>(sc);
   add_scatter_functions<double>(sc);
   add_scatter_functions<float>(sc);

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -69,6 +69,20 @@ void common(nb::module_& m)
       .value("min", dolfinx::Table::Reduction::min)
       .value("average", dolfinx::Table::Reduction::average);
 
+  nb::class_<dolfinx::common::Scatterer<>>(m, "Scatterer")
+      .def("__init__",
+           [](dolfinx::common::Scatterer<>* self, dolfinx::common::IndexMap& im,
+              int bs) { new (self) dolfinx::common::Scatterer<>(im, bs); })
+      .def(
+          "scatter_fwd",
+          [](dolfinx::common::Scatterer<>& self,
+             nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig> data_in,
+             nb::ndarray<std::int64_t, nb::ndim<1>, nb::c_contig> data_out)
+          {
+            self.scatter_fwd(std::span(data_in.data(), data_in.size()),
+                             std::span(data_out.data(), data_out.size()));
+          });
+
   // dolfinx::common::IndexMap
   nb::class_<dolfinx::common::IndexMap>(m, "IndexMap")
       .def(
@@ -113,8 +127,10 @@ void common(nb::module_& m)
           nb::arg("comm"), nb::arg("local_size"), nb::arg("dest_src"),
           nb::arg("ghosts"), nb::arg("ghost_owners"))
       .def_prop_ro(
-          "comm", [](const dolfinx::common::IndexMap& self)
-          { return MPICommWrapper(self.comm()); }, nb::keep_alive<0, 1>())
+          "comm",
+          [](const dolfinx::common::IndexMap& self)
+          { return MPICommWrapper(self.comm()); },
+          nb::keep_alive<0, 1>())
       .def_prop_ro("size_local", &dolfinx::common::IndexMap::size_local)
       .def_prop_ro("size_global", &dolfinx::common::IndexMap::size_global)
       .def_prop_ro("num_ghosts", &dolfinx::common::IndexMap::num_ghosts)

--- a/python/test/unit/common/test_scatterer.py
+++ b/python/test/unit/common/test_scatterer.py
@@ -1,0 +1,57 @@
+from mpi4py import MPI
+
+import numpy as np
+import pytest
+
+import dolfinx
+from dolfinx import cpp as _cpp
+
+
+@pytest.mark.parametrize("dtype", [np.int64, np.float64, np.float32])
+def test_scatter_forward(dtype):
+    """Test forward and reverse scatter."""
+    comm = MPI.COMM_WORLD
+
+    # Create an index map with shared entries across all processes
+    local_size = 50
+    dest = np.delete(np.arange(0, comm.size, dtype=np.int32), comm.rank)
+    map_ghosts = np.array(
+        [local_size * dest[r] + r % local_size for r in range(len(dest))], dtype=np.int64
+    )
+    src = dest
+    map = dolfinx.common.IndexMap(comm, local_size, [dest, src], map_ghosts, src)
+    assert map.size_global == local_size * comm.size
+
+    sc = _cpp.common.Scatterer(map, 1)
+    v = np.zeros((map.size_local + map.num_ghosts), dtype=dtype)
+
+    # Fill local part with rank of this process and scatter
+    v[: map.size_local] = comm.rank
+    assert np.all(v[map.size_local :] == 0)
+    sc.scatter_fwd(v, v[map.size_local :])
+    # Received values should match the owners in the index map
+    assert np.all(v[map.size_local :] == map.owners)
+
+
+@pytest.mark.parametrize("dtype", [np.int64])
+def test_scatter_reverse(dtype):
+    """Test forward and reverse scatter."""
+    comm = MPI.COMM_WORLD
+
+    # Create an index map sharing first entry with other processes
+    local_size = 50
+    dest = np.delete(np.arange(0, comm.size, dtype=np.int32), comm.rank)
+    map_ghosts = np.array(
+        [local_size * dest[r] for r in range(len(dest))], dtype=np.int64
+    )
+    src = dest
+    map = dolfinx.common.IndexMap(comm, local_size, [dest, src], map_ghosts, src)
+    assert map.size_global == local_size * comm.size
+
+    # Fill ghost part with ones and reverse scatter
+    sc = _cpp.common.Scatterer(map, 1)
+    v = np.zeros((local_size + map.num_ghosts), dtype=dtype)
+    v[local_size:] = 1
+
+    sc.scatter_rev(v, v[local_size:])
+    assert sum(v[:local_size]) == comm.size - 1


### PR DESCRIPTION
Exposes the `common::Scatterer` class which updates data that is described by an `IndexMap` in parallel.

* Adds a simple test
