### PR TITLE
Integrate C++ tests into project cmake

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -109,6 +109,7 @@ jobs:
           --warn-uninitialized
           -G Ninja
           -DCMAKE_BUILD_TYPE=Developer
+          -DBUILD_TESTING=true
           -DDOLFINX_ENABLE_PETSC=false
 
       - name: Build and install (C++)

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -108,8 +108,7 @@ jobs:
           -Werror=dev
           --warn-uninitialized
           -G Ninja
-          -DCMAKE_BUILD_TYPE=Developer 
-          -DBUILD_TESTING=true
+          -DCMAKE_BUILD_TYPE=Developer
           -DDOLFINX_ENABLE_PETSC=false
 
       - name: Build and install (C++)

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -101,23 +101,26 @@ jobs:
           pip install --no-build-isolation git+https://github.com/fenics/basix.git@${{ env.basix_ref }}
           pip install --no-build-isolation git+https://github.com/fenics/ffcx.git@${{ env.ffcx_ref }}
 
-      - name: Configure and install C++
+      - name: Configure (C++)
+        working-directory: cpp
+        run: >
+          cmake -B build -S .
+          -Werror=dev
+          --warn-uninitialized
+          -G Ninja
+          -DCMAKE_BUILD_TYPE=Developer 
+          -DBUILD_TESTING=true
+          -DDOLFINX_ENABLE_PETSC=false
+
+      - name: Build and install (C++)
+        working-directory: cpp/build
         run: |
-          cmake -Werror=dev --warn-uninitialized -G Ninja -DDOLFINX_ENABLE_PETSC=false -DCMAKE_BUILD_TYPE=Developer -B build -S cpp/
-          cmake --build build
-          sudo cmake --install build
-      - name: Build C++ unit tests
-        run: |
-          cmake -Werror=dev --warn-uninitialized -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build/test/ -S cpp/test/
-          cmake --build build/test
-      - name: Run C++ unit tests (serial)
-        run: |
-          cd build/test
-          ctest -V --output-on-failure -R unittests
-      - name: Run C++ unit tests (MPI)
-        run: |
-          cd build/test
-          mpirun -n 3 ctest -V --output-on-failure -R unittests
+          cmake --build .
+          sudo cmake --install .
+
+      - name: Run tests (C++)
+        working-directory: cpp/build
+        run: ctest -V --output-on-failure -R unittests
 
       - name: Build Python interface
         run: |
@@ -186,24 +189,30 @@ jobs:
           pip install --no-build-isolation git+https://github.com/FEniCS/basix.git@${{ env.basix_ref }}
           pip install --no-build-isolation git+https://github.com/FEniCS/ffcx.git@${{ env.ffcx_ref }}
 
-      - name: Configure, build and install C++ library
-        run: |
-          cmake -Werror=dev --warn-uninitialized -G Ninja -DCMAKE_BUILD_TYPE=Developer -DDOLFINX_ENABLE_ADIOS2=true -DDOLFINX_ENABLE_KAHIP=true -DDOLFINX_ENABLE_PARMETIS=false -DDOLFINX_ENABLE_PETSC=true -DDOLFINX_ENABLE_SCOTCH=true -DDOLFINX_ENABLE_SLEPC=true -B build -S cpp/
-          cmake --build build
-          cmake --install build
+      - name: Configure (C++)
+        working-directory: cpp
+        run: >
+          cmake -B build -S .
+          -Werror=dev
+          --warn-uninitialized
+          -G Ninja
+          -DCMAKE_BUILD_TYPE=Developer
+          -DBUILD_TESTING=true
+          -DDOLFINX_ENABLE_ADIOS2=true
+          -DDOLFINX_ENABLE_KAHIP=true
+          -DDOLFINX_ENABLE_PETSC=true
+          -DDOLFINX_ENABLE_SCOTCH=true
+          -DDOLFINX_ENABLE_SLEPC=true 
+          -DDOLFINX_ENABLE_PARMETIS=false
 
-      - name: Build C++ unit tests
-        run: |
-          cmake -Werror=dev --warn-uninitialized -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build/test/ -S cpp/test/
-          cmake --build build/test
-      - name: Run C++ unit tests (serial)
-        run: |
-          cd build/test
-          ctest -V --output-on-failure -R unittests
-      - name: Run C++ unit tests (MPI)
-        run: |
-          cd build/test
-          mpirun -n 3 ctest -V --output-on-failure -R unittests
+      - name: Build and install (C++)
+        working-directory: cpp/build
+        run: cmake --build . --target install
+
+      - name: Run tests (C++)
+        working-directory: cpp/build
+        run: ctest -V --output-on-failure -R unittests
+
       - name: Build and run C++ regression tests (serial and MPI (np=2))
         run: |
           cmake -Werror=dev --warn-uninitialized -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build/demo/ -S cpp/demo/

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Run tests (C++)
         working-directory: cpp/build
