### PR TITLE
Reenable Windows CI on main

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,6 +3,7 @@ name: CI (Windows)
 on:
   push:
     branches:
+      - main
       - release
     tags:
       - "v*"


### PR DESCRIPTION
CI badges we show related to main status must stay enabled
