### PR TITLE
Undefined call to cell_num_entities for point meshes.

### DIFF
--- a/cpp/dolfinx/mesh/permutationcomputation.cpp
+++ b/cpp/dolfinx/mesh/permutationcomputation.cpp
@@ -293,9 +293,7 @@ mesh::compute_entity_permutations(const mesh::Topology& topology)
   const std::int32_t num_cells = topology.connectivity(tdim, 0)->num_nodes();
   // Point meshes have no facets per cell and cell_num_entities(vertex, -1) is
   // undefined
-  int facets_per_cell = 0;
-  if (tdim > 0)
-    facets_per_cell = cell_num_entities(cell_type, tdim - 1);
+  int facets_per_cell = (tdim > 0) ? cell_num_entities(cell_type, tdim - 1) : 0;
 
   std::vector<std::uint32_t> cell_permutation_info(num_cells, 0);
   std::vector<std::uint8_t> facet_permutations(num_cells * facets_per_cell);


### PR DESCRIPTION
For point/vertex meshes, creating facet permutations does not make sense.
Currently cell_num_entities(vertex,-1) results in different behavior in Release and Debug mode.

This is fix until we do a fundamental redesign of `compute_entity_permutations` (ref https://github.com/FEniCS/dolfinx/issues/1671 https://github.com/FEniCS/dolfinx/issues/3856 https://github.com/FEniCS/dolfinx/issues/1250)

I would really like this to be backported to 0.10, as it is breaking some of my packages that do 1D-0D coupling.