### PR TITLE
Allow built-in meshes to be embedded in gdim >= tdim

### DIFF
--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -291,12 +291,14 @@ create_interval(MPI_Comm comm, std::int64_t n, std::array<T, 2> p,
     for (std::size_t i = 0; i < npts; i++)
       x[i * gdim] = x1d[i];
     return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
-                       {npts, gdim}, partitioner, 2, reorder_fn);
+                       {npts, static_cast<std::size_t>(gdim)}, partitioner, 2,
+                       reorder_fn);
   }
   else
   {
     return create_mesh(comm, MPI_COMM_NULL, {}, element, MPI_COMM_NULL,
-                       std::vector<T>{}, {0, gdim}, partitioner, 2, reorder_fn);
+                       std::vector<T>{}, {0, static_cast<std::size_t>(gdim)},
+                       partitioner, 2, reorder_fn);
   }
 }
 
@@ -679,12 +681,14 @@ Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
       xg[i * gdim + 1] = x[2 * i + 1];
     }
     return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, xg,
-                       {npts, gdim}, partitioner, 2, reorder_fn);
+                       {npts, static_cast<std::size_t>(gdim)}, partitioner, 2,
+                       reorder_fn);
   }
   else
   {
     return create_mesh(comm, MPI_COMM_NULL, {}, element, MPI_COMM_NULL,
-                       std::vector<T>{}, {0, gdim}, partitioner, 2, reorder_fn);
+                       std::vector<T>{}, {0, static_cast<std::size_t>(gdim)},
+                       partitioner, 2, reorder_fn);
   }
 }
 
@@ -743,12 +747,14 @@ Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
       xg[i * gdim + 1] = x[2 * i + 1];
     }
     return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, xg,
