### PR TITLE
Clean up demo postprocessing

### DIFF
--- a/docker/Dockerfile.end-user
+++ b/docker/Dockerfile.end-user
@@ -156,7 +156,7 @@ RUN pip install --no-cache-dir jupyter jupyterlab
 
 # pyvista dependencies from apt
 RUN apt-get -qq update && \
-    apt-get -y install libgl1-mesa-dev xvfb && \
+    apt-get -y install libgl1-mesa-dev mesa-utils  && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -175,4 +175,5 @@ COPY dolfinx/docker/complex-kernel.json /usr/local/share/jupyter/kernels/python3
 
 EXPOSE 8888/tcp
 ENV SHELL /bin/bash
+ENV PYVISTA_JUPYTER_BACKEND=trame
 ENTRYPOINT ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]

--- a/python/demo/demo_axis.py
+++ b/python/demo/demo_axis.py
@@ -19,6 +19,7 @@
 # +
 import sys
 from functools import partial
+from pathlib import Path
 
 from mpi4py import MPI
 from petsc4py import PETSc
@@ -456,6 +457,8 @@ MPI.COMM_WORLD.barrier()
 
 # Visually check of the mesh and of the subdomains using PyVista:
 
+out_folder = Path("out_axis")
+out_folder.mkdir(parents=True, exist_ok=True)
 tdim = mesh_data.mesh.topology.dim
 if have_pyvista:
     topology, cell_types, geometry = plot.vtk_mesh(mesh_data.mesh, 2)
@@ -471,8 +474,7 @@ if have_pyvista:
     if not pyvista.OFF_SCREEN:
         plotter.show()
     else:
-        pyvista.start_xvfb()
-        figure = plotter.screenshot("sphere_axis_mesh.png", window_size=[500, 500])
+        figure = plotter.screenshot(out_folder / "sphere_axis_mesh.png", window_size=[500, 500])
 
 # For the $\hat{\rho}$ and $\hat{z}$ components of the electric field,
 # we will use Nedelec elements, while for the $\hat{\phi}$ components we
@@ -786,6 +788,6 @@ if has_vtx:
     Es_dg = fem.Function(W)
     Es_expr = fem.Expression(Esh, W.element.interpolation_points)
     Es_dg.interpolate(Es_expr)
-    with VTXWriter(mesh_data.mesh.comm, "sols/Es.bp", Es_dg) as f:
+    with VTXWriter(mesh_data.mesh.comm, out_folder / "Es.bp", Es_dg) as f:
         f.write(0.0)
 # -

--- a/python/demo/demo_biharmonic.py
+++ b/python/demo/demo_biharmonic.py
@@ -116,6 +116,8 @@
 
 
 # +
+from pathlib import Path
+
 from mpi4py import MPI
 from petsc4py.PETSc import ScalarType  # type: ignore
 
@@ -236,7 +238,9 @@ assert problem.solver.getConvergedReason() > 0
 # The solution can be written to a  {py:class}`XDMFFile
 # <dolfinx.io.XDMFFile>` file visualization with ParaView or VisIt
 
-with io.XDMFFile(msh.comm, "out_biharmonic/biharmonic.xdmf", "w") as file:
+out_folder = Path("out_biharmonic")
+out_folder.mkdir(parents=True, exist_ok=True)
+with io.XDMFFile(msh.comm, out_folder / "biharmonic.xdmf", "w") as file:
     V1 = fem.functionspace(msh, ("Lagrange", 1))
     u1 = fem.Function(V1)
     u1.interpolate(uh)
@@ -258,8 +262,7 @@ try:
     warped = grid.warp_by_scalar()
     plotter.add_mesh(warped)
     if pyvista.OFF_SCREEN:
-        pyvista.start_xvfb(wait=0.1)
-        plotter.screenshot("uh_biharmonic.png")
+        plotter.screenshot(out_folder / "uh_biharmonic.png")
     else:
         plotter.show()
 except ModuleNotFoundError:

--- a/python/demo/demo_half_loaded_waveguide.py
+++ b/python/demo/demo_half_loaded_waveguide.py
@@ -40,6 +40,8 @@
 # problem:
 
 # +
+from pathlib import Path
+
 from mpi4py import MPI
 from petsc4py import PETSc
 
@@ -426,6 +428,9 @@ eh = fem.Function(V)
 
 kz_list = []
 
+out_folder = Path("out_half_loaded_waveguide")
+out_folder.mkdir(parents=True, exist_ok=True)
+
 for i, kz in vals:
     # Save eigenvector in eh
     eps.getEigenpair(i, eh.x.petsc_vec)
@@ -461,10 +466,10 @@ for i, kz in vals:
 
         if has_vtx:
             # Save solutions
-            with VTXWriter(msh.comm, f"sols/Et_{i}.bp", Et_dg) as f:
+            with VTXWriter(msh.comm, out_folder / f"/Et_{i}.bp", Et_dg) as f:
                 f.write(0.0)
 
