### PR TITLE
More debugging of Gmsh issue

### DIFF
--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -769,10 +769,12 @@ def test_gmsh_input_2d(order, cell_type, dtype):
         gmsh_cell_id = gmsh.model.mesh.getElementType("quadrangle", order)
     # This checks that recombination was successful - i.e. only one element type in mesh.
     if list(element_types) != [gmsh_cell_id]:
-        pytest.xfail(
+        msg = (
             f"Expected a single Gmsh element type {gmsh_cell_id}, "
             f"got {list(element_types)} - gmsh recombination failed."
         )
+        gmsh.finalize()
+        pytest.xfail(msg)
     (
         _name,
         _dim,
@@ -846,10 +848,12 @@ def test_gmsh_input_3d(order, cell_type, dtype):
         )
     # This checks that recombination was successful - i.e. only one element type in mesh.
     if list(element_types) != [gmsh_cell_id]:
-        pytest.xfail(
+        msg = (
             f"Expected a single Gmsh element type {gmsh_cell_id}, "
             f"got {list(element_types)} - gmsh recombination failed."
         )
+        gmsh.finalize()
+        pytest.xfail(msg)
     (
         _name,
         _dim,

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -763,6 +763,14 @@ def test_gmsh_input_2d(order, cell_type, dtype):
     x = points[srt]
 
     element_types, _element_tags, node_tags = gmsh.model.mesh.getElements(dim=2)
+    if cell_type == CellType.triangle:
+        gmsh_cell_id = gmsh.model.mesh.getElementType("triangle", order)
+    elif cell_type == CellType.quadrilateral:
+        gmsh_cell_id = gmsh.model.mesh.getElementType("quadrangle", order)
+    if list(element_types) != [gmsh_cell_id]:
+        raise RuntimeError(
+            f"Expected a single Gmsh element type {gmsh_cell_id}, got {list(element_types)}."
+        )
     (
         _name,
         _dim,
@@ -773,10 +781,6 @@ def test_gmsh_input_2d(order, cell_type, dtype):
     ) = gmsh.model.mesh.getElementProperties(element_types[0])
 
     cells = node_tags[0].reshape(-1, num_nodes) - 1
-    if cell_type == CellType.triangle:
-        gmsh_cell_id = gmsh.model.mesh.getElementType("triangle", order)
-    elif cell_type == CellType.quadrilateral:
-        gmsh_cell_id = gmsh.model.mesh.getElementType("quadrangle", order)
     gmsh.finalize()
 
     cells = cells[:, cell_perm_array(cell_type, cells.shape[1])].copy()
@@ -830,6 +834,18 @@ def test_gmsh_input_3d(order, cell_type, dtype):
     x = points[srt]
 
     element_types, _element_tags, node_tags = gmsh.model.mesh.getElements(dim=3)
+    if cell_type == CellType.tetrahedron:
+        gmsh_cell_id = MPI.COMM_WORLD.bcast(
+            gmsh.model.mesh.getElementType("tetrahedron", order), root=0
+        )
+    elif cell_type == CellType.hexahedron:
+        gmsh_cell_id = MPI.COMM_WORLD.bcast(
+            gmsh.model.mesh.getElementType("hexahedron", order), root=0
+        )
+    if list(element_types) != [gmsh_cell_id]:
+        raise RuntimeError(
+            f"Expected a single Gmsh element type {gmsh_cell_id}, got {list(element_types)}."
+        )
     (
         _name,
         _dim,
@@ -840,14 +856,6 @@ def test_gmsh_input_3d(order, cell_type, dtype):
     ) = gmsh.model.mesh.getElementProperties(element_types[0])
 
     cells = node_tags[0].reshape(-1, num_nodes) - 1
-    if cell_type == CellType.tetrahedron:
-        gmsh_cell_id = MPI.COMM_WORLD.bcast(
-            gmsh.model.mesh.getElementType("tetrahedron", order), root=0
-        )
-    elif cell_type == CellType.hexahedron:
-        gmsh_cell_id = MPI.COMM_WORLD.bcast(
-            gmsh.model.mesh.getElementType("hexahedron", order), root=0
-        )
     gmsh.finalize()
 
     # Permute the mesh topology from Gmsh ordering to DOLFINx ordering

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -767,9 +767,11 @@ def test_gmsh_input_2d(order, cell_type, dtype):
         gmsh_cell_id = gmsh.model.mesh.getElementType("triangle", order)
     elif cell_type == CellType.quadrilateral:
         gmsh_cell_id = gmsh.model.mesh.getElementType("quadrangle", order)
+    # This checks that recombination was successful - i.e. only one element type in mesh.
     if list(element_types) != [gmsh_cell_id]:
-        raise RuntimeError(
-            f"Expected a single Gmsh element type {gmsh_cell_id}, got {list(element_types)}."
+        pytest.xfail(
+            f"Expected a single Gmsh element type {gmsh_cell_id}, "
+            f"got {list(element_types)} - gmsh recombination failed."
         )
     (
         _name,
@@ -842,9 +844,11 @@ def test_gmsh_input_3d(order, cell_type, dtype):
         gmsh_cell_id = MPI.COMM_WORLD.bcast(
             gmsh.model.mesh.getElementType("hexahedron", order), root=0
         )
+    # This checks that recombination was successful - i.e. only one element type in mesh.
     if list(element_types) != [gmsh_cell_id]:
-        raise RuntimeError(
-            f"Expected a single Gmsh element type {gmsh_cell_id}, got {list(element_types)}."
+        pytest.xfail(
+            f"Expected a single Gmsh element type {gmsh_cell_id}, "
+            f"got {list(element_types)} - gmsh recombination failed."
         )
     (
         _name,


### PR DESCRIPTION
Bit mysterious this gmsh higher order error. What we can say is that on one platform we seem to sometimes get tetrahedron in the hexahedron mesh. This new PR creates an xfail if recombination (i.e. a creating a mesh with only one element type) fails.

Will file issue to revisit.