-                       {npts, gdim}, partitioner, 2, reorder_fn);
+                       {npts, static_cast<std::size_t>(gdim)}, partitioner, 2,
+                       reorder_fn);
   }
   else
   {
     return create_mesh(comm, MPI_COMM_NULL, {}, element, MPI_COMM_NULL,
-                       std::vector<T>{}, {0, gdim}, partitioner, 2, reorder_fn);
+                       std::vector<T>{}, {0, static_cast<std::size_t>(gdim)},
+                       partitioner, 2, reorder_fn);
   }
 }
 } // namespace impl

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -109,7 +109,7 @@ Mesh<T> create_box(MPI_Comm comm, MPI_Comm subcomm,
                    const CellReorderFunction& reorder_fn = graph::reorder_gps)
 {
   if (std::ranges::any_of(n, [](auto e) { return e < 1; }))
-    throw std::runtime_error("At least one cell per dimension is required");
+    throw std::runtime_error("At least one cell is required.");
 
   for (int32_t i = 0; i < 3; i++)
   {
@@ -191,7 +191,7 @@ Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
     throw std::runtime_error(
         "gdim must be >= 2 for rectangle mesh.");
   if (std::ranges::any_of(n, [](auto e) { return e < 1; }))
-    throw std::runtime_error("At least one cell per dimension is required");
+    throw std::runtime_error("At least one cell per dimension is required.");
 
   for (int32_t i = 0; i < 2; i++)
   {
@@ -210,7 +210,7 @@ Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
   case CellType::quadrilateral:
     return impl::build_quad<T>(comm, p, n, partitioner, reorder_fn, gdim);
   default:
-    throw std::runtime_error("Generate rectangle mesh. Wrong cell type");
+    throw std::runtime_error("Generate rectangle mesh. Wrong cell type.");
   }
 }
 
@@ -266,7 +266,7 @@ Mesh<T> create_interval(MPI_Comm comm, std::int64_t n, std::array<T, 2> p,
   if (gdim < 1)
     throw std::runtime_error("gdim must be >= 1 for interval mesh.");
   if (n < 1)
-    throw std::runtime_error("At least one cell is required.");
+    throw std::runtime_error("At least one cell per dimension is required.");
 
   const auto [a, b] = p;
   if (a >= b)

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -188,8 +188,7 @@ Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                          = graph::reorder_gps)
 {
   if (gdim < 2)
-    throw std::runtime_error(
-        "gdim must be >= 2 for rectangle mesh.");
+    throw std::runtime_error("gdim must be >= 2 for rectangle mesh.");
   if (std::ranges::any_of(n, [](auto e) { return e < 1; }))
     throw std::runtime_error("At least one cell per dimension is required.");
 

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -526,6 +526,7 @@ Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                   DiagonalType diagonal, const CellReorderFunction& reorder_fn,
                   std::size_t gdim)
 {
+  assert(gdim >= 2);
   fem::CoordinateElement<T> element(CellType::triangle, 1);
   if (dolfinx::MPI::rank(comm) == 0)
   {
@@ -694,6 +695,7 @@ Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                    const CellPartitionFunction& partitioner,
                    const CellReorderFunction& reorder_fn, std::size_t gdim)
 {
+  assert(gdim >= 2);
   fem::CoordinateElement<T> element(CellType::quadrilateral, 1);
   if (dolfinx::MPI::rank(comm) == 0)
   {

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -179,13 +179,12 @@ Mesh<T> create_box(MPI_Comm comm, std::array<std::array<T, 3>, 2> p,
 /// @param[in] reorder_fn Function for (locally) reordering cells
 /// @return Mesh
 template <std::floating_point T = double>
-Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
-                         std::array<std::int64_t, 2> n, CellType celltype,
-                         CellPartitionFunction partitioner,
-                         DiagonalType diagonal = DiagonalType::right,
-                         int gdim = 2,
-                         const CellReorderFunction& reorder_fn
-                         = graph::reorder_gps)
+Mesh<T>
+create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
+                 std::array<std::int64_t, 2> n, CellType celltype,
+                 CellPartitionFunction partitioner,
+                 DiagonalType diagonal = DiagonalType::right, int gdim = 2,
+                 const CellReorderFunction& reorder_fn = graph::reorder_gps)
 {
   if (gdim < 2 || gdim > 3)
     throw std::runtime_error("2 <= gdim <= 3 for rectangle mesh.");
@@ -255,12 +254,11 @@ Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
 /// @param[in] reorder_fn Function for (locally) reordering cells
 /// @return A mesh.
 template <std::floating_point T = double>
-Mesh<T> create_interval(MPI_Comm comm, std::int64_t n, std::array<T, 2> p,
-                        mesh::GhostMode ghost_mode = mesh::GhostMode::none,
-                        CellPartitionFunction partitioner = nullptr,
-                        int gdim = 1,
-                        const CellReorderFunction& reorder_fn
-                        = graph::reorder_gps)
+Mesh<T>
+create_interval(MPI_Comm comm, std::int64_t n, std::array<T, 2> p,
+                mesh::GhostMode ghost_mode = mesh::GhostMode::none,
+                CellPartitionFunction partitioner = nullptr, int gdim = 1,
+                const CellReorderFunction& reorder_fn = graph::reorder_gps)
 {
   if (gdim < 1 || gdim > 3)
     throw std::runtime_error("1 <= gdim <= 3 for interval mesh.");
@@ -526,9 +524,9 @@ Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                   int gdim)
 {
   fem::CoordinateElement<T> element(CellType::triangle, 1);
-  if (gdim < 2 || gdim > 3) {
-    throw std::runtime_error("2 <= gdim <= 3 for tri mesh.")
-  }
+  if (gdim < 2 || gdim > 3)
+    throw std::runtime_error("2 <= gdim <= 3 for tri mesh.");
+
   if (dolfinx::MPI::rank(comm) == 0)
   {
     const auto [p0, p1] = p;
@@ -696,9 +694,9 @@ Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                    const CellPartitionFunction& partitioner,
                    const CellReorderFunction& reorder_fn, int gdim)
 {
-  if (gdim < 2 || gdim > 3) {
-    throw std::runtime_error("2 <= gdim <= 3 for quad mesh.")
-  }
+  if (gdim < 2 || gdim > 3)
+    throw std::runtime_error("2 <= gdim <= 3 for quad mesh.");
+
   fem::CoordinateElement<T> element(CellType::quadrilateral, 1);
   if (dolfinx::MPI::rank(comm) == 0)
   {

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -46,13 +46,13 @@ Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                   std::array<std::int64_t, 2> n,
                   const CellPartitionFunction& partitioner,
                   DiagonalType diagonal, const CellReorderFunction& reorder_fn,
-                  std::size_t gdim);
+                  int gdim);
 
 template <std::floating_point T>
 Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                    std::array<std::int64_t, 2> n,
                    const CellPartitionFunction& partitioner,
-                   const CellReorderFunction& reorder_fn, std::size_t gdim);
+                   const CellReorderFunction& reorder_fn, int gdim);
 
 template <std::floating_point T>
 std::vector<T> create_geom(MPI_Comm comm, std::array<std::array<T, 3>, 2> p,
@@ -183,7 +183,7 @@ Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                          std::array<std::int64_t, 2> n, CellType celltype,
                          CellPartitionFunction partitioner,
                          DiagonalType diagonal = DiagonalType::right,
-                         std::size_t gdim = 2,
+                         int gdim = 2,
                          const CellReorderFunction& reorder_fn
                          = graph::reorder_gps)
 {
@@ -233,7 +233,7 @@ template <std::floating_point T = double>
 Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                          std::array<std::int64_t, 2> n, CellType celltype,
                          DiagonalType diagonal = DiagonalType::right,
-                         std::size_t gdim = 2)
+                         int gdim = 2)
 {
   return create_rectangle<T>(comm, p, n, celltype, nullptr, diagonal, gdim);
 }
@@ -258,7 +258,7 @@ template <std::floating_point T = double>
 Mesh<T> create_interval(MPI_Comm comm, std::int64_t n, std::array<T, 2> p,
                         mesh::GhostMode ghost_mode = mesh::GhostMode::none,
                         CellPartitionFunction partitioner = nullptr,
-                        std::size_t gdim = 1,
+                        int gdim = 1,
                         const CellReorderFunction& reorder_fn
                         = graph::reorder_gps)
 {
@@ -523,7 +523,7 @@ Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                   std::array<std::int64_t, 2> n,
                   const CellPartitionFunction& partitioner,
                   DiagonalType diagonal, const CellReorderFunction& reorder_fn,
-                  std::size_t gdim)
+                  int gdim)
 {
   assert(gdim >= 2);
   fem::CoordinateElement<T> element(CellType::triangle, 1);
@@ -692,7 +692,7 @@ template <std::floating_point T>
 Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                    std::array<std::int64_t, 2> n,
                    const CellPartitionFunction& partitioner,
-                   const CellReorderFunction& reorder_fn, std::size_t gdim)
+                   const CellReorderFunction& reorder_fn, int gdim)
 {
   assert(gdim >= 2);
   fem::CoordinateElement<T> element(CellType::quadrilateral, 1);

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -187,8 +187,8 @@ Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                          const CellReorderFunction& reorder_fn
                          = graph::reorder_gps)
 {
-  if (gdim < 2)
-    throw std::runtime_error("gdim must be >= 2 for rectangle mesh.");
+  if (gdim < 2 || gdim > 3)
+    throw std::runtime_error("2 <= gdim <= 3 for rectangle mesh.");
   if (std::ranges::any_of(n, [](auto e) { return e < 1; }))
     throw std::runtime_error("At least one cell per dimension is required.");
 
@@ -262,8 +262,8 @@ Mesh<T> create_interval(MPI_Comm comm, std::int64_t n, std::array<T, 2> p,
                         const CellReorderFunction& reorder_fn
                         = graph::reorder_gps)
 {
-  if (gdim < 1)
-    throw std::runtime_error("gdim must be >= 1 for interval mesh.");
+  if (gdim < 1 || gdim > 3)
+    throw std::runtime_error("1 <= gdim <= 3 for interval mesh.");
   if (n < 1)
     throw std::runtime_error("At least one cell per dimension is required.");
 
@@ -525,8 +525,10 @@ Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                   DiagonalType diagonal, const CellReorderFunction& reorder_fn,
                   int gdim)
 {
-  assert(gdim >= 2);
   fem::CoordinateElement<T> element(CellType::triangle, 1);
+  if (gdim < 2 || gdim > 3) {
+    throw std::runtime_error("2 <= gdim <= 3 for tri mesh.")
+  }
   if (dolfinx::MPI::rank(comm) == 0)
   {
     const auto [p0, p1] = p;
@@ -694,7 +696,9 @@ Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                    const CellPartitionFunction& partitioner,
                    const CellReorderFunction& reorder_fn, int gdim)
 {
-  assert(gdim >= 2);
+  if (gdim < 2 || gdim > 3) {
+    throw std::runtime_error("2 <= gdim <= 3 for quad mesh.")
+  }
   fem::CoordinateElement<T> element(CellType::quadrilateral, 1);
   if (dolfinx::MPI::rank(comm) == 0)
   {

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -174,18 +174,18 @@ Mesh<T> create_box(MPI_Comm comm, std::array<std::array<T, 3>, 2> p,
 /// @param[in] partitioner Partitioning function for distributing cells
 /// across MPI ranks.
 /// @param[in] diagonal Direction of diagonals
-/// @param[in] reorder_fn Function for (locally) reordering cells
 /// @param[in] gdim Geometric dimension. Must be >= 2. Coordinates are
 /// embedded in the first 2 components; remaining components are zero.
+/// @param[in] reorder_fn Function for (locally) reordering cells
 /// @return Mesh
 template <std::floating_point T = double>
 Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                          std::array<std::int64_t, 2> n, CellType celltype,
                          CellPartitionFunction partitioner,
                          DiagonalType diagonal = DiagonalType::right,
+                         std::size_t gdim = 2,
                          const CellReorderFunction& reorder_fn
-                         = graph::reorder_gps,
-                         std::size_t gdim = 2)
+                         = graph::reorder_gps)
 {
   if (gdim < 2)
     throw std::runtime_error(
@@ -236,8 +236,7 @@ Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                          DiagonalType diagonal = DiagonalType::right,
                          std::size_t gdim = 2)
 {
-  return create_rectangle<T>(comm, p, n, celltype, nullptr, diagonal,
-                             graph::reorder_gps, gdim);
+  return create_rectangle<T>(comm, p, n, celltype, nullptr, diagonal, gdim);
 }
 
 /// @brief Interval mesh of the 1D line `[a, b]`.
@@ -252,17 +251,17 @@ Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
 /// @param[in] ghost_mode ghost mode of the created mesh, defaults to none
 /// @param[in] partitioner Partitioning function for distributing cells
 /// across MPI ranks.
-/// @param[in] reorder_fn Function for (locally) reordering cells
 /// @param[in] gdim Geometric dimension. Must be >= 1. The interval lies
 /// along the first coordinate axis; remaining components are zero.
+/// @param[in] reorder_fn Function for (locally) reordering cells
 /// @return A mesh.
 template <std::floating_point T = double>
 Mesh<T> create_interval(MPI_Comm comm, std::int64_t n, std::array<T, 2> p,
                         mesh::GhostMode ghost_mode = mesh::GhostMode::none,
                         CellPartitionFunction partitioner = nullptr,
+                        std::size_t gdim = 1,
                         const CellReorderFunction& reorder_fn
-                        = graph::reorder_gps,
-                        std::size_t gdim = 1)
+                        = graph::reorder_gps)
 {
   if (gdim < 1)
     throw std::runtime_error("gdim must be >= 1 for interval mesh.");

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -45,13 +45,14 @@ template <std::floating_point T>
 Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                   std::array<std::int64_t, 2> n,
                   const CellPartitionFunction& partitioner,
-                  DiagonalType diagonal, const CellReorderFunction& reorder_fn);
+                  DiagonalType diagonal, const CellReorderFunction& reorder_fn,
+                  std::size_t gdim);
 
 template <std::floating_point T>
 Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                    std::array<std::int64_t, 2> n,
                    const CellPartitionFunction& partitioner,
-                   const CellReorderFunction& reorder_fn);
+                   const CellReorderFunction& reorder_fn, std::size_t gdim);
 
 template <std::floating_point T>
 std::vector<T> create_geom(MPI_Comm comm, std::array<std::array<T, 3>, 2> p,
@@ -174,6 +175,8 @@ Mesh<T> create_box(MPI_Comm comm, std::array<std::array<T, 3>, 2> p,
 /// across MPI ranks.
 /// @param[in] diagonal Direction of diagonals
 /// @param[in] reorder_fn Function for (locally) reordering cells
+/// @param[in] gdim Geometric dimension. Must be >= 2. Coordinates are
+/// embedded in the first 2 components; remaining components are zero.
 /// @return Mesh
 template <std::floating_point T = double>
 Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
@@ -181,8 +184,12 @@ Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                          CellPartitionFunction partitioner,
                          DiagonalType diagonal = DiagonalType::right,
                          const CellReorderFunction& reorder_fn
-                         = graph::reorder_gps)
+                         = graph::reorder_gps,
+                         std::size_t gdim = 2)
 {
+  if (gdim < 2)
+    throw std::runtime_error(
+        "Geometric dimension must be >= 2 for rectangle mesh.");
   if (std::ranges::any_of(n, [](auto e) { return e < 1; }))
     throw std::runtime_error("At least one cell per dimension is required");
 
@@ -198,9 +205,10 @@ Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
   switch (celltype)
   {
   case CellType::triangle:
-    return impl::build_tri<T>(comm, p, n, partitioner, diagonal, reorder_fn);
+    return impl::build_tri<T>(comm, p, n, partitioner, diagonal, reorder_fn,
+                              gdim);
   case CellType::quadrilateral:
-    return impl::build_quad<T>(comm, p, n, partitioner, reorder_fn);
+    return impl::build_quad<T>(comm, p, n, partitioner, reorder_fn, gdim);
   default:
     throw std::runtime_error("Generate rectangle mesh. Wrong cell type");
   }
@@ -219,13 +227,17 @@ Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
 /// @param[in] n Number of cells in each direction
 /// @param[in] celltype Cell shape
 /// @param[in] diagonal Direction of diagonals
+/// @param[in] gdim Geometric dimension. Must be >= 2. Coordinates are
+/// embedded in the first 2 components; remaining components are zero.
 /// @return Mesh
 template <std::floating_point T = double>
 Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                          std::array<std::int64_t, 2> n, CellType celltype,
-                         DiagonalType diagonal = DiagonalType::right)
+                         DiagonalType diagonal = DiagonalType::right,
+                         std::size_t gdim = 2)
 {
-  return create_rectangle<T>(comm, p, n, celltype, nullptr, diagonal);
+  return create_rectangle<T>(comm, p, n, celltype, nullptr, diagonal,
+                             graph::reorder_gps, gdim);
 }
 
 /// @brief Interval mesh of the 1D line `[a, b]`.
