### PR TITLE
Add explicit `<format>` includes

### DIFF
--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -17,6 +17,7 @@
 #include <dolfinx/fem/FunctionSpace.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/Topology.h>
+#include <format>
 #include <pugixml.hpp>
 #include <string>
 

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -15,6 +15,7 @@
 #include <dolfinx/common/sort.h>
 #include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/graph/partition.h>
+#include <format>
 #include <numeric>
 #include <random>
 #include <set>


### PR DESCRIPTION
Follow up to #3853 and #3829

Add an explicit `#include <format>` in every `cpp` file that uses `std::format`. Not sure why CI hasn't caught this, I guess that the header is getting included implicitly due another import.

Helps on Colab, which is still shipping old gcc 12 and [requires hacky workarounds to have our minimal use of `std::format` working](https://github.com/fem-on-colab/fem-on-colab/commit/dbceae9f885bcaff159d55ffffd847dd67872035).