### PR TITLE
Simplify PETSc wrapper solve return type

### DIFF
--- a/python/demo/demo_axis.py
+++ b/python/demo/demo_axis.py
@@ -678,9 +678,9 @@ for m in m_list:
             "pc_factor_mat_solver_type": mat_factor_backend,
         },
     )
-    Esh_m, _, converged_reason, _ = problem.solve()
+    Esh_m = problem.solve()
     assert isinstance(Esh_m, fem.Function)
-    assert converged_reason > 0
+    assert problem.solver.getConvergedReason() > 0
 
     # Scattered magnetic field
     Hsh_m = -1j * curl_axis(Esh_m, m, rho) / (Z0 * k0)

--- a/python/demo/demo_biharmonic.py
+++ b/python/demo/demo_biharmonic.py
@@ -235,9 +235,9 @@ problem = LinearProblem(
     petsc_options_prefix="demo_biharmonic_",
     petsc_options={"ksp_type": "preonly", "pc_type": "lu"},
 )
-uh, _, convergence_reason, _ = problem.solve()
+uh = problem.solve()
 assert isinstance(uh, fem.Function)
-assert convergence_reason > 0
+assert problem.solver.getConvergedReason() > 0
 
 # The solution can be written to a  {py:class}`XDMFFile
 # <dolfinx.io.XDMFFile>` file visualization with ParaView or VisIt

--- a/python/demo/demo_cahn-hilliard.py
+++ b/python/demo/demo_cahn-hilliard.py
@@ -339,12 +339,17 @@ if have_pyvista:
 
 c = u.sub(0)
 u0.x.array[:] = u.x.array
+step = 0
 while t < T:
     t += dt
-    _, _, converged_reason, num_iterations = problem.solve()
-    print(f"Step {int(t / dt)}: {converged_reason=} {num_iterations=}")
+    _ = problem.solve()
+    converged_reason = problem.solver.getConvergedReason()
+    assert converged_reason > 0
+    num_iterations = problem.solver.getIterationNumber()
+    print(f"Step {step}: {converged_reason=} {num_iterations=}")
     u0.x.array[:] = u.x.array
     file.write_function(c, t)
+    step += 1
 
     # Update the plot window
     if have_pyvista:

--- a/python/demo/demo_helmholtz.py
+++ b/python/demo/demo_helmholtz.py
@@ -106,8 +106,8 @@ problem = LinearProblem(
     petsc_options_prefix="demo_helmholtz_",
     petsc_options={"ksp_type": "preonly", "pc_type": "lu"},
 )
-_1, _2, convergence_reason, _3 = problem.solve()  # Cannot unpack typed tuple to same variable _
-assert convergence_reason > 0
+_ = problem.solve()
+assert problem.solver.getConvergedReason() > 0
 
 # Save solution in XDMF format (to be viewed in ParaView, for example)
 with XDMFFile(

--- a/python/demo/demo_mixed-poisson.py
+++ b/python/demo/demo_mixed-poisson.py
@@ -346,7 +346,8 @@ else:
 # vectors `u` and `sigma`.
 
 # +
-_1, _2, converged_reason, _3 = problem.solve()
+problem.solve()
+converged_reason = problem.solver.getConvergedReason()
 assert converged_reason > 0, f"Krylov solver has not converged, reason: {converged_reason}."
 # -
 

--- a/python/demo/demo_pml.py
+++ b/python/demo/demo_pml.py
@@ -723,9 +723,9 @@ problem = LinearProblem(
         "pc_factor_mat_solver_type": mat_factor_backend,
     },
 )
-Esh, _, convergence_reason, _ = problem.solve()
+Esh = problem.solve()
+assert problem.solver.getConvergedReason() > 0
 assert isinstance(Esh, fem.Function)
-assert convergence_reason > 0
 # -
 
 # Let's now save the solution in a `bp`-file. In order to do so, we need

--- a/python/demo/demo_poisson.py
+++ b/python/demo/demo_poisson.py
@@ -153,20 +153,19 @@ L = ufl.inner(f, v) * ufl.dx + ufl.inner(g, v) * ufl.ds
 # A {py:class}`LinearProblem <dolfinx.fem.petsc.LinearProblem>` object is
 # created that brings together the variational problem, the Dirichlet
 # boundary condition, and which specifies the linear solver. In this
-# case an LU solver is used. The {py:func}`solve
+# case an LU solver is used, and we ask that PETSc throws an error
+# if the solver does not converge. The {py:func}`solve
 # <dolfinx.fem.petsc.LinearProblem.solve>` computes the solution.
