### PR TITLE
Expose original cell indices

### DIFF
--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -703,14 +703,11 @@ void mesh(nb::module_& m)
             const std::vector<std::vector<std::int64_t>>& indices
                 = self.original_cell_index;
             std::vector<nb::ndarray<const std::int64_t, nb::numpy>> idx_nb;
-            idx_nb.reserve(indices.size());
-            std::ranges::for_each(
-                indices,
-                [&idx_nb](const std::vector<std::int64_t>& idx)
-                {
-                  idx_nb.push_back(nb::ndarray<const std::int64_t, nb::numpy>(
-                      idx.data(), {idx.size()}));
-                });
+            for (auto& oci : indices)
+            {
+              idx_nb.push_back(nb::ndarray<const std::int64_t, nb::numpy>(
+                  oci.data(), {oci.size()}));
+            }
             return idx_nb;
           })
       .def("connectivity",


### PR DESCRIPTION
Required to be able to read higher order meshes from external software, such as NetGen.
With this binding exposed, I am able to make a code for reading netgen mixed meshes, such as
<img width="698" height="686" alt="image" src="https://github.com/user-attachments/assets/5bfc5ba2-dcfe-4aa1-8ddd-e688de60b248" />
into DOLFINx.