### PR TITLE
Add most linear and quadratic vtk cell types from VTK to IO

### DIFF
--- a/cpp/dolfinx/io/VTKHDF.h
+++ b/cpp/dolfinx/io/VTKHDF.h
@@ -330,19 +330,6 @@ mesh::Mesh<U> read_mesh(MPI_Comm comm, const std::filesystem::path& filename,
       = hdf5::read_dataset<std::uint8_t>(dset_id, local_cell_range, true);
   H5Dclose(dset_id);
 
-  // Create reverse map (VTK -> DOLFINx cell type)
-  std::map<std::uint8_t, mesh::CellType> vtk_to_dolfinx;
-  {
-    for (auto type : {mesh::CellType::point, mesh::CellType::interval,
-                      mesh::CellType::triangle, mesh::CellType::quadrilateral,
-                      mesh::CellType::tetrahedron, mesh::CellType::prism,
-                      mesh::CellType::pyramid, mesh::CellType::hexahedron})
-    {
-      vtk_to_dolfinx.insert(
-          {cells::get_vtk_cell_type(type, mesh::cell_dim(type)), type});
-    }
-  }
-
   // Read in offsets to determine the different cell-types in the mesh
   dset_id = hdf5::open_dataset(h5file, "/VTKHDF/Offsets");
   std::vector<std::int64_t> offsets = hdf5::read_dataset<std::int64_t>(
@@ -355,8 +342,13 @@ mesh::Mesh<U> read_mesh(MPI_Comm comm, const std::filesystem::path& filename,
   for (std::size_t i = 0; i < types.size(); ++i)
   {
     std::int64_t num_nodes = offsets[i + 1] - offsets[i];
+    auto [cell_type, degree] = io::cells::vtk_to_dolfinx(types[i]);
+    // If arbitrary order Lagrange VTK cell, determine degree from number of
+    // nodes
+
     std::uint8_t cell_degree
-        = cells::cell_degree(vtk_to_dolfinx.at(types[i]), num_nodes);
+        = degree != -1 ? (std::uint8_t)degree
+                       : io::cells::cell_degree(cell_type, num_nodes);
     types_unique.push_back({types[i], cell_degree});
     cell_degrees.push_back(cell_degree);
   }
@@ -403,7 +395,7 @@ mesh::Mesh<U> read_mesh(MPI_Comm comm, const std::filesystem::path& filename,
   std::vector<std::uint8_t> dolfinx_cell_degree;
   for (std::array<std::uint8_t, 2> ct : recv_types)
   {
-    mesh::CellType cell_type = vtk_to_dolfinx.at(ct[0]);
+    mesh::CellType cell_type = std::get<0>(io::cells::vtk_to_dolfinx(ct[0]));
     type_to_index.insert({ct, dolfinx_cell_degree.size()});
     dolfinx_cell_degree.push_back(ct[1]);
     dolfinx_cell_type.push_back(cell_type);

--- a/cpp/dolfinx/io/VTKHDF.h
+++ b/cpp/dolfinx/io/VTKHDF.h
@@ -343,12 +343,11 @@ mesh::Mesh<U> read_mesh(MPI_Comm comm, const std::filesystem::path& filename,
   {
     std::int64_t num_nodes = offsets[i + 1] - offsets[i];
     auto [cell_type, degree] = io::cells::vtk_to_dolfinx(types[i]);
-    // If arbitrary order Lagrange VTK cell, determine degree from number of
+    // If arbitrary order Lagrange VTK cell (indicated by -1), determine degree from number of
     // nodes
 
     std::uint8_t cell_degree
-        = degree != -1 ? (std::uint8_t)degree
-                       : io::cells::cell_degree(cell_type, num_nodes);
+        = degree == -1 ? io::cells::cell_degree(cell_type, num_nodes) : (std::uint8_t)degree;
     types_unique.push_back({types[i], cell_degree});
     cell_degrees.push_back(cell_degree);
   }

--- a/cpp/dolfinx/io/VTKHDF.h
+++ b/cpp/dolfinx/io/VTKHDF.h
@@ -343,11 +343,12 @@ mesh::Mesh<U> read_mesh(MPI_Comm comm, const std::filesystem::path& filename,
   {
     std::int64_t num_nodes = offsets[i + 1] - offsets[i];
     auto [cell_type, degree] = io::cells::vtk_to_dolfinx(types[i]);
-    // If arbitrary order Lagrange VTK cell (indicated by -1), determine degree from number of
-    // nodes
+    // If arbitrary order Lagrange VTK cell (indicated by -1), determine degree
+    // from number of nodes
 
     std::uint8_t cell_degree
-        = degree == -1 ? io::cells::cell_degree(cell_type, num_nodes) : (std::uint8_t)degree;
+        = degree == -1 ? io::cells::cell_degree(cell_type, num_nodes)
+                       : (std::uint8_t)degree;
     types_unique.push_back({types[i], cell_degree});
     cell_degrees.push_back(cell_degree);
   }

--- a/cpp/dolfinx/io/cells.h
+++ b/cpp/dolfinx/io/cells.h
@@ -190,52 +190,53 @@ vtk_to_dolfinx(std::int8_t vtk_cell_type)
     // https://vtk.org/doc/nightly/html/vtkCellType_8h_source.html
     switch (vtk_cell_type)
     {
+      using enum mesh::CellType;
     case 1:
-      return {mesh::CellType::point, -1};
+      return {point, -1};
     case 3:
-      return {mesh::CellType::interval, 1};
+      return {interval, 1};
     case 5:
-      return {mesh::CellType::triangle, 1};
+      return {triangle, 1};
     case 9:
-      return {mesh::CellType::quadrilateral, 1};
+      return {quadrilateral, 1};
     case 10:
-      return {mesh::CellType::tetrahedron, 1};
+      return {tetrahedron, 1};
     case 12:
-      return {mesh::CellType::hexahedron, 1};
+      return {hexahedron, 1};
     case 13:
-      return {mesh::CellType::prism, 1};
+      return {prism, 1};
     case 14:
-      return {mesh::CellType::pyramid, 1};
+      return {pyramid, 1};
     case 21:
-      return {mesh::CellType::interval, 2};
+      return {interval, 2};
     case 22:
-      return {mesh::CellType::triangle, 2};
+      return {triangle, 2};
     case 23:
-      return {mesh::CellType::quadrilateral, 2};
+      return {quadrilateral, 2};
     case 24:
-      return {mesh::CellType::tetrahedron, 2};
+      return {tetrahedron, 2};
     case 25:
-      return {mesh::CellType::hexahedron, 2};
+      return {hexahedron, 2};
     case 26:
-      return {mesh::CellType::prism, 2};
+      return {prism, 2};
     case 27:
-      return {mesh::CellType::pyramid, 2};
+      return {pyramid, 2};
     case 35:
-      return {mesh::CellType::interval, 3};
+      return {interval, 3};
     case 68:
-      return {mesh::CellType::interval, -1};
+      return {interval, -1};
     case 69:
-      return {mesh::CellType::triangle, -1};
+      return {triangle, -1};
     case 70:
-      return {mesh::CellType::quadrilateral, -1};
+      return {quadrilateral, -1};
     case 71:
-      return {mesh::CellType::tetrahedron, -1};
+      return {tetrahedron, -1};
     case 72:
-      return {mesh::CellType::hexahedron, -1};
+      return {hexahedron, -1};
     case 73:
-      return {mesh::CellType::prism, -1};
+      return {prism, -1};
     case 74:
-      return {mesh::CellType::pyramid,
+      return {pyramid,
               -1}; // Not implemented in VTK yet, but added as placeholder.
     default:
       break;

--- a/cpp/dolfinx/io/cells.h
+++ b/cpp/dolfinx/io/cells.h
@@ -177,4 +177,71 @@ std::vector<std::int64_t> apply_permutation(std::span<const std::int64_t> cells,
 /// @return VTK cell identifier.
 std::int8_t get_vtk_cell_type(mesh::CellType cell, int dim);
 
+/// @brief Get DOLFINx cell type and degree from VTK cell type.
+///
+/// @param[in] vtk_cell_type VTK cell type identifier.
+/// @return Return the cell type and degree. If arbitrary order Lagragian cell
+/// from VTK is supplied, return -1 for the degree.
+inline std::tuple<mesh::CellType, std::int8_t>
+vtk_to_dolfinx(std::int8_t vtk_cell_type)
+{
+  {
+    // For a complete overview of VTK cell types, see
+    // https://vtk.org/doc/nightly/html/vtkCellType_8h_source.html
+    switch (vtk_cell_type)
+    {
+    case 1:
+      return {mesh::CellType::point, -1};
+    case 3:
+      return {mesh::CellType::interval, 1};
+    case 5:
+      return {mesh::CellType::triangle, 1};
+    case 9:
+      return {mesh::CellType::quadrilateral, 1};
+    case 10:
+      return {mesh::CellType::tetrahedron, 1};
+    case 12:
+      return {mesh::CellType::hexahedron, 1};
+    case 13:
+      return {mesh::CellType::prism, 1};
+    case 14:
+      return {mesh::CellType::pyramid, 1};
+    case 21:
+      return {mesh::CellType::interval, 2};
+    case 22:
+      return {mesh::CellType::triangle, 2};
+    case 23:
+      return {mesh::CellType::quadrilateral, 2};
+    case 24:
+      return {mesh::CellType::tetrahedron, 2};
+    case 25:
+      return {mesh::CellType::hexahedron, 2};
+    case 26:
+      return {mesh::CellType::prism, 2};
+    case 27:
+      return {mesh::CellType::pyramid, 2};
+    case 35:
+      return {mesh::CellType::interval, 3};
+    case 68:
+      return {mesh::CellType::interval, -1};
+    case 69:
+      return {mesh::CellType::triangle, -1};
+    case 70:
+      return {mesh::CellType::quadrilateral, -1};
+    case 71:
+      return {mesh::CellType::tetrahedron, -1};
+    case 72:
+      return {mesh::CellType::hexahedron, -1};
+    case 73:
+      return {mesh::CellType::prism, -1};
+    case 74:
+      return {mesh::CellType::pyramid,
+              -1}; // Not implemented in VTK yet, but added as placeholder.
+    default:
+      break;
+    }
+    throw std::runtime_error("Unknown VTK cell type");
+  }
+}
+
 } // namespace dolfinx::io::cells


### PR DESCRIPTION
When we write out VTK and VTKHDF files, it is optimal to use VTK_ARBITRARY_LAGRANGE cells as we don't need to
do special handling for the various degrees.

However, when we want to read in general purpose meshes with VTKHDF, we should support all the cell types that we support that VTK has an extensive set of different versions of. (especially linear and quadratic cells)

This PR adds a look-up for all linear cells and quadratic cells in VTK. This means that we can read second order pyramids, and meshes that have been defined with the more traditional VTKCellType such as `triangle`. 
MWE for second order pyramid:
```python
import h5py
import numpy as np

# 1. Define the 13 points for the quadratic pyramid
# Base corners (z=0) and Apex (z=1)
pts = [
    [-1.0, -1.0,  0.0], # Node 0: Base corner
    [ 1.0, -1.0,  0.0], # Node 1: Base corner
    [ 1.0,  1.0,  0.0], # Node 2: Base corner
    [-1.0,  1.0,  0.0], # Node 3: Base corner
    [ 0.0,  0.0,  1.0], # Node 4: Apex

    # CURVED: Mid-edge nodes on the base (z=0)
    # Bowed outward by 0.5 units away from the center
    [ 0.0, -1.5,  0.0], # Node 5: Mid 0-1 (Shifted -Y)
    [ 1.5,  0.0,  0.0], # Node 6: Mid 1-2 (Shifted +X)
    [ 0.0,  1.5,  0.0], # Node 7: Mid 2-3 (Shifted +Y)
    [-1.5,  0.0,  0.0], # Node 8: Mid 3-0 (Shifted -X)

    # CURVED: Mid-edge nodes on the triangular faces (z=0.5)
    # Flared outward radially by 0.3 units
    [-0.8, -0.8,  0.5], # Node 9:  Mid 0-4
    [ 0.8, -0.8,  0.5], # Node 10: Mid 1-4
    [ 0.8,  0.8,  0.5], # Node 11: Mid 2-4
    [-0.8,  0.8,  0.5]  # Node 12: Mid 3-4
]
points_array = np.array(pts, dtype=np.float32)

# 2. Define the Unstructured Grid connectivity
# Cell type 27 is VTK_QUADRATIC_PYRAMID
cell_types = np.array([27], dtype=np.uint8)

# Connectivity is just 0 through 12 in order
connectivity = np.arange(13, dtype=np.int64)

# Offsets for a single 13-point cell: [start_index, end_index]
offsets = np.array([0, 13], dtype=np.int64)

filename = "quadratic_pyramid.vtkhdf"
# 3. Create the VTKHDF file
with h5py.File(filename, "w") as f:
    
    # Create the root VTKHDF group
    vtkhdf_group = f.create_group("VTKHDF")
    
    # Add required VTKHDF attributes
    vtkhdf_group.attrs["Version"] = np.array([2, 0], dtype=np.int64)
    vtkhdf_group.attrs["Type"] = np.bytes_("UnstructuredGrid")
    
    # Write the datasets
    vtkhdf_group.create_dataset("NumberOfPoints", data=np.array([13], dtype=np.int64))
    vtkhdf_group.create_dataset("NumberOfCells", data=np.array([1], dtype=np.int64))
    vtkhdf_group.create_dataset("NumberOfConnectivityIds", data=np.array([13], dtype=np.int64))
    
    vtkhdf_group.create_dataset("Points", data=points_array)
    vtkhdf_group.create_dataset("Types", data=cell_types)
    vtkhdf_group.create_dataset("Connectivity", data=connectivity)
    vtkhdf_group.create_dataset("Offsets", data=offsets)

print(f"Successfully created '{filename}'")

from mpi4py import MPI
import dolfinx
mesh = dolfinx.io.vtkhdf.read_mesh(MPI.COMM_WORLD, "quadratic_pyramid.vtkhdf")
print(mesh.geometry.cmap().degree, mesh.topology.cell_type)

```
yielding:
```bash
2 CellType.pyramid
```
and visualized in paraview as:
<img width="2190" height="1822" alt="image" src="https://github.com/user-attachments/assets/d84f2a32-7d7b-4eab-a927-381f557a0673" />
