### PR TITLE
Refactor gmshio to use correct naming of subentities

### DIFF
--- a/python/demo/demo_axis.py
+++ b/python/demo/demo_axis.py
@@ -590,6 +590,7 @@ gcs = np.pi * radius_sph**2
 # Marker functions for the scattering efficiency integral
 marker = fem.Function(D)
 scatt_facets = mesh_data.facet_tags.find(scatt_tag)
+mesh_data.mesh.topology.create_connectivity(tdim - 1, tdim)
 incident_cells = mesh.compute_incident_entities(
     mesh_data.mesh.topology, scatt_facets, tdim - 1, tdim
 )

--- a/python/demo/demo_axis.py
+++ b/python/demo/demo_axis.py
@@ -590,7 +590,6 @@ gcs = np.pi * radius_sph**2
 # Marker functions for the scattering efficiency integral
 marker = fem.Function(D)
 scatt_facets = mesh_data.facet_tags.find(scatt_tag)
-mesh_data.mesh.topology.create_connectivity(tdim - 1, tdim)
 incident_cells = mesh.compute_incident_entities(
     mesh_data.mesh.topology, scatt_facets, tdim - 1, tdim
 )

--- a/python/demo/demo_gmsh.py
+++ b/python/demo/demo_gmsh.py
@@ -36,7 +36,8 @@ except ImportError:
 
 # +
 def gmsh_sphere(model: gmsh.model, name: str) -> gmsh.model:
-    """Create a Gmsh model of a sphere.
+    """Create a Gmsh model of a sphere and tag sub entitites
+    from all co-dimensions (peaks, ridges, facets and cells).
 
     Args:
         model: Gmsh model to add the mesh to.
@@ -53,9 +54,15 @@ def gmsh_sphere(model: gmsh.model, name: str) -> gmsh.model:
     # Synchronize OpenCascade representation with gmsh model
     model.occ.synchronize()
 
-    # Add physical marker for cells. It is important to call this
-    # function after OpenCascade synchronization
-    model.add_physical_group(dim=3, tags=[sphere])
+    # Add physical tag for sphere
+    model.add_physical_group(dim=3, tags=[sphere], tag=1)
+
+    # Embed all sub-entities from the GMSH model into the sphere and tag them
+    for dim in [0, 1, 2]:
+        entities = model.getEntities(dim)
+        entity_ids = [entity[1] for entity in entities]
+        model.mesh.embed(dim, entity_ids, 3, sphere)
+        model.add_physical_group(dim=dim, tags=entity_ids, tag=dim)
 
     # Generate the mesh
     model.mesh.generate(dim=3)