@@ -241,14 +253,19 @@ Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
 /// @param[in] partitioner Partitioning function for distributing cells
 /// across MPI ranks.
 /// @param[in] reorder_fn Function for (locally) reordering cells
+/// @param[in] gdim Geometric dimension. Must be >= 1. The interval lies
+/// along the first coordinate axis; remaining components are zero.
 /// @return A mesh.
 template <std::floating_point T = double>
 Mesh<T> create_interval(MPI_Comm comm, std::int64_t n, std::array<T, 2> p,
                         mesh::GhostMode ghost_mode = mesh::GhostMode::none,
                         CellPartitionFunction partitioner = nullptr,
                         const CellReorderFunction& reorder_fn
-                        = graph::reorder_gps)
+                        = graph::reorder_gps,
+                        std::size_t gdim = 1)
 {
+  if (gdim < 1)
+    throw std::runtime_error("Geometric dimension must be >= 1.");
   if (n < 1)
     throw std::runtime_error("At least one cell is required.");
 
@@ -267,14 +284,18 @@ Mesh<T> create_interval(MPI_Comm comm, std::int64_t n, std::array<T, 2> p,
   fem::CoordinateElement<T> element(CellType::interval, 1);
   if (dolfinx::MPI::rank(comm) == 0)
   {
-    auto [x, cells] = impl::create_interval_cells<T>(p, n);
+    auto [x1d, cells] = impl::create_interval_cells<T>(p, n);
+    std::size_t npts = x1d.size();
+    std::vector<T> x(npts * gdim, T(0));
+    for (std::size_t i = 0; i < npts; i++)
+      x[i * gdim] = x1d[i];
     return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
-                       {x.size(), 1}, partitioner, 2, reorder_fn);
+                       {npts, gdim}, partitioner, 2, reorder_fn);
   }
   else
   {
     return create_mesh(comm, MPI_COMM_NULL, {}, element, MPI_COMM_NULL,
-                       std::vector<T>{}, {0, 1}, partitioner, 2, reorder_fn);
+                       std::vector<T>{}, {0, gdim}, partitioner, 2, reorder_fn);
   }
 }
 
