### PR TITLE
Install custom built libraries to proper locations on RedHat image

### DIFF
--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -21,9 +21,6 @@ jobs:
 
     name: Rocky build and test
 
-    env:
-      LD_LIBRARY_PATH: /usr/local/lib
-
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -21,6 +21,9 @@ jobs:
 
     name: Rocky build and test
 
+    env:
+      LD_LIBRARY_PATH: /usr/local/lib
+
     steps:
       - uses: actions/checkout@v4
 

--- a/docker/Dockerfile.redhat
+++ b/docker/Dockerfile.redhat
@@ -46,7 +46,7 @@ RUN dnf -y update && \
 RUN curl -L -O https://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz && \
     tar -xf mpich-${MPICH_VERSION}.tar.gz && \
     cd mpich-${MPICH_VERSION} && \
-    FCFLAGS=-fallow-argument-mismatch FFLAGS=-fallow-argument-mismatch ./configure --with-device=ch4:ofi --enable-shared --prefix=/usr/local && \
+    FCFLAGS=-fallow-argument-mismatch FFLAGS=-fallow-argument-mismatch ./configure --with-device=ch4:ofi --enable-shared --prefix=/usr/local --libdir=/usr/local/lib64 && \
     make -j${BUILD_NP} install && \
     rm -rf /tmp/*
 
@@ -54,7 +54,7 @@ RUN curl -L -O https://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${M
 RUN curl -L -O https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_${HDF5_VERSION}.tar.gz && \
     tar -xf hdf5_${HDF5_VERSION}.tar.gz && \
     cd hdf5-hdf5_${HDF5_VERSION} && \
-    ./configure --prefix=/usr/local --enable-parallel --enable-shared --enable-static=no && \
+    ./configure --prefix=/usr/local --libdir=/usr/local/lib64 --enable-parallel --enable-shared --enable-static=no && \
     make -j${BUILD_NP} install && \
     rm -rf /tmp/*
 
@@ -74,6 +74,7 @@ RUN git clone -b v${PETSC_VERSION}  https://gitlab.com/petsc/petsc.git && \
     --download-scalapack \
     --download-superlu_dist \
     --prefix=/usr/local \
+    --libdir=/usr/local/lib64 \
     --with-make-np=${BUILD_NP} && \
     make all && \
     make install && \

--- a/docker/Dockerfile.redhat
+++ b/docker/Dockerfile.redhat
@@ -42,6 +42,11 @@ RUN dnf -y update && \
     dnf -y clean all && \
     rm -rf /var/cache
 
+# Broaden default minimal dynamic library path lookup to /usr/local/lib (PETSc
+# issue #1154) and /usr/local/lib64
+RUN echo "/usr/local/lib/" > /etc/ld.so.conf.d/usr-local-lib.conf && \
+    echo "/usr/local/lib64" > /etc/ld.so.conf.d/usr-local-lib64.conf
+
 # Build MPICH (see https://github.com/pmodels/mpich/issues/5811)
 RUN curl -L -O https://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz && \
     tar -xf mpich-${MPICH_VERSION}.tar.gz && \
@@ -80,7 +85,8 @@ RUN git clone -b v${PETSC_VERSION}  https://gitlab.com/petsc/petsc.git && \
     make install && \
     cd src/binding/petsc4py && \
     PETSC_DIR=/usr/local python3 -m pip install --no-cache-dir . && \
-    rm -rf /tmp/*
+    rm -rf /tmp/* && \
+    ldconfig
 
 ENV PETSC_DIR=/usr/local
 


### PR DESCRIPTION
- mpi4py suddenly switched to a binary wheel and it could not find libmpi*.
- It turns out MPI/HDF5/PETSc libs were being installed to `/usr/local/lib` which is not correct on RedHat`/usr/local/lib64`.
- In addition, new RedHat doesn't even place `/usr/local/lib*` on the dynamic linkers search paths.

This PR
- Installs MPI/HDF5 libs into `/usr/local/lib64`.
- Preemptively tries to use PETSc's build system put libs in `/usr/local/lib64` but that doens't yet work , see https://gitlab.com/petsc/petsc/-/issues/1154.
- Puts `/usr/local/lib*` on the dynamic linkers search path (properly, not a hack).