### PR TITLE
Add default scalar type cast

### DIFF
--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -98,9 +98,9 @@ class Form:
         return self._cpp_object.function_spaces
 
     @property
-    def dtype(self) -> np.floating:
+    def dtype(self) -> np.dtype:
         """Scalar type of this form."""
-        return np.dtype(self._cpp_object.dtype).type
+        return np.dtype(self._cpp_object.dtype)
 
     @property
     def mesh(self) -> typing.Union[_cpp.mesh.Mesh_float32, _cpp.mesh.Mesh_float64]:

--- a/python/test/unit/fem/test_assemble_submesh.py
+++ b/python/test/unit/fem/test_assemble_submesh.py
@@ -762,7 +762,7 @@ def test_interior_interface():
     a = fem.form(ufl.inner(f_0("+") * u_0("+"), v_1("-")) * dS(1), entity_maps=entity_maps)
 
     # Create a Dirichlet boundary condition
-    scalar_type = a.dtype
+    scalar_type = a.dtype.type
     c_bc = scalar_type(1.0)
     bc_facets = locate_entities_boundary(smsh_0, fdim, bc_marker)
     bc_dofs = fem.locate_dofs_topological(V_0, fdim, bc_facets)


### PR DESCRIPTION
Fixes https://github.com/FEniCS/ufl/issues/399.

Caused by default scalar type being complex in the ufl dolfinx integration test. In this case form, function and coefficients are constructed from default type (complex), but the boundary condition from a float value. This caused a mismatch.

Tested at https://github.com/FEniCS/ufl/actions/runs/16607427384/job/46982707793