@@ -498,7 +519,8 @@ template <std::floating_point T>
 Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                   std::array<std::int64_t, 2> n,
                   const CellPartitionFunction& partitioner,
-                  DiagonalType diagonal, const CellReorderFunction& reorder_fn)
+                  DiagonalType diagonal, const CellReorderFunction& reorder_fn,
+                  std::size_t gdim)
 {
   fem::CoordinateElement<T> element(CellType::triangle, 1);
   if (dolfinx::MPI::rank(comm) == 0)
@@ -640,13 +662,20 @@ Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
     }
     }
 
-    return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
-                       {x.size() / 2, 2}, partitioner, 2, reorder_fn);
+    std::size_t npts = x.size() / 2;
+    std::vector<T> xg(npts * gdim, T(0));
+    for (std::size_t i = 0; i < npts; i++)
+    {
+      xg[i * gdim] = x[2 * i];
+      xg[i * gdim + 1] = x[2 * i + 1];
+    }
+    return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, xg,
+                       {npts, gdim}, partitioner, 2, reorder_fn);
   }
   else
   {
     return create_mesh(comm, MPI_COMM_NULL, {}, element, MPI_COMM_NULL,
-                       std::vector<T>{}, {0, 2}, partitioner, 2, reorder_fn);
+                       std::vector<T>{}, {0, gdim}, partitioner, 2, reorder_fn);
   }
 }
 
@@ -654,7 +683,7 @@ template <std::floating_point T>
 Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
                    std::array<std::int64_t, 2> n,
                    const CellPartitionFunction& partitioner,
-                   const CellReorderFunction& reorder_fn)
+                   const CellReorderFunction& reorder_fn, std::size_t gdim)
 {
   fem::CoordinateElement<T> element(CellType::quadrilateral, 1);
   if (dolfinx::MPI::rank(comm) == 0)
@@ -689,13 +718,20 @@ Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
       }
     }
 
