### PR TITLE
Introduce nix: use prebuilt binary packages from nixpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,19 @@ with [various
 versions](https://packages.debian.org/search?keywords=python3-dolfinx&searchon=names&exact=1&suite=all&section=all)
 of Debian. Install with `apt-get install fenicsx`.
 
+#### Nix packages
+
+[Nix](https://nixos.org/) is a tool that takes a unique
+approach to package management and system configuration.
+
+To create a python venv with system-site dolfinxs and 
+pyvista from nixpkgs:
+
+```shell
+nix-shell -p "python3.withPackages (ps: with ps; [ fenics-dolfinx pyvista ])" \
+  --run "python -m venv --system-site-packages .venv"
+```
+
 #### Docker images
 
 To run a Docker image with the latest release of DOLFINx:


### PR DESCRIPTION
# install nix
One can try the nix way in multiple platforms:

docker:
```
docker run -it nixos/nix
```

linux distro/macos:
```
# lix(another nix implemention) installer, easy to uninstall
curl -sSf -L https://install.lix.systems/lix | sh -s -- install
```
or 
```
# official nix installer, hard to uninstall, see https://nix.dev/manual/nix/2.24/installation/uninstall
sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install) --daemon
```

# install fenics-dolfinx
Once you have nix installed in your system, try this one-line to create python-venv with dolfinx installed
```
nix-shell -p "python3.withPackages (ps: with ps; [ fenics-dolfinx pyvista ])" \
  --run "python -m venv --system-site-packages .venv"
```

One might wonder where's the mpiexec that is compatible with the prebuilt petsc library, you can manually install mpi from nixpkgs by
```
#for nix flake enabled
nix profile install mpi

#for nix flake disabled
nix-env -iA mpi
```
or adding this [shellHook](https://github.com/NixOS/nixpkgs/issues/458510) to your zshrc 