### PR TITLE
conda: avoid defaults channel

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,10 +1,16 @@
 name: Conda install
 
 on:
+  # build on push/pr to this file
+  push:
+    paths:
+      - .github/workflows/conda.yml
   # Uncomment the below 'push' to trigger on push
-  #push:
   #  branches:
   #     - "**"
+  pull_request:
+    paths:
+      - .github/workflows/conda.yml
   schedule:
     # '*' is a special character in YAML, so string must be quoted
     - cron: "0 2 * * WED"

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -37,7 +37,8 @@ jobs:
         with:
           auto-update-conda: true
           channels: conda-forge
-          mamba-version: "*"
+          mamba-version: ">=2.6"
+          miniforge-version: latest
           python-version: ${{ matrix.python-version }}
       
       # TODO: These could probably be merged into one cross-platform step.

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -36,17 +36,19 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
+          channels: conda-forge
+          mamba-version: "*"
           python-version: ${{ matrix.python-version }}
       
       # TODO: These could probably be merged into one cross-platform step.
       - name: Install DOLFINx with MPICH (Unix-like)
         if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
         run: |
-          conda install -c conda-forge fenics-dolfinx mpich petsc=*=${{ matrix.petsc-scalar-type }}*
+          mamba install fenics-dolfinx mpich petsc=*=${{ matrix.petsc-scalar-type }}*
       - name: Install DOLFINx (Windows)
         if: ${{ runner.os == 'Windows' }}
         run: |
-          conda install -c conda-forge fenics-dolfinx
+          mamba install fenics-dolfinx
       
       - name: Test (Unix-like)
         if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}


### PR DESCRIPTION
updates setup-conda on ci to use miniforge instead of miniconda, which avoids getting anything from the defaults (Anaconda) channel. Also switches the installer to mamba>=2.6, which enables sharded repo data (less downloads, should be faster solves).

I'm not sure what's going on in #4191, but it's always a good idea to make sure channels aren't mixed before diving too deep into debugging conda installs.

closes #4191 if it works