### PR TITLE
Make `ctest` test only dependency

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -483,6 +483,7 @@ add_subdirectory(dolfinx)
 # Unit testing
 option(BUILD_TESTING "Build DOLFINx unit tests and create test target." OFF)
 if (BUILD_TESTING)
+  include(CTest)
   add_subdirectory(test)
 endif()
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -482,7 +482,6 @@ add_subdirectory(dolfinx)
 # ------------------------------------------------------------------------------
 # Unit testing
 option(BUILD_TESTING "Build DOLFINx unit tests and create test target." OFF)
-include(CTest)
 if (BUILD_TESTING)
   add_subdirectory(test)
 endif()

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(CTest)
+
 find_package(Catch2 3)
 
 if(NOT Catch2_FOUND)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(CTest)
-
 find_package(Catch2 3)
 
 if(NOT Catch2_FOUND)


### PR DESCRIPTION
Only include  `ctest` if testing is enabled, removes the dependency on `ctest`, for builds without `BUILD_TESTING`.

Follow up to https://github.com/FEniCS/dolfinx/pull/3858