### PR TITLE
Check PETSc options prefix is not empty

### DIFF
--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -888,6 +888,9 @@ class LinearProblem:
         self._solver = PETSc.KSP().create(self.A.comm)
         self.solver.setOperators(self.A, self.P_mat)
 
+        if petsc_options_prefix == "":
+            raise ValueError("PETSc options prefix can not be empty.")
+
         self._petsc_options_prefix = petsc_options_prefix
         self.solver.setOptionsPrefix(petsc_options_prefix)
         self.A.setOptionsPrefix(f"{petsc_options_prefix}A_")
@@ -1332,6 +1335,9 @@ class NonlinearProblem:
             partial(assemble_jacobian, u, self.J, self.preconditioner, bcs), self.A, self.P_mat
         )
         self.solver.setFunction(partial(assemble_residual, u, self.F, self.J, bcs), self.b)
+
+        if petsc_options_prefix == "":
+            raise ValueError("PETSc options prefix can not be empty.")
 
         self.solver.setOptionsPrefix(petsc_options_prefix)
         self.A.setOptionsPrefix(f"{petsc_options_prefix}A_")

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -889,7 +889,7 @@ class LinearProblem:
         self.solver.setOperators(self.A, self.P_mat)
 
         if petsc_options_prefix == "":
-            raise ValueError("PETSc options prefix can not be empty.")
+            raise ValueError("PETSc options prefix cannot be empty.")
 
         self._petsc_options_prefix = petsc_options_prefix
         self.solver.setOptionsPrefix(petsc_options_prefix)
@@ -1337,7 +1337,7 @@ class NonlinearProblem:
         self.solver.setFunction(partial(assemble_residual, u, self.F, self.J, bcs), self.b)
 
         if petsc_options_prefix == "":
-            raise ValueError("PETSc options prefix can not be empty.")
+            raise ValueError("PETSc options prefix cannot be empty.")
 
         self.solver.setOptionsPrefix(petsc_options_prefix)
         self.A.setOptionsPrefix(f"{petsc_options_prefix}A_")


### PR DESCRIPTION
Follow up to https://github.com/FEniCS/dolfinx/pull/3785.

Passing an empty `petsc_options_prefix` string breaks. This is composed of PETSc's optional type handling  of `getOptionsPrefix` and input of `setOptionsPrefix` not aligning, and the internal empty c-string being encoded  as "\0" instead of "". 

As an empty prefix is not desirable, we just raise to avoid this.

Debugged with @jhale.