-            with VTXWriter(msh.comm, f"sols/Ez_{i}.bp", ezh) as f:
+            with VTXWriter(msh.comm, out_folder / f"sols/Ez_{i}.bp", ezh) as f:
                 f.write(0.0)
 
         # Visualize solutions with Pyvista
@@ -482,11 +487,10 @@ for i, kz in vals:
             plotter.add_mesh(V_grid.copy(), show_edges=False)
             plotter.view_xy()
             plotter.link_views()
-            if not pyvista.OFF_SCREEN:
-                plotter.show()
+            if pyvista.OFF_SCREEN:
+                plotter.screenshot(out_folder / "Et.png", window_size=[400, 400])
             else:
-                pyvista.start_xvfb()
-                plotter.screenshot("Et.png", window_size=[400, 400])
+                plotter.show()
 
         if have_pyvista:
             V_lagr, lagr_dofs = V.sub(1).collapse()
@@ -497,9 +501,7 @@ for i, kz in vals:
             plotter.add_mesh(V_grid.copy(), show_edges=False)
             plotter.view_xy()
             plotter.link_views()
-            if not pyvista.OFF_SCREEN:
-                plotter.show()
+            if pyvista.OFF_SCREEN:
+                plotter.screenshot(out_folder / "Ez.png", window_size=[400, 400])
             else:
-                pyvista.start_xvfb()
-                plotter.screenshot("Ez.png", window_size=[400, 400])
-# -
+                plotter.show()

--- a/python/demo/demo_interpolation-io.py
+++ b/python/demo/demo_interpolation-io.py
@@ -29,6 +29,8 @@
 
 
 # +
+from pathlib import Path
+
 from mpi4py import MPI
 
 import numpy as np
@@ -75,10 +77,12 @@ u0.interpolate(u)
 # discontinuous and the $x_1$-component should appear continuous.
 # We use the {py:class}`dolfinx.io.VTXWriter` to store the data.
 
+out_folder = Path("output_nedelec")
+out_folder.mkdir(parents=True, exist_ok=True)
 if has_adios2:
     from dolfinx.io import VTXWriter
 
-    with VTXWriter(msh.comm, "output_nedelec.bp", u0, "bp4") as f:
+    with VTXWriter(msh.comm, out_folder / "output_nedelec.bp", u0) as f:
         f.write(0.0)
 else:
     print("ADIOS2 required for VTX output")
@@ -121,8 +125,7 @@ try:
     # If pyvista environment variable is set to off-screen (static)
     # plotting save png
     if pyvista.OFF_SCREEN:
-        pyvista.start_xvfb(wait=0.1)
-        pl.screenshot("uh.png")
+        pl.screenshot(out_folder / "uh.png")
     else:
         pl.show()
 except ModuleNotFoundError:

--- a/python/demo/demo_poisson.py
+++ b/python/demo/demo_poisson.py
@@ -70,6 +70,8 @@
 # The modules that will be used are imported:
 
 # +
+from pathlib import Path
+
 from mpi4py import MPI
 from petsc4py.PETSc import ScalarType  # type: ignore
 
@@ -168,7 +170,9 @@ assert isinstance(uh, fem.Function)
 # or [VisIt](https://visit-dav.github.io/visit-website/):
 
 # +
-with io.XDMFFile(msh.comm, "out_poisson/poisson.xdmf", "w") as file:
+out_folder = Path("out_poisson")
+out_folder.mkdir(parents=True, exist_ok=True)
+with io.XDMFFile(msh.comm, out_folder / "poisson.xdmf", "w") as file:
     file.write_mesh(msh)
     file.write_function(uh)
 # -
@@ -188,8 +192,7 @@ try:
     warped = grid.warp_by_scalar()
     plotter.add_mesh(warped)
     if pyvista.OFF_SCREEN:
-        pyvista.start_xvfb(wait=0.1)
-        plotter.screenshot("uh_poisson.png")
+        plotter.screenshot(out_folder / "uh_poisson.png")
     else:
         plotter.show()
 except ModuleNotFoundError:

--- a/python/demo/demo_pyvista.py
+++ b/python/demo/demo_pyvista.py
@@ -30,6 +30,8 @@
 
 
 # +
+from pathlib import Path
+
 from mpi4py import MPI
 
 import numpy as np
@@ -39,14 +41,11 @@ import dolfinx.plot as plot
 from dolfinx.fem import Function, functionspace
 from dolfinx.mesh import CellType, compute_midpoints, create_unit_cube, create_unit_square, meshtags
 
-# If environment variable PYVISTA_OFF_SCREEN is set to true save a png
-# otherwise create interactive plot
-if pyvista.OFF_SCREEN:
-    pyvista.start_xvfb(wait=0.1)
-
 # Set some global options for all plots
 transparent = False
 figsize = 800
