### PR TITLE
Remove `typing.Optional`

### DIFF
--- a/python/dolfinx/common.py
+++ b/python/dolfinx/common.py
@@ -117,7 +117,7 @@ class Timer:
 
     _cpp_object: _cpp.common.Timer
 
-    def __init__(self, name: typing.Optional[str] = None):
+    def __init__(self, name: str | None = None):
         """Create timer.
 
         Args:

--- a/python/dolfinx/common.py
+++ b/python/dolfinx/common.py
@@ -7,7 +7,6 @@
 
 import datetime
 import functools
-import typing
 
 from dolfinx import cpp as _cpp
 from dolfinx.cpp.common import (

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -110,7 +110,7 @@ def create_vector(L: Form) -> la.Vector:
     return la.vector(dofmap.index_map, dofmap.index_map_bs, dtype=L.dtype)
 
 
-def create_matrix(a: Form, block_mode: typing.Optional[la.BlockMode] = None) -> la.MatrixCSR:
+def create_matrix(a: Form, block_mode: la.BlockMode | None = None) -> la.MatrixCSR:
     """Create a sparse matrix that is compatible with a given bilinear
     form.
 
@@ -133,7 +133,7 @@ def create_matrix(a: Form, block_mode: typing.Optional[la.BlockMode] = None) -> 
 # -- Scalar assembly ------------------------------------------------------
 
 
-def assemble_scalar(M: Form, constants: typing.Optional[np.ndarray] = None, coeffs=None):
+def assemble_scalar(M: Form, constants: np.ndarray | None = None, coeffs=None):
     """Assemble functional. The returned value is local and not
     accumulated across processes.
 
@@ -164,14 +164,12 @@ def assemble_scalar(M: Form, constants: typing.Optional[np.ndarray] = None, coef
 
 
 @functools.singledispatch
-def assemble_vector(L: typing.Any, constants: typing.Optional[np.ndarray] = None, coeffs=None):
+def assemble_vector(L: typing.Any, constants: np.ndarray | None = None, coeffs=None):
     return _assemble_vector_form(L, constants, coeffs)
 
 
 @assemble_vector.register(Form)
-def _assemble_vector_form(
-    L: Form, constants: typing.Optional[np.ndarray] = None, coeffs=None
-) -> la.Vector:
+def _assemble_vector_form(L: Form, constants: np.ndarray | None = None, coeffs=None) -> la.Vector:
     """Assemble linear form into a new Vector.
 
     Args:
