### PR TITLE
Add dtype coverage for mixed topology test

### DIFF
--- a/python/test/unit/mesh/test_mixed_topology.py
+++ b/python/test/unit/mesh/test_mixed_topology.py
@@ -330,9 +330,9 @@ def test_locate_entities(dtype):
         cells = [np.array([], dtype=np.int64), np.array([], dtype=np.int64)]
         geom = np.array([], dtype=dtype)
 
-    part = create_cell_partitioner(GhostMode.none, 2, dtype=dtype)
+    part = create_cell_partitioner(GhostMode.none, 2)
     hexahedron = coordinate_element(CellType.hexahedron, 1, dtype=dtype)
-    prism = coordinate_element(CellType.prism, 1)
+    prism = coordinate_element(CellType.prism, 1, dtype=dtype)
     comm = MPI.COMM_WORLD
     max_cells_per_facet = 2
     mesh = create_mesh(

--- a/python/test/unit/mesh/test_mixed_topology.py
+++ b/python/test/unit/mesh/test_mixed_topology.py
@@ -301,6 +301,7 @@ def test_create_entities():
     # Triangle and quad to prism (facet->cell)
     mesh.topology.create_connectivity(2, 3)
 
+
 @pytest.mark.skip_in_parallel
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_locate_entities(dtype):

--- a/python/test/unit/mesh/test_mixed_topology.py
+++ b/python/test/unit/mesh/test_mixed_topology.py
@@ -329,9 +329,9 @@ def test_locate_entities(dtype):
     else:
         cells = [np.array([], dtype=np.int64), np.array([], dtype=np.int64)]
         geom = np.array([], dtype=dtype)
-        
-    part = create_cell_partitioner(GhostMode.none, 2)
-    hexahedron = coordinate_element(CellType.hexahedron, 1)
+
+    part = create_cell_partitioner(GhostMode.none, 2, dtype=dtype)
+    hexahedron = coordinate_element(CellType.hexahedron, 1, dtype=dtype)
     prism = coordinate_element(CellType.prism, 1)
     comm = MPI.COMM_WORLD
     max_cells_per_facet = 2

--- a/python/test/unit/mesh/test_mixed_topology.py
+++ b/python/test/unit/mesh/test_mixed_topology.py
@@ -301,9 +301,9 @@ def test_create_entities():
     # Triangle and quad to prism (facet->cell)
     mesh.topology.create_connectivity(2, 3)
 
-
 @pytest.mark.skip_in_parallel
-def test_locate_entities():
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_locate_entities(dtype):
     # Create a unit cube mesh with one hex and two wedges
     if MPI.COMM_WORLD.rank == 0:
         hexes = np.array([0, 1, 3, 4, 6, 7, 9, 10], dtype=np.int64)
@@ -324,12 +324,12 @@ def test_locate_entities():
                 [0.5, 1.0, 1.0],
                 [1.0, 1.0, 1.0],
             ],
-            dtype=np.float64,
+            dtype=dtype,
         )
     else:
         cells = [np.array([], dtype=np.int64), np.array([], dtype=np.int64)]
-        geom = np.array([], dtype=np.float64)
-
+        geom = np.array([], dtype=dtype)
+        
     part = create_cell_partitioner(GhostMode.none, 2)
     hexahedron = coordinate_element(CellType.hexahedron, 1)
     prism = coordinate_element(CellType.prism, 1)


### PR DESCRIPTION
## Summary
Refers to #4098.

Parameterize `test_locate_entities` in `test_mixed_topology.py` over `np.float32` and `np.float64`.
This improves mixed topology test coverage for float types.
Following the suggestion to keep mixed topology PRs small, I started with a single focused test.