### PR TITLE
Deactivate ruff 3.9 deprecation

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -102,7 +102,11 @@ select = [
       "FLY",    # use f-string not static joins
       "NPY201", # numpy 2.x ruleset
 ]
-ignore = ["UP007", "RUF012"]
+ignore = [
+      "UP007",
+      "RUF012",
+      "UP045", # Ractivate once Python 3.9 EoL
+]
 allowed-confusables = ["σ"]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
As discussed we want to support Python 3.9 until EoL. This deactivates the necessary ruff check, which deprecates the usage of `typing.Optional`. After EoL of 3.9 this can be reverted (fixed) with https://github.com/FEniCS/dolfinx/pull/3755.