### PR TITLE
Add Conda 3.13 to weekly conda install check

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -22,6 +22,9 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.12"
             petsc-scalar-type: "complex"
+        exclude:
+          - os: windows-2022
+            python-version: "3.13"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     # This is necessary to ensure conda environment is activated in every step.


### PR DESCRIPTION
- **Remove deprecated macos-13 runner, add Python 3.13.**
- **Exclude Windows 3.13.**
