### PR TITLE
Mypy check on non-isolated install

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches:
-      - release
-    tags:
-      - "v*"
+    # branches:
+    #   - release
+    # tags:
+    #   - "v*"
   pull_request:
     branches:
       - main
@@ -131,6 +131,12 @@ jobs:
         run: |
           pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Developer" 'python/[test]'
           python -c "from mpi4py import MPI; import dolfinx; assert not dolfinx.has_petsc; assert not dolfinx.has_petsc4py; assert dolfinx.has_superlu_dist"
+
+      - name: Run mypy
+        working-directory: python
+        run: |
+          pip install mypy types-cffi scipy-stubs
+          mypy -p dolfinx
 
       - name: Run mypy  # Use a venv to avoid NumPy upgrades that are incompatible with numba
         working-directory: python

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    # branches:
-    #   - release
-    # tags:
-    #   - "v*"
+    branches:
+      - release
+    tags:
+      - "v*"
   pull_request:
     branches:
       - main

--- a/python/dolfinx/__init__.py
+++ b/python/dolfinx/__init__.py
@@ -11,6 +11,11 @@ import sys
 # Template placeholder for injecting Windows dll directories in CI
 # WINDOWSDLL
 
+import numpy as _np
+
+default_scalar_type: _np.dtype
+default_real_type: _np.dtype
+
 try:
     from petsc4py import PETSc as _PETSc
 
@@ -19,13 +24,13 @@ try:
 
     assert dolfinx.common.has_petsc4py
 
-    default_scalar_type = _PETSc.ScalarType  # type: ignore
-    default_real_type = _PETSc.RealType  # type: ignore
+    default_scalar_type = _PETSc.ScalarType
+    default_real_type = _PETSc.RealType
 except ImportError:
-    import numpy as _np
+    default_scalar_type = _np.float64  # type: ignore
+    default_real_type = _np.float64  # type: ignore
 
-    default_scalar_type = _np.float64
-    default_real_type = _np.float64
+del _np
 
 from dolfinx import common
 from dolfinx import cpp as _cpp

--- a/python/dolfinx/__init__.py
+++ b/python/dolfinx/__init__.py
@@ -13,8 +13,8 @@ import sys
 
 import numpy as _np
 
-default_scalar_type: _np.dtype
-default_real_type: _np.dtype
+default_scalar_type: type[_np.floating | _np.complexfloating]
+default_real_type: type[_np.floating]
 
 try:
     from petsc4py import PETSc as _PETSc
@@ -24,11 +24,11 @@ try:
 
     assert dolfinx.common.has_petsc4py
 
-    default_scalar_type = _PETSc.ScalarType
-    default_real_type = _PETSc.RealType
+    default_scalar_type = _PETSc.ScalarType  # type: ignore
+    default_real_type = _PETSc.RealType  # type: ignore
 except ImportError:
-    default_scalar_type = _np.float64  # type: ignore
-    default_real_type = _np.float64  # type: ignore
+    default_scalar_type = _np.float64
+    default_real_type = _np.float64
 
 del _np
 

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -792,15 +792,15 @@ def derivative_block(
     """  # noqa: D301
     if isinstance(F, ufl.Form) and not F.arguments():
         if isinstance(u, Function):
-            return _derive_univariate_residual(F, u, du)
+            return _derive_univariate_residual(F, u, du)  # type: ignore
         elif isinstance(u, Sequence):
-            return _derive_block_residual(F, u, du)
+            return _derive_block_residual(F, u, du)  # type: ignore
         else:
             raise ValueError("u must be either a ufl.Function or a sequence of ufl.Function")
     elif isinstance(F, ufl.Form) and len(F.arguments()) == 1:
         return _derive_univariate_jacobian(F, u, du)  # type: ignore[arg-type]
     elif isinstance(F, Sequence):
-        return _derive_block_jacobian(F, u, du)
+        return _derive_block_jacobian(F, u, du)  # type: ignore
     else:
         raise ValueError(
             "F must be either a UFL form (with rank zero or one), or a sequence of "

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -694,7 +694,7 @@ class FunctionSpace(ufl.FunctionSpace, Generic[Real]):
 
     def __init__(
         self,
-        mesh: Mesh,
+        mesh: Mesh[Real],
         element: ufl.finiteelement.AbstractFiniteElement,
         cppV: (_cpp.fem.FunctionSpace_float32 | _cpp.fem.FunctionSpace_float64),
     ):

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -663,14 +663,16 @@ def functionspace(
     if ufl_e.is_real:
         cpp_dofmap = _cpp.fem.build_real_element_dofmap(
             mesh.topology._cpp_object,
-            element.basix_element.entity_dofs,
-            element.basix_element.entity_closure_dofs,
-            int(np.prod(element.value_shape)),
+            element.basix_element.entity_dofs,  # type: ignore
+            element.basix_element.entity_closure_dofs,  # type: ignore
+            int(np.prod(element.value_shape)),  # type: ignore
         )
     else:
         cpp_dofmap = _cpp.fem.create_dofmap(
-            mesh.comm, mesh.topology._cpp_object, element._cpp_object
-        )  # type: ignore
+            mesh.comm,
+            mesh.topology._cpp_object,
+            element._cpp_object,  # type: ignore
+        )
     assert np.issubdtype(mesh.geometry.x.dtype, element.dtype), (  # type: ignore
         "Mesh and element dtype are not compatible."
     )

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -1231,10 +1231,10 @@ class NonlinearProblem:
         )
 
         if J is None:
-            J = derivative_block(F, u)
+            J = derivative_block(F, u)  # type: ignore
 
         self._J = _create_form(
-            J,
+            J,  # type: ignore
             form_compiler_options=form_compiler_options,
             jit_options=jit_options,
             entity_maps=entity_maps,


### PR DESCRIPTION
Adds mypy check to run on full fledged (non-PETSc) install. This allows dependency lookups and runtime awareness which enriches coverage of the `mypy` invocation.

This was previously done in the BASIx CI already, which caught in multiple occasions more strict typing errors https://github.com/FEniCS/basix/blob/main/.github/workflows/dolfinx-tests.yml#L86.

This should be extended to also check the `test/` and `demo/` source trees (and alter to the PETSc aware runs), to follow in another PR as this hot-fixes the BASIx CI.

Ref https://github.com/FEniCS/dolfinx/issues/4059#issuecomment-4287461055, accompanies https://github.com/FEniCS/basix/pull/1004.