### PR TITLE
fix: added missing thread import

### DIFF
--- a/cpp/dolfinx/geometry/gjk.h
+++ b/cpp/dolfinx/geometry/gjk.h
@@ -10,11 +10,11 @@
 #include <array>
 #include <boost/multiprecision/cpp_bin_float.hpp>
 #include <cmath>
-#include <thread>
 #include <concepts>
 #include <limits>
 #include <numeric>
 #include <span>
+#include <thread>
 #include <utility>
 #include <vector>
 

--- a/cpp/dolfinx/geometry/gjk.h
+++ b/cpp/dolfinx/geometry/gjk.h
@@ -10,6 +10,7 @@
 #include <array>
 #include <boost/multiprecision/cpp_bin_float.hpp>
 #include <cmath>
+#include <thread>
 #include <concepts>
 #include <limits>
 #include <numeric>

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <array>
+#include <thread>
 #include <cstdint>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/graph/AdjacencyList.h>

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <array>
-#include <thread>
 #include <cstdint>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/graph/AdjacencyList.h>
@@ -15,6 +14,7 @@
 #include <memory>
 #include <optional>
 #include <span>
+#include <thread>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -65,7 +65,8 @@ public:
       std::vector<std::shared_ptr<const common::IndexMap>> cell_maps,
       std::vector<std::shared_ptr<graph::AdjacencyList<std::int32_t>>> cells,
       const std::optional<std::vector<std::vector<std::int64_t>>>&
-          original_cell_index = std::nullopt,
+          original_cell_index
+      = std::nullopt,
       int num_threads = 1);
 
   /// Copy constructor

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -65,8 +65,7 @@ public:
       std::vector<std::shared_ptr<const common::IndexMap>> cell_maps,
       std::vector<std::shared_ptr<graph::AdjacencyList<std::int32_t>>> cells,
       const std::optional<std::vector<std::vector<std::int64_t>>>&
-          original_cell_index
-      = std::nullopt,
+          original_cell_index = std::nullopt,
       int num_threads = 1);
 
   /// Copy constructor


### PR DESCRIPTION
Compiling with spack on wsl with Ubuntu, gjk.h and Topology.h seem to be missing an #include <thread>. After adding the import the compilation works. In this PR the includes are added.