### PR TITLE
Add missing <format> include in `mesh/utils.h`

### DIFF
--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -18,6 +18,7 @@
 #include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/graph/ordering.h>
 #include <dolfinx/graph/partition.h>
+#include <format>
 #include <functional>
 #include <mpi.h>
 #include <numeric>


### PR DESCRIPTION
Follow up to #4172

Detected when building for Colab, which has an ancient `gcc`.
I guess that newer `gcc` versions somehow automatically include the header, but it doesn't hurt to have it listed explicitly, as it already done in every other file that has `std::format`.