### PR TITLE
Remove `mpiexec` in cmake test target

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -118,9 +118,12 @@ jobs:
           cmake --build .
           sudo cmake --install .
 
-      - name: Run tests (C++)
+      - name: Run tests (C++, serial)
         working-directory: cpp/build
-        run: cmake --build . --target test
+        run: mpirun -np 1 cmake --build . --target test
+      - name: Run tests (C++, MPI, np=3)
+        working-directory: cpp/build
+        run: mpirun -np 3 cmake --build . --target test
 
       - name: Build Python interface
         run: |
@@ -147,11 +150,12 @@ jobs:
         run: |
           pip install pytest-xdist
           python -m pytest -n auto -m serial --durations=10 python/demo/test.py
-      - name: Run demos (Python, MPI (np=3))
+      - name: Run demos (Python, MPI, np=3)
         run: python -m pytest -m mpi --num-proc=3 python/demo/test.py
-      - name: Run unit tests
+
+      - name: Run tests (Python, serial)
         run: python -m pytest -n auto -m "not petsc4py and not adios2" python/test/unit
-      - name: Run unit tests (MPI, np=3)
+      - name: Run tests (Python, MPI, np=3)
         run: mpirun -np 3 python -m pytest -m "not petsc4py and not adios2" python/test/unit
 
   build-with-petsc:
@@ -209,9 +213,12 @@ jobs:
         working-directory: cpp/build
         run: cmake --build . --target install
 
-      - name: Run tests (C++)
+      - name: Run tests (C++, serial)
         working-directory: cpp/build
-        run: ctest -V --output-on-failure -R unittests
+        run: mpiexec -np 1 ctest -V --output-on-failure -R unittests
+      - name: Run tests (C++, MPI, np=3)
+        working-directory: cpp/build
+        run: mpiexec -np 3 ctest -V --output-on-failure -R unittests
 
       - name: Build and run C++ regression tests (serial and MPI (np=2))
         run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -118,10 +118,10 @@ jobs:
           cmake --build .
           sudo cmake --install .
 
-      - name: Run tests (C++, serial)
+      - name: Run tests via target (C++, serial)
         working-directory: cpp/build
         run: mpirun -np 1 cmake --build . --target test
-      - name: Run tests (C++, MPI, np=3)
+      - name: Run tests via target (C++, MPI, np=3)
         working-directory: cpp/build
         run: mpirun -np 3 cmake --build . --target test
 

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -95,14 +95,21 @@ jobs:
           . ./spack-src/share/spack/setup-env.sh
           spack env activate .
           cmake -Werror=dev --warn-uninitialized -G Ninja -DBUILD_TESTING=true -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx-src/cpp/
-          cmake --build build --target install
+          cmake --build build
 
-      - name: Run tests (C++)
+      - name: Run tests without install (C++, serial and MPI np=2)
         run: |
           . ./spack-src/share/spack/setup-env.sh
           spack env activate .
           cd build
-          ctest -V --output-on-failure -R unittests
+          mpirun -np 1 ctest -V --output-on-failure -R unittests
+          mpirun -np 2 ctest -V --output-on-failure -R unittests
+
+      - name: Install C++
+        run: |
+          . ./spack-src/share/spack/setup-env.sh
+          spack env activate .
+          cmake --build build --target install
 
       - name: Build and run C++ regression tests (serial and MPI (np=2))
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -92,9 +92,12 @@ jobs:
           cmake --build .
           sudo cmake --install .
 
-      - name: Run tests (C++)
+      - name: Run tests (C++, serial)
         working-directory: cpp/build
-        run: ctest -V --output-on-failure -R unittests
+        run: mpiexec -np 1 ctest -V --output-on-failure -R unittests
+      - name: Run tests (C++, MPI, np=3)
+        working-directory: cpp/build
+        run: mpiexec -np 3 ctest -V --output-on-failure -R unittests
 
       - name: Build and install DOLFINx Python interface
         run: |
@@ -106,10 +109,10 @@ jobs:
           mpiexec -np 1 python -c "import dolfinx; from mpi4py import MPI; dolfinx.mesh.create_rectangle(comm=MPI.COMM_WORLD, points=((0, 0), (2, 1)), n=(32, 16))"
           mpiexec -np 2 python -c "import dolfinx; from mpi4py import MPI; dolfinx.mesh.create_rectangle(comm=MPI.COMM_WORLD, points=((0, 0), (2, 1)), n=(32, 16))"
 
-      - name: Run Python unit tests (serial)
+      - name: Run tests (Python, serial)
         run: |
           python -m pip install pytest-xdist
           mpiexec -np 1 python3 -m pytest -n=auto --durations=50 python/test/unit/
-      - name: Run Python unit tests (MPI, np=3)
+      - name: Run tests (Python, MPI, np=3)
         run: |
           mpiexec -np 3 python3 -m pytest python/test/unit/

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -481,8 +481,7 @@ add_subdirectory(dolfinx)
 
 # ------------------------------------------------------------------------------
 # Unit testing
-option(BUILD_TESTING "Build DOLFINx unit tests." OFF)
-set(DOLFINX_TEST_MPI_PROCESSES "1;3" CACHE STRING "List of process counts to run tests with.")
+option(BUILD_TESTING "Build DOLFINx unit tests and create test target." OFF)
 include(CTest)
 if (BUILD_TESTING)
   add_subdirectory(test)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -62,10 +62,11 @@ if(WIN32)
   target_link_libraries(unittests PRIVATE bcrypt)
 endif()
 
+# Required to find FFCx generated headers.
 target_include_directories(
   unittests PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 )
-# makes version.h accessible
+# Required to find version.h
 target_include_directories(
   unittests PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../>
 )
@@ -84,7 +85,6 @@ target_compile_options(
     $<$<AND:$<CONFIG:Developer>,$<COMPILE_LANGUAGE:CXX>>:${DOLFINX_CXX_DEVELOPER_FLAGS}>
 )
 
-# TODO: should not be set in test and dolfinx but in cpp once.
 if(ENABLE_CLANG_TIDY)
   find_program(CLANG_TIDY NAMES clang-tidy REQUIRED)
   set_target_properties(
@@ -95,9 +95,7 @@ if(ENABLE_CLANG_TIDY)
   )
 endif()
 
-# Nice for debugging tests one at a time - but extremely slow due to process
-# spawning/tear down: catch_discover_tests(unittests)
+# Uncommenting line allows for debugging individual tests, but slow. 
+#catch_discover_tests(unittests)
 
-foreach(np IN LISTS DOLFINX_TEST_MPI_PROCESSES)
-  add_test(NAME unittests_np_${np} COMMAND mpiexec -np ${np} ./unittests)
-endforeach()
+add_test(NAME unittests COMMAND $<TARGET_FILE:unittests>)


### PR DESCRIPTION
Exporting a test target is nice but the fixed `mpiexec` hits walls quickly - we have no idea what downstream consumers need to use.