### PR TITLE
Remove zeros in sparse matrix multiplication

### DIFF
--- a/cpp/dolfinx/la/matmul.h
+++ b/cpp/dolfinx/la/matmul.h
@@ -378,11 +378,12 @@ fetch_ghost_rows(const dolfinx::la::MatrixCSR<T>& A,
     std::int32_t src_start = ghost_row_ptr[perm[i]];
     std::int32_t src_end = ghost_row_ptr[perm[i] + 1];
     std::int32_t dst_start = orig_ghost_row_ptr[i];
-    std::copy(recv_col_local.begin() + src_start,
-              recv_col_local.begin() + src_end,
-              orig_recv_col_local.begin() + dst_start);
-    std::copy(recv_vals.begin() + src_start, recv_vals.begin() + src_end,
-              orig_recv_vals.begin() + dst_start);
+    std::copy(std::next(recv_col_local.begin(), src_start),
+              std::next(recv_col_local.begin(), src_end),
+              std::next(orig_recv_col_local.begin(), dst_start));
+    std::copy(std::next(recv_vals.begin(), src_start),
+              std::next(recv_vals.begin(), src_end),
+              std::next(orig_recv_vals.begin(), dst_start));
   }
 
   return {new_col_map, orig_ghost_row_ptr, orig_recv_col_local, orig_recv_vals};
@@ -466,12 +467,13 @@ matmul(const dolfinx::la::MatrixCSR<T>& A, const dolfinx::la::MatrixCSR<T>& B,
         const std::int32_t c = cols_B[kb];
         const std::int32_t k
             = c < num_owned_cols_B ? c : b_ghost_remap[c - num_owned_cols_B];
-        if (!in_row[k])
+        T acc_val = a * vals_B[kb];
+        if (!in_row[k] and acc_val != T(0))
         {
           in_row[k] = true;
           row_cols.push_back(k);
         }
-        acc[k] += a * vals_B[kb];
+        acc[k] += acc_val;
       }
     }
 
@@ -484,13 +486,27 @@ matmul(const dolfinx::la::MatrixCSR<T>& A, const dolfinx::la::MatrixCSR<T>& B,
       for (std::int32_t kb = ghost_row_ptr[g]; kb < ghost_row_ptr[g + 1]; ++kb)
       {
         const std::int32_t k = ghost_cols[kb];
-        if (!in_row[k])
+        T acc_val = a * ghost_vals[kb];
+        if (!in_row[k] and acc_val != T(0))
         {
           in_row[k] = true;
           row_cols.push_back(k);
         }
-        acc[k] += a * ghost_vals[kb];
+        acc[k] += acc_val;
       }
+    }
+
+    // Remove zeros produced by exact cancellation in the SpGEMM.
+    auto pos = row_cols.begin();
+    while (pos != row_cols.end())
+    {
+      if (acc[*pos] == T(0))
+      {
+        in_row[*pos] = false;
+        pos = row_cols.erase(pos);
+      }
+      else
+        ++pos;
     }
 
     // Sort touched indices to satisfy the CSR sorted-column invariant

--- a/python/test/unit/la/test_matmul.py
+++ b/python/test/unit/la/test_matmul.py
@@ -73,9 +73,10 @@ def test_matmul_rect(dtype, mat_random, mat_gather):
     assert np.allclose(C.to_dense()[:nrC, :], Cscipy.todense()[lrC0:lrC1])
 
 
-def test_matmul_zeros(mat_random, mat_gather):
-    A = mat_random(0, 0, 123, np.float64)
-    B = mat_random(0, 0, 321, np.float64)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
+def test_matmul_zeros(dtype, mat_random, mat_gather):
+    A = mat_random(0, 0, 123, dtype)
+    B = mat_random(0, 0, 321, dtype)
 
     # Create structural zeros in B
     pos = 0

--- a/python/test/unit/la/test_matmul.py
+++ b/python/test/unit/la/test_matmul.py
@@ -73,7 +73,15 @@ def test_matmul_rect(dtype, mat_random, mat_gather):
     assert np.allclose(C.to_dense()[:nrC, :], Cscipy.todense()[lrC0:lrC1])
 
 
-@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        np.float32,
+        np.float64,
+        np.complex64,
+        np.complex128,
+    ],
+)
 def test_matmul_zeros(dtype, mat_random, mat_gather):
     A = mat_random(0, 0, 123, dtype)
     B = mat_random(0, 0, 321, dtype)

--- a/python/test/unit/la/test_matmul.py
+++ b/python/test/unit/la/test_matmul.py
@@ -73,6 +73,28 @@ def test_matmul_rect(dtype, mat_random, mat_gather):
     assert np.allclose(C.to_dense()[:nrC, :], Cscipy.todense()[lrC0:lrC1])
 
 
+def test_matmul_zeros(mat_random, mat_gather):
+    A = mat_random(0, 0, 123, np.float64)
+    B = mat_random(0, 0, 321, np.float64)
+
+    # Create structural zeros in B
+    pos = 0
+    for i in range(B.index_map(0).size_local):
+        for j in range(B.indptr[i], B.indptr[i + 1]):
+            if i != B.indices[j]:
+                B.data[pos] = 0.0
+            pos += 1
+    As = mat_gather(A)
+    Bs = mat_gather(B)
+
+    Cs = As @ Bs
+    C0 = A.matmul(B)
+
+    C = mat_gather(C0)
+    assert C.nnz == Cs.nnz
+    assert np.allclose(Cs.todense(), C.todense())
+
+
 def test_bad_shape(mat_random):
     # Test matmul of incompatible matrices (should raise an error)
     A = mat_random(0, 1, 12345, np.float64)

--- a/python/test/unit/la/test_matmul.py
+++ b/python/test/unit/la/test_matmul.py
@@ -84,15 +84,28 @@ def test_matmul_rect(dtype, mat_random, mat_gather):
 )
 def test_matmul_zeros(dtype, mat_random, mat_gather):
     A = mat_random(0, 0, 123, dtype)
+    # Make first two entries in row zero of A (+1, +1).
+    A.data[0] = 1.0
+    A.data[1] = 1.0
     B = mat_random(0, 0, 321, dtype)
 
-    # Create structural zeros in B
+    rank = A.index_map(0).comm.rank
+
+    # Create structural zeros in B and new structural zero in product
+    # by making the first two entries in column zero of B (+1, -1).
     pos = 0
+    global_zero = B.index_map(1).global_to_local(np.zeros(1))
     for i in range(B.index_map(0).size_local):
         for j in range(B.indptr[i], B.indptr[i + 1]):
-            if i != B.indices[j]:
-                B.data[pos] = 0.0
+            if B.indices[j] == global_zero:
+                if rank == 0 and i == 0:
+                    B.data[pos] = 1.0
+                elif rank == 0 and i == 1:
+                    B.data[pos] = -1.0
+                else:
+                    B.data[pos] = 0.0
             pos += 1
+
     As = mat_gather(A)
     Bs = mat_gather(B)
 


### PR DESCRIPTION
Removes literal zeros from a matrix-matrix product, reducing memory footprint.