### PR TITLE
Update ADIOS2 version to 2.12.0

### DIFF
--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -12,7 +12,7 @@
 #    docker build --target dev-env --file dolfinx/docker/Dockerfile.test-env --build-arg PETSC_SLEPC_OPTFLAGS="-O2 -march=native" .
 #
 
-ARG ADIOS2_VERSION=2.11.0
+ARG ADIOS2_VERSION=2.12.0
 ARG DOXYGEN_VERSION=1_16_1
 ARG GMSH_VERSION=4_15_2
 ARG HDF5_VERSION=2.1.1


### PR DESCRIPTION
Includes a fix for detecting HDF5 2.0 for ADIOS2 which would be nice to have in the docker images:
(https://github.com/ornladios/ADIOS2/pull/4814)