### PR TITLE
Fix Spack builds and Clang 22 with older version of Catch2

### DIFF
--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: spack/spack
-          ref: develop
+          ref: v1.1.1
           path: spack-src
 
       - name: Get upstream Spack packages

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -92,7 +92,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           . ./spack-src/share/spack/setup-env.sh
-          spack -e py buildcache push --base-image ghcr.io/almalinux/almalinux:10 --update-index local-buildcache
+          spack debug report
+          spack -d -e py buildcache push --base-image ghcr.io/almalinux/almalinux:10 --update-index local-buildcache
         if: ${{ !cancelled() }}
 
       - name: Load FEniCS testing environment variables

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: spack/spack
-          ref: develop
+          ref: v1.1.1
           path: spack-src
 
       - name: Get upstream Spack packages

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Spack
         uses: spack/setup-spack@main
         with:
-          ref: develop      # Spack version (examples: develop, releases/v0.23)
+          ref: v1.1.1      # Spack version (examples: develop, releases/v0.23)
           color: true       # Force color output (SPACK_COLOR=always)
           path: spack-src   # Where to clone Spack
       - name: Add Spack package repository

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -44,9 +44,9 @@ jobs:
       - name: Set up Spack
         uses: spack/setup-spack@main
         with:
-          ref: v1.1.1      # Spack version (examples: develop, releases/v0.23)
-          color: true       # Force color output (SPACK_COLOR=always)
-          path: spack-src   # Where to clone Spack
+          spack_ref: v1.1.1
+          color: true
+          path: spack-src
       - name: Add Spack package repository
         if: github.event_name == 'workflow_dispatch'
         shell: spack-bash {0}
@@ -98,9 +98,9 @@ jobs:
       - name: Set up Spack
         uses: spack/setup-spack@main
         with:
-          ref: develop      # Spack version (examples: develop, releases/v0.23)
-          color: true       # Force color output (SPACK_COLOR=always)
-          path: spack-src   # Where to clone Spack
+          spack_ref: v1.1.1
+          color: true
+          path: spack-src
       - name: Add Spack package repository
         if: github.event_name == 'workflow_dispatch'
         shell: spack-bash {0}

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -42,7 +42,7 @@ if (PROJECT_IS_TOP_LEVEL)
   endif()
 
   if(GLIBCXX)
-	  list(APPEND DOLFINX_CXX_DEVELOPER_DEFINITIONS _GLIBCXX_ASSERTIONS)
+    list(APPEND DOLFINX_CXX_DEVELOPER_DEFINITIONS _GLIBCXX_ASSERTIONS)
   endif()
 
   # Turn off some checks in gcc12 and gcc13 due to false positives with the fmt
@@ -104,9 +104,9 @@ add_executable(
 target_link_libraries(unittests PRIVATE Catch2::Catch2 dolfinx)
 target_compile_features(unittests PRIVATE cxx_std_20 c_std_17)
 
-# NOTE: Fixes when using Catch2 <= 3.13 with Clang 22.
+# NOTE: Fixes when using Catch2 <= 3.13 with Clang 22 and derivatives.
 # https://github.com/catchorg/Catch2/blob/devel/docs/release-notes.md#3140
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
   target_compile_options(unittests PRIVATE -Wno-c2y-extensions)
 endif()
 

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -104,6 +104,12 @@ add_executable(
 target_link_libraries(unittests PRIVATE Catch2::Catch2 dolfinx)
 target_compile_features(unittests PRIVATE cxx_std_20 c_std_17)
 
+# NOTE: Fixes when using Catch2 <= 3.13 with Clang 22.
+# https://github.com/catchorg/Catch2/blob/devel/docs/release-notes.md#3140
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(unittests PRIVATE -Wno-c2y-extensions)
+endif()
+
 # UUID requires bcrypt to be linked on Windows, broken in vcpkg.
 # https://github.com/microsoft/vcpkg/issues/4481
 if(WIN32)


### PR DESCRIPTION
Issue 1:

See https://github.com/catchorg/Catch2/blob/devel/docs/release-notes.md#3140.

"Suppressed the new Clang warning about __COUNTER__ usage. (#3076)"

This raises a warning which results in an error due to our strict compiler flags. Can be removed once Catch 3.14 is available in Spack.

Issue 2:

Current `develop` branch of Spack tools cannot correctly push/pull from the GitHub OCI registry. Pinning to v1.1.1 fixes this. It would probably be best to use stable releases of Spack tooling 
