### PR TITLE
Attempt to fix Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -143,7 +143,7 @@ jobs:
         working-directory: dolfinx-src/python
         run: |
           pip install scikit-build-core
-          python -m pip install --no-binary mpi4py (python -m scikit_build_core.build requires | Out-String | ConvertFrom-Json)
+          python -m pip install (python -m scikit_build_core.build requires | Out-String | ConvertFrom-Json)
 
       - name: Install DOLFINx (Python)
         working-directory: dolfinx-src/python


### PR DESCRIPTION
Error is during from source build of mpi4py - says Intel MPI doesn't have right ABI (seems odd).
