### PR TITLE
Fix XDMF time series

### DIFF
--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -7,6 +7,7 @@
 #include "xdmf_function.h"
 #include "xdmf_mesh.h"
 #include "xdmf_utils.h"
+#include <algorithm>
 #include <basix/mdspan.hpp>
 #include <boost/lexical_cast.hpp>
 #include <dolfinx/common/IndexMap.h>
@@ -205,9 +206,9 @@ void xdmf_function::add_function(MPI_Comm comm, const fem::Function<T, U>& u,
     // -- Real case, add data item
     std::string t_str = boost::lexical_cast<std::string>(t);
     std::replace(t_str.begin(), t_str.end(), '.', '_');
-    auto data_item_name = dataset_name.append("/").append(t_str);
+    dataset_name.append("/").append(t_str);
 
-    xdmf_utils::add_data_item(attr_node, h5_id, data_item_name, u, offset,
+    xdmf_utils::add_data_item(attr_node, h5_id, dataset_name, u, offset,
                               {num_values, num_components}, "", use_mpi_io);
   }
 }

--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -167,13 +167,11 @@ void xdmf_function::add_function(MPI_Comm comm, const fem::Function<T, U>& u,
   std::vector<std::string> components = {""};
   if constexpr (!std::is_scalar_v<T>)
     components = {"real_", "imag_"};
-  std::string t_str = boost::lexical_cast<std::string>(t);
-  std::replace(t_str.begin(), t_str.end(), '.', '_');
+
   for (const auto& component : components)
   {
     std::string attr_name = component + u.name;
-    std::string dataset_name
-        = "/Function/" + attr_name.append("/").append(t_str);
+    std::string dataset_name = "/Function/" + attr_name;
 
     // Add attribute node
     pugi::xml_node attr_node = xml_node.append_child("Attribute");
@@ -205,7 +203,11 @@ void xdmf_function::add_function(MPI_Comm comm, const fem::Function<T, U>& u,
       u = std::span<const T>(data_values);
 
     // -- Real case, add data item
-    xdmf_utils::add_data_item(attr_node, h5_id, dataset_name, u, offset,
+    std::string t_str = boost::lexical_cast<std::string>(t);
+    std::replace(t_str.begin(), t_str.end(), '.', '_');
+    auto data_item_name = dataset_name.append("/").append(t_str);
+
+    xdmf_utils::add_data_item(attr_node, h5_id, data_item_name, u, offset,
                               {num_values, num_components}, "", use_mpi_io);
   }
 }

--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -174,7 +174,6 @@ void xdmf_function::add_function(MPI_Comm comm, const fem::Function<T, U>& u,
   for (const auto& component : components)
   {
     std::string attr_name = component + u.name;
-    std::string dataset_name = "/Function/" + attr_name;
 
     // Add attribute node
     pugi::xml_node attr_node = xml_node.append_child("Attribute");
@@ -206,9 +205,8 @@ void xdmf_function::add_function(MPI_Comm comm, const fem::Function<T, U>& u,
       u = std::span<const T>(data_values);
 
     // -- Real case, add data item
-    dataset_name.append("/").append(t_str);
-
-    xdmf_utils::add_data_item(attr_node, h5_id, dataset_name, u, offset,
+    std::string h5_path = std::format("/Function/{}/{}", attr_name, t_str);
+    xdmf_utils::add_data_item(attr_node, h5_id, h5_path, u, offset,
                               {num_values, num_components}, "", use_mpi_io);
   }
 }

--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -169,6 +169,8 @@ void xdmf_function::add_function(MPI_Comm comm, const fem::Function<T, U>& u,
   if constexpr (!std::is_scalar_v<T>)
     components = {"real_", "imag_"};
 
+  std::string t_str = boost::lexical_cast<std::string>(t);
+  std::replace(t_str.begin(), t_str.end(), '.', '_');
   for (const auto& component : components)
   {
     std::string attr_name = component + u.name;
@@ -204,8 +206,6 @@ void xdmf_function::add_function(MPI_Comm comm, const fem::Function<T, U>& u,
       u = std::span<const T>(data_values);
 
     // -- Real case, add data item
-    std::string t_str = boost::lexical_cast<std::string>(t);
-    std::replace(t_str.begin(), t_str.end(), '.', '_');
     dataset_name.append("/").append(t_str);
 
     xdmf_utils::add_data_item(attr_node, h5_id, dataset_name, u, offset,


### PR DESCRIPTION
Time info in function name should not be part of the attributes, only the data item's name needs to be differentiated between the different time steps by name.

This caused time step data for a function `u` to not be named `u/0`, `u/1`, ... - which broke paraviews time step visualisation. 


Fixes https://github.com/FEniCS/dolfinx/issues/3828