-    return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
-                       {x.size() / 2, 2}, partitioner, 2, reorder_fn);
+    std::size_t npts = x.size() / 2;
+    std::vector<T> xg(npts * gdim, T(0));
+    for (std::size_t i = 0; i < npts; i++)
+    {
+      xg[i * gdim] = x[2 * i];
+      xg[i * gdim + 1] = x[2 * i + 1];
+    }
+    return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, xg,
+                       {npts, gdim}, partitioner, 2, reorder_fn);
   }
   else
   {
     return create_mesh(comm, MPI_COMM_NULL, {}, element, MPI_COMM_NULL,
-                       std::vector<T>{}, {0, 2}, partitioner, 2, reorder_fn);
+                       std::vector<T>{}, {0, gdim}, partitioner, 2, reorder_fn);
   }
 }
 } // namespace impl

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -189,7 +189,7 @@ Mesh<T> create_rectangle(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
 {
   if (gdim < 2)
     throw std::runtime_error(
-        "Geometric dimension must be >= 2 for rectangle mesh.");
+        "gdim must be >= 2 for rectangle mesh.");
   if (std::ranges::any_of(n, [](auto e) { return e < 1; }))
     throw std::runtime_error("At least one cell per dimension is required");
 
@@ -265,7 +265,7 @@ Mesh<T> create_interval(MPI_Comm comm, std::int64_t n, std::array<T, 2> p,
                         std::size_t gdim = 1)
 {
   if (gdim < 1)
-    throw std::runtime_error("Geometric dimension must be >= 1.");
+    throw std::runtime_error("gdim must be >= 1 for interval mesh.");
   if (n < 1)
     throw std::runtime_error("At least one cell is required.");
 

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -285,6 +285,11 @@ Mesh<T> create_interval(MPI_Comm comm, std::int64_t n, std::array<T, 2> p,
   {
     auto [x1d, cells] = impl::create_interval_cells<T>(p, n);
     std::size_t npts = x1d.size();
+    if (gdim == 1)
+    {
+      return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF,
+                         x1d, {npts, 1}, partitioner, 2, reorder_fn);
+    }
     std::vector<T> x(npts * gdim, T(0));
     for (std::size_t i = 0; i < npts; i++)
       x[i * gdim] = x1d[i];
@@ -662,6 +667,11 @@ Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
     }
 
     std::size_t npts = x.size() / 2;
+    if (gdim == 2)
+    {
+      return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
+                         {npts, 2}, partitioner, 2, reorder_fn);
+    }
     std::vector<T> xg(npts * gdim, T(0));
     for (std::size_t i = 0; i < npts; i++)
     {
@@ -718,6 +728,11 @@ Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
     }
 
     std::size_t npts = x.size() / 2;
+    if (gdim == 2)
+    {
+      return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
+                         {npts, 2}, partitioner, 2, reorder_fn);
+    }
     std::vector<T> xg(npts * gdim, T(0));
     for (std::size_t i = 0; i < npts; i++)
     {

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -958,6 +958,7 @@ def create_interval(
     dtype: npt.DTypeLike = default_real_type,
     ghost_mode=GhostMode.shared_facet,
     partitioner=None,
+    gdim: int = 1,
 ) -> Mesh:
     """Create an interval mesh.
 
@@ -971,6 +972,8 @@ def create_interval(
             are ``GhostMode.none`` and ``GhostMode.shared_facet``.
         partitioner: Partitioning function to use for determining the
             parallel distribution of cells across MPI ranks.
+        gdim: Geometric dimension. The interval lies along the first
+            coordinate axis; remaining components are zero.
 
     Returns:
         An interval mesh.
@@ -983,14 +986,14 @@ def create_interval(
             "interval",
             1,
             lagrange_variant=basix.LagrangeVariant.unset,
-            shape=(1,),
+            shape=(gdim,),
             dtype=dtype,
         )
     )  # type: ignore
     if np.issubdtype(dtype, np.float32):
-        msh = _cpp.mesh.create_interval_float32(comm, nx, points, ghost_mode, partitioner)
+        msh = _cpp.mesh.create_interval_float32(comm, nx, points, ghost_mode, partitioner, gdim)
     elif np.issubdtype(dtype, np.float64):
-        msh = _cpp.mesh.create_interval_float64(comm, nx, points, ghost_mode, partitioner)
+        msh = _cpp.mesh.create_interval_float64(comm, nx, points, ghost_mode, partitioner, gdim)
     else:
         raise RuntimeError(f"Unsupported mesh geometry float type: {dtype}")
 
@@ -1003,24 +1006,26 @@ def create_unit_interval(
     dtype: npt.DTypeLike = default_real_type,
     ghost_mode=GhostMode.shared_facet,
     partitioner=None,
+    gdim: int = 1,
 ) -> Mesh:
     """Create a mesh on the unit interval.
 
     Args:
         comm: MPI communicator.
         nx: Number of cells.
-        points: Coordinates of the end points.
         dtype: Float type for the mesh geometry(``numpy.float32``
             or ``numpy.float64``).
         ghost_mode: Ghost mode used in the mesh partitioning. Options
             are ``GhostMode.none`` and ``GhostMode.shared_facet``.
         partitioner: Partitioning function to use for determining the
             parallel distribution of cells across MPI ranks.
+        gdim: Geometric dimension. The interval lies along the first
+            coordinate axis; remaining components are zero.
 
     Returns:
         A unit interval mesh with end points at 0 and 1.
     """
-    return create_interval(comm, nx, [0.0, 1.0], dtype, ghost_mode, partitioner)
+    return create_interval(comm, nx, [0.0, 1.0], dtype, ghost_mode, partitioner, gdim)
 
 
 def create_rectangle(
@@ -1032,6 +1037,7 @@ def create_rectangle(
     ghost_mode=GhostMode.shared_facet,
     partitioner=None,
     diagonal: DiagonalType = DiagonalType.right,
+    gdim: int = 2,
 ) -> Mesh:
     """Create a rectangle mesh.
 
@@ -1048,6 +1054,8 @@ def create_rectangle(
             cells across MPI ranks.
         diagonal: Direction of diagonal of triangular meshes.
             See :class:`DiagonalType` for available options.
+        gdim: Geometric dimension. The rectangle lies in the first 2
+            coordinate axes; remaining components are zero.
 
     Returns:
         A mesh of a rectangle.
@@ -1060,14 +1068,18 @@ def create_rectangle(
             cell_type.name,
             1,
             lagrange_variant=basix.LagrangeVariant.unset,
-            shape=(2,),
+            shape=(gdim,),
             dtype=dtype,
         )
     )  # type: ignore
     if np.issubdtype(dtype, np.float32):
-        msh = _cpp.mesh.create_rectangle_float32(comm, points, n, cell_type, partitioner, diagonal)
+        msh = _cpp.mesh.create_rectangle_float32(
+            comm, points, n, cell_type, partitioner, diagonal, gdim
+        )
     elif np.issubdtype(dtype, np.float64):
-        msh = _cpp.mesh.create_rectangle_float64(comm, points, n, cell_type, partitioner, diagonal)
+        msh = _cpp.mesh.create_rectangle_float64(
+            comm, points, n, cell_type, partitioner, diagonal, gdim
+        )
     else:
         raise RuntimeError(f"Unsupported mesh geometry float type: {dtype}")
 
@@ -1083,6 +1095,7 @@ def create_unit_square(
     ghost_mode=GhostMode.shared_facet,
     partitioner=None,
     diagonal: DiagonalType = DiagonalType.right,
+    gdim: int = 2,
 ) -> Mesh:
     """Create a mesh of a unit square.
 
@@ -1099,6 +1112,8 @@ def create_unit_square(
         diagonal:
             Direction of diagonal. See :class:`DiagonalType` for
             available options.
+        gdim: Geometric dimension. The square lies in the first 2
+            coordinate axes; remaining components are zero.
 
     Returns:
         A mesh of a square with corners at ``(0, 0)`` and ``(1, 1)``.
@@ -1112,6 +1127,7 @@ def create_unit_square(
         ghost_mode,
         partitioner,
         diagonal,
+        gdim,
     )
 
 

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -1025,7 +1025,9 @@ def create_unit_interval(
     Returns:
         A unit interval mesh with end points at 0 and 1.
     """
-    return create_interval(comm, nx, [0.0, 1.0], dtype, ghost_mode, partitioner, gdim)
+    return create_interval(
+        comm, nx, [0.0, 1.0], dtype=dtype, ghost_mode=ghost_mode, partitioner=partitioner, gdim=gdim
+    )
 
 
 def create_rectangle(
@@ -1123,11 +1125,11 @@ def create_unit_square(
         [np.array([0.0, 0.0]), np.array([1.0, 1.0])],
         (nx, ny),
         cell_type,
-        dtype,
-        ghost_mode,
-        partitioner,
-        diagonal,
-        gdim,
+        dtype=dtype,
+        ghost_mode=ghost_mode,
+        partitioner=partitioner,
+        diagonal=diagonal,
+        gdim=gdim,
     )
 
 

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -269,8 +269,7 @@ void declare_mesh(nb::module_& m, std::string type)
       create_interval.c_str(),
       [](MPICommWrapper comm, std::int64_t n, std::array<T, 2> p,
          dolfinx::mesh::GhostMode mode,
-         const part::impl::PythonCellPartitionFunction& part,
-         std::size_t gdim)
+         const part::impl::PythonCellPartitionFunction& part, std::size_t gdim)
       {
         return dolfinx::mesh::create_interval<T>(
             comm.get(), n, p, mode,
@@ -292,8 +291,7 @@ void declare_mesh(nb::module_& m, std::string type)
             part::impl::create_cell_partitioner_cpp(part), diagonal, gdim);
       },
       nb::arg("comm"), nb::arg("p"), nb::arg("n"), nb::arg("celltype"),
-      nb::arg("partitioner").none(), nb::arg("diagonal"),
-      nb::arg("gdim") = 2);
+      nb::arg("partitioner").none(), nb::arg("diagonal"), nb::arg("gdim") = 2);
 
   std::string create_box("create_box_" + type);
   m.def(

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -269,14 +269,16 @@ void declare_mesh(nb::module_& m, std::string type)
       create_interval.c_str(),
       [](MPICommWrapper comm, std::int64_t n, std::array<T, 2> p,
          dolfinx::mesh::GhostMode mode,
-         const part::impl::PythonCellPartitionFunction& part)
+         const part::impl::PythonCellPartitionFunction& part,
+         std::size_t gdim)
       {
         return dolfinx::mesh::create_interval<T>(
             comm.get(), n, p, mode,
-            part::impl::create_cell_partitioner_cpp(part));
+            part::impl::create_cell_partitioner_cpp(part),
+            dolfinx::graph::reorder_gps, gdim);
       },
       nb::arg("comm"), nb::arg("n"), nb::arg("p"), nb::arg("ghost_mode"),
