### PR TITLE
Generalise `la::Vector` to support GPUs

### DIFF
--- a/cpp/demo/biharmonic/main.cpp
+++ b/cpp/demo/biharmonic/main.cpp
@@ -239,7 +239,7 @@ int main(int argc, char* argv[])
 
     b.set(0.0);
     fem::assemble_vector(b.mutable_array(), L);
-    fem::apply_lifting<T, U>(b.mutable_array(), {a}, {{bc}}, {}, T(1.0));
+    fem::apply_lifting(b.mutable_array(), {a}, {{bc}}, {}, T(1.0));
     b.scatter_rev(std::plus<T>());
     bc.set(b.mutable_array(), std::nullopt);
 

--- a/cpp/demo/custom_kernel/main.cpp
+++ b/cpp/demo/custom_kernel/main.cpp
@@ -141,7 +141,7 @@ double assemble_matrix1(const mesh::Geometry<T>& g, const fem::DofMap& dofmap,
   common::Timer timer("Assembler1 lambda (matrix)");
   md::mdspan<const T, md::extents<std::size_t, md::dynamic_extent, 3>> x(
       g.x().data(), g.x().size() / 3, 3);
-  fem::impl::assemble_cells<T>(
+  fem::impl::assemble_cells_matrix<T>(
       A.mat_add_values(), g.dofmap(), x, cells, {dofmap.map(), 1, cells}, ident,
       {dofmap.map(), 1, cells}, ident, {}, {}, kernel, {}, {}, {}, {});
   A.scatter_rev();
@@ -167,9 +167,9 @@ double assemble_vector1(const mesh::Geometry<T>& g, const fem::DofMap& dofmap,
   md::mdspan<const T, md::extents<std::size_t, md::dynamic_extent, 3>> x(
       g.x().data(), g.x().size() / 3, 3);
   common::Timer timer("Assembler1 lambda (vector)");
-  fem::impl::assemble_cells<T, 1>([](auto, auto, auto, auto) {},
-                                  b.mutable_array(), g.dofmap(), x, cells,
-                                  {dofmap.map(), 1, cells}, kernel, {}, {}, {});
+  fem::impl::assemble_cells<1>([](auto, auto, auto, auto) {}, b.mutable_array(),
+                               g.dofmap(), x, cells, {dofmap.map(), 1, cells},
+                               kernel, {}, {}, {});
   b.scatter_rev(std::plus<T>());
   return la::squared_norm(b);
 }
@@ -275,7 +275,7 @@ int main(int argc, char* argv[])
 {
   MPI_Init(&argc, &argv);
   dolfinx::init_logging(argc, argv);
-  assemble<float>(MPI_COMM_WORLD);
+  // assemble<float>(MPI_COMM_WORLD);
   assemble<double>(MPI_COMM_WORLD);
   MPI_Finalize();
   return 0;

--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -88,7 +88,7 @@ public:
       // Assemble b and update ghosts
       std::span b(_b.mutable_array());
       std::ranges::fill(b, 0);
-      fem::assemble_vector<T>(b, _l);
+      fem::assemble_vector(b, _l);
       VecGhostUpdateBegin(_b_petsc, ADD_VALUES, SCATTER_REVERSE);
       VecGhostUpdateEnd(_b_petsc, ADD_VALUES, SCATTER_REVERSE);
 

--- a/cpp/demo/mixed_poisson/main.cpp
+++ b/cpp/demo/mixed_poisson/main.cpp
@@ -332,7 +332,7 @@ int main(int argc, char* argv[])
 
     // Modify unconstrained dofs on RHS to account for Dirichlet BC dofs
     // (constrained dofs), and perform parallel update on the vector.
-    fem::apply_lifting<T, U>(b.mutable_array(), {a}, {{bc}}, {}, T(1));
+    fem::apply_lifting(b.mutable_array(), {a}, {{bc}}, {}, T(1));
     b.scatter_rev(std::plus<T>());
 
     // Set value for constrained dofs

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -224,7 +224,7 @@ int main(int argc, char* argv[])
 
     b.set(0.0);
     fem::assemble_vector(b.mutable_array(), L);
-    fem::apply_lifting<T, U>(b.mutable_array(), {a}, {{bc}}, {}, T(1));
+    fem::apply_lifting(b.mutable_array(), {a}, {{bc}}, {}, T(1));
     b.scatter_rev(std::plus<T>());
     bc.set(b.mutable_array(), std::nullopt);
 

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -61,7 +61,7 @@ using mdspan2_t = md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>;
 /// @param cell_info1 Cell permutation information for the trial
 /// function mesh.
 template <dolfinx::scalar T>
-void assemble_cells(
+void assemble_cells_matrix(
     la::MatSet<T> auto mat_set, mdspan2_t x_dofmap,
     md::mdspan<const scalar_value_t<T>,
                md::extents<std::size_t, md::dynamic_extent, 3>>
@@ -605,10 +605,11 @@ void assemble_matrix(
       std::span cells1 = a.domain_arg(IntegralType::cell, 1, i, cell_type_idx);
       auto& [coeffs, cstride] = coefficients.at({IntegralType::cell, i});
       assert(cells.size() * cstride == coeffs.size());
-      impl::assemble_cells(mat_set, x_dofmap, x, cells, {dofs0, bs0, cells0},
-                           P0, {dofs1, bs1, cells1}, P1T, bc0, bc1, fn,
-                           md::mdspan(coeffs.data(), cells.size(), cstride),
-                           constants, cell_info0, cell_info1);
+      impl::assemble_cells_matrix(
+          mat_set, x_dofmap, x, cells, {dofs0, bs0, cells0}, P0,
+          {dofs1, bs1, cells1}, P1T, bc0, bc1, fn,
+          md::mdspan(coeffs.data(), cells.size(), cstride), constants,
+          cell_info0, cell_info1);
     }
 
     md::mdspan<const std::uint8_t, md::dextents<std::size_t, 2>> perms;

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -76,22 +76,34 @@ using mdspan2_t = md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>;
 /// conditions applied.
 /// @param[in] x0 Vector used in the lifting.
 /// @param[in] alpha Scaling to apply.
-template <dolfinx::scalar T, int _bs0 = -1, int _bs1 = -1>
+template <int _bs0 = -1, int _bs1 = -1, typename V>
 void _lift_bc_cells(
-    std::span<T> b, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_t<T>,
-               md::extents<std::size_t, md::dynamic_extent, 3>>
+    V&& b, mdspan2_t x_dofmap,
+    md::mdspan<
+        const scalar_value_t<typename std::remove_cvref_t<V>::value_type>,
+        md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
-    FEkernel<T> auto kernel, std::span<const std::int32_t> cells,
+    FEkernel<typename std::remove_cvref_t<V>::value_type> auto kernel,
+    std::span<const std::int32_t> cells,
     std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap0,
-    fem::DofTransformKernel<T> auto P0,
+    fem::DofTransformKernel<typename std::remove_cvref_t<V>::value_type> auto
+        P0,
     std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap1,
-    fem::DofTransformKernel<T> auto P1T, std::span<const T> constants,
-    md::mdspan<const T, md::dextents<std::size_t, 2>> coeffs,
+    fem::DofTransformKernel<typename std::remove_cvref_t<V>::value_type> auto
+        P1T,
+    std::span<const typename std::remove_cvref_t<V>::value_type> constants,
+    md::mdspan<const typename std::remove_cvref_t<V>::value_type,
+               md::dextents<std::size_t, 2>>
+        coeffs,
     std::span<const std::uint32_t> cell_info0,
-    std::span<const std::uint32_t> cell_info1, std::span<const T> bc_values1,
-    std::span<const std::int8_t> bc_markers1, std::span<const T> x0, T alpha)
+    std::span<const std::uint32_t> cell_info1,
+    std::span<const typename std::remove_cvref_t<V>::value_type> bc_values1,
+    std::span<const std::int8_t> bc_markers1,
+    std::span<const typename std::remove_cvref_t<V>::value_type> x0,
+    typename std::remove_cvref_t<V>::value_type alpha)
 {
+  using T = typename std::remove_cvref_t<V>::value_type;
+
   if (cells.empty())
     return;
 
@@ -260,13 +272,14 @@ void _lift_bc_cells(
 /// local_facet_idx)` is the permutation value for the facet attached to
 /// the cell `cell_idx` with local index `local_facet_idx` relative to
 /// the cell. Empty if facet permutations are not required.
-template <dolfinx::scalar T>
+template <typename V>
 void _lift_bc_exterior_facets(
-    std::span<T> b, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_t<T>,
-               md::extents<std::size_t, md::dynamic_extent, 3>>
+    V&& b, mdspan2_t x_dofmap,
+    md::mdspan<
+        const scalar_value_t<typename std::remove_cvref_t<V>::value_type>,
+        md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
-    FEkernel<T> auto kernel,
+    FEkernel<typename std::remove_cvref_t<V>::value_type> auto kernel,
     md::mdspan<const std::int32_t,
                md::extents<std::size_t, md::dynamic_extent, 2>>
         facets,
@@ -274,18 +287,27 @@ void _lift_bc_exterior_facets(
                md::mdspan<const std::int32_t,
                           md::extents<std::size_t, md::dynamic_extent, 2>>>
         dofmap0,
-    fem::DofTransformKernel<T> auto P0,
+    fem::DofTransformKernel<typename std::remove_cvref_t<V>::value_type> auto
+        P0,
     std::tuple<mdspan2_t, int,
                md::mdspan<const std::int32_t,
                           md::extents<std::size_t, md::dynamic_extent, 2>>>
         dofmap1,
-    fem::DofTransformKernel<T> auto P1T, std::span<const T> constants,
-    md::mdspan<const T, md::dextents<std::size_t, 2>> coeffs,
+    fem::DofTransformKernel<typename std::remove_cvref_t<V>::value_type> auto
+        P1T,
+    std::span<const typename std::remove_cvref_t<V>::value_type> constants,
+    md::mdspan<const typename std::remove_cvref_t<V>::value_type,
+               md::dextents<std::size_t, 2>>
+        coeffs,
     std::span<const std::uint32_t> cell_info0,
-    std::span<const std::uint32_t> cell_info1, std::span<const T> bc_values1,
-    std::span<const std::int8_t> bc_markers1, std::span<const T> x0, T alpha,
+    std::span<const std::uint32_t> cell_info1,
+    std::span<const typename std::remove_cvref_t<V>::value_type> bc_values1,
+    std::span<const std::int8_t> bc_markers1,
+    std::span<const typename std::remove_cvref_t<V>::value_type> x0,
+    typename std::remove_cvref_t<V>::value_type alpha,
     md::mdspan<const std::uint8_t, md::dextents<std::size_t, 2>> perms)
 {
+  using T = typename std::remove_cvref_t<V>::value_type;
   if (facets.empty())
     return;
 
@@ -416,13 +438,14 @@ void _lift_bc_exterior_facets(
 /// local_facet_idx)` is the permutation value for the facet attached to
 /// the cell `cell_idx` with local index `local_facet_idx` relative to
 /// the cell. Empty if facet permutations are not required.
-template <dolfinx::scalar T>
+template <typename V>
 void _lift_bc_interior_facets(
-    std::span<T> b, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_t<T>,
-               md::extents<std::size_t, md::dynamic_extent, 3>>
+    V&& b, mdspan2_t x_dofmap,
+    md::mdspan<
+        const scalar_value_t<typename std::remove_cvref_t<V>::value_type>,
+        md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
-    FEkernel<T> auto kernel,
+    FEkernel<typename std::remove_cvref_t<V>::value_type> auto kernel,
     md::mdspan<const std::int32_t,
                md::extents<std::size_t, md::dynamic_extent, 2, 2>>
         facets,
@@ -430,20 +453,28 @@ void _lift_bc_interior_facets(
                md::mdspan<const std::int32_t,
                           md::extents<std::size_t, md::dynamic_extent, 2, 2>>>
         dofmap0,
-    fem::DofTransformKernel<T> auto P0,
+    fem::DofTransformKernel<typename std::remove_cvref_t<V>::value_type> auto
+        P0,
     std::tuple<mdspan2_t, int,
                md::mdspan<const std::int32_t,
                           md::extents<std::size_t, md::dynamic_extent, 2, 2>>>
         dofmap1,
-    fem::DofTransformKernel<T> auto P1T, std::span<const T> constants,
-    md::mdspan<const T, md::extents<std::size_t, md::dynamic_extent, 2,
-                                    md::dynamic_extent>>
+    fem::DofTransformKernel<typename std::remove_cvref_t<V>::value_type> auto
+        P1T,
+    std::span<const typename std::remove_cvref_t<V>::value_type> constants,
+    md::mdspan<
+        const typename std::remove_cvref_t<V>::value_type,
+        md::extents<std::size_t, md::dynamic_extent, 2, md::dynamic_extent>>
         coeffs,
     std::span<const std::uint32_t> cell_info0,
-    std::span<const std::uint32_t> cell_info1, std::span<const T> bc_values1,
-    std::span<const std::int8_t> bc_markers1, std::span<const T> x0, T alpha,
+    std::span<const std::uint32_t> cell_info1,
+    std::span<const typename std::remove_cvref_t<V>::value_type> bc_values1,
+    std::span<const std::int8_t> bc_markers1,
+    std::span<const typename std::remove_cvref_t<V>::value_type> x0,
+    typename std::remove_cvref_t<V>::value_type alpha,
     md::mdspan<const std::uint8_t, md::dextents<std::size_t, 2>> perms)
 {
+  using T = typename std::remove_cvref_t<V>::value_type;
   if (facets.empty())
     return;
 
@@ -660,18 +691,26 @@ void _lift_bc_interior_facets(
 /// coefficient for cell `i`.
 /// @param[in] cell_info0 Cell permutation information for the test
 /// function mesh.
-template <dolfinx::scalar T, int _bs = -1>
+template <int _bs = -1, typename V>
 void assemble_cells(
-    fem::DofTransformKernel<T> auto P0, std::span<T> b, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_t<T>,
-               md::extents<std::size_t, md::dynamic_extent, 3>>
+    fem::DofTransformKernel<typename std::remove_cvref_t<V>::value_type> auto
+        P0,
+    V&& b, mdspan2_t x_dofmap,
+    md::mdspan<
+        const scalar_value_t<typename std::remove_cvref_t<V>::value_type>,
+        md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     std::span<const std::int32_t> cells,
     std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap,
-    FEkernel<T> auto kernel, std::span<const T> constants,
-    md::mdspan<const T, md::dextents<std::size_t, 2>> coeffs,
+    FEkernel<typename std::remove_cvref_t<V>::value_type> auto kernel,
+    std::span<const typename std::remove_cvref_t<V>::value_type> constants,
+    md::mdspan<const typename std::remove_cvref_t<V>::value_type,
+               md::dextents<std::size_t, 2>>
+        coeffs,
     std::span<const std::uint32_t> cell_info0)
 {
+  using T = typename std::remove_cvref_t<V>::value_type;
+
   if (cells.empty())
     return;
 
@@ -742,11 +781,14 @@ void assemble_cells(
 /// function mesh.
 /// @param[in] perms Facet permutation integer. Empty if facet
 /// permutations are not required.
-template <dolfinx::scalar T, int _bs = -1>
+template <int _bs = -1, typename V>
 void assemble_exterior_facets(
-    fem::DofTransformKernel<T> auto P0, std::span<T> b, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_t<T>,
-               md::extents<std::size_t, md::dynamic_extent, 3>>
+    fem::DofTransformKernel<typename std::remove_cvref_t<V>::value_type> auto
+        P0,
+    V&& b, mdspan2_t x_dofmap,
+    md::mdspan<
+        const scalar_value_t<typename std::remove_cvref_t<V>::value_type>,
+        md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     md::mdspan<const std::int32_t,
                std::extents<std::size_t, md::dynamic_extent, 2>>
@@ -755,11 +797,16 @@ void assemble_exterior_facets(
                md::mdspan<const std::int32_t,
                           std::extents<std::size_t, md::dynamic_extent, 2>>>
         dofmap,
-    FEkernel<T> auto fn, std::span<const T> constants,
-    md::mdspan<const T, md::dextents<std::size_t, 2>> coeffs,
+    FEkernel<typename std::remove_cvref_t<V>::value_type> auto fn,
+    std::span<const typename std::remove_cvref_t<V>::value_type> constants,
+    md::mdspan<const typename std::remove_cvref_t<V>::value_type,
+               md::dextents<std::size_t, 2>>
+        coeffs,
     std::span<const std::uint32_t> cell_info0,
     md::mdspan<const std::uint8_t, md::dextents<std::size_t, 2>> perms)
 {
+  using T = typename std::remove_cvref_t<V>::value_type;
+
   if (facets.empty())
     return;
 
@@ -837,11 +884,14 @@ void assemble_exterior_facets(
 /// function mesh.
 /// @param[in] perms Facet permutation integer. Empty if facet
 /// permutations are not required.
-template <dolfinx::scalar T, int _bs = -1>
+template <int _bs = -1, typename V>
 void assemble_interior_facets(
-    fem::DofTransformKernel<T> auto P0, std::span<T> b, mdspan2_t x_dofmap,
-    md::mdspan<const scalar_value_t<T>,
-               md::extents<std::size_t, md::dynamic_extent, 3>>
+    fem::DofTransformKernel<typename std::remove_cvref_t<V>::value_type> auto
+        P0,
+    V&& b, mdspan2_t x_dofmap,
+    md::mdspan<
+        const scalar_value_t<typename std::remove_cvref_t<V>::value_type>,
+        md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
     md::mdspan<const std::int32_t,
                std::extents<std::size_t, md::dynamic_extent, 2, 2>>
@@ -850,13 +900,18 @@ void assemble_interior_facets(
                md::mdspan<const std::int32_t,
                           std::extents<std::size_t, md::dynamic_extent, 2, 2>>>
         dofmap,
-    FEkernel<T> auto fn, std::span<const T> constants,
-    md::mdspan<const T, md::extents<std::size_t, md::dynamic_extent, 2,
-                                    md::dynamic_extent>>
+    FEkernel<typename std::remove_cvref_t<V>::value_type> auto fn,
+    std::span<const typename std::remove_cvref_t<V>::value_type> constants,
+    md::mdspan<
+        const typename std::remove_cvref_t<V>::value_type,
+        md::extents<std::size_t, md::dynamic_extent, 2, md::dynamic_extent>>
         coeffs,
     std::span<const std::uint32_t> cell_info0,
     md::mdspan<const std::uint8_t, md::dextents<std::size_t, 2>> perms)
 {
+  using T = typename std::remove_cvref_t<V>::value_type;
+  using X = scalar_value_t<T>;
+
   if (facets.empty())
     return;
 
@@ -864,7 +919,6 @@ void assemble_interior_facets(
   assert(_bs < 0 or _bs == bs);
 
   // Create data structures used in assembly
-  using X = scalar_value_t<T>;
   std::vector<X> cdofs(2 * x_dofmap.extent(1) * 3);
   std::span<X> cdofs0(cdofs.data(), x_dofmap.extent(1) * 3);
   std::span<X> cdofs1(cdofs.data() + x_dofmap.extent(1) * 3,
@@ -958,18 +1012,26 @@ void assemble_interior_facets(
 /// @param[in] x0 The array used in the lifting, typically a 'current
 /// solution' in a Newton method
 /// @param[in] alpha Scaling to apply
-template <dolfinx::scalar T, std::floating_point U>
-void lift_bc(std::span<T> b, const Form<T, U>& a, mdspan2_t x_dofmap,
-             md::mdspan<const scalar_value_t<T>,
-                        md::extents<std::size_t, md::dynamic_extent, 3>>
-                 x,
-             std::span<const T> constants,
-             const std::map<std::pair<IntegralType, int>,
-                            std::pair<std::span<const T>, int>>& coefficients,
-             std::span<const T> bc_values1,
-             std::span<const std::int8_t> bc_markers1, std::span<const T> x0,
-             T alpha)
+template <typename V, std::floating_point U>
+void lift_bc(
+    V&& b, const Form<typename std::remove_cvref_t<V>::value_type, U>& a,
+    mdspan2_t x_dofmap,
+    md::mdspan<
+        const scalar_value_t<typename std::remove_cvref_t<V>::value_type>,
+        md::extents<std::size_t, md::dynamic_extent, 3>>
+        x,
+    std::span<const typename std::remove_cvref_t<V>::value_type> constants,
+    const std::map<
+        std::pair<IntegralType, int>,
+        std::pair<std::span<const typename std::remove_cvref_t<V>::value_type>,
+                  int>>& coefficients,
+    std::span<const typename std::remove_cvref_t<V>::value_type> bc_values1,
+    std::span<const std::int8_t> bc_markers1,
+    std::span<const typename std::remove_cvref_t<V>::value_type> x0,
+    typename std::remove_cvref_t<V>::value_type alpha)
 {
+  using T = typename std::remove_cvref_t<V>::value_type;
+
   // Integration domain mesh
   std::shared_ptr<const mesh::Mesh<U>> mesh = a.mesh();
   assert(mesh);
@@ -1023,17 +1085,17 @@ void lift_bc(std::span<T> b, const Form<T, U>& a, mdspan2_t x_dofmap,
     auto coeffs = md::mdspan(_coeffs.data(), cells.size(), cstride);
     if (bs0 == 1 and bs1 == 1)
     {
-      _lift_bc_cells<T, 1, 1>(
-          b, x_dofmap, x, kernel, cells, {dofmap0, bs0, cells0}, P0,
-          {dofmap1, bs1, cells1}, P1T, constants, coeffs, cell_info0,
-          cell_info1, bc_values1, bc_markers1, x0, alpha);
+      _lift_bc_cells<1, 1>(b, x_dofmap, x, kernel, cells,
+                           {dofmap0, bs0, cells0}, P0, {dofmap1, bs1, cells1},
+                           P1T, constants, coeffs, cell_info0, cell_info1,
+                           bc_values1, bc_markers1, x0, alpha);
     }
     else if (bs0 == 3 and bs1 == 3)
     {
-      _lift_bc_cells<T, 3, 3>(
-          b, x_dofmap, x, kernel, cells, {dofmap0, bs0, cells0}, P0,
-          {dofmap1, bs1, cells1}, P1T, constants, coeffs, cell_info0,
-          cell_info1, bc_values1, bc_markers1, x0, alpha);
+      _lift_bc_cells<3, 3>(b, x_dofmap, x, kernel, cells,
+                           {dofmap0, bs0, cells0}, P0, {dofmap1, bs1, cells1},
+                           P1T, constants, coeffs, cell_info0, cell_info1,
+                           bc_values1, bc_markers1, x0, alpha);
     }
     else
     {
@@ -1127,17 +1189,28 @@ void lift_bc(std::span<T> b, const Form<T, U>& a, mdspan2_t x_dofmap,
 /// `a[2]`/ `x0[2]` block.
 /// @param[in] x0 Arrays used in the lifting.
 /// @param[in] alpha Scaling to apply.
-template <dolfinx::scalar T, std::floating_point U>
+template <typename V, std::floating_point U>
 void apply_lifting(
-    std::span<T> b,
-    std::vector<std::optional<std::reference_wrapper<const Form<T, U>>>> a,
-    const std::vector<std::span<const T>>& constants,
-    const std::vector<std::map<std::pair<IntegralType, int>,
-                               std::pair<std::span<const T>, int>>>& coeffs,
+    V&& b,
+    std::vector<std::optional<std::reference_wrapper<
+        const Form<typename std::remove_cvref_t<V>::value_type, U>>>>
+        a,
     const std::vector<
-        std::vector<std::reference_wrapper<const DirichletBC<T, U>>>>& bcs1,
-    const std::vector<std::span<const T>>& x0, T alpha)
+        std::span<const typename std::remove_cvref_t<V>::value_type>>&
+        constants,
+    const std::vector<std::map<
+        std::pair<IntegralType, int>,
+        std::pair<std::span<const typename std::remove_cvref_t<V>::value_type>,
+                  int>>>& coeffs,
+    const std::vector<std::vector<std::reference_wrapper<
+        const DirichletBC<typename std::remove_cvref_t<V>::value_type, U>>>>&
+        bcs1,
+    const std::vector<
+        std::span<const typename std::remove_cvref_t<V>::value_type>>& x0,
+    typename std::remove_cvref_t<V>::value_type alpha)
 {
+  using T = typename std::remove_cvref_t<V>::value_type;
+
   if (!x0.empty() and x0.size() != a.size())
   {
     throw std::runtime_error(
@@ -1183,13 +1256,13 @@ void apply_lifting(
 
       if (!x0.empty())
       {
-        lift_bc<T>(b, a[j]->get(), x_dofmap, x, constants[j], coeffs[j],
-                   bc_values1, bc_markers1, x0[j], alpha);
+        lift_bc(b, a[j]->get(), x_dofmap, x, constants[j], coeffs[j],
+                bc_values1, bc_markers1, x0[j], alpha);
       }
       else
       {
-        lift_bc<T>(b, a[j]->get(), x_dofmap, x, constants[j], coeffs[j],
-                   bc_values1, bc_markers1, std::span<const T>(), alpha);
+        lift_bc(b, a[j]->get(), x_dofmap, x, constants[j], coeffs[j],
+                bc_values1, bc_markers1, std::span<const T>(), alpha);
       }
     }
   }
@@ -1202,16 +1275,21 @@ void apply_lifting(
 /// @param[in] x Mesh coordinates.
 /// @param[in] constants Packed constants that appear in `L`.
 /// @param[in] coefficients Packed coefficients that appear in `L`.
-template <dolfinx::scalar T, std::floating_point U>
+template <typename V, std::floating_point U>
 void assemble_vector(
-    std::span<T> b, const Form<T, U>& L,
-    md::mdspan<const scalar_value_t<T>,
-               md::extents<std::size_t, md::dynamic_extent, 3>>
+    V&& b, const Form<typename std::remove_cvref_t<V>::value_type, U>& L,
+    md::mdspan<
+        const scalar_value_t<typename std::remove_cvref_t<V>::value_type>,
+        md::extents<std::size_t, md::dynamic_extent, 3>>
         x,
-    std::span<const T> constants,
-    const std::map<std::pair<IntegralType, int>,
-                   std::pair<std::span<const T>, int>>& coefficients)
+    std::span<const typename std::remove_cvref_t<V>::value_type> constants,
+    const std::map<
+        std::pair<IntegralType, int>,
+        std::pair<std::span<const typename std::remove_cvref_t<V>::value_type>,
+                  int>>& coefficients)
 {
+  using T = typename std::remove_cvref_t<V>::value_type;
+
   // Integration domain mesh
   std::shared_ptr<const mesh::Mesh<U>> mesh = L.mesh();
   assert(mesh);
@@ -1256,13 +1334,13 @@ void assemble_vector(
       assert(cells.size() * cstride == coeffs.size());
       if (bs == 1)
       {
-        impl::assemble_cells<T, 1>(
+        impl::assemble_cells<1>(
             P0, b, x_dofmap, x, cells, {dofs, bs, cells0}, fn, constants,
             md::mdspan(coeffs.data(), cells.size(), cstride), cell_info0);
       }
       else if (bs == 3)
       {
-        impl::assemble_cells<T, 3>(
+        impl::assemble_cells<3>(
             P0, b, x_dofmap, x, cells, {dofs, bs, cells0}, fn, constants,
             md::mdspan(coeffs.data(), cells.size(), cstride), cell_info0);
       }
@@ -1304,14 +1382,14 @@ void assemble_vector(
       assert((facets.size() / 2) * cstride == coeffs.size());
       if (bs == 1)
       {
-        impl::assemble_exterior_facets<T, 1>(
+        impl::assemble_exterior_facets<1>(
             P0, b, x_dofmap, x, facets, {dofs, bs, facets1}, fn, constants,
             md::mdspan(coeffs.data(), facets.extent(0), cstride), cell_info0,
             perms);
       }
       else if (bs == 3)
       {
-        impl::assemble_exterior_facets<T, 3>(
+        impl::assemble_exterior_facets<3>(
             P0, b, x_dofmap, x, facets, {dofs, bs, facets1}, fn, constants,
             md::mdspan(coeffs.data(), facets.size() / 2, cstride), cell_info0,
             perms);
@@ -1343,7 +1421,7 @@ void assemble_vector(
       assert((facets.size() / 4) * 2 * cstride == coeffs.size());
       if (bs == 1)
       {
-        impl::assemble_interior_facets<T, 1>(
+        impl::assemble_interior_facets<1>(
             P0, b, x_dofmap, x,
             mdspanx22_t(facets.data(), facets.size() / 4, 2, 2),
             {*dofmap, bs,
@@ -1354,7 +1432,7 @@ void assemble_vector(
       }
       else if (bs == 3)
       {
-        impl::assemble_interior_facets<T, 3>(
+        impl::assemble_interior_facets<3>(
             P0, b, x_dofmap, x,
             mdspanx22_t(facets.data(), facets.size() / 4, 2, 2),
             {*dofmap, bs,
@@ -1384,12 +1462,16 @@ void assemble_vector(
 /// @param[in] L Linear forms to assemble into b.
 /// @param[in] constants Packed constants that appear in `L`.
 /// @param[in] coefficients Packed coefficients that appear in `L.`
-template <dolfinx::scalar T, std::floating_point U>
+template <typename V, std::floating_point U>
 void assemble_vector(
-    std::span<T> b, const Form<T, U>& L, std::span<const T> constants,
-    const std::map<std::pair<IntegralType, int>,
-                   std::pair<std::span<const T>, int>>& coefficients)
+    V&& b, const Form<typename std::remove_cvref_t<V>::value_type, U>& L,
+    std::span<const typename std::remove_cvref_t<V>::value_type> constants,
+    const std::map<
+        std::pair<IntegralType, int>,
+        std::pair<std::span<const typename std::remove_cvref_t<V>::value_type>,
+                  int>>& coefficients)
 {
+  using T = typename std::remove_cvref_t<V>::value_type;
   using mdspanx3_t
       = md::mdspan<const scalar_value_t<T>,
                    md::extents<std::size_t, md::dynamic_extent, 3>>;
@@ -1399,14 +1481,14 @@ void assemble_vector(
   auto x = mesh->geometry().x();
   if constexpr (std::is_same_v<U, scalar_value_t<T>>)
   {
-    assemble_vector(b, L, mdspanx3_t(x.data(), x.size() / 3, 3), constants,
-                    coefficients);
+    impl::assemble_vector(b, L, mdspanx3_t(x.data(), x.size() / 3, 3),
+                          constants, coefficients);
   }
   else
   {
     std::vector<scalar_value_t<T>> _x(x.begin(), x.end());
-    assemble_vector(b, L, mdspanx3_t(_x.data(), _x.size() / 3, 3), constants,
-                    coefficients);
+    impl::assemble_vector(b, L, mdspanx3_t(_x.data(), _x.size() / 3, 3),
+                          constants, coefficients);
   }
 }
 } // namespace dolfinx::fem::impl

--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -420,7 +420,7 @@ void apply_lifting(
   std::span<PetscScalar> _b(array, n);
 
   if (x0.empty())
-    fem::apply_lifting<PetscScalar>(_b, a, bcs1, {}, alpha);
+    fem::apply_lifting(_b, a, bcs1, {}, alpha);
   else
   {
     std::vector<std::span<const PetscScalar>> x0_ref;
@@ -437,7 +437,7 @@ void apply_lifting(
     }
 
     std::vector x0_tmp(x0_ref.begin(), x0_ref.end());
-    fem::apply_lifting<PetscScalar>(_b, a, bcs1, x0_tmp, alpha);
+    fem::apply_lifting(_b, a, bcs1, x0_tmp, alpha);
 
     for (std::size_t i = 0; i < x0_local.size(); ++i)
     {

--- a/cpp/dolfinx/io/VTKFile.cpp
+++ b/cpp/dolfinx/io/VTKFile.cpp
@@ -540,7 +540,7 @@ void write_function(
         if (mesh0->geometry().dim() == 3)
           add_data(_u.get().name,
                    std::span<const std::size_t>(component_vector),
-                   _u.get().x()->array(), data_node);
+                   std::span(_u.get().x()->array()), data_node);
         else
         {
           // Pad with zeros and then add

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -479,7 +479,7 @@ public:
   std::array<int, 2> block_size() const { return _bs; }
 
 private:
-  // Maps for the distribution of the ows and columns
+  // Maps for the distribution of the rows and columns
   std::array<std::shared_ptr<const common::IndexMap>, 2> _index_maps;
 
   // Block mode (compact or expanded)

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -117,7 +117,6 @@ public:
 
     _scatterer->scatter_fwd_end(_request);
     std::int32_t local_size = _bs * _map->size_local();
-    // std::int32_t num_ghosts = _bs * _map->num_ghosts();
     unpack(_buffer_remote.data(), _scatterer->remote_indices(),
            _x.data() + local_size, [](auto /*a*/, auto b) { return b; });
   }
@@ -179,8 +178,9 @@ public:
   /// received data can be summed or inserted into the local portion of
   /// the vector.
   ///
-  /// @param op IndexMap operation (add or insert)
   /// @note Collective MPI operation
+  ///
+  /// @param op IndexMap operation (add or insert)
   template <class BinaryOperation>
   void scatter_rev(BinaryOperation op)
   {
@@ -263,7 +263,8 @@ auto inner_product(const V& a, const V& b)
 }
 
 /// @brief Compute the squared L2 norm of vector.
-/// @note Collective MPI operation
+///
+/// @note Collective MPI operation.
 template <class V>
 auto squared_norm(const V& a)
 {
@@ -273,9 +274,11 @@ auto squared_norm(const V& a)
 }
 
 /// @brief Compute the norm of the vector.
-/// @note Collective MPI operation
-/// @param x A vector
-/// @param type Norm type
+///
+/// @note Collective MPI operation.
+///
+/// @param x Vector to compute the norm of.
+/// @param type Norm type.
 template <class V>
 auto norm(const V& x, Norm type = Norm::l2)
 {

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -76,11 +76,14 @@ public:
   /// Move Assignment operator
   Vector& operator=(Vector&& x) = default;
 
-  /// Set all entries (including ghosts)
+  /// @brief Set all entries (including ghosts).
+  ///
   /// @param[in] v The value to set all entries to (on calling rank)
   void set(value_type v) { std::ranges::fill(_x, v); }
 
-  /// Begin scatter of local data from owner to ghosts on other ranks
+  /// @brief Begin scatter of local data from owner to ghosts on other
+  /// ranks.
+  ///
   /// @note Collective MPI operation
   void scatter_fwd_begin()
   {
@@ -118,7 +121,8 @@ public:
            [](auto /*a*/, auto b) { return b; });
   }
 
-  /// Scatter local data to ghost positions on other ranks
+  /// @brief Scatter local data to ghost positions on other ranks.
+  ///
   /// @note Collective MPI operation
   void scatter_fwd()
   {
@@ -146,9 +150,12 @@ public:
                                   _request);
   }
 
-  /// End scatter of ghost data to owner. This process may receive data
-  /// from more than one process, and the received data can be summed or
-  /// inserted into the local portion of the vector.
+  /// @brief End scatter of ghost data to owner.
+  ///
+  /// This process may receive data from more than one process, and the
+  /// received data can be summed or inserted into the local portion of
+  /// the vector.
+  ///
   /// @param op The operation to perform when adding/setting received
   /// values (add or insert)
   /// @note Collective MPI operation
@@ -158,7 +165,6 @@ public:
     const std::int32_t local_size = _bs * _map->size_local();
     std::span<value_type> x_local(_x.data(), local_size);
     _scatterer->scatter_rev_end(_request);
-
     auto unpack = [](auto&& in, auto&& idx, auto&& out, auto op)
     {
       for (std::size_t i = 0; i < idx.size(); ++i)
@@ -167,9 +173,12 @@ public:
     unpack(_buffer_local, _scatterer->local_indices(), x_local, op);
   }
 
-  /// Scatter ghost data to owner. This process may receive data from
-  /// more than one process, and the received data can be summed or
-  /// inserted into the local portion of the vector.
+  /// @brief Scatter ghost data to owner.
+  ///
+  /// This process may receive data from more than one process, and the
+  /// received data can be summed or inserted into the local portion of
+  /// the vector.
+  ///
   /// @param op IndexMap operation (add or insert)
   /// @note Collective MPI operation
   template <class BinaryOperation>
@@ -214,12 +223,16 @@ private:
   container_type _x;
 };
 
-/// Compute the inner product of two vectors. The two vectors must have
-/// the same parallel layout
+/// @brief Compute the inner product of two vectors.
+///
+/// Computes `a^{H} b` (`a^{T} b` if `a` and `b` are real). The two
+/// vectors must have the same parallel layout.
+///
 /// @note Collective MPI operation
-/// @param a A vector
-/// @param b A vector
-/// @return Returns `a^{H} b` (`a^{T} b` if `a` and `b` are real)
+///
+/// @param a Vector `a`.
+/// @param b Vector `b`.
+/// @return Inner product between `a` and `b`.
 template <class V>
 auto inner_product(const V& a, const V& b)
 {
@@ -249,7 +262,7 @@ auto inner_product(const V& a, const V& b)
   return result;
 }
 
-/// Compute the squared L2 norm of vector
+/// @brief Compute the squared L2 norm of vector.
 /// @note Collective MPI operation
 template <class V>
 auto squared_norm(const V& a)
@@ -259,7 +272,7 @@ auto squared_norm(const V& a)
   return std::real(result);
 }
 
-/// Compute the norm of the vector
+/// @brief Compute the norm of the vector.
 /// @note Collective MPI operation
 /// @param x A vector
 /// @param type Norm type
@@ -301,11 +314,12 @@ auto norm(const V& x, Norm type = Norm::l2)
   }
 }
 
-/// Orthonormalize a set of vectors
+/// @brief Orthonormalize a set of vectors.
+///
+/// @tparam V dolfinx::la::Vector
 /// @param[in,out] basis The set of vectors to orthonormalise. The
 /// vectors must have identical parallel layouts. The vectors are
 /// modified in-place.
-/// @tparam V dolfinx::la::Vector
 template <class V>
 void orthonormalize(std::vector<std::reference_wrapper<V>> basis)
 {

--- a/cpp/dolfinx/refinement/uniform.cpp
+++ b/cpp/dolfinx/refinement/uniform.cpp
@@ -144,9 +144,7 @@ refinement::uniform_refine(const mesh::Mesh<T>& mesh,
               local_range[0] + entity_offsets[j]);
 
     common::Scatterer sc(*index_maps[j], 1);
-    sc.scatter_fwd(std::span<const std::int64_t>(new_v[j]),
-                   std::span(std::next(new_v[j].begin(), num_entities),
-                             index_maps[j]->num_ghosts()));
+    sc.scatter_fwd(new_v[j].data(), new_v[j].data() + num_entities);
   }
 
   // Create new topology

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -62,11 +62,10 @@ void test_scatter_fwd(int n)
                           { return i == val * ((mpi_rank + 1) % mpi_size); }));
 
   std::vector<MPI_Request> requests
-      = sct.create_request_vector(decltype(sct)::type::p2p);
-
+      = sct.create_request_vector(common::ScattererType::p2p);
   std::ranges::fill(data_ghost, 0);
-  sct.scatter_fwd_begin<std::int64_t>(data_local, data_ghost, requests,
-                                      decltype(sct)::type::p2p);
+  sct.scatter_fwd_begin(data_local.data(), data_ghost.data(), requests,
+                        common::ScattererType::p2p);
   sct.scatter_fwd_end(requests);
 
   CHECK(
@@ -124,12 +123,11 @@ void test_scatter_rev()
       out[idx[i]] = op(out[idx[i]], in[i]);
   };
 
-  sct.scatter_rev_begin<std::int64_t>(data_ghost, remote_buffer, local_buffer,
-                                      pack_fn, requests,
-                                      decltype(sct)::type::p2p);
-  //
-  sct.scatter_rev_end<std::int64_t>(local_buffer, data_local, unpack_fn,
-                                    std::plus<std::int64_t>(), requests);
+  sct.scatter_rev_begin(data_ghost.data(), remote_buffer.data(),
+                        local_buffer.data(), pack_fn, requests,
+                        common::ScattererType::p2p);
+  sct.scatter_rev_end(local_buffer.data(), data_local.data(), unpack_fn,
+                      std::plus<std::int64_t>(), requests);
 
   sum = std::reduce(data_local.begin(), data_local.end(), 0);
   CHECK(sum == 2 * n * value * num_ghosts);

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -62,7 +62,7 @@ void test_scatter_fwd(int n)
                           { return i == val * ((mpi_rank + 1) % mpi_size); }));
 
   std::vector<MPI_Request> requests
-      = sct.create_request_vector(common::ScattererType::p2p);
+      = sct.create_requests(common::ScattererType::p2p);
   std::ranges::fill(data_ghost, 0);
   sct.scatter_fwd_begin(data_local.data(), data_ghost.data(), requests,
                         common::ScattererType::p2p);

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -55,7 +55,7 @@ void test_scatter_fwd(int n)
   std::vector<std::int64_t> data_ghost(n * num_ghosts, -1);
 
   // Scatter values to ghost and check value is correctly received
-  sct.scatter_fwd<std::int64_t>(data_local, data_ghost);
+  sct.scatter_fwd<std::int64_t>(data_local.data(), data_ghost.data());
   CHECK((int)data_ghost.size() == n * num_ghosts);
   CHECK(
       std::ranges::all_of(data_ghost, [=](auto i)
@@ -92,8 +92,7 @@ void test_scatter_rev()
   std::int64_t value = 15;
   std::vector<std::int64_t> data_local(n * size_local, 0);
   std::vector<std::int64_t> data_ghost(n * num_ghosts, value);
-  sct.scatter_rev(std::span<std::int64_t>(data_local),
-                  std::span<const std::int64_t>(data_ghost),
+  sct.scatter_rev(data_local.data(), data_ghost.data(),
                   std::plus<std::int64_t>());
 
   std::int64_t sum;
@@ -101,8 +100,7 @@ void test_scatter_rev()
   sum = std::reduce(data_local.begin(), data_local.end(), 0);
   CHECK(sum == n * value * num_ghosts);
 
-  sct.scatter_rev(std::span<std::int64_t>(data_local),
-                  std::span<const std::int64_t>(data_ghost),
+  sct.scatter_rev(data_local.data(), data_ghost.data(),
                   [](auto /*a*/, auto b) { return b; });
 
   sum = std::reduce(data_local.begin(), data_local.end(), 0);

--- a/python/dolfinx/wrappers/assemble.cpp
+++ b/python/dolfinx/wrappers/assemble.cpp
@@ -336,7 +336,7 @@ void declare_assembly_functions(nb::module_& m)
                         nb::ndarray<const T, nb::ndim<2>, nb::c_contig>>&
              coefficients)
       {
-        dolfinx::fem::assemble_vector<T>(
+        dolfinx::fem::assemble_vector(
             std::span(b.data(), b.size()), L,
             std::span(constants.data(), constants.size()),
             dolfinx_wrappers::py_to_cpp_coeffs(coefficients));
@@ -567,8 +567,8 @@ void declare_assembly_functions(nb::module_& m)
             coeffs, std::back_inserter(_coeffs),
             [](auto& c) { return dolfinx_wrappers::py_to_cpp_coeffs(c); });
 
-        dolfinx::fem::apply_lifting<T>(std::span<T>(b.data(), b.size()), _a,
-                                       _constants, _coeffs, _bcs, _x0, alpha);
+        dolfinx::fem::apply_lifting(std::span<T>(b.data(), b.size()), _a,
+                                    _constants, _coeffs, _bcs, _x0, alpha);
       },
       nb::arg("b").noconvert(), nb::arg("a"), nb::arg("constants"),
       nb::arg("coeffs"), nb::arg("bcs1"), nb::arg("x0"), nb::arg("alpha"),

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -56,8 +56,8 @@ void add_scatter_functions(nb::class_<dolfinx::common::Scatterer<>>& sc)
          nb::ndarray<const T, nb::ndim<1>, nb::c_contig> local_data,
          nb::ndarray<T, nb::ndim<1>, nb::c_contig> remote_data)
       {
-        self.scatter_fwd(std::span(local_data.data(), local_data.size()),
-                         std::span(remote_data.data(), remote_data.size()));
+        // TODO: add size check
+        self.scatter_fwd(local_data.data(), remote_data.data());
       },
       nb::arg("local_data"), nb::arg("remote_data"));
 
@@ -67,9 +67,8 @@ void add_scatter_functions(nb::class_<dolfinx::common::Scatterer<>>& sc)
          nb::ndarray<T, nb::ndim<1>, nb::c_contig> local_data,
          nb::ndarray<const T, nb::ndim<1>, nb::c_contig> remote_data)
       {
-        self.scatter_rev(std::span(local_data.data(), local_data.size()),
-                         std::span(remote_data.data(), remote_data.size()),
-                         std::plus<T>());
+        // TODO: add size checks
+        self.scatter_rev(local_data.data(), remote_data.data(), std::plus<T>());
       },
       nb::arg("local_data"), nb::arg("remote_data"));
 }


### PR DESCRIPTION
Allows the user to specify the container types for `la::Vector` and `common::Scatterer`. The containers can, for example, be `thrust::device_vector` for on-device storage of data for a multi-GPU `Vector`.

- Changes the data return type for `la::Vector::array` from `std::span` to `container_type&`.
- Changes some  `common::Scatterer` args to plains pointers, which can be device pointers. Using spans was misleading because device entries can't be accessed by `operator[]`.
- Communication of  on-device data requires a GPU-ware MPI build.
- Improves `common::Scatterer` documentation.
- Improve type deduction in assembler functions, reducing need to use to supply template arguments.