### PR TITLE
Allow copy of MatrixCSR to different storage (GPU support)

### DIFF
--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -188,9 +188,9 @@ public:
   /// @brief Copy-convert to different container types.
   /// @note "update" data for reverse scatter is not copied.
   template <typename Mat>
-    requires requires(Mat A) {
-      // TODO, see examples in la::Vector
-    }
+    // requires requires(Mat A) {
+    //   //TODO, see examples in la::Vector
+    // }
   explicit MatrixCSR(const Mat& A)
       : _index_maps(A.index_maps()), _block_mode(A.block_mode()),
         _bs(A.block_size()), _data(A.values()), _cols(A.cols()),

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -191,8 +191,7 @@ public:
   MatrixCSR(MatrixCSR<AltT, AltU, AltV, AltW>& A)
       : _index_maps(A._index_maps), _block_mode(A._block_mode), _bs(A._bs),
         _data(A._data), _cols(A._cols), _row_ptr(A._row_ptr),
-        _off_diagonal_offset(A._off_diagonal_offset), _comm(A._comm),
-
+        _off_diagonal_offset(A._off_diagonal_offset), _comm(A._comm)
   {
   }
 

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -469,7 +469,8 @@ public:
   /// columns that may exist in the owned rows.
   ///
   /// @return Row (0) and column (1) index maps
-  std::array<std::shared_ptr<const common::IndexMap>, 2>& index_maps() const
+  const std::array<std::shared_ptr<const common::IndexMap>, 2>&
+  index_maps() const
   {
     return _index_maps;
   }

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -42,7 +42,7 @@ enum class BlockMode : int
 /// code.
 ///
 /// @tparam Scalar Scalar type of matrix entries
-/// @tparam Container Container type fir storing matrix entries
+/// @tparam Container Container type for storing matrix entries
 /// @tparam ColContainer Column index container type
 /// @tparam RowPtrContainer Row pointer container type
 template <typename Scalar, typename Container = std::vector<Scalar>,
@@ -198,16 +198,6 @@ public:
         _comm(A.comm())
   {
   }
-
-  // /// @brief Copy to another container type
-  // /// @note "update" data for reverse scatter is not copied.
-  // template <typename AltT, typename AltU, typename AltV, typename AltW>
-  // MatrixCSR(MatrixCSR<AltT, AltU, AltV, AltW>& A)
-  //     : _index_maps(A._index_maps), _block_mode(A._block_mode), _bs(A._bs),
-  //       _data(A._data), _cols(A._cols), _row_ptr(A._row_ptr),
-  //       _off_diagonal_offset(A._off_diagonal_offset), _comm(A._comm)
-  // {
-  // }
 
   /// @brief Set all non-zero local entries to a value including entries
   /// in ghost rows.
@@ -522,7 +512,7 @@ public:
   /// @return Block sizes for rows (0) and columns (1).
   std::array<int, 2> block_size() const { return _bs; }
 
-  /// @brief Get 'block mode;.
+  /// @brief Get 'block mode'.
   /// @return block sizes for rows and columns
   BlockMode block_mode() const { return _block_mode; }
 

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -174,7 +174,7 @@ public:
   /// to a block of data (stored row major), or "expanded" where each
   /// matrix entry is individual. In the "expanded" case, the sparsity
   /// is expanded for every entry in the block, and the block size of
-  /// the matrix is set to (1, 1).
+  /// the matrix is set to `(1, 1)`.
   MatrixCSR(const SparsityPattern& p, BlockMode mode = BlockMode::compact);
 
   /// Move constructor
@@ -188,9 +188,9 @@ public:
   /// @brief Copy-convert to different container types.
   /// @note "update" data for reverse scatter is not copied.
   template <typename Mat>
-    // requires requires(Mat A) {
-    //   //TODO, see examples in la::Vector
-    // }
+  // requires requires(Mat A) {
+  //   //TODO, see examples in la::Vector
+  // }
   explicit MatrixCSR(const Mat& A)
       : _index_maps(A.index_maps()), _block_mode(A.block_mode()),
         _bs(A.block_size()), _data(A.values()), _cols(A.cols()),

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -469,7 +469,7 @@ public:
   /// columns that may exist in the owned rows.
   ///
   /// @return Row (0) and column (1) index maps
-  std::vector<std::shared_ptr<const common::IndexMap>>& index_maps() const
+  std::array<std::shared_ptr<const common::IndexMap>, 2>& index_maps() const
   {
     return _index_maps;
   }

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -42,20 +42,14 @@ enum class BlockMode : int
 /// code.
 ///
 /// @tparam Scalar Scalar type of matrix entries
-/// @tparam Container Sequence container type to store matrix entries
+/// @tparam Container Container type fir storing matrix entries
 /// @tparam ColContainer Column index container type
 /// @tparam RowPtrContainer Row pointer container type