-      nb::arg("partitioner").none());
+      nb::arg("partitioner").none(), nb::arg("gdim") = 1);
 
   std::string create_rectangle("create_rectangle_" + type);
   m.def(
@@ -284,14 +286,16 @@ void declare_mesh(nb::module_& m, std::string type)
       [](MPICommWrapper comm, std::array<std::array<T, 2>, 2> p,
          std::array<std::int64_t, 2> n, dolfinx::mesh::CellType celltype,
          const part::impl::PythonCellPartitionFunction& part,
-         dolfinx::mesh::DiagonalType diagonal)
+         dolfinx::mesh::DiagonalType diagonal, std::size_t gdim)
       {
         return dolfinx::mesh::create_rectangle<T>(
             comm.get(), p, n, celltype,
-            part::impl::create_cell_partitioner_cpp(part), diagonal);
+            part::impl::create_cell_partitioner_cpp(part), diagonal,
+            dolfinx::graph::reorder_gps, gdim);
       },
       nb::arg("comm"), nb::arg("p"), nb::arg("n"), nb::arg("celltype"),
-      nb::arg("partitioner").none(), nb::arg("diagonal"));
+      nb::arg("partitioner").none(), nb::arg("diagonal"),
+      nb::arg("gdim") = 2);
 
   std::string create_box("create_box_" + type);
   m.def(

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -269,7 +269,7 @@ void declare_mesh(nb::module_& m, std::string type)
       create_interval.c_str(),
       [](MPICommWrapper comm, std::int64_t n, std::array<T, 2> p,
          dolfinx::mesh::GhostMode mode,
-         const part::impl::PythonCellPartitionFunction& part, std::size_t gdim)
+         const part::impl::PythonCellPartitionFunction& part, int gdim)
       {
         return dolfinx::mesh::create_interval<T>(
             comm.get(), n, p, mode,
@@ -284,7 +284,7 @@ void declare_mesh(nb::module_& m, std::string type)
       [](MPICommWrapper comm, std::array<std::array<T, 2>, 2> p,
          std::array<std::int64_t, 2> n, dolfinx::mesh::CellType celltype,
          const part::impl::PythonCellPartitionFunction& part,
-         dolfinx::mesh::DiagonalType diagonal, std::size_t gdim)
+         dolfinx::mesh::DiagonalType diagonal, int gdim)
       {
         return dolfinx::mesh::create_rectangle<T>(
             comm.get(), p, n, celltype,

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -274,8 +274,7 @@ void declare_mesh(nb::module_& m, std::string type)
       {
         return dolfinx::mesh::create_interval<T>(
             comm.get(), n, p, mode,
-            part::impl::create_cell_partitioner_cpp(part),
-            dolfinx::graph::reorder_gps, gdim);
+            part::impl::create_cell_partitioner_cpp(part), gdim);
       },
       nb::arg("comm"), nb::arg("n"), nb::arg("p"), nb::arg("ghost_mode"),
       nb::arg("partitioner").none(), nb::arg("gdim") = 1);
@@ -290,8 +289,7 @@ void declare_mesh(nb::module_& m, std::string type)
       {
         return dolfinx::mesh::create_rectangle<T>(
             comm.get(), p, n, celltype,
-            part::impl::create_cell_partitioner_cpp(part), diagonal,
-            dolfinx::graph::reorder_gps, gdim);
+            part::impl::create_cell_partitioner_cpp(part), diagonal, gdim);
       },
       nb::arg("comm"), nb::arg("p"), nb::arg("n"), nb::arg("celltype"),
       nb::arg("partitioner").none(), nb::arg("diagonal"),

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -769,10 +769,12 @@ def test_gmsh_input_2d(order, cell_type, dtype):
         gmsh_cell_id = gmsh.model.mesh.getElementType("quadrangle", order)
     # This checks that recombination was successful - i.e. only one element type in mesh.
     if list(element_types) != [gmsh_cell_id]:
