### PR TITLE
Template SparsityPattern for MatrixCSR constructor

### DIFF
--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -23,7 +23,6 @@
 // allowing alternative implentations that can provide these essentials.
 template <typename T>
 concept SparsityImplementation = requires(T sp, int i) {
-
   { sp.graph() };
   requires std::forward_iterator<typename decltype(sp.graph().first)::iterator>;
   requires std::convertible_to<std::int32_t,


### PR DESCRIPTION
Template the `SparsityPattern` to give more flexibility when creating MatrixCSR (e.g. on GPU).