### PR TITLE
Add maximum marking

### DIFF
--- a/cpp/dolfinx/refinement/CMakeLists.txt
+++ b/cpp/dolfinx/refinement/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(HEADERS_refinement
   ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_refinement.h
   ${CMAKE_CURRENT_SOURCE_DIR}/interval.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/mark.h
   ${CMAKE_CURRENT_SOURCE_DIR}/plaza.h
   ${CMAKE_CURRENT_SOURCE_DIR}/refine.h
   ${CMAKE_CURRENT_SOURCE_DIR}/utils.h

--- a/cpp/dolfinx/refinement/mark.h
+++ b/cpp/dolfinx/refinement/mark.h
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 Paul T. Kühner
+//
+// This file is part of DOLFINX (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <concepts>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <mpi.h>
+#include <spdlog/spdlog.h>
+#include <vector>
+
+#include "dolfinx/common/MPI.h"
+
+namespace dolfinx::refinement
+{
+
+/// @brief Maximum marking of a marker.
+///
+/// @param[in] marker Input marker (local) - usually an error indicator per
+/// entity
+/// @param[in] theta Cut off parameter, 0 ≤ θ ≤ 1
+/// @param[in] comm Communicator over which the maximum is computed.
+/// @return Indices (local) of marker elements, which satisfy: marker_i ≥ θ
+/// max(marker).
+template <std::floating_point T>
+std::vector<std::int32_t> mark_maximum(std::span<const T> marker, T theta,
+                                       MPI_Comm comm)
+{
+  assert((0 <= theta) && (theta <= 1));
+
+  T max = marker.empty() ? std::numeric_limits<T>::min()
+                         : std::ranges::max(marker);
+  MPI_Allreduce(MPI_IN_PLACE, &max, 1, dolfinx::MPI::mpi_t<T>, MPI_MAX, comm);
+
+  auto mark = [=](auto e) { return e >= theta * max; };
+
+  std::vector<std::int32_t> indices;
+  indices.reserve(std::ranges::count_if(marker, mark));
+
+  for (std::int32_t i = 0; i < static_cast<std::int32_t>(marker.size()); ++i)
+  {
+    if (mark(marker[i]))
+      indices.push_back(i);
+  }
+
+  spdlog::info("Marking (max) {} / {} (local) entities.", indices.size(),
+               marker.size());
+
+  return indices;
+}
+
+} // namespace dolfinx::refinement

--- a/cpp/dolfinx/refinement/mark.h
+++ b/cpp/dolfinx/refinement/mark.h
@@ -33,7 +33,8 @@ template <std::floating_point T>
 std::vector<std::int32_t> mark_maximum(std::span<const T> marker, T theta,
                                        MPI_Comm comm)
 {
-  assert((0 <= theta) && (theta <= 1));
+  if ((theta < 0) || (theta > 1))
+    throw std::invalid_argument("Theta needs to fullfill 0 ≤ θ ≤ 1.");
 
   T max = marker.empty() ? std::numeric_limits<T>::min()
                          : std::ranges::max(marker);

--- a/cpp/dolfinx/refinement/mark.h
+++ b/cpp/dolfinx/refinement/mark.h
@@ -10,7 +10,6 @@
 #include <cassert>
 #include <concepts>
 #include <cstdint>
-#include <iterator>
 #include <limits>
 #include <mpi.h>
 #include <spdlog/spdlog.h>
@@ -25,7 +24,7 @@ namespace dolfinx::refinement
 ///
 /// @param[in] marker Input marker (local) - usually an error indicator per
 /// entity
-/// @param[in] theta Cut off parameter, 0 ≤ θ ≤ 1
+/// @param[in] theta Cut off parameter, 0 < θ < 1
 /// @param[in] comm Communicator over which the maximum is computed.
 /// @return Indices (local) of marker elements, which satisfy: marker_i ≥ θ
 /// max(marker).
@@ -33,15 +32,14 @@ template <std::floating_point T>
 std::vector<std::int32_t> mark_maximum(std::span<const T> marker, T theta,
                                        MPI_Comm comm)
 {
-  if ((theta < 0) || (theta > 1))
-    throw std::invalid_argument("Theta needs to fullfill 0 ≤ θ ≤ 1.");
+  if ((theta <= 0) || (theta >= 1))
+    throw std::invalid_argument("Theta needs to fullfill 0 < θ < 1.");
 
   T max = marker.empty() ? std::numeric_limits<T>::lowest()
                          : std::ranges::max(marker);
   MPI_Allreduce(MPI_IN_PLACE, &max, 1, dolfinx::MPI::mpi_t<T>, MPI_MAX, comm);
 
-  auto mark = [=](T e)
-  { return e + std::numeric_limits<T>::epsilon() * 1e2 > theta * max; };
+  auto mark = [=](T e) { return e > theta * max; };
 
   std::vector<std::int32_t> indices;
   indices.reserve(std::ranges::count_if(marker, mark));

--- a/cpp/dolfinx/refinement/mark.h
+++ b/cpp/dolfinx/refinement/mark.h
@@ -40,7 +40,8 @@ std::vector<std::int32_t> mark_maximum(std::span<const T> marker, T theta,
                          : std::ranges::max(marker);
   MPI_Allreduce(MPI_IN_PLACE, &max, 1, dolfinx::MPI::mpi_t<T>, MPI_MAX, comm);
 
-  auto mark = [=](T e) { return e >= theta * max; };
+  auto mark = [=](T e)
+  { return e + std::numeric_limits<T>::epsilon() * 1e2 > theta * max; };
 
   std::vector<std::int32_t> indices;
   indices.reserve(std::ranges::count_if(marker, mark));

--- a/cpp/dolfinx/refinement/mark.h
+++ b/cpp/dolfinx/refinement/mark.h
@@ -36,7 +36,7 @@ std::vector<std::int32_t> mark_maximum(std::span<const T> marker, T theta,
   if ((theta < 0) || (theta > 1))
     throw std::invalid_argument("Theta needs to fullfill 0 ≤ θ ≤ 1.");
 
-  T max = marker.empty() ? std::numeric_limits<T>::min()
+  T max = marker.empty() ? std::numeric_limits<T>::lowest()
                          : std::ranges::max(marker);
   MPI_Allreduce(MPI_IN_PLACE, &max, 1, dolfinx::MPI::mpi_t<T>, MPI_MAX, comm);
 

--- a/cpp/dolfinx/refinement/mark.h
+++ b/cpp/dolfinx/refinement/mark.h
@@ -40,7 +40,7 @@ std::vector<std::int32_t> mark_maximum(std::span<const T> marker, T theta,
                          : std::ranges::max(marker);
   MPI_Allreduce(MPI_IN_PLACE, &max, 1, dolfinx::MPI::mpi_t<T>, MPI_MAX, comm);
 
-  auto mark = [=](auto e) { return e >= theta * max; };
+  auto mark = [=](T e) { return e >= theta * max; };
 
   std::vector<std::int32_t> indices;
   indices.reserve(std::ranges::count_if(marker, mark));

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -97,6 +97,7 @@ add_executable(
   mesh/refinement/interval.cpp
   mesh/refinement/option.cpp
   mesh/refinement/rectangle.cpp
+  mesh/refinement/mark.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/expr.c
   ${CMAKE_CURRENT_BINARY_DIR}/poisson.c
 )

--- a/cpp/test/mesh/refinement/mark.cpp
+++ b/cpp/test/mesh/refinement/mark.cpp
@@ -8,6 +8,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/refinement/mark.h>
+#include <iostream>
 #include <mpi.h>
 #include <vector>
 
@@ -28,7 +29,7 @@ TEMPLATE_TEST_CASE("Mark maximum", "[refinement][mark][maximum]", double, float)
 
   std::vector<TestType> marker;
   marker.reserve(10);
-  for (std::size_t i = 0; i < marker.size(); i++)
+  for (std::size_t i = 0; i < 10; i++)
     marker.push_back(10 * dolfinx::MPI::rank(comm) + i);
 
   TestType theta = 0.5;

--- a/cpp/test/mesh/refinement/mark.cpp
+++ b/cpp/test/mesh/refinement/mark.cpp
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 Paul T. Kühner
+//
+// This file is part of DOLFINX (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+
+#include <algorithm>
+#include <catch2/catch_template_test_macros.hpp>
+#include <dolfinx/common/MPI.h>
+#include <dolfinx/refinement/mark.h>
+#include <mpi.h>
+#include <vector>
+
+using namespace dolfinx;
+using namespace dolfinx::refinement;
+
+TEMPLATE_TEST_CASE("Mark maximum empty", "[refinement][mark][maximum]", double,
+                   float)
+{
+  std::vector<TestType> marker;
+  auto indices = mark_maximum<TestType>(marker, .5, MPI_COMM_WORLD);
+  CHECK(indices.size() == 0);
+}
+
+TEMPLATE_TEST_CASE("Mark maximum", "[refinement][mark][maximum]", double, float)
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  std::vector<TestType> marker;
+  marker.reserve(10);
+  for (std::size_t i = 0; i < marker.size(); i++)
+    marker.push_back(10 * dolfinx::MPI::rank(comm) + i);
+
+  TestType theta = 0.5;
+  auto indices = mark_maximum<TestType>(marker, theta, MPI_COMM_WORLD);
+
+  CHECK(std::ranges::all_of(
+      indices, [&](auto e)
+      { return (0 <= e) && (e <= static_cast<std::int32_t>(marker.size())); }));
+
+  TestType max = dolfinx::MPI::size(comm) * 10 - 1;
+  auto mark = [=](auto e) { return e >= theta * max; };
+
+  CHECK(std::ranges::count_if(marker, mark)
+        == static_cast<std::int32_t>(indices.size()));
+
+  for (std::int32_t i = 0; i < static_cast<std::int32_t>(marker.size()); ++i)
+  {
+    bool expect_marked = mark(marker[i]);
+    bool marked = std::ranges::find(indices, i) != indices.end();
+    CHECK(expect_marked == marked);
+  }
+}

--- a/cpp/test/mesh/refinement/mark.cpp
+++ b/cpp/test/mesh/refinement/mark.cpp
@@ -22,14 +22,6 @@ TEMPLATE_TEST_CASE("Mark maximum empty", "[refinement][mark][maximum]", double,
   CHECK(indices.size() == 0);
 }
 
-TEMPLATE_TEST_CASE("Mark maximum ones", "[refinement][mark][maximum]", double,
-                   float)
-{
-  std::vector<TestType> marker(10, 1.0);
-  auto indices = mark_maximum<TestType>(marker, 1.0, MPI_COMM_WORLD);
-  CHECK(indices.size() == 10);
-}
-
 TEMPLATE_TEST_CASE("Mark maximum", "[refinement][mark][maximum]", double, float)
 {
   MPI_Comm comm = MPI_COMM_WORLD;
@@ -47,7 +39,7 @@ TEMPLATE_TEST_CASE("Mark maximum", "[refinement][mark][maximum]", double, float)
       { return (0 <= e) && (e <= static_cast<std::int32_t>(marker.size())); }));
 
   TestType max = dolfinx::MPI::size(comm) * 10 - 1;
-  auto mark = [=](auto e) { return e >= theta * max; };
+  auto mark = [=](auto e) { return e > theta * max; };
 
   CHECK(std::ranges::count_if(marker, mark)
         == static_cast<std::int32_t>(indices.size()));

--- a/cpp/test/mesh/refinement/mark.cpp
+++ b/cpp/test/mesh/refinement/mark.cpp
@@ -23,6 +23,14 @@ TEMPLATE_TEST_CASE("Mark maximum empty", "[refinement][mark][maximum]", double,
   CHECK(indices.size() == 0);
 }
 
+TEMPLATE_TEST_CASE("Mark maximum ones", "[refinement][mark][maximum]", double,
+                   float)
+{
+  std::vector<TestType> marker(10, 1.0);
+  auto indices = mark_maximum<TestType>(marker, 1.0, MPI_COMM_WORLD);
+  CHECK(indices.size() == 10);
+}
+
 TEMPLATE_TEST_CASE("Mark maximum", "[refinement][mark][maximum]", double, float)
 {
   MPI_Comm comm = MPI_COMM_WORLD;

--- a/cpp/test/mesh/refinement/mark.cpp
+++ b/cpp/test/mesh/refinement/mark.cpp
@@ -8,7 +8,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/refinement/mark.h>
-#include <iostream>
 #include <mpi.h>
 #include <vector>
 
@@ -41,7 +40,7 @@ TEMPLATE_TEST_CASE("Mark maximum", "[refinement][mark][maximum]", double, float)
     marker.push_back(10 * dolfinx::MPI::rank(comm) + i);
 
   TestType theta = 0.5;
-  auto indices = mark_maximum<TestType>(marker, theta, MPI_COMM_WORLD);
+  auto indices = mark_maximum<TestType>(marker, theta, comm);
 
   CHECK(std::ranges::all_of(
       indices, [&](auto e)

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -35,6 +35,7 @@ from dolfinx.cpp.mesh import (
 from dolfinx.cpp.refinement import (
     IdentityPartitionerPlaceholder,
     RefinementOption,
+    mark_maximum,
 )
 from dolfinx.cpp.refinement import (
     uniform_refine as _uniform_refine,
@@ -72,6 +73,7 @@ __all__ = [
     "exterior_facet_indices",
     "locate_entities",
     "locate_entities_boundary",
+    "mark_maximum",
     "meshtags",
     "meshtags_from_entities",
     "refine",

--- a/python/dolfinx/wrappers/dolfinx_wrappers/refinement.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/refinement.h
@@ -7,10 +7,13 @@
 
 #pragma once
 
+#include "MPICommWrapper.h"
 #include "array.h"
+#include "caster_mpi.h"
 #include "mesh.h"
 #include <concepts>
 #include <dolfinx/mesh/Mesh.h>
+#include <dolfinx/refinement/mark.h>
 #include <dolfinx/refinement/option.h>
 #include <dolfinx/refinement/refine.h>
 #include <dolfinx/refinement/uniform.h>
@@ -121,6 +124,16 @@ void declare_refinement(nanobind::module_& m)
       },
       nb::arg("mesh"), nb::arg("edges").none(), nb::arg("partitioner").none(),
       nb::arg("option"));
+
+  m.def(
+      "mark_maximum",
+      [](nb::ndarray<const T, nb::ndim<1>, nb::c_contig> marker, T theta,
+         MPICommWrapper comm)
+      {
+        return dolfinx_wrappers::as_nbarray(dolfinx::refinement::mark_maximum(
+            std::span(marker.data(), marker.size()), theta, comm.get()));
+      },
+      nb::arg("marker"), nb::arg("theta"), nb::arg("comm"));
 }
 
 } // namespace dolfinx_wrappers

--- a/python/test/unit/refinement/test_mark.py
+++ b/python/test/unit/refinement/test_mark.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2026 Paul T. Kühner
+#
+# This file is part of DOLFINx (https://www.fenicsproject.org)
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+
+from mpi4py import MPI
+
+import numpy as np
+import pytest
+
+from dolfinx import mesh
+
+
+@pytest.mark.parametrize("theta", np.linspace(0, 1, num=5, endpoint=True))
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_mark_maximum(theta: float, dtype: np.dtype) -> None:
+    msh = mesh.create_unit_square(comm := MPI.COMM_WORLD, n := 10, n, dtype=dtype)
+
+    tdim = msh.topology.dim
+    cell_count = (cell_im := msh.topology.index_map(tdim)).size_local + cell_im.num_ghosts
+    marker = np.random.default_rng(0).random(cell_count)
+
+    marked_cells = mesh.mark_maximum(marker, theta, comm)
+
+    assert np.allclose(
+        marked_cells,
+        np.argwhere(marker >= theta * comm.allreduce(np.max(marker), MPI.MAX)).flatten(),
+    )
+
+    msh.topology.create_entities(1)
+    marked_edges = mesh.compute_incident_entities(msh.topology, marked_cells, tdim, 1)
+    mesh.refine(msh, marked_edges)

--- a/python/test/unit/refinement/test_mark.py
+++ b/python/test/unit/refinement/test_mark.py
@@ -25,7 +25,7 @@ def test_mark_maximum(theta: float, dtype: np.dtype) -> None:
 
     assert np.allclose(
         marked_cells,
-        np.argwhere(marker >= theta * comm.allreduce(np.max(marker), MPI.MAX)).flatten(),
+        np.argwhere(marker > theta * comm.allreduce(np.max(marker), MPI.MAX)).flatten(),
     )
 
     msh.topology.create_entities(1)

--- a/python/test/unit/refinement/test_mark.py
+++ b/python/test/unit/refinement/test_mark.py
@@ -12,7 +12,7 @@ import pytest
 from dolfinx import mesh
 
 
-@pytest.mark.parametrize("theta", np.linspace(0, 1, num=5, endpoint=True))
+@pytest.mark.parametrize("theta", [0.2, 0.4, 0.6, 0.8])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_mark_maximum(theta: float, dtype: np.dtype) -> None:
     msh = mesh.create_unit_square(comm := MPI.COMM_WORLD, n := 10, n, dtype=dtype)


### PR DESCRIPTION
Implements a maximum marking criterion for AFEM schemes, i.e. for $\theta \in (0, 1)$ and a marker $\eta \in \mathbb{R}^N$, computes

$$
  \mathcal{I} = \left\\{ i \ | \ \eta_i > \theta \max_j \eta_j \right\\}.
$$

In particular this introduces/defines the interface for other marking routines (to follow in the future): based on a process local list of (entity-)indicators the (local) marked index set of it is computed.

<details>

<summary>
Test program to visualise results (parallel ready).
</summary>

```python
from mpi4py import MPI

import numpy as np

from dolfinx import mesh, plot
import pyvista as pv

mesh_0 = mesh.create_unit_square(comm := MPI.COMM_WORLD, n := 10, n)

cell_im = mesh_0.topology.index_map(tdim := mesh_0.topology.dim)
cell_count = cell_im.size_local + cell_im.num_ghosts

marker = np.random.random(cell_count)
marked_cells = mesh.mark_maximum(marker, theta := 0.5, comm)

mesh_0.topology.create_entities(1)
marked_edges = mesh.compute_incident_entities(mesh_0.topology, marked_cells, tdim, 1)

mesh_1, _, _ = mesh.refine(mesh_0, marked_edges)

grid_0 = pv.UnstructuredGrid(*plot.vtk_mesh(mesh_0))
grid_1 = pv.UnstructuredGrid(*plot.vtk_mesh(mesh_1))

plotter = pv.Plotter(shape=(1, 2))
plotter.subplot(0, 0)
plotter.add_mesh(grid_0, show_edges=True)
plotter.view_xy()
plotter.add_text("mesh_0", position="upper_left")

plotter.subplot(0, 1)
plotter.add_mesh(grid_1, show_edges=True)
plotter.view_xy()
plotter.add_text("mesh_1", position="upper_left")

plotter.link_views()
plotter.show()

```
</details>

Work towards https://github.com/FEniCS/dolfinx/issues/4141.