### PR TITLE
Fix Mesh.RecombineAll option from 2 to 1

### DIFF
--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -806,7 +806,7 @@ def test_gmsh_input_3d(order, cell_type, dtype):
     gmsh.initialize()
     if cell_type == CellType.hexahedron:
         gmsh.option.setNumber("Mesh.RecombinationAlgorithm", 2)
-        gmsh.option.setNumber("Mesh.RecombineAll", 2)
+        gmsh.option.setNumber("Mesh.RecombineAll", 1)
     gmsh.option.setNumber("Mesh.CharacteristicLengthMin", res)
     gmsh.option.setNumber("Mesh.CharacteristicLengthMax", res)
 


### PR DESCRIPTION
Not sure about this yet, perhaps some subtle change in how gmsh treats options.

Edit: Does seem to fix a CI failure on AlmaLinux where Gmsh is being installed.