### PR TITLE
More fixes to DirichletBC.dof_indices

### DIFF
--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -255,12 +255,13 @@ class DirichletBC
 {
 private:
   /// Compute number of owned dofs indices. Will contain 'gaps' for
-  /// sub-spaces.
+  /// sub-spaces. The dofs must be unrolled.
   std::size_t num_owned(const DofMap& dofmap,
                         std::span<const std::int32_t> dofs)
   {
+    int bs = dofmap.index_map_bs();
     std::int32_t map_size = dofmap.index_map->size_local();
-    std::int32_t owned_size = map_size;
+    std::int32_t owned_size = bs * map_size;
     auto it = std::ranges::lower_bound(dofs, owned_size);
     return std::distance(dofs.begin(), it);
   }
@@ -324,8 +325,7 @@ public:
                                    std::vector<std::int32_t>>
   DirichletBC(std::shared_ptr<const Constant<T>> g, X&& dofs,
               std::shared_ptr<const FunctionSpace<U>> V)
-      : _function_space(V), _g(g), _dofs0(std::forward<X>(dofs)),
-        _owned_indices0(num_owned(*V->dofmap(), _dofs0))
+      : _function_space(V), _g(g), _dofs0(std::forward<X>(dofs))
   {
     assert(g);
     assert(V);
@@ -351,10 +351,9 @@ public:
 
     // Unroll _dofs0 if dofmap block size > 1
     if (const int bs = V->dofmap()->bs(); bs > 1)
-    {
-      _owned_indices0 *= bs;
       _dofs0 = unroll_dofs(_dofs0, bs);
-    }
+
+    _owned_indices0 = num_owned(*_function_space->dofmap(), _dofs0);
   }
 
   /// @brief Create a representation of a Dirichlet boundary condition
@@ -374,17 +373,15 @@ public:
                                    std::vector<std::int32_t>>
   DirichletBC(std::shared_ptr<const Function<T, U>> g, X&& dofs)
       : _function_space(g->function_space()), _g(g),
-        _dofs0(std::forward<X>(dofs)),
-        _owned_indices0(num_owned(*_function_space->dofmap(), _dofs0))
+        _dofs0(std::forward<X>(dofs))
   {
     assert(_function_space);
 
     // Unroll _dofs0 if dofmap block size > 1
     if (const int bs = _function_space->dofmap()->bs(); bs > 1)
-    {
-      _owned_indices0 *= bs;
       _dofs0 = unroll_dofs(_dofs0, bs);
-    }
+
+    _owned_indices0 = num_owned(*_function_space->dofmap(), _dofs0);
   }
 
   /// @brief Create a representation of a Dirichlet boundary condition


### PR DESCRIPTION
PR https://github.com/FEniCS/dolfinx/pull/3937 missed the case of subspaces -- there is a third DirichletBC constructor that does not unroll and multiply with blocksize, as the incoming dofs must be already unrolled.

I've reverted changes in `num_owned`, but compute `_owned_indices0` from unrolled dofs always, later in the constructor.