### PR TITLE
Enable XDMF file closing and reopening.

### DIFF
--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -156,6 +156,8 @@ void XDMFFile::close()
 // modification to re-create the _xml_doc object.
 void XDMFFile::reopen()
 {
+  // As we are re-opening the file, open it in "append" mode.
+  _file_mode = "a";
   open(true);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -61,81 +61,84 @@ void XDMFFile::open(bool reopen)
     _h5_id = -1;
   }
 
-  if(not reopen){
+  if (not reopen)
+  {
     if (_file_mode == "r")
-      {
-	// Load XML doc from file
-	pugi::xml_parse_result result = _xml_doc->load_file(_filename.c_str());
-	if (!result)
-	  throw std::runtime_error("Failed to load xml document from file.");
-	
-	if (_xml_doc->child("Xdmf").empty())
-	  throw std::runtime_error("Empty <Xdmf> root node.");
-	
-	if (_xml_doc->child("Xdmf").child("Domain").empty())
-	  throw std::runtime_error("Empty <Domain> node.");
-      }
+    {
+      // Load XML doc from file
+      pugi::xml_parse_result result = _xml_doc->load_file(_filename.c_str());
+      if (!result)
+        throw std::runtime_error("Failed to load xml document from file.");
+
+      if (_xml_doc->child("Xdmf").empty())
+        throw std::runtime_error("Empty <Xdmf> root node.");
+
+      if (_xml_doc->child("Xdmf").child("Domain").empty())
+        throw std::runtime_error("Empty <Domain> node.");
+    }
     else if (_file_mode == "w")
+    {
+      if (_encoding == Encoding::ASCII and dolfinx::MPI::size(_comm.comm()) > 1)
       {
-	if (_encoding == Encoding::ASCII and dolfinx::MPI::size(_comm.comm()) > 1)
-	  {
-	    throw std::runtime_error(
-				     "ASCII encoding is not supported for writing files in parallel.");
-	  }
-	
-	_xml_doc->reset();
-	
-	// Add XDMF node and version attribute
-	_xml_doc->append_child(pugi::node_doctype)
-	  .set_value("Xdmf SYSTEM \"Xdmf.dtd\" []");
-	pugi::xml_node xdmf_node = _xml_doc->append_child("Xdmf");
-	assert(xdmf_node);
-	xdmf_node.append_attribute("Version") = "3.0";
-	xdmf_node.append_attribute("xmlns:xi") = "https://www.w3.org/2001/XInclude";
-	
-	pugi::xml_node domain_node = xdmf_node.append_child("Domain");
-	if (!domain_node)
-	  throw std::runtime_error("Failed to append xml/xdmf Domain.");
+        throw std::runtime_error(
+            "ASCII encoding is not supported for writing files in parallel.");
       }
+
+      _xml_doc->reset();
+
+      // Add XDMF node and version attribute
+      _xml_doc->append_child(pugi::node_doctype)
+          .set_value("Xdmf SYSTEM \"Xdmf.dtd\" []");
+      pugi::xml_node xdmf_node = _xml_doc->append_child("Xdmf");
+      assert(xdmf_node);
+      xdmf_node.append_attribute("Version") = "3.0";
+      xdmf_node.append_attribute("xmlns:xi")
+          = "https://www.w3.org/2001/XInclude";
+
+      pugi::xml_node domain_node = xdmf_node.append_child("Domain");
+      if (!domain_node)
+        throw std::runtime_error("Failed to append xml/xdmf Domain.");
+    }
     else if (_file_mode == "a")
+    {
+      if (_encoding == Encoding::ASCII and dolfinx::MPI::size(_comm.comm()) > 1)
       {
-	if (_encoding == Encoding::ASCII and dolfinx::MPI::size(_comm.comm()) > 1)
-	  {
-	    throw std::runtime_error("ASCII encoding is not supported for appending "
-				     "to files in parallel.");
-	  }
-	
-	if (std::filesystem::exists(_filename))
-	  {
-	    // Load XML doc from file
-	    [[maybe_unused]] pugi::xml_parse_result result
-	      = _xml_doc->load_file(_filename.c_str());
-	    assert(result);
-	    
-	    if (_xml_doc->child("Xdmf").empty())
-	      throw std::runtime_error("Empty <Xdmf> root node.");
-	    
-	    if (_xml_doc->child("Xdmf").child("Domain").empty())
-	      throw std::runtime_error("Empty <Domain> node.");
-	  }
-	else
-	  {
-	    _xml_doc->reset();
-	    
-	    // Add XDMF node and version attribute
-	    _xml_doc->append_child(pugi::node_doctype)
-	      .set_value("Xdmf SYSTEM \"Xdmf.dtd\" []");
-	    pugi::xml_node xdmf_node = _xml_doc->append_child("Xdmf");
-	    assert(xdmf_node);
-	    xdmf_node.append_attribute("Version") = "3.0";
-	    xdmf_node.append_attribute("xmlns:xi")
-	      = "https://www.w3.org/2001/XInclude";
-	    
-	    pugi::xml_node domain_node = xdmf_node.append_child("Domain");
-	    if (!domain_node)
-	      throw std::runtime_error("Failed to append xml/xdmf Domain.");
-	  }
+        throw std::runtime_error(
+            "ASCII encoding is not supported for appending "
+            "to files in parallel.");
       }
+
+      if (std::filesystem::exists(_filename))
+      {
+        // Load XML doc from file
+        [[maybe_unused]] pugi::xml_parse_result result
+            = _xml_doc->load_file(_filename.c_str());
+        assert(result);
+
+        if (_xml_doc->child("Xdmf").empty())
+          throw std::runtime_error("Empty <Xdmf> root node.");
+
+        if (_xml_doc->child("Xdmf").child("Domain").empty())
+          throw std::runtime_error("Empty <Domain> node.");
+      }
+      else
+      {
+        _xml_doc->reset();
+
+        // Add XDMF node and version attribute
+        _xml_doc->append_child(pugi::node_doctype)
+            .set_value("Xdmf SYSTEM \"Xdmf.dtd\" []");
+        pugi::xml_node xdmf_node = _xml_doc->append_child("Xdmf");
+        assert(xdmf_node);
+        xdmf_node.append_attribute("Version") = "3.0";
+        xdmf_node.append_attribute("xmlns:xi")
+            = "https://www.w3.org/2001/XInclude";
+
+        pugi::xml_node domain_node = xdmf_node.append_child("Domain");
+        if (!domain_node)
+          throw std::runtime_error("Failed to append xml/xdmf Domain.");
+      }
+    }
   }
 }
 //-----------------------------------------------------------------------------
