### PR TITLE
Consistency of input arguments to `LinearProblem`

### DIFF
--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -864,7 +864,7 @@ class LinearProblem:
         else:
             self._u = u
 
-        self.bcs = bcs
+        self.bcs = bcs if bcs is not None else []
 
         self._solver = PETSc.KSP().create(self.A.comm)  # type: ignore[attr-defined]
         self.solver.setOperators(self.A, self.P_mat)

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -139,7 +139,7 @@ def create_vector(
         ]
         if kind == PETSc.Vec.Type.NEST:  # type: ignore[attr-defined]
             return _cpp.fem.petsc.create_vector_nest(maps)
-        elif kind == PETSc.Vec.Type.MPI:  # type: ignore[attr-defined]
+        elif kind == PETSc.Vec.Type.MPI or kind is None:  # type: ignore[attr-defined]
             off_owned = tuple(
                 itertools.accumulate(maps, lambda off, m: off + m[0].size_local * m[1], initial=0)
             )


### PR DESCRIPTION
As pointed out in https://github.com/FEniCS/dolfinx/issues/3848
there are some inconsistencies in `LinearProblem` and `create_vector`.

According to the documentation, `create_vector` should create a `dolfinx`-blocked vector **if** kind is None. This was currently not the case. 

Similarly, this means that the default behavior of `LinearProblem` should reflect this, and `kind=None` gives you the DOLFINx blocked system.

Finally, default bcs=None was not correctly handled.