### PR TITLE
Downgrade SLEPc

### DIFF
--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -23,7 +23,7 @@ ARG KAHIP_VERSION=3.18
 # https://numba.readthedocs.io/en/stable/user/installing.html#version-support-information
 ARG NUMPY_VERSION=2.1.3
 ARG PETSC_VERSION=3.23.2
-ARG SLEPC_VERSION=3.23.2
+ARG SLEPC_VERSION=3.23.1
 ARG SPDLOG_VERSION=1.15.1
 
 ARG MPICH_VERSION=4.2.3


### PR DESCRIPTION
Apparently, SLEPc does not sync with PETSc for every patch, see https://gitlab.com/slepc/slepc/-/issues/93#note_2528067046. Downgrading. 