-        run: ctest -V --output-on-failure -R unittests
+        run: cmake --build . --target test
 
       - name: Build Python interface
         run: |

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -98,7 +98,7 @@ jobs:
           cmake --build build --target install
 
       - name: Run tests (C++)
-        working-directory: cpp/build
+        working-directory: dolfinx-src/cpp/build
         run: |
           . ./spack-src/share/spack/setup-env.sh
           ctest -V --output-on-failure -R unittests

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -95,21 +95,14 @@ jobs:
           . ./spack-src/share/spack/setup-env.sh
           spack env activate .
           cmake -Werror=dev --warn-uninitialized -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx-src/cpp/
-          cmake --build build
-          cmake --install build
+          cmake --build build --target install
 
-      - name: Build C++ unit tests
+      - name: Run tests (C++)
+        working-directory: cpp/build
         run: |
           . ./spack-src/share/spack/setup-env.sh
-          spack env activate .
-          cmake -Werror=dev --warn-uninitialized -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build/test/ -S dolfinx-src/cpp/test/
-          cmake --build build/test
-      - name: Run C++ unit tests (serial and MPI)
-        run: |
-          . ./spack-src/share/spack/setup-env.sh
-          spack env activate .
-          cd build/test
-          mpiexec -np 2 ctest -V --output-on-failure -R unittests
+          ctest -V --output-on-failure -R unittests
+
       - name: Build and run C++ regression tests (serial and MPI (np=2))
         run: |
           . ./spack-src/share/spack/setup-env.sh

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Run tests (C++)
         run: |
           . ./spack-src/share/spack/setup-env.sh
+          spack env activate .
           cd build
           ctest -V --output-on-failure -R unittests
 

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -98,9 +98,9 @@ jobs:
           cmake --build build --target install
 
       - name: Run tests (C++)
-        working-directory: dolfinx-src/cpp/build
         run: |
           . ./spack-src/share/spack/setup-env.sh
+          cd build
           ctest -V --output-on-failure -R unittests
 
       - name: Build and run C++ regression tests (serial and MPI (np=2))

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -90,19 +90,12 @@ jobs:
           pip install git+https://github.com/fenics/basix.git@${{ env.basix_ref }}
           pip install git+https://github.com/fenics/ffcx.git@${{ env.ffcx_ref }}
 
-      - name: Configure and build C++
+      - name: Configure, build and test C++
         run: |
           . ./spack-src/share/spack/setup-env.sh
           spack env activate .
           cmake -Werror=dev --warn-uninitialized -G Ninja -DBUILD_TESTING=true -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx-src/cpp/
-          cmake --build build --target install
-
-      - name: Run tests (C++)
-        run: |
-          . ./spack-src/share/spack/setup-env.sh
-          spack env activate .
-          cd build
-          ctest -V --output-on-failure -R unittests
+          cmake --build build --target test --target install
 
       - name: Build and run C++ regression tests (serial and MPI (np=2))
         run: |

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           . ./spack-src/share/spack/setup-env.sh
           spack env activate .
-          cmake -Werror=dev --warn-uninitialized -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx-src/cpp/
+          cmake -Werror=dev --warn-uninitialized -G Ninja -DBUILD_TESTING=true -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx-src/cpp/
           cmake --build build --target install
 
       - name: Run tests (C++)

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -90,12 +90,19 @@ jobs:
           pip install git+https://github.com/fenics/basix.git@${{ env.basix_ref }}
           pip install git+https://github.com/fenics/ffcx.git@${{ env.ffcx_ref }}
 
-      - name: Configure, build and test C++
+      - name: Configure and build C++
         run: |
           . ./spack-src/share/spack/setup-env.sh
           spack env activate .
           cmake -Werror=dev --warn-uninitialized -G Ninja -DBUILD_TESTING=true -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx-src/cpp/
-          cmake --build build --target test --target install
+          cmake --build build --target install
+
+      - name: Run tests (C++)
+        run: |
+          . ./spack-src/share/spack/setup-env.sh
+          spack env activate .
+          cd build
+          ctest -V --output-on-failure -R unittests
 
       - name: Build and run C++ regression tests (serial and MPI (np=2))
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -84,6 +84,7 @@ jobs:
           -Werror=dev
           --warn-uninitialized
           -G Ninja 
+          -DBUILD_TESTING=true
 
       - name: Build and install (C++)
         working-directory: cpp/build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -77,26 +77,23 @@ jobs:
           python -m pip install git+https://github.com/fenics/basix.git@${{ env.basix_ref }}
           python -m pip install git+https://github.com/fenics/ffcx.git@${{ env.ffcx_ref }}
 
