### PR TITLE
Improve GMSH usage in tests

### DIFF
--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -747,7 +747,7 @@ def test_gmsh_input_2d(order, cell_type, dtype):
         # Force mesh to have no triangles
         gmsh.option.setNumber("Mesh.RecombinationAlgorithm", 3)
 
-    tag = gmsh.model.occ.addSphere(0, 0, 0, 1, tag=1)
+    tag = gmsh.model.occ.addSphere(0, 0, 0, 1)
     gmsh.model.occ.synchronize()
     gmsh.model.addPhysicalGroup(2, [tag], tag=1)
 


### PR DESCRIPTION
Caught on AlmaLinux: https://github.com/FEniCS/dolfinx/actions/runs/17941604590/job/51019342972?pr=3931

Seems like some versions of GMSH requires to use physical tags.

We require that in `dolfinx.io.gmsh`, so we should use it properly in the tests as well.