### PR TITLE
Extend test coverage for `fem.Function(..., dtype=dtype)` for `dtype` different from `PETSc.ScalarType`

### DIFF
--- a/python/dolfinx/__init__.py
+++ b/python/dolfinx/__init__.py
@@ -21,11 +21,33 @@ try:
 
     default_scalar_type = _PETSc.ScalarType  # type: ignore
     default_real_type = _PETSc.RealType  # type: ignore
+
+    import numpy as _np
+
+    if _np.issubdtype(default_scalar_type, _np.complexfloating):
+        default_complex_type = default_scalar_type
+    elif _np.issubdtype(default_scalar_type, _np.float32):
+        default_complex_type = _np.complex64
+    elif _np.issubdtype(default_scalar_type, _np.float64):
+        default_complex_type = _np.complex128
+    else:
+        import warnings
+
+        warnings.warn(f"Unable to determine default complex type from {default_scalar_type}")
+
+        default_complex_type = None
+
+        del warnings
+
+    del _np
 except ImportError:
     import numpy as _np
 
     default_scalar_type = _np.float64
     default_real_type = _np.float64
+    default_complex_type = _np.complex128
+
+    del _np
 
 from dolfinx import common
 from dolfinx import cpp as _cpp

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -332,6 +332,10 @@ class Function(ufl.Coefficient):
             if dtype is None:
                 dtype = default_scalar_type
 
+        assert np.issubdtype(V.element.dtype, np.dtype(dtype).type(0).real.dtype), (
+            "Incompatible FunctionSpace dtype and requested dtype."
+        )
+
         # Create cpp Function
         def functiontype(dtype):
             if np.issubdtype(dtype, np.float32):

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -332,10 +332,6 @@ class Function(ufl.Coefficient):
             if dtype is None:
                 dtype = default_scalar_type
 
-        assert np.issubdtype(V.element.dtype, np.dtype(dtype).type(0).real.dtype), (
-            "Incompatible FunctionSpace dtype and requested dtype."
-        )
-
         # Create cpp Function
         def functiontype(dtype):
             if np.issubdtype(dtype, np.float32):

--- a/python/dolfinx/la/__init__.py
+++ b/python/dolfinx/la/__init__.py
@@ -96,11 +96,19 @@ class Vector:
         """
         assert dolfinx.has_petsc4py
 
-        from dolfinx.la.petsc import create_vector_wrap
+        from petsc4py import PETSc
 
-        if self._petsc_x is None:
-            self._petsc_x = create_vector_wrap(self)
-        return self._petsc_x
+        if np.can_cast(self.array.dtype, PETSc.ScalarType, casting="safe"):
+            from dolfinx.la.petsc import create_vector_wrap
+
+            if self._petsc_x is None:
+                self._petsc_x = create_vector_wrap(self)
+            return self._petsc_x
+        else:
+            raise TypeError(
+                f"Cannot create PETSc vector: Vector dtype {self.array.dtype} cannot be cast "
+                f"to {PETSc.ScalarType}"
+            )
 
     def scatter_forward(self) -> None:
         """Update ghost entries."""

--- a/python/test/unit/fem/test_function.py
+++ b/python/test/unit/fem/test_function.py
@@ -234,7 +234,7 @@ def test_interpolation_function(mesh):
         default_complex_type,
     ],
 )
-def test_function_dtype(dtype):
+def test_function_dtype_creation(dtype):
     """
     Test creation of a function with non-default dtype.
 
@@ -253,6 +253,27 @@ def test_function_dtype(dtype):
         assert np.allclose(f.x.array.imag, 0.0)
     else:
         assert np.allclose(f.x.array, 1.0)
+
+@pytest.mark.petsc4py
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        default_scalar_type,
+        default_real_type,
+        default_complex_type,
+    ],
+)
+def test_function_dtype_petsc_vec(dtype):
+    """
+    Test petsc_vec property of a function with non-default dtype.
+
+    Extracting the PETSc vector may not be allowed in all cases.
+    """
+    mesh = create_unit_cube(MPI.COMM_WORLD, 3, 3, 3, dtype=default_real_type)
+    V = functionspace(mesh, ("Lagrange", 1))
+
+    f = Function(V, dtype=dtype)
+    f.x.array[:] = 1
 
     if np.issubdtype(dtype, np.complexfloating) and not np.issubdtype(
         default_scalar_type, np.complexfloating

--- a/python/test/unit/fem/test_function.py
+++ b/python/test/unit/fem/test_function.py
@@ -254,6 +254,7 @@ def test_function_dtype_creation(dtype):
     else:
         assert np.allclose(f.x.array, 1.0)
 
+
 @pytest.mark.petsc4py
 @pytest.mark.parametrize(
     "dtype",


### PR DESCRIPTION
Context: while working on #3783 I wanted to create a complex-valued `fem.Function` even if my `PETSc.ScalarType` is real. The rationale there is that the eigenfunctions may be complex-valued even if the PETSc matrix is real.
I can't remember this specific discussion in the past, and I can't seem to find any *basic* test coverage for this case.

Please review this regardless of your opinion about #3783. I think that having this case tested is a nice way to further show that we can untie ourselves from PETSc, and it is a low hanging fruit with all the `dtype` infrastracture already in place. After all, I can't think of a reason why one should be forbidden from creating a complex-valued function even if, for whatever reason (say, PETSc installation), they computed its real and its imaginary parts separately.

Feel free to suggest further tests to be added. For instance, in the case of #3783 I would expect that I would need to compute the L^2 norm of the eigenfunction. If this is not as straightforward as passing the custom `fem.Function.dtype` to `fem.form` then we may want to check if that works too. Seems to me however that the parametrization `dtype_parametrize` in `test/unit/fem/test_assembler.py`  already covers that.