### PR TITLE
Remove `column_index_map` from SparsityPattern

### DIFF
--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -36,7 +36,6 @@ concept SparsityImplementation = requires(T sp, int i) {
   {
     sp.index_map(i)
   } -> std::same_as<std::shared_ptr<const dolfinx::common::IndexMap>>;
-  //  { sp.column_index_map() } -> std::same_as<dolfinx::common::IndexMap>;
 };
 
 namespace dolfinx::la

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -36,7 +36,7 @@ concept SparsityImplementation = requires(T sp, int i) {
   {
     sp.index_map(i)
   } -> std::same_as<std::shared_ptr<const dolfinx::common::IndexMap>>;
-  { sp.column_index_map() } -> std::same_as<dolfinx::common::IndexMap>;
+  //  { sp.column_index_map() } -> std::same_as<dolfinx::common::IndexMap>;
 };
 
 namespace dolfinx::la
@@ -591,9 +591,8 @@ private:
 template <typename U, typename V, typename W, typename X>
 template <SparsityImplementation SparsityType>
 MatrixCSR<U, V, W, X>::MatrixCSR(const SparsityType& p, BlockMode mode)
-    : _index_maps({p.index_map(0),
-                   std::make_shared<common::IndexMap>(p.column_index_map())}),
-      _block_mode(mode), _bs({p.block_size(0), p.block_size(1)}),
+    : _index_maps({p.index_map(0), p.index_map(1)}), _block_mode(mode),
+      _bs({p.block_size(0), p.block_size(1)}),
       _data(p.graph().first.size() * _bs[0] * _bs[1], 0),
       _cols(p.graph().first.begin(), p.graph().first.end()),
       _row_ptr(p.graph().second.begin(), p.graph().second.end()),

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -228,17 +228,6 @@ std::vector<std::int64_t> SparsityPattern::column_indices() const
   return global;
 }
 //-----------------------------------------------------------------------------
-// common::IndexMap SparsityPattern::column_index_map() const
-// {
-//   if (_offsets.empty())
-//     throw std::runtime_error("Sparsity pattern has not been finalised.");
-
-//   std::array range = _index_maps[1]->local_range();
-//   const std::int32_t local_size = range[1] - range[0];
-//   return common::IndexMap(_comm.comm(), local_size, _col_ghosts,
-//                           _col_ghost_owners);
-// }
-//-----------------------------------------------------------------------------
 int SparsityPattern::block_size(int dim) const { return _bs[dim]; }
 //-----------------------------------------------------------------------------
 void SparsityPattern::finalize()

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -228,16 +228,16 @@ std::vector<std::int64_t> SparsityPattern::column_indices() const
   return global;
 }
 //-----------------------------------------------------------------------------
-common::IndexMap SparsityPattern::column_index_map() const
-{
-  if (_offsets.empty())
-    throw std::runtime_error("Sparsity pattern has not been finalised.");
+// common::IndexMap SparsityPattern::column_index_map() const
+// {
+//   if (_offsets.empty())
+//     throw std::runtime_error("Sparsity pattern has not been finalised.");
 
-  std::array range = _index_maps[1]->local_range();
-  const std::int32_t local_size = range[1] - range[0];
-  return common::IndexMap(_comm.comm(), local_size, _col_ghosts,
-                          _col_ghost_owners);
-}
+//   std::array range = _index_maps[1]->local_range();
+//   const std::int32_t local_size = range[1] - range[0];
+//   return common::IndexMap(_comm.comm(), local_size, _col_ghosts,
+//                           _col_ghost_owners);
+// }
 //-----------------------------------------------------------------------------
 int SparsityPattern::block_size(int dim) const { return _bs[dim]; }
 //-----------------------------------------------------------------------------
@@ -402,6 +402,11 @@ void SparsityPattern::finalize()
   // Column count increased due to received rows from other processes
   spdlog::info("Column ghost size increased from {} to {}",
                _index_maps[1]->ghosts().size(), _col_ghosts.size());
+
+  // Update to new column index map
+  _index_maps[1] = std::make_shared<common::IndexMap>(
+      _comm.comm(), _index_maps[1]->size_local(), _col_ghosts,
+      _col_ghost_owners);
 }
 //-----------------------------------------------------------------------------
 std::int64_t SparsityPattern::num_nonzeros() const

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -93,6 +93,8 @@ public:
 
   /// @brief Index map for given dimension dimension. Returns the index
   /// map for rows and columns that will be set by the current MPI rank.
+  /// @note After finalization, the column index map is updated to account for
+  /// additional column entries from other processes.
   /// @param[in] dim Requested map, row (0) or column (1).
   /// @return The index map.
   std::shared_ptr<const common::IndexMap> index_map(int dim) const;
@@ -104,14 +106,6 @@ public:
   /// @return Global index non-zero columns on this process, including
   /// ghosts.
   std::vector<std::int64_t> column_indices() const;
-
-  /// @brief Builds the index map for columns after assembly of the
-  /// sparsity pattern
-  /// @return Map for all non-zero columns on this process, including
-  /// ghosts
-  /// @todo Should this be compted and stored when finalising the
-  /// SparsityPattern?
-  common::IndexMap column_index_map() const;
 
   /// @brief Return index map block size for dimension dim
   int block_size(int dim) const;

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -86,7 +86,6 @@ void la(nb::module_& m)
           nb::arg("comm"), nb::arg("patterns"), nb::arg("maps"), nb::arg("bs"))
       .def("index_map", &dolfinx::la::SparsityPattern::index_map,
            nb::arg("dim"))
-      .def("column_index_map", &dolfinx::la::SparsityPattern::column_index_map)
       .def("finalize", &dolfinx::la::SparsityPattern::finalize)
       .def_prop_ro("num_nonzeros", &dolfinx::la::SparsityPattern::num_nonzeros)
       .def(


### PR DESCRIPTION
Remove `column_index_map` from SparsityPattern, just use `index_map(1)` instead after finalisation.