### PR TITLE
Check fit for int_t on SuperLUDist boundary

### DIFF
--- a/cpp/vcpkg.json
+++ b/cpp/vcpkg.json
@@ -2,7 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "dependencies": [
     "boost-algorithm",
-    "boost-numeric",
     "boost-functional",
     "boost-lexical-cast",
     "boost-multiprecision",


### PR DESCRIPTION
Defensive check on max of opaque `int_t` type.
