### PR TITLE
dtype coverage for mixed topology tests

### DIFF
--- a/python/test/unit/mesh/test_create_mixed_mesh.py
+++ b/python/test/unit/mesh/test_create_mixed_mesh.py
@@ -1,6 +1,7 @@
 from mpi4py import MPI
 
 import numpy as np
+import pytest
 
 from dolfinx.cpp.mesh import (
     GhostMode,
@@ -10,7 +11,8 @@ from dolfinx.fem import coordinate_element
 from dolfinx.mesh import CellType, create_cell_partitioner
 
 
-def test_create_mixed_mesh():
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_create_mixed_mesh(dtype):
     nx = 7
     ny = 11
     nz = 8
@@ -70,15 +72,15 @@ def test_create_mixed_mesh():
         geom += [[ix / nx, iy / ny, iz / nz]]
 
     if MPI.COMM_WORLD.rank == 0:
-        cells_np = [np.array(c, dtype=np.int64) for c in cells]
-        geomx = np.array(geom, dtype=np.float64)
+        cells_np = [np.array(c) for c in cells]
+        geomx = np.array(geom, dtype=dtype)
     else:
-        cells_np = [np.zeros(0, dtype=np.int64) for c in cells]
-        geomx = np.zeros((0, 3), dtype=np.float64)
+        cells_np = [np.zeros(0) for c in cells]
+        geomx = np.zeros((0, 3), dtype=dtype)
 
-    hexahedron = coordinate_element(CellType.hexahedron, 1)
-    pyramid = coordinate_element(CellType.pyramid, 1, variant=1)
-    tetrahedron = coordinate_element(CellType.tetrahedron, 1)
+    hexahedron = coordinate_element(CellType.hexahedron, 1, dtype=dtype)
+    pyramid = coordinate_element(CellType.pyramid, 1, variant=1, dtype=dtype)
+    tetrahedron = coordinate_element(CellType.tetrahedron, 1, dtype=dtype)
 
     part = create_cell_partitioner(GhostMode.none, 2)
     max_cells_per_facet = 2

--- a/python/test/unit/mesh/test_create_mixed_mesh.py
+++ b/python/test/unit/mesh/test_create_mixed_mesh.py
@@ -75,7 +75,7 @@ def test_create_mixed_mesh(dtype):
         cells_np = [np.array(c, dtype=np.int64) for c in cells]
         geomx = np.array(geom, dtype=dtype)
     else:
-        cells_np = [np.zeros(0) for c in cells]
+        cells_np = [np.zeros(0, dtype=np.int64) for c in cells]
         geomx = np.zeros((0, 3), dtype=dtype)
 
     hexahedron = coordinate_element(CellType.hexahedron, 1, dtype=dtype)

--- a/python/test/unit/mesh/test_create_mixed_mesh.py
+++ b/python/test/unit/mesh/test_create_mixed_mesh.py
@@ -72,7 +72,7 @@ def test_create_mixed_mesh(dtype):
         geom += [[ix / nx, iy / ny, iz / nz]]
 
     if MPI.COMM_WORLD.rank == 0:
-        cells_np = [np.array(c) for c in cells]
+        cells_np = [np.array(c, dtype=np.int64) for c in cells]
         geomx = np.array(geom, dtype=dtype)
     else:
         cells_np = [np.zeros(0) for c in cells]

--- a/python/test/unit/mesh/test_mixed_topology.py
+++ b/python/test/unit/mesh/test_mixed_topology.py
@@ -27,7 +27,8 @@ from dolfinx.log import LogLevel, set_log_level
 from dolfinx.mesh import CellType, GhostMode, Mesh, Topology, create_unit_cube
 
 
-def test_mixed_topology_mesh():
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_mixed_topology_mesh(dtype):
     set_log_level(LogLevel.INFO)
 
     cells = [[0, 1, 2, 1, 2, 3], [2, 3, 4, 5]]
@@ -79,14 +80,12 @@ def test_mixed_topology_mesh():
     assert topology.connectivity((2, 1), (0, 0)).num_nodes == 1
 
     # Create dofmaps for Geometry
-    tri = coordinate_element(CellType.triangle, 1)
-    quad = coordinate_element(CellType.quadrilateral, 1)
+    tri = coordinate_element(CellType.triangle, 1, dtype=dtype)
+    quad = coordinate_element(CellType.quadrilateral, 1, dtype=dtype)
     nodes = np.array([0, 1, 2, 3, 4, 5], dtype=np.int64)
     xdofs = np.array([0, 1, 2, 1, 2, 3, 2, 3, 4, 5], dtype=np.int64)
-    x = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 1.0, 2.0, 0.0], dtype=np.float64)
-    geom = create_geometry(
-        topology._cpp_object, [tri._cpp_object, quad._cpp_object], nodes, xdofs, x, 2
-    )
+    x = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 1.0, 2.0, 0.0], dtype=dtype)
+    geom = create_geometry(topology, [tri._cpp_object, quad._cpp_object], nodes, xdofs, x, 2)
     print(geom.x)
     print(geom.index_map().size_local)
     print(geom.dofmaps(0))

--- a/python/test/unit/mesh/test_mixed_topology.py
+++ b/python/test/unit/mesh/test_mixed_topology.py
@@ -85,7 +85,7 @@ def test_mixed_topology_mesh(dtype):
     nodes = np.array([0, 1, 2, 3, 4, 5], dtype=np.int64)
     xdofs = np.array([0, 1, 2, 1, 2, 3, 2, 3, 4, 5], dtype=np.int64)
     x = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 1.0, 2.0, 0.0], dtype=dtype)
-    geom = create_geometry(topology, [tri._cpp_object, quad._cpp_object], nodes, xdofs, x, 2)
+    geom = create_geometry(topology._cpp_object, [tri._cpp_object, quad._cpp_object], nodes, xdofs, x, 2)
     print(geom.x)
     print(geom.index_map().size_local)
     print(geom.dofmaps(0))

--- a/python/test/unit/mesh/test_mixed_topology.py
+++ b/python/test/unit/mesh/test_mixed_topology.py
@@ -85,7 +85,9 @@ def test_mixed_topology_mesh(dtype):
     nodes = np.array([0, 1, 2, 3, 4, 5], dtype=np.int64)
     xdofs = np.array([0, 1, 2, 1, 2, 3, 2, 3, 4, 5], dtype=np.int64)
     x = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 1.0, 2.0, 0.0], dtype=dtype)
-    geom = create_geometry(topology._cpp_object, [tri._cpp_object, quad._cpp_object], nodes, xdofs, x, 2)
+    geom = create_geometry(
+        topology._cpp_object, [tri._cpp_object, quad._cpp_object], nodes, xdofs, x, 2
+    )
     print(geom.x)
     print(geom.index_map().size_local)
     print(geom.dofmaps(0))


### PR DESCRIPTION
## Summary

Add dtype coverage (`float32` and `float64`) to selected mixed-topology mesh tests.

## Changes

- Parametrized:
  - `test_create_mixed_mesh`
  - `test_mixed_topology_mesh`

- Updated:
  - Geometry arrays to use `dtype`
  - `coordinate_element(..., dtype=dtype)`

- Kept:
  - Topology/index arrays as `int64` (unchanged)

## Rationale

- These tests operate at the mesh/geometry level and are naturally dtype-agnostic, making them suitable for dtype parametrization.
- FEM-level tests (e.g., dofmap tests) were explored but not included due to current limitations:
  Basix UFL elements default to `float64`, leading to dtype mismatches when using `float32`.
