### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13, macos-14, windows-2022]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         petsc-scalar-type: ["real"]
         include:
           - os: ubuntu-latest

--- a/python/dolfinx/common.py
+++ b/python/dolfinx/common.py
@@ -7,7 +7,6 @@
 
 import datetime
 import functools
-import typing
 
 from dolfinx import cpp as _cpp
 from dolfinx.cpp.common import (
@@ -117,7 +116,7 @@ class Timer:
 
     _cpp_object: _cpp.common.Timer
 
-    def __init__(self, name: typing.Optional[str] = None):
+    def __init__(self, name: str | None = None):
         """Create timer.
 
         Args:

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -109,7 +109,7 @@ def create_vector(L: Form) -> la.Vector:
     return la.vector(dofmap.index_map, dofmap.index_map_bs, dtype=L.dtype)
 
 
-def create_matrix(a: Form, block_mode: typing.Optional[la.BlockMode] = None) -> la.MatrixCSR:
+def create_matrix(a: Form, block_mode: la.BlockMode | None = None) -> la.MatrixCSR:
     """Create a sparse matrix that is compatible with a given bilinear
     form.
 
@@ -134,8 +134,8 @@ def create_matrix(a: Form, block_mode: typing.Optional[la.BlockMode] = None) -> 
 
 def assemble_scalar(
     M: Form,
-    constants: typing.Optional[npt.NDArray] = None,
-    coeffs: typing.Optional[dict[tuple[IntegralType, int], npt.NDArray]] = None,
+    constants: npt.NDArray | None = None,
+    coeffs: dict[tuple[IntegralType, int], npt.NDArray] | None = None,
 ) -> typing.Union[float, complex]:
     """Assemble functional. The returned value is local and not
     accumulated across processes.
@@ -169,8 +169,8 @@ def assemble_scalar(
 @functools.singledispatch
 def assemble_vector(
     L: typing.Any,
-    constants: typing.Optional[npt.NDArray] = None,
-    coeffs: typing.Optional[dict[tuple[IntegralType, int], npt.NDArray]] = None,
+    constants: npt.NDArray | None = None,
+    coeffs: dict[tuple[IntegralType, int], npt.NDArray] | None = None,
 ) -> la.Vector:
     return _assemble_vector_form(L, constants, coeffs)
 
@@ -178,8 +178,8 @@ def assemble_vector(
 @assemble_vector.register
 def _assemble_vector_form(
     L: Form,
-    constants: typing.Optional[npt.NDArray] = None,
-    coeffs: typing.Optional[dict[tuple[IntegralType, int], npt.NDArray]] = None,
+    constants: npt.NDArray | None = None,
+    coeffs: dict[tuple[IntegralType, int], npt.NDArray] | None = None,
 ) -> la.Vector:
     """Assemble linear form into a new Vector.
 
@@ -216,8 +216,8 @@ def _assemble_vector_form(
 def _assemble_vector_array(
     b: npt.NDArray,
     L: Form,
-    constants: typing.Optional[npt.NDArray] = None,
-    coeffs: typing.Optional[dict[tuple[IntegralType, int], npt.NDArray]] = None,
+    constants: npt.NDArray | None = None,
+    coeffs: dict[tuple[IntegralType, int], npt.NDArray] | None = None,
 ) -> npt.NDArray:
     """Assemble linear form into an existing array.
 
@@ -253,11 +253,11 @@ def _assemble_vector_array(
 @functools.singledispatch
 def assemble_matrix(
     a: typing.Any,
-    bcs: typing.Optional[Sequence[DirichletBC]] = None,
+    bcs: Sequence[DirichletBC] | None = None,
     diag: float = 1.0,
-    constants: typing.Optional[npt.NDArray] = None,
-    coeffs: typing.Optional[dict[tuple[IntegralType, int], npt.NDArray]] = None,
-    block_mode: typing.Optional[la.BlockMode] = None,
+    constants: npt.NDArray | None = None,
+    coeffs: dict[tuple[IntegralType, int], npt.NDArray] | None = None,
+    block_mode: la.BlockMode | None = None,
 ) -> la.MatrixCSR:
     """Assemble bilinear form into a matrix.
 
@@ -294,10 +294,10 @@ def assemble_matrix(
 def _assemble_matrix_csr(
     A: la.MatrixCSR,
     a: Form,
-    bcs: typing.Optional[Sequence[DirichletBC]] = None,
+    bcs: Sequence[DirichletBC] | None = None,
     diag: float = 1.0,
-    constants: typing.Optional[npt.NDArray] = None,
-    coeffs: typing.Optional[dict[tuple[IntegralType, int], npt.NDArray]] = None,
+    constants: npt.NDArray | None = None,
+    coeffs: dict[tuple[IntegralType, int], npt.NDArray] | None = None,
 ) -> la.MatrixCSR:
     """Assemble bilinear form into a matrix.
 
@@ -341,10 +341,10 @@ def apply_lifting(
     b: npt.NDArray,
     a: Sequence[Form],
     bcs: Sequence[Sequence[DirichletBC]],
-    x0: typing.Optional[Sequence[npt.NDArray]] = None,
+    x0: Sequence[npt.NDArray] | None = None,
     alpha: float = 1,
-    constants: typing.Optional[npt.NDArray] = None,
-    coeffs: typing.Optional[dict[tuple[IntegralType, int], npt.NDArray]] = None,
+    constants: npt.NDArray | None = None,
+    coeffs: dict[tuple[IntegralType, int], npt.NDArray] | None = None,
 ) -> None:
     """Modify right-hand side vector ``b`` for lifting of Dirichlet
     boundary conditions.
@@ -459,7 +459,7 @@ def apply_lifting(
 def set_bc(
     b: npt.NDArray,
     bcs: Sequence[DirichletBC],
-    x0: typing.Optional[npt.NDArray] = None,
+    x0: npt.NDArray | None = None,
     alpha: float = 1,
 ) -> None:
     """Insert boundary condition values into vector.

--- a/python/dolfinx/fem/bcs.py
+++ b/python/dolfinx/fem/bcs.py
@@ -132,7 +132,7 @@ class DirichletBC:
         return self._cpp_object.function_space
 
     def set(
-        self, x: npt.NDArray, x0: typing.Optional[npt.NDArray[np.int32]] = None, alpha: float = 1
+        self, x: npt.NDArray, x0: npt.NDArray[np.int32] | None = None, alpha: float = 1
     ) -> None:
         """Set entries in an array that are constrained by Dirichlet
         boundary conditions.
@@ -178,7 +178,7 @@ class DirichletBC:
 def dirichletbc(
     value: typing.Union[Function, Constant, np.ndarray],
     dofs: npt.NDArray[np.int32],
-    V: typing.Optional[dolfinx.fem.FunctionSpace] = None,
+    V: dolfinx.fem.FunctionSpace | None = None,
 ) -> DirichletBC:
     """Create a representation of Dirichlet boundary condition which
     is imposed on a linear system.

--- a/python/dolfinx/fem/element.py
+++ b/python/dolfinx/fem/element.py
@@ -38,7 +38,7 @@ class CoordinateElement:
             cmap: A C++ CoordinateElement.
         """
         assert isinstance(
-            cmap, (_cpp.fem.CoordinateElement_float32, _cpp.fem.CoordinateElement_float64)
+            cmap, _cpp.fem.CoordinateElement_float32 | _cpp.fem.CoordinateElement_float64
         )
         self._cpp_object = cmap
 

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -39,7 +39,7 @@ class Form:
         _cpp.fem.Form_float32,
         _cpp.fem.Form_float64,
     ]
-    _code: typing.Optional[typing.Union[str, list[str]]]
+    _code: typing.Union[str, list[str]] | None
 
     def __init__(
         self,
@@ -50,8 +50,8 @@ class Form:
             _cpp.fem.Form_float64,
         ],
         ufcx_form=None,
-        code: typing.Optional[typing.Union[str, list[str]]] = None,
-        module: typing.Optional[typing.Union[types.ModuleType, list[types.ModuleType]]] = None,
+        code: typing.Union[str, list[str]] | None = None,
+        module: typing.Union[types.ModuleType, list[types.ModuleType]] | None = None,
     ):
         """A finite element form.
 
@@ -124,7 +124,7 @@ class Form:
 
 def get_integration_domains(
     integral_type: IntegralType,
-    subdomain: typing.Optional[typing.Union[MeshTags, list[tuple[int, np.ndarray]]]],
+    subdomain: typing.Union[MeshTags, list[tuple[int, np.ndarray]]] | None,
     subdomain_ids: list[int],
 ) -> list[tuple[int, np.ndarray]]:
     """Get integration domains from subdomain data.
@@ -225,9 +225,9 @@ _ufl_to_dolfinx_domain = {
 def mixed_topology_form(
     forms: Sequence[ufl.Form],
     dtype: npt.DTypeLike = default_scalar_type,
-    form_compiler_options: typing.Optional[dict] = None,
-    jit_options: typing.Optional[dict] = None,
-    entity_maps: typing.Optional[Sequence[_EntityMap]] = None,
+    form_compiler_options: dict | None = None,
+    jit_options: dict | None = None,
+    entity_maps: Sequence[_EntityMap] | None = None,
 ):
     """
     Create a mixed-topology from from an array of Forms.
@@ -304,9 +304,9 @@ def mixed_topology_form(
 def form(
     form: typing.Union[ufl.Form, Sequence[ufl.Form], Sequence[Sequence[ufl.Form]]],
     dtype: npt.DTypeLike = default_scalar_type,
-    form_compiler_options: typing.Optional[dict] = None,
-    jit_options: typing.Optional[dict] = None,
-    entity_maps: typing.Optional[Sequence[_EntityMap]] = None,
+    form_compiler_options: dict | None = None,
+    jit_options: dict | None = None,
+    entity_maps: Sequence[_EntityMap] | None = None,
 ):
     """Create a Form or list of Forms.
 
@@ -514,8 +514,8 @@ class CompiledForm:
 def compile_form(
     comm: MPI.Intracomm,
     form: ufl.Form,
-    form_compiler_options: typing.Optional[dict] = {"scalar_type": default_scalar_type},
-    jit_options: typing.Optional[dict] = None,
+    form_compiler_options: dict | None = {"scalar_type": default_scalar_type},
+    jit_options: dict | None = None,
 ) -> CompiledForm:
     """Compile UFL form without associated DOLFINx data.
 
@@ -572,7 +572,7 @@ def create_form(
     subdomains: dict[IntegralType, list[tuple[int, np.ndarray]]],
     coefficient_map: dict[ufl.Coefficient, Function],
     constant_map: dict[ufl.Constant, Constant],
-    entity_maps: typing.Optional[Sequence[_EntityMap]] = None,
+    entity_maps: Sequence[_EntityMap] | None = None,
 ) -> Form:
     """Create a Form object from a data-independent compiled form.
 
@@ -650,7 +650,7 @@ def create_form(
 def derivative_block(
     F: typing.Union[ufl.Form, Sequence[ufl.Form]],
     u: typing.Union[Function, Sequence[Function]],
-    du: typing.Optional[typing.Union[ufl.Argument, Sequence[ufl.Argument]]] = None,
+    du: typing.Union[ufl.Argument, Sequence[ufl.Argument]] | None = None,
 ) -> typing.Union[ufl.Form, Sequence[Sequence[ufl.Form]]]:
     """Return the UFL derivative of a (list of) UFL rank one form(s).
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -95,10 +95,10 @@ class Expression:
         self,
         e: ufl.core.expr.Expr,
         X: np.ndarray,
-        comm: typing.Optional[_MPI.Comm] = None,
-        form_compiler_options: typing.Optional[dict] = None,
-        jit_options: typing.Optional[dict] = None,
-        dtype: typing.Optional[npt.DTypeLike] = None,
+        comm: _MPI.Comm | None = None,
+        form_compiler_options: dict | None = None,
+        jit_options: dict | None = None,
+        dtype: npt.DTypeLike | None = None,
     ):
         """Create a DOLFINx Expression.
 
@@ -198,7 +198,7 @@ class Expression:
         self,
         mesh: Mesh,
         entities: np.ndarray,
-        values: typing.Optional[np.ndarray] = None,
+        values: np.ndarray | None = None,
     ) -> np.ndarray:
         """Evaluate Expression on entities.
 
@@ -275,7 +275,7 @@ class Expression:
         return self._cpp_object.value_size
 
     @property
-    def argument_space(self) -> typing.Optional[FunctionSpace]:
+    def argument_space(self) -> FunctionSpace | None:
         """Argument function space if Expression has argument."""
         return self._argument_space
 
@@ -309,9 +309,9 @@ class Function(ufl.Coefficient):
     def __init__(
         self,
         V: FunctionSpace,
-        x: typing.Optional[la.Vector] = None,
-        name: typing.Optional[str] = None,
-        dtype: typing.Optional[npt.DTypeLike] = None,
+        x: la.Vector | None = None,
+        name: str | None = None,
+        dtype: npt.DTypeLike | None = None,
     ):
         """Initialize a finite element Function.
 
@@ -429,8 +429,8 @@ class Function(ufl.Coefficient):
     def interpolate(
         self,
         u0: typing.Union[Callable, Expression, Function],
-        cells0: typing.Optional[np.ndarray] = None,
-        cells1: typing.Optional[np.ndarray] = None,
+        cells0: np.ndarray | None = None,
+        cells1: np.ndarray | None = None,
     ) -> None:
         """Interpolate an expression.
 
@@ -574,8 +574,8 @@ class ElementMetaData(typing.NamedTuple):
 
     family: str
     degree: int
-    shape: typing.Optional[tuple[int, ...]] = None
-    symmetry: typing.Optional[bool] = None
+    shape: tuple[int, ...] | None = None
+    symmetry: bool | None = None
 
 
 def functionspace(

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -82,9 +82,7 @@ __all__ = [
 # -- Vector instantiation -------------------------------------------------
 
 
-def create_vector(
-    L: typing.Union[Form, Sequence[Form]], kind: typing.Optional[str] = None
-) -> PETSc.Vec:  # type: ignore[name-defined]
+def create_vector(L: typing.Union[Form, Sequence[Form]], kind: str | None = None) -> PETSc.Vec:  # type: ignore[name-defined]
     """Create a PETSc vector that is compatible with a linear form(s).
 
     Three cases are supported:
@@ -168,7 +166,7 @@ def create_vector(
 
 def create_matrix(
     a: typing.Union[Form, Sequence[Sequence[Form]]],
-    kind: typing.Optional[typing.Union[str, Sequence[Sequence[str]]]] = None,
+    kind: typing.Union[str, Sequence[Sequence[str]]] | None = None,
 ) -> PETSc.Mat:  # type: ignore[name-defined]
     """Create a PETSc matrix that is compatible with the (sequence) of
     bilinear form(s).
@@ -221,14 +219,13 @@ def create_matrix(
 @functools.singledispatch
 def assemble_vector(
     L: typing.Union[Form, Sequence[Form]],
-    constants: typing.Optional[typing.Union[npt.NDArray, Sequence[npt.NDArray]]] = None,
-    coeffs: typing.Optional[
-        typing.Union[
-            dict[tuple[IntegralType, int], npt.NDArray],
-            Sequence[dict[tuple[IntegralType, int], npt.NDArray]],
-        ]
-    ] = None,
-    kind: typing.Optional[str] = None,
+    constants: typing.Union[npt.NDArray, Sequence[npt.NDArray]] | None = None,
+    coeffs: typing.Union[
+        dict[tuple[IntegralType, int], npt.NDArray],
+        Sequence[dict[tuple[IntegralType, int], npt.NDArray]],
+    ]
+    | None = None,
+    kind: str | None = None,
 ) -> PETSc.Vec:  # type: ignore[name-defined]
     """Assemble linear form(s) into a new PETSc vector.
 
@@ -286,13 +283,12 @@ def assemble_vector(
 def _(
     b: PETSc.Vec,  # type: ignore[name-defined]
     L: typing.Union[Form, Sequence[Form]],
-    constants: typing.Optional[typing.Union[npt.NDArray, Sequence[npt.NDArray]]] = None,
-    coeffs: typing.Optional[
-        typing.Union[
-            dict[tuple[IntegralType, int], npt.NDArray],
-            Sequence[dict[tuple[IntegralType, int], npt.NDArray]],
-        ]
-    ] = None,
+    constants: typing.Union[npt.NDArray, Sequence[npt.NDArray]] | None = None,
+    coeffs: typing.Union[
+        dict[tuple[IntegralType, int], npt.NDArray],
+        Sequence[dict[tuple[IntegralType, int], npt.NDArray]],
+    ]
+    | None = None,
 ) -> PETSc.Vec:  # type: ignore[name-defined]
     """Assemble linear form(s) into a PETSc vector.
 
@@ -356,17 +352,14 @@ def _(
 @functools.singledispatch
 def assemble_matrix(
     a: typing.Union[Form, Sequence[Sequence[Form]]],
-    bcs: typing.Optional[Sequence[DirichletBC]] = None,
+    bcs: Sequence[DirichletBC] | None = None,
     diag: float = 1,
-    constants: typing.Optional[
-        typing.Union[Sequence[npt.NDArray], Sequence[Sequence[npt.NDArray]]]
-    ] = None,
-    coeffs: typing.Optional[
-        typing.Union[
-            dict[tuple[IntegralType, int], npt.NDArray],
-            Sequence[dict[tuple[IntegralType, int], npt.NDArray]],
-        ]
-    ] = None,
+    constants: typing.Union[Sequence[npt.NDArray], Sequence[Sequence[npt.NDArray]]] | None = None,
+    coeffs: typing.Union[
+        dict[tuple[IntegralType, int], npt.NDArray],
+        Sequence[dict[tuple[IntegralType, int], npt.NDArray]],
+    ]
+    | None = None,
     kind=None,
 ):
     """Assemble a bilinear form into a matrix.
@@ -427,15 +420,14 @@ def assemble_matrix(
 def _(
     A: PETSc.Mat,  # type: ignore[name-defined]
     a: typing.Union[Form, Sequence[Sequence[Form]]],
-    bcs: typing.Optional[Sequence[DirichletBC]] = None,
+    bcs: Sequence[DirichletBC] | None = None,
     diag: float = 1,
-    constants: typing.Optional[typing.Union[npt.NDArray, Sequence[Sequence[npt.NDArray]]]] = None,
-    coeffs: typing.Optional[
-        typing.Union[
-            dict[tuple[IntegralType, int], npt.NDArray],
-            Sequence[Sequence[dict[tuple[IntegralType, int], npt.NDArray]]],
-        ]
-    ] = None,
+    constants: typing.Union[npt.NDArray, Sequence[Sequence[npt.NDArray]]] | None = None,
+    coeffs: typing.Union[
+        dict[tuple[IntegralType, int], npt.NDArray],
+        Sequence[Sequence[dict[tuple[IntegralType, int], npt.NDArray]]],
+    ]
+    | None = None,
 ) -> PETSc.Mat:  # type: ignore[name-defined]
     """Assemble bilinear form into a matrix.
 
@@ -539,18 +531,15 @@ def _(
 def apply_lifting(
     b: PETSc.Vec,  # type: ignore[name-defined]
     a: typing.Union[Sequence[Form], Sequence[Sequence[Form]]],
-    bcs: typing.Optional[typing.Union[Sequence[DirichletBC], Sequence[Sequence[DirichletBC]]]],
-    x0: typing.Optional[Sequence[PETSc.Vec]] = None,  # type: ignore[name-defined]
+    bcs: typing.Union[Sequence[DirichletBC], Sequence[Sequence[DirichletBC]]] | None,
+    x0: Sequence[PETSc.Vec] | None = None,  # type: ignore[name-defined]
     alpha: float = 1,
-    constants: typing.Optional[
-        typing.Union[Sequence[npt.NDArray], Sequence[Sequence[npt.NDArray]]]
-    ] = None,
-    coeffs: typing.Optional[
-        typing.Union[
-            dict[tuple[IntegralType, int], npt.NDArray],
-            Sequence[Sequence[dict[tuple[IntegralType, int], npt.NDArray]]],
-        ]
-    ] = None,
+    constants: typing.Union[Sequence[npt.NDArray], Sequence[Sequence[npt.NDArray]]] | None = None,
+    coeffs: typing.Union[
+        dict[tuple[IntegralType, int], npt.NDArray],
+        Sequence[Sequence[dict[tuple[IntegralType, int], npt.NDArray]]],
+    ]
+    | None = None,
 ) -> None:
     r"""Modify the right-hand side PETSc vector ``b`` to account for
     constraints (Dirichlet boundary conitions).
@@ -659,7 +648,7 @@ def apply_lifting(
 def set_bc(
     b: PETSc.Vec,  # type: ignore[name-defined]
     bcs: typing.Union[Sequence[DirichletBC], Sequence[Sequence[DirichletBC]]],
-    x0: typing.Optional[PETSc.Vec] = None,  # type: ignore[name-defined]
+    x0: PETSc.Vec | None = None,  # type: ignore[name-defined]
     alpha: float = 1,
 ) -> None:
     r"""Set constraint (Dirchlet boundary condition) values in an vector.
@@ -731,14 +720,14 @@ class LinearProblem:
         L: typing.Union[ufl.Form, Sequence[ufl.Form]],
         *,
         petsc_options_prefix: str,
-        bcs: typing.Optional[Sequence[DirichletBC]] = None,
-        u: typing.Optional[typing.Union[_Function, Sequence[_Function]]] = None,
-        P: typing.Optional[typing.Union[ufl.Form, Sequence[Sequence[ufl.Form]]]] = None,
-        kind: typing.Optional[typing.Union[str, Sequence[Sequence[str]]]] = None,
-        petsc_options: typing.Optional[dict] = None,
-        form_compiler_options: typing.Optional[dict] = None,
-        jit_options: typing.Optional[dict] = None,
-        entity_maps: typing.Optional[Sequence[_EntityMap]] = None,
+        bcs: Sequence[DirichletBC] | None = None,
+        u: typing.Union[_Function, Sequence[_Function]] | None = None,
+        P: typing.Union[ufl.Form, Sequence[Sequence[ufl.Form]]] | None = None,
+        kind: typing.Union[str, Sequence[Sequence[str]]] | None = None,
+        petsc_options: dict | None = None,
+        form_compiler_options: dict | None = None,
+        jit_options: dict | None = None,
+        entity_maps: Sequence[_EntityMap] | None = None,
     ) -> None:
         """Initialize solver for a linear variational problem.
 
@@ -1132,7 +1121,7 @@ def assemble_residual(
 def assemble_jacobian(
     u: typing.Union[Sequence[_Function], _Function],
     jacobian: typing.Union[Form, Sequence[Sequence[Form]]],
-    preconditioner: typing.Optional[typing.Union[Form, Sequence[Sequence[Form]]]],
+    preconditioner: typing.Union[Form, Sequence[Sequence[Form]]] | None,
     bcs: Sequence[DirichletBC],
     _snes: PETSc.SNES,  # type: ignore[name-defined]
     x: PETSc.Vec,  # type: ignore[name-defined]
@@ -1206,14 +1195,14 @@ class NonlinearProblem:
         u: typing.Union[_Function, Sequence[_Function]],
         *,
         petsc_options_prefix: str,
-        bcs: typing.Optional[Sequence[DirichletBC]] = None,
-        J: typing.Optional[typing.Union[ufl.form.Form, Sequence[Sequence[ufl.form.Form]]]] = None,
-        P: typing.Optional[typing.Union[ufl.form.Form, Sequence[Sequence[ufl.form.Form]]]] = None,
-        kind: typing.Optional[typing.Union[str, Sequence[Sequence[str]]]] = None,
-        petsc_options: typing.Optional[dict] = None,
-        form_compiler_options: typing.Optional[dict] = None,
-        jit_options: typing.Optional[dict] = None,
-        entity_maps: typing.Optional[Sequence[_EntityMap]] = None,
+        bcs: Sequence[DirichletBC] | None = None,
+        J: typing.Union[ufl.form.Form, Sequence[Sequence[ufl.form.Form]]] | None = None,
+        P: typing.Union[ufl.form.Form, Sequence[Sequence[ufl.form.Form]]] | None = None,
+        kind: typing.Union[str, Sequence[Sequence[str]]] | None = None,
+        petsc_options: dict | None = None,
+        form_compiler_options: dict | None = None,
+        jit_options: dict | None = None,
+        entity_maps: Sequence[_EntityMap] | None = None,
     ):
         """
         Initialize solver for a nonlinear variational problem.
@@ -1423,7 +1412,7 @@ class NonlinearProblem:
         return self._J
 
     @property
-    def preconditioner(self) -> typing.Optional[typing.Union[Form, Sequence[Sequence[Form]]]]:
+    def preconditioner(self) -> typing.Union[Form, Sequence[Sequence[Form]]] | None:
         """The compiled preconditioner."""
         return self._preconditioner
 
@@ -1433,7 +1422,7 @@ class NonlinearProblem:
         return self._A
 
     @property
-    def P_mat(self) -> typing.Optional[PETSc.Mat]:  # type: ignore[name-defined]
+    def P_mat(self) -> PETSc.Mat | None:  # type: ignore[name-defined]
         """Preconditioner matrix."""
         return self._P_mat
 
@@ -1492,10 +1481,10 @@ class NewtonSolverNonlinearProblem:
         self,
         F: ufl.form.Form,
         u: _Function,
-        bcs: typing.Optional[Sequence[DirichletBC]] = None,
+        bcs: Sequence[DirichletBC] | None = None,
         J: ufl.form.Form = None,
-        form_compiler_options: typing.Optional[dict] = None,
-        jit_options: typing.Optional[dict] = None,
+        form_compiler_options: dict | None = None,
+        jit_options: dict | None = None,
     ):
         """Initialize solver for solving a non-linear problem using
         Newton's method`.

--- a/python/dolfinx/geometry.py
+++ b/python/dolfinx/geometry.py
@@ -116,7 +116,7 @@ class BoundingBoxTree:
 def bb_tree(
     mesh: Mesh,
     dim: int,
-    entities: typing.Optional[npt.NDArray[np.int32]] = None,
+    entities: npt.NDArray[np.int32] | None = None,
     padding: float = 0.0,
 ) -> BoundingBoxTree:
     """Create a bounding box tree for use in collision detection.

--- a/python/dolfinx/graph.py
+++ b/python/dolfinx/graph.py
@@ -7,7 +7,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -118,7 +118,7 @@ class AdjacencyList:
 
 
 def adjacencylist(
-    data: npt.NDArray[Union[np.int32, np.int64]], offsets: Optional[npt.NDArray[np.int32]] = None
+    data: npt.NDArray[Union[np.int32, np.int64]], offsets: npt.NDArray[np.int32] | None = None
 ) -> AdjacencyList:
     """Create an :class:`AdjacencyList` for `int32` or `int64` datasets.
 

--- a/python/dolfinx/io/gmsh.py
+++ b/python/dolfinx/io/gmsh.py
@@ -105,10 +105,10 @@ class MeshData(typing.NamedTuple):
     """
 
     mesh: Mesh
-    cell_tags: typing.Optional[MeshTags]
-    facet_tags: typing.Optional[MeshTags]
-    ridge_tags: typing.Optional[MeshTags]
-    peak_tags: typing.Optional[MeshTags]
+    cell_tags: MeshTags | None
+    facet_tags: MeshTags | None
+    ridge_tags: MeshTags | None
+    peak_tags: MeshTags | None
     physical_groups: dict[str, PhysicalGroup]
 
 
@@ -160,7 +160,7 @@ def cell_perm_array(cell_type: CellType, num_nodes: int) -> list[int]:
 
 
 def extract_topology_and_markers(
-    model, name: typing.Optional[str] = None
+    model, name: str | None = None
 ) -> tuple[dict[int, TopologyDict], dict[str, PhysicalGroup]]:
     """Extract all entities tagged with a physical marker in the gmsh
     model.
@@ -243,7 +243,7 @@ def extract_topology_and_markers(
     return topologies, physical_groups
 
 
-def extract_geometry(model, name: typing.Optional[str] = None) -> npt.NDArray[np.float64]:
+def extract_geometry(model, name: str | None = None) -> npt.NDArray[np.float64]:
     """Extract the mesh geometry from a Gmsh model.
 
     Returns an array of shape ``(num_nodes, 3)``, where the i-th row
@@ -282,9 +282,8 @@ def model_to_mesh(
     comm: _MPI.Comm,
     rank: int,
     gdim: int = 3,
-    partitioner: typing.Optional[
-        Callable[[_MPI.Comm, int, int, _AdjacencyList_int32], _AdjacencyList_int32]
-    ] = None,
+    partitioner: Callable[[_MPI.Comm, int, int, _AdjacencyList_int32], _AdjacencyList_int32]
+    | None = None,
     dtype=default_real_type,
 ) -> MeshData:
     """Create a Mesh from a Gmsh model.
@@ -393,7 +392,7 @@ def model_to_mesh(
     # Create MeshTags for all sub entities
     topology = mesh.topology
     codim_to_name = {0: "cell", 1: "facet", 2: "ridge", 3: "peak"}
-    dolfinx_meshtags: dict[str, typing.Optional[MeshTags]] = {}
+    dolfinx_meshtags: dict[str, MeshTags | None] = {}
     for codim in [0, 1, 2, 3]:
         key = f"{codim_to_name[codim]}_tags"
         if (
@@ -436,9 +435,7 @@ def read_from_msh(
     comm: _MPI.Comm,
     rank: int = 0,
     gdim: int = 3,
-    partitioner: typing.Optional[
-        Callable[[_MPI.Comm, int, int, AdjacencyList], _AdjacencyList_int32]
-    ] = None,
+    partitioner: Callable[[_MPI.Comm, int, int, AdjacencyList], _AdjacencyList_int32] | None = None,
 ) -> MeshData:
     """Read a Gmsh .msh file and return a :class:`dolfinx.mesh.Mesh` and
     cell facet markers.

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -249,7 +249,7 @@ class XDMFFile(_cpp.io.XDMFFile):
         self,
         mesh: Mesh,
         name: str,
-        attribute_name: typing.Optional[str] = None,
+        attribute_name: str | None = None,
         xpath: str = "/Xdmf/Domain",
     ) -> MeshTags:
         """Read MeshTags with a specific name as specified in the XMDF

--- a/python/dolfinx/jit.py
+++ b/python/dolfinx/jit.py
@@ -10,7 +10,6 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Optional
 
 from mpi4py import MPI
 
@@ -123,7 +122,7 @@ def _load_options():
     return (user_options, pwd_options)
 
 
-def get_options(priority_options: Optional[dict] = None) -> dict:
+def get_options(priority_options: dict | None = None) -> dict:
     """Return a copy of the merged JIT option values for DOLFINx.
 
     Args:
@@ -156,7 +155,7 @@ def get_options(priority_options: Optional[dict] = None) -> dict:
 
 @mpi_jit_decorator
 def ffcx_jit(
-    ufl_object, form_compiler_options: Optional[dict] = None, jit_options: Optional[dict] = None
+    ufl_object, form_compiler_options: dict | None = None, jit_options: dict | None = None
 ):
     """Compile UFL object with FFCx and CFFI.
 

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -273,12 +273,12 @@ class Mesh:
     _mesh: typing.Union[_cpp.mesh.Mesh_float32, _cpp.mesh.Mesh_float64]
     _topology: Topology
     _geometry: Geometry
-    _ufl_domain: typing.Optional[ufl.Mesh]
+    _ufl_domain: ufl.Mesh | None
 
     def __init__(
         self,
         msh: typing.Union[_cpp.mesh.Mesh_float32, _cpp.mesh.Mesh_float64],
-        domain: typing.Optional[ufl.Mesh],
+        domain: ufl.Mesh | None,
     ):
         """Initialize mesh from a C++ mesh.
 
@@ -319,7 +319,7 @@ class Mesh:
         """
         return ufl.Cell(self.topology.cell_name())
 
-    def ufl_domain(self) -> typing.Optional[ufl.Mesh]:
+    def ufl_domain(self) -> ufl.Mesh | None:
         """Return the ufl domain corresponding to the mesh.
 
         Returns:
@@ -593,7 +593,7 @@ def transfer_meshtag(
     meshtag: MeshTags,
     msh1: Mesh,
     parent_cell: npt.NDArray[np.int32],
-    parent_facet: typing.Optional[npt.NDArray[np.int8]] = None,
+    parent_facet: npt.NDArray[np.int8] | None = None,
 ) -> MeshTags:
     """Generate cell mesh tags on a refined mesh from the mesh tags on the
     coarse parent mesh.
@@ -627,7 +627,7 @@ def transfer_meshtag(
 
 def refine(
     msh: Mesh,
-    edges: typing.Optional[np.ndarray] = None,
+    edges: np.ndarray | None = None,
     partitioner: typing.Union[
         Callable, IdentityPartitionerPlaceholder
     ] = IdentityPartitionerPlaceholder(),
@@ -679,7 +679,7 @@ def create_mesh(
         _CoordinateElement,
     ],
     x: npt.NDArray[np.floating],
-    partitioner: typing.Optional[Callable] = None,
+    partitioner: Callable | None = None,
 ) -> Mesh:
     """Create a mesh from topology and geometry arrays.
 

--- a/python/dolfinx/plot.py
+++ b/python/dolfinx/plot.py
@@ -6,7 +6,6 @@
 """Support functions for plotting"""
 
 import functools
-import typing
 
 import numpy as np
 
@@ -31,7 +30,7 @@ _first_order_vtk = {
 
 
 @functools.singledispatch
-def vtk_mesh(msh: mesh.Mesh, dim: typing.Optional[int] = None, entities=None):
+def vtk_mesh(msh: mesh.Mesh, dim: int | None = None, entities=None):
     """Create vtk mesh topology data for mesh entities of a given
     dimension. The vertex indices in the returned topology array are the
     indices for the associated entry in the mesh geometry.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -111,7 +111,6 @@ select = [
 ignore = [
       "UP007",
       "RUF012",
-      "UP045",  # Ractivate once Python 3.9 EoL
 ]
 allowed-confusables = ["σ"]
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -13,7 +13,7 @@ name = "fenics-dolfinx"
 version = "0.10.0.dev0"
 description = "DOLFINx Python interface"
 readme = "../README.md"
-requires-python = ">=3.9.0"
+requires-python = ">=3.10.0"
 license = { file = "../COPYING.LESSER" }
 authors = [
       { email = "fenics-steering-council@googlegroups.com" },

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -256,7 +256,7 @@ def test_basix_element(V, W, Q, V2):
     for V_ in (V, W, V2):
         e = V_.element.basix_element
         assert isinstance(
-            e, (basix._basixcpp.FiniteElement_float64, basix._basixcpp.FiniteElement_float32)
+            e, basix._basixcpp.FiniteElement_float64 | basix._basixcpp.FiniteElement_float32
         )
 
     # Mixed spaces do not yet return a basix element

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,7 +12,7 @@ sonar.organization=fenics
 sonar.sourceEncoding=UTF-8
 
 # Set python version
-sonar.python.version=3.9, 3.10, 3.11, 3.12
+sonar.python.version=3.10, 3.11, 3.12
 
 # Exclude source files
 # sonar.exclusions=


### PR DESCRIPTION
Python 3.9 reaches EoL at 2025-10.

Together with
- https://github.com/FEniCS/ufl/pull/414 
- https://github.com/FEniCS/ffcx/pull/782
- https://github.com/FEniCS/basix/pull/954

raises min. Python version across FEniCS to 3.10.

Fixes https://github.com/FEniCS/dolfinx/issues/3758