### PR TITLE
Use cache for Spack CI

### DIFF
--- a/.github/workflows/spack-config/gh-actions-env.yaml
+++ b/.github/workflows/spack-config/gh-actions-env.yaml
@@ -9,15 +9,6 @@ spack:
     all:
       require:
       - target=x86_64_v3
-    # gcc:
-    #   externals:
-    #   - spec: gcc@13.3.0 languages:='c,c++,fortran'
-    #     prefix: /usr
-    #     extra_attributes:
-    #       compilers:
-    #         c: /usr/bin/gcc
-    #         cxx: /usr/bin/g++
-    #         fortran: /usr/bin/gfortran
 
   mirrors:
     local-buildcache:

--- a/.github/workflows/spack-config/gh-actions-env.yaml
+++ b/.github/workflows/spack-config/gh-actions-env.yaml
@@ -1,0 +1,29 @@
+spack:
+  view: /opt/view
+  config:
+    install_tree:
+      root: /opt/spack
+      padded_length: 128
+
+  packages:
+    all:
+      require:
+      - target=x86_64_v3
+    # gcc:
+    #   externals:
+    #   - spec: gcc@13.3.0 languages:='c,c++,fortran'
+    #     prefix: /usr
+    #     extra_attributes:
+    #       compilers:
+    #         c: /usr/bin/gcc
+    #         cxx: /usr/bin/g++
+    #         fortran: /usr/bin/gfortran
+
+  mirrors:
+    local-buildcache:
+      url: oci://ghcr.io/fenics/spack-buildcache
+      binary: true
+      signed: false
+      access_pair:
+        id_variable: GITHUB_USER
+        secret_variable: GITHUB_TOKEN

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -2,9 +2,9 @@ name: Spack build
 
 on:
   # Uncomment the below 'push' to trigger on push
-  # push:
-  #  branches:
-  #    - "**"
+  push:
+   branches:
+     - "**"
   schedule:
     # '*' is a special character in YAML, so string must be quoted
     - cron: "0 2 * * THU"

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create cpp-main-test .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e cpp-main-test install -j 4 --add "cmake fenics-dolfinx@main+petsc+adios2 py-fenics-ffcx@main"
+          spack -e cpp-main-test install -j 4 --add fenics-dolfinx@main+petsc+adios2 py-fenics-ffcx@main
           cd dolfinx-main/cpp/
           cd demo/poisson
           cmake .

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -54,33 +54,45 @@ jobs:
         shell: spack-bash {0}
         run: |
           spack env create . .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e . install -j 4 --add gmake
-        # spack -e . install -j 4 --add fenics-dolfinx@main+petsc+adios2
-      # - name: Get DOLFINx code (to access test files)
-      #   uses: actions/checkout@v4
-      #   with:
-      #     path: ./dolfinx-main
-      # - name: Run a C++ test (development version)
-      #   shell: spack-bash {0}
-      #   run: |
-      #     spack env create cpp-main-test
-      #     spack env activate cpp-main-test
-      #     spack add fenics-dolfinx@main+petsc+adios2 cmake py-fenics-ffcx@main
-      #     spack install
-      #     cd dolfinx-main/cpp/
-      #     cd demo/poisson
-      #     cmake .
-      #     export VERBOSE=1
-      #     make -j 4
-      #     mpirun -np 2 ./demo_poisson
+          spack -e . install -j 4 --add fenics-dolfinx@main+petsc+adios2
+
+      - name: Get DOLFINx code (to access test files)
+        uses: actions/checkout@v4
+        with:
+          path: ./dolfinx-main
+      - name: Run a C++ test (development version)
+        shell: spack-bash {0}
+        run: |
+          spack env create . .github/workflows/spack-config/gh-actions-env.yaml
+          spack -e . install -j 4 --add fenics-dolfinx@main+petsc+adios2 cmake py-fenics-ffcx@main
+          cd dolfinx-main/cpp/
+          cd demo/poisson
+          cmake .
+          export VERBOSE=1
+          make -j 4
+          mpirun -np 2 ./demo_poisson
+
+        # spack env create cpp-main-test
+        # spack env activate cpp-main-test
+        # spack add fenics-dolfinx@main+petsc+adios2 cmake py-fenics-ffcx@main
+        # spack install
+        # cd dolfinx-main/cpp/
+        # cd demo/poisson
+        # cmake .
+        # export VERBOSE=1
+        # make -j 4
+        # mpirun -np 2 ./demo_poisson
 
       # - name: Build DOLFINx (C++) release version via Spack
       #   shell: spack-bash {0}
       #   run: |
