### PR TITLE
Force non random order of execution for C++ tests

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -92,10 +92,11 @@ jobs:
         run: |
           cd build/test
           mpiexec -np 1 ctest -V --output-on-failure -R unittests
-      - name: Run C++ unit tests (MPI)
-        run: |
-          cd build/test
-          mpiexec -np 3 ctest -V --output-on-failure -R unittests
+      # FixMe: currently broken after open mpi version bump.
+      # - name: Run C++ unit tests (MPI)
+      #   run: |
+      #     cd build/test
+      #     mpiexec -np 3 ctest -V --output-on-failure -R unittests
 
       - name: Build and install DOLFINx Python interface
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           export PATH="$(brew --prefix gfortran)/bin:$(brew --prefix bison)/bin:$PATH"
           export PATH="$(brew --prefix make)/libexec/gnubin:$PATH"
-          git clone -b release https://gitlab.com/petsc/petsc.git petsc
+          git clone --depth 1 --branch release https://gitlab.com/petsc/petsc.git petsc
           cd petsc
           python ./configure \
             --with-64-bit-indices=no \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Run C++ unit tests (MPI)
         run: |
           cd build/test
-          mpiexec -np 3 ctest -V --output-on-failure -R unittests 
+          mpiexec -np 3 ctest -V --output-on-failure -R unittests
 
       - name: Build and install DOLFINx Python interface
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -92,11 +92,11 @@ jobs:
         run: |
           cd build/test
           mpiexec -np 1 ctest -V --output-on-failure -R unittests
-      # FixMe: currently broken after open mpi version bump.
-      # - name: Run C++ unit tests (MPI)
-      #   run: |
-      #     cd build/test
-      #     mpiexec -np 3 ctest -V --output-on-failure -R unittests
+
+      - name: Run C++ unit tests (MPI)
+        run: |
+          cd build/test
+          mpiexec -np 3 ctest -V --output-on-failure -R unittests 
 
       - name: Build and install DOLFINx Python interface
         run: |

--- a/cpp/test/main.cpp
+++ b/cpp/test/main.cpp
@@ -10,7 +10,13 @@ int main(int argc, char* argv[])
   // Parallel tests require MPI initialization before any tests run and
   // termination only after all tests complete.
   MPI_Init(&argc, &argv);
-  int result = Catch::Session().run(argc, argv);
+
+  // Configure test session
+  auto session = Catch::Session();
+
+  // Default order is for Catch version >= 3.9.0 changed to rnadom
+  session.configData().runOrder = Catch::TestRunOrder::Declared;
+  int result = session.run(argc, argv);
   MPI_Finalize();
   return result;
 }

--- a/cpp/test/main.cpp
+++ b/cpp/test/main.cpp
@@ -14,9 +14,13 @@ int main(int argc, char* argv[])
   // Configure test session
   auto session = Catch::Session();
 
-  // Default order is for Catch version >= 3.9.0 changed to rnadom
+  // Default order is for Catch version >= 3.9.0 changed to random.
+  // MPI testing requires same order of execution across processes.
   session.configData().runOrder = Catch::TestRunOrder::Declared;
+
+  // Run test session.
   int result = session.run(argc, argv);
+
   MPI_Finalize();
   return result;
 }

--- a/cpp/test/main.cpp
+++ b/cpp/test/main.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* argv[])
   // Configure test session
   auto session = Catch::Session();
 
-  // Default order is for Catch version >= 3.9.0 changed to random.
+  // Default order for Catch version >= 3.9.0 changed to random.
   // MPI testing requires same order of execution across processes.
   session.configData().runOrder = Catch::TestRunOrder::Declared;
 


### PR DESCRIPTION
Catch2 [`>=3.9.0`](https://github.com/catchorg/Catch2/releases/tag/v3.9.0) changes execution order to random by default. This needs to be deactivated for MPI parallel testing.