### PR TITLE
Make tests work as standalone project

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Build tests (C++, standalone)
         working-directory: cpp/test
         run: |
-          source /usr/local/lib/dolfinx/dolfinx.conf
+          . /usr/local/lib/dolfinx/dolfinx.conf
           cmake -B build -S .
           cmake --build build .
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -215,6 +215,7 @@ jobs:
       - name: Build tests (C++, standalone)
         working-directory: cpp/test
         run: |
+          source /usr/local/lib/dolfinx/dolfinx.conf
           cmake -B build -S .
           cmake --build build .
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -217,7 +217,7 @@ jobs:
         run: |
           . /usr/local/lib/dolfinx/dolfinx.conf
           cmake -B build -S .
-          cmake --build .
+          cmake --build build
 
       - name: Run tests (C++, serial)
         working-directory: cpp/test/build

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -217,7 +217,7 @@ jobs:
         run: |
           . /usr/local/lib/dolfinx/dolfinx.conf
           cmake -B build -S .
-          cmake --build build .
+          cmake --build .
 
       - name: Run tests (C++, serial)
         working-directory: cpp/test/build

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -215,7 +215,6 @@ jobs:
       - name: Build tests (C++, standalone)
         working-directory: cpp/test
         run: |
-          . /usr/local/lib/dolfinx/dolfinx.conf
           cmake -B build -S .
           cmake --build build
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -201,7 +201,6 @@ jobs:
           --warn-uninitialized
           -G Ninja
           -DCMAKE_BUILD_TYPE=Developer
-          -DBUILD_TESTING=true
           -DDOLFINX_ENABLE_ADIOS2=true
           -DDOLFINX_ENABLE_KAHIP=true
           -DDOLFINX_ENABLE_PETSC=true
@@ -213,11 +212,17 @@ jobs:
         working-directory: cpp/build
         run: cmake --build . --target install
 
+      - name: Build tests (C++, standalone)
+        working-directory: cpp/test
+        run: |
+          cmake -B build -S .
+          cmake --build build .
+
       - name: Run tests (C++, serial)
-        working-directory: cpp/build
+        working-directory: cpp/test/build
         run: mpiexec -np 1 ctest -V --output-on-failure -R unittests
       - name: Run tests (C++, MPI, np=3)
-        working-directory: cpp/build
+        working-directory: cpp/test/build
         run: mpiexec -np 3 ctest -V --output-on-failure -R unittests
 
       - name: Build and run C++ regression tests (serial and MPI (np=2))

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -11,8 +11,6 @@ if (PROJECT_IS_TOP_LEVEL)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(CMAKE_CXX_EXTENSIONS OFF)
 
-  # Add shared library paths so shared libs in non-system paths are founds
-  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
 endif()
 
 find_package(Catch2 3)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -10,7 +10,6 @@ if (PROJECT_IS_TOP_LEVEL)
   set(CMAKE_CXX_STANDARD 20)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(CMAKE_CXX_EXTENSIONS OFF)
-
 endif()
 
 find_package(Catch2 3)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -1,3 +1,12 @@
+cmake_minimum_required(VERSION 3.21)
+
+project(tests)
+
+if (PROJECT_IS_TOP_LEVEL)
+  include(Ctest) # enables testing
+  find_package(dolfinx)
+endif()
+
 find_package(Catch2 3)
 
 if(NOT Catch2_FOUND)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -4,7 +4,7 @@ project(dolfinx-tests LANGUAGES C CXX)
 
 if (PROJECT_IS_TOP_LEVEL)
   include(CTest) # enables testing
-  find_package(dolfinx)
+  find_package(DOLFINX REQUIRED)
 
   set(CMAKE_C_STANDARD 17) # For FFCx generated .c files.
   set(CMAKE_CXX_STANDARD 20)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -63,7 +63,7 @@ add_executable(
   ${CMAKE_CURRENT_BINARY_DIR}/expr.c
   ${CMAKE_CURRENT_BINARY_DIR}/poisson.c
 )
-target_link_libraries(unittests PRIVATE Catch2::Catch2WithMain dolfinx)
+target_link_libraries(unittests PRIVATE Catch2::Catch2 dolfinx)
 
 # UUID requires bcrypt to be linked on Windows, broken in vcpkg.
 # https://github.com/microsoft/vcpkg/issues/4481

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -75,10 +75,13 @@ endif()
 target_include_directories(
   unittests PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 )
-# Required to find version.h
-target_include_directories(
-  unittests PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../>
-)
+
+if (NOT PROJECT_IS_TOP_LEVEL)
+  # Required to find version.h
+  target_include_directories(
+    unittests PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../>
+  )
+endif()
 
 set_target_properties(
   unittests

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -5,11 +5,6 @@ project(dolfinx-tests LANGUAGES C CXX)
 if (PROJECT_IS_TOP_LEVEL)
   include(CTest) # enables testing
   find_package(DOLFINX REQUIRED)
-
-  set(CMAKE_C_STANDARD 17) # For FFCx generated .c files.
-  set(CMAKE_CXX_STANDARD 20)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 
 find_package(Catch2 3)
@@ -90,7 +85,7 @@ endif()
 
 set_target_properties(
   unittests
-  PROPERTIES CMAKE_C_STANDARD 17
+  PROPERTIES CMAKE_C_STANDARD 17 # For FFCx generated .c files.
              CMAKE_CXX_STANDARD 20
              CMAKE_CXX_STANDARD_REQUIRED ON
              CMAKE_CXX_EXTENSIONS OFF

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.21)
 project(tests)
 
 if (PROJECT_IS_TOP_LEVEL)
-  include(Ctest) # enables testing
+  include(CTest) # enables testing
   find_package(dolfinx)
 endif()
 

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -1,10 +1,18 @@
 cmake_minimum_required(VERSION 3.21)
 
-project(tests)
+project(dolfinx-tests LANGUAGES C CXX)
 
 if (PROJECT_IS_TOP_LEVEL)
   include(CTest) # enables testing
   find_package(dolfinx)
+
+  set(CMAKE_C_STANDARD 17) # For FFCx generated .c files.
+  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+
+  # Add shared library paths so shared libs in non-system paths are founds
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
 endif()
 
 find_package(Catch2 3)


### PR DESCRIPTION
Allows to also use the c++ tests as a standalone project. Building on top of an already installed dolfinx version.

Also fixes a bad linkage against `Catch2::Catch2WithMain` - since we provide our own `main` - we need to link against `Catch2::Catch2`.