### PR TITLE
Fix Windows CI for `.env`-file config variables.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Load environment variables
         run: |
           cat dolfinx-src/.github/workflows/fenicsx-refs.env >> $env:GITHUB_ENV
-      
       - name: Set up Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Correct way of adding values in Windows Powershell is described in: https://stackoverflow.com/questions/66733076/github-actions-set-environment-variable-for-windows-build-with-powershell