-
 # +
 problem = LinearProblem(
     a,
     L,
     bcs=[bc],
     petsc_options_prefix="demo_poisson_",
-    petsc_options={"ksp_type": "preonly", "pc_type": "lu"},
+    petsc_options={"ksp_type": "preonly", "pc_type": "lu", "ksp_error_if_not_converged": True},
 )
-uh, _, convergence_reason, _ = problem.solve()
+uh = problem.solve()
 assert isinstance(uh, fem.Function)
-assert convergence_reason > 0
 # -
 
 # The solution can be written to a {py:class}`XDMFFile

--- a/python/demo/demo_pyamg.py
+++ b/python/demo/demo_pyamg.py
@@ -53,7 +53,7 @@ from dolfinx.mesh import CellType, create_box, locate_entities_boundary
 
 
 # +
-def poisson_problem(dtype: npt.DTypeLike, solver_type: str):
+def poisson_problem(dtype: npt.DTypeLike, solver_type: str) -> None:
     """Solve a 3D Poisson problem using Ruge-Stuben algebraic multigrid.
 
     Args:
@@ -159,7 +159,7 @@ def nullspace_elasticty(Q: fem.FunctionSpace) -> list[np.ndarray]:
 
 
 # +
-def elasticity_problem(dtype):
+def elasticity_problem(dtype) -> None:
     """Solve a 3D linearised elasticity problem using a smoothed
     aggregation algebraic multigrid method.
 

--- a/python/demo/demo_scattering_boundary_conditions.py
+++ b/python/demo/demo_scattering_boundary_conditions.py
@@ -635,8 +635,8 @@ problem = LinearProblem(
     petsc_options_prefix="demo_scattering_boundary_conditions_",
     petsc_options={"ksp_type": "preonly", "pc_type": "lu"},
 )
-Esh, _, convergence_reason, _ = problem.solve()
-assert convergence_reason > 0
+(Esh,) = problem.solve()
+assert problem.solve.getConvergedReason() > 0
 
 # We save the solution as an [ADIOS2
 # bp](https://adios2.readthedocs.io/en/latest/ecosystem/visualization.html)

--- a/python/demo/demo_scattering_boundary_conditions.py
+++ b/python/demo/demo_scattering_boundary_conditions.py
@@ -636,7 +636,7 @@ problem = LinearProblem(
     petsc_options={"ksp_type": "preonly", "pc_type": "lu"},
 )
 (Esh,) = problem.solve()
-assert problem.solve.getConvergedReason() > 0
+assert problem.solver.getConvergedReason() > 0
 
 # We save the solution as an [ADIOS2
 # bp](https://adios2.readthedocs.io/en/latest/ecosystem/visualization.html)

--- a/python/demo/demo_scattering_boundary_conditions.py
+++ b/python/demo/demo_scattering_boundary_conditions.py
@@ -635,7 +635,7 @@ problem = LinearProblem(
     petsc_options_prefix="demo_scattering_boundary_conditions_",
     petsc_options={"ksp_type": "preonly", "pc_type": "lu"},
 )
-(Esh,) = problem.solve()
+Esh = problem.solve()
 assert problem.solver.getConvergedReason() > 0
 
 # We save the solution as an [ADIOS2

--- a/python/demo/demo_stokes.py
+++ b/python/demo/demo_stokes.py
@@ -263,12 +263,11 @@ def nested_iterative_solver_high_level():
     P00.setOption(PETSc.Mat.Option.SPD, True)
     P11.setOption(PETSc.Mat.Option.SPD, True)
 
-    (u_h, p_h), _, convergence_reason, num_its = problem.solve()
-    # Because left-hand side operator is only assembled now we can
-    # only test that the null-space is setup correctly after calling
-    # solve.
+    u_h, p_h = problem.solve()
+    assert problem.solver.getConvergedReason() > 0
+    # Because left-hand side operator is only assembled during solve
+    # we can only test the null space at this point.
     assert nsp.test(problem.A)
-    assert convergence_reason > 0
 
     # Compute norms of the solution vectors
     norm_u = la.norm(u_h.x)

--- a/python/demo/demo_tnt-elements.py
+++ b/python/demo/demo_tnt-elements.py
@@ -283,9 +283,11 @@ def poisson_error(V: fem.FunctionSpace):
         petsc_options_prefix="demo_tnt_elements_",
         petsc_options={"ksp_rtol": ksp_rtol},
     )