-      - name: Build and install DOLFINx C++ library
-        run: |
-          cmake -Werror=dev --warn-uninitialized -G Ninja -B build -S cpp/
-          cmake --build build
-          sudo cmake --install build
+      - name: Configure (C++)
+        working-directory: cpp
+        run: >
+          cmake -B build -S cpp/
+          -Werror=dev
+          --warn-uninitialized
+          -G Ninja 
 
-      - name: Build C++ unit tests
+      - name: Build and install (C++)
+        working-directory: cpp/build
         run: |
-          cmake -Werror=dev --warn-uninitialized -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build/test/ -S cpp/test/
-          cmake --build build/test
+          cmake --build .
+          sudo cmake --install .
 
-      - name: Run C++ unit tests (serial)
-        run: |
-          cd build/test
-          mpiexec -np 1 ctest -V --output-on-failure -R unittests
-
-      - name: Run C++ unit tests (MPI)
-        run: |
-          cd build/test
-          mpiexec -np 3 ctest -V --output-on-failure -R unittests
+      - name: Run tests (C++)
+        working-directory: cpp/build
+        run: ctest -V --output-on-failure -R unittests
 
       - name: Build and install DOLFINx Python interface
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Configure (C++)
         working-directory: cpp
         run: >
-          cmake -B build -S cpp/
+          cmake -B build -S .
           -Werror=dev
           --warn-uninitialized
           -G Ninja 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -482,6 +482,7 @@ add_subdirectory(dolfinx)
 # ------------------------------------------------------------------------------
 # Unit testing
 option(BUILD_TESTING "Build DOLFINx unit tests." OFF)
+set(CMAKE_SKIP_TEST_ALL_DEPENDENCY FALSE) # Ensure compile before test execution.
 set(DOLFINX_TEST_MPI_PROCESSES "1;3" CACHE STRING "List of process counts to run tests with.")
 include(CTest)
 if (BUILD_TESTING)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -482,7 +482,7 @@ add_subdirectory(dolfinx)
 # ------------------------------------------------------------------------------
 # Unit testing
 option(BUILD_TESTING "Build DOLFINx unit tests." OFF)
-set(TEST_PROCESSES "1;3" CACHE STRING "List of process counts to run tests with.")
+set(DOLFINX_TEST_MPI_PROCESSES "1;3" CACHE STRING "List of process counts to run tests with.")
 include(CTest)
 if (BUILD_TESTING)
   add_subdirectory(test)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -480,6 +480,15 @@ endif()
 add_subdirectory(dolfinx)
 
 # ------------------------------------------------------------------------------
+# Unit testing
+option(BUILD_TESTING "Build DOLFINx unit tests." OFF)
+set(TEST_PROCESSES "1;3" CACHE STRING "List of process counts to run tests with.")
+include(CTest)
+if (BUILD_TESTING)
+  add_subdirectory(test)
+endif()
+
+# ------------------------------------------------------------------------------
 # Generate and install helper file dolfinx.conf
 
 # FIXME: Can CMake provide the library path name variable?

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -482,7 +482,6 @@ add_subdirectory(dolfinx)
 # ------------------------------------------------------------------------------
 # Unit testing
 option(BUILD_TESTING "Build DOLFINx unit tests." OFF)
-set(CMAKE_SKIP_TEST_ALL_DEPENDENCY FALSE) # Ensure compile before test execution.
 set(DOLFINX_TEST_MPI_PROCESSES "1;3" CACHE STRING "List of process counts to run tests with.")
 include(CTest)
 if (BUILD_TESTING)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -1,39 +1,3 @@
-cmake_minimum_required(VERSION 3.21)
-
-project(dolfinx-tests LANGUAGES C CXX)
-set(CMAKE_C_STANDARD 17) # For FFCx generated .c files.
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-# Find DOLFINx config file
-find_package(DOLFINX REQUIRED)
-
-include(FeatureSummary)
-
-# Add shared library paths so shared libs in non-system paths are found
-option(CMAKE_INSTALL_RPATH_USE_LINK_PATH "Add paths to linker search and installed rpath." ON)
-
-# clang-tidy
-option(ENABLE_CLANG_TIDY "Run clang-tidy while building" OFF)
-add_feature_info(ENABLE_CLANG_TIDY ENABLE_CLANG_TIDY "Run clang-tidy while building")
-
-add_custom_command(
-  OUTPUT expr.c
-  COMMAND ffcx ${CMAKE_CURRENT_SOURCE_DIR}/fem/expr.py
-  VERBATIM
-  DEPENDS fem/expr.py
-  COMMENT "Compile expr.py using FFCx"
-)
-
-add_custom_command(
-  OUTPUT poisson.c
-  COMMAND ffcx ${CMAKE_CURRENT_SOURCE_DIR}/poisson.py
-  VERBATIM
-  DEPENDS poisson.py
-  COMMENT "Compile poisson.py using FFCx"
-)
-
 find_package(Catch2 3)
 
 if(NOT Catch2_FOUND)
