### PR TITLE
Pep-0604 - Removing `typing.Union`

### DIFF
--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -26,8 +26,8 @@ from dolfinx.fem.forms import Form
 
 
 def pack_constants(
-    form: typing.Union[Form, Sequence[Form]],
-) -> typing.Union[npt.NDArray, Sequence[npt.NDArray]]:
+    form: Form | Sequence[Form],
+) -> npt.NDArray | Sequence[npt.NDArray]:
     """Pack form constants for use in assembly.
 
     Pack the 'constants' that appear in forms. The packed constants can
@@ -58,10 +58,10 @@ def pack_constants(
 
 
 def pack_coefficients(
-    form: typing.Union[Form, Sequence[Form]],
-) -> typing.Union[
-    dict[tuple[IntegralType, int], npt.NDArray], list[dict[tuple[IntegralType, int], npt.NDArray]]
-]:
+    form: Form | Sequence[Form],
+) -> (
+    dict[tuple[IntegralType, int], npt.NDArray] | list[dict[tuple[IntegralType, int], npt.NDArray]]
+):
     """Pack form coefficients for use in assembly.
 
     Pack the ``coefficients`` that appear in forms. The packed
@@ -136,7 +136,7 @@ def assemble_scalar(
     M: Form,
     constants: npt.NDArray | None = None,
     coeffs: dict[tuple[IntegralType, int], npt.NDArray] | None = None,
-) -> typing.Union[float, complex]:
+) -> float | complex:
     """Assemble functional. The returned value is local and not
     accumulated across processes.
 

--- a/python/dolfinx/fem/bcs.py
+++ b/python/dolfinx/fem/bcs.py
@@ -22,7 +22,7 @@ from dolfinx.fem.function import Constant, Function, FunctionSpace
 
 
 def locate_dofs_geometrical(
-    V: typing.Union[dolfinx.fem.FunctionSpace, Iterable[dolfinx.fem.FunctionSpace]],
+    V: dolfinx.fem.FunctionSpace | Iterable[dolfinx.fem.FunctionSpace],
     marker: Callable,
 ) -> np.ndarray:
     """Locate degrees-of-freedom geometrically using a marker function.
