### PR TITLE
Pin scipy max version

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -42,7 +42,12 @@ docs = [
 lint = ["ruff>=0.2.0"]
 optional = ["numba", "pyamg"]
 petsc4py = ["petsc4py"]
-test = ["pytest", "scipy", "matplotlib", "fenics-dolfinx[optional]"]
+test = [
+      "pytest",
+      "scipy<1.16.0", # pyamg not compatible
+      "matplotlib",
+      "fenics-dolfinx[optional]"
+]
 ci = [
       "mypy",
       "pytest-xdist",


### PR DESCRIPTION
`pyamg` not compatibly with newly release `scipy` 1.16.0. 

Should be reverted once https://github.com/pyamg/pyamg/pull/449 is in a `pyamg` release.