### PR TITLE
Revert some clang-tidy changes

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,20 +1,20 @@
 name: clang-tidy
 
 on:
-  schedule:
-    # daily at 1am
-    - cron: "0 1 * * *"
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - "**"
-    tags:
-      - "v*"
-  merge_group:
-    branches:
-      - main
+  # schedule:
+  #   # daily at 1am
+  #   - cron: "0 1 * * *"
+  # pull_request:
+  #   branches:
+  #     - main
+  # push:
+  #   branches:
+  #     - "**"
+  #   tags:
+  #     - "v*"
+  # merge_group:
+  #   branches:
+  #     - main
   workflow_dispatch:
 
 jobs:
@@ -28,7 +28,7 @@ jobs:
       PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install dependencies
         run: |
           apt-get update
@@ -44,7 +44,7 @@ jobs:
           pip install git+https://github.com/FEniCS/basix.git@${{ env.basix_ref }}
           pip install git+https://github.com/FEniCS/ffcx.git@${{ env.ffcx_ref }}
 
-      - name: Configure (C++ lib) 
+      - name: Configure (C++ lib)
         run: >
           cmake -G Ninja
           -B build
@@ -57,10 +57,10 @@ jobs:
           -DDOLFINX_ENABLE_SCOTCH=ON
           -DDOLFINX_ENABLE_SLEPC=ON
           -DDOLFINX_ENABLE_PARMETIS=OFF
-      
+
       - name: Build (C++ lib)
         run: cmake --build build
-      
+
       - name: Install (C++ lib)
         run: cmake --install build
 

--- a/cpp/dolfinx/fem/CoordinateElement.h
+++ b/cpp/dolfinx/fem/CoordinateElement.h
@@ -212,7 +212,7 @@ public:
   /// 0, 0)`.
   /// @param[in] x Physical coordinates (shape=(num_points, gdim)).
   template <typename U, typename V, typename W>