@@ -46,6 +10,26 @@ if(NOT Catch2_FOUND)
   )
   FetchContent_MakeAvailable(Catch2)
 endif()
+
+include(Catch)
+
+# FFCx compile: expr.py -> expr.c
+add_custom_command(
+  OUTPUT expr.c
+  COMMAND ffcx ${CMAKE_CURRENT_SOURCE_DIR}/fem/expr.py
+  VERBATIM
+  DEPENDS fem/expr.py
+  COMMENT "Compile expr.py using FFCx"
+)
+
+# FFCx compile: poisson.py -> poisson.c
+add_custom_command(
+  OUTPUT poisson.c
+  COMMAND ffcx ${CMAKE_CURRENT_SOURCE_DIR}/poisson.py
+  VERBATIM
+  DEPENDS poisson.py
+  COMMENT "Compile poisson.py using FFCx"
+)
 
 add_executable(
   unittests
@@ -78,29 +62,42 @@ if(WIN32)
   target_link_libraries(unittests PRIVATE bcrypt)
 endif()
 
-target_include_directories(unittests PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+target_include_directories(
+  unittests PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+)
+# makes version.h accessible
+target_include_directories(
+  unittests PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../>
+)
 
-# Add some strict compiler checks only on C++ part (Developer).
-include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag("-Wall -Werror -Wextra -pedantic" HAVE_PEDANTIC)
-
-if(HAVE_PEDANTIC)
-  list(APPEND DOLFINX_CXX_DEVELOPER_FLAGS -Wall;-Werror;-Wextra;-pedantic)
-endif()
+set_target_properties(
+  unittests
+  PROPERTIES CMAKE_C_STANDARD 17
+             CMAKE_CXX_STANDARD 20
+             CMAKE_CXX_STANDARD_REQUIRED ON
+             CMAKE_CXX_EXTENSIONS OFF
+)
 
 target_compile_options(
   unittests
   PRIVATE
-  $<$<AND:$<CONFIG:Developer>,$<COMPILE_LANGUAGE:CXX>>:${DOLFINX_CXX_DEVELOPER_FLAGS}>
+    $<$<AND:$<CONFIG:Developer>,$<COMPILE_LANGUAGE:CXX>>:${DOLFINX_CXX_DEVELOPER_FLAGS}>
 )
 
+# TODO: should not be set in test and dolfinx but in cpp once.
 if(ENABLE_CLANG_TIDY)
   find_program(CLANG_TIDY NAMES clang-tidy REQUIRED)
-  set_target_properties(unittests PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY};--config-file=${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy")
+  set_target_properties(
+    unittests
+    PROPERTIES
+      CXX_CLANG_TIDY
+      "${CLANG_TIDY};--config-file=${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-tidy"
+  )
 endif()
 
-# Enable testing
-enable_testing()
+# Nice for debugging tests one at a time - but extremely slow due to process
+# spawning/tear down: catch_discover_tests(unittests)
 
-# Test target
-add_test(unittests unittests)
+foreach(np IN LISTS TEST_PROCESSES)
+  add_test(NAME unittests_np_${np} COMMAND mpiexec -np ${np} ./unittests)
+endforeach()

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -98,6 +98,6 @@ endif()
 # Nice for debugging tests one at a time - but extremely slow due to process
 # spawning/tear down: catch_discover_tests(unittests)
 
-foreach(np IN LISTS TEST_PROCESSES)
+foreach(np IN LISTS DOLFINX_TEST_MPI_PROCESSES)
   add_test(NAME unittests_np_${np} COMMAND mpiexec -np ${np} ./unittests)
 endforeach()


### PR DESCRIPTION
Includes the c++ tests into the root cmake project with the standard `CMake` testing functionality.

- Standard flag [`BUILD_TESTING`](https://cmake.org/cmake/help/latest/variable/BUILD_TESTING.html) enables/disables build of tests
- All compile time flags, settings etc are inherited now from the central project setup and do not require to be reconfigured.
- Test build/execution do not require a prior installation.
- Parallel test cases are run through `ctetst` automatically (Removing the need to rerun with different parallelisation settings
- New option `DOLFINX_TEST_MPI_PROCESSES` encodes the process counts to run during the test phase

This is motivated by
1. Development experience on the C++ end, the install + change directory + compile/run tests setup simplifies to
```bash
ninja && ctest
```
which automatically tests the setup as performed in the CIs.
2. Combines compile of dolfinx (library) and tests into a combined step.
3.  compliance with the cmake tooling.

This could/should be extended to include the demos in another PR.