+out_folder = Path("out_pyvista")
+out_folder.mkdir(parents=True, exist_ok=True)
 # -
 
 # ## Plotting a finite element Function using warp by scalar
@@ -101,7 +100,7 @@ def plot_scalar():
     subplotter.add_mesh(warped, show_edges=True, scalar_bar_args=sargs)
     if pyvista.OFF_SCREEN:
         subplotter.screenshot(
-            "2D_function_warp.png",
+            out_folder / "2D_function_warp.png",
             transparent_background=transparent,
             window_size=[figsize, figsize],
         )
@@ -157,7 +156,9 @@ def plot_meshtags():
 
     if pyvista.OFF_SCREEN:
         subplotter.screenshot(
-            "2D_markers.png", transparent_background=transparent, window_size=[2 * figsize, figsize]
+            out_folder / "2D_markers.png",
+            transparent_background=transparent,
+            window_size=[2 * figsize, figsize],
         )
     else:
         subplotter.show()
@@ -226,7 +227,7 @@ def plot_higher_order():
     plotter.view_xy()
     if pyvista.OFF_SCREEN:
         plotter.screenshot(
-            f"DG_{MPI.COMM_WORLD.rank}.png",
+            out_folder / f"DG_{MPI.COMM_WORLD.rank}.png",
             transparent_background=transparent,
             window_size=[figsize, figsize],
         )
@@ -289,7 +290,7 @@ def plot_nedelec():
     # Save as png if we are using a container with no rendering
     if pyvista.OFF_SCREEN:
         plotter.screenshot(
-            "3D_wireframe_with_vectors.png",
+            out_folder / "3D_wireframe_with_vectors.png",
             transparent_background=transparent,
             window_size=[figsize, figsize],
         )
@@ -332,7 +333,7 @@ def plot_streamlines():
     plotter.view_xy()
     if pyvista.OFF_SCREEN:
         plotter.screenshot(
-            f"streamlines_{MPI.COMM_WORLD.rank}.png",
+            out_folder / f"streamlines_{MPI.COMM_WORLD.rank}.png",
             transparent_background=transparent,
             window_size=[figsize, figsize],
         )

--- a/python/demo/demo_types.py
+++ b/python/demo/demo_types.py
@@ -26,6 +26,7 @@
 
 # +
 import sys
+from pathlib import Path
 
 from mpi4py import MPI
 
@@ -45,6 +46,10 @@ from dolfinx import fem, la, mesh, plot
 comm = MPI.COMM_SELF
 # -
 
+# We create an output directory for storing results and figures
+
+out_folder = Path("out_types")
+out_folder.mkdir(parents=True, exist_ok=True)
 
 # Create a function that solves the Poisson equation using different
 # precision float and complex scalar types for the finite element
@@ -65,8 +70,7 @@ def display_scalar(u, name, filter=np.real):
         plotter.add_mesh(grid.warp_by_scalar())
         plotter.add_title(f"{name}: real" if filter is np.real else f"{name}: imag")
         if pyvista.OFF_SCREEN:
-            pyvista.start_xvfb(wait=0.1)
-            plotter.screenshot(f"u_{'real' if filter is np.real else 'imag'}.png")
+            plotter.screenshot(out_folder / f"u_{'real' if filter is np.real else 'imag'}.png")
         else:
             plotter.show()
     except ModuleNotFoundError:
@@ -87,8 +91,7 @@ def display_vector(u, name, filter=np.real):
         plotter.add_mesh(grid.warp_by_scalar(), show_edges=True)
         plotter.add_title(f"{name}: real" if filter is np.real else f"{name}: imag")
         if pyvista.OFF_SCREEN:
-            pyvista.start_xvfb(wait=0.1)
-            plotter.screenshot(f"u_{'real' if filter is np.real else 'imag'}.png")
+            plotter.screenshot(out_folder / f"u_{'real' if filter is np.real else 'imag'}.png")
         else:
             plotter.show()
     except ModuleNotFoundError:


### PR DESCRIPTION
XVFB (The virtual frame buffer) is a pain. It only works on linux, and causes all kinds of weird behavior.
With later versions of vtk (>=9.4.0) (https://docs.vtk.org/en/latest/advanced/available_python_wheels.html) they are shipped with omesa support.

Additionally, pyvista is deprecating xvfb (https://github.com/pyvista/pyvista/blob/aabfb3db2b0d4980de9e94e66272240efba4ed95/pyvista/plotting/utilities/xvfb.py#L48-L52) so we really need to move on.

In this PR I've:
1. Removed xvfb from all demos. Visualization still works with both PYVISTA_OFF_SCREEN=True or PYVISTA_OFF_SCREEN=False.
2. Create output folder for all output. We had an inconsistent usage of folders for output and placing figures/files directly in the demos folder.

Side-note:
I've also implemented this in the DOLFINx tutorial, and jupyterlab rendering still works nicely (with less config than previously).