### PR TITLE
Revert `python/CMakeLists.txt` change made in #3756

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.21)
 
-project(dolfinx_nanobind LANGUAGES CXX C)
+project(dolfinx_nanobind LANGUAGES CXX)
 
 if(WIN32)
   # Windows requires all symbols to be manually exported. This flag exports all


### PR DESCRIPTION
PR  #3756 added `C` as a language in  `python/CMakeLists.txt`. Change breaks Spack builds - build doesn't depend on C so Spack doesn't make a C compiler available.

Change in `python/CMakeLists.txt` seems unrelated to the PR and no text in the PR explaining change.