### PR TITLE
add cpp stub files

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -196,18 +196,18 @@ nanobind_add_stub(
   INSTALL_TIME
   OUTPUT_PATH dolfinx
   OUTPUT
-    cpp/fem/__init__.pyi
-    cpp/fem/petsc.pyi
-    cpp/la/__init__.pyi
-    cpp/la/petsc.pyi
-    cpp/nls/__init__.pyi
-    cpp/nls/petsc.pyi
-    cpp/__init__.pyi
-    cpp/common.pyi
-    cpp/geometry.pyi
-    cpp/graph.pyi
-    cpp/io.pyi
-    cpp/log.pyi
-    cpp/mesh.pyi
-    cpp/refinement.pyi
+    dolfinx/cpp/fem/__init__.pyi
+    dolfinx/cpp/fem/petsc.pyi
+    dolfinx/cpp/la/__init__.pyi
+    dolfinx/cpp/la/petsc.pyi
+    dolfinx/cpp/nls/__init__.pyi
+    dolfinx/cpp/nls/petsc.pyi
+    dolfinx/cpp/__init__.pyi
+    dolfinx/cpp/common.pyi
+    dolfinx/cpp/geometry.pyi
+    dolfinx/cpp/graph.pyi
+    dolfinx/cpp/io.pyi
+    dolfinx/cpp/log.pyi
+    dolfinx/cpp/mesh.pyi
+    dolfinx/cpp/refinement.pyi
 )


### PR DESCRIPTION
Hi, this patch generate stub files for dolfinx.cpp module using nanobind's builtin nanobind_add_stub macro.
An extra marker file py.typed will be generated under site-packages/dolfinx/cpp/py.typed. Not sure if this is needed as we have a top-level one in site-packages/dolfinx/py.typed.