### PR TITLE
Adds `xfail` test for scotch partitioner

### DIFF
--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -782,6 +782,5 @@ def test_mesh_single_process_distribution(partitioner):
     for conn in ((0, 1), (1, 0)):
         mesh.topology.create_connectivity(*conn)
         adj = mesh.topology.connectivity(*conn)
-        print(adj.array)
         for i in range(adj.num_nodes):
             assert adj.links(i).size == 2


### PR DESCRIPTION
Discovered by @drew-parsons 

Scotch partitioner fails on `test_mesh_single_process_distribution` in parallel, while KaHIP and Parmetis produce the expected result. This needs further debugging. This PR ensures a passing CI.