### PR TITLE
Extend derivative block to derive residuals from functionals

### DIFF
--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -702,12 +702,11 @@ def _derive_block_residual(
 ) -> Sequence[ufl.Form]:
     if du is None:
         du = ufl.TestFunctions(ufl.MixedFunctionSpace(*(u_i.function_space for u_i in u)))
-    elif (not isinstance(du, Sequence) 
-            or not len(u) == len(du) 
+    elif (not isinstance(du, Sequence)
             or not all(isinstance(du_i, ufl.Argument) and du_i.number() == 0 for du_i in du)):
             raise ValueError(
-                "When F is a functional of N functions, du must be a sequence "
-                "containing N test functions"
+                "When F is a functional of multiple functions, du must be a sequence of test "
+                "functions"
             )
     return ufl.extract_blocks(ufl.derivative(F, u, du))
 

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -793,7 +793,7 @@ def derivative_block(
         else:
             raise ValueError("u must be either a ufl.Function or a sequence of ufl.Function")
     elif isinstance(F, ufl.Form) and len(F.arguments()) == 1:
-        return _derive_univariate_jacobian(F, u, du)
+        return _derive_univariate_jacobian(F, u, du)  # type: ignore[arg-type]
     elif isinstance(F, Sequence):
         return _derive_block_jacobian(F, u, du)
     else:

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -757,22 +757,34 @@ def derivative_block(
     This is commonly used to derive a block residual from a functional, or to
     derive a block Jacobian from a block residual.
 
-    If ``F`` is a univariate rank zero form, returns the residual computed as
-    :math:`R = \\frac{\\partial F}{\\partial u}[\\delta u]`.
+    Four cases are supported:
 
-    If ``F`` is a rank one form, returns the Jacobian computed as :math:`J =
-    \\frac{\\partial F}{\\partial u}[\\delta u]`.
+    1. ``F`` is a rank-zero ``ufl.Form``, and ``u`` is a ``ufl.Function``.
+        Returns a ``ufl.Form`` representing the residual :math:`R =
+        \\frac{\\partial F}{\\partial u}[\\delta u]`. This is equivalent to
+        calling {py:func}`ufl.derivative` directly.
 
-    The two operations above are identical to calling {py:func}`ufl.derivative` directly.
+    2. ``F`` is a rank-zero `ufl.Form``, and ``u`` is a list of ``ufl.Function``.
+        Returns a list of ``ufl.Form`` representing the block residual :math:`R`,
+        with :math:`R_i = \\frac{\\partial F}{\\partial u_i}[\\delta u_i]`, where
+        :math:`\\delta u_i` is a test subfunction of the mixed space defined by
+        ``u``. This is equivalent to calling {py:func}`ufl.extract_blocks` on the
+        result from {py:func}`ufl.derivative`.
 
-    If ``F`` is a multivariate rank zero form, returns the block residual as a list with
-    :math:`R_i = \\frac{\\partial F}{\\partial u_i}[\\delta u_i]`, where 
-    :math:`\\delta u_i` is a test subfunction of the mixed space defined by u. This is
-    equivalent to calling {py:func}`ufl.extract_blocks` on the result from {py:func}`ufl.derivative`.
+    3. ``F`` is a rank-one `ufl.Form``, and ``u`` is a ``ufl.Function``.
+       Returns a ``ufl.Form`` representing the Jacobian :math:`J =
+       \\frac{\\partial F}{\\partial u}[\\delta u]`. This is equivalent to
+       calling {py:func}`ufl.derivative` directly.
 
-    If ``F`` is a list of rank one forms, returns the block Jacobian as a list of lists with
-    :math:`J_{ij} = \\frac{\\partial F_i}{u_j}[\\delta u_j]` using {py:func}`ufl.derivative`
-    called component-wise.
+    4. ``F`` is a list of rank-one `ufl.Form``, and ``u`` is a list of
+       ``ufl.Function``. Returns a list of lists representing the block Jacobian
+       :math:`J`, with :math:`J_{ij} = \\frac{\\partial F_i}{u_j}[\\delta u_j]`
+       using {py:func}`ufl.derivative` called component-wise.
+
+    Args:
+        F: UFL form(s) to be derived.
+        u: Function(s) with respect to the derivative is computed.
+        du: UFL argument(s) representing the direction of the derivative.
     """  # noqa: D301
     
     if isinstance(F, ufl.Form) and not F.arguments():

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -695,7 +695,7 @@ def _derive_univariate_residual(
     return ufl.derivative(F, u, du)
 
 
-def _derive_multivariate_residual(
+def _derive_block_residual(
     F: ufl.Form,
     u: Sequence[ufl.Form],
     du: Sequence[ufl.Argument] | None = None,
@@ -728,7 +728,7 @@ def _derive_univariate_jacobian(
     return ufl.derivative(F, u, du)
 
 
-def _derive_multivariate_jacobian(
+def _derive_block_jacobian(
     F: Sequence[ufl.Form],
     u: Sequence[ufl.Form],
     du: Sequence[ufl.Argument] | None = None,
@@ -783,13 +783,13 @@ def derivative_block(
         if isinstance(u, Function):
             return _derive_univariate_residual(F, u, du)
         elif isinstance(u, Sequence):
-            return _derive_multivariate_residual(F, u, du)
+            return _derive_block_residual(F, u, du)
         else:
             raise ValueError("u must be either a ufl.Function or a sequence of ufl.Function")
     elif isinstance(F, ufl.Form) and len(F.arguments()) == 1:
         return _derive_univariate_jacobian(F, u, du)
     elif isinstance(F, Sequence):
-        return _derive_multivariate_jacobian(F, u, du)
+        return _derive_block_jacobian(F, u, du)
     else:
         raise ValueError(
             "F must be either a UFL form (with rank zero or one), or a sequence of "

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -700,8 +700,6 @@ def _derive_block_residual(
     u: Sequence[ufl.Form],
     du: Sequence[ufl.Argument] | None = None,
 ) -> Sequence[ufl.Form]:
-    if not all(isinstance(u_i, Function) for u_i in u):
-        raise ValueError("u contains some non ufl.Function elements")
     if du is None:
         du = ufl.TestFunctions(ufl.MixedFunctionSpace(*(u_i.function_space for u_i in u)))
     elif (not isinstance(du, Sequence) 
@@ -737,8 +735,6 @@ def _derive_block_jacobian(
         raise ValueError("F contains some non rank-one ufl.Form elements")
     if not isinstance(u, Sequence):
         raise ValueError("When F is a sequence, u must be a sequence")
-    if not all(isinstance(u_i, Function) for u_i in u):
-        raise ValueError("u contains some non ufl.Function elements")
     if du is None:
         du = [ufl.TrialFunction(u_i.function_space) for u_i in u]
     elif (not isinstance(du, Sequence)

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -699,6 +699,23 @@ def derivative_block(
     \\frac{\\partial F}{\\partial u}[\\delta u]`. This is identical to
     calling ``ufl.derivative`` directly.
     """  # noqa: D301
+    
+    if isinstance(F, ufl.Form) and not F.arguments():  # if F is a functional
+        if isinstance(u, Function):
+            if du is None:
+                du = ufl.TestFunction(u.function_space)
+            elif not isinstance(du, ufl.Argument):
+                raise ValueError("When F is a functional of a single function, du must be a ufl.Argument")
+        elif all([isinstance(u_i, Function) for u_i in u]):
+            if du is None:
+                du = ufl.TestFunctions(ufl.MixedFunctionSpace(*(u_i.function_space for u_i in u)))
+            elif len(u) != len(du) or not all([isinstance(du_i, ufl.Argument) for du_i in du]):
+                raise ValueError("When F is a functional of N functions, du must be a sequence containing N ufl.Argument")
+        else:
+            raise ValueError("u must be a function or sequence of functions")
+        return ufl.extract_blocks(ufl.derivative(F, u, du))
+
+
     if isinstance(F, ufl.Form):
         if not isinstance(u, Function):
             raise ValueError("Must provide a single function when F is a UFL form")

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -730,13 +730,15 @@ def derivative_block(
             raise ValueError("Must provide a single function when F is a UFL form")
         if du is None:
             du = ufl.TrialFunction(u.function_space)
+        elif not (isinstance(du, ufl.Argument) and du.number() == 1):
+            raise ValueError("When F is a rank-one UFL form, du must be a trial function")
         return ufl.derivative(F, u, du)
     else:
         if not all([isinstance(Fi, ufl.Form) for Fi in F]):
             raise ValueError("F must be a sequence of UFL forms")
         if du is not None:
-            if len(F) != len(du)
-                raise ValueError("Number of forms and du must be equal")
+            if len(F) != len(du) or not all([isinstance(du_i, ufl.Argument) and du_i.number() == 1 for du_i in du]):
+                raise ValueError("Number of forms and du must be equal, and du must only contain trial functions")
         else:
             du = [ufl.TrialFunction(u_i.function_space) for u_i in u]
         return [[ufl.derivative(Fi, u_j, du_j) for u_j, du_j in zip(u, du)] for Fi in F]

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -706,8 +706,6 @@ def _derive_univariate_jacobian(
     u: Function,
     du: ufl.Argument | None = None,
 ) -> ufl.Form:
-    if not isinstance(u, Function):
-        raise ValueError("When F is a rank-one UFL form, u must be a ufl.Function")
     if du is None:
         du = ufl.TrialFunction(u.function_space)
     return ufl.derivative(F, u, du)

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -762,19 +762,20 @@ def derivative_block(
     This is commonly used to derive a block residual from a functional, or to
     derive a block Jacobian from a block residual.
 
-    If ``F`` is a univariate rank zero form, the residual is computed as
+    If ``F`` is a univariate rank zero form, returns the residual computed as
     :math:`R = \\frac{\\partial F}{\\partial u}[\\delta u]`.
 
-    If ``F`` is a multivariate rank zero form, the residual is a list with
-    :math:`R_i = \\frac{\\partial F}{\\partial u_i}[\\delta u_i]`, where 
-    :math:`\\delta u_i` is a test subfunction of the mixed space defined by u.
-
-    If ``F`` is a rank one form, the Jacobian is computed as :math:`J =
+    If ``F`` is a rank one form, returns the Jacobian computed as :math:`J =
     \\frac{\\partial F}{\\partial u}[\\delta u]`.
 
-    All three operations above are identical to calling {py:func}`ufl.derivative` directly.
+    The two operations above are identical to calling {py:func}`ufl.derivative` directly.
 
-    If ``F`` is a list of rank one forms, the Jacobian is a list of lists with
+    If ``F`` is a multivariate rank zero form, returns the block residual as a list with
+    :math:`R_i = \\frac{\\partial F}{\\partial u_i}[\\delta u_i]`, where 
+    :math:`\\delta u_i` is a test subfunction of the mixed space defined by u. This is
+    equivalent to calling {py:func}`ufl.extract_blocks` on the result from {py:func}`ufl.derivative`.
+
+    If ``F`` is a list of rank one forms, returns the block Jacobian as a list of lists with
     :math:`J_{ij} = \\frac{\\partial F_i}{u_j}[\\delta u_j]` using {py:func}`ufl.derivative`
     called component-wise.
     """  # noqa: D301

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -691,7 +691,7 @@ def derivative_block(
     This is commonly used to derive a block Jacobian from a block
     residual.
 
-    If ``F_i`` is a list of forms, the Jacobian is a list of lists with
+    If ``F`` is a list of rank one forms, the Jacobian is a list of lists with
     :math:`J_{ij} = \\frac{\\partial F_i}{u_j}[\\delta u_j]` using
     ``ufl.derivative`` called component-wise.
 

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -681,6 +681,76 @@ def create_form(
     return Form(f, form.ufcx_form, form.code)
 
 
+def _derive_univariate_residual(
+    F: ufl.Form,
+    u: Function,
+    du: ufl.Argument | None = None,
+) -> ufl.Form:
+    if du is None:
+        du = ufl.TestFunction(u.function_space)
+    elif not isinstance(du, ufl.Argument) or du.number() != 0:
+        raise ValueError(
+            "When F is a functional of a single function, du must be a test function"
+        )
+    return ufl.extract_blocks(ufl.derivative(F, u, du))
+
+
+def _derive_multivariate_residual(
+    F: ufl.Form,
+    u: Sequence[ufl.Form],
+    du: Sequence[ufl.Argument] | None = None,
+) -> Sequence[ufl.Form]:
+    if not all([isinstance(u_i, Function) for u_i in u]):
+        raise ValueError("u contains some non ufl.Function elements")
+    if du is None:
+        du = ufl.TestFunctions(ufl.MixedFunctionSpace(*(u_i.function_space for u_i in u)))
+    elif (not isinstance(du, Sequence) 
+            or not len(u) == len(du) 
+            or not all([isinstance(du_i, ufl.Argument) and du_i.number() == 0 for du_i in du])):
+            raise ValueError(
+                "When F is a functional of N functions, du must be a sequence "
+                "containing N test functions"
+            )
+    return ufl.extract_blocks(ufl.derivative(F, u, du))
+
+
+def _derive_univariate_jacobian(
+    F: ufl.Form,
+    u: Function,
+    du: ufl.Argument | None = None,
+) -> ufl.Form:
+    if not isinstance(u, Function):
+        raise ValueError("When F is a rank-one UFL form, u must be a ufl.Function")
+    if du is None:
+        du = ufl.TrialFunction(u.function_space)
+    elif not isinstance(du, ufl.Argument) or du.number() != 1:
+        raise ValueError("When F is a rank-one UFL form, du must be a trial function")
+    return ufl.derivative(F, u, du)
+
+
+def _derive_multivariate_jacobian(
+    F: Sequence[ufl.Form],
+    u: Sequence[ufl.Form],
+    du: Sequence[ufl.Argument] | None = None,
+) -> Sequence[Sequence[ufl.Form]]:
+    if not all([isinstance(F_i, ufl.Form) and len(F_i.arguments()) == 1  for F_i in F]):
+        raise ValueError("F contains some non rank-one ufl.Form elements")
+    if not isinstance(u, Sequence):
+        raise ValueError("When F is a sequence, u must be a sequence")
+    if not all([isinstance(u_i, Function) for u_i in u]):
+        raise ValueError("u contains some non ufl.Function elements")
+    if du is None:
+        du = [ufl.TrialFunction(u_i.function_space) for u_i in u]
+    elif (not isinstance(du, Sequence)
+            or not len(u) == len(du)
+            or not all([isinstance(du_i, ufl.Argument) and du_i.number() == 1 for du_i in du])):
+            raise ValueError(
+                "When F is a list of N rank-one forms, du must be a sequence "
+                "containing N trial functions"
+            )
+    return [[ufl.derivative(Fi, u_j, du_j) for u_j, du_j in zip(u, du)] for Fi in F]
+
+
 def derivative_block(
     F: ufl.Form | Sequence[ufl.Form],
     u: Function | Sequence[Function],
@@ -709,56 +779,17 @@ def derivative_block(
     called component-wise.
     """  # noqa: D301
     
-    if isinstance(F, ufl.Form) and not F.arguments():  # if F is a functional
+    if isinstance(F, ufl.Form) and not F.arguments():
         if isinstance(u, Function):
-            if du is None:
-                du = ufl.TestFunction(u.function_space)
-            elif not isinstance(du, ufl.Argument) or du.number() != 0:
-                raise ValueError(
-                    "When F is a functional of a single function, du must be a test function"
-                )
+            return _derive_univariate_residual(F, u, du)
         elif isinstance(u, Sequence):
-            if not all([isinstance(u_i, Function) for u_i in u]):
-                raise ValueError("u contains some non ufl.Function elements")
-            if du is None:
-                du = ufl.TestFunctions(ufl.MixedFunctionSpace(*(u_i.function_space for u_i in u)))
-            elif (not isinstance(du, Sequence) 
-                    or not len(u) == len(du) 
-                    or not all([isinstance(du_i, ufl.Argument) and du_i.number() == 0 for du_i in du])):
-                    raise ValueError(
-                        "When F is a functional of N functions, du must be a sequence "
-                        "containing N test functions"
-                    )
+            return _derive_multivariate_residual(F, u, du)
         else:
-            raise ValueError("u must be a function or sequence of functions")
-        return ufl.extract_blocks(ufl.derivative(F, u, du))
-
+            raise ValueError("u must be either a ufl.Function or a sequence of ufl.Function")
     elif isinstance(F, ufl.Form) and len(F.arguments()) == 1:
-        if not isinstance(u, Function):
-            raise ValueError("When F is a rank-one UFL form, u must be a ufl.Function")
-        if du is None:
-            du = ufl.TrialFunction(u.function_space)
-        elif not isinstance(du, ufl.Argument) or du.number() != 1:
-            raise ValueError("When F is a rank-one UFL form, du must be a trial function")
-        return ufl.derivative(F, u, du)
+        return _derive_univariate_jacobian(F, u, du)
     elif isinstance(F, Sequence):
-        if not all([isinstance(F_i, ufl.Form) and len(F_i.arguments()) == 1  for F_i in F]):
-            raise ValueError("F contains some non rank-one ufl.Form elements")
-        if not isinstance(u, Sequence):
-            raise ValueError("When F is a sequence, u must be a sequence")
-        if not all([isinstance(u_i, Function) for u_i in u]):
-            raise ValueError("u contains some non ufl.Function elements")
-        if du is None:
-            du = [ufl.TrialFunction(u_i.function_space) for u_i in u]
-        elif (not isinstance(du, Sequence)
-                or not len(u) == len(du)
-                or not all([isinstance(du_i, ufl.Argument) and du_i.number() == 1 for du_i in du])):
-                raise ValueError(
-                    "When F is a list of N rank-one forms, du must be a sequence "
-                    "containing N trial functions"
-                )
-        return [[ufl.derivative(Fi, u_j, du_j) for u_j, du_j in zip(u, du)] for Fi in F]
-    
+        return _derive_multivariate_jacobian(F, u, du)
     else:
         raise ValueError(
             "F must be either a UFL form (with rank zero or one), or a sequence of "

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -725,7 +725,7 @@ def _derive_block_jacobian(
             "When F is a list of N forms, du must be a sequence "
             "containing N functions"
         )
-    return [[ufl.derivative(Fi, u_j, du_j) for u_j, du_j in zip(u, du)] for Fi in F]
+    return [[ufl.derivative(F_i, u_j, du_j) for u_j, du_j in zip(u, du)] for F_i in F]
 
 
 def derivative_block(

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -713,13 +713,13 @@ def derivative_block(
         if isinstance(u, Function):
             if du is None:
                 du = ufl.TestFunction(u.function_space)
-            elif not isinstance(du, ufl.Argument):
-                raise ValueError("When F is a functional of a single function, du must be a ufl.Argument")
+            elif not (isinstance(du, ufl.Argument) and du.number() == 0):
+                raise ValueError("When F is a functional of a single function, du must be a test function")
         elif all([isinstance(u_i, Function) for u_i in u]):
             if du is None:
                 du = ufl.TestFunctions(ufl.MixedFunctionSpace(*(u_i.function_space for u_i in u)))
-            elif len(u) != len(du) or not all([isinstance(du_i, ufl.Argument) for du_i in du]):
-                raise ValueError("When F is a functional of N functions, du must be a sequence containing N ufl.Argument")
+            elif len(u) != len(du) or not all([isinstance(du_i, ufl.Argument) and du_i.number() == 0 for du_i in du]):
+                raise ValueError("When F is a functional of N functions, du must be a sequence containing N test functions")
         else:
             raise ValueError("u must be a function or sequence of functions")
         return ufl.extract_blocks(ufl.derivative(F, u, du))

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -686,18 +686,27 @@ def derivative_block(
     u: Function | Sequence[Function],
     du: ufl.Argument | Sequence[ufl.Argument] | None = None,
 ) -> ufl.Form | Sequence[Sequence[ufl.Form]]:
-    """Return the UFL derivative of a (list of) UFL rank one form(s).
+    """Return the UFL derivative of a UFL rank zero form, or the UFL derivative
+    of a (list of) rank one form(s).
 
-    This is commonly used to derive a block Jacobian from a block
-    residual.
+    This is commonly used to derive a block residual from a functional, or to
+    derive a block Jacobian from a block residual.
+
+    If ``F`` is a univariate rank zero form, the residual is computed as
+    :math:`R = \\frac{\\partial F}{\\partial u}[\\delta u]`.
+
+    If ``F`` is a multivariate rank zero form, the residual is a list with
+    :math:`R_i = \\frac{\\partial F}{\\partial u_i}[\\delta u_i]`, where 
+    :math:`\\delta u_i` is a test subfunction of the mixed space defined by u.
+
+    If ``F`` is a rank one form, the Jacobian is computed as :math:`J =
+    \\frac{\\partial F}{\\partial u}[\\delta u]`.
+
+    All three operations above are identical to calling ``ufl.derivative`` directly.
 
     If ``F`` is a list of rank one forms, the Jacobian is a list of lists with
-    :math:`J_{ij} = \\frac{\\partial F_i}{u_j}[\\delta u_j]` using
-    ``ufl.derivative`` called component-wise.
-
-    If ``F`` is a form, the Jacobian is computed as :math:`J =
-    \\frac{\\partial F}{\\partial u}[\\delta u]`. This is identical to
-    calling ``ufl.derivative`` directly.
+    :math:`J_{ij} = \\frac{\\partial F_i}{u_j}[\\delta u_j]` using ``ufl.derivative``
+    called component-wise.
     """  # noqa: D301
     
     if isinstance(F, ufl.Form) and not F.arguments():  # if F is a functional

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -693,7 +693,7 @@ def _derive_univariate_residual(
 
 def _derive_block_residual(
     F: ufl.Form,
-    u: Sequence[ufl.Form],
+    u: Sequence[Function],
     du: Sequence[ufl.Argument] | None = None,
 ) -> Sequence[ufl.Form]:
     if du is None:
@@ -713,7 +713,7 @@ def _derive_univariate_jacobian(
 
 def _derive_block_jacobian(
     F: Sequence[ufl.Form],
-    u: Sequence[ufl.Form],
+    u: Sequence[Function],
     du: Sequence[ufl.Argument] | None = None,
 ) -> Sequence[Sequence[ufl.Form]]:
     if not isinstance(u, Sequence):

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -692,7 +692,7 @@ def _derive_univariate_residual(
         raise ValueError(
             "When F is a functional of a single function, du must be a test function"
         )
-    return ufl.extract_blocks(ufl.derivative(F, u, du))
+    return ufl.derivative(F, u, du)
 
 
 def _derive_multivariate_residual(

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -688,10 +688,6 @@ def _derive_univariate_residual(
 ) -> ufl.Form:
     if du is None:
         du = ufl.TestFunction(u.function_space)
-    elif not isinstance(du, ufl.Argument) or du.number() != 0:
-        raise ValueError(
-            "When F is a functional of a single function, du must be a test function"
-        )
     return ufl.derivative(F, u, du)
 
 
@@ -702,12 +698,6 @@ def _derive_block_residual(
 ) -> Sequence[ufl.Form]:
     if du is None:
         du = ufl.TestFunctions(ufl.MixedFunctionSpace(*(u_i.function_space for u_i in u)))
-    elif (not isinstance(du, Sequence)
-            or not all(isinstance(du_i, ufl.Argument) and du_i.number() == 0 for du_i in du)):
-            raise ValueError(
-                "When F is a functional of multiple functions, du must be a sequence of test "
-                "functions"
-            )
     return ufl.extract_blocks(ufl.derivative(F, u, du))
 
 
@@ -720,8 +710,6 @@ def _derive_univariate_jacobian(
         raise ValueError("When F is a rank-one UFL form, u must be a ufl.Function")
     if du is None:
         du = ufl.TrialFunction(u.function_space)
-    elif not isinstance(du, ufl.Argument) or du.number() != 1:
-        raise ValueError("When F is a rank-one UFL form, du must be a trial function")
     return ufl.derivative(F, u, du)
 
 
@@ -730,19 +718,15 @@ def _derive_block_jacobian(
     u: Sequence[ufl.Form],
     du: Sequence[ufl.Argument] | None = None,
 ) -> Sequence[Sequence[ufl.Form]]:
-    if not all(isinstance(F_i, ufl.Form) and len(F_i.arguments()) == 1  for F_i in F):
-        raise ValueError("F contains some non rank-one ufl.Form elements")
     if not isinstance(u, Sequence):
         raise ValueError("When F is a sequence, u must be a sequence")
     if du is None:
         du = [ufl.TrialFunction(u_i.function_space) for u_i in u]
-    elif (not isinstance(du, Sequence)
-            or not len(u) == len(du)
-            or not all(isinstance(du_i, ufl.Argument) and du_i.number() == 1 for du_i in du)):
-            raise ValueError(
-                "When F is a list of N rank-one forms, du must be a sequence "
-                "containing N trial functions"
-            )
+    elif (not isinstance(du, Sequence) or not len(u) == len(du)):
+        raise ValueError(
+            "When F is a list of N forms, du must be a sequence "
+            "containing N functions"
+        )
     return [[ufl.derivative(Fi, u_j, du_j) for u_j, du_j in zip(u, du)] for Fi in F]
 
 

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -700,13 +700,13 @@ def _derive_multivariate_residual(
     u: Sequence[ufl.Form],
     du: Sequence[ufl.Argument] | None = None,
 ) -> Sequence[ufl.Form]:
-    if not all([isinstance(u_i, Function) for u_i in u]):
+    if not all(isinstance(u_i, Function) for u_i in u):
         raise ValueError("u contains some non ufl.Function elements")
     if du is None:
         du = ufl.TestFunctions(ufl.MixedFunctionSpace(*(u_i.function_space for u_i in u)))
     elif (not isinstance(du, Sequence) 
             or not len(u) == len(du) 
-            or not all([isinstance(du_i, ufl.Argument) and du_i.number() == 0 for du_i in du])):
+            or not all(isinstance(du_i, ufl.Argument) and du_i.number() == 0 for du_i in du)):
             raise ValueError(
                 "When F is a functional of N functions, du must be a sequence "
                 "containing N test functions"
@@ -733,17 +733,17 @@ def _derive_multivariate_jacobian(
     u: Sequence[ufl.Form],
     du: Sequence[ufl.Argument] | None = None,
 ) -> Sequence[Sequence[ufl.Form]]:
-    if not all([isinstance(F_i, ufl.Form) and len(F_i.arguments()) == 1  for F_i in F]):
+    if not all(isinstance(F_i, ufl.Form) and len(F_i.arguments()) == 1  for F_i in F):
         raise ValueError("F contains some non rank-one ufl.Form elements")
     if not isinstance(u, Sequence):
         raise ValueError("When F is a sequence, u must be a sequence")
-    if not all([isinstance(u_i, Function) for u_i in u]):
+    if not all(isinstance(u_i, Function) for u_i in u):
         raise ValueError("u contains some non ufl.Function elements")
     if du is None:
         du = [ufl.TrialFunction(u_i.function_space) for u_i in u]
     elif (not isinstance(du, Sequence)
             or not len(u) == len(du)
-            or not all([isinstance(du_i, ufl.Argument) and du_i.number() == 1 for du_i in du])):
+            or not all(isinstance(du_i, ufl.Argument) and du_i.number() == 1 for du_i in du)):
             raise ValueError(
                 "When F is a list of N rank-one forms, du must be a sequence "
                 "containing N trial functions"

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -685,7 +685,7 @@ def derivative_block(
     F: ufl.Form | Sequence[ufl.Form],
     u: Function | Sequence[Function],
     du: ufl.Argument | Sequence[ufl.Argument] | None = None,
-) -> ufl.Form | Sequence[Sequence[ufl.Form]]:
+) -> ufl.Form | Sequence[ufl.Form] | Sequence[Sequence[ufl.Form]]:
     """Return the UFL derivative of a UFL rank zero form, or the UFL derivative
     of a (list of) rank one form(s).
 

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -720,10 +720,9 @@ def _derive_block_jacobian(
         raise ValueError("When F is a sequence, u must be a sequence")
     if du is None:
         du = [ufl.TrialFunction(u_i.function_space) for u_i in u]
-    elif (not isinstance(du, Sequence) or not len(u) == len(du)):
+    elif not isinstance(du, Sequence) or not len(u) == len(du):
         raise ValueError(
-            "When F is a list of N forms, du must be a sequence "
-            "containing N functions"
+            "When F is a list of N forms, du must be a sequence containing N functions"
         )
     return [[ufl.derivative(F_i, u_j, du_j) for u_j, du_j in zip(u, du)] for F_i in F]
 

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -32,6 +32,8 @@ if typing.TYPE_CHECKING:
     from dolfinx.mesh import EntityMap as _EntityMap
     from dolfinx.mesh import Mesh, MeshTags
 
+from typing import cast
+
 
 class Form:
     """A finite element form."""
@@ -787,14 +789,20 @@ def derivative_block(
     """  # noqa: D301
     if isinstance(F, ufl.Form) and not F.arguments():
         if isinstance(u, Function):
+            du = cast(ufl.Argument | None, du)
             return _derive_univariate_residual(F, u, du)
         elif isinstance(u, Sequence):
+            du = cast(Sequence[ufl.Argument] | None, du)
             return _derive_block_residual(F, u, du)
         else:
             raise ValueError("u must be either a ufl.Function or a sequence of ufl.Function")
     elif isinstance(F, ufl.Form) and len(F.arguments()) == 1:
+        u = cast(Function, u)
+        du = cast(ufl.Argument | None, du)
         return _derive_univariate_jacobian(F, u, du)
     elif isinstance(F, Sequence):
+        u = cast(Sequence[Function], u)
+        du = cast(Sequence[ufl.Argument] | None, du)
         return _derive_block_jacobian(F, u, du)
     else:
         raise ValueError(

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2017-2026 Chris N. Richardson, Garth N. Wells,
-# Michal Habera, Jørgen S. Dokken and Jack S. Hale
+# Michal Habera, Jørgen S. Dokken, Jack S. Hale and Jose Fernandez
 #
 # This file is part of DOLFINx (https://www.fenicsproject.org)
 #

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -702,10 +702,10 @@ def derivative_block(
     If ``F`` is a rank one form, the Jacobian is computed as :math:`J =
     \\frac{\\partial F}{\\partial u}[\\delta u]`.
 
-    All three operations above are identical to calling ``ufl.derivative`` directly.
+    All three operations above are identical to calling {py:func}`ufl.derivative` directly.
 
     If ``F`` is a list of rank one forms, the Jacobian is a list of lists with
-    :math:`J_{ij} = \\frac{\\partial F_i}{u_j}[\\delta u_j]` using ``ufl.derivative``
+    :math:`J_{ij} = \\frac{\\partial F_i}{u_j}[\\delta u_j]` using {py:func}`ufl.derivative`
     called component-wise.
     """  # noqa: D301
     

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -32,8 +32,6 @@ if typing.TYPE_CHECKING:
     from dolfinx.mesh import EntityMap as _EntityMap
     from dolfinx.mesh import Mesh, MeshTags
 
-from typing import cast
-
 
 class Form:
     """A finite element form."""
@@ -789,20 +787,14 @@ def derivative_block(
     """  # noqa: D301
     if isinstance(F, ufl.Form) and not F.arguments():
         if isinstance(u, Function):
-            du = cast(ufl.Argument | None, du)
             return _derive_univariate_residual(F, u, du)
         elif isinstance(u, Sequence):
-            du = cast(Sequence[ufl.Argument] | None, du)
             return _derive_block_residual(F, u, du)
         else:
             raise ValueError("u must be either a ufl.Function or a sequence of ufl.Function")
     elif isinstance(F, ufl.Form) and len(F.arguments()) == 1:
-        u = cast(Function, u)
-        du = cast(ufl.Argument | None, du)
         return _derive_univariate_jacobian(F, u, du)
     elif isinstance(F, Sequence):
-        u = cast(Sequence[Function], u)
-        du = cast(Sequence[ufl.Argument] | None, du)
         return _derive_block_jacobian(F, u, du)
     else:
         raise ValueError(

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -713,32 +713,54 @@ def derivative_block(
         if isinstance(u, Function):
             if du is None:
                 du = ufl.TestFunction(u.function_space)
-            elif not (isinstance(du, ufl.Argument) and du.number() == 0):
-                raise ValueError("When F is a functional of a single function, du must be a test function")
-        elif all([isinstance(u_i, Function) for u_i in u]):
+            elif not isinstance(du, ufl.Argument) or du.number() != 0:
+                raise ValueError(
+                    "When F is a functional of a single function, du must be a test function"
+                )
+        elif isinstance(u, Sequence):
+            if not all([isinstance(u_i, Function) for u_i in u]):
+                raise ValueError("u contains some non ufl.Function elements")
             if du is None:
                 du = ufl.TestFunctions(ufl.MixedFunctionSpace(*(u_i.function_space for u_i in u)))
-            elif len(u) != len(du) or not all([isinstance(du_i, ufl.Argument) and du_i.number() == 0 for du_i in du]):
-                raise ValueError("When F is a functional of N functions, du must be a sequence containing N test functions")
+            elif (not isinstance(du, Sequence) 
+                    or not len(u) == len(du) 
+                    or not all([isinstance(du_i, ufl.Argument) and du_i.number() == 0 for du_i in du])):
+                    raise ValueError(
+                        "When F is a functional of N functions, du must be a sequence "
+                        "containing N test functions"
+                    )
         else:
             raise ValueError("u must be a function or sequence of functions")
         return ufl.extract_blocks(ufl.derivative(F, u, du))
 
-
-    if isinstance(F, ufl.Form):
+    elif isinstance(F, ufl.Form) and len(F.arguments()) == 1:
         if not isinstance(u, Function):
-            raise ValueError("Must provide a single function when F is a UFL form")
+            raise ValueError("When F is a rank-one UFL form, u must be a ufl.Function")
         if du is None:
             du = ufl.TrialFunction(u.function_space)
-        elif not (isinstance(du, ufl.Argument) and du.number() == 1):
+        elif not isinstance(du, ufl.Argument) or du.number() != 1:
             raise ValueError("When F is a rank-one UFL form, du must be a trial function")
         return ufl.derivative(F, u, du)
-    else:
-        if not all([isinstance(Fi, ufl.Form) for Fi in F]):
-            raise ValueError("F must be a sequence of UFL forms")
-        if du is not None:
-            if len(F) != len(du) or not all([isinstance(du_i, ufl.Argument) and du_i.number() == 1 for du_i in du]):
-                raise ValueError("Number of forms and du must be equal, and du must only contain trial functions")
-        else:
+    elif isinstance(F, Sequence):
+        if not all([isinstance(F_i, ufl.Form) and len(F_i.arguments()) == 1  for F_i in F]):
+            raise ValueError("F contains some non rank-one ufl.Form elements")
+        if not isinstance(u, Sequence):
+            raise ValueError("When F is a sequence, u must be a sequence")
+        if not all([isinstance(u_i, Function) for u_i in u]):
+            raise ValueError("u contains some non ufl.Function elements")
+        if du is None:
             du = [ufl.TrialFunction(u_i.function_space) for u_i in u]
+        elif (not isinstance(du, Sequence)
+                or not len(u) == len(du)
+                or not all([isinstance(du_i, ufl.Argument) and du_i.number() == 1 for du_i in du])):
+                raise ValueError(
+                    "When F is a list of N rank-one forms, du must be a sequence "
+                    "containing N trial functions"
+                )
         return [[ufl.derivative(Fi, u_j, du_j) for u_j, du_j in zip(u, du)] for Fi in F]
+    
+    else:
+        raise ValueError(
+            "F must be either a UFL form (with rank zero or one), or a sequence of "
+            "rank-one UFL forms."
+        )

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -732,10 +732,11 @@ def derivative_block(
             du = ufl.TrialFunction(u.function_space)
         return ufl.derivative(F, u, du)
     else:
-        assert all([isinstance(Fi, ufl.Form) for Fi in F]), "F must be a sequence of UFL forms"
-        assert len(F) == len(u), "Number of forms and functions must be equal"
+        if not all([isinstance(Fi, ufl.Form) for Fi in F]):
+            raise ValueError("F must be a sequence of UFL forms")
         if du is not None:
-            assert len(F) == len(du), "Number of forms and du must be equal"
+            if len(F) != len(du)
+                raise ValueError("Number of forms and du must be equal")
         else:
             du = [ufl.TrialFunction(u_i.function_space) for u_i in u]
         return [[ufl.derivative(Fi, u_j, du_j) for u_j, du_j in zip(u, du)] for Fi in F]

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -733,42 +733,59 @@ def derivative_block(
     u: Function | Sequence[Function],
     du: ufl.Argument | Sequence[ufl.Argument] | None = None,
 ) -> ufl.Form | Sequence[ufl.Form] | Sequence[Sequence[ufl.Form]]:
-    """Return the UFL derivative of a UFL rank zero form, or the UFL derivative
-    of a (list of) rank one form(s).
+    """Return the UFL derivative of a form or list of forms.
 
-    This is commonly used to derive a block residual from a functional, or to
-    derive a block Jacobian from a block residual.
+    This is commonly used to derive a block residual from a functional, or
+    to derive a block Jacobian from a block residual.
 
     Four cases are supported:
 
     1. ``F`` is a rank-zero ``ufl.Form``, and ``u`` is a ``ufl.Function``.
-        Returns a ``ufl.Form`` representing the residual :math:`R =
-        \\frac{\\partial F}{\\partial u}[\\delta u]`. This is equivalent to
-        calling {py:func}`ufl.derivative` directly.
+       Returns a ``ufl.Form`` representing the residual
 
-    2. ``F`` is a rank-zero `ufl.Form``, and ``u`` is a list of ``ufl.Function``.
-        Returns a list of ``ufl.Form`` representing the block residual :math:`R`,
-        with :math:`R_i = \\frac{\\partial F}{\\partial u_i}[\\delta u_i]`, where
-        :math:`\\delta u_i` is a test subfunction of the mixed space defined by
-        ``u``. This is equivalent to calling {py:func}`ufl.extract_blocks` on the
-        result from {py:func}`ufl.derivative`.
+       .. math::
 
-    3. ``F`` is a rank-one `ufl.Form``, and ``u`` is a ``ufl.Function``.
-       Returns a ``ufl.Form`` representing the Jacobian :math:`J =
-       \\frac{\\partial F}{\\partial u}[\\delta u]`. This is equivalent to
-       calling {py:func}`ufl.derivative` directly.
+           R = \\frac{\\partial F}{\\partial u}[\\delta u].
 
-    4. ``F`` is a list of rank-one `ufl.Form``, and ``u`` is a list of
-       ``ufl.Function``. Returns a list of lists representing the block Jacobian
-       :math:`J`, with :math:`J_{ij} = \\frac{\\partial F_i}{u_j}[\\delta u_j]`
-       using {py:func}`ufl.derivative` called component-wise.
+       This is equivalent to calling :func:`ufl.derivative` directly.
+
+    2. ``F`` is a rank-zero ``ufl.Form``, and ``u`` is a list of
+       ``ufl.Function``. Returns a list of ``ufl.Form`` representing the
+       block residual :math:`R`, with
+
+       .. math::
+
+           R_i = \\frac{\\partial F}{\\partial u_i}[\\delta u_i],
+
+       where :math:`\\delta u_i` is a test subfunction of the mixed
+       space defined by ``u``. This is equivalent to calling
+       :func:`ufl.extract_blocks` on the result from
+       :func:`ufl.derivative`.
+
+    3. ``F`` is a rank-one ``ufl.Form``, and ``u`` is a ``ufl.Function``.
+       Returns a ``ufl.Form`` representing the Jacobian
+
+       .. math::
+
+           J = \\frac{\\partial F}{\\partial u}[\\delta u].
+
+       This is equivalent to calling :func:`ufl.derivative` directly.
+
+    4. ``F`` is a list of rank-one ``ufl.Form``, and ``u`` is a list of
+       ``ufl.Function``. Returns a list of lists representing the block
+       Jacobian :math:`J`, with
+
+       .. math::
+
+           J_{ij} = \\frac{\\partial F_i}{\\partial u_j}[\\delta u_j]
+
+       using :func:`ufl.derivative` called component-wise.
 
     Args:
         F: UFL form(s) to be derived.
         u: Function(s) with respect to the derivative is computed.
         du: UFL argument(s) representing the direction of the derivative.
     """  # noqa: D301
-    
     if isinstance(F, ufl.Form) and not F.arguments():
         if isinstance(u, Function):
             return _derive_univariate_residual(F, u, du)

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -1239,7 +1239,9 @@ class NonlinearProblem:
         )
 
         if J is None:
-            J = derivative_block(F, u)
+            result = derivative_block(F, u)
+            assert isinstance(result, type(J))
+            J = result
 
         self._J = _create_form(
             J,

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -1239,9 +1239,7 @@ class NonlinearProblem:
         )
 
         if J is None:
-            result = derivative_block(F, u)
-            assert isinstance(result, type(J))
-            J = result
+            J = derivative_block(F, u)
 
         self._J = _create_form(
             J,

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -151,9 +151,6 @@ def test_derivative_block():
     M = f0**2 * dx  # univariate functional
 
     with pytest.raises(ValueError):
-        derivative_block(M, u0, v0)  # second argument not a ufl.Function
-
-    with pytest.raises(ValueError):
         derivative_block(M, f0, u0)  # third argument not a test function
 
     F = derivative_block(M, f0)
@@ -197,9 +194,6 @@ def test_derivative_block():
 
     with pytest.raises(ValueError):
         derivative_block(F, [f0, f1], [u0])  # third argument has wrong length
-
-    with pytest.raises(ValueError):
-        derivative_block(F, [f0, u1], [u0, u1])  # second argument contains a non ufl.Function
 
     with pytest.raises(ValueError):
         derivative_block(F, [f0, f1], u0) # third argument not a sequence

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -151,6 +151,9 @@ def test_derivative_block():
     F = f0**2 * dx  # univariate functional
 
     with pytest.raises(ValueError):
+        derivative_block(F, u0, v0)  # second argument not a ufl.Function
+
+    with pytest.raises(ValueError):
         derivative_block(F, f0, u0)  # third argument not a test function
 
     R = derivative_block(F, f0)
@@ -165,7 +168,10 @@ def test_derivative_block():
     assert isinstance(R, ufl_form) and len(R.arguments()) == 1
 
     with pytest.raises(ValueError):
-        J = derivative_block(R, f0, f1) # third argument wrongly isn't a trial function
+        derivative_block(R, u0, u0) # second argument not a ufl.Function
+
+    with pytest.raises(ValueError):
+        derivative_block(R, f0, v0) # third argument not a trial function
 
     J = derivative_block(R, f0)
     assert isinstance(J, ufl_form) and len(J.arguments()) == 2
@@ -182,6 +188,12 @@ def test_derivative_block():
     with pytest.raises(ValueError):
         derivative_block(F, [f0, f1], [u0, v1])  # third argument contains a non test function
 
+    with pytest.raises(ValueError):
+        derivative_block(F, f0, [u0, u1])  # second argument not a sequence
+
+    with pytest.raises(ValueError):
+        derivative_block(F, [f0, f1], u0)  # third argument not a sequence
+
     R = derivative_block(F, [f0, f1])
     assert all([isinstance(R_i, ufl_form) and len(R_i.arguments()) == 1 for R_i in R])
 
@@ -192,7 +204,10 @@ def test_derivative_block():
         derivative_block(R, [f0, f1], [u0])  # third argument has wrong length
 
     with pytest.raises(ValueError):
-        J = derivative_block(R, [f0, f1], [u0, f1])  # third argument contains a non-trial function
+        derivative_block(R, [f0, u1], [u0, u1])  # second argument contains a non ufl.Function
+
+    with pytest.raises(ValueError):
+        derivative_block(R, [f0, f1], u0) # third argument not a sequence
 
     J = derivative_block(R, [f0, f1])
     assert all([isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2 for J_i in J for J_ij in J_i])

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -15,9 +15,11 @@ import basix
 import basix.ufl
 import dolfinx
 from dolfinx.fem import IntegralType, extract_function_spaces, form, functionspace
-from dolfinx.fem.forms import form_cpp_class
+from dolfinx.fem.forms import form_cpp_class, derivative_block
 from dolfinx.mesh import create_unit_square
-from ufl import Measure, SpatialCoordinate, TestFunction, TrialFunction, dx, inner
+from ufl import Measure, SpatialCoordinate, TestFunction, TrialFunction, dx, inner, Form as ufl_form, TrialFunctions, TestFunctions, MixedFunctionSpace
+
+from collections.abc import Sequence
 
 
 def test_extract_forms():
@@ -132,3 +134,62 @@ def test_multiple_measures_one_subdomain_data():
     J_local = dolfinx.fem.assemble_scalar(J)
     J_global = comm.allreduce(J_local, op=MPI.SUM)
     assert np.isclose(J_global, 1 / 3 + 1 / 2)
+
+
+def test_derivative_block():
+    """Test the function derivative_block"""
+    mesh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, 10)
+    V0 = functionspace(mesh, ("Lagrange", 1))
+    V1 = functionspace(mesh, ("Lagrange", 2))
+    V = MixedFunctionSpace(V0, V1)
+
+    f0, f1 = dolfinx.fem.Function(V0), dolfinx.fem.Function(V1)
+    v0, v1 = TestFunctions(V)
+    u0, u1 = TrialFunctions(V)
+
+
+    F = f0**2 * dx  # univariate functional
+
+    with pytest.raises(ValueError):
+        derivative_block(F, f0, u0)  # third argument not a test function
+
+    R = derivative_block(F, f0)
+    assert isinstance(R, ufl_form) and len(R.arguments()) == 1
+
+    R = derivative_block(F, f0, v0)
+    assert isinstance(R, Sequence) and len(R) == 1
+    assert isinstance(R[0], ufl_form) and len(R[0].arguments()) == 1
+
+    v0_no_mixed_space = TestFunction(V0)
+    R = derivative_block(F, f0, v0_no_mixed_space)
+    assert isinstance(R, ufl_form) and len(R.arguments()) == 1
+
+    J = derivative_block(R, f0)
+    assert isinstance(J, ufl_form) and len(J.arguments()) == 2
+
+    J = derivative_block(R, f0, u0)
+    assert isinstance(J, ufl_form) and len(J.arguments()) == 2
+
+
+    F = f0**2 * f1 * dx  # multivariate functional
+
+    with pytest.raises(ValueError):
+        derivative_block(F, [f0, f1], [v0])  # third argument has wrong length
+
+    with pytest.raises(ValueError):
+        derivative_block(F, [f0, f1], [u0, v1])  # third argument contains a non test function
+
+    R = derivative_block(F, [f0, f1])
+    assert all([isinstance(R_i, ufl_form) and len(R_i.arguments()) == 1 for R_i in R])
+
+    R = derivative_block(F, [f0, f1], [v0, v1])
+    assert all([isinstance(R_i, ufl_form) and len(R_i.arguments()) == 1 for R_i in R])
+
+    with pytest.raises(AssertionError):
+        derivative_block(R, [f0, f1], [u0])  # third argument has wrong length
+
+    J = derivative_block(R, [f0, f1])
+    assert all([isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2 for J_i in J for J_ij in J_i])
+
+    J = derivative_block(R, [f0, f1], [u0, u1])
+    assert all([isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2 for J_i in J for J_ij in J_i])

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -156,9 +156,6 @@ def test_derivative_block():
     F = derivative_block(M, f0, v0)
     assert isinstance(F, ufl_form) and len(F.arguments()) == 1
 
-    with pytest.raises(ValueError):
-        derivative_block(F, u0, u0) # second argument not a ufl.Function
-
     J = derivative_block(F, f0)
     assert isinstance(J, ufl_form) and len(J.arguments()) == 2
 

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -15,9 +15,20 @@ import basix
 import basix.ufl
 import dolfinx
 from dolfinx.fem import IntegralType, extract_function_spaces, form, functionspace
-from dolfinx.fem.forms import form_cpp_class, derivative_block
+from dolfinx.fem.forms import derivative_block, form_cpp_class
 from dolfinx.mesh import create_unit_square
-from ufl import Measure, SpatialCoordinate, TestFunction, TrialFunction, dx, inner, Form as ufl_form, TrialFunctions, TestFunctions, MixedFunctionSpace
+from ufl import Form as ufl_form
+from ufl import (
+    Measure,
+    MixedFunctionSpace,
+    SpatialCoordinate,
+    TestFunction,
+    TestFunctions,
+    TrialFunction,
+    TrialFunctions,
+    dx,
+    inner,
+)
 
 
 def test_extract_forms():
@@ -135,7 +146,7 @@ def test_multiple_measures_one_subdomain_data():
 
 
 def test_derivative_block():
-    """Test the function derivative_block"""
+    """Test the function derivative_block."""
     mesh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, 10)
     V0 = functionspace(mesh, ("Lagrange", 1))
     V1 = functionspace(mesh, ("Lagrange", 2))
@@ -164,10 +175,16 @@ def test_derivative_block():
     M_block = f0**2 * f1 * dx  # multivariate functional
 
     F_block = derivative_block(M_block, [f0, f1])
-    assert all([isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1 for F_i in F_block])
+    assert all(
+        isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1
+        for F_i in F_block
+    )
 
     F_block = derivative_block(M_block, [f0, f1], [v0, v1])
-    assert all([isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1 for F_i in F_block])
+    assert all(
+        isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1
+        for F_i in F_block
+    )
 
     with pytest.raises(ValueError):
         derivative_block(F_block, f0)  # second argument not a sequence
@@ -179,7 +196,13 @@ def test_derivative_block():
         derivative_block(F_block, [f0, f1], u0) # third argument not a sequence
 
     J_block = derivative_block(F_block, [f0, f1])
-    assert all([isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2 for J_i in J_block for J_ij in J_i])
+    assert all(
+        isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2
+        for J_i in J_block for J_ij in J_i
+    )
 
     J_block = derivative_block(F_block, [f0, f1], [u0, u1])
-    assert all([isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2 for J_i in J_block for J_ij in J_i])
+    assert all(
+        isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2
+        for J_i in J_block for J_ij in J_i
+    )

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -19,8 +19,6 @@ from dolfinx.fem.forms import form_cpp_class, derivative_block
 from dolfinx.mesh import create_unit_square
 from ufl import Measure, SpatialCoordinate, TestFunction, TrialFunction, dx, inner, Form as ufl_form, TrialFunctions, TestFunctions, MixedFunctionSpace
 
-from collections.abc import Sequence
-
 
 def test_extract_forms():
     """Test extraction on unique function spaces for rows and columns of
@@ -170,6 +168,9 @@ def test_derivative_block():
 
     F_block = derivative_block(M_block, [f0, f1], [v0, v1])
     assert all([isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1 for F_i in F_block])
+
+    with pytest.raises(ValueError):
+        derivative_block(F_block, f0)  # second argument not a sequence
 
     with pytest.raises(ValueError):
         derivative_block(F_block, [f0, f1], [u0])  # third argument has wrong length

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -165,12 +165,6 @@ def test_derivative_block():
 
     M_block = f0**2 * f1 * dx  # multivariate functional
 
-    with pytest.raises(ValueError):
-        derivative_block(M_block, f0, [v0, v1])  # second argument not a sequence
-
-    with pytest.raises(ValueError):
-        derivative_block(M_block, [f0, f1], v0)  # third argument not a sequence
-
     F_block = derivative_block(M_block, [f0, f1])
     assert all([isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1 for F_i in F_block])
 

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -178,10 +178,10 @@ def test_derivative_block():
         derivative_block(M, [f0, f1], [u0, v1])  # third argument contains a non test function
 
     with pytest.raises(ValueError):
-        derivative_block(M, f0, [u0, u1])  # second argument not a sequence
+        derivative_block(M, f0, [v0, v1])  # second argument not a sequence
 
     with pytest.raises(ValueError):
-        derivative_block(M, [f0, f1], u0)  # third argument not a sequence
+        derivative_block(M, [f0, f1], v0)  # third argument not a sequence
 
     F = derivative_block(M, [f0, f1])
     assert all([isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1 for F_i in F])

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -160,11 +160,6 @@ def test_derivative_block():
     assert isinstance(R, ufl_form) and len(R.arguments()) == 1
 
     R = derivative_block(F, f0, v0)
-    assert isinstance(R, Sequence) and len(R) == 1
-    assert isinstance(R[0], ufl_form) and len(R[0].arguments()) == 1
-
-    v0_no_mixed_space = TestFunction(V0)
-    R = derivative_block(F, f0, v0_no_mixed_space)
     assert isinstance(R, ufl_form) and len(R.arguments()) == 1
 
     with pytest.raises(ValueError):

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -148,64 +148,64 @@ def test_derivative_block():
     u0, u1 = TrialFunctions(V)
 
 
-    F = f0**2 * dx  # univariate functional
+    M = f0**2 * dx  # univariate functional
 
     with pytest.raises(ValueError):
-        derivative_block(F, u0, v0)  # second argument not a ufl.Function
+        derivative_block(M, u0, v0)  # second argument not a ufl.Function
 
     with pytest.raises(ValueError):
-        derivative_block(F, f0, u0)  # third argument not a test function
+        derivative_block(M, f0, u0)  # third argument not a test function
 
-    R = derivative_block(F, f0)
-    assert isinstance(R, ufl_form) and len(R.arguments()) == 1
+    F = derivative_block(M, f0)
+    assert isinstance(F, ufl_form) and len(F.arguments()) == 1
 
-    R = derivative_block(F, f0, v0)
-    assert isinstance(R, ufl_form) and len(R.arguments()) == 1
-
-    with pytest.raises(ValueError):
-        derivative_block(R, u0, u0) # second argument not a ufl.Function
+    F = derivative_block(M, f0, v0)
+    assert isinstance(F, ufl_form) and len(F.arguments()) == 1
 
     with pytest.raises(ValueError):
-        derivative_block(R, f0, v0) # third argument not a trial function
+        derivative_block(F, u0, u0) # second argument not a ufl.Function
 
-    J = derivative_block(R, f0)
+    with pytest.raises(ValueError):
+        derivative_block(F, f0, v0) # third argument not a trial function
+
+    J = derivative_block(F, f0)
     assert isinstance(J, ufl_form) and len(J.arguments()) == 2
 
-    J = derivative_block(R, f0, u0)
+    J = derivative_block(F, f0, u0)
     assert isinstance(J, ufl_form) and len(J.arguments()) == 2
 
 
-    F = f0**2 * f1 * dx  # multivariate functional
+    M = f0**2 * f1 * dx  # multivariate functional
 
     with pytest.raises(ValueError):
-        derivative_block(F, [f0, f1], [v0])  # third argument has wrong length
+        derivative_block(M, [f0, f1], [v0])  # third argument has wrong length
 
     with pytest.raises(ValueError):
-        derivative_block(F, [f0, f1], [u0, v1])  # third argument contains a non test function
+        derivative_block(M, [f0, f1], [u0, v1])  # third argument contains a non test function
 
     with pytest.raises(ValueError):
-        derivative_block(F, f0, [u0, u1])  # second argument not a sequence
+        derivative_block(M, f0, [u0, u1])  # second argument not a sequence
 
     with pytest.raises(ValueError):
-        derivative_block(F, [f0, f1], u0)  # third argument not a sequence
+        derivative_block(M, [f0, f1], u0)  # third argument not a sequence
 
-    R = derivative_block(F, [f0, f1])
-    assert all([isinstance(R_i, ufl_form) and len(R_i.arguments()) == 1 for R_i in R])
+    F = derivative_block(M, [f0, f1])
+    assert all([isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1 for F_i in F])
 
-    R = derivative_block(F, [f0, f1], [v0, v1])
-    assert all([isinstance(R_i, ufl_form) and len(R_i.arguments()) == 1 for R_i in R])
-
-    with pytest.raises(ValueError):
-        derivative_block(R, [f0, f1], [u0])  # third argument has wrong length
+    F = derivative_block(M, [f0, f1], [v0, v1])
+    assert all([isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1 for F_i in F])
 
     with pytest.raises(ValueError):
-        derivative_block(R, [f0, u1], [u0, u1])  # second argument contains a non ufl.Function
+        derivative_block(F, [f0, f1], [u0])  # third argument has wrong length
 
     with pytest.raises(ValueError):
-        derivative_block(R, [f0, f1], u0) # third argument not a sequence
+        derivative_block(F, [f0, u1], [u0, u1])  # second argument contains a non ufl.Function
 
-    J = derivative_block(R, [f0, f1])
+    with pytest.raises(ValueError):
+        derivative_block(F, [f0, f1], u0) # third argument not a sequence
+
+    J = derivative_block(F, [f0, f1])
     assert all([isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2 for J_i in J for J_ij in J_i])
 
-    J = derivative_block(R, [f0, f1], [u0, u1])
+    J = derivative_block(F, [f0, f1], [u0, u1])
     assert all([isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2 for J_i in J for J_ij in J_i])

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -164,6 +164,9 @@ def test_derivative_block():
     R = derivative_block(F, f0, v0_no_mixed_space)
     assert isinstance(R, ufl_form) and len(R.arguments()) == 1
 
+    with pytest.raises(ValueError):
+        J = derivative_block(R, f0, f1) # third argument wrongly isn't a trial function
+
     J = derivative_block(R, f0)
     assert isinstance(J, ufl_form) and len(J.arguments()) == 2
 
@@ -187,6 +190,9 @@ def test_derivative_block():
 
     with pytest.raises(ValueError):
         derivative_block(R, [f0, f1], [u0])  # third argument has wrong length
+
+    with pytest.raises(ValueError):
+        J = derivative_block(R, [f0, f1], [u0, f1])  # third argument contains a non-trial function
 
     J = derivative_block(R, [f0, f1])
     assert all([isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2 for J_i in J for J_ij in J_i])

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -185,7 +185,7 @@ def test_derivative_block():
     R = derivative_block(F, [f0, f1], [v0, v1])
     assert all([isinstance(R_i, ufl_form) and len(R_i.arguments()) == 1 for R_i in R])
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         derivative_block(R, [f0, f1], [u0])  # third argument has wrong length
 
     J = derivative_block(R, [f0, f1])

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -175,9 +175,6 @@ def test_derivative_block():
     M = f0**2 * f1 * dx  # multivariate functional
 
     with pytest.raises(ValueError):
-        derivative_block(M, [f0, f1], [v0])  # third argument has wrong length
-
-    with pytest.raises(ValueError):
         derivative_block(M, [f0, f1], [u0, v1])  # third argument contains a non test function
 
     with pytest.raises(ValueError):

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -1,6 +1,6 @@
 """Tests for DOLFINx integration of various form operations."""
 
-# Copyright (C) 2021 Garth N. Wells
+# Copyright (C) 2021-2026 Garth N. Wells and Jose Fernandez
 #
 # This file is part of DOLFINx (https://www.fenicsproject.org)
 #

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -156,7 +156,6 @@ def test_derivative_block():
     v0, v1 = TestFunctions(V)
     u0, u1 = TrialFunctions(V)
 
-
     M = f0**2 * dx  # univariate functional
 
     F = derivative_block(M, f0)
@@ -171,20 +170,13 @@ def test_derivative_block():
     J = derivative_block(F, f0, u0)
     assert isinstance(J, ufl_form) and len(J.arguments()) == 2
 
-
     M_block = f0**2 * f1 * dx  # multivariate functional
 
     F_block = derivative_block(M_block, [f0, f1])
-    assert all(
-        isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1
-        for F_i in F_block
-    )
+    assert all(isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1 for F_i in F_block)
 
     F_block = derivative_block(M_block, [f0, f1], [v0, v1])
-    assert all(
-        isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1
-        for F_i in F_block
-    )
+    assert all(isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1 for F_i in F_block)
 
     with pytest.raises(ValueError):
         derivative_block(F_block, f0)  # second argument not a sequence
@@ -193,16 +185,14 @@ def test_derivative_block():
         derivative_block(F_block, [f0, f1], [u0])  # third argument has wrong length
 
     with pytest.raises(ValueError):
-        derivative_block(F_block, [f0, f1], u0) # third argument not a sequence
+        derivative_block(F_block, [f0, f1], u0)  # third argument not a sequence
 
     J_block = derivative_block(F_block, [f0, f1])
     assert all(
-        isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2
-        for J_i in J_block for J_ij in J_i
+        isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2 for J_i in J_block for J_ij in J_i
     )
 
     J_block = derivative_block(F_block, [f0, f1], [u0, u1])
     assert all(
-        isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2
-        for J_i in J_block for J_ij in J_i
+        isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2 for J_i in J_block for J_ij in J_i
     )

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -172,31 +172,31 @@ def test_derivative_block():
     assert isinstance(J, ufl_form) and len(J.arguments()) == 2
 
 
-    M = f0**2 * f1 * dx  # multivariate functional
+    M_block = f0**2 * f1 * dx  # multivariate functional
 
     with pytest.raises(ValueError):
-        derivative_block(M, [f0, f1], [u0, v1])  # third argument contains a non test function
+        derivative_block(M_block, [f0, f1], [u0, v1])  # third argument contains a non test function
 
     with pytest.raises(ValueError):
-        derivative_block(M, f0, [v0, v1])  # second argument not a sequence
+        derivative_block(M_block, f0, [v0, v1])  # second argument not a sequence
 
     with pytest.raises(ValueError):
-        derivative_block(M, [f0, f1], v0)  # third argument not a sequence
+        derivative_block(M_block, [f0, f1], v0)  # third argument not a sequence
 
-    F = derivative_block(M, [f0, f1])
-    assert all([isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1 for F_i in F])
+    F_block = derivative_block(M_block, [f0, f1])
+    assert all([isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1 for F_i in F_block])
 
-    F = derivative_block(M, [f0, f1], [v0, v1])
-    assert all([isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1 for F_i in F])
-
-    with pytest.raises(ValueError):
-        derivative_block(F, [f0, f1], [u0])  # third argument has wrong length
+    F_block = derivative_block(M_block, [f0, f1], [v0, v1])
+    assert all([isinstance(F_i, ufl_form) and len(F_i.arguments()) == 1 for F_i in F_block])
 
     with pytest.raises(ValueError):
-        derivative_block(F, [f0, f1], u0) # third argument not a sequence
+        derivative_block(F_block, [f0, f1], [u0])  # third argument has wrong length
 
-    J = derivative_block(F, [f0, f1])
-    assert all([isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2 for J_i in J for J_ij in J_i])
+    with pytest.raises(ValueError):
+        derivative_block(F_block, [f0, f1], u0) # third argument not a sequence
 
-    J = derivative_block(F, [f0, f1], [u0, u1])
-    assert all([isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2 for J_i in J for J_ij in J_i])
+    J_block = derivative_block(F_block, [f0, f1])
+    assert all([isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2 for J_i in J_block for J_ij in J_i])
+
+    J_block = derivative_block(F_block, [f0, f1], [u0, u1])
+    assert all([isinstance(J_ij, ufl_form) and len(J_ij.arguments()) == 2 for J_i in J_block for J_ij in J_i])

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -150,9 +150,6 @@ def test_derivative_block():
 
     M = f0**2 * dx  # univariate functional
 
-    with pytest.raises(ValueError):
-        derivative_block(M, f0, u0)  # third argument not a test function
-
     F = derivative_block(M, f0)
     assert isinstance(F, ufl_form) and len(F.arguments()) == 1
 
@@ -162,9 +159,6 @@ def test_derivative_block():
     with pytest.raises(ValueError):
         derivative_block(F, u0, u0) # second argument not a ufl.Function
 
-    with pytest.raises(ValueError):
-        derivative_block(F, f0, v0) # third argument not a trial function
-
     J = derivative_block(F, f0)
     assert isinstance(J, ufl_form) and len(J.arguments()) == 2
 
@@ -173,9 +167,6 @@ def test_derivative_block():
 
 
     M_block = f0**2 * f1 * dx  # multivariate functional
-
-    with pytest.raises(ValueError):
-        derivative_block(M_block, [f0, f1], [u0, v1])  # third argument contains a non test function
 
     with pytest.raises(ValueError):
         derivative_block(M_block, f0, [v0, v1])  # second argument not a sequence


### PR DESCRIPTION
Make `fem.forms.derivative_block` work on functionals to derive residuals, as described in #3766.

The following notes could be useful for the review:
1. The new logic is in a new code paragraph, independent of the original code. Not sure if a different style is preferred
2. I have used `ValueError` exceptions as opposed to `assert`s, assuming that the checks are on user input (as opposed to checks against bugs). The original code however has some `assert`s, so I’m not sure which is their right intent
3. I have not covered the case where `F` is a list of functionals
4. The original code creates a list of trial functions independently. Perhaps it should be updated to use `ufl.TrialFunctions(ufl.MixedFunctionSpace(…))`?
5. As in the original code, I have not checked that `du` is the correct type of argument (test vs trial), but possibly this might be helpful

CLOSES: #3766 