-template <class Scalar, class Container = std::vector<Scalar>,
-          class ColContainer = std::vector<std::int32_t>,
-          class RowPtrContainer = std::vector<std::int64_t>>
+template <typename Scalar, typename Container = std::vector<Scalar>,
+          typename ColContainer = std::vector<std::int32_t>,
+          typename RowPtrContainer = std::vector<std::int64_t>>
 class MatrixCSR
 {
-  // Allow access for copy construction to different container types
-  template <class AltT, class AltU, class AltV, class AltW>
-  friend class MatrixCSR;
-
-  static_assert(std::is_same_v<typename Container::value_type, Scalar>);
-
 public:
   /// Scalar type
   using value_type = Scalar;
@@ -71,6 +65,8 @@ public:
 
   static_assert(std::is_same_v<value_type, typename container_type::value_type>,
                 "Scalar type and container value type must be the same.");
+  static_assert(std::is_integral_v<typename column_container_type::value_type>);
+  static_assert(std::is_integral_v<typename rowptr_container_type::value_type>);
 
   /// @brief Insertion functor for setting values in a matrix. It is
   /// typically used in finite element assembly functions.
@@ -185,15 +181,33 @@ public:
   /// @todo Check handling of MPI_Request
   MatrixCSR(MatrixCSR&& A) = default;
 
-  /// @brief Copy to another container type
+  /// Copy constructor
+  /// @todo Check handling of MPI_Request
+  MatrixCSR(const MatrixCSR& A) = default;
+
+  /// @brief Copy-convert to different container types.
   /// @note "update" data for reverse scatter is not copied.
-  template <typename AltT, typename AltU, typename AltV, typename AltW>
-  MatrixCSR(MatrixCSR<AltT, AltU, AltV, AltW>& A)
-      : _index_maps(A._index_maps), _block_mode(A._block_mode), _bs(A._bs),
-        _data(A._data), _cols(A._cols), _row_ptr(A._row_ptr),
-        _off_diagonal_offset(A._off_diagonal_offset), _comm(A._comm)
+  template <typename Mat>
+    requires requires(Mat A) {
+      // TODO, see examples in la::Vector
+    }
+  explicit MatrixCSR(const Mat& A)
+      : _index_maps(A.index_maps()), _block_mode(A.block_mode()),
+        _bs(A.block_size()), _data(A.values()), _cols(A.cols()),
+        _row_ptr(A.row_ptr()), _off_diagonal_offset(A.off_diag_offset()),
+        _comm(A.comm())
   {
   }
+
+  // /// @brief Copy to another container type
+  // /// @note "update" data for reverse scatter is not copied.
+  // template <typename AltT, typename AltU, typename AltV, typename AltW>
+  // MatrixCSR(MatrixCSR<AltT, AltU, AltV, AltW>& A)
+  //     : _index_maps(A._index_maps), _block_mode(A._block_mode), _bs(A._bs),
+  //       _data(A._data), _cols(A._cols), _row_ptr(A._row_ptr),
+  //       _off_diagonal_offset(A._off_diagonal_offset), _comm(A._comm)
+  // {
+  // }
 
   /// @brief Set all non-zero local entries to a value including entries
   /// in ghost rows.
@@ -454,7 +468,19 @@ public:
   /// inserted into and the column IndexMap contains all local and ghost
   /// columns that may exist in the owned rows.
   ///
-  /// @return Row (0) or column (1) index maps
+  /// @return Row (0) and column (1) index maps
+  std::vector<std::shared_ptr<const common::IndexMap>>& index_maps() const
+  {
+    return _index_maps;
+  }
+
+  /// @brief Index map for the row or column space.
+  ///
+  /// The row IndexMap contains ghost entries for rows which may be
+  /// inserted into and the column IndexMap contains all local and ghost
+  /// columns that may exist in the owned rows.
+  ///
+  /// @return Row (0) or column (1) index map.
   std::shared_ptr<const common::IndexMap> index_map(int dim) const
   {
     return _index_maps.at(dim);
@@ -488,11 +514,15 @@ public:
     return _off_diagonal_offset;
   }
 
-  /// Block size
-  /// @return block sizes for rows and columns
+  /// @brief Get block sizes.
+  /// @return Block sizes for rows (0) and columns (1).
   std::array<int, 2> block_size() const { return _bs; }
 
-protected:
+  /// @brief Get 'block mode;.
+  /// @return block sizes for rows and columns
+  BlockMode block_mode() const { return _block_mode; }
+
+private:
   // Maps for the distribution of the rows and columns
   std::array<std::shared_ptr<const common::IndexMap>, 2> _index_maps;
 

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -462,6 +462,9 @@ public:
   /// @param[in,out] y Vector to accumulate the result into.
   void mult(Vector<value_type>& x, Vector<value_type>& y);
 
+  /// @brief Get MPI communicator that matrix is defined on.
+  MPI_Comm comm() const { return _comm.comm(); }
+
   /// @brief Index maps for the row and column space.
   ///
   /// The row IndexMap contains ghost entries for rows which may be


### PR DESCRIPTION
Enables a "copy constructor" for `la::MatrixCSR` to a different storage type (typically `thrust::device_vector`) allowing a CPU-based matrix to be simply copied to GPU.