-    uh, _, convergence_reason, num_its = problem.solve()
-    assert convergence_reason > 0, (
-        f"Failed to converge, reason: {convergence_reason}, iterations: {num_its}"
+    uh = problem.solve()
+    converged_reason = problem.solver.getConvergedReason()
+    num_its = problem.solver.getIterationNumber()
+    assert converged_reason > 0, (
+        f"Failed to converge, reason: {converged_reason}, iterations: {num_its}"
     )
 
     M = (u_exact - uh) ** 2 * ufl.dx

--- a/python/test/unit/fem/test_petsc_nonlinear_assembler.py
+++ b/python/test/unit/fem/test_petsc_nonlinear_assembler.py
@@ -384,9 +384,9 @@ class TestNLSPETSc:
                 petsc_options=petsc_options,
             )
 
-            _, x, converged_reason, _ = problem.solve()
-            assert converged_reason > 0
-            xnorm = x.norm()
+            problem.solve()
+            assert problem.solver.getConvergedReason() > 0
+            xnorm = problem.x.norm()
             return xnorm
 
         norm0 = blocked_solve()
@@ -484,11 +484,11 @@ class TestNLSPETSc:
                 petsc_options=petsc_options,
                 kind="mpi",
             )
-            _, x, converged_reason, _ = problem.solve()
-            assert converged_reason > 0
+            problem.solve()
+            assert problem.solver.getConvergedReason() > 0
             Jnorm = problem.solver.getJacobian()[0].norm()
             Fnorm = problem.solver.getFunction()[0].norm()
-            xnorm = x.norm()
+            xnorm = problem.x.norm()
             return Jnorm, Fnorm, xnorm
 
         def nested():
@@ -517,9 +517,9 @@ class TestNLSPETSc:
                 ["u", nested_IS[0][0]], ["p", nested_IS[1][1]]
             )
 
-            _, x, converged_reason, _ = problem.solve()
-            assert converged_reason > 0
-            xnorm = x.norm()
+            problem.solve()
+            assert problem.solver.getConvergedReason() > 0
+            xnorm = problem.x.norm()
             Jnorm = nest_matrix_norm(problem.solver.getJacobian()[0])
             Fnorm = problem.solver.getFunction()[0].norm()
             return Jnorm, Fnorm, xnorm
@@ -575,9 +575,9 @@ class TestNLSPETSc:
                 petsc_options_prefix="test_assembly_solve_taylor_hood_nl__monolithic_",
                 petsc_options=petsc_options,
             )
-            _, x, converged_reason, _ = problem.solve()
-            assert converged_reason > 0
-            xnorm = x.norm()
+            problem.solve()
+            assert problem.solver.getConvergedReason() > 0
+            xnorm = problem.x.norm()
             Jnorm = problem.solver.getJacobian()[0].norm()
             Fnorm = problem.solver.getFunction()[0].norm()
             return Jnorm, Fnorm, xnorm

--- a/python/test/unit/fem/test_petsc_solver_wrappers.py
+++ b/python/test/unit/fem/test_petsc_solver_wrappers.py
@@ -62,8 +62,8 @@ class TestPETScSolverWrappers:
             petsc_options_prefix=petsc_options_prefix_linear,
             petsc_options=petsc_options_linear,
         )
-        u_lin, _, convergence_reason, _ = linear_problem.solve()
-        assert convergence_reason > 0
+        u_lin = linear_problem.solve()
+        assert linear_problem.solver.getConvergedReason() > 0
 
         # Compare LinearProblem solution against the one obtained by
         # legacy NewtonSolverNonlinearProblem
@@ -109,8 +109,8 @@ class TestPETScSolverWrappers:
             petsc_options_prefix=petsc_options_prefix_nonlinear,
             petsc_options=petsc_options_nonlinear,
         )
-        _, _, converged_reason, _ = nonlinear_problem.solve()
-        assert converged_reason > 0
+        nonlinear_problem.solve()
+        assert nonlinear_problem.solver.getConvergedReason() > 0
 
         assert np.allclose(u_lin.x.array, u_nonlin.x.array, atol=eps, rtol=eps)
 
@@ -205,8 +205,8 @@ class TestPETScSolverWrappers:
             petsc_options_prefix=petsc_options_prefix,
             petsc_options=petsc_options,
         )
-        wh, _, convergence_reason, _ = problem.solve()
-        assert convergence_reason > 0
+        wh = problem.solve()
+        assert problem.solver.getConvergedReason() > 0
         if kind is None:
             uh, ph = wh.split()
         else:


### PR DESCRIPTION
- Users are encouraged to use PETSc native interface to getConvergedReason throughout all demos and tests.
- Consistent return of DOLFINx native function(s) for LinearProblem and NonlinearProblem.

Will tidy up documentation next.