@@ -168,9 +175,9 @@ def create_mesh(comm: MPI.Comm, model: gmsh.model, name: str, filename: str, mod
     if mesh_data.facet_tags is not None:
         mesh_data.facet_tags.name = f"{name}_facets"
     if mesh_data.ridge_tags is not None:
-        mesh_data.ridge_tags.name = f"{name}_edges"
+        mesh_data.ridge_tags.name = f"{name}_ridges"
     if mesh_data.peak_tags is not None:
-        mesh_data.peak_tags.name = f"{name}_vertices"
+        mesh_data.peak_tags.name = f"{name}_peaks"
     with XDMFFile(mesh_data.mesh.comm, filename, mode) as file:
         mesh_data.mesh.topology.create_connectivity(2, 3)
         mesh_data.mesh.topology.create_connectivity(1, 3)

--- a/python/demo/demo_gmsh.py
+++ b/python/demo/demo_gmsh.py
@@ -167,10 +167,10 @@ def create_mesh(comm: MPI.Comm, model: gmsh.model, name: str, filename: str, mod
         mesh_data.cell_tags.name = f"{name}_cells"
     if mesh_data.facet_tags is not None:
         mesh_data.facet_tags.name = f"{name}_facets"
-    if mesh_data.edge_tags is not None:
-        mesh_data.edge_tags.name = f"{name}_edges"
-    if mesh_data.vertex_tags is not None:
-        mesh_data.vertex_tags.name = f"{name}_vertices"
+    if mesh_data.ridge_tags is not None:
+        mesh_data.ridge_tags.name = f"{name}_edges"
+    if mesh_data.peak_tags is not None:
+        mesh_data.peak_tags.name = f"{name}_vertices"
     with XDMFFile(mesh_data.mesh.comm, filename, mode) as file:
         mesh_data.mesh.topology.create_connectivity(2, 3)
         mesh_data.mesh.topology.create_connectivity(1, 3)
@@ -188,15 +188,15 @@ def create_mesh(comm: MPI.Comm, model: gmsh.model, name: str, filename: str, mod
                 mesh_data.mesh.geometry,
                 geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
             )
-        if mesh_data.edge_tags is not None:
+        if mesh_data.ridge_tags is not None:
             file.write_meshtags(
-                mesh_data.edge_tags,
+                mesh_data.ridge_tags,
                 mesh_data.mesh.geometry,
                 geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
             )
-        if mesh_data.vertex_tags is not None:
+        if mesh_data.peak_tags is not None:
             file.write_meshtags(
-                mesh_data.vertex_tags,
+                mesh_data.peak_tags,
                 mesh_data.mesh.geometry,
                 geometry_xpath=f"/Xdmf/Domain/Grid[@Name='{name}']/Geometry",
             )

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -366,7 +366,7 @@ def model_to_mesh(
         local_entities, local_values = distribute_entity_data(
             mesh, tdim - codim, marked_entities, entity_values
         )
-        mesh.topology.create_connectivity(tdim - codim, 0)
+        mesh.topology.create_connectivity(tdim - codim, tdim)
         adj = adjacencylist(local_entities)
         et = meshtags_from_entities(
             mesh, tdim - codim, adj, local_values.astype(np.int32, copy=False)

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -344,7 +344,7 @@ def model_to_mesh(
     mesh = create_mesh(comm, cells, x[:, :gdim].astype(dtype, copy=False), ufl_domain, partitioner)
 
     codim_to_name = {0: "cell", 1: "facet", 2: "ridge", 3: "peak"}
-    dolfinx_meshtags: dict[str, MeshTags] = {}
+    dolfinx_meshtags: dict[str, typing.Optional[MeshTags]] = {}
     # Create MeshTags for facets
     topology = mesh.topology
     tdim = topology.dim

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -351,10 +351,8 @@ def model_to_mesh(
     for codim in [0, 1, 2, 3]:
         key = f"{codim_to_name[codim]}_tags"
         if (
-            (codim == 1
-            and topology.cell_type == CellType.prism)
-            or topology.cell_type == CellType.pyramid
-        ):
+            codim == 1 and topology.cell_type == CellType.prism
+        ) or topology.cell_type == CellType.pyramid:
             raise RuntimeError(f"Unsupported facet tag for type {topology.cell_type}")
 
         meshtag_data = meshtags.get(codim, None)

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -185,7 +185,7 @@ def extract_topology_and_markers(
             # i.e. facets of prisms and pyramid meshes are not supported
             (entity_types, entity_tags, entity_topologies) = model.mesh.getElements(dim, tag=entity)
 
-            if len(entity_types) == 2:
+            if len(entity_types) > 1:
                 raise RuntimeError(
                     f"Unsupported mesh with multiple cell types {entity_types} for entity {entity}"
                 )

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -318,7 +318,7 @@ def model_to_mesh(
         physical_groups = comm.bcast(None, root=rank)
 
     # Check for facet, edge and vertex data and broadcast relevant info if True
-    meshtags: dict[int, tuple[bool, npt.NDArray[np.int32], npt.NDArray[np.int32]]] = {}
+    meshtags: dict[int, tuple[npt.NDArray[np.int32], npt.NDArray[np.int32]]] = {}
     for codim in [0, 1, 2, 3]:
         # Check if we have any tagged entities on root process and distribute
         if comm.bcast(tdim - codim in cell_dimensions, root=rank):
@@ -344,7 +344,7 @@ def model_to_mesh(
     mesh = create_mesh(comm, cells, x[:, :gdim].astype(dtype, copy=False), ufl_domain, partitioner)
 
     codim_to_name = {0: "cell", 1: "facet", 2: "ridge", 3: "peak"}
-    dolfinx_meshtags: dict[int, MeshTags] = {}
+    dolfinx_meshtags: dict[str, MeshTags] = {}
     # Create MeshTags for facets
     topology = mesh.topology
     tdim = topology.dim
@@ -374,7 +374,7 @@ def model_to_mesh(
         et.name = key
         dolfinx_meshtags[key] = et
 
-    return MeshData(mesh, **dolfinx_meshtags, physical_groups=physical_groups)
+    return MeshData(mesh, physical_groups=physical_groups, **dolfinx_meshtags)
 
 
 def read_from_msh(

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -184,7 +184,13 @@ def extract_topology_and_markers(
             # one cell-type,
             # i.e. facets of prisms and pyramid meshes are not supported
             (entity_types, entity_tags, entity_topologies) = model.mesh.getElements(dim, tag=entity)
-            assert len(entity_types) == 1
+
+            if len(entity_types) == 2:
+                raise RuntimeError(
+                    f"Unsupported mesh with multiple cell types {entity_types} for entity {entity}"
+                )
+            elif len(entity_types) == 0:
+                continue
 
             # Determine number of local nodes per element to create the
             # topology of the elements

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -79,8 +79,8 @@ class MeshData(typing.NamedTuple):
         mesh: Mesh.
         cell_tags: MeshTags for cells.
         facet_tags: MeshTags for facets (codim 1).
-        ridge_tags: MeshTags for edges (codim 2).
-        peak_tags: MeshTags for vertices (codim 3).
+        ridge_tags: MeshTags for ridges (codim 2).
+        peak_tags: MeshTags for peaks (codim 3).
         physical_groups: Physical groups in the mesh, where the key
             is the physical name and the value is a tuple with the
             dimension and tag.


### PR DESCRIPTION
- Simplifies the data-structures within `model_to_mesh`.
- All tagged groups are treated in the same way, looping through all sub-entities
- Correct name for codimensional entities (peak, ridge, edge, facet, cell).
- Add various documentation