### PR TITLE
Use `cmap(i)` in `Geometry`

### DIFF
--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -287,8 +287,7 @@ public:
       const auto [X, Xshape] = _elements[i]->interpolation_points();
 
       // Get coordinate map
-      const CoordinateElement<geometry_type>& cmap
-          = _mesh->geometry().cmap(i);
+      const CoordinateElement<geometry_type>& cmap = _mesh->geometry().cmap(i);
 
       // Prepare cell geometry
       auto x_dofmap = _mesh->geometry().dofmap(i);

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -288,7 +288,7 @@ public:
 
       // Get coordinate map
       const CoordinateElement<geometry_type>& cmap
-          = _mesh->geometry().cmaps()[i];
+          = _mesh->geometry().cmap(i);
 
       // Prepare cell geometry
       auto x_dofmap = _mesh->geometry().dofmap(i);

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -58,21 +58,23 @@ std::vector<T> interpolation_coords(const fem::FiniteElement<T>& element,
                                     CellRange auto&& cells)
 {
   // Find CoordinateElement appropriate to element
-  const std::vector<CoordinateElement<T>>& cmaps = geometry.cmaps();
-  mesh::CellType cell_type = element.cell_type();
-  auto it
-      = std::find_if(cmaps.begin(), cmaps.end(), [&cell_type](const auto& cm)
-                     { return cell_type == cm.cell_shape(); });
-  if (it == cmaps.end())
+  auto cmap_index = [&geometry](mesh::CellType cell_type)
+  {
+    for (int i = 0; i < geometry.num_maps(); ++i)
+    {
+      if (geometry.cmap(i).cell_shape() == cell_type)
+        return i;
+    }
     throw std::runtime_error("Cannot find CoordinateElement for FiniteElement");
-  int index = std::distance(cmaps.begin(), it);
+  };
+  int index = cmap_index(element.cell_type());
 
   // Get geometry data and the element coordinate map
   const std::size_t gdim = geometry.dim();
   auto x_dofmap = geometry.dofmap(index);
   std::span<const T> x_g = geometry.x();
 
-  const CoordinateElement<T>& cmap = cmaps.at(index);
+  const CoordinateElement<T>& cmap = geometry.cmap(index);
   const std::size_t num_dofs_g = cmap.dim();
 
   // Get the interpolation points on the reference cells

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -60,7 +60,7 @@ std::vector<T> interpolation_coords(const fem::FiniteElement<T>& element,
   // Find CoordinateElement appropriate to element
   auto cmap_index = [&geometry](mesh::CellType cell_type)
   {
-    for (int i = 0; i < geometry.num_maps(); ++i)
+    for (std::size_t i = 0; i < geometry.num_maps(); ++i)
     {
       if (geometry.cmap(i).cell_shape() == cell_type)
         return i;

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -531,12 +531,12 @@ Form<T, U> create_form_factory(
       = [&geo = mesh->geometry()](const ufcx_integral& integral,
                                   std::size_t cell_idx)
   {
-    if (integral.coordinate_element_hash != geo.cmaps().at(cell_idx).hash())
+    if (integral.coordinate_element_hash != geo.cmap(cell_idx).hash())
     {
       throw std::runtime_error(
           "Generated integral geometry element does not match mesh geometry: "
           + std::to_string(integral.coordinate_element_hash) + ", "
-          + std::to_string(geo.cmaps().at(cell_idx).hash()));
+          + std::to_string(geo.cmap(cell_idx).hash()));
     }
   };
 

--- a/cpp/dolfinx/io/VTKHDF.h
+++ b/cpp/dolfinx/io/VTKHDF.h
@@ -102,7 +102,7 @@ void write_mesh(const std::filesystem::path& filename,
   std::vector<std::int64_t> cell_stop_pos;
   for (std::size_t i = 0; i < cell_index_maps.size(); ++i)
   {
-    num_nodes_per_cell.push_back(mesh.geometry().cmaps()[i].dim());
+    num_nodes_per_cell.push_back(mesh.geometry().cmap(i).dim());
     std::array<std::int64_t, 2> r = cell_index_maps[i]->local_range();
     cell_start_pos.push_back(r[0]);
     cell_stop_pos.push_back(r[1]);

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -154,22 +154,23 @@ public:
   ///
   /// The coordinate element `cmaps()[i]` corresponds to the
   /// degree-of-freedom map `dofmap(i)`.
-  ///
+  /// @param i The coordinate map to fetch
   /// @return The coordinate/geometry elements.
-  const std::vector<fem::CoordinateElement<value_type>>& cmaps() const
+  const fem::CoordinateElement<value_type>& cmap(std::optional<int> i
+                                                 = std::nullopt) const
   {
-    return _cmaps;
-  }
-
-  /// @brief The element that describes the geometry map.
-  ///
-  /// @return The coordinate/geometry element
-  const fem::CoordinateElement<value_type>& cmap() const
-  {
-    if (_cmaps.size() > 1)
+    if (i.has_value())
+      return _cmaps.at(*i);
+    else if (_cmaps.size() > 1)
       throw std::runtime_error("Multiple cmaps.");
     return _cmaps.front();
   }
+
+  /// @brief Number of coordinate maps and dofmaps
+  /// (which must be the same) in the
+  /// geometry, when consisting of different cells.
+  /// @return Number of dofmaps and coordinate maps.
+  std::size_t num_maps() const { return _cmaps.size(); }
 
   /// @brief Global user indices.
   const std::vector<std::int64_t>& input_global_indices() const

--- a/cpp/dolfinx/refinement/uniform.cpp
+++ b/cpp/dolfinx/refinement/uniform.cpp
@@ -78,7 +78,7 @@ refinement::uniform_refine(const mesh::Mesh<T>& mesh,
     // Get geometry for each cell type
     auto x_dofmap = mesh.geometry().dofmap(j);
     auto c_to_v = topology->connectivity({tdim, j}, {0, 0});
-    auto dof_layout = mesh.geometry().cmaps().at(j).create_dof_layout();
+    auto dof_layout = mesh.geometry().cmap(j).create_dof_layout();
     std::vector<int> entity_dofs(dof_layout.num_dofs());
     for (int k = 0; k < dof_layout.num_dofs(); ++k)
       entity_dofs[k] = dof_layout.entity_dofs(0, k).front();
@@ -295,9 +295,13 @@ refinement::uniform_refine(const mesh::Mesh<T>& mesh,
   spdlog::debug("Create new mesh");
   std::vector<std::span<const std::int64_t>> topo_span(mixed_topology.begin(),
                                                        mixed_topology.end());
+
+  std::vector<fem::CoordinateElement<T>> geometry_cmaps;
+  for (std::size_t i = 0; i < mesh.geometry().num_maps(); ++i)
+    geometry_cmaps.push_back(mesh.geometry().cmap(i));
   mesh::Mesh new_mesh = mesh::create_mesh(
-      mesh.comm(), mesh.comm(), topo_span, mesh.geometry().cmaps(), mesh.comm(),
-      new_x, {new_x.size() / 3, 3}, partitioner, 2);
+      mesh.comm(), mesh.comm(), topo_span, geometry_cmaps, mesh.comm(), new_x,
+      {new_x.size() / 3, 3}, partitioner, 2);
 
   return new_mesh;
 }

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -323,7 +323,7 @@ def distribute_entity_data(
         mesh.topology._cpp_object,
         mesh.geometry.input_global_indices,
         mesh.geometry.index_map().size_global,
-        mesh.geometry.cmap.create_dof_layout(),
+        mesh.geometry.cmap().create_dof_layout(),
         mesh.geometry.dofmap,
         entity_dim,
         entities,

--- a/python/dolfinx/io/vtkhdf.py
+++ b/python/dolfinx/io/vtkhdf.py
@@ -59,8 +59,8 @@ def read_mesh(
         # FIXME: not yet defined for mixed topology
         domain = None
     else:
-        cell_degree = mesh_cpp.geometry.cmap.degree
-        variant = mesh_cpp.geometry.cmap.variant
+        cell_degree = mesh_cpp.geometry.cmap().degree
+        variant = mesh_cpp.geometry.cmap().variant
         domain = ufl.Mesh(
             basix.ufl.element(
                 "Lagrange", cell_types[0].name, cell_degree, variant, shape=(mesh_cpp.geometry.dim,)

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -286,10 +286,9 @@ class Geometry:
         """
         self._cpp_object = geometry
 
-    @property
-    def cmap(self) -> _CoordinateElement:
-        """Element that describes the geometry map."""
-        return _CoordinateElement(self._cpp_object.cmap)
+    def cmap(self, i=None) -> _CoordinateElement:
+        """Element that describes the ith geometry map."""
+        return _CoordinateElement(self._cpp_object.cmap(i))
 
     @property
     def dim(self):
@@ -860,8 +859,8 @@ def create_submesh(
         basix.ufl.element(
             "Lagrange",
             to_string(submsh.topology.cell_type),
-            submsh.geometry.cmap.degree,
-            basix.LagrangeVariant(submsh.geometry.cmap.variant),
+            submsh.geometry.cmap().degree,
+            basix.LagrangeVariant(submsh.geometry.cmap().variant),
             shape=(submsh.geometry.dim,),
             dtype=submsh.geometry.x.dtype,
         )

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -215,7 +215,7 @@ void declare_mesh(nb::module_& m, std::string type)
       .def(
           "cmap", [](dolfinx::mesh::Geometry<T>& self, std::optional<int> i)
           { return self.cmap(i); }, "The ith coordinate map",
-        nb::arg("i").none())
+          nb::arg("i").none())
       .def_prop_ro(
           "input_global_indices",
           [](const dolfinx::mesh::Geometry<T>& self)

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -209,12 +209,12 @@ void declare_mesh(nb::module_& m, std::string type)
           nb::rv_policy::reference_internal,
           "Return coordinates of all geometry points. Each row is the "
           "coordinate of a point.")
-      .def_prop_ro(
+      .def(
           "cmap", [](dolfinx::mesh::Geometry<T>& self) { return self.cmap(); },
           "The coordinate map")
       .def(
-          "cmaps", [](dolfinx::mesh::Geometry<T>& self, int i)
-          { return self.cmaps()[i]; }, "The ith coordinate map")
+          "cmap", [](dolfinx::mesh::Geometry<T>& self, int i)
+          { return self.cmap(i); }, "The ith coordinate map")
       .def_prop_ro(
           "input_global_indices",
           [](const dolfinx::mesh::Geometry<T>& self)

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -213,8 +213,9 @@ void declare_mesh(nb::module_& m, std::string type)
           "cmap", [](dolfinx::mesh::Geometry<T>& self) { return self.cmap(); },
           "The coordinate map")
       .def(
-          "cmap", [](dolfinx::mesh::Geometry<T>& self, int i)
-          { return self.cmap(i); }, "The ith coordinate map")
+          "cmap", [](dolfinx::mesh::Geometry<T>& self, std::optional<int> i)
+          { return self.cmap(i); }, "The ith coordinate map",
+        nb::arg("i").none())
       .def_prop_ro(
           "input_global_indices",
           [](const dolfinx::mesh::Geometry<T>& self)

--- a/python/test/unit/fem/test_dof_permuting.py
+++ b/python/test/unit/fem/test_dof_permuting.py
@@ -159,7 +159,7 @@ def test_dof_positions(cell_type, space_type):
     # for each global dof number
     coord_dofs = mesh.geometry.dofmap
     x_g = mesh.geometry.x
-    cmap = mesh.geometry.cmap
+    cmap = mesh.geometry.cmap()
     tdim = mesh.topology.dim
 
     V = functionspace(mesh, space_type)

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -332,7 +332,7 @@ def test_higher_order_coordinate_map(points, celltype, order):
     X = V.element.interpolation_points
     coord_dofs = mesh.geometry.dofmap
     x_g = mesh.geometry.x
-    cmap = mesh.geometry.cmap
+    cmap = mesh.geometry.cmap()
 
     x_coord_new = np.zeros([len(points), mesh.geometry.dim])
 
@@ -412,7 +412,7 @@ def test_higher_order_tetra_coordinate_map(order):
     for node in range(points.shape[0]):
         x_coord_new[node] = x_g[x_dofs[0, node], : mesh.geometry.dim]
 
-    x = mesh.geometry.cmap.push_forward(X, x_coord_new)
+    x = mesh.geometry.cmap().push_forward(X, x_coord_new)
     assert np.allclose(x[:, 0], X[:, 0], atol=100 * np.finfo(mesh.geometry.x.dtype).eps)
     assert np.allclose(x[:, 1], 2 * X[:, 1], atol=100 * np.finfo(mesh.geometry.x.dtype).eps)
     assert np.allclose(x[:, 2], 3 * X[:, 2], atol=100 * np.finfo(mesh.geometry.x.dtype).eps)

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -328,7 +328,7 @@ def test_assembly_into_quadrature_function(dtype):
     e_exact_eval = np.zeros_like(local)
     for cell in range(num_cells):
         xg = x_g[coord_dofs[cell], :tdim]
-        x = mesh.geometry.cmap.push_forward(quadrature_points, xg)
+        x = mesh.geometry.cmap().push_forward(quadrature_points, xg)
         e_exact_eval[Q_dofs_unrolled[cell]] = e_exact(x.T).T.flatten()
     assert np.allclose(local, e_exact_eval)
 

--- a/python/test/unit/io/test_gmsh.py
+++ b/python/test/unit/io/test_gmsh.py
@@ -55,7 +55,7 @@ def test_physical_tags(marker_mode):
 
     msh, cell_tags = gmsh_tet_model(1)
     gdim = msh.geometry.dim
-    assert msh.geometry.cmap.degree == 1
+    assert msh.geometry.cmap().degree == 1
     assert msh.geometry.dim == gdim
     local_values = np.unique(cell_tags.values)
     all_values = np.unique(np.hstack(msh.comm.allgather(local_values)))

--- a/python/test/unit/io/test_vtkhdf.py
+++ b/python/test/unit/io/test_vtkhdf.py
@@ -102,8 +102,8 @@ def test_read_write_higher_order():
         mesh_in = read_mesh(MPI.COMM_WORLD, "mixed_mesh_second_order.vtkhdf", gdim=gdim)
         assert mesh_in.geometry.dim == gdim
         assert mesh_in.geometry.index_map().size_global == 12
-        cmap_0 = mesh_in.geometry._cpp_object.cmaps(0)
-        cmap_1 = mesh_in.geometry._cpp_object.cmaps(1)
+        cmap_0 = mesh_in.geometry.cmap(0)
+        cmap_1 = mesh_in.geometry.cmap(1)
         assert cmap_0.degree == 2
         assert cmap_1.degree == 2
 

--- a/python/test/unit/io/test_xdmf_function.py
+++ b/python/test/unit/io/test_xdmf_function.py
@@ -288,7 +288,7 @@ def test_higher_order_function(tempdir):
     # -- Degree 1 mesh (tet)
     msh = gmsh_tet_model(1)
     gdim = msh.geometry.dim
-    assert msh.geometry.cmap.degree == 1
+    assert msh.geometry.cmap().degree == 1
 
     # Write P1 Function
     u = Function(functionspace(msh, ("Lagrange", 1, (gdim,))))
@@ -308,7 +308,7 @@ def test_higher_order_function(tempdir):
     # -- Degree 2 mesh (tet)
     msh = gmsh_tet_model(2)
     gdim = msh.geometry.dim
-    assert msh.geometry.cmap.degree == 2
+    assert msh.geometry.cmap().degree == 2
 
     # Write P1 Function (exception expected)
     u = Function(functionspace(msh, ("Lagrange", 1, (gdim,))))
@@ -329,7 +329,7 @@ def test_higher_order_function(tempdir):
     # NOTE: XDMF/ParaView does not support TETRAHEDRON_20
     msh = gmsh_tet_model(3)
     gdim = msh.geometry.dim
-    assert msh.geometry.cmap.degree == 3
+    assert msh.geometry.cmap().degree == 3
 
     # Write P2 Function (exception expected)
     u = Function(functionspace(msh, ("Lagrange", 2, (gdim,))))
@@ -372,7 +372,7 @@ def test_higher_order_function(tempdir):
     # --  Degree 2 mesh (hex)
     msh = gmsh_hex_model(2)
     gdim = msh.geometry.dim
-    assert msh.geometry.cmap.degree == 2
+    assert msh.geometry.cmap().degree == 2
 
     # Write Q1 Function (exception expected)
     u = Function(functionspace(msh, ("Lagrange", 1, (gdim,))))
@@ -393,7 +393,7 @@ def test_higher_order_function(tempdir):
     #
     # # Degree 3 mesh (hex)
     # msh = gmsh_hex_model(3)
-    # assert msh.geometry.cmap.degree == 3
+    # assert msh.geometry.cmap().degree == 3
     # gdim = msh.geometry.dim
     # u = Function(functionspace(msh, ("Lagrange", 1, (gdim,))))
     # with pytest.raises(RuntimeError):

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -717,26 +717,26 @@ def test_mesh_create_cmap(dtype):
     # ufl.Mesh case
     domain = ufl.Mesh(element("Lagrange", shape, degree, shape=(2,), dtype=dtype))
     msh = _mesh.create_mesh(MPI.COMM_WORLD, cells, domain, x)
-    assert msh.geometry.cmap.dim == 3
+    assert msh.geometry.cmap().dim == 3
     assert msh.ufl_domain().ufl_coordinate_element().reference_value_shape == (2,)
 
     # basix.ufl.element
     domain = element("Lagrange", shape, degree, shape=(2,), dtype=dtype)
     msh = _mesh.create_mesh(MPI.COMM_WORLD, cells, domain, x)
-    assert msh.geometry.cmap.dim == 3
+    assert msh.geometry.cmap().dim == 3
     assert msh.ufl_domain().ufl_coordinate_element().reference_value_shape == (2,)
 
     # basix.finite_element
     domain = basix.create_element(basix.ElementFamily.P, basix.CellType[shape], degree, dtype=dtype)
     msh = _mesh.create_mesh(MPI.COMM_WORLD, cells, domain, x)
-    assert msh.geometry.cmap.dim == 3
+    assert msh.geometry.cmap().dim == 3
     assert msh.ufl_domain().ufl_coordinate_element().reference_value_shape == (2,)
 
     # cpp.fem.CoordinateElement
     e = basix.create_element(basix.ElementFamily.P, basix.CellType[shape], degree, dtype=dtype)
     domain = coordinate_element(e)
     msh = _mesh.create_mesh(MPI.COMM_WORLD, cells, domain, x)
-    assert msh.geometry.cmap.dim == 3
+    assert msh.geometry.cmap().dim == 3
     assert msh.ufl_domain() is None
 
 


### PR DESCRIPTION
Replaces previous convoluted access with `geometry.cmaps()[i]`