### PR TITLE
Fix python compilation against adios2 2.10.2

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.21)
 
-project(dolfinx_nanobind LANGUAGES CXX)
+project(dolfinx_nanobind LANGUAGES C CXX)
 
 if(WIN32)
   # Windows requires all symbols to be manually exported. This flag exports all


### PR DESCRIPTION
Refer to:

https://github.com/TESSEorg/ttg/issues/86
https://github.com/FEniCS/dolfinx/pull/3734

to build on current debian testing (trixie), which is on adios2 2.10.2