### PR TITLE
Fix Spack on main weekly run

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -60,7 +60,7 @@ jobs:
         shell: spack-bash {0}
         run: |
           spack env create dolfinx .github/workflows/spack-config/gh-actions-env.yml
-          spack -e dolfinx install -j4 -p2 --use-buildcache=package:never,dependencies:auto --add fenics-dolfinx@main+petsc
+          spack -e dolfinx install -j4 -p2 --use-buildcache=package:never,dependencies:auto --add fenics-dolfinx@main+petsc ^petsc+mumps
           spack repo list
           spack config get repos
       - name: Run a C++ test
@@ -68,7 +68,7 @@ jobs:
         run: |
           cat .github/workflows/spack-config/gh-actions-env.yml
           spack env create dolfinx-test .github/workflows/spack-config/gh-actions-env.yml
-          spack -e dolfinx-test install -j4 -p2 --use-buildcache=package:never,dependencies:auto --add fenics-dolfinx@main+petsc py-fenics-ffcx@main
+          spack -e dolfinx-test install -j4 -p2 --use-buildcache=package:never,dependencies:auto --add fenics-dolfinx@main+petsc ^petsc+mumps py-fenics-ffcx@main
           spack env activate dolfinx-test
           spack load cmake
           cd cpp/demo/poisson


### PR DESCRIPTION
Poisson currently fails complaining about lack of LU solver options - this configures PETSc with MUMPS.
