### PR TITLE
Fix Spack CI cache issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
           spack -e py develop --no-clone --path $GITHUB_WORKSPACE/ffcx-src py-fenics-ffcx@main
           spack -e py develop --no-clone --path $GITHUB_WORKSPACE/ffcx-src fenics-ufcx@main
           spack -e py develop --no-clone --path $GITHUB_WORKSPACE/dolfinx-src fenics-dolfinx@main
+          spack -e py develop --no-clone --path $GITHUB_WORKSPACE/dolfinx-src py-fenics-dolfinx@main
 
       - name: Build library (Python)
         run: |


### PR DESCRIPTION
This ensures that all FEniCS-related Spack packages have 'provenance'. Quite why Spack cannot integrate directly with git in develop mode is not clear.