### PR TITLE
Bugfix: mesh construction from mesh data on single process

### DIFF
--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -12,6 +12,7 @@
 #include <dolfinx/common/log.h>
 #include <dolfinx/common/sort.h>
 #include <dolfinx/graph/AdjacencyList.h>
+#include <iostream>
 #include <mpi.h>
 #include <numeric>
 #include <optional>
@@ -133,7 +134,8 @@ graph::AdjacencyList<std::int64_t> compute_nonlocal_dual_graph(
   std::array<std::int64_t, 2> vertex_range;
   {
     // Compute local quantities.
-    vertex_range[0] = 0;
+    vertex_range[0]
+        = facets.size() > 0 ? std::numeric_limits<std::int64_t>::max() : 0;
     vertex_range[1] = 0;
 
     for (std::size_t i = 0; i < facets.size();

--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -12,7 +12,6 @@
 #include <dolfinx/common/log.h>
 #include <dolfinx/common/sort.h>
 #include <dolfinx/graph/AdjacencyList.h>
-#include <iostream>
 #include <mpi.h>
 #include <numeric>
 #include <optional>

--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -133,30 +133,31 @@ graph::AdjacencyList<std::int64_t> compute_nonlocal_dual_graph(
   std::array<std::int64_t, 2> vertex_range;
   {
     // Compute local quantities.
-    // Note: to allow for single reduction we store -min_vertex_index,
-    // i.e. max (-min_vertex_index) = min (min_vertex_index).
-    vertex_range[0] = std::numeric_limits<std::int64_t>::min();
-    vertex_range[1] = -1;
+    vertex_range[0] = 0;
+    vertex_range[1] = 0;
 
     for (std::size_t i = 0; i < facets.size();
          i += local_max_vertices_per_facet)
     {
-      vertex_range[0] = std::max(vertex_range[0], -facets[i]);
+      vertex_range[0] = std::min(vertex_range[0], facets[i]);
       vertex_range[1] = std::max(vertex_range[1], facets[i]);
     }
 
     // Exchange.
+    // Note: to allow for single reduction we store -min_vertex_index,
+    // i.e. max -x_i = min x_i.
     std::array<std::int64_t, 3> send
         = {static_cast<std::int64_t>(local_max_vertices_per_facet),
-           vertex_range[0], vertex_range[1]};
+           -vertex_range[0], vertex_range[1]};
     std::array<std::int64_t, 3> recv;
     MPI_Allreduce(send.data(), recv.data(), 3, MPI_INT64_T, MPI_MAX, comm);
-    assert(recv[1] != std::numeric_limits<std::int64_t>::min());
-    assert(recv[2] != -1);
 
     // Unpack.
     max_vertices_per_facet = recv[0];
+    assert(max_vertices_per_facet >= 0);
     vertex_range = {-recv[1], recv[2] + 1};
+    assert(0 <= vertex_range[0]);
+    assert(vertex_range[0] <= vertex_range[1]);
   }
   spdlog::debug("Max. vertices per facet={}", max_vertices_per_facet);
   const std::int32_t buffer_shape1 = max_vertices_per_facet + 1;


### PR DESCRIPTION
Minimal reproducible example (fails on `main`):

```python
from mpi4py import MPI

import numpy as np

import basix
import ufl
from dolfinx.mesh import create_mesh

comm = MPI.COMM_WORLD


if comm.rank == 0:
    cells = np.zeros((0, 2), dtype=np.int32)
    x = np.zeros((0, 3), dtype=np.float64)
else:
    #    2
    #  / |
    # 0--1
    cells = np.array([[0, 1], [1, 2], [2, 0]], dtype=np.int32)
    x = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float64)

element = ufl.Mesh(basix.ufl.element("Lagrange", "interval", 1, shape=(3,)))
mesh = create_mesh(MPI.COMM_WORLD, cells, element, x)
```

Problem arises in the cases where the dual graph is already the global one, thus no facets are available on one process and the default assigned value breaks the parallel reduction of the size/range.