@@ -54,7 +54,7 @@ def locate_dofs_geometrical(
 
 
 def locate_dofs_topological(
-    V: typing.Union[dolfinx.fem.FunctionSpace, Iterable[dolfinx.fem.FunctionSpace]],
+    V: dolfinx.fem.FunctionSpace | Iterable[dolfinx.fem.FunctionSpace],
     entity_dim: int,
     entities: npt.NDArray[np.int32],
     remote: bool = True,
@@ -90,12 +90,12 @@ def locate_dofs_topological(
 
 
 class DirichletBC:
-    _cpp_object: typing.Union[
-        _cpp.fem.DirichletBC_complex64,
-        _cpp.fem.DirichletBC_complex128,
-        _cpp.fem.DirichletBC_float32,
-        _cpp.fem.DirichletBC_float64,
-    ]
+    _cpp_object: (
+        _cpp.fem.DirichletBC_complex64
+        | _cpp.fem.DirichletBC_complex128
+        | _cpp.fem.DirichletBC_float32
+        | _cpp.fem.DirichletBC_float64
+    )
 
     def __init__(self, bc):
         """Representation of Dirichlet boundary condition which is imposed
@@ -122,7 +122,7 @@ class DirichletBC:
         self._cpp_object = bc
 
     @property
-    def g(self) -> typing.Union[Function, Constant, np.ndarray]:
+    def g(self) -> Function | Constant | np.ndarray:
         """The boundary condition value(s)"""
         return self._cpp_object.value
 
@@ -176,7 +176,7 @@ class DirichletBC:
 
 
 def dirichletbc(
-    value: typing.Union[Function, Constant, np.ndarray],
+    value: Function | Constant | np.ndarray,
     dofs: npt.NDArray[np.int32],
     V: dolfinx.fem.FunctionSpace | None = None,
 ) -> DirichletBC:
@@ -237,7 +237,7 @@ def dirichletbc(
 
 
 def bcs_by_block(
-    spaces: Iterable[typing.Union[FunctionSpace, None]], bcs: Iterable[DirichletBC]
+    spaces: Iterable[FunctionSpace | None], bcs: Iterable[DirichletBC]
 ) -> list[list[DirichletBC]]:
     """Arrange Dirichlet boundary conditions by the function space that
     they constrain.

--- a/python/dolfinx/fem/element.py
+++ b/python/dolfinx/fem/element.py
@@ -19,13 +19,10 @@ from dolfinx import cpp as _cpp
 class CoordinateElement:
     """Coordinate element describing the geometry map for mesh cells."""
 
-    _cpp_object: typing.Union[
-        _cpp.fem.CoordinateElement_float32, _cpp.fem.CoordinateElement_float64
-    ]
+    _cpp_object: _cpp.fem.CoordinateElement_float32 | _cpp.fem.CoordinateElement_float64
 
     def __init__(
-        self,
-        cmap: typing.Union[_cpp.fem.CoordinateElement_float32, _cpp.fem.CoordinateElement_float64],
+        self, cmap: _cpp.fem.CoordinateElement_float32 | _cpp.fem.CoordinateElement_float64
     ):
         """Create a coordinate map element.
 
@@ -66,9 +63,9 @@ class CoordinateElement:
 
     def push_forward(
         self,
-        X: typing.Union[npt.NDArray[np.float32], npt.NDArray[np.float64]],
-        cell_geometry: typing.Union[npt.NDArray[np.float32], npt.NDArray[np.float64]],
-    ) -> typing.Union[npt.NDArray[np.float32], npt.NDArray[np.float64]]:
+        X: npt.NDArray[np.float32] | npt.NDArray[np.float64],
+        cell_geometry: npt.NDArray[np.float32] | npt.NDArray[np.float64],
+    ) -> npt.NDArray[np.float32] | npt.NDArray[np.float64]:
         """Push points on the reference cell forward to the physical cell.
 
         Args:
@@ -86,9 +83,9 @@ class CoordinateElement:
 
     def pull_back(
         self,
-        x: typing.Union[npt.NDArray[np.float32], npt.NDArray[np.float64]],
-        cell_geometry: typing.Union[npt.NDArray[np.float32], npt.NDArray[np.float64]],
-    ) -> typing.Union[npt.NDArray[np.float32], npt.NDArray[np.float64]]:
+        x: npt.NDArray[np.float32] | npt.NDArray[np.float64],
+        cell_geometry: npt.NDArray[np.float32] | npt.NDArray[np.float64],
+    ) -> npt.NDArray[np.float32] | npt.NDArray[np.float64]:
         """Pull points on the physical cell back to the reference cell.
 
         For non-affine cells, the pull-back is a nonlinear operation.
@@ -169,11 +166,11 @@ def _(e: basix.finite_element.FiniteElement):
 
 
 class FiniteElement:
-    _cpp_object: typing.Union[_cpp.fem.FiniteElement_float32, _cpp.fem.FiniteElement_float64]
+    _cpp_object: _cpp.fem.FiniteElement_float32 | _cpp.fem.FiniteElement_float64
 
     def __init__(
         self,
-        cpp_object: typing.Union[_cpp.fem.FiniteElement_float32, _cpp.fem.FiniteElement_float64],
+        cpp_object: _cpp.fem.FiniteElement_float32 | _cpp.fem.FiniteElement_float64,
     ):
         """Creates a Python wrapper for the exported finite element class.
 

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -33,25 +33,23 @@ if typing.TYPE_CHECKING:
 
 
 class Form:
-    _cpp_object: typing.Union[
-        _cpp.fem.Form_complex64,
-        _cpp.fem.Form_complex128,
-        _cpp.fem.Form_float32,
-        _cpp.fem.Form_float64,
-    ]
-    _code: typing.Union[str, list[str]] | None
+    _cpp_object: (
+        _cpp.fem.Form_complex64
+        | _cpp.fem.Form_complex128
+        | _cpp.fem.Form_float32
+        | _cpp.fem.Form_float64
+    )
+    _code: str | list[str] | None
 
     def __init__(
         self,
-        form: typing.Union[
-            _cpp.fem.Form_complex64,
-            _cpp.fem.Form_complex128,
-            _cpp.fem.Form_float32,
-            _cpp.fem.Form_float64,
-        ],
+        form: _cpp.fem.Form_complex64
+        | _cpp.fem.Form_complex128
+        | _cpp.fem.Form_float32
+        | _cpp.fem.Form_float64,
         ufcx_form=None,
-        code: typing.Union[str, list[str]] | None = None,
-        module: typing.Union[types.ModuleType, list[types.ModuleType]] | None = None,
+        code: str | list[str] | None = None,
+        module: types.ModuleType | list[types.ModuleType] | None = None,
     ):
         """A finite element form.
 
@@ -78,12 +76,12 @@ class Form:
         return self._ufcx_form
 
     @property
-    def code(self) -> typing.Union[str, list[str], None]:
+    def code(self) -> str | list[str] | None:
         """C code strings."""
         return self._code
 
     @property
-    def module(self) -> typing.Union[types.ModuleType, list[types.ModuleType], None]:
+    def module(self) -> types.ModuleType | list[types.ModuleType] | None:
         """The CFFI module"""
         return self._module
 
@@ -102,7 +100,7 @@ class Form:
         return np.dtype(self._cpp_object.dtype)
 
     @property
-    def mesh(self) -> typing.Union[_cpp.mesh.Mesh_float32, _cpp.mesh.Mesh_float64]:
+    def mesh(self) -> _cpp.mesh.Mesh_float32 | _cpp.mesh.Mesh_float64:
         """Mesh on which this form is defined."""
         return self._cpp_object.mesh
 
@@ -124,7 +122,7 @@ class Form:
 
 def get_integration_domains(
     integral_type: IntegralType,
-    subdomain: typing.Union[MeshTags, list[tuple[int, np.ndarray]]] | None,
+    subdomain: MeshTags | list[tuple[int, np.ndarray]] | None,
     subdomain_ids: list[int],
 ) -> list[tuple[int, np.ndarray]]:
     """Get integration domains from subdomain data.
@@ -186,9 +184,12 @@ def get_integration_domains(
 
 def form_cpp_class(
     dtype: npt.DTypeLike,
-) -> typing.Union[
-    _cpp.fem.Form_float32, _cpp.fem.Form_float64, _cpp.fem.Form_complex64, _cpp.fem.Form_complex128
-]:
+) -> (
+    _cpp.fem.Form_float32
+    | _cpp.fem.Form_float64
+    | _cpp.fem.Form_complex64
+    | _cpp.fem.Form_complex128
+):
     """Return the wrapped C++ class of a variational form of a specific
     scalar type.
 
@@ -302,7 +303,7 @@ def mixed_topology_form(
 
 
 def form(
-    form: typing.Union[ufl.Form, Sequence[ufl.Form], Sequence[Sequence[ufl.Form]]],
+    form: ufl.Form | Sequence[ufl.Form] | Sequence[Sequence[ufl.Form]],
     dtype: npt.DTypeLike = default_scalar_type,
     form_compiler_options: dict | None = None,
     jit_options: dict | None = None,
@@ -440,9 +441,9 @@ def form(
 
 
 def extract_function_spaces(
-    forms: typing.Union[Iterable[Form], Iterable[Iterable[Form]]],
+    forms: ufl.Form | Sequence[ufl.Form] | Sequence[Sequence[ufl.Form]],
     index: int = 0,
-) -> list[typing.Union[None, FunctionSpace]]:
+) -> list[None | FunctionSpace]:
     """Extract common function spaces from an array of forms.
 
     If ``forms`` is a list of linear form, this function returns of list
@@ -534,12 +535,12 @@ def compile_form(
 
 def form_cpp_creator(
     dtype: npt.DTypeLike,
-) -> typing.Union[
-    _cpp.fem.Form_float32,
-    _cpp.fem.Form_float64,
-    _cpp.fem.Form_complex64,
-    _cpp.fem.Form_complex128,
-]:
+) -> (
+    _cpp.fem.Form_float32
+    | _cpp.fem.Form_float64
+    | _cpp.fem.Form_complex64
+    | _cpp.fem.Form_complex128
+):
     """Return the wrapped C++ constructor for creating a variational form
     of a specific scalar type.
 
@@ -648,10 +649,10 @@ def create_form(
 
 
 def derivative_block(
-    F: typing.Union[ufl.Form, Sequence[ufl.Form]],
-    u: typing.Union[Function, Sequence[Function]],
-    du: typing.Union[ufl.Argument, Sequence[ufl.Argument]] | None = None,
-) -> typing.Union[ufl.Form, Sequence[Sequence[ufl.Form]]]:
+    F: ufl.Form | Sequence[ufl.Form],
+    u: Function | Sequence[Function],
+    du: ufl.Argument | Sequence[ufl.Argument] | None = None,
+) -> ufl.Form | Sequence[Sequence[ufl.Form]]:
     """Return the UFL derivative of a (list of) UFL rank one form(s).
 
     This is commonly used to derive a block Jacobian from a block

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -30,17 +30,17 @@ if typing.TYPE_CHECKING:
 
 
 class Constant(ufl.Constant):
-    _cpp_object: typing.Union[
-        _cpp.fem.Constant_complex64,
-        _cpp.fem.Constant_complex128,
-        _cpp.fem.Constant_float32,
-        _cpp.fem.Constant_float64,
-    ]
+    _cpp_object: (
+        _cpp.fem.Constant_complex64
+        | _cpp.fem.Constant_complex128
+        | _cpp.fem.Constant_float32
+        | _cpp.fem.Constant_float64
+    )
 
     def __init__(
         self,
         domain,
-        c: typing.Union[float, np.floating, complex, np.complexfloating, Sequence, np.ndarray],
+        c: float | np.floating | complex | np.complexfloating | Sequence | np.ndarray,
     ):
         """A constant with respect to a domain.
 
@@ -299,12 +299,12 @@ class Function(ufl.Coefficient):
     (domain, element and dofmap) and a vector holding the
     degrees-of-freedom."""
 
-    _cpp_object: typing.Union[
-        _cpp.fem.Function_complex64,
-        _cpp.fem.Function_complex128,
-        _cpp.fem.Function_float32,
-        _cpp.fem.Function_float64,
-    ]
+    _cpp_object: (
+        _cpp.fem.Function_complex64
+        | _cpp.fem.Function_complex128
+        | _cpp.fem.Function_float32
+        | _cpp.fem.Function_float64
+    )
 
     def __init__(
         self,
@@ -428,7 +428,7 @@ class Function(ufl.Coefficient):
 
     def interpolate(
         self,
-        u0: typing.Union[Callable, Expression, Function],
+        u0: Callable | Expression | Function,
         cells0: np.ndarray | None = None,
         cells1: np.ndarray | None = None,
     ) -> None:
@@ -580,13 +580,13 @@ class ElementMetaData(typing.NamedTuple):
 
 def functionspace(
     mesh: Mesh,
-    element: typing.Union[
-        ufl.finiteelement.AbstractFiniteElement,
-        ElementMetaData,
-        tuple[str, int],
-        tuple[str, int, tuple],
-        tuple[str, int, tuple, bool],
-    ],
+    element: (
+        ufl.finiteelement.AbstractFiniteElement
+        | ElementMetaData
+        | tuple[str, int]
+        | tuple[str, int, tuple]
+        | tuple[str, int, tuple, bool]
+    ),
 ) -> FunctionSpace:
     """Create a finite element function space.
 
@@ -634,14 +634,14 @@ def functionspace(
 class FunctionSpace(ufl.FunctionSpace):
     """A space on which Functions (fields) can be defined."""
 
-    _cpp_object: typing.Union[_cpp.fem.FunctionSpace_float32, _cpp.fem.FunctionSpace_float64]
+    _cpp_object: _cpp.fem.FunctionSpace_float32 | _cpp.fem.FunctionSpace_float64
     _mesh: Mesh
 
     def __init__(
         self,
         mesh: Mesh,
         element: ufl.finiteelement.AbstractFiniteElement,
-        cppV: typing.Union[_cpp.fem.FunctionSpace_float32, _cpp.fem.FunctionSpace_float64],
+        cppV: (_cpp.fem.FunctionSpace_float32 | _cpp.fem.FunctionSpace_float64),
     ):
         """Create a finite element function space.
 

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -82,7 +82,7 @@ __all__ = [
 # -- Vector instantiation -------------------------------------------------
 
 
-def create_vector(L: typing.Union[Form, Sequence[Form]], kind: str | None = None) -> PETSc.Vec:  # type: ignore[name-defined]
+def create_vector(L: Form | Sequence[Form], kind: str | None = None) -> PETSc.Vec:  # type: ignore[name-defined]
     """Create a PETSc vector that is compatible with a linear form(s).
 
     Three cases are supported:
@@ -165,8 +165,8 @@ def create_vector(L: typing.Union[Form, Sequence[Form]], kind: str | None = None
 
 
 def create_matrix(
-    a: typing.Union[Form, Sequence[Sequence[Form]]],
-    kind: typing.Union[str, Sequence[Sequence[str]]] | None = None,
+    a: Form | Sequence[Sequence[Form]],
+    kind: str | Sequence[Sequence[str]] | None = None,
 ) -> PETSc.Mat:  # type: ignore[name-defined]
     """Create a PETSc matrix that is compatible with the (sequence) of
     bilinear form(s).
@@ -218,13 +218,13 @@ def create_matrix(
 
 @functools.singledispatch
 def assemble_vector(
-    L: typing.Union[Form, Sequence[Form]],
-    constants: typing.Union[npt.NDArray, Sequence[npt.NDArray]] | None = None,
-    coeffs: typing.Union[
-        dict[tuple[IntegralType, int], npt.NDArray],
-        Sequence[dict[tuple[IntegralType, int], npt.NDArray]],
-    ]
-    | None = None,
+    L: Form | Sequence[Form],
+    constants: npt.NDArray | Sequence[npt.NDArray] | None = None,
+    coeffs: (
+        dict[tuple[IntegralType, int], npt.NDArray]
+        | Sequence[dict[tuple[IntegralType, int], npt.NDArray]]
+        | None
+    ) = None,
     kind: str | None = None,
 ) -> PETSc.Vec:  # type: ignore[name-defined]
     """Assemble linear form(s) into a new PETSc vector.
@@ -282,13 +282,13 @@ def assemble_vector(
 @assemble_vector.register
 def _(
     b: PETSc.Vec,  # type: ignore[name-defined]
-    L: typing.Union[Form, Sequence[Form]],
-    constants: typing.Union[npt.NDArray, Sequence[npt.NDArray]] | None = None,
-    coeffs: typing.Union[
-        dict[tuple[IntegralType, int], npt.NDArray],
-        Sequence[dict[tuple[IntegralType, int], npt.NDArray]],
-    ]
-    | None = None,
+    L: Form | Sequence[Form],
+    constants: npt.NDArray | Sequence[npt.NDArray] | None = None,
+    coeffs: (
+        dict[tuple[IntegralType, int], npt.NDArray]
+        | Sequence[dict[tuple[IntegralType, int], npt.NDArray]]
+        | None
+    ) = None,
 ) -> PETSc.Vec:  # type: ignore[name-defined]
     """Assemble linear form(s) into a PETSc vector.
 
@@ -351,15 +351,15 @@ def _(
 # -- Matrix assembly ------------------------------------------------------
 @functools.singledispatch
 def assemble_matrix(
-    a: typing.Union[Form, Sequence[Sequence[Form]]],
+    a: Form | Sequence[Sequence[Form]],
     bcs: Sequence[DirichletBC] | None = None,
     diag: float = 1,
-    constants: typing.Union[Sequence[npt.NDArray], Sequence[Sequence[npt.NDArray]]] | None = None,
-    coeffs: typing.Union[
-        dict[tuple[IntegralType, int], npt.NDArray],
-        Sequence[dict[tuple[IntegralType, int], npt.NDArray]],
-    ]
-    | None = None,
+    constants: Sequence[npt.NDArray] | Sequence[Sequence[npt.NDArray]] | None = None,
+    coeffs: (
+        dict[tuple[IntegralType, int], npt.NDArray]
+        | Sequence[dict[tuple[IntegralType, int], npt.NDArray]]
+        | None
+    ) = None,
     kind=None,
 ):
     """Assemble a bilinear form into a matrix.
@@ -419,15 +419,15 @@ def assemble_matrix(
 @assemble_matrix.register
 def _(
     A: PETSc.Mat,  # type: ignore[name-defined]
-    a: typing.Union[Form, Sequence[Sequence[Form]]],
+    a: Form | Sequence[Sequence[Form]],
     bcs: Sequence[DirichletBC] | None = None,
     diag: float = 1,
-    constants: typing.Union[npt.NDArray, Sequence[Sequence[npt.NDArray]]] | None = None,
-    coeffs: typing.Union[
-        dict[tuple[IntegralType, int], npt.NDArray],
-        Sequence[Sequence[dict[tuple[IntegralType, int], npt.NDArray]]],
-    ]
-    | None = None,
+    constants: npt.NDArray | Sequence[Sequence[npt.NDArray]] | None = None,
+    coeffs: (
+        dict[tuple[IntegralType, int], npt.NDArray]
+        | Sequence[Sequence[dict[tuple[IntegralType, int], npt.NDArray]]]
+        | None
+    ) = None,
 ) -> PETSc.Mat:  # type: ignore[name-defined]
     """Assemble bilinear form into a matrix.
 
@@ -530,16 +530,16 @@ def _(
 
 def apply_lifting(
     b: PETSc.Vec,  # type: ignore[name-defined]
-    a: typing.Union[Sequence[Form], Sequence[Sequence[Form]]],
-    bcs: typing.Union[Sequence[DirichletBC], Sequence[Sequence[DirichletBC]]] | None,
+    a: Sequence[Form] | Sequence[Sequence[Form]],
+    bcs: Sequence[DirichletBC] | Sequence[Sequence[DirichletBC]] | None,
     x0: Sequence[PETSc.Vec] | None = None,  # type: ignore[name-defined]
     alpha: float = 1,
-    constants: typing.Union[Sequence[npt.NDArray], Sequence[Sequence[npt.NDArray]]] | None = None,
-    coeffs: typing.Union[
-        dict[tuple[IntegralType, int], npt.NDArray],
-        Sequence[Sequence[dict[tuple[IntegralType, int], npt.NDArray]]],
-    ]
-    | None = None,
+    constants: Sequence[npt.NDArray] | Sequence[Sequence[npt.NDArray]] | None = None,
+    coeffs: (
+        dict[tuple[IntegralType, int], npt.NDArray]
+        | Sequence[Sequence[dict[tuple[IntegralType, int], npt.NDArray]]]
+        | None
+    ) = None,
 ) -> None:
     r"""Modify the right-hand side PETSc vector ``b`` to account for
     constraints (Dirichlet boundary conitions).
@@ -647,7 +647,7 @@ def apply_lifting(
 
 def set_bc(
     b: PETSc.Vec,  # type: ignore[name-defined]
-    bcs: typing.Union[Sequence[DirichletBC], Sequence[Sequence[DirichletBC]]],
+    bcs: Sequence[DirichletBC] | Sequence[Sequence[DirichletBC]],
     x0: PETSc.Vec | None = None,  # type: ignore[name-defined]
     alpha: float = 1,
 ) -> None:
@@ -716,14 +716,14 @@ class LinearProblem:
 
     def __init__(
         self,
-        a: typing.Union[ufl.Form, Sequence[Sequence[ufl.Form]]],
-        L: typing.Union[ufl.Form, Sequence[ufl.Form]],
+        a: ufl.Form | Sequence[Sequence[ufl.Form]],
+        L: ufl.Form | Sequence[ufl.Form],
         *,
         petsc_options_prefix: str,
         bcs: Sequence[DirichletBC] | None = None,
-        u: typing.Union[_Function, Sequence[_Function]] | None = None,
-        P: typing.Union[ufl.Form, Sequence[Sequence[ufl.Form]]] | None = None,
-        kind: typing.Union[str, Sequence[Sequence[str]]] | None = None,
+        u: _Function | Sequence[_Function] | None = None,
+        P: ufl.Form | Sequence[Sequence[ufl.Form]] | None = None,
+        kind: str | Sequence[Sequence[str]] | None = None,
         petsc_options: dict | None = None,
         form_compiler_options: dict | None = None,
         jit_options: dict | None = None,
@@ -842,7 +842,7 @@ class LinearProblem:
         self._b = create_vector(self.L, kind=kind)
         self._x = create_vector(self.L, kind=kind)
 
-        self._u: typing.Union[_Function, Sequence[_Function]]
+        self._u: _Function | Sequence[_Function]
         if u is None:
             # Extract function space for unknown from the right hand
             # side of the equation.
@@ -905,7 +905,7 @@ class LinearProblem:
         if self._P_mat is not None:
             self._P_mat.destroy()
 
-    def solve(self) -> typing.Union[_Function, Sequence[_Function]]:
+    def solve(self) -> _Function | Sequence[_Function]:
         """Solve the problem.
 
         This method updates the solution ``u`` function(s) stored in the
@@ -967,17 +967,17 @@ class LinearProblem:
         return self.u
 
     @property
-    def L(self) -> typing.Union[Form, Sequence[Form]]:
+    def L(self) -> Form | Sequence[Form]:
         """The compiled linear form representing the left-hand side."""
         return self._L
 
     @property
-    def a(self) -> typing.Union[Form, Sequence[Form]]:
+    def a(self) -> Form | Sequence[Form]:
         """The compiled bilinear form representing the right-hand side."""
         return self._a
 
     @property
-    def preconditioner(self) -> typing.Union[Form, Sequence[Form]]:
+    def preconditioner(self) -> Form | Sequence[Form]:
         """The compiled bilinear form representing the preconditioner."""
         return self._preconditioner
 
@@ -1012,7 +1012,7 @@ class LinearProblem:
         return self._solver
 
     @property
-    def u(self) -> typing.Union[_Function, Sequence[_Function]]:
+    def u(self) -> _Function | Sequence[_Function]:
         """Solution function(s).
 
         Note:
@@ -1055,9 +1055,9 @@ def _assign_block_data(forms: Sequence[Form], vec: PETSc.Vec):  # type: ignore[n
 
 
 def assemble_residual(
-    u: typing.Union[_Function, Sequence[_Function]],
-    residual: typing.Union[Form, Sequence[Form]],
-    jacobian: typing.Union[Form, Sequence[Sequence[Form]]],
+    u: _Function | Sequence[_Function],
+    residual: Form | Sequence[Form],
+    jacobian: Form | Sequence[Sequence[Form]],
     bcs: Sequence[DirichletBC],
     _snes: PETSc.SNES,  # type: ignore[name-defined]
     x: PETSc.Vec,  # type: ignore[name-defined]
@@ -1119,9 +1119,9 @@ def assemble_residual(
 
 
 def assemble_jacobian(
-    u: typing.Union[Sequence[_Function], _Function],
-    jacobian: typing.Union[Form, Sequence[Sequence[Form]]],
-    preconditioner: typing.Union[Form, Sequence[Sequence[Form]]] | None,
+    u: Sequence[_Function] | _Function,
+    jacobian: Form | Sequence[Sequence[Form]],
+    preconditioner: Form | Sequence[Sequence[Form]] | None,
     bcs: Sequence[DirichletBC],
     _snes: PETSc.SNES,  # type: ignore[name-defined]
     x: PETSc.Vec,  # type: ignore[name-defined]
@@ -1191,14 +1191,14 @@ class NonlinearProblem:
 
     def __init__(
         self,
-        F: typing.Union[ufl.form.Form, Sequence[ufl.form.Form]],
-        u: typing.Union[_Function, Sequence[_Function]],
+        F: ufl.form.Form | Sequence[ufl.form.Form],
+        u: _Function | Sequence[_Function],
         *,
         petsc_options_prefix: str,
         bcs: Sequence[DirichletBC] | None = None,
-        J: typing.Union[ufl.form.Form, Sequence[Sequence[ufl.form.Form]]] | None = None,
-        P: typing.Union[ufl.form.Form, Sequence[Sequence[ufl.form.Form]]] | None = None,
-        kind: typing.Union[str, Sequence[Sequence[str]]] | None = None,
+        J: ufl.form.Form | Sequence[Sequence[ufl.form.Form]] | None = None,
+        P: ufl.form.Form | Sequence[Sequence[ufl.form.Form]] | None = None,
+        kind: str | Sequence[Sequence[str]] | None = None,
         petsc_options: dict | None = None,
         form_compiler_options: dict | None = None,
         jit_options: dict | None = None,
@@ -1365,7 +1365,7 @@ class NonlinearProblem:
             )
             self.solver.getKSP().getPC().setFieldSplitIS(*fieldsplit_IS)
 
-    def solve(self) -> typing.Union[_Function, Sequence[_Function]]:
+    def solve(self) -> _Function | Sequence[_Function]:
         """Solve the problem.
 
         This method updates the solution ``u`` function(s) stored in the
@@ -1402,17 +1402,17 @@ class NonlinearProblem:
             self._P_mat.destroy()
 
     @property
-    def F(self) -> typing.Union[Form, Sequence[Form]]:
+    def F(self) -> Form | Sequence[Form]:
         """The compiled residual."""
         return self._F
 
     @property
-    def J(self) -> typing.Union[Form, Sequence[Sequence[Form]]]:
+    def J(self) -> Form | Sequence[Sequence[Form]]:
         """The compiled Jacobian."""
         return self._J
 
     @property
-    def preconditioner(self) -> typing.Union[Form, Sequence[Sequence[Form]]] | None:
+    def preconditioner(self) -> Form | Sequence[Sequence[Form]] | None:
         """The compiled preconditioner."""
         return self._preconditioner
 
@@ -1447,7 +1447,7 @@ class NonlinearProblem:
         return self._snes
 
     @property
-    def u(self) -> typing.Union[_Function, Sequence[_Function]]:
+    def u(self) -> _Function | Sequence[_Function]:
         """Solution function(s).
 
         Note:
@@ -1636,7 +1636,7 @@ def interpolation_matrix(V0: _FunctionSpace, V1: _FunctionSpace) -> PETSc.Mat:  
 
 
 @functools.singledispatch
-def assign(u: typing.Union[_Function, Sequence[_Function]], x: PETSc.Vec):  # type: ignore[name-defined]
+def assign(u: _Function | Sequence[_Function], x: PETSc.Vec):  # type: ignore[name-defined]
     """Assign :class:`Function` degrees-of-freedom to a vector.
 
     Assigns degree-of-freedom values in ``u``, which is possibly a
@@ -1665,7 +1665,7 @@ def assign(u: typing.Union[_Function, Sequence[_Function]], x: PETSc.Vec):  # ty
 
 
 @assign.register
-def _(x: PETSc.Vec, u: typing.Union[_Function, Sequence[_Function]]):  # type: ignore[name-defined]
+def _(x: PETSc.Vec, u: _Function | Sequence[_Function]):  # type: ignore[name-defined]
     """Assign vector entries to :class:`Function` degrees-of-freedom.
 
     Assigns values in ``x`` to the degrees-of-freedom of ``u``, which is

--- a/python/dolfinx/geometry.py
+++ b/python/dolfinx/geometry.py
@@ -37,9 +37,7 @@ class PointOwnershipData:
     """Convenience class for storing data related to the ownership of
     points."""
 
-    _cpp_object: typing.Union[
-        _cpp.geometry.PointOwnershipData_float32, _cpp.geometry.PointOwnershipData_float64
-    ]
+    _cpp_object: _cpp.geometry.PointOwnershipData_float32 | _cpp.geometry.PointOwnershipData_float64
 
     def __init__(self, ownership_data):
         """Wrap a C++ PointOwnershipData."""
@@ -67,9 +65,7 @@ class PointOwnershipData:
 class BoundingBoxTree:
     """Bounding box trees used in collision detection."""
 
-    _cpp_object: typing.Union[
-        _cpp.geometry.BoundingBoxTree_float32, _cpp.geometry.BoundingBoxTree_float64
-    ]
+    _cpp_object: _cpp.geometry.BoundingBoxTree_float32 | _cpp.geometry.BoundingBoxTree_float64
 
     def __init__(self, tree):
         """Wrap a C++ BoundingBoxTree.
@@ -87,7 +83,7 @@ class BoundingBoxTree:
         return self._cpp_object.num_bboxes
 
     @property
-    def bbox_coordinates(self) -> typing.Union[npt.NDArray[np.float32], npt.NDArray[np.float64]]:
+    def bbox_coordinates(self) -> npt.NDArray[np.float32] | npt.NDArray[np.float64]:
         """Coordinates of lower and upper corners of bounding boxes.
 
         Note:

--- a/python/dolfinx/io/gmsh.py
+++ b/python/dolfinx/io/gmsh.py
@@ -431,7 +431,7 @@ def model_to_mesh(
 
 
 def read_from_msh(
-    filename: typing.Union[str, Path],
+    filename: str | Path,
     comm: _MPI.Comm,
     rank: int = 0,
     gdim: int = 3,

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -42,13 +42,13 @@ if _cpp.common.has_adios2:
         The files can be viewed using Paraview.
         """
 
-        _cpp_object: typing.Union[_cpp.io.VTXWriter_float32, _cpp.io.VTXWriter_float64]
+        _cpp_object: _cpp.io.VTXWriter_float32 | _cpp.io.VTXWriter_float64
 
         def __init__(
             self,
             comm: _MPI.Comm,
-            filename: typing.Union[str, Path],
-            output: typing.Union[Mesh, Function, list[Function], tuple[Function]],
+            filename: str | Path,
+            output: Mesh | Function | list[Function] | tuple[Function],
             engine: str = "BPFile",
             mesh_policy: VTXMeshPolicy = VTXMeshPolicy.update,
         ):
@@ -128,7 +128,7 @@ class VTKFile(_cpp.io.VTKFile):
         """Write mesh to file for a given time (default 0.0)"""
         self.write(mesh._cpp_object, t)
 
-    def write_function(self, u: typing.Union[list[Function], Function], t: float = 0.0) -> None:
+    def write_function(self, u: list[Function] | Function, t: float = 0.0) -> None:
         """Write a single function or a list of functions to file for a
         given time (default 0.0)"""
         cpp_objects = [u._cpp_object] if isinstance(u, Function) else [_u._cpp_object for _u in u]

--- a/python/dolfinx/io/vtkhdf.py
+++ b/python/dolfinx/io/vtkhdf.py
@@ -25,7 +25,7 @@ from dolfinx.mesh import Mesh
 
 def read_mesh(
     comm: _MPI.Comm,
-    filename: typing.Union[str, Path],
+    filename: str | Path,
     dtype: npt.DTypeLike = np.float64,
     gdim: int = 3,
 ):
@@ -58,7 +58,7 @@ def read_mesh(
     return Mesh(mesh_cpp, domain)
 
 
-def write_mesh(filename: typing.Union[str, Path], mesh: Mesh):
+def write_mesh(filename: str | Path, mesh: Mesh):
     """Write a mesh to file in VTKHDF format
 
     Args:
@@ -68,7 +68,7 @@ def write_mesh(filename: typing.Union[str, Path], mesh: Mesh):
     write_vtkhdf_mesh(filename, mesh._cpp_object)
 
 
-def write_point_data(filename: typing.Union[str, Path], mesh: Mesh, data: npt.NDArray, time: float):
+def write_point_data(filename: str | Path, mesh: Mesh, data: npt.NDArray, time: float):
     """Write data at vertices of the mesh.
 
     Args:
@@ -80,7 +80,7 @@ def write_point_data(filename: typing.Union[str, Path], mesh: Mesh, data: npt.ND
     write_vtkhdf_data("Point", filename, mesh._cpp_object, data, time)
 
 
-def write_cell_data(filename: typing.Union[str, Path], mesh: Mesh, data: npt.NDArray, time: float):
+def write_cell_data(filename: str | Path, mesh: Mesh, data: npt.NDArray, time: float):
     """Write data at cells of the mesh.
 
     Args:

--- a/python/dolfinx/la/__init__.py
+++ b/python/dolfinx/la/__init__.py
@@ -29,27 +29,27 @@ __all__ = [
 
 
 class Vector:
-    _cpp_object: typing.Union[
-        _cpp.la.Vector_float32,
-        _cpp.la.Vector_float64,
-        _cpp.la.Vector_complex64,
-        _cpp.la.Vector_complex128,
-        _cpp.la.Vector_int8,
-        _cpp.la.Vector_int32,
-        _cpp.la.Vector_int64,
-    ]
+    _cpp_object: (
+        _cpp.la.Vector_float32
+        | _cpp.la.Vector_float64
+        | _cpp.la.Vector_complex64
+        | _cpp.la.Vector_complex128
+        | _cpp.la.Vector_int8
+        | _cpp.la.Vector_int32
+        | _cpp.la.Vector_int64
+    )
 
     def __init__(
         self,
-        x: typing.Union[
-            _cpp.la.Vector_float32,
-            _cpp.la.Vector_float64,
-            _cpp.la.Vector_complex64,
-            _cpp.la.Vector_complex128,
-            _cpp.la.Vector_int8,
-            _cpp.la.Vector_int32,
-            _cpp.la.Vector_int64,
-        ],
+        x: (
+            _cpp.la.Vector_float32
+            | _cpp.la.Vector_float64
+            | _cpp.la.Vector_complex64
+            | _cpp.la.Vector_complex128
+            | _cpp.la.Vector_int8
+            | _cpp.la.Vector_int32
+            | _cpp.la.Vector_int64
+        ),
     ):
         """A distributed vector object.
 
@@ -117,21 +117,21 @@ class Vector:
 
 
 class MatrixCSR:
-    _cpp_object: typing.Union[
-        _cpp.la.MatrixCSR_float32,
-        _cpp.la.MatrixCSR_float64,
-        _cpp.la.MatrixCSR_complex64,
-        _cpp.la.MatrixCSR_complex128,
-    ]
+    _cpp_object: (
+        _cpp.la.MatrixCSR_float32
+        | _cpp.la.MatrixCSR_float64
+        | _cpp.la.MatrixCSR_complex64
+        | _cpp.la.MatrixCSR_complex128
+    )
 
     def __init__(
         self,
-        A: typing.Union[
-            _cpp.la.MatrixCSR_float32,
-            _cpp.la.MatrixCSR_float64,
-            _cpp.la.MatrixCSR_complex64,
-            _cpp.la.MatrixCSR_complex128,
-        ],
+        A: (
+            _cpp.la.MatrixCSR_float32
+            | _cpp.la.MatrixCSR_float64
+            | _cpp.la.MatrixCSR_complex64
+            | _cpp.la.MatrixCSR_complex128
+        ),
     ):
         """A distributed sparse matrix that uses compressed sparse row
         storage.

--- a/python/dolfinx/la/petsc.py
+++ b/python/dolfinx/la/petsc.py
@@ -89,7 +89,7 @@ def create_vector_wrap(x: Vector) -> PETSc.Vec:  # type: ignore[name-defined]
 
 @functools.singledispatch
 def assign(
-    x0: typing.Union[npt.NDArray[np.inexact], Sequence[npt.NDArray[np.inexact]]],
+    x0: npt.NDArray[np.inexact] | Sequence[npt.NDArray[np.inexact]],
     x1: PETSc.Vec,  # type: ignore[name-defined]
 ):
     """Assign ``x0`` values to a PETSc vector ``x1``.
@@ -137,14 +137,13 @@ def assign(
 @assign.register
 def _(
     x0: PETSc.Vec,  # type: ignore[name-defined]
-    x1: typing.Union[npt.NDArray[np.inexact], Sequence[npt.NDArray[np.inexact]]],
+    x1: npt.NDArray[np.inexact] | Sequence[npt.NDArray[np.inexact]],
 ):
     """Assign PETSc vector ``x0`` values to (blocked) array(s) ``x1``.
 
     This function performs the reverse of the assignment performed by
-    the version of :func:`.assign(x0:
-    typing.Union[npt.NDArray[np.inexact],
-    list[npt.NDArray[np.inexact]]], x1: PETSc.Vec)`.
+    the version of :func:`.assign(x0: (npt.NDArray[np.inexact] |
+    list[npt.NDArray[np.inexact]]), x1: PETSc.Vec)`.
 
     Args:
         x0: Vector that will have its values assigned to ``x1``.

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -217,11 +217,9 @@ class Topology:
 class Geometry:
     """The geometry of a :class:`dolfinx.mesh.Mesh`"""
 
-    _cpp_object: typing.Union[_cpp.mesh.Geometry_float32, _cpp.mesh.Geometry_float64]
+    _cpp_object: _cpp.mesh.Geometry_float32 | _cpp.mesh.Geometry_float64
 
-    def __init__(
-        self, geometry: typing.Union[_cpp.mesh.Geometry_float32, _cpp.mesh.Geometry_float64]
-    ):
+    def __init__(self, geometry: _cpp.mesh.Geometry_float32 | _cpp.mesh.Geometry_float64):
         """Initialize a geometry from a C++ geometry.
 
         Args:
@@ -262,7 +260,7 @@ class Geometry:
         return self._cpp_object.input_global_indices
 
     @property
-    def x(self) -> typing.Union[npt.NDArray[np.float32], npt.NDArray[np.float64]]:
+    def x(self) -> npt.NDArray[np.float32] | npt.NDArray[np.float64]:
         """Geometry coordinate points,  ``shape=(num_points, 3)``."""
         return self._cpp_object.x
 
@@ -270,14 +268,14 @@ class Geometry:
 class Mesh:
     """A mesh."""
 
-    _mesh: typing.Union[_cpp.mesh.Mesh_float32, _cpp.mesh.Mesh_float64]
+    _mesh: _cpp.mesh.Mesh_float32 | _cpp.mesh.Mesh_float64
     _topology: Topology
     _geometry: Geometry
     _ufl_domain: ufl.Mesh | None
 
     def __init__(
         self,
-        msh: typing.Union[_cpp.mesh.Mesh_float32, _cpp.mesh.Mesh_float64],
+        msh: _cpp.mesh.Mesh_float32 | _cpp.mesh.Mesh_float64,
         domain: ufl.Mesh | None,
     ):
         """Initialize mesh from a C++ mesh.
@@ -628,9 +626,7 @@ def transfer_meshtag(
 def refine(
     msh: Mesh,
     edges: np.ndarray | None = None,
-    partitioner: typing.Union[
-        Callable, IdentityPartitionerPlaceholder
-    ] = IdentityPartitionerPlaceholder(),
+    partitioner: Callable | IdentityPartitionerPlaceholder = IdentityPartitionerPlaceholder(),
     option: RefinementOption = RefinementOption.parent_cell,
 ) -> tuple[Mesh, npt.NDArray[np.int32], npt.NDArray[np.int8]]:
     """Refine a mesh.
@@ -672,12 +668,7 @@ def refine(
 def create_mesh(
     comm: _MPI.Comm,
     cells: npt.NDArray[np.int64],
-    e: typing.Union[
-        ufl.Mesh,
-        basix.finite_element.FiniteElement,
-        basix.ufl._BasixElement,
-        _CoordinateElement,
-    ],
+    e: ufl.Mesh | basix.finite_element.FiniteElement | basix.ufl._BasixElement | _CoordinateElement,
     x: npt.NDArray[np.floating],
     partitioner: Callable | None = None,
 ) -> Mesh:
@@ -744,7 +735,7 @@ def create_mesh(
 
     x = np.asarray(x, dtype=dtype, order="C")
     cells = np.asarray(cells, dtype=np.int64, order="C")
-    msh: typing.Union[_cpp.mesh.Mesh_float32, _cpp.mesh.Mesh_float64] = _cpp.mesh.create_mesh(
+    msh: _cpp.mesh.Mesh_float32 | _cpp.mesh.Mesh_float64 = _cpp.mesh.create_mesh(
         comm, cells, cmap._cpp_object, x, partitioner
     )
 
@@ -788,7 +779,7 @@ def meshtags(
     msh: Mesh,
     dim: int,
     entities: npt.NDArray[np.int32],
-    values: typing.Union[np.ndarray, int, float],
+    values: np.ndarray | int | float,
 ) -> MeshTags:
     """Create a MeshTags object that associates data with a subset of
     mesh entities.


### PR DESCRIPTION
With 3.10 being minimal version, we can use | in favor of typing.Union, ref: https://peps.python.org/pep-0604/