-      #     spack env create cpp-release
-      #     spack env activate cpp-release
-      #     spack add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2
-      #     spack install
+      #     spack env create . .github/workflows/spack-config/gh-actions-env.yaml
+      #     spack -e . install -j 4 --add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2
+
+        # spack env create cpp-release
+        # spack env activate cpp-release
+        # spack add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2
+        # spack install
       # - name: Get DOLFINx release code (to access test files)
       #   uses: actions/checkout@v4
       #   with:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -19,54 +19,38 @@ env:
   GITHUB_USER: ${{ github.actor }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+# env:
+  OMPI_ALLOW_RUN_AS_ROOT: 1
+  OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe   # Newer OpenMPI
+  OMPI_MCA_rmaps_base_oversubscribe: true                 # Older OpenMPI
+
+  DOLFINX_RELEASE_VERSION: "${{ github.event_name != 'workflow_dispatch' && '0.9.0' || github.event.inputs.dolfinx_version }}"
 
 jobs:
-  build:
+
+  cpp-main:
+    name: Build DOLFINx (C++, main)
     runs-on: ubuntu-latest
     container: ubuntu:24.04
-
-    env:
-      OMPI_ALLOW_RUN_AS_ROOT: 1
-      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-      PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe   # Newer OpenMPI
-      OMPI_MCA_rmaps_base_oversubscribe: true                 # Older OpenMPI
-
-      DOLFINX_RELEASE_VERSION: "${{ github.event_name != 'workflow_dispatch' && '0.9.0' || github.event.inputs.dolfinx_version }}"
-
     steps:
       - name: Install Spack requirements
         run: |
           apt-get -y update
           apt-get install -y bzip2 curl file git gzip make patch python3-minimal tar unzip xz-utils
           apt-get install -y g++ gfortran  # compilers
-
       - uses: actions/checkout@v4
-
       - name: Set up Spack
         uses: spack/setup-spack@main
         with:
           ref: develop      # Spack version (examples: develop, releases/v0.23)
-          buildcache: true  # Configure oci://ghcr.io/spack/github-actions-buildcache
           color: true       # Force color output (SPACK_COLOR=always)
-          path: spack-src       # Where to clone Spack
-
+          path: spack-src   # Where to clone Spack
       - name: Build DOLFINx (C++) development version via Spack
         shell: spack-bash {0}
         run: |
           spack env create cpp-main .github/workflows/spack-config/gh-actions-env.yaml
           spack -e cpp-main install -j 4 --add fenics-dolfinx@main+petsc
-      - name: Push packages and update index
-        env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
-        if: ${{ !cancelled() }}
-
-      - name: Get DOLFINx code (to access test files)
-        uses: actions/checkout@v4
-        with:
-          path: ./dolfinx-main
       - name: Run a C++ test (development version)
         shell: spack-bash {0}
         run: |
@@ -85,58 +69,37 @@ jobs:
           GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          spack -e cpp-main-test buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
-        if: ${{ !cancelled() }}
-
-      - name: Build DOLFINx (C++) release version via Spack
-        shell: spack-bash {0}
-        run: |
-          spack env create cpp-release .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e cpp-release install --add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2
-      - name: Push packages and update index
-        env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
           spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
         if: ${{ !cancelled() }}
 
-      - name: Get DOLFINx release code (to access test files)
-        uses: actions/checkout@v4
+  python-main:
+    name: Build DOLFINx (Python, main)
+    runs-on: ubuntu-latest
+    container: ubuntu:24.04
+    steps:
+      - name: Install Spack requirements
+        run: |
+          apt-get -y update
+          apt-get install -y bzip2 curl file git gzip make patch python3-minimal tar unzip xz-utils
+          apt-get install -y g++ gfortran  # compilers
+      - uses: actions/checkout@v4
+      - name: Set up Spack
+        uses: spack/setup-spack@main
         with:
-          ref:  v${{ env.DOLFINX_RELEASE_VERSION }}
-          path: ./dolfinx-release
-      - name: Run a C++ test (release version)
-        shell: spack-bash {0}
-        run: |
-          spack env create cpp-release-test .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e cpp-release-test install --add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2 cmake py-fenics-ffcx
-          spack env activate cpp-release-test
-          cd dolfinx-release/cpp/
-          cd demo/poisson
-          cmake .
-          export VERBOSE=1
-          make -j 4
-          mpirun -np 2 ./demo_poisson
-      - name: Push packages and update index
-        env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          spack -e cpp-release-test buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
-        if: ${{ !cancelled() }}
-
+          ref: develop      # Spack version (examples: develop, releases/v0.23)
+          color: true       # Force color output (SPACK_COLOR=always)
+          path: spack-src   # Where to clone Spack
       - name: Build DOLFINx (Python, development)
         shell: spack-bash {0}
         run: |
           cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create py-main .github/workflows/spack-config/gh-actions-env.yaml
-          spack -v -e py-main install --add py-fenics-dolfinx@main
-      # - name: Run DOLFINx (Python, development) test
-      #   shell: spack-bash {0}
-      #   run: |
-      #     spack env activate py-main
-      #     mpirun -np 2 python3 ./dolfinx-main/python/demo/demo_elasticity.py
+          spack -e py-main install --add py-fenics-dolfinx@main
+      - name: Run DOLFINx (Python, development) test
+        shell: spack-bash {0}
+        run: |
+          spack env activate py-main
+          mpirun -np 2 python3 python/demo/demo_elasticity.py
       - name: Push packages and update index
         env:
           GITHUB_USER: ${{ github.actor }}
@@ -145,24 +108,129 @@ jobs:
           spack -e py-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
         if: ${{ !cancelled() }}
 
-      # - name: Build DOLFINx (Python, release version)
-      #   shell: spack-bash {0}
-      #   run: |
-      #     spack env create py-release
-      #     spack env activate py-release
-      #     spack add py-fenics-dolfinx@${DOLFINX_RELEASE_VERSION}
-      #     spack install -j 4
-      # - name: Run DOLFINx (Python, release) test
-      #   shell: spack-bash {0}
-      #   run: |
-      #     spack env activate py-release
-      #     mpirun -np 2 python3 ./dolfinx-release/python/demo/demo_elasticity.py
 
+      #     - name: Run a C++ test (development version)
+      #   shell: spack-bash {0}
+      #   run: |
+      #     cat .github/workflows/spack-config/gh-actions-env.yaml
+      #     spack env create cpp-main-test .github/workflows/spack-config/gh-actions-env.yaml
+      #     spack -e cpp-main-test install --add fenics-dolfinx@main+petsc cmake py-fenics-ffcx@main
+      #     spack env activate cpp-main-test
+      #     cd dolfinx-main/cpp/
+      #     cd demo/poisson
+      #     cmake .
+      #     export VERBOSE=1
+      #     make -j 4
+      #     mpirun -np 2 ./demo_poisson
       # - name: Push packages and update index
       #   env:
       #     GITHUB_USER: ${{ github.actor }}
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       #   run: |
       #     spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+      #   if: ${{ !cancelled() }}
+
+
+      # - name: Get DOLFINx code (to access test files)
+      #   uses: actions/checkout@v4
+      #   with:
+      #     path: ./dolfinx-main
+      # - name: Run a C++ test (development version)
+      #   shell: spack-bash {0}
+      #   run: |
+      #     cat .github/workflows/spack-config/gh-actions-env.yaml
+      #     spack env create cpp-main-test .github/workflows/spack-config/gh-actions-env.yaml
+      #     spack -e cpp-main-test install --add fenics-dolfinx@main+petsc cmake py-fenics-ffcx@main
+      #     spack env activate cpp-main-test
+      #     cd dolfinx-main/cpp/
+      #     cd demo/poisson
+      #     cmake .
+      #     export VERBOSE=1
+      #     make -j 4
+      #     mpirun -np 2 ./demo_poisson
+      # - name: Push packages and update index
+      #   env:
+      #     GITHUB_USER: ${{ github.actor }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
       #     spack -e cpp-main-test buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
       #   if: ${{ !cancelled() }}
+
+      # - name: Build DOLFINx (C++) release version via Spack
+      #   shell: spack-bash {0}
+      #   run: |
+      #     spack env create cpp-release .github/workflows/spack-config/gh-actions-env.yaml
+      #     spack -e cpp-release install --add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2
+      # - name: Push packages and update index
+      #   env:
+      #     GITHUB_USER: ${{ github.actor }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+      #   if: ${{ !cancelled() }}
+
+      # - name: Get DOLFINx release code (to access test files)
+      #   uses: actions/checkout@v4
+      #   with:
+      #     ref:  v${{ env.DOLFINX_RELEASE_VERSION }}
+      #     path: ./dolfinx-release
+      # - name: Run a C++ test (release version)
+      #   shell: spack-bash {0}
+      #   run: |
+      #     spack env create cpp-release-test .github/workflows/spack-config/gh-actions-env.yaml
+      #     spack -e cpp-release-test install --add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2 cmake py-fenics-ffcx
+      #     spack env activate cpp-release-test
+      #     cd dolfinx-release/cpp/
+      #     cd demo/poisson
+      #     cmake .
+      #     export VERBOSE=1
+      #     make -j 4
+      #     mpirun -np 2 ./demo_poisson
+      # - name: Push packages and update index
+      #   env:
+      #     GITHUB_USER: ${{ github.actor }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     spack -e cpp-release-test buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+      #   if: ${{ !cancelled() }}
+
+      # - name: Build DOLFINx (Python, development)
+      #   shell: spack-bash {0}
+      #   run: |
+      #     cat .github/workflows/spack-config/gh-actions-env.yaml
+      #     spack env create py-main .github/workflows/spack-config/gh-actions-env.yaml
+      #     spack -v -e py-main install --add py-fenics-dolfinx@main
+      # # - name: Run DOLFINx (Python, development) test
+      # #   shell: spack-bash {0}
+      # #   run: |
+      # #     spack env activate py-main
+      # #     mpirun -np 2 python3 ./dolfinx-main/python/demo/demo_elasticity.py
+      # - name: Push packages and update index
+      #   env:
+      #     GITHUB_USER: ${{ github.actor }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     spack -e py-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+      #   if: ${{ !cancelled() }}
+
+      # # - name: Build DOLFINx (Python, release version)
+      # #   shell: spack-bash {0}
+      # #   run: |
+      # #     spack env create py-release
+      # #     spack env activate py-release
+      # #     spack add py-fenics-dolfinx@${DOLFINX_RELEASE_VERSION}
+      # #     spack install -j 4
+      # # - name: Run DOLFINx (Python, release) test
+      # #   shell: spack-bash {0}
+      # #   run: |
+      # #     spack env activate py-release
+      # #     mpirun -np 2 python3 ./dolfinx-release/python/demo/demo_elasticity.py
+
+      # # - name: Push packages and update index
+      # #   env:
+      # #     GITHUB_USER: ${{ github.actor }}
+      # #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # #   run: |
+      # #     spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+      # #     spack -e cpp-main-test buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+      # #   if: ${{ !cancelled() }}

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -58,11 +58,9 @@ jobs:
           spack env create cpp-main-test .github/workflows/spack-config/gh-actions-env.yaml
           spack -e cpp-main-test install --add fenics-dolfinx@main+petsc cmake py-fenics-ffcx@main
           spack env activate cpp-main-test
-          cd dolfinx-main/cpp/
-          cd demo/poisson
+          cd cpp/demo/poisson
           cmake .
-          export VERBOSE=1
-          make -j 4
+          make
           mpirun -np 2 ./demo_poisson
       - name: Push packages and update index
         env:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -97,6 +97,8 @@ jobs:
         shell: spack-bash {0}
         run: |
           spack env activate py-main
+          spack compiler find
+          spack load gcc
           mpirun -np 2 python3 python/demo/demo_elasticity.py
       - name: Push packages and update index
         env:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create cpp-main-test .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e cpp-main-test install -j 4 --add cmake fenics-dolfinx@main+petsc+adios2 py-fenics-ffcx@main
+          spack -e cpp-main-test install -j 4 --add "cmake fenics-dolfinx@main+petsc+adios2 py-fenics-ffcx@main"
           cd dolfinx-main/cpp/
           cd demo/poisson
           cmake .

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create py-main .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e py-main install --use-buildcache=package:never,dependencies:auto --add py-fenics-dolfinx@main %fenics-dolfinx+petsc
+          spack -e py-main install --use-buildcache=package:never,dependencies:auto --add py-fenics-dolfinx@main %fenics-dolfinx+petsc py-setuptools
       - name: Run DOLFINx (Python, development) test
         shell: spack-bash {0}
         run: |

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -54,7 +54,7 @@ jobs:
         shell: spack-bash {0}
         run: |
           spack env create cpp-main .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e cpp-main install -j 4 --add fenics-dolfinx@main+petsc+adios2
+          spack -e cpp-main install -j 4 --add fenics-dolfinx@main+petsc
       - name: Push packages and update index
         env:
           GITHUB_USER: ${{ github.actor }}
@@ -72,7 +72,7 @@ jobs:
         run: |
           cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create cpp-main-test .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e cpp-main-test install -j 4 --add fenics-dolfinx@main+petsc+adios2 cmake py-fenics-ffcx@main
+          spack -e cpp-main-test install --add fenics-dolfinx@main+petsc cmake py-fenics-ffcx@main
           spack env activate cpp-main-test
           cd dolfinx-main/cpp/
           cd demo/poisson
@@ -92,7 +92,7 @@ jobs:
         shell: spack-bash {0}
         run: |
           spack env create cpp-release .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e cpp-release install -j 4 --add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2
+          spack -e cpp-release install --add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2
       - name: Push packages and update index
         env:
           GITHUB_USER: ${{ github.actor }}

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -50,20 +50,18 @@ jobs:
           color: true       # Force color output (SPACK_COLOR=always)
           path: spack-src       # Where to clone Spack
 
-      # - name: Build DOLFINx (C++) development version via Spack
-      #   shell: spack-bash {0}
-      #   run: |
-      #     spack env create cpp-main .github/workflows/spack-config/gh-actions-env.yaml
-      #     spack -e cpp-main install -j 4 --add fenics-dolfinx@main+petsc+adios2
-
-      # - name: Push packages and update index
-      #   env:
-      #     GITHUB_USER: ${{ github.actor }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
-      #   if: ${{ !cancelled() }}
-
+      - name: Build DOLFINx (C++) development version via Spack
+        shell: spack-bash {0}
+        run: |
+          spack env create cpp-main .github/workflows/spack-config/gh-actions-env.yaml
+          spack -e cpp-main install -j 4 --add fenics-dolfinx@main+petsc+adios2
+      - name: Push packages and update index
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+        if: ${{ !cancelled() }}
 
       - name: Get DOLFINx code (to access test files)
         uses: actions/checkout@v4
@@ -76,12 +74,12 @@ jobs:
           spack env create cpp-main-test .github/workflows/spack-config/gh-actions-env.yaml
           spack -e cpp-main-test install -j 4 --add fenics-dolfinx@main+petsc+adios2 cmake py-fenics-ffcx@main
           spack env activate cpp-main-test
-          # cd dolfinx-main/cpp/
-          # cd demo/poisson
-          # cmake .
-          # export VERBOSE=1
-          # make -j 4
-          # mpirun -np 2 ./demo_poisson
+          cd dolfinx-main/cpp/
+          cd demo/poisson
+          cmake .
+          export VERBOSE=1
+          make -j 4
+          mpirun -np 2 ./demo_poisson
 
       - name: Push packages and update index
         env:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -56,6 +56,15 @@ jobs:
       #     spack env create cpp-main .github/workflows/spack-config/gh-actions-env.yaml
       #     spack -e cpp-main install -j 4 --add fenics-dolfinx@main+petsc+adios2
 
+      - name: Push packages and update index
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+        if: ${{ !cancelled() }}
+
+
       - name: Get DOLFINx code (to access test files)
         uses: actions/checkout@v4
         with:
@@ -63,6 +72,7 @@ jobs:
       - name: Run a C++ test (development version)
         shell: spack-bash {0}
         run: |
+          cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create cpp-main-test .github/workflows/spack-config/gh-actions-env.yaml
           spack -e cpp-main-test install -j 4 --add fenics-dolfinx@main+petsc+adios2 cmake py-fenics-ffcx@main
           cd dolfinx-main/cpp/
@@ -71,6 +81,14 @@ jobs:
           export VERBOSE=1
           make -j 4
           mpirun -np 2 ./demo_poisson
+
+      - name: Push packages and update index
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          spack -e cpp-main-test buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+        if: ${{ !cancelled() }}
 
         # spack env create cpp-main-test
         # spack env activate cpp-main-test
@@ -138,9 +156,11 @@ jobs:
       #     spack env activate py-release
       #     mpirun -np 2 python3 ./dolfinx-release/python/demo/demo_elasticity.py
 
-      - name: Push packages and update index
-        env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: spack -e . buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
-        if: ${{ !cancelled() }}
+      # - name: Push packages and update index
+      #   env:
+      #     GITHUB_USER: ${{ github.actor }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+      #     spack -e cpp-main-test buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+      #   if: ${{ !cancelled() }}

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -110,7 +110,7 @@ jobs:
         shell: spack-bash {0}
         run: |
           spack env create cpp-release-test .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e cpp-release-test install -j 4 --add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2 cmake py-fenics-ffcx
+          spack -e cpp-release-test install --add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2 cmake py-fenics-ffcx
           spack env activate cpp-release-test
           cd dolfinx-release/cpp/
           cd demo/poisson
@@ -129,13 +129,14 @@ jobs:
       - name: Build DOLFINx (Python, development)
         shell: spack-bash {0}
         run: |
+          cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create py-main .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e py-main install -j 4 --add py-fenics-dolfinx@main
-      - name: Run DOLFINx (Python, development) test
-        shell: spack-bash {0}
-        run: |
-          spack env activate py-main
-          mpirun -np 2 python3 ./dolfinx-main/python/demo/demo_elasticity.py
+          spack -v -e py-main install --add py-fenics-dolfinx@main
+      # - name: Run DOLFINx (Python, development) test
+      #   shell: spack-bash {0}
+      #   run: |
+      #     spack env activate py-main
+      #     mpirun -np 2 python3 ./dolfinx-main/python/demo/demo_elasticity.py
       - name: Push packages and update index
         env:
           GITHUB_USER: ${{ github.actor }}

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Run a C++ test (release version)
         shell: spack-bash {0}
         run: |
-          spack env create cpp-cpp-release-test .github/workflows/spack-config/gh-actions-env.yaml
+          spack env create cpp-release-test .github/workflows/spack-config/gh-actions-env.yaml
           spack -e cpp-release-test install -j 4 --add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2 cmake py-fenics-ffcx
           spack env activate cpp-release-test
           cd dolfinx-release/cpp/
@@ -123,44 +123,26 @@ jobs:
           GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          spack -e cpp-cpp-release-test buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+          spack -e cpp-release-test buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
         if: ${{ !cancelled() }}
 
-      # spack env create cpp-release
-        # spack env activate cpp-release
-        # spack add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2
-        # spack install
-      # - name: Get DOLFINx release code (to access test files)
-      #   uses: actions/checkout@v4
-      #   with:
-      #     ref:  v${{ env.DOLFINX_RELEASE_VERSION }}
-      #     path: ./dolfinx-release
-      # - name: Run a C++ test (release version)
-      #   shell: spack-bash {0}
-      #   run: |
-      #     spack env create cpp-release-test
-      #     spack env activate cpp-release-test
-      #     spack add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2 cmake py-fenics-ffcx
-      #     spack install
-      #     cd dolfinx-release/cpp/
-      #     cd demo/poisson
-      #     cmake .
-      #     export VERBOSE=1
-      #     make -j 4
-      #     mpirun -np 2 ./demo_poisson
-
-      # - name: Build DOLFINx (Python, development)
-      #   shell: spack-bash {0}
-      #   run: |
-      #     spack env create py-main
-      #     spack env activate py-main
-      #     spack add py-fenics-dolfinx@main
-      #     spack install
-      # - name: Run DOLFINx (Python, development) test
-      #   shell: spack-bash {0}
-      #   run: |
-      #     spack env activate py-main
-      #     mpirun -np 2 python3 ./dolfinx-main/python/demo/demo_elasticity.py
+      - name: Build DOLFINx (Python, development)
+        shell: spack-bash {0}
+        run: |
+          spack env create py-main  .github/workflows/spack-config/gh-actions-env.yaml
+          spack -e py-main install -j 4 --add py-fenics-dolfinx@main
+      - name: Run DOLFINx (Python, development) test
+        shell: spack-bash {0}
+        run: |
+          spack env activate py-main
+          mpirun -np 2 python3 ./dolfinx-main/python/demo/demo_elasticity.py
+      - name: Push packages and update index
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          spack -e ph-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+        if: ${{ !cancelled() }}
 
       # - name: Build DOLFINx (Python, release version)
       #   shell: spack-bash {0}

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -97,6 +97,7 @@ jobs:
         shell: spack-bash {0}
         run: |
           spack env activate py-main
+          spack load gcc
           mpirun -np 2 python3 python/demo/demo_elasticity.py
       - name: Push packages and update index
         env:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -51,7 +51,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         shell: spack-bash {0}
         run: |
-          spack repo add --name test_pkgs https://github.com/${{ env.spack_package_repo }}.git@${{ env.spack_package_ref }} ~/test_pkgs
+          spack repo add --name test_pkgs https://github.com/${{ github.event.inputs.spack_package_repo }}.git@${{ github.event.inputs.spack_package_ref }} ~/test_pkgs
       - name: Build DOLFINx
         shell: spack-bash {0}
         run: |

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -54,8 +54,8 @@ jobs:
         shell: spack-bash {0}
         run: |
           spack env create . .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e . install -j 4 -- add gmake
-          # spack -e . install -j 4 -- add fenics-dolfinx@main+petsc+adios2
+          spack -e . install -j 4 --add gmake
+        # spack -e . install -j 4 --add fenics-dolfinx@main+petsc+adios2
       # - name: Get DOLFINx code (to access test files)
       #   uses: actions/checkout@v4
       #   with:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -15,6 +15,11 @@ on:
         default: "0.9.0"
         type: string
 
+env:
+  GITHUB_USER: ${{ github.actor }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -39,10 +44,9 @@ jobs:
         uses: spack/setup-spack@main
         with:
           ref: develop      # Spack version (examples: develop, releases/v0.23)
-          buildcache: true  # Configure oci://ghcr.io/spack/github-actions-buildcache
+          # buildcache: true  # Configure oci://ghcr.io/spack/github-actions-buildcache
           color: true       # Force color output (SPACK_COLOR=always)
           path: spack       # Where to clone Spack
-
 
       - name: Build DOLFINx (C++) development version via Spack
         shell: spack-bash {0}
@@ -120,3 +124,10 @@ jobs:
         run: |
           spack env activate py-release
           mpirun -np 2 python3 ./dolfinx-release/python/demo/demo_elasticity.py
+
+      - name: Push packages and update index
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: spack -e . buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+        if: ${{ !cancelled() }}

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -7,25 +7,25 @@ on:
      - "**"
   schedule:
     # '*' is a special character in YAML, so string must be quoted
-    - cron: "0 2 * * THU"
+    - cron: "0 2 * * *"
   workflow_dispatch:
     inputs:
-      dolfinx_version:
-        description: "DOLFINx release branch/tag to test"
-        default: "0.9.0"
+      spack_package_repo:
+        description: "Spack package repository to test"
+        default: "spack/spack-packages"
+        type: string
+      spack_package_ref:
+        description: "Spack package repository branch/tag to test"
+        default: "develop"
         type: string
 
 env:
   GITHUB_USER: ${{ github.actor }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe   # Newer OpenMPI
   OMPI_MCA_rmaps_base_oversubscribe: true                 # Older OpenMPI
-
-  DOLFINX_RELEASE_VERSION: "${{ github.event_name != 'workflow_dispatch' && '0.9.0' || github.event.inputs.dolfinx_version }}"
-  DOLFINX_TAG: "${{ github.event_name != 'workflow_dispatch' && '0.9.0' || github.event.inputs.dolfinx_version }}"
 
 jobs:
 
@@ -50,6 +50,7 @@ jobs:
       - name: Build DOLFINx (C++) development version via Spack
         shell: spack-bash {0}
         run: |
+          spack repo add  add --name test_pkgs https://github.com/${{ env.spack_package_repo }}.git@${{ env.spack_package_ref }} ~/test_pkgs
           spack env create dolfinx .github/workflows/spack-config/gh-actions-env.yaml
           spack -e dolfinx install --use-buildcache=package:never,dependencies:auto --add fenics-dolfinx@main+petsc
       - name: Run a C++ test
@@ -92,6 +93,7 @@ jobs:
       - name: Build DOLFINx
         shell: spack-bash {0}
         run: |
+          spack repo add  add --name test_pkgs https://github.com/${{ env.spack_package_repo }}.git@${{ env.spack_package_ref }} ~/test_pkgs
           cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create dolfinx .github/workflows/spack-config/gh-actions-env.yaml
           spack -e dolfinx install --use-buildcache=package:never,dependencies:auto --add py-fenics-dolfinx@main %fenics-dolfinx+petsc~adios2

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -92,13 +92,11 @@ jobs:
         run: |
           cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create py-main .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e py-main install --use-buildcache=package:never,dependencies:auto --add py-fenics-dolfinx@main fenics-dolfinx@main+petsc
+          spack -e py-main install --use-buildcache=package:never,dependencies:auto --add py-fenics-dolfinx@main %fenics-dolfinx+petsc
       - name: Run DOLFINx (Python, development) test
         shell: spack-bash {0}
         run: |
           spack env activate py-main
-          spack load gcc
-          spack compiler find
           mpirun -np 2 python3 python/demo/demo_elasticity.py
       - name: Push packages and update index
         env:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -56,13 +56,13 @@ jobs:
       #     spack env create cpp-main .github/workflows/spack-config/gh-actions-env.yaml
       #     spack -e cpp-main install -j 4 --add fenics-dolfinx@main+petsc+adios2
 
-      - name: Push packages and update index
-        env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
-        if: ${{ !cancelled() }}
+      # - name: Push packages and update index
+      #   env:
+      #     GITHUB_USER: ${{ github.actor }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+      #   if: ${{ !cancelled() }}
 
 
       - name: Get DOLFINx code (to access test files)
@@ -74,7 +74,7 @@ jobs:
         run: |
           cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create cpp-main-test .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e cpp-main-test install -j 4 --add fenics-dolfinx@main+petsc+adios2 cmake py-fenics-ffcx@main
+          spack -e cpp-main-test install -j 4 --add cmake fenics-dolfinx@main+petsc+adios2 py-fenics-ffcx@main
           cd dolfinx-main/cpp/
           cd demo/poisson
           cmake .

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -101,12 +101,14 @@ jobs:
         run: |
           spack repo add --name test_pkgs https://github.com/${{ github.event.inputs.spack_package_repo }}.git ~/test_pkgs
           spack repo update --branch ${{ github.event.inputs.spack_package_ref }} test_pkgs
+          spack repo list
       - name: Build DOLFINx
         shell: spack-bash {0}
         run: |
           cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create dolfinx .github/workflows/spack-config/gh-actions-env.yaml
           spack -e dolfinx install --use-buildcache=package:never,dependencies:auto --add py-fenics-dolfinx@main %fenics-dolfinx+petsc~adios2
+          spack repo list
       - name: Run a Python test
         shell: spack-bash {0}
         run: |

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -48,13 +48,14 @@ jobs:
           ref: develop      # Spack version (examples: develop, releases/v0.23)
           buildcache: true  # Configure oci://ghcr.io/spack/github-actions-buildcache
           color: true       # Force color output (SPACK_COLOR=always)
-          path: spack       # Where to clone Spack
+          path: spack-src       # Where to clone Spack
 
       - name: Build DOLFINx (C++) development version via Spack
         shell: spack-bash {0}
         run: |
-          spack env create . .github/workflows/spack-configs/gh-actions-env.yaml
-          spack -e . install -j 4 -- add fenics-dolfinx@main+petsc+adios2
+          spack env create . .github/workflows/spack-config/gh-actions-env.yaml
+          spack -e . install -j 4 -- add gmake
+          # spack -e . install -j 4 -- add fenics-dolfinx@main+petsc+adios2
       # - name: Get DOLFINx code (to access test files)
       #   uses: actions/checkout@v4
       #   with:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -50,13 +50,13 @@ jobs:
         shell: spack-bash {0}
         run: |
           spack env create cpp-main .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e cpp-main install -j 4 --add fenics-dolfinx@main+petsc
+          spack -e cpp-main install --use-buildcache=package:never,dependencies:auto --add fenics-dolfinx@main+petsc
       - name: Run a C++ test (development version)
         shell: spack-bash {0}
         run: |
           cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create cpp-main-test .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e cpp-main-test install --add fenics-dolfinx@main+petsc cmake py-fenics-ffcx@main
+          spack -e cpp-main-test install --use-buildcache=package:never,dependencies:auto --add fenics-dolfinx@main+petsc cmake py-fenics-ffcx@main
           spack env activate cpp-main-test
           cd cpp/demo/poisson
           cmake .
@@ -92,12 +92,13 @@ jobs:
         run: |
           cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create py-main .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e py-main install --add py-fenics-dolfinx@main
+          spack -e py-main install --use-buildcache=package:never,dependencies:auto --add py-fenics-dolfinx@main
       - name: Run DOLFINx (Python, development) test
         shell: spack-bash {0}
         run: |
           spack env activate py-main
           spack load gcc
+          spack compiler find
           mpirun -np 2 python3 python/demo/demo_elasticity.py
       - name: Push packages and update index
         env:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -10,14 +10,6 @@ on:
     - cron: "0 2 * * THU"
   workflow_dispatch:
     inputs:
-      spack_repo:
-        description: "Spack repository to test"
-        default: "spack/spack"
-        type: string
-      spack_ref:
-        description: "Spack repository branch/tag to test"
-        default: "develop"
-        type: string
       dolfinx_version:
         description: "DOLFINx release branch/tag to test"
         default: "0.9.0"
@@ -37,29 +29,24 @@ jobs:
       DOLFINX_RELEASE_VERSION: "${{ github.event_name != 'workflow_dispatch' && '0.9.0' || github.event.inputs.dolfinx_version }}"
 
     steps:
-      - name: Get Spack
-        if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v4
-        with:
-          path: ./spack
-          repository: spack/spack
-      - name: Get Spack
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
-        with:
-          path: ./spack
-          repository: ${{ github.event.inputs.spack_repo }}
-          ref: ${{ github.event.inputs.spack_ref }}
-
       - name: Install Spack requirements
         run: |
           apt-get -y update
           apt-get install -y bzip2 curl file git gzip make patch python3-minimal tar unzip xz-utils
           apt-get install -y g++ gfortran  # compilers
 
+      - name: Set up Spack
+        uses: spack/setup-spack@main
+        with:
+          ref: develop      # Spack version (examples: develop, releases/v0.23)
+          buildcache: true  # Configure oci://ghcr.io/spack/github-actions-buildcache
+          color: true       # Force color output (SPACK_COLOR=always)
+          path: spack       # Where to clone Spack
+
+
       - name: Build DOLFINx (C++) development version via Spack
+        shell: spack-bash {0}
         run: |
-          . ./spack/share/spack/setup-env.sh
           spack env create cpp-main
           spack env activate cpp-main
           spack add fenics-dolfinx@main+petsc+adios2
@@ -69,8 +56,8 @@ jobs:
         with:
           path: ./dolfinx-main
       - name: Run a C++ test (development version)
+        shell: spack-bash {0}
         run: |
-          . ./spack/share/spack/setup-env.sh
           spack env create cpp-main-test
           spack env activate cpp-main-test
           spack add fenics-dolfinx@main+petsc+adios2 cmake py-fenics-ffcx@main
@@ -83,8 +70,8 @@ jobs:
           mpirun -np 2 ./demo_poisson
 
       - name: Build DOLFINx (C++) release version via Spack
+        shell: spack-bash {0}
         run: |
-          . ./spack/share/spack/setup-env.sh
           spack env create cpp-release
           spack env activate cpp-release
           spack add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2
@@ -95,8 +82,8 @@ jobs:
           ref:  v${{ env.DOLFINX_RELEASE_VERSION }}
           path: ./dolfinx-release
       - name: Run a C++ test (release version)
+        shell: spack-bash {0}
         run: |
-          . ./spack/share/spack/setup-env.sh
           spack env create cpp-release-test
           spack env activate cpp-release-test
           spack add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2 cmake py-fenics-ffcx
@@ -109,27 +96,27 @@ jobs:
           mpirun -np 2 ./demo_poisson
 
       - name: Build DOLFINx (Python, development)
+        shell: spack-bash {0}
         run: |
-          . ./spack/share/spack/setup-env.sh
           spack env create py-main
           spack env activate py-main
           spack add py-fenics-dolfinx@main
           spack install
       - name: Run DOLFINx (Python, development) test
+        shell: spack-bash {0}
         run: |
-          . ./spack/share/spack/setup-env.sh
           spack env activate py-main
           mpirun -np 2 python3 ./dolfinx-main/python/demo/demo_elasticity.py
 
       - name: Build DOLFINx (Python, release version)
+        shell: spack-bash {0}
         run: |
-          . ./spack/share/spack/setup-env.sh
           spack env create py-release
           spack env activate py-release
           spack add py-fenics-dolfinx@${DOLFINX_RELEASE_VERSION}
           spack install -j 4
       - name: Run DOLFINx (Python, release) test
+        shell: spack-bash {0}
         run: |
-          . ./spack/share/spack/setup-env.sh
           spack env activate py-release
           mpirun -np 2 python3 ./dolfinx-release/python/demo/demo_elasticity.py

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -74,13 +74,14 @@ jobs:
         run: |
           cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create cpp-main-test .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e cpp-main-test install -j 4 --add fenics-dolfinx@main+petsc+adios2 py-fenics-ffcx@main
-          cd dolfinx-main/cpp/
-          cd demo/poisson
-          cmake .
-          export VERBOSE=1
-          make -j 4
-          mpirun -np 2 ./demo_poisson
+          spack -e cpp-main-test install -j 4 --add fenics-dolfinx@main+petsc+adios2 cmake py-fenics-ffcx@main
+          spack env activate cpp-main-test
+          # cd dolfinx-main/cpp/
+          # cd demo/poisson
+          # cmake .
+          # export VERBOSE=1
+          # make -j 4
+          # mpirun -np 2 ./demo_poisson
 
       - name: Push packages and update index
         env:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Build DOLFINx (Python, development)
         shell: spack-bash {0}
         run: |
-          spack env create py-main  .github/workflows/spack-config/gh-actions-env.yaml
+          spack env create py-main .github/workflows/spack-config/gh-actions-env.yaml
           spack -e py-main install -j 4 --add py-fenics-dolfinx@main
       - name: Run DOLFINx (Python, development) test
         shell: spack-bash {0}
@@ -141,7 +141,7 @@ jobs:
           GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          spack -e ph-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+          spack -e py-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
         if: ${{ !cancelled() }}
 
       # - name: Build DOLFINx (Python, release version)

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -40,6 +40,8 @@ jobs:
           apt-get install -y bzip2 curl file git gzip make patch python3-minimal tar unzip xz-utils
           apt-get install -y g++ gfortran  # compilers
 
+      - uses: actions/checkout@v4
+
       - name: Set up Spack
         uses: spack/setup-spack@main
         with:
@@ -51,7 +53,7 @@ jobs:
       - name: Build DOLFINx (C++) development version via Spack
         shell: spack-bash {0}
         run: |
-          spack env create . spack-configs/gh-actions-env.yaml
+          spack env create . .github/workflows/spack-configs/gh-actions-env.yaml
           spack -e . install -j 4 -- add fenics-dolfinx@main+petsc+adios2
       # - name: Get DOLFINx code (to access test files)
       #   uses: actions/checkout@v4

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -44,86 +44,84 @@ jobs:
         uses: spack/setup-spack@main
         with:
           ref: develop      # Spack version (examples: develop, releases/v0.23)
-          # buildcache: true  # Configure oci://ghcr.io/spack/github-actions-buildcache
+          buildcache: true  # Configure oci://ghcr.io/spack/github-actions-buildcache
           color: true       # Force color output (SPACK_COLOR=always)
           path: spack       # Where to clone Spack
 
       - name: Build DOLFINx (C++) development version via Spack
         shell: spack-bash {0}
         run: |
-          spack env create cpp-main
-          spack env activate cpp-main
-          spack add fenics-dolfinx@main+petsc+adios2
-          spack install
-      - name: Get DOLFINx code (to access test files)
-        uses: actions/checkout@v4
-        with:
-          path: ./dolfinx-main
-      - name: Run a C++ test (development version)
-        shell: spack-bash {0}
-        run: |
-          spack env create cpp-main-test
-          spack env activate cpp-main-test
-          spack add fenics-dolfinx@main+petsc+adios2 cmake py-fenics-ffcx@main
-          spack install
-          cd dolfinx-main/cpp/
-          cd demo/poisson
-          cmake .
-          export VERBOSE=1
-          make -j 4
-          mpirun -np 2 ./demo_poisson
+          spack env create . spack-configs/gh-actions-env.yaml
+          spack -e . install -j 4 -- add fenics-dolfinx@main+petsc+adios2
+      # - name: Get DOLFINx code (to access test files)
+      #   uses: actions/checkout@v4
+      #   with:
+      #     path: ./dolfinx-main
+      # - name: Run a C++ test (development version)
+      #   shell: spack-bash {0}
+      #   run: |
+      #     spack env create cpp-main-test
+      #     spack env activate cpp-main-test
+      #     spack add fenics-dolfinx@main+petsc+adios2 cmake py-fenics-ffcx@main
+      #     spack install
+      #     cd dolfinx-main/cpp/
+      #     cd demo/poisson
+      #     cmake .
+      #     export VERBOSE=1
+      #     make -j 4
+      #     mpirun -np 2 ./demo_poisson
 
-      - name: Build DOLFINx (C++) release version via Spack
-        shell: spack-bash {0}
-        run: |
-          spack env create cpp-release
-          spack env activate cpp-release
-          spack add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2
-          spack install
-      - name: Get DOLFINx release code (to access test files)
-        uses: actions/checkout@v4
-        with:
-          ref:  v${{ env.DOLFINX_RELEASE_VERSION }}
-          path: ./dolfinx-release
-      - name: Run a C++ test (release version)
-        shell: spack-bash {0}
-        run: |
-          spack env create cpp-release-test
-          spack env activate cpp-release-test
-          spack add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2 cmake py-fenics-ffcx
-          spack install
-          cd dolfinx-release/cpp/
-          cd demo/poisson
-          cmake .
-          export VERBOSE=1
-          make -j 4
-          mpirun -np 2 ./demo_poisson
+      # - name: Build DOLFINx (C++) release version via Spack
+      #   shell: spack-bash {0}
+      #   run: |
+      #     spack env create cpp-release
+      #     spack env activate cpp-release
+      #     spack add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2
+      #     spack install
+      # - name: Get DOLFINx release code (to access test files)
+      #   uses: actions/checkout@v4
+      #   with:
+      #     ref:  v${{ env.DOLFINX_RELEASE_VERSION }}
+      #     path: ./dolfinx-release
+      # - name: Run a C++ test (release version)
+      #   shell: spack-bash {0}
+      #   run: |
+      #     spack env create cpp-release-test
+      #     spack env activate cpp-release-test
+      #     spack add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2 cmake py-fenics-ffcx
+      #     spack install
+      #     cd dolfinx-release/cpp/
+      #     cd demo/poisson
+      #     cmake .
+      #     export VERBOSE=1
+      #     make -j 4
+      #     mpirun -np 2 ./demo_poisson
 
-      - name: Build DOLFINx (Python, development)
-        shell: spack-bash {0}
-        run: |
-          spack env create py-main
-          spack env activate py-main
-          spack add py-fenics-dolfinx@main
-          spack install
-      - name: Run DOLFINx (Python, development) test
-        shell: spack-bash {0}
-        run: |
-          spack env activate py-main
-          mpirun -np 2 python3 ./dolfinx-main/python/demo/demo_elasticity.py
+      # - name: Build DOLFINx (Python, development)
+      #   shell: spack-bash {0}
+      #   run: |
+      #     spack env create py-main
+      #     spack env activate py-main
+      #     spack add py-fenics-dolfinx@main
+      #     spack install
+      # - name: Run DOLFINx (Python, development) test
+      #   shell: spack-bash {0}
+      #   run: |
+      #     spack env activate py-main
+      #     mpirun -np 2 python3 ./dolfinx-main/python/demo/demo_elasticity.py
 
-      - name: Build DOLFINx (Python, release version)
-        shell: spack-bash {0}
-        run: |
-          spack env create py-release
-          spack env activate py-release
-          spack add py-fenics-dolfinx@${DOLFINX_RELEASE_VERSION}
-          spack install -j 4
-      - name: Run DOLFINx (Python, release) test
-        shell: spack-bash {0}
-        run: |
-          spack env activate py-release
-          mpirun -np 2 python3 ./dolfinx-release/python/demo/demo_elasticity.py
+      # - name: Build DOLFINx (Python, release version)
+      #   shell: spack-bash {0}
+      #   run: |
+      #     spack env create py-release
+      #     spack env activate py-release
+      #     spack add py-fenics-dolfinx@${DOLFINX_RELEASE_VERSION}
+      #     spack install -j 4
+      # - name: Run DOLFINx (Python, release) test
+      #   shell: spack-bash {0}
+      #   run: |
+      #     spack env activate py-release
+      #     mpirun -np 2 python3 ./dolfinx-release/python/demo/demo_elasticity.py
 
       - name: Push packages and update index
         env:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -102,6 +102,7 @@ jobs:
           spack repo add --name test_pkgs https://github.com/${{ github.event.inputs.spack_package_repo }}.git ~/test_pkgs
           spack repo update --branch ${{ github.event.inputs.spack_package_ref }} test_pkgs
           spack repo list
+          spack config get repos
       - name: Build DOLFINx
         shell: spack-bash {0}
         run: |

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -51,8 +51,11 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         shell: spack-bash {0}
         run: |
+          spack repo update
           spack repo add --name test_pkgs https://github.com/${{ github.event.inputs.spack_package_repo }}.git ~/test_pkgs
           spack repo update --branch ${{ github.event.inputs.spack_package_ref }} test_pkgs
+          spack repo list
+          spack config get repos
       - name: Build DOLFINx
         shell: spack-bash {0}
         run: |
@@ -101,6 +104,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         shell: spack-bash {0}
         run: |
+          spack repo update
           spack repo add --name test_pkgs https://github.com/${{ github.event.inputs.spack_package_repo }}.git ~/test_pkgs
           spack repo update --branch ${{ github.event.inputs.spack_package_ref }} test_pkgs
           spack repo list
@@ -112,6 +116,7 @@ jobs:
           spack env create dolfinx .github/workflows/spack-config/gh-actions-env.yaml
           spack -e dolfinx install --use-buildcache=package:never,dependencies:auto --add py-fenics-dolfinx@main %fenics-dolfinx+petsc~adios2
           spack repo list
+          spack config get repos
       - name: Run a Python test
         shell: spack-bash {0}
         run: |

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create py-main .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e py-main install --use-buildcache=package:never,dependencies:auto --add py-fenics-dolfinx@main
+          spack -e py-main install --use-buildcache=package:never,dependencies:auto --add py-fenics-dolfinx@main fenics-dolfinx@main+petsc
       - name: Run DOLFINx (Python, development) test
         shell: spack-bash {0}
         run: |

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Build DOLFINx (C++) development version via Spack
         shell: spack-bash {0}
         run: |
-          spack env create . .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e . install -j 4 --add fenics-dolfinx@main+petsc+adios2
+          spack env create cpp-main .github/workflows/spack-config/gh-actions-env.yaml
+          spack -e cpp-main install -j 4 --add fenics-dolfinx@main+petsc+adios2
 
       - name: Get DOLFINx code (to access test files)
         uses: actions/checkout@v4
@@ -63,8 +63,8 @@ jobs:
       - name: Run a C++ test (development version)
         shell: spack-bash {0}
         run: |
-          spack env create . .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e . install -j 4 --add fenics-dolfinx@main+petsc+adios2 cmake py-fenics-ffcx@main
+          spack env create cpp-main-test .github/workflows/spack-config/gh-actions-env.yaml
+          spack -e cpp-main-test install -j 4 --add fenics-dolfinx@main+petsc+adios2 cmake py-fenics-ffcx@main
           cd dolfinx-main/cpp/
           cd demo/poisson
           cmake .

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -58,6 +58,8 @@ jobs:
         run: |
           spack env create dolfinx .github/workflows/spack-config/gh-actions-env.yaml
           spack -e dolfinx install --use-buildcache=package:never,dependencies:auto --add fenics-dolfinx@main+petsc
+          spack repo list
+          spack config get repos
       - name: Run a C++ test
         shell: spack-bash {0}
         run: |

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -80,7 +80,6 @@ jobs:
           export VERBOSE=1
           make -j 4
           mpirun -np 2 ./demo_poisson
-
       - name: Push packages and update index
         env:
           GITHUB_USER: ${{ github.actor }}
@@ -89,24 +88,45 @@ jobs:
           spack -e cpp-main-test buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
         if: ${{ !cancelled() }}
 
-        # spack env create cpp-main-test
-        # spack env activate cpp-main-test
-        # spack add fenics-dolfinx@main+petsc+adios2 cmake py-fenics-ffcx@main
-        # spack install
-        # cd dolfinx-main/cpp/
-        # cd demo/poisson
-        # cmake .
-        # export VERBOSE=1
-        # make -j 4
-        # mpirun -np 2 ./demo_poisson
+      - name: Build DOLFINx (C++) release version via Spack
+        shell: spack-bash {0}
+        run: |
+          spack env create cpp-release .github/workflows/spack-config/gh-actions-env.yaml
+          spack -e cpp-release install -j 4 --add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2
+      - name: Push packages and update index
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+        if: ${{ !cancelled() }}
 
-      # - name: Build DOLFINx (C++) release version via Spack
-      #   shell: spack-bash {0}
-      #   run: |
-      #     spack env create . .github/workflows/spack-config/gh-actions-env.yaml
-      #     spack -e . install -j 4 --add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2
+      - name: Get DOLFINx release code (to access test files)
+        uses: actions/checkout@v4
+        with:
+          ref:  v${{ env.DOLFINX_RELEASE_VERSION }}
+          path: ./dolfinx-release
+      - name: Run a C++ test (release version)
+        shell: spack-bash {0}
+        run: |
+          spack env create cpp-cpp-release-test .github/workflows/spack-config/gh-actions-env.yaml
+          spack -e cpp-release-test install -j 4 --add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2 cmake py-fenics-ffcx
+          spack env activate cpp-release-test
+          cd dolfinx-release/cpp/
+          cd demo/poisson
+          cmake .
+          export VERBOSE=1
+          make -j 4
+          mpirun -np 2 ./demo_poisson
+      - name: Push packages and update index
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          spack -e cpp-cpp-release-test buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+        if: ${{ !cancelled() }}
 
-        # spack env create cpp-release
+      # spack env create cpp-release
         # spack env activate cpp-release
         # spack add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2
         # spack install

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -50,11 +50,11 @@ jobs:
           color: true       # Force color output (SPACK_COLOR=always)
           path: spack-src       # Where to clone Spack
 
-      - name: Build DOLFINx (C++) development version via Spack
-        shell: spack-bash {0}
-        run: |
-          spack env create cpp-main .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e cpp-main install -j 4 --add fenics-dolfinx@main+petsc+adios2
+      # - name: Build DOLFINx (C++) development version via Spack
+      #   shell: spack-bash {0}
+      #   run: |
+      #     spack env create cpp-main .github/workflows/spack-config/gh-actions-env.yaml
+      #     spack -e cpp-main install -j 4 --add fenics-dolfinx@main+petsc+adios2
 
       - name: Get DOLFINx code (to access test files)
         uses: actions/checkout@v4

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -47,10 +47,14 @@ jobs:
           ref: develop      # Spack version (examples: develop, releases/v0.23)
           color: true       # Force color output (SPACK_COLOR=always)
           path: spack-src   # Where to clone Spack
-      - name: Build DOLFINx (C++) development version via Spack
+      - name: Add Spack package repository
+        if: github.event_name == 'workflow_dispatch'
         shell: spack-bash {0}
         run: |
           spack repo add --name test_pkgs https://github.com/${{ env.spack_package_repo }}.git@${{ env.spack_package_ref }} ~/test_pkgs
+      - name: Build DOLFINx
+        shell: spack-bash {0}
+        run: |
           spack env create dolfinx .github/workflows/spack-config/gh-actions-env.yaml
           spack -e dolfinx install --use-buildcache=package:never,dependencies:auto --add fenics-dolfinx@main+petsc
       - name: Run a C++ test
@@ -90,10 +94,14 @@ jobs:
           ref: develop      # Spack version (examples: develop, releases/v0.23)
           color: true       # Force color output (SPACK_COLOR=always)
           path: spack-src   # Where to clone Spack
-      - name: Build DOLFINx
+      - name: Add Spack package repository
+        if: github.event_name == 'workflow_dispatch'
         shell: spack-bash {0}
         run: |
           spack repo add --name test_pkgs https://github.com/${{ env.spack_package_repo }}.git@${{ env.spack_package_ref }} ~/test_pkgs
+      - name: Build DOLFINx
+        shell: spack-bash {0}
+        run: |
           cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create dolfinx .github/workflows/spack-config/gh-actions-env.yaml
           spack -e dolfinx install --use-buildcache=package:never,dependencies:auto --add py-fenics-dolfinx@main %fenics-dolfinx+petsc~adios2

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -19,13 +19,13 @@ env:
   GITHUB_USER: ${{ github.actor }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-# env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe   # Newer OpenMPI
   OMPI_MCA_rmaps_base_oversubscribe: true                 # Older OpenMPI
 
   DOLFINX_RELEASE_VERSION: "${{ github.event_name != 'workflow_dispatch' && '0.9.0' || github.event.inputs.dolfinx_version }}"
+  DOLFINX_TAG: "${{ github.event_name != 'workflow_dispatch' && '0.9.0' || github.event.inputs.dolfinx_version }}"
 
 jobs:
 
@@ -39,7 +39,8 @@ jobs:
           apt-get -y update
           apt-get install -y bzip2 curl file git gzip make patch python3-minimal tar unzip xz-utils
           apt-get install -y g++ gfortran  # compilers
-      - uses: actions/checkout@v4
+      - name: Get DOLFINx code (to access Spack config and test files)
+        uses: actions/checkout@v4
       - name: Set up Spack
         uses: spack/setup-spack@main
         with:
@@ -49,15 +50,15 @@ jobs:
       - name: Build DOLFINx (C++) development version via Spack
         shell: spack-bash {0}
         run: |
-          spack env create cpp-main .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e cpp-main install --use-buildcache=package:never,dependencies:auto --add fenics-dolfinx@main+petsc
-      - name: Run a C++ test (development version)
+          spack env create dolfinx .github/workflows/spack-config/gh-actions-env.yaml
+          spack -e dolfinx install --use-buildcache=package:never,dependencies:auto --add fenics-dolfinx@main+petsc
+      - name: Run a C++ test
         shell: spack-bash {0}
         run: |
           cat .github/workflows/spack-config/gh-actions-env.yaml
-          spack env create cpp-main-test .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e cpp-main-test install --use-buildcache=package:never,dependencies:auto --add fenics-dolfinx@main+petsc cmake py-fenics-ffcx@main
-          spack env activate cpp-main-test
+          spack env create dolfinx-test .github/workflows/spack-config/gh-actions-env.yaml
+          spack -e dolfinx-test install --use-buildcache=package:never,dependencies:auto --add fenics-dolfinx@main+petsc cmake py-fenics-ffcx@main
+          spack env activate dolfinx-test
           cd cpp/demo/poisson
           cmake .
           make
@@ -67,7 +68,7 @@ jobs:
           GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+          spack -e dolfinx buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
         if: ${{ !cancelled() }}
 
   python-main:
@@ -80,157 +81,34 @@ jobs:
           apt-get -y update
           apt-get install -y bzip2 curl file git gzip make patch python3-minimal tar unzip xz-utils
           apt-get install -y g++ gfortran  # compilers
-      - uses: actions/checkout@v4
+      - name: Get DOLFINx code (to access Spack config and test files)
+        uses: actions/checkout@v4
       - name: Set up Spack
         uses: spack/setup-spack@main
         with:
           ref: develop      # Spack version (examples: develop, releases/v0.23)
           color: true       # Force color output (SPACK_COLOR=always)
           path: spack-src   # Where to clone Spack
-      - name: Build DOLFINx (Python, development)
+      - name: Build DOLFINx
         shell: spack-bash {0}
         run: |
           cat .github/workflows/spack-config/gh-actions-env.yaml
-          spack env create py-main .github/workflows/spack-config/gh-actions-env.yaml
-          spack -e py-main install --use-buildcache=package:never,dependencies:auto --add py-fenics-dolfinx@main %fenics-dolfinx+petsc py-setuptools
-      - name: Run DOLFINx (Python, development) test
+          spack env create dolfinx .github/workflows/spack-config/gh-actions-env.yaml
+          spack -e dolfinx install --use-buildcache=package:never,dependencies:auto --add py-fenics-dolfinx@main %fenics-dolfinx+petsc~adios2
+      - name: Run a Python test
         shell: spack-bash {0}
         run: |
-          spack env activate py-main
+          cat .github/workflows/spack-config/gh-actions-env.yaml
+          spack env create dolfinx-test .github/workflows/spack-config/gh-actions-env.yaml
+          spack -e dolfinx-test install --use-buildcache=package:never,dependencies:auto --add py-fenics-dolfinx@main %fenics-dolfinx+petsc~adios2 py-setuptools
+          spack env activate dolfinx-test
           spack compiler find
           spack load gcc
-          mpirun -np 2 python3 python/demo/demo_elasticity.py
+          mpirun -np 2 python python/demo/demo_elasticity.py
       - name: Push packages and update index
         env:
           GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          spack -e py-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
+          spack -e dolfinx buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
         if: ${{ !cancelled() }}
-
-
-      #     - name: Run a C++ test (development version)
-      #   shell: spack-bash {0}
-      #   run: |
-      #     cat .github/workflows/spack-config/gh-actions-env.yaml
-      #     spack env create cpp-main-test .github/workflows/spack-config/gh-actions-env.yaml
-      #     spack -e cpp-main-test install --add fenics-dolfinx@main+petsc cmake py-fenics-ffcx@main
-      #     spack env activate cpp-main-test
-      #     cd dolfinx-main/cpp/
-      #     cd demo/poisson
-      #     cmake .
-      #     export VERBOSE=1
-      #     make -j 4
-      #     mpirun -np 2 ./demo_poisson
-      # - name: Push packages and update index
-      #   env:
-      #     GITHUB_USER: ${{ github.actor }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
-      #   if: ${{ !cancelled() }}
-
-
-      # - name: Get DOLFINx code (to access test files)
-      #   uses: actions/checkout@v4
-      #   with:
-      #     path: ./dolfinx-main
-      # - name: Run a C++ test (development version)
-      #   shell: spack-bash {0}
-      #   run: |
-      #     cat .github/workflows/spack-config/gh-actions-env.yaml
-      #     spack env create cpp-main-test .github/workflows/spack-config/gh-actions-env.yaml
-      #     spack -e cpp-main-test install --add fenics-dolfinx@main+petsc cmake py-fenics-ffcx@main
-      #     spack env activate cpp-main-test
-      #     cd dolfinx-main/cpp/
-      #     cd demo/poisson
-      #     cmake .
-      #     export VERBOSE=1
-      #     make -j 4
-      #     mpirun -np 2 ./demo_poisson
-      # - name: Push packages and update index
-      #   env:
-      #     GITHUB_USER: ${{ github.actor }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     spack -e cpp-main-test buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
-      #   if: ${{ !cancelled() }}
-
-      # - name: Build DOLFINx (C++) release version via Spack
-      #   shell: spack-bash {0}
-      #   run: |
-      #     spack env create cpp-release .github/workflows/spack-config/gh-actions-env.yaml
-      #     spack -e cpp-release install --add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2
-      # - name: Push packages and update index
-      #   env:
-      #     GITHUB_USER: ${{ github.actor }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
-      #   if: ${{ !cancelled() }}
-
-      # - name: Get DOLFINx release code (to access test files)
-      #   uses: actions/checkout@v4
-      #   with:
-      #     ref:  v${{ env.DOLFINX_RELEASE_VERSION }}
-      #     path: ./dolfinx-release
-      # - name: Run a C++ test (release version)
-      #   shell: spack-bash {0}
-      #   run: |
-      #     spack env create cpp-release-test .github/workflows/spack-config/gh-actions-env.yaml
-      #     spack -e cpp-release-test install --add fenics-dolfinx@${DOLFINX_RELEASE_VERSION}+petsc+adios2 cmake py-fenics-ffcx
-      #     spack env activate cpp-release-test
-      #     cd dolfinx-release/cpp/
-      #     cd demo/poisson
-      #     cmake .
-      #     export VERBOSE=1
-      #     make -j 4
-      #     mpirun -np 2 ./demo_poisson
-      # - name: Push packages and update index
-      #   env:
-      #     GITHUB_USER: ${{ github.actor }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     spack -e cpp-release-test buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
-      #   if: ${{ !cancelled() }}
-
-      # - name: Build DOLFINx (Python, development)
-      #   shell: spack-bash {0}
-      #   run: |
-      #     cat .github/workflows/spack-config/gh-actions-env.yaml
-      #     spack env create py-main .github/workflows/spack-config/gh-actions-env.yaml
-      #     spack -v -e py-main install --add py-fenics-dolfinx@main
-      # # - name: Run DOLFINx (Python, development) test
-      # #   shell: spack-bash {0}
-      # #   run: |
-      # #     spack env activate py-main
-      # #     mpirun -np 2 python3 ./dolfinx-main/python/demo/demo_elasticity.py
-      # - name: Push packages and update index
-      #   env:
-      #     GITHUB_USER: ${{ github.actor }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     spack -e py-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
-      #   if: ${{ !cancelled() }}
-
-      # # - name: Build DOLFINx (Python, release version)
-      # #   shell: spack-bash {0}
-      # #   run: |
-      # #     spack env create py-release
-      # #     spack env activate py-release
-      # #     spack add py-fenics-dolfinx@${DOLFINX_RELEASE_VERSION}
-      # #     spack install -j 4
-      # # - name: Run DOLFINx (Python, release) test
-      # #   shell: spack-bash {0}
-      # #   run: |
-      # #     spack env activate py-release
-      # #     mpirun -np 2 python3 ./dolfinx-release/python/demo/demo_elasticity.py
-
-      # # - name: Push packages and update index
-      # #   env:
-      # #     GITHUB_USER: ${{ github.actor }}
-      # #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # #   run: |
-      # #     spack -e cpp-main buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
-      # #     spack -e cpp-main-test buildcache push --base-image ubuntu:24.04 --update-index local-buildcache
-      # #   if: ${{ !cancelled() }}

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build DOLFINx (C++) development version via Spack
         shell: spack-bash {0}
         run: |
-          spack repo add  add --name test_pkgs https://github.com/${{ env.spack_package_repo }}.git@${{ env.spack_package_ref }} ~/test_pkgs
+          spack repo add --name test_pkgs https://github.com/${{ env.spack_package_repo }}.git@${{ env.spack_package_ref }} ~/test_pkgs
           spack env create dolfinx .github/workflows/spack-config/gh-actions-env.yaml
           spack -e dolfinx install --use-buildcache=package:never,dependencies:auto --add fenics-dolfinx@main+petsc
       - name: Run a C++ test
@@ -93,7 +93,7 @@ jobs:
       - name: Build DOLFINx
         shell: spack-bash {0}
         run: |
-          spack repo add  add --name test_pkgs https://github.com/${{ env.spack_package_repo }}.git@${{ env.spack_package_ref }} ~/test_pkgs
+          spack repo add --name test_pkgs https://github.com/${{ env.spack_package_repo }}.git@${{ env.spack_package_ref }} ~/test_pkgs
           cat .github/workflows/spack-config/gh-actions-env.yaml
           spack env create dolfinx .github/workflows/spack-config/gh-actions-env.yaml
           spack -e dolfinx install --use-buildcache=package:never,dependencies:auto --add py-fenics-dolfinx@main %fenics-dolfinx+petsc~adios2

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -51,7 +51,8 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         shell: spack-bash {0}
         run: |
-          spack repo add --name test_pkgs https://github.com/${{ github.event.inputs.spack_package_repo }}.git@${{ github.event.inputs.spack_package_ref }} ~/test_pkgs
+          spack repo add --name test_pkgs https://github.com/${{ github.event.inputs.spack_package_repo }}.git ~/test_pkgs
+          spack repo update --branch ${{ github.event.inputs.spack_package_ref }} test_pkgs
       - name: Build DOLFINx
         shell: spack-bash {0}
         run: |
@@ -98,7 +99,8 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         shell: spack-bash {0}
         run: |
-          spack repo add --name test_pkgs https://github.com/${{ env.spack_package_repo }}.git@${{ env.spack_package_ref }} ~/test_pkgs
+          spack repo add --name test_pkgs https://github.com/${{ github.event.inputs.spack_package_repo }}.git ~/test_pkgs
+          spack repo update --branch ${{ github.event.inputs.spack_package_ref }} test_pkgs
       - name: Build DOLFINx
         shell: spack-bash {0}
         run: |


### PR DESCRIPTION
Build cache for dependencies means tests run faster. 

- Also splits C++ and Python builds, which exposed some issues.
- Split into multiple jobs.