-  static void pull_back_affine(U&& X, const V& K, const std::array<T, 3>& x0,
+  static void pull_back_affine(U&& X, const V& K, std::array<T, 3> x0,
                                const W& x)
   {
     assert(X.extent(0) == x.extent(0));

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -150,7 +150,7 @@ std::vector<std::int32_t> locate_dofs_geometrical(const FunctionSpace<T>& V,
 /// V[1]. The returned dofs are 'unrolled', i.e. block size = 1.
 template <std::floating_point T, typename U>
 std::array<std::vector<std::int32_t>, 2> locate_dofs_geometrical(
-    const std::array<std::reference_wrapper<const FunctionSpace<T>>, 2>& V,
+    std::array<std::reference_wrapper<const FunctionSpace<T>>, 2> V,
     U marker_fn)
 {
   // FIXME: Calling V.tabulate_dof_coordinates() is very expensive,

--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -44,7 +44,7 @@ namespace petsc
 /// object.
 template <std::floating_point T>
 Mat create_matrix(const Form<PetscScalar, T>& a,
-                  const std::optional<std::string>& type = std::nullopt)
+                  std::optional<std::string> type = std::nullopt)
 {
   la::SparsityPattern pattern = fem::create_sparsity_pattern(a);
   pattern.finalize();
@@ -64,7 +64,7 @@ Mat create_matrix(const Form<PetscScalar, T>& a,
 template <std::floating_point T>
 Mat create_matrix_block(
     const std::vector<std::vector<const Form<PetscScalar, T>*>>& a,
-    const std::optional<std::string>& type = std::nullopt)
+    std::optional<std::string> type = std::nullopt)
 {
   // Extract and check row/column ranges
   std::array<std::vector<std::shared_ptr<const FunctionSpace<T>>>, 2> V

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -129,7 +129,7 @@ graph::build::distribute(MPI_Comm comm,
     assert(send_disp.back() == (std::int32_t)dest_to_index.size());
     for (std::size_t i = 0; i < dest_to_index.size(); ++i)
     {
-      const std::array<int, 3>& dest_data = dest_to_index[i];
+      std::array<int, 3> dest_data = dest_to_index[i];
       const std::size_t pos = dest_data[1];
 
       std::span b(send_buffer.data() + i * buffer_shape1, buffer_shape1);

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -17,9 +17,8 @@ using namespace dolfinx::la;
 
 //-----------------------------------------------------------------------------
 SparsityPattern::SparsityPattern(
-    MPI_Comm comm,
-    const std::array<std::shared_ptr<const common::IndexMap>, 2>& maps,
-    const std::array<int, 2>& bs)
+    MPI_Comm comm, std::array<std::shared_ptr<const common::IndexMap>, 2> maps,
+    std::array<int, 2> bs)
     : _comm(comm), _index_maps(maps), _bs(bs),
       _row_cache(maps[0]->size_local() + maps[0]->num_ghosts())
 {

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -30,10 +30,9 @@ public:
   /// @param[in] maps Index maps describing the [0] row and [1] column
   /// index ranges (up to a block size).
   /// @param[in] bs Block sizes for the [0] row and [1] column maps.
-  SparsityPattern(
-      MPI_Comm comm,
-      const std::array<std::shared_ptr<const common::IndexMap>, 2>& maps,
-      const std::array<int, 2>& bs);
+  SparsityPattern(MPI_Comm comm,
+                  std::array<std::shared_ptr<const common::IndexMap>, 2> maps,
+                  std::array<int, 2> bs);
 
   /// Create a new sparsity pattern by concatenating sub-patterns, e.g.
   /// pattern =[ pattern00 ][ pattern 01]

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -135,8 +135,7 @@ private:
 /// @note Entities that do not exist on this rank are ignored.
 /// @warning `entities` must not contain duplicate entities.
 template <typename T>
-MeshTags<T> create_meshtags(const std::shared_ptr<const Topology>& topology,
-                            int dim,
+MeshTags<T> create_meshtags(std::shared_ptr<const Topology> topology, int dim,
                             const graph::AdjacencyList<std::int32_t>& entities,
                             std::span<const T> values)
 {

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -740,7 +740,7 @@ build_entity_types(const std::vector<CellType>& cell_types)
 //-----------------------------------------------------------------------------
 Topology::Topology(
     std::vector<CellType> cell_types,
-    const std::shared_ptr<const common::IndexMap>& vertex_map,
+    std::shared_ptr<const common::IndexMap> vertex_map,
     std::vector<std::shared_ptr<const common::IndexMap>> cell_maps,
     std::vector<std::shared_ptr<graph::AdjacencyList<std::int32_t>>> cells,
     const std::optional<std::vector<std::vector<std::int64_t>>>& original_index)

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -59,7 +59,7 @@ public:
   /// `cells`.
   Topology(
       std::vector<CellType> cell_types,
-      const std::shared_ptr<const common::IndexMap>& vertex_map,
+      std::shared_ptr<const common::IndexMap> vertex_map,
       std::vector<std::shared_ptr<const common::IndexMap>> cell_maps,
       std::vector<std::shared_ptr<graph::AdjacencyList<std::int32_t>>> cells,
       const std::optional<std::vector<std::vector<std::int64_t>>>&

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -48,7 +48,7 @@ Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                   DiagonalType diagonal, const CellReorderFunction& reorder_fn);
 
 template <std::floating_point T>
-Mesh<T> build_quad(MPI_Comm comm, const std::array<std::array<T, 2>, 2> p,
+Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                    std::array<std::int64_t, 2> n,
                    const CellPartitionFunction& partitioner,
                    const CellReorderFunction& reorder_fn);
@@ -651,7 +651,7 @@ Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
 }
 
 template <std::floating_point T>
-Mesh<T> build_quad(MPI_Comm comm, const std::array<std::array<T, 2>, 2> p,
+Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                    std::array<std::int64_t, 2> n,
                    const CellPartitionFunction& partitioner,
                    const CellReorderFunction& reorder_fn)

--- a/python/dolfinx/wrappers/assemble.cpp
+++ b/python/dolfinx/wrappers/assemble.cpp
@@ -198,7 +198,7 @@ void declare_assembly_functions(nb::module_& m)
                   = e.second.first.empty()
                         ? 0
                         : e.second.first.size() / e.second.second;
-              return std::pair<const std::pair<dolfinx::fem::IntegralType, int>,
+              return std::pair<std::pair<dolfinx::fem::IntegralType, int>,
                                nb::ndarray<T, nb::numpy>>(
                   e.first,
                   dolfinx_wrappers::as_nbarray(
@@ -212,7 +212,7 @@ void declare_assembly_functions(nb::module_& m)
   m.def(
       "pack_coefficients",
       [](const dolfinx::fem::Expression<T, U>& e,
-         const nb::ndarray<const std::int32_t, nb::c_contig>& entities)
+         nb::ndarray<const std::int32_t, nb::c_contig> entities)
       {
         std::vector<int> coffsets = e.coefficient_offsets();
         const std::vector<std::shared_ptr<const dolfinx::fem::Function<T, U>>>&
@@ -262,12 +262,12 @@ void declare_assembly_functions(nb::module_& m)
   // Expression
   m.def(
       "tabulate_expression",
-      [](const nb::ndarray<T, nb::c_contig>& values,
+      [](nb::ndarray<T, nb::c_contig> values,
          const dolfinx::fem::Expression<T, U>& e,
-         const nb::ndarray<const T, nb::ndim<1>, nb::c_contig>& constants,
-         const nb::ndarray<const T, nb::ndim<2>, nb::c_contig>& coeffs,
+         nb::ndarray<const T, nb::ndim<1>, nb::c_contig> constants,
+         nb::ndarray<const T, nb::ndim<2>, nb::c_contig> coeffs,
          const dolfinx::mesh::Mesh<U>& mesh,
-         const nb::ndarray<const std::int32_t, nb::c_contig>& entities)
+         nb::ndarray<const std::int32_t, nb::c_contig> entities)
       {
         std::optional<std::pair<
             std::reference_wrapper<const dolfinx::fem::FiniteElement<U>>,
@@ -314,7 +314,7 @@ void declare_assembly_functions(nb::module_& m)
   m.def(
       "assemble_scalar",
       [](const dolfinx::fem::Form<T, U>& M,
-         const nb::ndarray<const T, nb::ndim<1>, nb::c_contig>& constants,
+         nb::ndarray<const T, nb::ndim<1>, nb::c_contig> constants,
          const std::map<std::pair<dolfinx::fem::IntegralType, int>,
                         nb::ndarray<const T, nb::ndim<2>, nb::c_contig>>&
              coefficients)
@@ -329,9 +329,9 @@ void declare_assembly_functions(nb::module_& m)
   // Vector
   m.def(
       "assemble_vector",
-      [](const nb::ndarray<T, nb::ndim<1>, nb::c_contig>& b,
+      [](nb::ndarray<T, nb::ndim<1>, nb::c_contig> b,
          const dolfinx::fem::Form<T, U>& L,
-         const nb::ndarray<const T, nb::ndim<1>, nb::c_contig>& constants,
+         nb::ndarray<const T, nb::ndim<1>, nb::c_contig> constants,
          const std::map<std::pair<dolfinx::fem::IntegralType, int>,
                         nb::ndarray<const T, nb::ndim<2>, nb::c_contig>>&
              coefficients)
@@ -348,7 +348,7 @@ void declare_assembly_functions(nb::module_& m)
   m.def(
       "assemble_matrix",
       [](dolfinx::la::MatrixCSR<T>& A, const dolfinx::fem::Form<T, U>& a,
-         const nb::ndarray<const T, nb::ndim<1>, nb::c_contig>& constants,
+         nb::ndarray<const T, nb::ndim<1>, nb::c_contig> constants,
          const std::map<std::pair<dolfinx::fem::IntegralType, int>,
                         nb::ndarray<const T, nb::ndim<2>, nb::c_contig>>&
              coefficients,
@@ -466,7 +466,7 @@ void declare_assembly_functions(nb::module_& m)
   m.def(
       "insert_diagonal",
       [](dolfinx::la::MatrixCSR<T>& A,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>& rows,
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> rows,
          T diagonal)
       {
         dolfinx::fem::set_diagonal(
@@ -514,7 +514,7 @@ void declare_assembly_functions(nb::module_& m)
   // BC modifiers
   m.def(
       "apply_lifting",
-      [](const nb::ndarray<T, nb::ndim<1>, nb::c_contig>& b,
+      [](nb::ndarray<T, nb::ndim<1>, nb::c_contig> b,
          const std::vector<const dolfinx::fem::Form<T, U>*>& a,
          const std::vector<nb::ndarray<const T, nb::ndim<1>, nb::c_contig>>&
              constants,

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -53,8 +53,8 @@ void add_scatter_functions(nb::class_<dolfinx::common::Scatterer<>>& sc)
   sc.def(
       "scatter_fwd",
       [](dolfinx::common::Scatterer<>& self,
-         const nb::ndarray<const T, nb::ndim<1>, nb::c_contig>& local_data,
-         const nb::ndarray<T, nb::ndim<1>, nb::c_contig>& remote_data)
+         nb::ndarray<const T, nb::ndim<1>, nb::c_contig> local_data,
+         nb::ndarray<T, nb::ndim<1>, nb::c_contig> remote_data)
       {
         self.scatter_fwd(std::span(local_data.data(), local_data.size()),
                          std::span(remote_data.data(), remote_data.size()));
@@ -64,8 +64,8 @@ void add_scatter_functions(nb::class_<dolfinx::common::Scatterer<>>& sc)
   sc.def(
       "scatter_rev",
       [](dolfinx::common::Scatterer<>& self,
-         const nb::ndarray<T, nb::ndim<1>, nb::c_contig>& local_data,
-         const nb::ndarray<const T, nb::ndim<1>, nb::c_contig>& remote_data)
+         nb::ndarray<T, nb::ndim<1>, nb::c_contig> local_data,
+         nb::ndarray<const T, nb::ndim<1>, nb::c_contig> remote_data)
       {
         self.scatter_rev(std::span(local_data.data(), local_data.size()),
                          std::span(remote_data.data(), remote_data.size()),
@@ -115,10 +115,8 @@ void common(nb::module_& m)
           "__init__",
           [](dolfinx::common::IndexMap* self, MPICommWrapper comm,
              std::int32_t local_size,
-             const nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>&
-                 ghosts,
-             const nb::ndarray<const int, nb::ndim<1>, nb::c_contig>&
-                 ghost_owners,
+             nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig> ghosts,
+             nb::ndarray<const int, nb::ndim<1>, nb::c_contig> ghost_owners,
              int tag)
           {
             new (self) dolfinx::common::IndexMap(
@@ -133,10 +131,8 @@ void common(nb::module_& m)
              std::int32_t local_size,
              std::array<nb::ndarray<const int, nb::ndim<1>, nb::c_contig>, 2>
                  dest_src,
-             const nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>&
-                 ghosts,
-             const nb::ndarray<const int, nb::ndim<1>, nb::c_contig>&
-                 ghost_owners)
+             nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig> ghosts,
+             nb::ndarray<const int, nb::ndim<1>, nb::c_contig> ghost_owners)
           {
             std::array<std::vector<int>, 2> ranks;
             ranks[0].assign(dest_src[0].data(),
@@ -183,8 +179,7 @@ void common(nb::module_& m)
       .def(
           "local_to_global",
           [](const dolfinx::common::IndexMap& self,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                 local)
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> local)
           {
             std::vector<std::int64_t> global(local.size());
             self.local_to_global(std::span(local.data(), local.size()), global);
@@ -194,8 +189,7 @@ void common(nb::module_& m)
       .def(
           "global_to_local",
           [](const dolfinx::common::IndexMap& self,
-             const nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>&
-                 global)
+             nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig> global)
           {
             std::vector<std::int32_t> local(global.size());
             self.global_to_local(std::span(global.data(), global.size()),
@@ -248,8 +242,7 @@ void common(nb::module_& m)
   m.def(
       "create_sub_index_map",
       [](const dolfinx::common::IndexMap& imap,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-             indices,
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> indices,
          bool allow_owner_change)
       {
         auto [map, submap_to_map] = dolfinx::common::create_sub_index_map(

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -67,7 +67,7 @@ struct geom_type<T, std::void_t<typename T::value_type>>
 };
 
 template <typename T>
-void declare_function_space(nb::module_& m, const std::string& type)
+void declare_function_space(nb::module_& m, std::string type)
 {
   {
     std::string pyclass_name = "FunctionSpace_" + type;
@@ -130,7 +130,7 @@ void declare_function_space(nb::module_& m, const std::string& type)
             "__init__",
             [](dolfinx::fem::FiniteElement<T>* self,
                dolfinx::mesh::CellType cell_type,
-               const nb::ndarray<T, nb::ndim<2>, nb::c_contig>& points,
+               nb::ndarray<T, nb::ndim<2>, nb::c_contig> points,
                const std::vector<std::size_t>& block_shape, bool symmetry)
             {
               std::span<T> pdata(points.data(), points.size());
@@ -170,9 +170,9 @@ void declare_function_space(nb::module_& m, const std::string& type)
         .def(
             "T_apply",
             [](const dolfinx::fem::FiniteElement<T>& self,
-               const nb::ndarray<T, nb::ndim<1>, nb::c_contig>& x,
-               const nb::ndarray<const std::uint32_t, nb::ndim<1>,
-                                 nb::c_contig>& cell_permutations,
+               nb::ndarray<T, nb::ndim<1>, nb::c_contig> x,
+               nb::ndarray<const std::uint32_t, nb::ndim<1>, nb::c_contig>
+                   cell_permutations,
                int dim)
             {
               const std::size_t data_per_cell
@@ -190,9 +190,9 @@ void declare_function_space(nb::module_& m, const std::string& type)
         .def(
             "Tt_apply",
             [](const dolfinx::fem::FiniteElement<T>& self,
-               const nb::ndarray<T, nb::ndim<1>, nb::c_contig>& x,
-               const nb::ndarray<const std::uint32_t, nb::ndim<1>,
-                                 nb::c_contig>& cell_permutations,
+               nb::ndarray<T, nb::ndim<1>, nb::c_contig> x,
+               nb::ndarray<const std::uint32_t, nb::ndim<1>, nb::c_contig>
+                   cell_permutations,
                int dim)
             {
               const std::size_t data_per_cell
@@ -210,9 +210,9 @@ void declare_function_space(nb::module_& m, const std::string& type)
         .def(
             "Tt_inv_apply",
             [](const dolfinx::fem::FiniteElement<T>& self,
-               const nb::ndarray<T, nb::ndim<1>, nb::c_contig>& x,
-               const nb::ndarray<const std::uint32_t, nb::ndim<1>,
-                                 nb::c_contig>& cell_permutations,
+               nb::ndarray<T, nb::ndim<1>, nb::c_contig> x,
+               nb::ndarray<const std::uint32_t, nb::ndim<1>, nb::c_contig>
+                   cell_permutations,
                int dim)
             {
               const std::size_t data_per_cell
@@ -232,9 +232,9 @@ void declare_function_space(nb::module_& m, const std::string& type)
         .def(
             "T_apply",
             [](const dolfinx::fem::FiniteElement<T>& self,
-               const nb::ndarray<std::complex<T>, nb::ndim<1>, nb::c_contig>& x,
-               const nb::ndarray<const std::uint32_t, nb::ndim<1>,
-                                 nb::c_contig>& cell_permutations,
+               nb::ndarray<std::complex<T>, nb::ndim<1>, nb::c_contig> x,
+               nb::ndarray<const std::uint32_t, nb::ndim<1>, nb::c_contig>
+                   cell_permutations,
                int dim)
             {
               const std::size_t data_per_cell
@@ -253,9 +253,9 @@ void declare_function_space(nb::module_& m, const std::string& type)
         .def(
             "Tt_apply",
             [](const dolfinx::fem::FiniteElement<T>& self,
-               const nb::ndarray<std::complex<T>, nb::ndim<1>, nb::c_contig>& x,
-               const nb::ndarray<const std::uint32_t, nb::ndim<1>,
-                                 nb::c_contig>& cell_permutations,
+               nb::ndarray<std::complex<T>, nb::ndim<1>, nb::c_contig> x,
+               nb::ndarray<const std::uint32_t, nb::ndim<1>, nb::c_contig>
+                   cell_permutations,
                int dim)
             {
               const std::size_t data_per_cell
@@ -274,9 +274,9 @@ void declare_function_space(nb::module_& m, const std::string& type)
         .def(
             "Tt_inv_apply",
             [](const dolfinx::fem::FiniteElement<T>& self,
-               const nb::ndarray<std::complex<T>, nb::ndim<1>, nb::c_contig>& x,
-               const nb::ndarray<const std::uint32_t, nb::ndim<1>,
-                                 nb::c_contig>& cell_permutations,
+               nb::ndarray<std::complex<T>, nb::ndim<1>, nb::c_contig> x,
+               nb::ndarray<const std::uint32_t, nb::ndim<1>, nb::c_contig>
+                   cell_permutations,
                int dim)
             {
               const std::size_t data_per_cell
@@ -301,7 +301,7 @@ void declare_function_space(nb::module_& m, const std::string& type)
 
 // Declare DirichletBC objects for type T
 template <typename T>
-void declare_objects(nb::module_& m, const std::string& type)
+void declare_objects(nb::module_& m, std::string type)
 {
   using U = typename dolfinx::scalar_value_t<T>;
 
@@ -316,10 +316,9 @@ void declare_objects(nb::module_& m, const std::string& type)
       .def(
           "__init__",
           [](dolfinx::fem::DirichletBC<T, U>* bc,
-             const nb::ndarray<const T, nb::c_contig>& g,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                 dofs,
-             const std::shared_ptr<const dolfinx::fem::FunctionSpace<U>>& V)
+             nb::ndarray<const T, nb::c_contig> g,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> dofs,
+             std::shared_ptr<const dolfinx::fem::FunctionSpace<U>> V)
           {
             std::vector<std::size_t> shape(g.shape_ptr(),
                                            g.shape_ptr() + g.ndim());
@@ -332,10 +331,9 @@ void declare_objects(nb::module_& m, const std::string& type)
       .def(
           "__init__",
           [](dolfinx::fem::DirichletBC<T, U>* bc,
-             const std::shared_ptr<const dolfinx::fem::Constant<T>>& g,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                 dofs,
-             const std::shared_ptr<const dolfinx::fem::FunctionSpace<U>>& V)
+             std::shared_ptr<const dolfinx::fem::Constant<T>> g,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> dofs,
+             std::shared_ptr<const dolfinx::fem::FunctionSpace<U>> V)
           {
             new (bc) dolfinx::fem::DirichletBC<T, U>(
                 g, std::vector(dofs.data(), dofs.data() + dofs.size()), V);
@@ -344,9 +342,8 @@ void declare_objects(nb::module_& m, const std::string& type)
       .def(
           "__init__",
           [](dolfinx::fem::DirichletBC<T, U>* bc,
-             const std::shared_ptr<const dolfinx::fem::Function<T, U>>& g,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                 dofs)
+             std::shared_ptr<const dolfinx::fem::Function<T, U>> g,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> dofs)
           {
             new (bc) dolfinx::fem::DirichletBC<T, U>(
                 g, std::vector(dofs.data(), dofs.data() + dofs.size()));
@@ -355,11 +352,11 @@ void declare_objects(nb::module_& m, const std::string& type)
       .def(
           "__init__",
           [](dolfinx::fem::DirichletBC<T, U>* bc,
-             const std::shared_ptr<const dolfinx::fem::Function<T, U>>& g,
+             std::shared_ptr<const dolfinx::fem::Function<T, U>> g,
              std::array<
                  nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>, 2>
                  V_g_dofs,
-             const std::shared_ptr<const dolfinx::fem::FunctionSpace<U>>& V)
+             std::shared_ptr<const dolfinx::fem::FunctionSpace<U>> V)
           {
             std::array dofs
                 = {std::vector(V_g_dofs[0].data(),
@@ -385,7 +382,7 @@ void declare_objects(nb::module_& m, const std::string& type)
       .def(
           "set",
           [](const dolfinx::fem::DirichletBC<T, U>& self,
-             const nb::ndarray<T, nb::ndim<1>, nb::c_contig>& b,
+             nb::ndarray<T, nb::ndim<1>, nb::c_contig> b,
              std::optional<nb::ndarray<const T, nb::ndim<1>, nb::c_contig>> x0,
              T alpha)
           {
@@ -420,9 +417,8 @@ void declare_objects(nb::module_& m, const std::string& type)
       .def(
           "interpolate",
           [](dolfinx::fem::Function<T, U>& self,
-             const nb::ndarray<const T, nb::ndim<1>, nb::c_contig>& f,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                 cells)
+             nb::ndarray<const T, nb::ndim<1>, nb::c_contig> f,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> cells)
           {
             dolfinx::fem::interpolate(self, std::span(f.data(), f.size()),
                                       {1, f.size()},
@@ -432,9 +428,8 @@ void declare_objects(nb::module_& m, const std::string& type)
       .def(
           "interpolate",
           [](dolfinx::fem::Function<T, U>& self,
-             const nb::ndarray<const T, nb::ndim<2>, nb::c_contig>& f,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                 cells)
+             nb::ndarray<const T, nb::ndim<2>, nb::c_contig> f,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> cells)
           {
             dolfinx::fem::interpolate(self, std::span(f.data(), f.size()),
                                       {f.shape(0), f.shape(1)},
@@ -445,10 +440,8 @@ void declare_objects(nb::module_& m, const std::string& type)
           "interpolate",
           [](dolfinx::fem::Function<T, U>& self,
              dolfinx::fem::Function<T, U>& u0,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                 cells0,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                 cells1)
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> cells0,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> cells1)
           {
             self.interpolate(u0, std::span(cells0.data(), cells0.size()),
                              std::span(cells1.data(), cells1.size()));
@@ -459,8 +452,7 @@ void declare_objects(nb::module_& m, const std::string& type)
           "interpolate",
           [](dolfinx::fem::Function<T, U>& self,
              dolfinx::fem::Function<T, U>& u,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                 cells,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> cells,
              const dolfinx::geometry::PointOwnershipData<U>& interpolation_data)
           {
             self.interpolate(u, std::span(cells.data(), cells.size()),
@@ -472,8 +464,7 @@ void declare_objects(nb::module_& m, const std::string& type)
       .def(
           "interpolate_ptr",
           [](dolfinx::fem::Function<T, U>& self, std::uintptr_t addr,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                 cells)
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> cells)
           {
             assert(self.function_space());
             auto element = self.function_space()->element();
@@ -504,8 +495,8 @@ void declare_objects(nb::module_& m, const std::string& type)
           "interpolate",
           [](dolfinx::fem::Function<T, U>& self,
              const dolfinx::fem::Expression<T, U>& e0,
-             const nb::ndarray<const std::int32_t, nb::c_contig>& cells0,
-             const nb::ndarray<const std::int32_t, nb::c_contig>& cells1)
+             nb::ndarray<const std::int32_t, nb::c_contig> cells0,
+             nb::ndarray<const std::int32_t, nb::c_contig> cells1)
           {
             self.interpolate(e0, std::span(cells0.data(), cells0.size()),
                              std::span(cells1.data(), cells1.size()));
@@ -518,10 +509,9 @@ void declare_objects(nb::module_& m, const std::string& type)
       .def(
           "eval",
           [](const dolfinx::fem::Function<T, U>& self,
-             const nb::ndarray<const U, nb::ndim<2>, nb::c_contig>& x,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                 cells,
-             const nb::ndarray<T, nb::ndim<2>, nb::c_contig>& u)
+             nb::ndarray<const U, nb::ndim<2>, nb::c_contig> x,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> cells,
+             nb::ndarray<T, nb::ndim<2>, nb::c_contig> u)
           {
             // TODO: handle 1d case
             self.eval(std::span(x.data(), x.size()), {x.shape(0), x.shape(1)},
@@ -542,7 +532,7 @@ void declare_objects(nb::module_& m, const std::string& type)
       .def(
           "__init__",
           [](dolfinx::fem::Constant<T>* cp,
-             const nb::ndarray<const T, nb::c_contig>& c)
+             nb::ndarray<const T, nb::c_contig> c)
           {
             std::vector<std::size_t> shape(c.shape_ptr(),
                                            c.shape_ptr() + c.ndim());
@@ -572,10 +562,10 @@ void declare_objects(nb::module_& m, const std::string& type)
                  const dolfinx::fem::Function<T, U>>>& coefficients,
              const std::vector<
                  std::shared_ptr<const dolfinx::fem::Constant<T>>>& constants,
-             const nb::ndarray<const U, nb::ndim<2>, nb::c_contig>& X,
+             nb::ndarray<const U, nb::ndim<2>, nb::c_contig> X,
              std::uintptr_t fn_addr,
              const std::vector<std::size_t>& value_shape,
-             const std::shared_ptr<const dolfinx::fem::FunctionSpace<U>>&
+             std::shared_ptr<const dolfinx::fem::FunctionSpace<U>>
                  argument_space)
           {
             auto tabulate_expression_ptr
@@ -617,8 +607,7 @@ void declare_objects(nb::module_& m, const std::string& type)
              coefficients,
          const std::vector<std::shared_ptr<const dolfinx::fem::Constant<T>>>&
              constants,
-         const std::shared_ptr<const dolfinx::fem::FunctionSpace<U>>&
-             argument_space)
+         std::shared_ptr<const dolfinx::fem::FunctionSpace<U>> argument_space)
       {
         const ufcx_expression* p
             = reinterpret_cast<const ufcx_expression*>(expression);
@@ -631,7 +620,7 @@ void declare_objects(nb::module_& m, const std::string& type)
 }
 
 template <typename T>
-void declare_form(nb::module_& m, const std::string& type)
+void declare_form(nb::module_& m, std::string type)
 {
   using U = typename dolfinx::scalar_value_t<T>;
 
@@ -659,7 +648,7 @@ void declare_form(nb::module_& m, const std::string& type)
              const std::map<std::shared_ptr<const dolfinx::mesh::Mesh<U>>,
                             nb::ndarray<const std::int32_t, nb::ndim<1>,
                                         nb::c_contig>>& entity_maps,
-             const std::shared_ptr<const dolfinx::mesh::Mesh<U>>& mesh)
+             std::shared_ptr<const dolfinx::mesh::Mesh<U>> mesh)
           {
             std::map<std::tuple<dolfinx::fem::IntegralType, int, int>,
                      dolfinx::fem::integral_data<T>>
@@ -712,7 +701,7 @@ void declare_form(nb::module_& m, const std::string& type)
              const std::map<std::shared_ptr<const dolfinx::mesh::Mesh<U>>,
                             nb::ndarray<const std::int32_t, nb::ndim<1>,
                                         nb::c_contig>>& entity_maps,
-             const std::shared_ptr<const dolfinx::mesh::Mesh<U>>& mesh)
+             std::shared_ptr<const dolfinx::mesh::Mesh<U>> mesh)
           {
             std::map<dolfinx::fem::IntegralType,
                      std::vector<std::pair<std::int32_t,
@@ -911,8 +900,8 @@ void declare_cmap(nb::module_& m, const std::string& type)
       .def(
           "push_forward",
           [](const dolfinx::fem::CoordinateElement<T>& self,
-             const nb::ndarray<const T, nb::ndim<2>, nb::c_contig>& X,
-             const nb::ndarray<const T, nb::ndim<2>, nb::c_contig>& cell_x)
+             nb::ndarray<const T, nb::ndim<2>, nb::c_contig> X,
+             nb::ndarray<const T, nb::ndim<2>, nb::c_contig> cell_x)
           {
             using mdspan2_t = md::mdspan<T, md::dextents<std::size_t, 2>>;
             using cmdspan2_t
@@ -943,9 +932,8 @@ void declare_cmap(nb::module_& m, const std::string& type)
       .def(
           "pull_back",
           [](const dolfinx::fem::CoordinateElement<T>& self,
-             const nb::ndarray<const T, nb::ndim<2>, nb::c_contig>& x,
-             const nb::ndarray<const T, nb::ndim<2>, nb::c_contig>&
-                 cell_geometry)
+             nb::ndarray<const T, nb::ndim<2>, nb::c_contig> x,
+             nb::ndarray<const T, nb::ndim<2>, nb::c_contig> cell_geometry)
           {
             std::size_t num_points = x.shape(0);
             std::size_t gdim = x.shape(1);
@@ -1051,8 +1039,7 @@ void declare_real_functions(nb::module_& m)
       [](const std::vector<
              std::shared_ptr<const dolfinx::fem::FunctionSpace<T>>>& V,
          int dim,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-             entities,
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities,
          bool remote)
       {
         if (V.size() != 2)
@@ -1071,8 +1058,7 @@ void declare_real_functions(nb::module_& m)
   m.def(
       "locate_dofs_topological",
       [](const dolfinx::fem::FunctionSpace<T>& V, int dim,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-             entities,
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities,
          bool remote)
       {
         return dolfinx_wrappers::as_nbarray(
@@ -1134,7 +1120,7 @@ void declare_real_functions(nb::module_& m)
       "interpolation_coords",
       [](const dolfinx::fem::FiniteElement<T>& e,
          const dolfinx::mesh::Geometry<T>& geometry,
-         const nb::ndarray<std::int32_t, nb::ndim<1>, nb::c_contig>& cells)
+         nb::ndarray<std::int32_t, nb::ndim<1>, nb::c_contig> cells)
       {
         std::vector<T> x = dolfinx::fem::interpolation_coords(
             e, geometry, std::span(cells.data(), cells.size()));
@@ -1147,8 +1133,7 @@ void declare_real_functions(nb::module_& m)
       [](const dolfinx::mesh::Geometry<T>& geometry0,
          const dolfinx::fem::FiniteElement<T>& element0,
          const dolfinx::mesh::Mesh<T>& mesh1,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-             cells,
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> cells,
          T padding)
       {
         return dolfinx::fem::create_interpolation_data(
@@ -1196,8 +1181,7 @@ void fem(nb::module_& m)
       "Build a dofmap on a mesh.");
   m.def(
       "transpose_dofmap",
-      [](const nb::ndarray<const std::int32_t, nb::ndim<2>, nb::c_contig>&
-             dofmap,
+      [](nb::ndarray<const std::int32_t, nb::ndim<2>, nb::c_contig> dofmap,
          int num_cells)
       {
         md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> _dofmap(
@@ -1210,8 +1194,7 @@ void fem(nb::module_& m)
       "compute_integration_domains",
       [](dolfinx::fem::IntegralType type,
          const dolfinx::mesh::Topology& topology,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-             entities)
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities)
       {
         return dolfinx_wrappers::as_nbarray(
             dolfinx::fem::compute_integration_domains(
@@ -1248,7 +1231,7 @@ void fem(nb::module_& m)
           "__init__",
           [](dolfinx::fem::DofMap* self,
              const dolfinx::fem::ElementDofLayout& element,
-             const std::shared_ptr<const dolfinx::common::IndexMap>& index_map,
+             std::shared_ptr<const dolfinx::common::IndexMap> index_map,
              int index_map_bs,
              const dolfinx::graph::AdjacencyList<std::int32_t>& dofmap, int bs)
           {

--- a/python/dolfinx/wrappers/geometry.cpp
+++ b/python/dolfinx/wrappers/geometry.cpp
@@ -88,7 +88,7 @@ void declare_bbtree(nb::module_& m, const std::string& type)
   m.def(
       "compute_collisions_points",
       [](const dolfinx::geometry::BoundingBoxTree<T>& tree,
-         const nb::ndarray<const T, nb::shape<3>, nb::c_contig>& points)
+         nb::ndarray<const T, nb::shape<3>, nb::c_contig> points)
       {
         return dolfinx::geometry::compute_collisions<T>(
             tree, std::span(points.data(), 3));
@@ -97,7 +97,7 @@ void declare_bbtree(nb::module_& m, const std::string& type)
   m.def(
       "compute_collisions_points",
       [](const dolfinx::geometry::BoundingBoxTree<T>& tree,
-         const nb::ndarray<const T, nb::shape<-1, 3>, nb::c_contig>& points)
+         nb::ndarray<const T, nb::shape<-1, 3>, nb::c_contig> points)
       {
         return dolfinx::geometry::compute_collisions<T>(
             tree, std::span(points.data(), points.size()));
@@ -119,7 +119,7 @@ void declare_bbtree(nb::module_& m, const std::string& type)
       [](const dolfinx::geometry::BoundingBoxTree<T>& tree,
          const dolfinx::geometry::BoundingBoxTree<T>& midpoint_tree,
          const dolfinx::mesh::Mesh<T>& mesh,
-         const nb::ndarray<const T, nb::shape<3>, nb::c_contig>& points)
+         nb::ndarray<const T, nb::shape<3>, nb::c_contig> points)
       {
         return dolfinx_wrappers::as_nbarray(
             dolfinx::geometry::compute_closest_entity<T>(
@@ -133,7 +133,7 @@ void declare_bbtree(nb::module_& m, const std::string& type)
       [](const dolfinx::geometry::BoundingBoxTree<T>& tree,
          const dolfinx::geometry::BoundingBoxTree<T>& midpoint_tree,
          const dolfinx::mesh::Mesh<T>& mesh,
-         const nb::ndarray<const T, nb::shape<-1, 3>, nb::c_contig>& points)
+         nb::ndarray<const T, nb::shape<-1, 3>, nb::c_contig> points)
       {
         return dolfinx_wrappers::as_nbarray(
             dolfinx::geometry::compute_closest_entity<T>(
@@ -145,8 +145,7 @@ void declare_bbtree(nb::module_& m, const std::string& type)
   m.def(
       "create_midpoint_tree",
       [](const dolfinx::mesh::Mesh<T>& mesh, int tdim,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-             entities)
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities)
       {
         return dolfinx::geometry::create_midpoint_tree(
             mesh, tdim,
@@ -157,7 +156,7 @@ void declare_bbtree(nb::module_& m, const std::string& type)
       "compute_colliding_cells",
       [](const dolfinx::mesh::Mesh<T>& mesh,
          const dolfinx::graph::AdjacencyList<int>& candidate_cells,
-         const nb::ndarray<const T, nb::shape<3>, nb::c_contig>& points)
+         nb::ndarray<const T, nb::shape<3>, nb::c_contig> points)
       {
         return dolfinx::geometry::compute_colliding_cells<T>(
             mesh, candidate_cells, std::span(points.data(), points.size()));
@@ -167,7 +166,7 @@ void declare_bbtree(nb::module_& m, const std::string& type)
       "compute_colliding_cells",
       [](const dolfinx::mesh::Mesh<T>& mesh,
          const dolfinx::graph::AdjacencyList<int>& candidate_cells,
-         const nb::ndarray<const T, nb::shape<-1, 3>, nb::c_contig>& points)
+         nb::ndarray<const T, nb::shape<-1, 3>, nb::c_contig> points)
       {
         return dolfinx::geometry::compute_colliding_cells<T>(
             mesh, candidate_cells, std::span(points.data(), points.size()));
@@ -177,8 +176,8 @@ void declare_bbtree(nb::module_& m, const std::string& type)
   std::string gjk_name = "compute_distance_gjk_" + type;
   m.def(
       gjk_name.c_str(),
-      [](const nb::ndarray<const T, nb::c_contig>& p,
-         const nb::ndarray<const T, nb::c_contig>& q)
+      [](nb::ndarray<const T, nb::c_contig> p,
+         nb::ndarray<const T, nb::c_contig> q)
       {
         std::size_t p_s0 = p.ndim() == 1 ? 1 : p.shape(0);
         std::size_t q_s0 = q.ndim() == 1 ? 1 : q.shape(0);
@@ -197,9 +196,8 @@ void declare_bbtree(nb::module_& m, const std::string& type)
   m.def(
       "squared_distance",
       [](const dolfinx::mesh::Mesh<T>& mesh, int dim,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-             indices,
-         const nb::ndarray<const T, nb::c_contig>& points)
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> indices,
+         nb::ndarray<const T, nb::c_contig> points)
       {
         std::size_t p_s0 = points.ndim() == 1 ? 1 : points.shape(0);
         std::span<const T> _p(points.data(), 3 * p_s0);
@@ -210,7 +208,7 @@ void declare_bbtree(nb::module_& m, const std::string& type)
       nb::arg("mesh"), nb::arg("dim"), nb::arg("indices"), nb::arg("points"));
   m.def("determine_point_ownership",
         [](const dolfinx::mesh::Mesh<T>& mesh,
-           const nb::ndarray<const T, nb::c_contig>& points, const T padding)
+           nb::ndarray<const T, nb::c_contig> points, const T padding)
         {
           std::size_t p_s0 = points.ndim() == 1 ? 1 : points.shape(0);
           std::span<const T> _p(points.data(), 3 * p_s0);
@@ -224,12 +222,12 @@ void declare_bbtree(nb::module_& m, const std::string& type)
       .def(
           "__init__",
           [](dolfinx::geometry::PointOwnershipData<T>* self,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>
                  src_owner,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>
                  dest_owners,
-             const nb::ndarray<const T, nb::ndim<1>, nb::c_contig>& dest_points,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
+             nb::ndarray<const T, nb::ndim<1>, nb::c_contig> dest_points,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>
                  dest_cells)
           {
             new (self) dolfinx::geometry::PointOwnershipData<T>{

--- a/python/dolfinx/wrappers/graph.cpp
+++ b/python/dolfinx/wrappers/graph.cpp
@@ -46,7 +46,7 @@ void declare_adjacency_list(nb::module_& m, const std::string& type)
       .def(
           "__init__",
           [](dolfinx::graph::AdjacencyList<T>* a,
-             const nb::ndarray<const T, nb::ndim<1>, nb::c_contig>& adj)
+             nb::ndarray<const T, nb::ndim<1>, nb::c_contig> adj)
           {
             std::vector<T> data(adj.data(), adj.data() + adj.size());
             new (a) dolfinx::graph::AdjacencyList<T>(
@@ -56,7 +56,7 @@ void declare_adjacency_list(nb::module_& m, const std::string& type)
       .def(
           "__init__",
           [](dolfinx::graph::AdjacencyList<T>* a,
-             const nb::ndarray<const T, nb::ndim<2>, nb::c_contig>& adj)
+             nb::ndarray<const T, nb::ndim<2>, nb::c_contig> adj)
           {
             std::vector<T> data(adj.data(), adj.data() + adj.size());
             new (a) dolfinx::graph::AdjacencyList<T>(
@@ -67,9 +67,8 @@ void declare_adjacency_list(nb::module_& m, const std::string& type)
       .def(
           "__init__",
           [](dolfinx::graph::AdjacencyList<T>* a,
-             const nb::ndarray<const T, nb::ndim<1>, nb::c_contig>& array,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                 displ)
+             nb::ndarray<const T, nb::ndim<1>, nb::c_contig> array,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> displ)
           {
             std::vector<T> data(array.data(), array.data() + array.size());
             std::vector<std::int32_t> offsets(displ.data(),

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -117,9 +117,9 @@ void declare_vtx_writer(nb::module_& m, const std::string& type)
         .def(
             "__init__",
             [](dolfinx::io::VTXWriter<T>* self, MPICommWrapper comm,
-               const std::filesystem::path& filename,
-               const std::shared_ptr<const dolfinx::mesh::Mesh<T>>& mesh,
-               const std::string& engine)
+               std::filesystem::path filename,
+               std::shared_ptr<const dolfinx::mesh::Mesh<T>> mesh,
+               std::string engine)
             {
               new (self)
                   dolfinx::io::VTXWriter<T>(comm.get(), filename, mesh, engine);
@@ -129,7 +129,7 @@ void declare_vtx_writer(nb::module_& m, const std::string& type)
         .def(
             "__init__",
             [](dolfinx::io::VTXWriter<T>* self, MPICommWrapper comm,
-               const std::filesystem::path& filename,
+               std::filesystem::path filename,
                const std::vector<std::variant<
                    std::shared_ptr<const dolfinx::fem::Function<float, T>>,
                    std::shared_ptr<const dolfinx::fem::Function<double, T>>,
@@ -159,16 +159,14 @@ void declare_data_types(nb::module_& m)
   m.def(
       "distribute_entity_data",
       [](const dolfinx::mesh::Topology& topology,
-         const nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>&
+         nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>
              input_global_indices,
          std::int64_t num_nodes_g,
          const dolfinx::fem::ElementDofLayout& cmap_dof_layout,
-         const nb::ndarray<const std::int32_t, nb::ndim<2>, nb::c_contig>&
-             xdofmap,
+         nb::ndarray<const std::int32_t, nb::ndim<2>, nb::c_contig> xdofmap,
          int entity_dim,
-         const nb::ndarray<const std::int64_t, nb::ndim<2>, nb::c_contig>&
-             entities,
-         const nb::ndarray<const T, nb::ndim<1>, nb::c_contig>& values)
+         nb::ndarray<const std::int64_t, nb::ndim<2>, nb::c_contig> entities,
+         nb::ndarray<const T, nb::ndim<1>, nb::c_contig> values)
       {
         assert(entities.shape(0) == values.size());
         mdspan_t<const std::int64_t, 2> entities_span(
@@ -210,8 +208,7 @@ void io(nb::module_& m)
 
   m.def(
       "extract_vtk_connectivity",
-      [](const nb::ndarray<const std::int32_t, nb::ndim<2>, nb::c_contig>&
-             dofmap,
+      [](nb::ndarray<const std::int32_t, nb::ndim<2>, nb::c_contig> dofmap,
          dolfinx::mesh::CellType cell)
       {
         mdspan_t<const std::int32_t, 2> _dofmap(dofmap.data(), dofmap.shape(0),
@@ -262,8 +259,7 @@ void io(nb::module_& m)
       .def(
           "__init__",
           [](dolfinx::io::XDMFFile* x, MPICommWrapper comm,
-             const std::filesystem::path& filename,
-             const std::string& file_mode,
+             std::filesystem::path filename, const std::string& file_mode,
              dolfinx::io::XDMFFile::Encoding encoding)
           {
             new (x) dolfinx::io::XDMFFile(comm.get(), filename, file_mode,
@@ -322,7 +318,7 @@ void io(nb::module_& m)
       .def(
           "__init__",
           [](dolfinx::io::VTKFile* v, MPICommWrapper comm,
-             const std::filesystem::path& filename, const std::string& mode)
+             std::filesystem::path filename, const std::string& mode)
           { new (v) dolfinx::io::VTKFile(comm.get(), filename, mode); },
           nb::arg("comm"), nb::arg("filename"), nb::arg("mode"))
       .def("close", &dolfinx::io::VTKFile::close);

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -234,9 +234,9 @@ void la(nb::module_& m)
       .def(
           "__init__",
           [](dolfinx::la::SparsityPattern* sp, MPICommWrapper comm,
-             const std::array<std::shared_ptr<const dolfinx::common::IndexMap>,
-                              2>& maps,
-             const std::array<int, 2>& bs)
+             std::array<std::shared_ptr<const dolfinx::common::IndexMap>, 2>
+                 maps,
+             std::array<int, 2> bs)
           { new (sp) dolfinx::la::SparsityPattern(comm.get(), maps, bs); },
           nb::arg("comm"), nb::arg("maps"), nb::arg("bs"))
       .def(
@@ -249,7 +249,7 @@ void la(nb::module_& m)
                      std::reference_wrapper<const dolfinx::common::IndexMap>,
                      int>>,
                  2>& maps,
-             const std::array<std::vector<int>, 2>& bs)
+             std::array<std::vector<int>, 2> bs)
           {
             new (sp)
                 dolfinx::la::SparsityPattern(comm.get(), patterns, maps, bs);
@@ -263,10 +263,8 @@ void la(nb::module_& m)
       .def(
           "insert",
           [](dolfinx::la::SparsityPattern& self,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                 rows,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                 cols)
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> rows,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> cols)
           {
             self.insert(std::span(rows.data(), rows.size()),
                         std::span(cols.data(), cols.size()));
@@ -279,8 +277,7 @@ void la(nb::module_& m)
       .def(
           "insert_diagonal",
           [](dolfinx::la::SparsityPattern& self,
-             const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                 rows)
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> rows)
           { self.insert_diagonal(std::span(rows.data(), rows.size())); },
           nb::arg("rows"))
       .def_prop_ro(

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -71,21 +71,20 @@ void declare_meshtags(nb::module_& m, const std::string& type)
   std::string pyclass_name = std::string("MeshTags_") + type;
   nb::class_<dolfinx::mesh::MeshTags<T>>(m, pyclass_name.c_str(),
                                          "MeshTags object")
-      .def("__init__",
-           [](dolfinx::mesh::MeshTags<T>* self,
-              const std::shared_ptr<const dolfinx::mesh::Topology>& topology,
-              int dim,
-              const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-                  indices,
-              const nb::ndarray<const T, nb::ndim<1>, nb::c_contig>& values)
-           {
-             std::vector<std::int32_t> indices_vec(
-                 indices.data(), indices.data() + indices.size());
-             std::vector<T> values_vec(values.data(),
-                                       values.data() + values.size());
-             new (self) dolfinx::mesh::MeshTags<T>(
-                 topology, dim, std::move(indices_vec), std::move(values_vec));
-           })
+      .def(
+          "__init__",
+          [](dolfinx::mesh::MeshTags<T>* self,
+             std::shared_ptr<const dolfinx::mesh::Topology> topology, int dim,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> indices,
+             nb::ndarray<const T, nb::ndim<1>, nb::c_contig> values)
+          {
+            std::vector<std::int32_t> indices_vec(
+                indices.data(), indices.data() + indices.size());
+            std::vector<T> values_vec(values.data(),
+                                      values.data() + values.size());
+            new (self) dolfinx::mesh::MeshTags<T>(
+                topology, dim, std::move(indices_vec), std::move(values_vec));
+          })
       .def_prop_ro("dtype", [](const dolfinx::mesh::MeshTags<T>&)
                    { return dolfinx_wrappers::numpy_dtype<T>(); })
       .def_rw("name", &dolfinx::mesh::MeshTags<T>::name)
@@ -112,9 +111,9 @@ void declare_meshtags(nb::module_& m, const std::string& type)
            { return as_nbarray(self.find(value)); });
 
   m.def("create_meshtags",
-        [](const std::shared_ptr<const dolfinx::mesh::Topology>& topology,
-           int dim, const dolfinx::graph::AdjacencyList<std::int32_t>& entities,
-           const nb::ndarray<const T, nb::ndim<1>, nb::c_contig>& values)
+        [](std::shared_ptr<const dolfinx::mesh::Topology> topology, int dim,
+           const dolfinx::graph::AdjacencyList<std::int32_t>& entities,
+           nb::ndarray<const T, nb::ndim<1>, nb::c_contig> values)
         {
           return dolfinx::mesh::create_meshtags(
               topology, dim, entities, std::span(values.data(), values.size()));
@@ -122,7 +121,7 @@ void declare_meshtags(nb::module_& m, const std::string& type)
 }
 
 template <typename T>
-void declare_mesh(nb::module_& m, const std::string& type)
+void declare_mesh(nb::module_& m, std::string type)
 {
   std::string pyclass_geometry_name = std::string("Geometry_") + type;
   nb::class_<dolfinx::mesh::Geometry<T>>(m, pyclass_geometry_name.c_str(),
@@ -131,11 +130,10 @@ void declare_mesh(nb::module_& m, const std::string& type)
           "__init__",
           [](dolfinx::mesh::Geometry<T>* self,
              std::shared_ptr<const dolfinx::common::IndexMap> index_map,
-             const nb::ndarray<const std::int32_t, nb::ndim<2>, nb::c_contig>&
-                 dofmap,
+             nb::ndarray<const std::int32_t, nb::ndim<2>, nb::c_contig> dofmap,
              const dolfinx::fem::CoordinateElement<T>& element,
-             const nb::ndarray<const T, nb::ndim<2>>& x,
-             const nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>&
+             nb::ndarray<const T, nb::ndim<2>> x,
+             nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>
                  input_global_indices)
           {
             int shape1 = x.shape(1);
@@ -288,7 +286,7 @@ void declare_mesh(nb::module_& m, const std::string& type)
            const std::vector<nb::ndarray<const std::int64_t, nb::ndim<1>,
                                          nb::c_contig>>& cells_nb,
            const std::vector<dolfinx::fem::CoordinateElement<T>>& elements,
-           const nb::ndarray<const T, nb::c_contig>& x,
+           nb::ndarray<const T, nb::c_contig> x,
            const part::impl::PythonCellPartitionFunction& p)
         {
           std::size_t shape1 = x.ndim() == 1 ? 1 : x.shape(1);
@@ -328,10 +326,9 @@ void declare_mesh(nb::module_& m, const std::string& type)
   m.def(
       "create_mesh",
       [](MPICommWrapper comm,
-         const nb::ndarray<const std::int64_t, nb::ndim<2>, nb::c_contig>&
-             cells,
+         nb::ndarray<const std::int64_t, nb::ndim<2>, nb::c_contig> cells,
          const dolfinx::fem::CoordinateElement<T>& element,
-         const nb::ndarray<const T, nb::c_contig>& x,
+         nb::ndarray<const T, nb::c_contig> x,
          const part::impl::PythonCellPartitionFunction& p)
       {
         std::size_t shape1 = x.ndim() == 1 ? 1 : x.shape(1);
@@ -371,8 +368,7 @@ void declare_mesh(nb::module_& m, const std::string& type)
   m.def(
       "create_submesh",
       [](const dolfinx::mesh::Mesh<T>& mesh, int dim,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-             entities)
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities)
       {
         std::tuple<dolfinx::mesh::Mesh<T>, std::vector<std::int32_t>,
                    std::vector<std::int32_t>, std::vector<std::int32_t>>
@@ -389,8 +385,7 @@ void declare_mesh(nb::module_& m, const std::string& type)
   m.def(
       "cell_normals",
       [](const dolfinx::mesh::Mesh<T>& mesh, int dim,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-             entities)
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities)
       {
         std::vector<T> n = dolfinx::mesh::cell_normals(
             mesh, dim, std::span(entities.data(), entities.size()));
@@ -400,8 +395,7 @@ void declare_mesh(nb::module_& m, const std::string& type)
   m.def(
       "h",
       [](const dolfinx::mesh::Mesh<T>& mesh, int dim,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-             entities)
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities)
       {
         return as_nbarray(dolfinx::mesh::h(
             mesh, std::span(entities.data(), entities.size()), dim));
@@ -411,8 +405,7 @@ void declare_mesh(nb::module_& m, const std::string& type)
   m.def(
       "compute_midpoints",
       [](const dolfinx::mesh::Mesh<T>& mesh, int dim,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-             entities)
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities)
       {
         std::vector<T> x = dolfinx::mesh::compute_midpoints(
             mesh, dim, std::span(entities.data(), entities.size()));
@@ -487,8 +480,7 @@ void declare_mesh(nb::module_& m, const std::string& type)
   m.def(
       "entities_to_geometry",
       [](const dolfinx::mesh::Mesh<T>& mesh, int dim,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-             entities,
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities,
          bool permute)
       {
         auto [geom_indices, idx_shape] = dolfinx::mesh::entities_to_geometry(
@@ -500,11 +492,9 @@ void declare_mesh(nb::module_& m, const std::string& type)
   m.def("create_geometry",
         [](const dolfinx::mesh::Topology& topology,
            const std::vector<dolfinx::fem::CoordinateElement<T>>& elements,
-           const nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>&
-               nodes,
-           const nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>&
-               xdofs,
-           const nb::ndarray<const T, nb::ndim<1>, nb::c_contig>& x, int dim)
+           nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig> nodes,
+           nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig> xdofs,
+           nb::ndarray<const T, nb::ndim<1>, nb::c_contig> x, int dim)
         {
           return dolfinx::mesh::create_geometry(
               topology, elements,
@@ -545,8 +535,7 @@ void mesh(nb::module_& m)
       "extract_topology",
       [](dolfinx::mesh::CellType cell_type,
          const dolfinx::fem::ElementDofLayout& layout,
-         const nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>&
-             cells)
+         nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig> cells)
       {
         return dolfinx_wrappers::as_nbarray(dolfinx::mesh::extract_topology(
             cell_type, layout, std::span(cells.data(), cells.size())));
@@ -605,12 +594,12 @@ void mesh(nb::module_& m)
       .def(
           "__init__",
           [](dolfinx::mesh::Topology* t, dolfinx::mesh::CellType cell_type,
-             const std::shared_ptr<const dolfinx::common::IndexMap>& vertex_map,
-             const std::shared_ptr<const dolfinx::common::IndexMap>& cell_map,
-             const std::shared_ptr<dolfinx::graph::AdjacencyList<std::int32_t>>&
-                 cells,
-             const std::optional<nb::ndarray<const std::int64_t, nb::ndim<1>,
-                                             nb::c_contig>>& original_index)
+             std::shared_ptr<const dolfinx::common::IndexMap> vertex_map,
+             std::shared_ptr<const dolfinx::common::IndexMap> cell_map,
+             std::shared_ptr<dolfinx::graph::AdjacencyList<std::int32_t>> cells,
+             std::optional<
+                 nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>>
+                 original_index)
           {
             using U = std::vector<std::vector<std::int64_t>>;
             using V = std::optional<U>;
@@ -663,7 +652,7 @@ void mesh(nb::module_& m)
                 idx.front().data(), {idx.front().size()});
           },
           [](dolfinx::mesh::Topology& self,
-             const nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>&
+             nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>
                  original_cell_indices)
           {
             self.original_cell_index.resize(1);
@@ -775,8 +764,7 @@ void mesh(nb::module_& m)
   m.def(
       "compute_incident_entities",
       [](const dolfinx::mesh::Topology& topology,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-             entities,
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> entities,
          int d0, int d1)
       {
         return dolfinx_wrappers::as_nbarray(

--- a/python/dolfinx/wrappers/petsc.cpp
+++ b/python/dolfinx/wrappers/petsc.cpp
@@ -175,8 +175,7 @@ void petsc_la_module(nb::module_& m)
   m.def(
       "create_matrix",
       [](dolfinx_wrappers::MPICommWrapper comm,
-         const dolfinx::la::SparsityPattern& p,
-         const std::optional<std::string>& type)
+         const dolfinx::la::SparsityPattern& p, std::optional<std::string> type)
       {
         Mat A = dolfinx::la::petsc::create_matrix(comm.get(), p, type);
         PyObject* obj = PyPetscMat_New(A);
@@ -309,8 +308,7 @@ void petsc_fem_module(nb::module_& m)
   m.def(
       "assemble_matrix",
       [](Mat A, const dolfinx::fem::Form<PetscScalar, PetscReal>& a,
-         const nb::ndarray<const PetscScalar, nb::ndim<1>, nb::c_contig>&
-             constants,
+         nb::ndarray<const PetscScalar, nb::ndim<1>, nb::c_contig> constants,
          const std::map<std::pair<dolfinx::fem::IntegralType, int>,
                         nb::ndarray<const PetscScalar, nb::ndim<2>,
                                     nb::c_contig>>& coefficients,
@@ -350,13 +348,12 @@ void petsc_fem_module(nb::module_& m)
   m.def(
       "assemble_matrix",
       [](Mat A, const dolfinx::fem::Form<PetscScalar, PetscReal>& a,
-         const nb::ndarray<const PetscScalar, nb::ndim<1>, nb::c_contig>&
-             constants,
+         nb::ndarray<const PetscScalar, nb::ndim<1>, nb::c_contig> constants,
          const std::map<std::pair<dolfinx::fem::IntegralType, int>,
                         nb::ndarray<const PetscScalar, nb::ndim<2>,
                                     nb::c_contig>>& coefficients,
-         const nb::ndarray<const std::int8_t, nb::ndim<1>, nb::c_contig>& rows0,
-         const nb::ndarray<const std::int8_t, nb::ndim<1>, nb::c_contig>& rows1,
+         nb::ndarray<const std::int8_t, nb::ndim<1>, nb::c_contig> rows0,
+         nb::ndarray<const std::int8_t, nb::ndim<1>, nb::c_contig> rows1,
          bool unrolled)
       {
         std::function<int(std::span<const std::int32_t>,

--- a/python/dolfinx/wrappers/refinement.cpp
+++ b/python/dolfinx/wrappers/refinement.cpp
@@ -134,11 +134,9 @@ void refinement(nb::module_& m)
   m.def(
       "transfer_facet_meshtag",
       [](const dolfinx::mesh::MeshTags<std::int32_t>& parent_meshtag,
-         const std::shared_ptr<const dolfinx::mesh::Topology>& topology1,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-             parent_cell,
-         const nb::ndarray<const std::int8_t, nb::ndim<1>, nb::c_contig>&
-             parent_facet)
+         std::shared_ptr<const dolfinx::mesh::Topology> topology1,
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> parent_cell,
+         nb::ndarray<const std::int8_t, nb::ndim<1>, nb::c_contig> parent_facet)
       {
         int tdim = parent_meshtag.topology()->dim();
         if (parent_meshtag.dim() != tdim - 1)
@@ -155,9 +153,8 @@ void refinement(nb::module_& m)
   m.def(
       "transfer_cell_meshtag",
       [](const dolfinx::mesh::MeshTags<std::int32_t>& parent_meshtag,
-         const std::shared_ptr<const dolfinx::mesh::Topology>& topology1,
-         const nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>&
-             parent_cell)
+         std::shared_ptr<const dolfinx::mesh::Topology> topology1,
+         nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> parent_cell)
       {
         int tdim = parent_meshtag.topology()->dim();
         if (parent_meshtag.dim() != tdim)


### PR DESCRIPTION
Revert changes that should not have been made.

C++ is too complicated for tools that changes the semantic of code.