### PR TITLE
Remove now ancient ruff pin.

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -49,7 +49,7 @@ docs = [
       "sphinxcontrib-bibtex",
       "fenics-dolfinx[demo]",
 ]
-lint = ["ruff>=0.2.0"]
+lint = ["ruff"]
 optional = ["numba"]
 petsc4py = ["petsc4py"]
 test = [


### PR DESCRIPTION
Related to issue #4142 - this pin is ancient and can be just left unpinned.
