### PR TITLE
Add real element to DOLFINx

### DIFF
--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -1,4 +1,5 @@
-// Copyright (C) 2008-2018 Anders Logg, Ola Skavhaug and Garth N. Wells
+// Copyright (C) 2008-2026 Anders Logg, Ola Skavhaug, Garth N. Wells and Jørgen
+// S. Dokken
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -12,6 +13,7 @@
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/Timer.h>
+#include <dolfinx/fem/DofMap.h>
 #include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/mesh/Topology.h>
 #include <dolfinx/mesh/cell_types.h>
@@ -689,4 +691,51 @@ fem::build_dofmap_data(
   return {std::move(index_map), element_dof_layouts.front().block_size(),
           std::move(dofmaps)};
 }
+
+//-----------------------------------------------------------------------------
+fem::DofMap fem::build_real_element_dofmap(
+    const mesh::Topology& topology,
+    const std::vector<std::vector<std::vector<int>>>& entity_dofs,
+    const std::vector<std::vector<std::vector<int>>>& entity_closure_dofs,
+    std::size_t value_size)
+{
+  // We select the process that owns cell 0 to have all dofs and all other
+  // processes ghost them
+  std::shared_ptr<const dolfinx::common::IndexMap> cell_map
+      = topology.index_map(topology.dim());
+  const int is_owner
+      = (cell_map->local_range()[0] == 0) and cell_map->size_local() > 0;
+
+  std::int32_t num_dofs = (is_owner) ? 1 : 0;
+  std::int32_t num_ghosts = (is_owner) ? 0 : 1;
+  std::vector<std::int64_t> ghosts(num_ghosts, 0);
+  ghosts.reserve(1);
+
+  // Send owning rank to all processes so that they can set owner of ghost dofs
+  int rank = dolfinx::MPI::rank(topology.comm());
+  std::array<int, 2> send_owner_pair = {is_owner, rank};
+  std::array<int, 2> recv_owner_pair;
+  MPI_Allreduce(&send_owner_pair, &recv_owner_pair, 1, MPI_2INT, MPI_MAXLOC,
+                topology.comm());
+  std::vector<int> owners(num_ghosts, recv_owner_pair[1]);
+  owners.reserve(1);
+
+  // Create index map
+  std::shared_ptr<const dolfinx::common::IndexMap> imap
+      = std::make_shared<const dolfinx::common::IndexMap>(
+          topology.comm(), num_dofs, ghosts, owners);
+
+  // Create element dof layout
+  dolfinx::fem::ElementDofLayout dof_layout(value_size, entity_dofs,
+                                            entity_closure_dofs, {}, {});
+
+  // Create dofmap array
+  std::size_t num_cells_on_process
+      = topology.index_map(topology.dim())->size_local()
+        + topology.index_map(topology.dim())->num_ghosts();
+
+  std::vector<std::int32_t> dofmap(num_cells_on_process, 0);
+  dofmap.reserve(1);
+  return dolfinx::fem::DofMap(dof_layout, imap, value_size, dofmap, value_size);
+};
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -721,9 +721,8 @@ fem::DofMap fem::build_real_element_dofmap(
   owners.reserve(1);
 
   // Create index map
-  auto imap
-      = std::make_shared<const dolfinx::common::IndexMap>(
-          topology.comm(), num_dofs, ghosts, owners);
+  auto imap = std::make_shared<const dolfinx::common::IndexMap>(
+      topology.comm(), num_dofs, ghosts, owners);
 
   // Create element dof layout
   dolfinx::fem::ElementDofLayout dof_layout(value_size, entity_dofs,

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -697,7 +697,7 @@ fem::DofMap fem::build_real_element_dofmap(
     const mesh::Topology& topology,
     const std::vector<std::vector<std::vector<int>>>& entity_dofs,
     const std::vector<std::vector<std::vector<int>>>& entity_closure_dofs,
-    std::size_t value_size)
+    int value_size)
 {
   // We select the process that owns cell 0 to have all dofs and all other
   // processes ghost them
@@ -721,7 +721,7 @@ fem::DofMap fem::build_real_element_dofmap(
   owners.reserve(1);
 
   // Create index map
-  std::shared_ptr<const dolfinx::common::IndexMap> imap
+  auto imap
       = std::make_shared<const dolfinx::common::IndexMap>(
           topology.comm(), num_dofs, ghosts, owners);
 
@@ -730,7 +730,7 @@ fem::DofMap fem::build_real_element_dofmap(
                                             entity_closure_dofs, {}, {});
 
   // Create dofmap array
-  std::size_t num_cells_on_process
+  std::int32_t num_cells_on_process
       = topology.index_map(topology.dim())->size_local()
         + topology.index_map(topology.dim())->num_ghosts();
 

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -704,10 +704,10 @@ fem::DofMap fem::build_real_element_dofmap(
   std::shared_ptr<const dolfinx::common::IndexMap> cell_map
       = topology.index_map(topology.dim());
   const int is_owner
-      = (cell_map->local_range()[0] == 0) and cell_map->size_local() > 0;
+      = (cell_map->local_range()[0] == 0) && cell_map->size_local() > 0;
 
-  std::int32_t num_dofs = (is_owner) ? 1 : 0;
-  std::int32_t num_ghosts = (is_owner) ? 0 : 1;
+  std::int32_t num_dofs = is_owner ? 1 : 0;
+  std::int32_t num_ghosts = is_owner ? 0 : 1;
   std::vector<std::int64_t> ghosts(num_ghosts, 0);
   ghosts.reserve(1);
 

--- a/cpp/dolfinx/fem/dofmapbuilder.h
+++ b/cpp/dolfinx/fem/dofmapbuilder.h
@@ -26,6 +26,7 @@ class Topology;
 namespace dolfinx::fem
 {
 class ElementDofLayout;
+class DofMap;
 
 /// Build dofmap data for elements on a mesh topology
 /// @param[in] comm MPI communicator
@@ -40,5 +41,19 @@ build_dofmap_data(MPI_Comm comm, const mesh::Topology& topology,
                   const std::vector<ElementDofLayout>& element_dof_layouts,
                   const std::function<std::vector<int>(
                       const graph::AdjacencyList<std::int32_t>&)>& reorder_fn);
+
+/// @brief Build a dofmap on a real element, i.e. a single constant dof shared
+/// by all cells.
+///
+/// @param[in] topology The mesh topology.
+/// @param[in] entity_dofs The dofs for each mesh entity.
+/// @param[in] entity_closure_dofs The closure dofs for each mesh entity.
+/// @param[in] value_shape The shape of the function space values.
+/// @return The dofmap for the real element.
+fem::DofMap build_real_element_dofmap(
+    const mesh::Topology& topology,
+    const std::vector<std::vector<std::vector<int>>>& entity_dofs,
+    const std::vector<std::vector<std::vector<int>>>& entity_closure_dofs,
+    std::size_t value_size);
 
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/dofmapbuilder.h
+++ b/cpp/dolfinx/fem/dofmapbuilder.h
@@ -48,7 +48,7 @@ build_dofmap_data(MPI_Comm comm, const mesh::Topology& topology,
 /// @param[in] topology The mesh topology.
 /// @param[in] entity_dofs The dofs for each mesh entity.
 /// @param[in] entity_closure_dofs The closure dofs for each mesh entity.
-/// @param[in] value_shape The shape of the function space values.
+/// @param[in] value_size The number of components for the real element.
 /// @return The dofmap for the real element.
 fem::DofMap build_real_element_dofmap(
     const mesh::Topology& topology,

--- a/cpp/dolfinx/fem/dofmapbuilder.h
+++ b/cpp/dolfinx/fem/dofmapbuilder.h
@@ -54,6 +54,6 @@ fem::DofMap build_real_element_dofmap(
     const mesh::Topology& topology,
     const std::vector<std::vector<std::vector<int>>>& entity_dofs,
     const std::vector<std::vector<std::vector<int>>>& entity_closure_dofs,
-    std::size_t value_size);
+    int value_size);
 
 } // namespace dolfinx::fem

--- a/python/dolfinx/fem/element.py
+++ b/python/dolfinx/fem/element.py
@@ -368,10 +368,6 @@ def finiteelement(
                 ufl_e.is_symmetric,
             )
         )
-    elif ufl_e.is_real:
-        basix_e = ufl_e.basix_element._e
-        value_shape = ufl_e.reference_value_shape if ufl_e.block_size > 1 else None
-        return FiniteElement(CppElement(basix_e, value_shape, ufl_e.is_symmetric))
     else:
         basix_e = ufl_e.basix_element._e
         value_shape = ufl_e.reference_value_shape if ufl_e.block_size > 1 else None

--- a/python/dolfinx/fem/element.py
+++ b/python/dolfinx/fem/element.py
@@ -368,6 +368,10 @@ def finiteelement(
                 ufl_e.is_symmetric,
             )
         )
+    elif ufl_e.is_real:
+        basix_e = ufl_e.basix_element._e
+        value_shape = ufl_e.reference_value_shape if ufl_e.block_size > 1 else None
+        return FiniteElement(CppElement(basix_e, value_shape, ufl_e.is_symmetric))
     else:
         basix_e = ufl_e.basix_element._e
         value_shape = ufl_e.reference_value_shape if ufl_e.block_size > 1 else None

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -655,7 +655,18 @@ def functionspace(
         raise ValueError("Non-matching UFL cell and mesh cell shapes.")
     # Create DOLFINx objects
     element = finiteelement(mesh.topology.cell_type, ufl_e, dtype)  # type: ignore
-    cpp_dofmap = _cpp.fem.create_dofmap(mesh.comm, mesh.topology._cpp_object, element._cpp_object)  # type: ignore
+
+    if ufl_e.is_real:
+        cpp_dofmap = _cpp.fem.build_real_element_dofmap(
+            mesh.topology._cpp_object,
+            element.basix_element.entity_dofs,
+            element.basix_element.entity_closure_dofs,
+            int(np.prod(element.value_shape)),
+        )
+    else:
+        cpp_dofmap = _cpp.fem.create_dofmap(
+            mesh.comm, mesh.topology._cpp_object, element._cpp_object
+        )  # type: ignore
     assert np.issubdtype(mesh.geometry.x.dtype, element.dtype), (  # type: ignore
         "Mesh and element dtype are not compatible."
     )

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -59,6 +59,21 @@ void fem(nb::module_& m)
       },
       nb::arg("comm"), nb::arg("topology"), nb::arg("layout"),
       "Build a dofmap on a mesh.");
+
+  m.def(
+      "build_real_element_dofmap",
+      [](const dolfinx::mesh::Topology& topology,
+         const std::vector<std::vector<std::vector<int>>>& entity_dofs,
+         const std::vector<std::vector<std::vector<int>>>& entity_closure_dofs,
+         std::size_t value_size)
+      {
+        return dolfinx::fem::build_real_element_dofmap(
+            topology, entity_dofs, entity_closure_dofs, value_size);
+      },
+      nb::arg("topology"), nb::arg("entity_dofs"),
+      nb::arg("entity_closure_dofs"), nb::arg("value_size"),
+      "Build a dofmap on a real element, i.e. a single constant dof shared by "
+      "all cells.");
   m.def(
       "transpose_dofmap",
       [](nb::ndarray<const std::int32_t, nb::ndim<2>, nb::c_contig> dofmap,

--- a/python/test/unit/fem/test_real_space.py
+++ b/python/test/unit/fem/test_real_space.py
@@ -5,7 +5,6 @@ import pytest
 
 import basix.ufl
 import dolfinx
-import dolfinx.fem.petsc
 import ufl
 
 

--- a/python/test/unit/fem/test_real_space.py
+++ b/python/test/unit/fem/test_real_space.py
@@ -81,7 +81,13 @@ def test_real_function_space_vector(cell_type, dtype):
         assert num_local_rows == 0
 
 
-@pytest.mark.parametrize("ftype, stype", [(np.float32, np.complex64), (np.float64, np.complex128)])
+@pytest.mark.parametrize(
+    "ftype, stype",
+    [
+        pytest.param(np.float32, np.complex64, marks=pytest.mark.xfail_win32_complex),
+        pytest.param(np.float64, np.complex128, marks=pytest.mark.xfail_win32_complex),
+    ],
+)
 def test_complex_real_space(ftype, stype):
     mesh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, 13, dtype=ftype)
 

--- a/python/test/unit/fem/test_real_space.py
+++ b/python/test/unit/fem/test_real_space.py
@@ -1,0 +1,112 @@
+from mpi4py import MPI
+
+import numpy as np
+import pytest
+
+import basix.ufl
+import dolfinx
+import dolfinx.fem.petsc
+import ufl
+
+
+@pytest.mark.parametrize("L", [0.1, 0.2, 0.3])
+@pytest.mark.parametrize("H", [1.3, 0.8, 0.2])
+@pytest.mark.parametrize(
+    "cell_type", [dolfinx.mesh.CellType.triangle, dolfinx.mesh.CellType.quadrilateral]
+)
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+def test_real_function_space_mass(L, H, cell_type, dtype):
+    """Test that real space mass matrix is the same as assembling the volume."""
+    mesh = dolfinx.mesh.create_rectangle(
+        MPI.COMM_WORLD, [[0.0, 0.0], [L, H]], [7, 9], cell_type, dtype=dtype
+    )
+
+    el = basix.ufl.real_element(mesh.basix_cell(), dtype=dtype)
+    V = dolfinx.fem.functionspace(mesh, el)
+    u = ufl.TrialFunction(V)
+    v = ufl.TestFunction(V)
+    a = ufl.inner(u, v) * ufl.dx
+
+    A = dolfinx.fem.assemble_matrix(dolfinx.fem.form(a, dtype=dtype), bcs=[])
+    A.scatter_reverse()
+    tol = 100 * np.finfo(dtype).eps
+    cell_map = mesh.topology.index_map(mesh.topology.dim)
+    if cell_map.size_local + cell_map.num_ghosts > 0:
+        assert len(A.data) == 1
+        if cell_map.local_range[0] == 0:
+            assert np.isclose(A.data[0], L * H, atol=tol)
+    else:
+        assert len(A.data) == 0
+        assert len(V.dofmap.list.flatten()) == 0
+        assert V.dofmap.index_map.size_local == 0
+        assert V.dofmap.index_map.num_ghosts == 1
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize(
+    "cell_type", [dolfinx.mesh.CellType.tetrahedron, dolfinx.mesh.CellType.hexahedron]
+)
+def test_real_function_space_vector(cell_type, dtype):
+    """Test assembling with real space test function is equal to assembling with a constant."""
+    mesh = dolfinx.mesh.create_unit_cube(MPI.COMM_WORLD, 2, 3, 5, cell_type, dtype=dtype)
+
+    V = dolfinx.fem.functionspace(mesh, ("Lagrange", 3))
+    v = ufl.TrialFunction(V)
+
+    el = basix.ufl.real_element(mesh.basix_cell(), dtype=dtype)
+    R = dolfinx.fem.functionspace(mesh, el)
+    u = ufl.TestFunction(R)
+    a_R = ufl.inner(u, v) * ufl.dx
+    form_rhs = dolfinx.fem.form(a_R, dtype=dtype)
+
+    A_R = dolfinx.fem.assemble_matrix(form_rhs, bcs=[])
+    A_R.scatter_reverse()
+
+    L = ufl.inner(ufl.constantvalue.IntValue(1), v) * ufl.dx
+    form_lhs = dolfinx.fem.form(L, dtype=dtype)
+    b = dolfinx.fem.assemble_vector(form_lhs)
+    b.scatter_reverse(dolfinx.la.InsertMode.add)
+    b.scatter_forward()
+
+    row_map = A_R.index_map(0)
+    num_local_rows = row_map.size_local
+    num_dofs = V.dofmap.index_map.size_local * V.dofmap.index_map_bs
+    tol = 100 * np.finfo(dtype).eps
+    if MPI.COMM_WORLD.rank == 0:
+        assert num_local_rows == 1
+        num_dofs_global = V.dofmap.index_map.size_global * V.dofmap.index_map_bs
+        assert A_R.indptr[1] - A_R.indptr[0] == num_dofs_global
+        np.testing.assert_allclose(A_R.indices, np.arange(num_dofs_global))
+        np.testing.assert_allclose(b.array[:num_dofs], A_R.data[:num_dofs], atol=tol)
+    else:
+        assert num_local_rows == 0
+
+
+@pytest.mark.parametrize("ftype, stype", [(np.float32, np.complex64), (np.float64, np.complex128)])
+def test_complex_real_space(ftype, stype):
+    mesh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, 13, dtype=ftype)
+
+    val = (2 + 3j, -4 + 5j)
+    value_shape = (2,)
+    el = basix.ufl.real_element(mesh.basix_cell(), value_shape=value_shape, dtype=ftype)
+    R = dolfinx.fem.functionspace(mesh, el)
+    u = dolfinx.fem.Function(R, dtype=stype)
+    u.x.array[0] = val[0]
+    u.x.array[1] = val[1]
+    u.x.scatter_forward()
+
+    V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1, value_shape))
+    v = ufl.TestFunction(V)
+    L = ufl.inner(u, v) * ufl.dx
+
+    b = dolfinx.fem.assemble_vector(dolfinx.fem.form(L, dtype=stype))
+    b.scatter_reverse(dolfinx.la.InsertMode.add)
+    b.scatter_forward()
+    const = dolfinx.fem.Constant(mesh, stype(val))
+    L_const = ufl.inner(const, v) * ufl.dx
+    b_const = dolfinx.fem.assemble_vector(dolfinx.fem.form(L_const, dtype=stype))
+    b_const.scatter_reverse(dolfinx.la.InsertMode.add)
+    b_const.scatter_forward()
+
+    tol = 100 * np.finfo(stype).eps
+    np.testing.assert_allclose(b.array, b_const.array, atol=tol)


### PR DESCRIPTION
Add the notion of real element to DOLFINx. Implemented based on https://github.com/scientificcomputing/scifem/blob/main/src/scifem.cpp
Relies on https://github.com/FEniCS/basix/pull/1001

One should not be able to make a `mixed_element` with real element. One should use the block constructor (i.e. MixedFunctionSpace or manually block it).

The real element is now:
- A DG-0 element in basix, gives the exact same kernel as with a DG-0/Constant.
- Gives the ownership of the DOF to the first process that has a cell (sometimes rank 0 has no cell).