@@ -205,7 +203,7 @@ def _assemble_vector_form(
 
 @assemble_vector.register(np.ndarray)
 def _assemble_vector_array(
-    b: np.ndarray, L: Form, constants: typing.Optional[np.ndarray] = None, coeffs=None
+    b: np.ndarray, L: Form, constants: np.ndarray | None = None, coeffs=None
 ):
     """Assemble linear form into an existing array.
 
@@ -241,11 +239,11 @@ def _assemble_vector_array(
 @functools.singledispatch
 def assemble_matrix(
     a: typing.Any,
-    bcs: typing.Optional[list[DirichletBC]] = None,
+    bcs: list[DirichletBC] | None = None,
     diagonal: float = 1.0,
-    constants: typing.Optional[np.ndarray] = None,
+    constants: np.ndarray | None = None,
     coeffs=None,
-    block_mode: typing.Optional[la.BlockMode] = None,
+    block_mode: la.BlockMode | None = None,
 ):
     """Assemble bilinear form into a matrix.
 
@@ -282,9 +280,9 @@ def assemble_matrix(
 def _assemble_matrix_csr(
     A: la.MatrixCSR,
     a: Form,
-    bcs: typing.Optional[list[DirichletBC]] = None,
+    bcs: list[DirichletBC] | None = None,
     diagonal: float = 1.0,
-    constants: typing.Optional[np.ndarray] = None,
+    constants: np.ndarray | None = None,
     coeffs=None,
 ) -> la.MatrixCSR:
     """Assemble bilinear form into a matrix.
@@ -329,9 +327,9 @@ def apply_lifting(
     b: np.ndarray,
     a: Iterable[Form],
     bcs: Iterable[Iterable[DirichletBC]],
-    x0: typing.Optional[Iterable[np.ndarray]] = None,
+    x0: Iterable[np.ndarray] | None = None,
     alpha: float = 1,
-    constants: typing.Optional[Iterable[np.ndarray]] = None,
+    constants: Iterable[np.ndarray] | None = None,
     coeffs=None,
 ) -> None:
     """Modify right-hand side vector ``b`` for lifting of Dirichlet
@@ -447,7 +445,7 @@ def apply_lifting(
 def set_bc(
     b: np.ndarray,
     bcs: list[DirichletBC],
-    x0: typing.Optional[np.ndarray] = None,
+    x0: np.ndarray | None = None,
     scale: float = 1,
 ) -> None:
     """Insert boundary condition values into vector.

--- a/python/dolfinx/fem/bcs.py
+++ b/python/dolfinx/fem/bcs.py
@@ -134,7 +134,7 @@ class DirichletBC:
         return self._cpp_object.function_space
 
     def set(
-        self, x: npt.NDArray, x0: typing.Optional[npt.NDArray[np.int32]] = None, alpha: float = 1
+        self, x: npt.NDArray, x0: npt.NDArray[np.int32] | None = None, alpha: float = 1
     ) -> None:
         """Set entries in an array that are constrained by Dirichlet
         boundary conditions.
@@ -180,7 +180,7 @@ class DirichletBC:
 def dirichletbc(
     value: typing.Union[Function, Constant, np.ndarray],
     dofs: npt.NDArray[np.int32],
-    V: typing.Optional[dolfinx.fem.FunctionSpace] = None,
+    V: dolfinx.fem.FunctionSpace | None = None,
 ) -> DirichletBC:
     """Create a representation of Dirichlet boundary condition which
     is imposed on a linear system.

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -37,7 +37,7 @@ class Form:
         _cpp.fem.Form_float32,
         _cpp.fem.Form_float64,
     ]
-    _code: typing.Optional[typing.Union[str, list[str]]]
+    _code: typing.Union[str, list[str]] | None
 
     def __init__(
         self,
@@ -48,8 +48,8 @@ class Form:
             _cpp.fem.Form_float64,
         ],
         ufcx_form=None,
-        code: typing.Optional[typing.Union[str, list[str]]] = None,
-        module: typing.Optional[typing.Union[types.ModuleType, list[types.ModuleType]]] = None,
+        code: typing.Union[str, list[str]] | None = None,
+        module: typing.Union[types.ModuleType, list[types.ModuleType]] | None = None,
     ):
         """A finite element form.
 
@@ -112,7 +112,7 @@ class Form:
 
 def get_integration_domains(
     integral_type: IntegralType,
-    subdomain: typing.Optional[typing.Union[MeshTags, list[tuple[int, np.ndarray]]]],
+    subdomain: typing.Union[MeshTags, list[tuple[int, np.ndarray]]] | None,
     subdomain_ids: list[int],
 ) -> list[tuple[int, np.ndarray]]:
     """Get integration domains from subdomain data.
@@ -201,9 +201,9 @@ _ufl_to_dolfinx_domain = {
 def mixed_topology_form(
     forms: typing.Iterable[ufl.Form],
     dtype: npt.DTypeLike = default_scalar_type,
-    form_compiler_options: typing.Optional[dict] = None,
-    jit_options: typing.Optional[dict] = None,
-    entity_maps: typing.Optional[dict[Mesh, np.typing.NDArray[np.int32]]] = None,
+    form_compiler_options: dict | None = None,
+    jit_options: dict | None = None,
+    entity_maps: dict[Mesh, np.typing.NDArray[np.int32]] | None = None,
 ):
     """
     Create a mixed-topology from from an array of Forms.
@@ -282,9 +282,9 @@ def mixed_topology_form(
 def form(
     form: typing.Union[ufl.Form, typing.Iterable[ufl.Form]],
     dtype: npt.DTypeLike = default_scalar_type,
-    form_compiler_options: typing.Optional[dict] = None,
-    jit_options: typing.Optional[dict] = None,
-    entity_maps: typing.Optional[dict[Mesh, np.typing.NDArray[np.int32]]] = None,
+    form_compiler_options: dict | None = None,
+    jit_options: dict | None = None,
+    entity_maps: dict[Mesh, np.typing.NDArray[np.int32]] | None = None,
 ):
     """Create a Form or list of Forms.
 
@@ -516,8 +516,8 @@ class CompiledForm:
 def compile_form(
     comm: MPI.Intracomm,
     form: ufl.Form,
-    form_compiler_options: typing.Optional[dict] = {"scalar_type": default_scalar_type},
-    jit_options: typing.Optional[dict] = None,
+    form_compiler_options: dict | None = {"scalar_type": default_scalar_type},
+    jit_options: dict | None = None,
 ) -> CompiledForm:
     """Compile UFL form without associated DOLFINx data.
 
@@ -649,7 +649,7 @@ def create_form(
 def derivative_block(
     F: typing.Union[ufl.Form, typing.Sequence[ufl.Form]],
     u: typing.Union[Function, typing.Sequence[Function]],
-    du: typing.Optional[typing.Union[ufl.Argument, typing.Sequence[ufl.Argument]]] = None,
+    du: typing.Union[ufl.Argument, typing.Sequence[ufl.Argument]] | None = None,
 ) -> typing.Union[ufl.Form, typing.Iterable[typing.Iterable[ufl.Form]]]:
     """Return the UFL derivative of a (list of) UFL rank one form(s).
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -92,10 +92,10 @@ class Expression:
         self,
         e: ufl.core.expr.Expr,
         X: np.ndarray,
-        comm: typing.Optional[_MPI.Comm] = None,
-        form_compiler_options: typing.Optional[dict] = None,
-        jit_options: typing.Optional[dict] = None,
-        dtype: typing.Optional[npt.DTypeLike] = None,
+        comm: _MPI.Comm | None = None,
+        form_compiler_options: dict | None = None,
+        jit_options: dict | None = None,
+        dtype: npt.DTypeLike | None = None,
     ):
         """Create a DOLFINx Expression.
 
@@ -198,7 +198,7 @@ class Expression:
         self,
         mesh: Mesh,
         entities: np.ndarray,
-        values: typing.Optional[np.ndarray] = None,
+        values: np.ndarray | None = None,
     ) -> np.ndarray:
         """Evaluate Expression on entities.
 
@@ -275,7 +275,7 @@ class Expression:
         return self._cpp_object.value_size
 
     @property
-    def argument_space(self) -> typing.Optional[FunctionSpace]:
+    def argument_space(self) -> FunctionSpace | None:
         """Argument function space if Expression has argument."""
         return self._argument_space
 
@@ -309,9 +309,9 @@ class Function(ufl.Coefficient):
     def __init__(
         self,
         V: FunctionSpace,
-        x: typing.Optional[la.Vector] = None,
-        name: typing.Optional[str] = None,
-        dtype: typing.Optional[npt.DTypeLike] = None,
+        x: la.Vector | None = None,
+        name: str | None = None,
+        dtype: npt.DTypeLike | None = None,
     ):
         """Initialize a finite element Function.
 
@@ -429,8 +429,8 @@ class Function(ufl.Coefficient):
     def interpolate(
         self,
         u0: typing.Union[typing.Callable, Expression, Function],
-        cells0: typing.Optional[np.ndarray] = None,
-        cells1: typing.Optional[np.ndarray] = None,
+        cells0: np.ndarray | None = None,
+        cells1: np.ndarray | None = None,
     ) -> None:
         """Interpolate an expression.
 
@@ -574,8 +574,8 @@ class ElementMetaData(typing.NamedTuple):
 
     family: str
     degree: int
-    shape: typing.Optional[tuple[int, ...]] = None
-    symmetry: typing.Optional[bool] = None
+    shape: tuple[int, ...] | None = None
+    symmetry: bool | None = None
 
 
 def functionspace(

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -111,9 +111,7 @@ def _extract_function_spaces(
 # -- Vector instantiation -------------------------------------------------
 
 
-def create_vector(
-    L: typing.Union[Form, Iterable[Form]], kind: typing.Optional[str] = None
-) -> PETSc.Vec:
+def create_vector(L: typing.Union[Form, Iterable[Form]], kind: str | None = None) -> PETSc.Vec:
     """Create a PETSc vector that is compatible with a linear form(s).
 
     Three cases are supported:
@@ -197,7 +195,7 @@ def create_vector(
 
 def create_matrix(
     a: typing.Union[Form, Iterable[Iterable[Form]]],
-    kind: typing.Optional[typing.Union[str, Iterable[Iterable[str]]]] = None,
+    kind: typing.Union[str, Iterable[Iterable[str]]] | None = None,
 ) -> PETSc.Mat:
     """Create a PETSc matrix that is compatible with the (sequence) of
     bilinear form(s).
@@ -249,14 +247,13 @@ def create_matrix(
 @functools.singledispatch
 def assemble_vector(
     L: typing.Union[Form, Iterable[Form]],
-    constants: typing.Optional[npt.NDArray, Iterable[npt.NDArray]] = None,
-    coeffs: typing.Optional[
-        typing.Union[
-            dict[tuple[IntegralType, int], npt.NDArray],
-            Iterable[dict[tuple[IntegralType, int], npt.NDArray]],
-        ]
-    ] = None,
-    kind: typing.Optional[str] = None,
+    constants: typing.Union[npt.NDArray, Iterable[npt.NDArray], None] = None,
+    coeffs: typing.Union[
+        dict[tuple[IntegralType, int], npt.NDArray],
+        Iterable[dict[tuple[IntegralType, int], npt.NDArray]],
+    ]
+    | None = None,
+    kind: str | None = None,
 ) -> PETSc.Vec:
     """Assemble linear form(s) into a new PETSc vector.
 
@@ -320,13 +317,12 @@ def assemble_vector(
 def _assemble_vector_vec(
     b: PETSc.Vec,
     L: typing.Union[Form, Iterable[Form]],
-    constants: typing.Optional[npt.NDArray, Iterable[npt.NDArray]] = None,
-    coeffs: typing.Optional[
-        typing.Union[
-            dict[tuple[IntegralType, int], npt.NDArray],
-            Iterable[dict[tuple[IntegralType, int], npt.NDArray]],
-        ]
-    ] = None,
+    constants: typing.Union[npt.NDArray, Iterable[npt.NDArray]] | None = None,
+    coeffs: typing.Union[
+        dict[tuple[IntegralType, int], npt.NDArray],
+        Iterable[dict[tuple[IntegralType, int], npt.NDArray]],
+    ]
+    | None = None,
 ) -> PETSc.Vec:
     """Assemble linear form(s) into a PETSc vector.
 
@@ -388,17 +384,14 @@ def _assemble_vector_vec(
 @functools.singledispatch
 def assemble_matrix(
     a: typing.Union[Form, Iterable[Iterable[Form]]],
-    bcs: typing.Optional[Iterable[DirichletBC]] = None,
+    bcs: Iterable[DirichletBC] | None = None,
     diag: float = 1,
-    constants: typing.Optional[
-        typing.Union[Iterable[np.ndarray], Iterable[Iterable[np.ndarray]]]
-    ] = None,
-    coeffs: typing.Optional[
-        typing.Union[
-            dict[tuple[IntegralType, int], npt.NDArray],
-            Iterable[dict[tuple[IntegralType, int], npt.NDArray]],
-        ]
-    ] = None,
+    constants: typing.Union[Iterable[np.ndarray], Iterable[Iterable[np.ndarray]]] | None = None,
+    coeffs: typing.Union[
+        dict[tuple[IntegralType, int], npt.NDArray],
+        Iterable[dict[tuple[IntegralType, int], npt.NDArray]],
+    ]
+    | None = None,
     kind=None,
 ):
     """Assemble a bilinear form into a matrix.
@@ -461,10 +454,10 @@ def assemble_matrix(
 def _assemble_matrix_block_mat(
     A: PETSc.Mat,
     a: Iterable[Iterable[Form]],
-    bcs: typing.Optional[Iterable[DirichletBC]],
+    bcs: Iterable[DirichletBC] | None,
     diag: float,
-    constants: typing.Optional[Iterable[npt.NDArray]] = None,
-    coeffs: typing.Optional[Iterable[Iterable[dict[tuple[IntegralType, int], npt.NDArray]]]] = None,
+    constants: Iterable[npt.NDArray] | None = None,
+    coeffs: Iterable[Iterable[dict[tuple[IntegralType, int], npt.NDArray]]] | None = None,
 ) -> PETSc.Mat:
     """Assemble bilinear forms into a blocked matrix."""
     consts = [pack_constants(forms) for forms in a] if constants is None else constants
@@ -516,15 +509,14 @@ def _assemble_matrix_block_mat(
 def assemble_matrix_mat(
     A: PETSc.Mat,
     a: typing.Union[Form, Iterable[Iterable[Form]]],
-    bcs: typing.Optional[Iterable[DirichletBC]] = None,
+    bcs: Iterable[DirichletBC] | None = None,
     diag: float = 1,
-    constants: typing.Optional[typing.Union[np.ndarray, Iterable[Iterable[np.ndarray]]]] = None,
-    coeffs: typing.Optional[
-        typing.Union[
-            dict[tuple[IntegralType, int], npt.NDArray],
-            Iterable[Iterable[dict[tuple[IntegralType, int], npt.NDArray]]],
-        ]
-    ] = None,
+    constants: typing.Union[np.ndarray, Iterable[Iterable[np.ndarray]]] | None = None,
+    coeffs: typing.Union[
+        dict[tuple[IntegralType, int], npt.NDArray],
+        Iterable[Iterable[dict[tuple[IntegralType, int], npt.NDArray]]],
+    ]
+    | None = None,
 ) -> PETSc.Mat:
     """Assemble bilinear form into a matrix.
 
@@ -574,12 +566,10 @@ def assemble_matrix_mat(
 def apply_lifting(
     b: PETSc.Vec,
     a: typing.Union[Iterable[Form], Iterable[Iterable[Form]]],
-    bcs: typing.Optional[typing.Union[Iterable[DirichletBC], Iterable[Iterable[DirichletBC]]]],
-    x0: typing.Optional[Iterable[PETSc.Vec]] = None,
+    bcs: typing.Union[Iterable[DirichletBC], Iterable[Iterable[DirichletBC]]] | None,
+    x0: Iterable[PETSc.Vec] | None = None,
     alpha: float = 1,
-    constants: typing.Optional[
-        typing.Union[Iterable[np.ndarray], Iterable[Iterable[np.ndarray]]]
-    ] = None,
+    constants: typing.Union[Iterable[np.ndarray], Iterable[Iterable[np.ndarray]]] | None = None,
     coeffs=None,
 ) -> None:
     """Modify the right-hand side PETSc vector ``b`` to account for
@@ -698,7 +688,7 @@ def apply_lifting(
 def set_bc(
     b: PETSc.Vec,
     bcs: typing.Union[Iterable[DirichletBC], Iterable[Iterable[DirichletBC]]],
-    x0: typing.Optional[PETSc.Vec] = None,
+    x0: PETSc.Vec | None = None,
     alpha: float = 1,
 ) -> None:
     r"""Set constraint (Dirchlet boundary condition) values in an vector.
@@ -757,14 +747,14 @@ class LinearProblem:
         self,
         a: typing.Union[ufl.Form, Iterable[Iterable[ufl.Form]]],
         L: typing.Union[ufl.Form, Iterable[ufl.Form]],
-        bcs: typing.Optional[Iterable[DirichletBC]] = None,
-        u: typing.Optional[typing.Union[_Function, Iterable[_Function]]] = None,
-        P: typing.Optional[typing.Union[ufl.Form, Iterable[Iterable[ufl.Form]]]] = None,
-        kind: typing.Optional[typing.Union[str, Iterable[Iterable[str]]]] = None,
-        petsc_options: typing.Optional[dict] = None,
-        form_compiler_options: typing.Optional[dict] = None,
-        jit_options: typing.Optional[dict] = None,
-        entity_maps: typing.Optional[dict[_Mesh, npt.NDArray[np.int32]]] = None,
+        bcs: Iterable[DirichletBC] | None = None,
+        u: typing.Union[_Function, Iterable[_Function]] | None = None,
+        P: typing.Union[ufl.Form, Iterable[Iterable[ufl.Form]]] | None = None,
+        kind: typing.Union[str, Iterable[Iterable[str]]] | None = None,
+        petsc_options: dict | None = None,
+        form_compiler_options: dict | None = None,
+        jit_options: dict | None = None,
+        entity_maps: dict[_Mesh, npt.NDArray[np.int32]] | None = None,
     ) -> None:
         """Initialize solver for a linear variational problem.
 
@@ -1090,7 +1080,7 @@ def assemble_residual(
 def assemble_jacobian(
     u: typing.Union[Sequence[_Function], _Function],
     jacobian: typing.Union[Form, typing.Iterable[typing.Iterable[Form]]],
-    preconditioner: typing.Optional[typing.Union[Form, typing.Iterable[typing.Iterable[Form]]]],
+    preconditioner: typing.Union[Form, typing.Iterable[typing.Iterable[Form]]] | None,
     bcs: typing.Iterable[DirichletBC],
     _snes: PETSc.SNES,  # type: ignore
     x: PETSc.Vec,  # type: ignore
@@ -1192,14 +1182,14 @@ class NonlinearProblem:
         self,
         F: typing.Union[ufl.form.Form, Sequence[ufl.form.Form]],
         u: typing.Union[_Function, Sequence[_Function]],
-        bcs: typing.Optional[Sequence[DirichletBC]] = None,
-        J: typing.Optional[typing.Union[ufl.form.Form, Sequence[Sequence[ufl.form.Form]]]] = None,
-        P: typing.Optional[typing.Union[ufl.form.Form, Sequence[Sequence[ufl.form.Form]]]] = None,
-        kind: typing.Optional[typing.Union[str, typing.Iterable[typing.Iterable[str]]]] = None,
-        form_compiler_options: typing.Optional[dict] = None,
-        jit_options: typing.Optional[dict] = None,
-        petsc_options: typing.Optional[dict] = None,
-        entity_maps: typing.Optional[dict[dolfinx.mesh.Mesh, npt.NDArray[np.int32]]] = None,
+        bcs: Sequence[DirichletBC] | None = None,
+        J: typing.Union[ufl.form.Form, Sequence[Sequence[ufl.form.Form]]] | None = None,
+        P: typing.Union[ufl.form.Form, Sequence[Sequence[ufl.form.Form]]] | None = None,
+        kind: typing.Union[str, typing.Iterable[typing.Iterable[str]]] | None = None,
+        form_compiler_options: dict | None = None,
+        jit_options: dict | None = None,
+        petsc_options: dict | None = None,
+        entity_maps: dict[dolfinx.mesh.Mesh, npt.NDArray[np.int32]] | None = None,
     ):
         """Class for solving nonlinear problems with SNES.
 
@@ -1350,7 +1340,7 @@ class NonlinearProblem:
         return self._J
 
     @property
-    def P(self) -> typing.Optional[typing.Union[Form, Iterable[Iterable[Form]]]]:
+    def P(self) -> typing.Union[Form, Iterable[Iterable[Form]]] | None:
         """The compiled preconditioner."""
         return self._P
 
@@ -1370,7 +1360,7 @@ class NonlinearProblem:
         return self._x
 
     @property
-    def P_mat(self) -> typing.Optional[PETSc.Vec]:
+    def P_mat(self) -> PETSc.Vec | None:
         """Preconditioner matrix."""
         return self._P_mat
 
@@ -1406,10 +1396,10 @@ class NewtonSolverNonlinearProblem:
         self,
         F: ufl.form.Form,
         u: _Function,
-        bcs: typing.Optional[Iterable[DirichletBC]] = None,
+        bcs: Iterable[DirichletBC] | None = None,
         J: ufl.form.Form = None,
-        form_compiler_options: typing.Optional[dict] = None,
-        jit_options: typing.Optional[dict] = None,
+        form_compiler_options: dict | None = None,
+        jit_options: dict | None = None,
     ):
         """Initialize solver for solving a non-linear problem using
         Newton's method`.

--- a/python/dolfinx/geometry.py
+++ b/python/dolfinx/geometry.py
@@ -116,7 +116,7 @@ class BoundingBoxTree:
 def bb_tree(
     mesh: Mesh,
     dim: int,
-    entities: typing.Optional[npt.NDArray[np.int32]] = None,
+    entities: npt.NDArray[np.int32] | None = None,
     padding: float = 0.0,
 ) -> BoundingBoxTree:
     """Create a bounding box tree for use in collision detection.

--- a/python/dolfinx/graph.py
+++ b/python/dolfinx/graph.py
@@ -7,7 +7,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -92,7 +92,7 @@ class AdjacencyList:
 
 
 def adjacencylist(
-    data: npt.NDArray[Union[np.int32, np.int64]], offsets: Optional[npt.NDArray[np.int32]] = None
+    data: npt.NDArray[Union[np.int32, np.int64]], offsets: npt.NDArray[np.int32] | None = None
 ) -> AdjacencyList:
     """Create an AdjacencyList for int32 or int64 datasets.
 

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -89,10 +89,10 @@ class MeshData(typing.NamedTuple):
     """
 
     mesh: Mesh
-    cell_tags: typing.Optional[MeshTags]
-    facet_tags: typing.Optional[MeshTags]
-    ridge_tags: typing.Optional[MeshTags]
-    peak_tags: typing.Optional[MeshTags]
+    cell_tags: MeshTags | None
+    facet_tags: MeshTags | None
+    ridge_tags: MeshTags | None
+    peak_tags: MeshTags | None
     physical_groups: dict[str, tuple[int, int]]
 
 
@@ -144,7 +144,7 @@ def cell_perm_array(cell_type: CellType, num_nodes: int) -> list[int]:
 
 
 def extract_topology_and_markers(
-    model, name: typing.Optional[str] = None
+    model, name: str | None = None
 ) -> tuple[dict[int, TopologyDict], dict[str, tuple[int, int]]]:
     """Extract all entities tagged with a physical marker in the gmsh
     model.
@@ -227,7 +227,7 @@ def extract_topology_and_markers(
     return topologies, physical_groups
 
 
-def extract_geometry(model, name: typing.Optional[str] = None) -> npt.NDArray[np.float64]:
+def extract_geometry(model, name: str | None = None) -> npt.NDArray[np.float64]:
     """Extract the mesh geometry from a Gmsh model.
 
     Returns an array of shape ``(num_nodes, 3)``, where the i-th row
@@ -266,9 +266,8 @@ def model_to_mesh(
     comm: _MPI.Comm,
     rank: int,
     gdim: int = 3,
-    partitioner: typing.Optional[
-        typing.Callable[[_MPI.Comm, int, int, AdjacencyList_int32], AdjacencyList_int32]
-    ] = None,
+    partitioner: typing.Callable[[_MPI.Comm, int, int, AdjacencyList_int32], AdjacencyList_int32]
+    | None = None,
     dtype=default_real_type,
 ) -> MeshData:
     """Create a Mesh from a Gmsh model.
@@ -374,7 +373,7 @@ def model_to_mesh(
     # Create MeshTags for all sub entities
     topology = mesh.topology
     codim_to_name = {0: "cell", 1: "facet", 2: "ridge", 3: "peak"}
-    dolfinx_meshtags: dict[str, typing.Optional[MeshTags]] = {}
+    dolfinx_meshtags: dict[str, MeshTags | None] = {}
     for codim in [0, 1, 2, 3]:
         key = f"{codim_to_name[codim]}_tags"
         if (
@@ -417,9 +416,8 @@ def read_from_msh(
     comm: _MPI.Comm,
     rank: int = 0,
     gdim: int = 3,
-    partitioner: typing.Optional[
-        typing.Callable[[_MPI.Comm, int, int, AdjacencyList], AdjacencyList_int32]
-    ] = None,
+    partitioner: typing.Callable[[_MPI.Comm, int, int, AdjacencyList], AdjacencyList_int32]
+    | None = None,
 ) -> MeshData:
     """Read a Gmsh .msh file and return a :class:`dolfinx.mesh.Mesh` and
     cell facet markers.

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -223,7 +223,7 @@ class XDMFFile(_cpp.io.XDMFFile):
         self,
         mesh: Mesh,
         name: str,
-        attribute_name: typing.Optional[str] = None,
+        attribute_name: str | None = None,
         xpath: str = "/Xdmf/Domain",
     ) -> MeshTags:
         """Read MeshTags with a specific name as specified in the XMDF

--- a/python/dolfinx/jit.py
+++ b/python/dolfinx/jit.py
@@ -10,7 +10,6 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Optional
 
 from mpi4py import MPI
 

--- a/python/dolfinx/jit.py
+++ b/python/dolfinx/jit.py
@@ -124,7 +124,7 @@ def _load_options():
     return (user_options, pwd_options)
 
 
-def get_options(priority_options: Optional[dict] = None) -> dict:
+def get_options(priority_options: dict | None = None) -> dict:
     """Return a copy of the merged JIT option values for DOLFINx.
 
     Args:
@@ -157,7 +157,7 @@ def get_options(priority_options: Optional[dict] = None) -> dict:
 
 @mpi_jit_decorator
 def ffcx_jit(
-    ufl_object, form_compiler_options: Optional[dict] = None, jit_options: Optional[dict] = None
+    ufl_object, form_compiler_options: dict | None = None, jit_options: dict | None = None
 ):
     """Compile UFL object with FFCx and CFFI.
 

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -264,9 +264,9 @@ class Mesh:
     _mesh: typing.Union[_cpp.mesh.Mesh_float32, _cpp.mesh.Mesh_float64]
     _topology: Topology
     _geometry: Geometry
-    _ufl_domain: typing.Optional[ufl.Mesh]
+    _ufl_domain: ufl.Mesh | None
 
-    def __init__(self, msh, domain: typing.Optional[ufl.Mesh]):
+    def __init__(self, msh, domain: ufl.Mesh | None):
         """Initialize mesh from a C++ mesh.
 
         Args:
@@ -493,7 +493,7 @@ def transfer_meshtag(
     meshtag: MeshTags,
     msh1: Mesh,
     parent_cell: npt.NDArray[np.int32],
-    parent_facet: typing.Optional[npt.NDArray[np.int8]] = None,
+    parent_facet: npt.NDArray[np.int8] | None = None,
 ) -> MeshTags:
     """Generate cell mesh tags on a refined mesh from the mesh tags on the
     coarse parent mesh.
@@ -527,8 +527,8 @@ def transfer_meshtag(
 
 def refine(
     msh: Mesh,
-    edges: typing.Optional[np.ndarray] = None,
-    partitioner: typing.Optional[typing.Callable] = create_cell_partitioner(GhostMode.none),
+    edges: np.ndarray | None = None,
+    partitioner: typing.Callable | None = create_cell_partitioner(GhostMode.none),
     option: RefinementOption = RefinementOption.none,
 ) -> tuple[Mesh, npt.NDArray[np.int32], npt.NDArray[np.int8]]:
     """Refine a mesh.
@@ -580,7 +580,7 @@ def create_mesh(
         basix.ufl._BasixElement,
         _CoordinateElement,
     ],
-    partitioner: typing.Optional[typing.Callable] = None,
+    partitioner: typing.Callable | None = None,
 ) -> Mesh:
     """Create a mesh from topology and geometry arrays.
 

--- a/python/dolfinx/plot.py
+++ b/python/dolfinx/plot.py
@@ -6,7 +6,6 @@
 """Support functions for plotting"""
 
 import functools
-import typing
 
 import numpy as np
 
@@ -31,7 +30,7 @@ _first_order_vtk = {
 
 
 @functools.singledispatch
-def vtk_mesh(msh: mesh.Mesh, dim: typing.Optional[int] = None, entities=None):
+def vtk_mesh(msh: mesh.Mesh, dim: int | None = None, entities=None):
     """Create vtk mesh topology data for mesh entities of a given
     dimension. The vertex indices in the returned topology array are the
     indices for the associated entry in the mesh geometry.


### PR DESCRIPTION
Ruff seems to have started to enforce Python 3.10 features (optional here).

Not sure if we want to do this now, or wait till EOL of Python 3.9 https://devguide.python.org/versions/.

Other option is to disable ruff check till that is the case.