### PR TITLE
Fix: CI C++ test compile time

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -219,7 +219,7 @@ jobs:
       - name: Build tests (C++, standalone)
         working-directory: cpp/test
         run: |
-          cmake -B build -S . -DCMAKE_BUILD_TYPE=Developer
+          cmake -B build -S . -DCMAKE_BUILD_TYPE=Developer -GNinja
           cmake --build build
 
       - name: Run tests (C++, serial)


### PR DESCRIPTION
The standalone tests build was not configured with `ninja`. 

Brings C++ test compile from ~2.5min down to ~1min.

Fixes https://github.com/FEniCS/dolfinx/issues/4040.