### PR TITLE
Fix order of arguments in docstring of `dolfinx.mesh.create_mesh`

### DIFF
--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -713,10 +713,10 @@ def create_mesh(
         comm: MPI communicator to define the mesh on.
         cells: Cells of the mesh. ``cells[i]`` are the 'nodes' of
             cell ``i``.
-        x: Mesh geometry ('node' coordinates), with shape
-            ``(num_nodes, gdim)``.
         e: UFL mesh. The mesh scalar type is determined by the scalar
             type of ``e``.
+        x: Mesh geometry ('node' coordinates), with shape
+            ``(num_nodes, gdim)``.
         partitioner: Function that determines the parallel distribution of
             cells across MPI ranks.
         max_facet_to_cell_links: Maximum number of cells a facet can


### PR DESCRIPTION
Make sure the order of the arguments in the docstring matches the order of the arguments to the function