### PR TITLE
Pin setuptools verison on macos CI (workaround petsc4py issue)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Build and install DOLFINx Python interface
         working-directory: python
         run: |
-          pip install pyamg
+          pip install pyamg pybind11>=2.8.0 setuptools_scm[toml]==8.3.0
           pip install scikit-build-core
           python -m scikit_build_core.build requires | python -c "import sys, json; print(' '.join(json.load(sys.stdin)))" | xargs pip install
           pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Developer" './[test]'


### PR DESCRIPTION
Temporary work-around until the next PETSc release. See https://gitlab.com/petsc/petsc/-/merge_requests/9016.