### PR TITLE
Get nestis from A instead of P

### DIFF
--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -896,10 +896,10 @@ class LinearProblem:
 
             opts.prefixPop()
 
-        if self.P_mat is not None and kind == "nest":
-            # Transfer nest IS on self.P_mat to PC of main KSP. This allows
+        if kind == "nest":
+            # Transfer nest IS on self.A_mat to PC of main KSP. This allows
             # fieldsplit preconditioning to be applied, if desired.
-            nest_IS = self.P_mat.getNestISs()
+            nest_IS = self.A.getNestISs()
             fieldsplit_IS = tuple(
                 [
                     (f"{u.name + '_' if u.name != 'f' else ''}{i}", IS)


### PR DESCRIPTION
There is no reason the nestIS should be gotten from P, and not A, as there are situations where you do not supply a preconditioner form, where you would need the index sets.

The index sets for A and P should be identical.

See for instance: https://github.com/jorgensd/dolfinx-tutorial/pull/264