### PR TITLE
Re-enable macOS main CI run

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,7 @@ on:
       - main
   push:
     branches:
+      - main
       - release
     tags:
       - "v*"


### PR DESCRIPTION
Not sure how this got dropped off but it leads to a permanently red badge