-        pytest.xfail(
+        msg = (
             f"Expected a single Gmsh element type {gmsh_cell_id}, "
             f"got {list(element_types)} - gmsh recombination failed."
         )
+        gmsh.finalize()
+        pytest.xfail(msg)
     (
         _name,
         _dim,
@@ -846,10 +848,12 @@ def test_gmsh_input_3d(order, cell_type, dtype):
         )
     # This checks that recombination was successful - i.e. only one element type in mesh.
     if list(element_types) != [gmsh_cell_id]:
-        pytest.xfail(
+        msg = (
             f"Expected a single Gmsh element type {gmsh_cell_id}, "
             f"got {list(element_types)} - gmsh recombination failed."
         )
+        gmsh.finalize()
+        pytest.xfail(msg)
     (
         _name,
         _dim,

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -779,7 +779,7 @@ def test_gmsh_input_2d(order, cell_type, dtype):
         gmsh_cell_id = gmsh.model.mesh.getElementType("quadrangle", order)
     gmsh.finalize()
 
-    cells = cells[:, cell_perm_array(cell_type, cells.shape[1])].copy()
+    cells = cells[:, cell_perm_array(cell_type, num_nodes)].copy()
     x = x.astype(dtype)
     mesh = create_mesh(MPI.COMM_WORLD, cells, ufl_mesh(gmsh_cell_id, x.shape[1], dtype=dtype), x)
     surface = assemble_scalar(form(1 * dx(mesh), dtype=dtype))
@@ -852,7 +852,7 @@ def test_gmsh_input_3d(order, cell_type, dtype):
 
     # Permute the mesh topology from Gmsh ordering to DOLFINx ordering
     domain = ufl_mesh(gmsh_cell_id, 3, dtype=dtype)
-    cells = cells[:, cell_perm_array(cell_type, cells.shape[1])].copy()
+    cells = cells[:, cell_perm_array(cell_type, num_nodes)].copy()
 
     x = x.astype(dtype)
     mesh = create_mesh(MPI.COMM_WORLD, cells, domain, x)

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -763,6 +763,14 @@ def test_gmsh_input_2d(order, cell_type, dtype):
     x = points[srt]
 
     element_types, _element_tags, node_tags = gmsh.model.mesh.getElements(dim=2)
+    if cell_type == CellType.triangle:
+        gmsh_cell_id = gmsh.model.mesh.getElementType("triangle", order)
+    elif cell_type == CellType.quadrilateral:
+        gmsh_cell_id = gmsh.model.mesh.getElementType("quadrangle", order)
+    if list(element_types) != [gmsh_cell_id]:
+        raise RuntimeError(
+            f"Expected a single Gmsh element type {gmsh_cell_id}, got {list(element_types)}."
+        )
     (
         _name,
         _dim,
@@ -773,10 +781,6 @@ def test_gmsh_input_2d(order, cell_type, dtype):
     ) = gmsh.model.mesh.getElementProperties(element_types[0])
 
     cells = node_tags[0].reshape(-1, num_nodes) - 1
-    if cell_type == CellType.triangle:
-        gmsh_cell_id = gmsh.model.mesh.getElementType("triangle", order)
-    elif cell_type == CellType.quadrilateral:
-        gmsh_cell_id = gmsh.model.mesh.getElementType("quadrangle", order)
     gmsh.finalize()
 
     cells = cells[:, cell_perm_array(cell_type, cells.shape[1])].copy()
@@ -830,6 +834,18 @@ def test_gmsh_input_3d(order, cell_type, dtype):
     x = points[srt]
 
     element_types, _element_tags, node_tags = gmsh.model.mesh.getElements(dim=3)
+    if cell_type == CellType.tetrahedron:
+        gmsh_cell_id = MPI.COMM_WORLD.bcast(
+            gmsh.model.mesh.getElementType("tetrahedron", order), root=0
+        )
+    elif cell_type == CellType.hexahedron:
+        gmsh_cell_id = MPI.COMM_WORLD.bcast(
+            gmsh.model.mesh.getElementType("hexahedron", order), root=0
+        )
+    if list(element_types) != [gmsh_cell_id]:
+        raise RuntimeError(
+            f"Expected a single Gmsh element type {gmsh_cell_id}, got {list(element_types)}."
+        )
     (
         _name,
         _dim,
@@ -840,14 +856,6 @@ def test_gmsh_input_3d(order, cell_type, dtype):
     ) = gmsh.model.mesh.getElementProperties(element_types[0])
 
     cells = node_tags[0].reshape(-1, num_nodes) - 1
-    if cell_type == CellType.tetrahedron:
-        gmsh_cell_id = MPI.COMM_WORLD.bcast(
-            gmsh.model.mesh.getElementType("tetrahedron", order), root=0
-        )
-    elif cell_type == CellType.hexahedron:
-        gmsh_cell_id = MPI.COMM_WORLD.bcast(
-            gmsh.model.mesh.getElementType("hexahedron", order), root=0
-        )
     gmsh.finalize()
 
     # Permute the mesh topology from Gmsh ordering to DOLFINx ordering

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -806,7 +806,7 @@ def test_gmsh_input_3d(order, cell_type, dtype):
     gmsh.initialize()
     if cell_type == CellType.hexahedron:
         gmsh.option.setNumber("Mesh.RecombinationAlgorithm", 2)
-        gmsh.option.setNumber("Mesh.RecombineAll", 2)
+        gmsh.option.setNumber("Mesh.RecombineAll", 1)
     gmsh.option.setNumber("Mesh.CharacteristicLengthMin", res)
     gmsh.option.setNumber("Mesh.CharacteristicLengthMax", res)
 

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -767,9 +767,11 @@ def test_gmsh_input_2d(order, cell_type, dtype):
         gmsh_cell_id = gmsh.model.mesh.getElementType("triangle", order)
     elif cell_type == CellType.quadrilateral:
         gmsh_cell_id = gmsh.model.mesh.getElementType("quadrangle", order)
+    # This checks that recombination was successful - i.e. only one element type in mesh.
     if list(element_types) != [gmsh_cell_id]:
-        raise RuntimeError(
-            f"Expected a single Gmsh element type {gmsh_cell_id}, got {list(element_types)}."
+        pytest.xfail(
+            f"Expected a single Gmsh element type {gmsh_cell_id}, "
+            f"got {list(element_types)} - gmsh recombination failed."
         )
     (
         _name,
@@ -842,9 +844,11 @@ def test_gmsh_input_3d(order, cell_type, dtype):
         gmsh_cell_id = MPI.COMM_WORLD.bcast(
             gmsh.model.mesh.getElementType("hexahedron", order), root=0
         )
+    # This checks that recombination was successful - i.e. only one element type in mesh.
     if list(element_types) != [gmsh_cell_id]:
-        raise RuntimeError(
-            f"Expected a single Gmsh element type {gmsh_cell_id}, got {list(element_types)}."
+        pytest.xfail(
+            f"Expected a single Gmsh element type {gmsh_cell_id}, "
+            f"got {list(element_types)} - gmsh recombination failed."
         )
     (
         _name,

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -327,21 +327,19 @@ def test_create_interval_gdim(gdim):
     mesh = create_interval(MPI.COMM_WORLD, 6, [0.0, 1.0], gdim=gdim)
     assert mesh.topology.dim == 1
     assert mesh.geometry.dim == gdim
-    assert mesh.geometry.x.shape[1] == gdim
-    if gdim > 1:
-        assert np.allclose(mesh.geometry.x[:, 1:], 0.0)
+    assert mesh.ufl_domain().ufl_coordinate_element().reference_value_shape == (gdim,)
 
 
 @pytest.mark.parametrize("cell_type", [CellType.triangle, CellType.quadrilateral])
 @pytest.mark.parametrize("gdim", [2, 3])
 def test_create_rectangle_gdim(gdim, cell_type):
     """Rectangle mesh embedded in gdim-dimensional space has correct tdim and gdim."""
-    mesh = create_rectangle(MPI.COMM_WORLD, [[0.0, 0.0], [1.0, 1.0]], [4, 4], cell_type, gdim=gdim)
+    mesh = create_rectangle(
+        MPI.COMM_WORLD, [[0.0, 0.0], [1.0, 1.0]], [4, 4], cell_type, gdim=gdim
+    )
     assert mesh.topology.dim == 2
     assert mesh.geometry.dim == gdim
-    assert mesh.geometry.x.shape[1] == gdim
-    if gdim == 3:
-        assert np.allclose(mesh.geometry.x[:, 2], 0.0)
+    assert mesh.ufl_domain().ufl_coordinate_element().reference_value_shape == (gdim,)
 
 
 @pytest.mark.skip_in_parallel

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -334,9 +334,7 @@ def test_create_interval_gdim(gdim):
 @pytest.mark.parametrize("gdim", [2, 3])
 def test_create_rectangle_gdim(gdim, cell_type):
     """Rectangle mesh embedded in gdim-dimensional space has correct tdim and gdim."""
-    mesh = create_rectangle(
-        MPI.COMM_WORLD, [[0.0, 0.0], [1.0, 1.0]], [4, 4], cell_type, gdim=gdim
-    )
+    mesh = create_rectangle(MPI.COMM_WORLD, [[0.0, 0.0], [1.0, 1.0]], [4, 4], cell_type, gdim=gdim)
     assert mesh.topology.dim == 2
     assert mesh.geometry.dim == gdim
     assert mesh.ufl_domain().ufl_coordinate_element().reference_value_shape == (gdim,)

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -327,7 +327,9 @@ def test_create_interval_gdim(gdim):
     mesh = create_interval(MPI.COMM_WORLD, 6, [0.0, 1.0], gdim=gdim)
     assert mesh.topology.dim == 1
     assert mesh.geometry.dim == gdim
-    assert mesh.ufl_domain().ufl_coordinate_element().reference_value_shape == (gdim,)
+    domain = mesh.ufl_domain()
+    assert domain is not None
+    assert domain.ufl_coordinate_element().reference_value_shape == (gdim,)
 
 
 @pytest.mark.parametrize("cell_type", [CellType.triangle, CellType.quadrilateral])
@@ -337,7 +339,9 @@ def test_create_rectangle_gdim(gdim, cell_type):
     mesh = create_rectangle(MPI.COMM_WORLD, [[0.0, 0.0], [1.0, 1.0]], [4, 4], cell_type, gdim=gdim)
     assert mesh.topology.dim == 2
     assert mesh.geometry.dim == gdim
-    assert mesh.ufl_domain().ufl_coordinate_element().reference_value_shape == (gdim,)
+    domain = mesh.ufl_domain()
+    assert domain is not None
+    assert domain.ufl_coordinate_element().reference_value_shape == (gdim,)
 
 
 @pytest.mark.skip_in_parallel

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -321,6 +321,29 @@ def test_create_box_prism():
     assert mesh.topology.index_map(3).size_global == 48
 
 
+@pytest.mark.parametrize("gdim", [1, 2, 3])
+def test_create_interval_gdim(gdim):
+    """Interval mesh embedded in gdim-dimensional space has correct tdim and gdim."""
+    mesh = create_interval(MPI.COMM_WORLD, 6, [0.0, 1.0], gdim=gdim)
+    assert mesh.topology.dim == 1
+    assert mesh.geometry.dim == gdim
+    assert mesh.geometry.x.shape[1] == gdim
+    if gdim > 1:
+        assert np.allclose(mesh.geometry.x[:, 1:], 0.0)
+
+
+@pytest.mark.parametrize("cell_type", [CellType.triangle, CellType.quadrilateral])
+@pytest.mark.parametrize("gdim", [2, 3])
+def test_create_rectangle_gdim(gdim, cell_type):
+    """Rectangle mesh embedded in gdim-dimensional space has correct tdim and gdim."""
+    mesh = create_rectangle(MPI.COMM_WORLD, [[0.0, 0.0], [1.0, 1.0]], [4, 4], cell_type, gdim=gdim)
+    assert mesh.topology.dim == 2
+    assert mesh.geometry.dim == gdim
+    assert mesh.geometry.x.shape[1] == gdim
+    if gdim == 3:
+        assert np.allclose(mesh.geometry.x[:, 2], 0.0)
+
+
 @pytest.mark.skip_in_parallel
 def test_get_coordinates():
     """Get coordinates of vertices."""


### PR DESCRIPTION
This is useful for working on manifold meshes without having to bring in an external mesh generator. Users can push geometry through an appropriate mapping. A next obvious step would be to create these "flat" meshes with higher-order coordinate elements, but that is a more substantial refactor.
