### PR TITLE
NonlinearProblem docstring improvements

### DIFF
--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -1381,7 +1381,7 @@ class NonlinearProblem:
                 opts[k] = v
 
             self.solver.setFromOptions()
-            
+
             # Tidy up global options
             for k in petsc_options.keys():
                 del opts[k]


### PR DESCRIPTION
- Improves API consistency across LinearSolver and NonlinearSolver.
- Documentation improvements, particularly various non-obvious points.
- Applies unique options prefixes to all held PETSc objects.
- Explicitly points out that `x` (Vector solution used by KSP/SNES) and `u` (Function solution returned by solve).
- Added some new property accessors.
- `petsc_options` are now only applied to KSP or the SNES, not the linear algebra objects - this is made explicit in the docstring. The previous LinearSolver also applied the options to `A` and `b`, but it wasn't clear why these were not applied to `x` and the new `P` object. It's also not clear whether one would want the same options applied to multiple different linear algebra objects.
