### PR TITLE
Bump adios to 2.12.1

### DIFF
--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -12,7 +12,7 @@
 #    docker build --target dev-env --file dolfinx/docker/Dockerfile.test-env --build-arg PETSC_SLEPC_OPTFLAGS="-O2 -march=native" .
 #
 
-ARG ADIOS2_VERSION=2.12.0
+ARG ADIOS2_VERSION=2.12.1
 ARG DOXYGEN_VERSION=1_16_1
 ARG GMSH_VERSION=4_15_2
 ARG HDF5_VERSION=2.1.1


### PR DESCRIPTION
Follow up to https://github.com/FEniCS/dolfinx/pull/4188 fixing the arm build.

Build running at https://github.com/FEniCS/dolfinx/actions/runs/25091689398.