### PR TITLE
Use overlay on top of Spack upstream

### DIFF
--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -36,23 +36,33 @@ jobs:
           dnf -y install file bzip2 ca-certificates git gzip patch python3 tar \
             unzip xz zstd gcc gcc-c++ gcc-gfortran
 
-      - name: Checkout Spack
+      - name: Get Spack
         uses: actions/checkout@v6
         with:
           repository: spack/spack
+          ref: develop
           path: spack-src
 
-      - name: Get Spack packages (custom)
+      - name: Get upstream Spack packages
         uses: actions/checkout@v6
         with:
-          repository: fenics/spack-packages
-          ref: fenics-testing
+          repository: spack/spack-packages
+          ref: develop
           path: spack-packages
+      - name: Get FEniCS Spack packages
+        uses: actions/checkout@v6
+        with:
+          repository: fenics/spack-fenics
+          ref: main
+          path: spack-fenics
+
       - name: Add Spack packages repo
         run: |
           . $GITHUB_WORKSPACE/spack-src/share/spack/setup-env.sh
           spack repo add --name builtin $GITHUB_WORKSPACE/spack-packages/repos/spack_repo/builtin
+          spack repo add --name fenics $GITHUB_WORKSPACE/spack-fenics/spack_repo/fenics
           spack config get repos
+          spack repo list
 
       - name: Checkout DOLFINx
         uses: actions/checkout@v6


### PR DESCRIPTION
Tests have begun to fail using out-of-date Spack fork.

On a side note, PRs don't seem to be going through at spack-packages.