@@ -148,8 +151,8 @@ void XDMFFile::close()
 //-----------------------------------------------------------------------------
 // AJ: TODO: Currently this assumes the file has not been changed externally
 // between the close and reopen, so all that is required is the HDF5 file handle
-// to be recreated. This _should_ be a safe assumption because there is no way to
-// signal from a running program when files are closed/open, so an external
+// to be recreated. This _should_ be a safe assumption because there is no way
+// to signal from a running program when files are closed/open, so an external
 // program should have no way of know if it's safe to modify a file that has
 // been already opened by this program. However, it's worth bearing this
 // potential issue in mind. To fix this the open() function would need some

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -82,6 +82,14 @@ public:
   /// no effect.
   void close();
 
+  /// Reopen a file that has been previously closed
+  ///
+  /// As only HDF5 files actually have any actions undertaken 
+  /// on the close call, this really only applies currently to HDF5
+  /// files. Re-open the file to the same state as it was in before
+  /// it was closed.
+  void reopen();
+
   /// Save Mesh
   /// @param[in] mesh
   /// @param[in] xpath XPath where Mesh Grid will be written
@@ -199,6 +207,12 @@ public:
   MPI_Comm comm() const;
 
 private:
+
+  // Private function that holds all the functionality required to open a
+  // file. Used here so it can be called either from the constructor or
+  // from the reopen function depending on what is required.
+  void open(bool reopen = false);
+  
   // MPI communicator
   dolfinx::MPI::Comm _comm;
 

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -84,7 +84,7 @@ public:
 
   /// Reopen a file that has been previously closed
   ///
-  /// As only HDF5 files actually have any actions undertaken 
+  /// As only HDF5 files actually have any actions undertaken
   /// on the close call, this really only applies currently to HDF5
   /// files. Re-open the file to the same state as it was in before
   /// it was closed.
@@ -207,12 +207,11 @@ public:
   MPI_Comm comm() const;
 
 private:
-
   // Private function that holds all the functionality required to open a
   // file. Used here so it can be called either from the constructor or
   // from the reopen function depending on what is required.
   void open(bool reopen = false);
-  
+
   // MPI communicator
   dolfinx::MPI::Comm _comm;
 


### PR DESCRIPTION
I've a program that runs for a long time. It writes a mesh and meshtags to the XDMF file (hdf5 format) at the beginning, and then periodically writes function data. This is all fine, and works. 

However, if I try to use the file to get intermediate results at any point it fails to load in something like Paraview. I'm assuming this is because the file has not been closed, this only happens at the end of the program.

Therefore, I've proposed functionality to allow the program to close and reopen the file to allow it to leave the file in a usable state unless it's actively being updated.

It also strikes me this is useful for long running simulations that may hit wallclock limits on schedulers (although there is no guarantee that wouldn't happen during I/O updates).

There are reasons you might not want to do this as well, including the fact the way it is implemented assumes the file isn't modified externally between the close() and reopen() operations (a reasonably safe assumption, but users being users....).