### PR TITLE
Ensure `dolfinx` does not expose warning to user

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -72,6 +72,7 @@ jobs:
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
       PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe   # Newer OpenMPI
       OMPI_MCA_rmaps_base_oversubscribe: true                 # Older OpenMPI
+      PYTEST_ADDOPTS: "-W error"
 
     name: Build and test
     steps:
@@ -176,6 +177,7 @@ jobs:
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
       PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
+      PYTEST_ADDOPTS: "-W error"
 
     name: Build and test (${{ matrix.petsc_arch }}, ${{ matrix.docker_image }})
     steps:

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -20,6 +20,7 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
+  PYTEST_ADDOPTS: "-W error"
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,6 +24,7 @@ jobs:
       PETSC_ARCH: arch-darwin-c-opt
       PETSC_DIR: ${{ github.workspace }}/petsc
       PETSC_VERSION: 3.23.6
+      PYTEST_ADDOPTS: "-W error"
 
     steps:
       - uses: actions/checkout@v5

--- a/python/dolfinx/graph.py
+++ b/python/dolfinx/graph.py
@@ -53,7 +53,7 @@ class AdjacencyList:
         cpp_object: Union[
             _cpp.graph.AdjacencyList_int32,
             _cpp.graph.AdjacencyList_int64,
-            _cpp.graph.AdjacencyList_AdjacencyList_int_sizet_int8__int32_int32,
+            _cpp.graph.AdjacencyList_int_sizet_int8__int32_int32,
         ],
     ):
         """Creates a Python wrapper for the exported adjacency list class.

--- a/python/dolfinx/graph.py
+++ b/python/dolfinx/graph.py
@@ -53,7 +53,7 @@ class AdjacencyList:
         cpp_object: Union[
             _cpp.graph.AdjacencyList_int32,
             _cpp.graph.AdjacencyList_int64,
-            _cpp.graph.AdjacencyList_int_sizet_int8__int32_int32,
+            _cpp.graph.AdjacencyList_AdjacencyList_int_sizet_int8__int32_int32,
         ],
     ):
         """Creates a Python wrapper for the exported adjacency list class.

--- a/python/dolfinx/io/__init__.py
+++ b/python/dolfinx/io/__init__.py
@@ -6,10 +6,10 @@
 """Tools for file input/output (IO)."""
 
 from dolfinx.common import has_adios2
-from dolfinx.io import gmsh, gmshio, vtkhdf
+from dolfinx.io import gmsh, vtkhdf
 from dolfinx.io.utils import VTKFile, XDMFFile, distribute_entity_data
 
-__all__ = ["VTKFile", "XDMFFile", "distribute_entity_data", "gmsh", "gmshio", "vtkhdf"]
+__all__ = ["VTKFile", "XDMFFile", "distribute_entity_data", "gmsh", "vtkhdf"]
 
 if has_adios2:
     # VTXWriter requires ADIOS2

--- a/python/dolfinx/io/gmshio.py
+++ b/python/dolfinx/io/gmshio.py
@@ -1,5 +1,0 @@
-import warnings
-
-from dolfinx.io.gmsh import *  # noqa: F403
-
-warnings.warn("dolfinx.io.gmshio is deprecated, use dolfinx.io.gmsh.", DeprecationWarning)

--- a/python/dolfinx/utils.py
+++ b/python/dolfinx/utils.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import ctypes as _ctypes
 import os
 import pathlib
-import warnings
 
 import numpy as np
 

--- a/python/dolfinx/utils.py
+++ b/python/dolfinx/utils.py
@@ -217,8 +217,8 @@ class cffi_utils:
         from dolfinx.log import LogLevel, log
 
         log(
-            "Could not import numba, so cffi/numba complex types were not registered.",
             LogLevel.INFO,
+            "Could not import numba, so cffi/numba complex types were not registered.",
         )
 
     try:
@@ -264,6 +264,6 @@ class cffi_utils:
         from dolfinx.log import LogLevel, log
 
         log(
-            "Could not import petsc4py, so cffi/PETSc ABI mode interface was not created.",
             LogLevel.INFO,
+            "Could not import petsc4py, so cffi/PETSc ABI mode interface was not created.",
         )

--- a/python/dolfinx/utils.py
+++ b/python/dolfinx/utils.py
@@ -215,9 +215,11 @@ class cffi_utils:
     except KeyError:
         pass
     except ImportError:
-        warnings.warn(
+        from dolfinx.log import LogLevel, log
+
+        log(
             "Could not import numba, so cffi/numba complex types were not registered.",
-            ImportWarning,
+            LogLevel.INFO,
         )
 
     try:
@@ -260,7 +262,9 @@ class cffi_utils:
     except KeyError:
         pass
     except ImportError:
-        warnings.warn(
+        from dolfinx.log import LogLevel, log
+
+        log(
             "Could not import petsc4py, so cffi/PETSc ABI mode interface was not created.",
-            ImportWarning,
+            LogLevel.INFO,
         )

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -467,7 +467,7 @@ def test_facet_expression(dtype):
     n = ufl.FacetNormal(mesh)
     mixed_expr = p * ufl.dot(ufl.grad(u), n)
     facet_expression = dolfinx.fem.Expression(
-        mixed_expr, np.array([[0.5]], dtype=dtype), dtype=dtype
+        mixed_expr, np.array([[0.5]], dtype=np.real(dtype(0)).dtype), dtype=dtype
     )
     subset_values = facet_expression.eval(mesh, boundary_entities)
     for values, midpoint in zip(subset_values, facet_midpoints):

--- a/python/test/unit/fem/test_petsc_solver_wrappers.py
+++ b/python/test/unit/fem/test_petsc_solver_wrappers.py
@@ -21,6 +21,7 @@ class TestPETScSolverWrappers:
         "mode",
         [dolfinx.mesh.GhostMode.none, dolfinx.mesh.GhostMode.shared_facet],
     )
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_compare_solution_linear_vs_nonlinear_problem(self, mode):
         """Test that the wrapper for Linear problem and NonlinearProblem give the same result"""
         from petsc4py import PETSc

--- a/python/test/unit/nls/test_newton.py
+++ b/python/test/unit/nls/test_newton.py
@@ -108,6 +108,7 @@ class NonlinearPDE_SNESProblem:
 
 @pytest.mark.petsc4py
 class TestNLS:
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_linear_pde(self):
         """Test Newton solver for a linear PDE."""
         from petsc4py import PETSc
@@ -157,6 +158,7 @@ class TestNLS:
         del solver
         assert ksp.refcount == 1
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_nonlinear_pde(self):
         """Test Newton solver for a simple nonlinear PDE"""
         from petsc4py import PETSc


### PR DESCRIPTION
Ensures and fixes warning propagation to caller. 

Triggered by: `import dolfinx` triggered now a deprecation warning after deprecation of `gmshio` in https://github.com/FEniCS/dolfinx/pull/3881. This is caused by including this module by default. Removes this include and passes `-W error` to the pytest calls in the CI which should catch such problems in the future.

Removes `gmshio`.