### PR TITLE
Indexing of Geometry cmaps and dofmaps for multiple cell types

### DIFF
--- a/cpp/demo/custom_kernel/main.cpp
+++ b/cpp/demo/custom_kernel/main.cpp
@@ -141,9 +141,10 @@ double assemble_matrix1(const mesh::Geometry<T>& g, const fem::DofMap& dofmap,
   common::Timer timer("Assembler1 lambda (matrix)");
   md::mdspan<const T, md::extents<std::size_t, md::dynamic_extent, 3>> x(
       g.x().data(), g.x().size() / 3, 3);
-  fem::impl::assemble_cells_matrix<T>(
-      A.mat_add_values(), g.dofmap(), x, cells, {dofmap.map(), 1, cells}, ident,
-      {dofmap.map(), 1, cells}, ident, {}, {}, kernel, {}, {}, {}, {});
+  fem::impl::assemble_cells_matrix<T>(A.mat_add_values(), g.dofmaps().front(),
+                                      x, cells, {dofmap.map(), 1, cells}, ident,
+                                      {dofmap.map(), 1, cells}, ident, {}, {},
+                                      kernel, {}, {}, {}, {});
   A.scatter_rev();
   return A.squared_norm();
 }
@@ -168,8 +169,8 @@ double assemble_vector1(const mesh::Geometry<T>& g, const fem::DofMap& dofmap,
       g.x().data(), g.x().size() / 3, 3);
   common::Timer timer("Assembler1 lambda (vector)");
   fem::impl::assemble_cells<1>([](auto, auto, auto, auto) {}, b.array(),
-                               g.dofmap(), x, cells, {dofmap.map(), 1, cells},
-                               kernel, {}, {}, {});
+                               g.dofmaps().front(), x, cells,
+                               {dofmap.map(), 1, cells}, kernel, {}, {}, {});
   b.scatter_rev(std::plus<T>());
   return la::squared_norm(b);
 }

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -492,7 +492,7 @@ public:
     const CoordinateElement<geometry_type>& cmap = mesh->geometry().cmaps().front();
 
     // Get geometry data
-    auto x_dofmap = mesh->geometry().dofmap();
+    auto x_dofmap = mesh->geometry().dofmaps().front();
     const std::size_t num_dofs_g = cmap.dim();
     auto x_g = mesh->geometry().x();
 

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -489,7 +489,7 @@ public:
     auto map = mesh->topology()->index_map(tdim);
 
     // Get coordinate map
-    const CoordinateElement<geometry_type>& cmap = mesh->geometry().cmap();
+    const CoordinateElement<geometry_type>& cmap = mesh->geometry().cmaps().front();
 
     // Get geometry data
     auto x_dofmap = mesh->geometry().dofmap();

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -489,7 +489,8 @@ public:
     auto map = mesh->topology()->index_map(tdim);
 
     // Get coordinate map
-    const CoordinateElement<geometry_type>& cmap = mesh->geometry().cmaps().front();
+    const CoordinateElement<geometry_type>& cmap
+        = mesh->geometry().cmaps().front();
 
     // Get geometry data
     auto x_dofmap = mesh->geometry().dofmaps().front();

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -287,7 +287,8 @@ public:
       const auto [X, Xshape] = _elements[i]->interpolation_points();
 
       // Get coordinate map
-      const CoordinateElement<geometry_type>& cmap = _mesh->geometry().cmaps().at(i);
+      const CoordinateElement<geometry_type>& cmap
+          = _mesh->geometry().cmaps().at(i);
 
       // Prepare cell geometry
       auto x_dofmap = _mesh->geometry().dofmaps().at(i);

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -290,7 +290,7 @@ public:
       const CoordinateElement<geometry_type>& cmap = _mesh->geometry().cmaps().at(i);
 
       // Prepare cell geometry
-      auto x_dofmap = _mesh->geometry().dofmap(i);
+      auto x_dofmap = _mesh->geometry().dofmaps().at(i);
       const std::size_t num_dofs_g = cmap.dim();
       std::vector<geometry_type> coordinate_dofs_b(num_dofs_g * gdim);
       mdspan2_t coordinate_dofs(coordinate_dofs_b.data(), num_dofs_g, gdim);

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -287,7 +287,7 @@ public:
       const auto [X, Xshape] = _elements[i]->interpolation_points();
 
       // Get coordinate map
-      const CoordinateElement<geometry_type>& cmap = _mesh->geometry().cmap(i);
+      const CoordinateElement<geometry_type>& cmap = _mesh->geometry().cmaps().at(i);
 
       // Prepare cell geometry
       auto x_dofmap = _mesh->geometry().dofmap(i);

--- a/cpp/dolfinx/fem/assemble_expression_impl.h
+++ b/cpp/dolfinx/fem/assemble_expression_impl.h
@@ -185,8 +185,8 @@ void tabulate_expression(
   }
 
   tabulate_expression<T, U>(values, fn, Xshape, value_size, num_argument_dofs,
-                            mesh.geometry().dofmaps().front(), mesh.geometry().x(),
-                            coeffs, constants, entities, cell_info,
-                            post_dof_transform);
+                            mesh.geometry().dofmaps().front(),
+                            mesh.geometry().x(), coeffs, constants, entities,
+                            cell_info, post_dof_transform);
 }
 } // namespace dolfinx::fem::impl

--- a/cpp/dolfinx/fem/assemble_expression_impl.h
+++ b/cpp/dolfinx/fem/assemble_expression_impl.h
@@ -185,7 +185,7 @@ void tabulate_expression(
   }
 
   tabulate_expression<T, U>(values, fn, Xshape, value_size, num_argument_dofs,
-                            mesh.geometry().dofmap(), mesh.geometry().x(),
+                            mesh.geometry().dofmaps().front(), mesh.geometry().x(),
                             coeffs, constants, entities, cell_info,
                             post_dof_transform);
 }

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -642,7 +642,7 @@ void assemble_matrix(
   for (int cell_type_idx = 0; cell_type_idx < num_cell_types; ++cell_type_idx)
   {
     // Geometry dofmap and data
-    mdspan2_t x_dofmap = mesh->geometry().dofmap(cell_type_idx);
+    mdspan2_t x_dofmap = mesh->geometry().dofmaps().at(cell_type_idx);
 
     // Get dofmap data
     std::shared_ptr<const fem::DofMap> dofmap0

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -581,7 +581,7 @@ void assemble_vector(
   for (int cell_type_idx = 0; cell_type_idx < num_cell_types; ++cell_type_idx)
   {
     // Geometry dofmap and data
-    mdspan2_t x_dofmap = mesh->geometry().dofmap(cell_type_idx);
+    mdspan2_t x_dofmap = mesh->geometry().dofmaps().at(cell_type_idx);
 
     // Get dofmap data
     assert(L.function_spaces().at(0));

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -175,7 +175,7 @@ T assemble_scalar(
   {
     // Geometry dofmap and data
     md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> x_dofmap
-        = mesh->geometry().dofmap(cell_type_idx);
+        = mesh->geometry().dofmaps().at(cell_type_idx);
     if constexpr (std::is_same_v<U, scalar_value_t<T>>)
     {
       val += impl::assemble_scalar(M, x_dofmap,

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -151,7 +151,7 @@ void discrete_curl(const FunctionSpace<T>& V0, const FunctionSpace<T>& V1,
   const auto [X, Xshape] = e1->interpolation_points();
 
   // Get/compute geometry map and evaluate at interpolation points
-  const CoordinateElement<T>& cmap = mesh->geometry().cmap();
+  const CoordinateElement<T>& cmap = mesh->geometry().cmaps().front();
   auto x_dofmap = mesh->geometry().dofmap();
   const std::size_t num_dofs_g = cmap.dim();
   std::span<const T> x_g = mesh->geometry().x();
@@ -453,7 +453,7 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
   const std::size_t value_size0 = V0.element()->reference_value_size();
 
   // Get geometry data
-  const CoordinateElement<U>& cmap = mesh->geometry().cmap();
+  const CoordinateElement<U>& cmap = mesh->geometry().cmaps().front();
   auto x_dofmap = mesh->geometry().dofmap();
   const std::size_t num_dofs_g = cmap.dim();
   std::span<const U> x_g = mesh->geometry().x();

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -152,7 +152,7 @@ void discrete_curl(const FunctionSpace<T>& V0, const FunctionSpace<T>& V1,
 
   // Get/compute geometry map and evaluate at interpolation points
   const CoordinateElement<T>& cmap = mesh->geometry().cmaps().front();
-  auto x_dofmap = mesh->geometry().dofmap();
+  auto x_dofmap = mesh->geometry().dofmaps().front();
   const std::size_t num_dofs_g = cmap.dim();
   std::span<const T> x_g = mesh->geometry().x();
   std::array<std::size_t, 4> Phi_g_shape = cmap.tabulate_shape(1, Xshape[0]);
@@ -454,7 +454,7 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
 
   // Get geometry data
   const CoordinateElement<U>& cmap = mesh->geometry().cmaps().front();
-  auto x_dofmap = mesh->geometry().dofmap();
+  auto x_dofmap = mesh->geometry().dofmaps().front();
   const std::size_t num_dofs_g = cmap.dim();
   std::span<const U> x_g = mesh->geometry().x();
 

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -56,7 +56,7 @@ std::vector<T> interpolation_coords(const fem::FiniteElement<T>& element,
   {
     for (std::size_t i = 0; i < geometry.num_maps(); ++i)
     {
-      if (geometry.cmap(i).cell_shape() == cell_type)
+      if (geometry.cmaps().at(i).cell_shape() == cell_type)
         return i;
     }
     throw std::runtime_error("Cannot find CoordinateElement for FiniteElement");
@@ -68,7 +68,7 @@ std::vector<T> interpolation_coords(const fem::FiniteElement<T>& element,
   auto x_dofmap = geometry.dofmap(index);
   std::span<const T> x_g = geometry.x();
 
-  const CoordinateElement<T>& cmap = geometry.cmap(index);
+  const CoordinateElement<T>& cmap = geometry.cmaps().at(index);
   const std::size_t num_dofs_g = cmap.dim();
 
   // Get the interpolation points on the reference cells
@@ -520,7 +520,7 @@ void interpolate_nonmatching_maps(Function<T, U>& u1,
   const std::size_t value_size_ref0 = element0->reference_value_size();
   const std::size_t value_size0 = V0->element()->reference_value_size();
 
-  const CoordinateElement<U>& cmap = mesh0->geometry().cmap();
+  const CoordinateElement<U>& cmap = mesh0->geometry().cmaps().front();
   auto x_dofmap = mesh0->geometry().dofmap();
   std::span<const U> x_g = mesh0->geometry().x();
 
@@ -927,7 +927,7 @@ void piola_mapped_evaluation(const FiniteElement<U>& element, bool symmetric,
     throw std::runtime_error("Interpolation data has the wrong shape.");
 
   // Get coordinate map
-  const CoordinateElement<U>& cmap = mesh.geometry().cmap();
+  const CoordinateElement<U>& cmap = mesh.geometry().cmaps().front();
 
   // Get geometry data
   auto x_dofmap = mesh.geometry().dofmap();

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -54,7 +54,7 @@ std::vector<T> interpolation_coords(const fem::FiniteElement<T>& element,
   // Find CoordinateElement appropriate to element
   auto cmap_index = [&geometry](mesh::CellType cell_type)
   {
-    for (std::size_t i = 0; i < geometry.num_maps(); ++i)
+    for (std::size_t i = 0; i < geometry.cmaps().size(); ++i)
     {
       if (geometry.cmaps().at(i).cell_shape() == cell_type)
         return i;

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -65,7 +65,7 @@ std::vector<T> interpolation_coords(const fem::FiniteElement<T>& element,
 
   // Get geometry data and the element coordinate map
   const std::size_t gdim = geometry.dim();
-  auto x_dofmap = geometry.dofmap(index);
+  auto x_dofmap = geometry.dofmaps().at(index);
   std::span<const T> x_g = geometry.x();
 
   const CoordinateElement<T>& cmap = geometry.cmaps().at(index);
@@ -521,7 +521,7 @@ void interpolate_nonmatching_maps(Function<T, U>& u1,
   const std::size_t value_size0 = V0->element()->reference_value_size();
 
   const CoordinateElement<U>& cmap = mesh0->geometry().cmaps().front();
-  auto x_dofmap = mesh0->geometry().dofmap();
+  auto x_dofmap = mesh0->geometry().dofmaps().front();
   std::span<const U> x_g = mesh0->geometry().x();
 
   // (0) is derivative index, (1) is the point index, (2) is the basis
@@ -930,7 +930,7 @@ void piola_mapped_evaluation(const FiniteElement<U>& element, bool symmetric,
   const CoordinateElement<U>& cmap = mesh.geometry().cmaps().front();
 
   // Get geometry data
-  auto x_dofmap = mesh.geometry().dofmap();
+  auto x_dofmap = mesh.geometry().dofmaps().front();
   const int num_dofs_g = cmap.dim();
   std::span<const U> x_g = mesh.geometry().x();
 

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -532,12 +532,12 @@ Form<T, U> create_form_factory(
       = [&geo = mesh->geometry()](const ufcx_integral& integral,
                                   std::size_t cell_idx)
   {
-    if (integral.coordinate_element_hash != geo.cmap(cell_idx).hash())
+    if (integral.coordinate_element_hash != geo.cmaps().at(cell_idx).hash())
     {
       throw std::runtime_error(
           "Generated integral geometry element does not match mesh geometry: "
           + std::to_string(integral.coordinate_element_hash) + ", "
-          + std::to_string(geo.cmap(cell_idx).hash()));
+          + std::to_string(geo.cmaps().at(cell_idx).hash()));
     }
   };
 
@@ -962,7 +962,7 @@ Expression<T, U> create_expression(
     assert(coefficients.front()->function_space());
     std::shared_ptr<const mesh::Mesh<U>> mesh
         = coefficients.front()->function_space()->mesh();
-    if (mesh->geometry().cmap().hash() != e.coordinate_element_hash)
+    if (mesh->geometry().cmaps().front().hash() != e.coordinate_element_hash)
     {
       throw std::runtime_error(
           "Expression and mesh geometric maps do not match.");
@@ -1082,7 +1082,7 @@ mesh::Mesh<T> interpolate_geometry(
         const graph::AdjacencyList<std::int32_t>&)>& reorder_fn = nullptr)
 {
   assert(mesh);
-  const CoordinateElement<T>& old_cmap = mesh->geometry().cmap();
+  const CoordinateElement<T>& old_cmap = mesh->geometry().cmaps().front();
   if (new_cmap.cell_shape() != old_cmap.cell_shape())
   {
     throw std::runtime_error(

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -106,7 +106,7 @@ std::vector<T> shortest_vector(const mesh::Mesh<T>& mesh, int dim,
       // Tabulate geometry dofs for the entity
       auto dofs = md::submdspan(x_dofmap, c, md::full_extent);
       const std::vector<int> entity_dofs
-          = geometry.cmap().create_dof_layout().entity_closure_dofs(
+          = geometry.cmaps().front().create_dof_layout().entity_closure_dofs(
               dim, local_cell_entity);
       std::vector<T> nodes(3 * entity_dofs.size());
       for (std::size_t i = 0; i < entity_dofs.size(); i++)

--- a/cpp/dolfinx/geometry/utils.h
+++ b/cpp/dolfinx/geometry/utils.h
@@ -57,7 +57,7 @@ std::vector<T> shortest_vector(const mesh::Mesh<T>& mesh, int dim,
   const mesh::Geometry<T>& geometry = mesh.geometry();
 
   std::span<const T> geom_dofs = geometry.x();
-  auto x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.dofmaps().front();
   std::vector<T> shortest_vectors;
   shortest_vectors.reserve(3 * entities.size());
   if (dim == tdim)
@@ -528,7 +528,7 @@ std::int32_t compute_first_colliding_cell(const mesh::Mesh<T>& mesh,
   {
     const mesh::Geometry<T>& geometry = mesh.geometry();
     std::span<const T> geom_dofs = geometry.x();
-    auto x_dofmap = geometry.dofmap();
+    auto x_dofmap = geometry.dofmaps().front();
     const std::size_t num_nodes = x_dofmap.extent(1);
     std::vector<T> coordinate_dofs(num_nodes * 3);
     for (auto cell : cells)
@@ -779,7 +779,7 @@ determine_point_ownership(const mesh::Mesh<T>& mesh, std::span<const T> points,
   // Get mesh geometry for closest entity
   const mesh::Geometry<T>& geometry = mesh.geometry();
   std::span<const T> geom_dofs = geometry.x();
-  auto x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.dofmaps().front();
 
   // Compute candidate cells for collisions (and extrapolation)
   const graph::AdjacencyList<std::int32_t> candidate_collisions

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -314,7 +314,7 @@ void vtx_write_mesh(adios2::IO& io, adios2::Engine& engine,
   engine.Put<std::uint32_t>(vertices, num_vertices);
 
   auto [vtkcells, shape]
-      = io::extract_vtk_connectivity(geometry.dofmap(), topology->cell_type());
+      = io::extract_vtk_connectivity(geometry.dofmaps().front(), topology->cell_type());
 
   // Add cell metadata
   int tdim = topology->dim();

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -313,8 +313,8 @@ void vtx_write_mesh(adios2::IO& io, adios2::Engine& engine,
       io, "NumberOfNodes", {adios2::LocalValueDim});
   engine.Put<std::uint32_t>(vertices, num_vertices);
 
-  auto [vtkcells, shape]
-      = io::extract_vtk_connectivity(geometry.dofmaps().front(), topology->cell_type());
+  auto [vtkcells, shape] = io::extract_vtk_connectivity(
+      geometry.dofmaps().front(), topology->cell_type());
 
   // Add cell metadata
   int tdim = topology->dim();

--- a/cpp/dolfinx/io/VTKFile.cpp
+++ b/cpp/dolfinx/io/VTKFile.cpp
@@ -408,7 +408,7 @@ void write_function(
   {
     std::vector<std::int64_t> tmp;
     std::tie(tmp, cshape) = io::extract_vtk_connectivity(
-        mesh0->geometry().dofmap(), topology0->cell_type());
+        mesh0->geometry().dofmaps().front(), topology0->cell_type());
     cells.assign(tmp.begin(), tmp.end());
     const mesh::Geometry<U>& geometry = mesh0->geometry();
     x.assign(geometry.x().begin(), geometry.x().end());
@@ -800,7 +800,7 @@ void io::VTKFile::write(const mesh::Mesh<U>& mesh, double time)
 
   // Add mesh data to "Piece" node
   const auto [cells, cshape]
-      = extract_vtk_connectivity(mesh.geometry().dofmap(), cell_type);
+      = extract_vtk_connectivity(mesh.geometry().dofmaps().front(), cell_type);
   std::array<std::size_t, 2> xshape = {geometry.x().size() / 3, 3};
   std::vector<std::uint8_t> x_ghost(xshape[0], 0);
   std::fill(std::next(x_ghost.begin(), xmap->size_local()), x_ghost.end(), 1);

--- a/cpp/dolfinx/io/VTKHDF.h
+++ b/cpp/dolfinx/io/VTKHDF.h
@@ -102,7 +102,7 @@ void write_mesh(const std::filesystem::path& filename,
   std::vector<std::int64_t> cell_stop_pos;
   for (std::size_t i = 0; i < cell_index_maps.size(); ++i)
   {
-    num_nodes_per_cell.push_back(mesh.geometry().cmap(i).dim());
+    num_nodes_per_cell.push_back(mesh.geometry().cmaps().at(i).dim());
     std::array<std::int64_t, 2> r = cell_index_maps[i]->local_range();
     cell_start_pos.push_back(r[0]);
     cell_stop_pos.push_back(r[1]);

--- a/cpp/dolfinx/io/VTKHDF.h
+++ b/cpp/dolfinx/io/VTKHDF.h
@@ -70,7 +70,7 @@ void write_mesh(const std::filesystem::path& filename,
   for (std::size_t i = 0; i < cell_index_maps.size(); ++i)
   {
     md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> g_dofmap
-        = mesh.geometry().dofmap(i);
+        = mesh.geometry().dofmaps().at(i);
 
     std::vector<std::uint16_t> perm
         = cells::perm_vtk(cell_types[i], g_dofmap.extent(1));

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -390,8 +390,9 @@ XDMFFile::read_meshtags(const mesh::Mesh<double>& mesh, const std::string& name,
       entities_values = io::distribute_entity_data<std::int32_t>(
           *mesh.topology(), mesh.geometry().input_global_indices(),
           mesh.geometry().index_map()->size_global(),
-          mesh.geometry().cmap().create_dof_layout(), mesh.geometry().dofmap(),
-          mesh::cell_dim(cell_type), entities_span, values);
+          mesh.geometry().cmaps().front().create_dof_layout(),
+          mesh.geometry().dofmap(), mesh::cell_dim(cell_type), entities_span,
+          values);
 
   spdlog::info("XDMF create meshtags");
   std::size_t num_vertices_per_entity = mesh::cell_num_entities(

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -391,8 +391,8 @@ XDMFFile::read_meshtags(const mesh::Mesh<double>& mesh, const std::string& name,
           *mesh.topology(), mesh.geometry().input_global_indices(),
           mesh.geometry().index_map()->size_global(),
           mesh.geometry().cmaps().front().create_dof_layout(),
-          mesh.geometry().dofmaps().front(), mesh::cell_dim(cell_type), entities_span,
-          values);
+          mesh.geometry().dofmaps().front(), mesh::cell_dim(cell_type),
+          entities_span, values);
 
   spdlog::info("XDMF create meshtags");
   std::size_t num_vertices_per_entity = mesh::cell_num_entities(

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -391,7 +391,7 @@ XDMFFile::read_meshtags(const mesh::Mesh<double>& mesh, const std::string& name,
           *mesh.topology(), mesh.geometry().input_global_indices(),
           mesh.geometry().index_map()->size_global(),
           mesh.geometry().cmaps().front().create_dof_layout(),
-          mesh.geometry().dofmap(), mesh::cell_dim(cell_type), entities_span,
+          mesh.geometry().dofmaps().front(), mesh::cell_dim(cell_type), entities_span,
           values);
 
   spdlog::info("XDMF create meshtags");

--- a/cpp/dolfinx/io/vtk_utils.h
+++ b/cpp/dolfinx/io/vtk_utils.h
@@ -89,7 +89,7 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace<T>& V)
   const fem::CoordinateElement<T>& cmap = mesh->geometry().cmaps().front();
 
   // Prepare cell geometry
-  auto dofmap_x = mesh->geometry().dofmap();
+  auto dofmap_x = mesh->geometry().dofmaps().front();
   std::span<const T> x_g = mesh->geometry().x();
   const std::size_t num_dofs_g = cmap.dim();
 

--- a/cpp/dolfinx/io/vtk_utils.h
+++ b/cpp/dolfinx/io/vtk_utils.h
@@ -86,7 +86,7 @@ tabulate_lagrange_dof_coordinates(const fem::FunctionSpace<T>& V)
   // Get the dof coordinates on the reference element and the  mesh
   // coordinate map
   const auto [X, Xshape] = element->interpolation_points();
-  const fem::CoordinateElement<T>& cmap = mesh->geometry().cmap();
+  const fem::CoordinateElement<T>& cmap = mesh->geometry().cmaps().front();
 
   // Prepare cell geometry
   auto dofmap_x = mesh->geometry().dofmap();

--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -111,7 +111,7 @@ void xdmf_function::add_function(MPI_Comm comm, const fem::Function<T, U>& u,
   {
     // Get number of geometry nodes per cell
     auto& geometry = mesh->geometry();
-    auto& cmap = geometry.cmap();
+    auto& cmap = geometry.cmaps().front();
     int cmap_dim = cmap.dim();
     int cell_dim = element->space_dimension() / element->block_size();
     if (cmap_dim != cell_dim)

--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -138,7 +138,7 @@ void xdmf_function::add_function(MPI_Comm comm, const fem::Function<T, U>& u,
     std::int32_t num_local_points = map_x->size_local();
 
     // Get dof array and pack into array (padded where appropriate)
-    auto dofmap_x = geometry.dofmap();
+    auto dofmap_x = geometry.dofmaps().front();
     data_values.resize(num_local_points * num_components, 0);
     for (std::int32_t c = 0; c < num_cells; ++c)
     {

--- a/cpp/dolfinx/io/xdmf_mesh.cpp
+++ b/cpp/dolfinx/io/xdmf_mesh.cpp
@@ -43,7 +43,7 @@ void xdmf_mesh::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
       = mesh::cell_entity_type(cell_type, dim, 0);
 
   const fem::ElementDofLayout cmap_dof_layout
-      = geometry.cmap().create_dof_layout();
+      = geometry.cmaps().front().create_dof_layout();
 
   // Get number of nodes per entity
   const int num_nodes_per_entity

--- a/cpp/dolfinx/io/xdmf_mesh.cpp
+++ b/cpp/dolfinx/io/xdmf_mesh.cpp
@@ -61,7 +61,7 @@ void xdmf_mesh::add_topology_data(MPI_Comm comm, pugi::xml_node& xml_node,
   // Pack topology data
   std::vector<std::int64_t> topology_data;
 
-  auto x_dofmap = geometry.dofmap();
+  auto x_dofmap = geometry.dofmaps().front();
   auto map_g = geometry.index_map();
   assert(map_g);
   const std::int64_t offset_g = map_g->local_range()[0];

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -151,26 +151,11 @@ public:
   std::span<value_type> x() { return _x; }
 
   /// @brief The elements that describes the geometry map.
-  ///
-  /// The coordinate element `cmaps()[i]` corresponds to the
-  /// degree-of-freedom map `dofmap(i)`.
-  /// @param i The coordinate map to fetch
   /// @return The coordinate/geometry elements.
-  const fem::CoordinateElement<value_type>& cmap(std::optional<int> i
-                                                 = std::nullopt) const
+  const std::vector<fem::CoordinateElement<value_type>>& cmaps() const
   {
-    if (i.has_value())
-      return _cmaps.at(*i);
-    else if (_cmaps.size() > 1)
-      throw std::runtime_error("Multiple cmaps.");
-    return _cmaps.front();
+    return _cmaps;
   }
-
-  /// @brief Number of coordinate maps and dofmaps
-  /// (which must be the same) in the
-  /// geometry, when consisting of different cells.
-  /// @return Number of dofmaps and coordinate maps.
-  std::size_t num_maps() const { return _cmaps.size(); }
 
   /// @brief Global user indices.
   const std::vector<std::int64_t>& input_global_indices() const

--- a/cpp/dolfinx/mesh/Geometry.h
+++ b/cpp/dolfinx/mesh/Geometry.h
@@ -109,25 +109,33 @@ public:
 
   /// @brief DofMap for the geometry.
   /// @return A 2D array with shape `(num_cells, dofs_per_cell)`.
+  /// @deprecated Use dofmaps().front() instead.
+  [[deprecated("Use dofmaps().front() instead.")]]
   md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>> dofmap() const
   {
     if (_dofmaps.size() != 1)
       throw std::runtime_error("Multiple dofmaps");
-    return this->dofmap(0);
+    std::size_t ndofs = _cmaps.front().dim();
+    return md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>(
+        _dofmaps.front().data(), _dofmaps.front().size() / ndofs, ndofs);
   }
 
-  /// @brief Degree-of-freedom map associated with the `i`th coordinate
+  /// @brief Degree-of-freedom map associated with each coordinate
   /// map element in the geometry.
-  /// @param[in] i Index of the requested degree-of-freedom map. The
-  /// degree-of-freedom map corresponds to the geometry element
-  /// `cmaps()[i]`.
-  /// @return A dofmap array, with shape `(num_cells, dofs_per_cell)`.
-  md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>
-  dofmap(std::size_t i) const
+  /// @return A list of dofmap arrays, each with shape `(num_cells,
+  /// dofs_per_cell)`.
+  std::vector<md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>>
+  dofmaps() const
   {
-    std::size_t ndofs = _cmaps.at(i).dim();
-    return md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>(
-        _dofmaps.at(i).data(), _dofmaps.at(i).size() / ndofs, ndofs);
+    std::vector<md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>>
+        dms(_dofmaps.size());
+    for (std::size_t i = 0; i < _dofmaps.size(); ++i)
+    {
+      std::size_t ndofs = _cmaps.at(i).dim();
+      dms[i] = md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>(
+          _dofmaps.at(i).data(), _dofmaps.at(i).size() / ndofs, ndofs);
+    }
+    return dms;
   }
 
   /// @brief Index map for the geometry 'degrees-of-freedom'.

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -1336,7 +1336,8 @@ create_subgeometry(const Mesh<T>& mesh, int dim,
 
   // Get the geometry dofs in the sub-geometry based on the entities in
   // sub-geometry
-  const fem::ElementDofLayout layout = geometry.cmaps().front().create_dof_layout();
+  const fem::ElementDofLayout layout
+      = geometry.cmaps().front().create_dof_layout();
 
   const std::vector<std::int32_t> x_indices
       = entities_to_geometry(mesh, dim, subentity_to_entity, true).first;
@@ -1386,11 +1387,13 @@ create_subgeometry(const Mesh<T>& mesh, int dim,
                          });
 
   // Sub-geometry coordinate element
-  CellType sub_xcell = cell_entity_type(geometry.cmaps().front().cell_shape(), dim, 0);
+  CellType sub_xcell
+      = cell_entity_type(geometry.cmaps().front().cell_shape(), dim, 0);
 
   // Special handling of point meshes, as they only support constant
   // basis functions
-  int degree = (sub_xcell == CellType::point) ? 0 : geometry.cmaps().front().degree();
+  int degree
+      = (sub_xcell == CellType::point) ? 0 : geometry.cmaps().front().degree();
   fem::CoordinateElement<T> sub_cmap(sub_xcell, degree,
                                      geometry.cmaps().front().variant());
 

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -129,7 +129,7 @@ compute_vertex_coords_boundary(const mesh::Mesh<T>& mesh, int dim,
   }
 
   // Get geometry data
-  auto x_dofmap = mesh.geometry().dofmap();
+  auto x_dofmap = mesh.geometry().dofmaps().front();
   std::span<const T> x_nodes = mesh.geometry().x();
 
   // Get all vertex 'node' indices
@@ -635,7 +635,7 @@ compute_vertex_coords(const mesh::Mesh<T>& mesh)
            num_cell_types = topology->entity_types(tdim).size();
        cell_type_idx < num_cell_types; ++cell_type_idx)
   {
-    auto x_dofmap = mesh.geometry().dofmap(cell_type_idx);
+    auto x_dofmap = mesh.geometry().dofmaps().at(cell_type_idx);
     auto c_to_v = topology->connectivity({tdim, cell_type_idx}, {0, 0});
     assert(c_to_v);
     for (int c = 0; c < c_to_v->num_nodes(); ++c)
@@ -875,7 +875,7 @@ entities_to_geometry(const Mesh<T>& mesh, int dim,
 
   const int tdim = topology->dim();
   const Geometry<T>& geometry = mesh.geometry();
-  auto xdofs = geometry.dofmap();
+  auto xdofs = geometry.dofmaps().front();
 
   // Get the DOF layout and the number of DOFs per entity
   const fem::CoordinateElement<T>& coord_ele = geometry.cmaps().front();

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -878,7 +878,7 @@ entities_to_geometry(const Mesh<T>& mesh, int dim,
   auto xdofs = geometry.dofmap();
 
   // Get the DOF layout and the number of DOFs per entity
-  const fem::CoordinateElement<T>& coord_ele = geometry.cmap();
+  const fem::CoordinateElement<T>& coord_ele = geometry.cmaps().front();
   const fem::ElementDofLayout layout = coord_ele.create_dof_layout();
   const std::size_t num_entity_dofs = layout.entity_closure_dofs(dim, 0).size();
   std::vector<std::int32_t> entity_xdofs;
@@ -1336,7 +1336,7 @@ create_subgeometry(const Mesh<T>& mesh, int dim,
 
   // Get the geometry dofs in the sub-geometry based on the entities in
   // sub-geometry
-  const fem::ElementDofLayout layout = geometry.cmap().create_dof_layout();
+  const fem::ElementDofLayout layout = geometry.cmaps().front().create_dof_layout();
 
   const std::vector<std::int32_t> x_indices
       = entities_to_geometry(mesh, dim, subentity_to_entity, true).first;
@@ -1386,13 +1386,13 @@ create_subgeometry(const Mesh<T>& mesh, int dim,
                          });
 
   // Sub-geometry coordinate element
-  CellType sub_xcell = cell_entity_type(geometry.cmap().cell_shape(), dim, 0);
+  CellType sub_xcell = cell_entity_type(geometry.cmaps().front().cell_shape(), dim, 0);
 
   // Special handling of point meshes, as they only support constant
   // basis functions
-  int degree = (sub_xcell == CellType::point) ? 0 : geometry.cmap().degree();
+  int degree = (sub_xcell == CellType::point) ? 0 : geometry.cmaps().front().degree();
   fem::CoordinateElement<T> sub_cmap(sub_xcell, degree,
-                                     geometry.cmap().variant());
+                                     geometry.cmaps().front().variant());
 
   // Sub-geometry input_global_indices
   const std::vector<std::int64_t>& igi = geometry.input_global_indices();

--- a/cpp/dolfinx/refinement/plaza.h
+++ b/cpp/dolfinx/refinement/plaza.h
@@ -167,7 +167,7 @@ face_long_edge(const mesh::Mesh<T>& mesh)
   if (tdim == 2)
     edge_ratio_ok.resize(num_faces);
 
-  auto x_dofmap = mesh.geometry().dofmap();
+  auto x_dofmap = mesh.geometry().dofmaps().front();
 
   auto c_to_v = mesh.topology()->connectivity(tdim, 0);
   assert(c_to_v);

--- a/cpp/dolfinx/refinement/refine.h
+++ b/cpp/dolfinx/refinement/refine.h
@@ -150,8 +150,8 @@ refine(const mesh::Mesh<T>& mesh,
   assert(std::holds_alternative<mesh::CellPartitionFunction>(partitioner));
 
   mesh::Mesh<T> mesh1 = mesh::create_mesh(
-      mesh.comm(), mesh.comm(), cell_adj.array(), mesh.geometry().cmaps().front(),
-      mesh.comm(), new_vertex_coords, xshape,
+      mesh.comm(), mesh.comm(), cell_adj.array(),
+      mesh.geometry().cmaps().front(), mesh.comm(), new_vertex_coords, xshape,
       std::get<mesh::CellPartitionFunction>(partitioner), 2);
 
   // Report the number of refined cells

--- a/cpp/dolfinx/refinement/refine.h
+++ b/cpp/dolfinx/refinement/refine.h
@@ -150,7 +150,7 @@ refine(const mesh::Mesh<T>& mesh,
   assert(std::holds_alternative<mesh::CellPartitionFunction>(partitioner));
 
   mesh::Mesh<T> mesh1 = mesh::create_mesh(
-      mesh.comm(), mesh.comm(), cell_adj.array(), mesh.geometry().cmap(),
+      mesh.comm(), mesh.comm(), cell_adj.array(), mesh.geometry().cmaps().front(),
       mesh.comm(), new_vertex_coords, xshape,
       std::get<mesh::CellPartitionFunction>(partitioner), 2);
 

--- a/cpp/dolfinx/refinement/uniform.cpp
+++ b/cpp/dolfinx/refinement/uniform.cpp
@@ -76,7 +76,7 @@ refinement::uniform_refine(const mesh::Mesh<T>& mesh,
   for (int j = 0; j < static_cast<int>(cell_entity_types.size()); ++j)
   {
     // Get geometry for each cell type
-    auto x_dofmap = mesh.geometry().dofmap(j);
+    auto x_dofmap = mesh.geometry().dofmaps().at(j);
     auto c_to_v = topology->connectivity({tdim, j}, {0, 0});
     auto dof_layout = mesh.geometry().cmaps().at(j).create_dof_layout();
     std::vector<int> entity_dofs(dof_layout.num_dofs());

--- a/cpp/dolfinx/refinement/uniform.cpp
+++ b/cpp/dolfinx/refinement/uniform.cpp
@@ -78,7 +78,7 @@ refinement::uniform_refine(const mesh::Mesh<T>& mesh,
     // Get geometry for each cell type
     auto x_dofmap = mesh.geometry().dofmap(j);
     auto c_to_v = topology->connectivity({tdim, j}, {0, 0});
-    auto dof_layout = mesh.geometry().cmap(j).create_dof_layout();
+    auto dof_layout = mesh.geometry().cmaps().at(j).create_dof_layout();
     std::vector<int> entity_dofs(dof_layout.num_dofs());
     for (int k = 0; k < dof_layout.num_dofs(); ++k)
       entity_dofs[k] = dof_layout.entity_dofs(0, k).front();
@@ -297,8 +297,8 @@ refinement::uniform_refine(const mesh::Mesh<T>& mesh,
                                                        mixed_topology.end());
 
   std::vector<fem::CoordinateElement<T>> geometry_cmaps;
-  for (std::size_t i = 0; i < mesh.geometry().num_maps(); ++i)
-    geometry_cmaps.push_back(mesh.geometry().cmap(i));
+  for (auto cm : mesh.geometry().cmaps())
+    geometry_cmaps.push_back(cm);
   mesh::Mesh new_mesh = mesh::create_mesh(
       mesh.comm(), mesh.comm(), topo_span, geometry_cmaps, mesh.comm(), new_x,
       {new_x.size() / 3, 3}, partitioner, 2);

--- a/cpp/dolfinx/refinement/utils.h
+++ b/cpp/dolfinx/refinement/utils.h
@@ -66,7 +66,7 @@ create_new_geometry(const mesh::Mesh<T>& mesh,
   auto map_c = mesh.topology()->index_map(tdim);
 
   assert(map_c);
-  auto dof_layout = mesh.geometry().cmap().create_dof_layout();
+  auto dof_layout = mesh.geometry().cmaps().front().create_dof_layout();
   auto entity_dofs_all = dof_layout.entity_dofs_all();
   for (int c = 0; c < map_c->size_local() + map_c->num_ghosts(); ++c)
   {

--- a/cpp/dolfinx/refinement/utils.h
+++ b/cpp/dolfinx/refinement/utils.h
@@ -55,7 +55,7 @@ create_new_geometry(const mesh::Mesh<T>& mesh,
                     const std::vector<std::int32_t>& marked_edge_list)
 {
   // Build map from vertex -> geometry dof
-  auto x_dofmap = mesh.geometry().dofmap();
+  auto x_dofmap = mesh.geometry().dofmaps().front();
   const int tdim = mesh.topology()->dim();
   auto c_to_v = mesh.topology()->connectivity(tdim, 0);
   assert(c_to_v);

--- a/python/demo/demo_mixed-topology.py
+++ b/python/demo/demo_mixed-topology.py
@@ -216,7 +216,7 @@ topologies = ["Hexahedron", "Wedge"]
 
 for j in range(2):
     vtk_topology = []
-    geom_dm = mesh.geometry.dofmaps(j)
+    geom_dm = mesh.geometry.dofmaps[j]
     for c in geom_dm:
         vtk_topology += list(c[perm[j]])
     topology_type = topologies[j]

--- a/python/dolfinx/fem/element.py
+++ b/python/dolfinx/fem/element.py
@@ -73,7 +73,7 @@ class CoordinateElement(Generic[Real]):
             cell_geometry: Coordinate 'degrees-of-freedom' (nodes) of
                 the cell, ``shape=(num_geometry_basis_functions,
                 geometrical_dimension)``. Can be created by accessing
-                ``geometry.x[geometry.dofmap.cell_dofs(i)]``,
+                ``geometry.x[geometry.dofmaps[0].cell_dofs(i)]``,
 
         Returns:
             Physical coordinates of the points reference points ``X``.
@@ -97,7 +97,7 @@ class CoordinateElement(Generic[Real]):
             cell_geometry: Physical coordinates describing the cell,
                 shape ``(num_of_geometry_basis_functions,
                 geometrical_dimension)``. They can be created by accessing
-                ``geometry.x[geometry.dofmap.cell_dofs(i)]``,
+                ``geometry.x[geometry.dofmaps[0].cell_dofs(i)]``,
             tol: Tolerance for convergence in Newton method for
                 nonaffine pullbacks.
             maxit: Maximum number of Newton iterations for

--- a/python/dolfinx/fem/utils.py
+++ b/python/dolfinx/fem/utils.py
@@ -212,8 +212,8 @@ def interpolate_geometry(msh: dolfinx.mesh.Mesh, cmap: CoordinateElement) -> dol
         basix.ufl.element(
             "Lagrange",
             _mesh.to_string(new_msh.topology.cell_type),
-            new_msh.geometry.cmap().degree,
-            basix.LagrangeVariant(new_msh.geometry.cmap().variant),
+            new_msh.geometry.cmaps[0].degree,
+            basix.LagrangeVariant(new_msh.geometry.cmaps[0].variant),
             shape=(new_msh.geometry.dim,),
             dtype=new_msh.geometry.x.dtype,
         )

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -323,7 +323,7 @@ def distribute_entity_data(
         mesh.topology._cpp_object,
         mesh.geometry.input_global_indices,
         mesh.geometry.index_map().size_global,
-        mesh.geometry.cmap().create_dof_layout(),
+        mesh.geometry.cmaps[0].create_dof_layout(),
         mesh.geometry.dofmap,
         entity_dim,
         entities,

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -324,7 +324,7 @@ def distribute_entity_data(
         mesh.geometry.input_global_indices,
         mesh.geometry.index_map().size_global,
         mesh.geometry.cmaps[0].create_dof_layout(),
-        mesh.geometry.dofmap,
+        mesh.geometry.dofmaps[0],
         entity_dim,
         entities,
         values,

--- a/python/dolfinx/io/vtkhdf.py
+++ b/python/dolfinx/io/vtkhdf.py
@@ -59,8 +59,8 @@ def read_mesh(
         # FIXME: not yet defined for mixed topology
         domain = None
     else:
-        cell_degree = mesh_cpp.geometry.cmap().degree
-        variant = mesh_cpp.geometry.cmap().variant
+        cell_degree = mesh_cpp.geometry.cmaps[0].degree
+        variant = mesh_cpp.geometry.cmaps[0].variant
         domain = ufl.Mesh(
             basix.ufl.element(
                 "Lagrange", cell_types[0].name, cell_degree, variant, shape=(mesh_cpp.geometry.dim,)

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -313,12 +313,22 @@ class Geometry(typing.Generic[Real]):
         return self._cpp_object.dim
 
     @property
+    def dofmaps(self) -> list[npt.NDArray[np.int32]]:
+        """The geometry dofmaps, one per cell type."""
+        return self._cpp_object.dofmaps
+
+    @property
     def dofmap(self) -> npt.NDArray[np.int32]:
-        """Dofmap for the geometry.
+        """Dofmap for the geometry (deprecated, use ``dofmaps[0]``).
 
         Shape is ``(num_cells, dofs_per_cell)``.
         """
-        return self._cpp_object.dofmap
+        warnings.warn(
+            "dofmap is deprecated. Use dofmaps[0] instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._cpp_object.dofmaps[0]
 
     def index_map(self) -> _IndexMap:
         """Index map for the geometry points (nodes) distribution."""

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import typing
+import warnings
 from collections.abc import Callable, Sequence
 from functools import singledispatch
 
@@ -291,9 +292,20 @@ class Geometry(typing.Generic[Real]):
         """
         self._cpp_object = geometry
 
-    def cmap(self, i=None) -> _CoordinateElement:
-        """Element that describes the ith geometry map."""
-        return _CoordinateElement(self._cpp_object.cmap(i))
+    @property
+    def cmaps(self) -> list[_CoordinateElement]:
+        """The coordinate maps."""
+        return [_CoordinateElement(cm) for cm in self._cpp_object.cmaps]
+
+    @property
+    def cmap(self) -> _CoordinateElement:
+        """The coordinate map (deprecated, use ``cmaps[0]``)."""
+        warnings.warn(
+            "cmap is deprecated. Use cmaps[0] instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.cmaps[0]
 
     @property
     def dim(self):
@@ -864,8 +876,8 @@ def create_submesh(
         basix.ufl.element(
             "Lagrange",
             to_string(submsh.topology.cell_type),
-            submsh.geometry.cmap().degree,
-            basix.LagrangeVariant(submsh.geometry.cmap().variant),
+            submsh.geometry.cmaps[0].degree,
+            basix.LagrangeVariant(submsh.geometry.cmaps[0].variant),
             shape=(submsh.geometry.dim,),
             dtype=submsh.geometry.x.dtype,
         )

--- a/python/dolfinx/wrappers/dolfinx_wrappers/fem.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/fem.h
@@ -1226,7 +1226,7 @@ void declare_real_functions(nb::module_& m)
         }
         else
         {
-          std::int32_t num_cells = geometry.dofmap().extent(0);
+          std::int32_t num_cells = geometry.dofmaps().front().extent(0);
           auto iota = std::ranges::iota_view(0, num_cells);
           x = dolfinx::fem::interpolation_coords(e, geometry, iota);
         }

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -201,8 +201,7 @@ void declare_mesh(nb::module_& m, std::string type)
                   dm.data_handle(), {dm.extent(0), dm.extent(1)}));
             return result;
           },
-          nb::rv_policy::reference_internal,
-          "The geometry dofmaps")
+          nb::rv_policy::reference_internal, "The geometry dofmaps")
       .def("index_map", &dolfinx::mesh::Geometry<T>::index_map)
       .def_prop_ro(
           "x",
@@ -216,10 +215,8 @@ void declare_mesh(nb::module_& m, std::string type)
           "Return coordinates of all geometry points. Each row is the "
           "coordinate of a point.")
       .def_prop_ro(
-          "cmaps",
-          [](dolfinx::mesh::Geometry<T>& self)
-          { return self.cmaps(); },
-          "The coordinate maps")
+          "cmaps", [](dolfinx::mesh::Geometry<T>& self)
+          { return self.cmaps(); }, "The coordinate maps")
       .def_prop_ro(
           "input_global_indices",
           [](const dolfinx::mesh::Geometry<T>& self)

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -191,25 +191,18 @@ void declare_mesh(nb::module_& m, std::string type)
       .def_prop_ro("dim", &dolfinx::mesh::Geometry<T>::dim,
                    "Geometric dimension")
       .def_prop_ro(
-          "dofmap",
+          "dofmaps",
           [](dolfinx::mesh::Geometry<T>& self)
           {
-            auto dofs = self.dofmap();
-            return nb::ndarray<const std::int32_t, nb::numpy>(
-                dofs.data_handle(), {dofs.extent(0), dofs.extent(1)});
+            auto dms = self.dofmaps();
+            nb::list result;
+            for (auto& dm : dms)
+              result.append(nb::ndarray<const std::int32_t, nb::numpy>(
+                  dm.data_handle(), {dm.extent(0), dm.extent(1)}));
+            return result;
           },
-          nb::rv_policy::reference_internal)
-      .def(
-          "dofmaps",
-          [](dolfinx::mesh::Geometry<T>& self, int i)
-          {
-            auto dofs = self.dofmap(i);
-            return nb::ndarray<const std::int32_t, nb::numpy>(
-                dofs.data_handle(), {dofs.extent(0), dofs.extent(1)});
-          },
-          nb::rv_policy::reference_internal, nb::arg("i"),
-          "Get the geometry dofmap associated with coordinate element i (mixed "
-          "topology)")
+          nb::rv_policy::reference_internal,
+          "The geometry dofmaps")
       .def("index_map", &dolfinx::mesh::Geometry<T>::index_map)
       .def_prop_ro(
           "x",

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -222,13 +222,11 @@ void declare_mesh(nb::module_& m, std::string type)
           nb::rv_policy::reference_internal,
           "Return coordinates of all geometry points. Each row is the "
           "coordinate of a point.")
-      .def(
-          "cmap", [](dolfinx::mesh::Geometry<T>& self) { return self.cmap(); },
-          "The coordinate map")
-      .def(
-          "cmap", [](dolfinx::mesh::Geometry<T>& self, std::optional<int> i)
-          { return self.cmap(i); }, "The ith coordinate map",
-          nb::arg("i").none())
+      .def_prop_ro(
+          "cmaps",
+          [](dolfinx::mesh::Geometry<T>& self)
+          { return self.cmaps(); },
+          "The coordinate maps")
       .def_prop_ro(
           "input_global_indices",
           [](const dolfinx::mesh::Geometry<T>& self)

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -144,7 +144,7 @@ def test_custom_mesh_loop_rank1(dtype):
 
     # Unpack mesh and dofmap data
     num_owned_cells = mesh.topology.index_map(mesh.topology.dim).size_local
-    x_dofs = mesh.geometry.dofmap
+    x_dofs = mesh.geometry.dofmaps[0]
     x = mesh.geometry.x
     dofmap = V.dofmap.list
 

--- a/python/test/unit/fem/test_dof_permuting.py
+++ b/python/test/unit/fem/test_dof_permuting.py
@@ -157,7 +157,7 @@ def test_dof_positions(cell_type, space_type):
 
     # Get coordinates of dofs and edges and check that they are the same
     # for each global dof number
-    coord_dofs = mesh.geometry.dofmap
+    coord_dofs = mesh.geometry.dofmaps[0]
     x_g = mesh.geometry.x
     cmap = mesh.geometry.cmaps[0]
     tdim = mesh.topology.dim

--- a/python/test/unit/fem/test_dof_permuting.py
+++ b/python/test/unit/fem/test_dof_permuting.py
@@ -159,7 +159,7 @@ def test_dof_positions(cell_type, space_type):
     # for each global dof number
     coord_dofs = mesh.geometry.dofmap
     x_g = mesh.geometry.x
-    cmap = mesh.geometry.cmap()
+    cmap = mesh.geometry.cmaps[0]
     tdim = mesh.topology.dim
 
     V = functionspace(mesh, space_type)

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -332,7 +332,7 @@ def test_higher_order_coordinate_map(points, celltype, order):
     X = V.element.interpolation_points
     coord_dofs = mesh.geometry.dofmap
     x_g = mesh.geometry.x
-    cmap = mesh.geometry.cmap()
+    cmap = mesh.geometry.cmaps[0]
 
     x_coord_new = np.zeros([len(points), mesh.geometry.dim])
 
@@ -412,7 +412,7 @@ def test_higher_order_tetra_coordinate_map(order):
     for node in range(points.shape[0]):
         x_coord_new[node] = x_g[x_dofs[0, node], : mesh.geometry.dim]
 
-    x = mesh.geometry.cmap().push_forward(X, x_coord_new)
+    x = mesh.geometry.cmaps[0].push_forward(X, x_coord_new)
     assert np.allclose(x[:, 0], X[:, 0], atol=100 * np.finfo(mesh.geometry.x.dtype).eps)
     assert np.allclose(x[:, 1], 2 * X[:, 1], atol=100 * np.finfo(mesh.geometry.x.dtype).eps)
     assert np.allclose(x[:, 2], 3 * X[:, 2], atol=100 * np.finfo(mesh.geometry.x.dtype).eps)

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -330,7 +330,7 @@ def test_higher_order_coordinate_map(points, celltype, order):
 
     V = functionspace(mesh, ("Lagrange", 2))
     X = V.element.interpolation_points
-    coord_dofs = mesh.geometry.dofmap
+    coord_dofs = mesh.geometry.dofmaps[0]
     x_g = mesh.geometry.x
     cmap = mesh.geometry.cmaps[0]
 
@@ -405,7 +405,7 @@ def test_higher_order_tetra_coordinate_map(order):
     mesh = create_mesh(MPI.COMM_WORLD, cells, domain, points)
     V = functionspace(mesh, ("Lagrange", order))
     X = V.element.interpolation_points
-    x_dofs = mesh.geometry.dofmap
+    x_dofs = mesh.geometry.dofmaps[0]
     x_g = mesh.geometry.x
 
     x_coord_new = np.zeros([len(points), mesh.geometry.dim])

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -371,10 +371,10 @@ def test_plus_minus_simple_vector(cell_type, pm, dtype):
 
     # Check that the above vectors all have the same values as the first
     # one, but permuted due to differently ordered dofs
-    dofmap0 = spaces[0].mesh.geometry.dofmap
+    dofmap0 = spaces[0].mesh.geometry.dofmaps[0]
     for result, space in zip(results[1:], spaces[1:]):
         # Get the data relating to two results
-        dofmap1 = space.mesh.geometry.dofmap
+        dofmap1 = space.mesh.geometry.dofmaps[0]
 
         # For each cell
         for cell in range(2):
@@ -426,10 +426,10 @@ def test_plus_minus_vector(cell_type, pm1, pm2, dtype):
 
     # Check that the above vectors all have the same values as the first
     # one, but permuted due to differently ordered dofs
-    dofmap0 = spaces[0].mesh.geometry.dofmap
+    dofmap0 = spaces[0].mesh.geometry.dofmaps[0]
     for result, space in zip(results[1:], spaces[1:]):
         # Get the data relating to two results
-        dofmap1 = space.mesh.geometry.dofmap
+        dofmap1 = space.mesh.geometry.dofmaps[0]
 
         # For each cell
         for cell in range(2):
@@ -477,10 +477,10 @@ def test_plus_minus_matrix(cell_type, pm1, pm2, dtype):
 
     # Check that the above matrices all have the same values, but
     # permuted due to differently ordered dofs
-    dofmap0 = spaces[0].mesh.geometry.dofmap
+    dofmap0 = spaces[0].mesh.geometry.dofmaps[0]
     for result, space in zip(results[1:], spaces[1:]):
         # Get the data relating to two results
-        dofmap1 = space.mesh.geometry.dofmap
+        dofmap1 = space.mesh.geometry.dofmaps[0]
         dof_order = []
 
         # For each cell

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -328,7 +328,7 @@ def test_assembly_into_quadrature_function(dtype):
     e_exact_eval = np.zeros_like(local)
     for cell in range(num_cells):
         xg = x_g[coord_dofs[cell], :tdim]
-        x = mesh.geometry.cmap().push_forward(quadrature_points, xg)
+        x = mesh.geometry.cmaps[0].push_forward(quadrature_points, xg)
         e_exact_eval[Q_dofs_unrolled[cell]] = e_exact(x.T).T.flatten()
     assert np.allclose(local, e_exact_eval)
 

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -314,7 +314,7 @@ def test_assembly_into_quadrature_function(dtype):
     # # FIXME: Below is only for testing purposes,
     # # never to be used in user code!
     # # TODO: Replace when interpolation into Quadrature element works.
-    coord_dofs = mesh.geometry.dofmap
+    coord_dofs = mesh.geometry.dofmaps[0]
     x_g = mesh.geometry.x
     tdim = mesh.topology.dim
     Q_dofs = Q.dofmap.list

--- a/python/test/unit/fem/test_interpolate_geometry.py
+++ b/python/test/unit/fem/test_interpolate_geometry.py
@@ -43,7 +43,7 @@ def test_interpolate_geometry_p1_to_p2(dtype):
     cmap = coordinate_element(CellType.triangle, 2, dtype=dtype)
 
     new_msh = interpolate_geometry(msh, cmap)
-    assert new_msh.geometry.cmap().degree == 2
+    assert new_msh.geometry.cmaps[0].degree == 2
 
     # Topology should be the same cpp object.
     assert new_msh.topology._cpp_object is msh.topology._cpp_object
@@ -68,7 +68,7 @@ def test_interpolate_geometry_p1_roundtrip(dtype):
 
     new_msh = interpolate_geometry(msh, cmap)
 
-    assert new_msh.geometry.cmap().degree == 1
+    assert new_msh.geometry.cmaps[0].degree == 1
     assert new_msh.topology._cpp_object is msh.topology._cpp_object
 
     x_old, x_new = msh.geometry.x, new_msh.geometry.x

--- a/python/test/unit/fem/test_interpolate_geometry.py
+++ b/python/test/unit/fem/test_interpolate_geometry.py
@@ -49,7 +49,7 @@ def test_interpolate_geometry_p1_to_p2(dtype):
     assert new_msh.topology._cpp_object is msh.topology._cpp_object
 
     x_old, x_new = msh.geometry.x, new_msh.geometry.x
-    dm_old, dm_new = msh.geometry.dofmap, new_msh.geometry.dofmap
+    dm_old, dm_new = msh.geometry.dofmaps[0], new_msh.geometry.dofmaps[0]
     assert dm_old.shape[0] == dm_new.shape[0]
     assert dm_new.shape[1] == 6
 
@@ -72,7 +72,7 @@ def test_interpolate_geometry_p1_roundtrip(dtype):
     assert new_msh.topology._cpp_object is msh.topology._cpp_object
 
     x_old, x_new = msh.geometry.x, new_msh.geometry.x
-    dm_old, dm_new = msh.geometry.dofmap, new_msh.geometry.dofmap
+    dm_old, dm_new = msh.geometry.dofmaps[0], new_msh.geometry.dofmaps[0]
     assert dm_old.shape == dm_new.shape
 
     atol = 10 * np.finfo(dtype).eps

--- a/python/test/unit/fem/test_petsc_custom_assembler.py
+++ b/python/test/unit/fem/test_petsc_custom_assembler.py
@@ -141,7 +141,7 @@ def test_custom_mesh_loop_petsc_rank2(set_vals, backend):
 
     # Unpack mesh and dofmap data
     num_owned_cells = mesh.topology.index_map(mesh.topology.dim).size_local
-    x_dofs = mesh.geometry.dofmap
+    x_dofs = mesh.geometry.dofmaps[0]
     x = mesh.geometry.x
     dofmap = V.dofmap.list.astype(np.dtype(PETSc.IntType))
 

--- a/python/test/unit/io/test_gmsh.py
+++ b/python/test/unit/io/test_gmsh.py
@@ -55,7 +55,7 @@ def test_physical_tags(marker_mode):
 
     msh, cell_tags = gmsh_tet_model(1)
     gdim = msh.geometry.dim
-    assert msh.geometry.cmap().degree == 1
+    assert msh.geometry.cmaps[0].degree == 1
     assert msh.geometry.dim == gdim
     local_values = np.unique(cell_tags.values)
     all_values = np.unique(np.hstack(msh.comm.allgather(local_values)))

--- a/python/test/unit/io/test_vtkhdf.py
+++ b/python/test/unit/io/test_vtkhdf.py
@@ -102,8 +102,8 @@ def test_read_write_higher_order():
         mesh_in = read_mesh(MPI.COMM_WORLD, "mixed_mesh_second_order.vtkhdf", gdim=gdim)
         assert mesh_in.geometry.dim == gdim
         assert mesh_in.geometry.index_map().size_global == 12
-        cmap_0 = mesh_in.geometry.cmap(0)
-        cmap_1 = mesh_in.geometry.cmap(1)
+        cmap_0 = mesh_in.geometry.cmaps[0]
+        cmap_1 = mesh_in.geometry.cmaps[1]
         assert cmap_0.degree == 2
         assert cmap_1.degree == 2
 

--- a/python/test/unit/io/test_xdmf_function.py
+++ b/python/test/unit/io/test_xdmf_function.py
@@ -288,7 +288,7 @@ def test_higher_order_function(tempdir):
     # -- Degree 1 mesh (tet)
     msh = gmsh_tet_model(1)
     gdim = msh.geometry.dim
-    assert msh.geometry.cmap().degree == 1
+    assert msh.geometry.cmaps[0].degree == 1
 
     # Write P1 Function
     u = Function(functionspace(msh, ("Lagrange", 1, (gdim,))))
@@ -308,7 +308,7 @@ def test_higher_order_function(tempdir):
     # -- Degree 2 mesh (tet)
     msh = gmsh_tet_model(2)
     gdim = msh.geometry.dim
-    assert msh.geometry.cmap().degree == 2
+    assert msh.geometry.cmaps[0].degree == 2
 
     # Write P1 Function (exception expected)
     u = Function(functionspace(msh, ("Lagrange", 1, (gdim,))))
@@ -329,7 +329,7 @@ def test_higher_order_function(tempdir):
     # NOTE: XDMF/ParaView does not support TETRAHEDRON_20
     msh = gmsh_tet_model(3)
     gdim = msh.geometry.dim
-    assert msh.geometry.cmap().degree == 3
+    assert msh.geometry.cmaps[0].degree == 3
 
     # Write P2 Function (exception expected)
     u = Function(functionspace(msh, ("Lagrange", 2, (gdim,))))
@@ -372,7 +372,7 @@ def test_higher_order_function(tempdir):
     # --  Degree 2 mesh (hex)
     msh = gmsh_hex_model(2)
     gdim = msh.geometry.dim
-    assert msh.geometry.cmap().degree == 2
+    assert msh.geometry.cmaps[0].degree == 2
 
     # Write Q1 Function (exception expected)
     u = Function(functionspace(msh, ("Lagrange", 1, (gdim,))))
@@ -393,7 +393,7 @@ def test_higher_order_function(tempdir):
     #
     # # Degree 3 mesh (hex)
     # msh = gmsh_hex_model(3)
-    # assert msh.geometry.cmap().degree == 3
+    # assert msh.geometry.cmaps[0].degree == 3
     # gdim = msh.geometry.dim
     # u = Function(functionspace(msh, ("Lagrange", 1, (gdim,))))
     # with pytest.raises(RuntimeError):

--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -763,7 +763,7 @@ def test_gmsh_mixed_mesh_2d(order, dtype):
         Js = []
         for i, cell_type in enumerate(mesh._cpp_object.topology.cell_types):
             cell_name = cell_type.name
-            cmap = mesh._cpp_object.geometry.cmap(i)
+            cmap = mesh._cpp_object.geometry.cmaps[i]
             domain = ufl.Mesh(
                 basix.ufl.element(
                     "Lagrange",
@@ -888,7 +888,7 @@ def test_gmsh_mixed_mesh_3d(order, dtype):
         Js = []
         for i, cell_type in enumerate(cell_types):
             cell_name = cell_type.name
-            cmap = mesh._cpp_object.geometry.cmap(i)
+            cmap = mesh._cpp_object.geometry.cmaps[i]
             domain = ufl.Mesh(
                 basix.ufl.element(
                     "Lagrange",

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -742,26 +742,26 @@ def test_mesh_create_cmap(dtype):
     # ufl.Mesh case
     domain = ufl.Mesh(element("Lagrange", shape, degree, shape=(2,), dtype=dtype))
     msh = _mesh.create_mesh(MPI.COMM_WORLD, cells, domain, x)
-    assert msh.geometry.cmap().dim == 3
+    assert msh.geometry.cmaps[0].dim == 3
     assert msh.ufl_domain().ufl_coordinate_element().reference_value_shape == (2,)
 
     # basix.ufl.element
     domain = element("Lagrange", shape, degree, shape=(2,), dtype=dtype)
     msh = _mesh.create_mesh(MPI.COMM_WORLD, cells, domain, x)
-    assert msh.geometry.cmap().dim == 3
+    assert msh.geometry.cmaps[0].dim == 3
     assert msh.ufl_domain().ufl_coordinate_element().reference_value_shape == (2,)
 
     # basix.finite_element
     domain = basix.create_element(basix.ElementFamily.P, basix.CellType[shape], degree, dtype=dtype)
     msh = _mesh.create_mesh(MPI.COMM_WORLD, cells, domain, x)
-    assert msh.geometry.cmap().dim == 3
+    assert msh.geometry.cmaps[0].dim == 3
     assert msh.ufl_domain().ufl_coordinate_element().reference_value_shape == (2,)
 
     # cpp.fem.CoordinateElement
     e = basix.create_element(basix.ElementFamily.P, basix.CellType[shape], degree, dtype=dtype)
     domain = coordinate_element(e)
     msh = _mesh.create_mesh(MPI.COMM_WORLD, cells, domain, x)
-    assert msh.geometry.cmap().dim == 3
+    assert msh.geometry.cmaps[0].dim == 3
     assert msh.ufl_domain() is None
 
 

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -99,7 +99,7 @@ def submesh_geometry_test(mesh, submesh, entity_map, geom_map, entity_dim):
         mesh.topology.create_entity_permutations()
         e_to_g = entities_to_geometry(mesh, entity_dim, np.array(submesh_to_mesh), True)
         for submesh_entity in range(len(submesh_to_mesh)):
-            submesh_x_dofs = submesh.geometry.dofmap[submesh_entity]
+            submesh_x_dofs = submesh.geometry.dofmaps[0][submesh_entity]
             # e_to_g[i] gets the mesh x_dofs of entities[i], which should
             # correspond to the x_dofs of cell i in the submesh
             mesh_x_dofs = e_to_g[submesh_entity]

--- a/python/test/unit/mesh/test_mixed_topology.py
+++ b/python/test/unit/mesh/test_mixed_topology.py
@@ -91,8 +91,8 @@ def test_mixed_topology_mesh(dtype):
     )
     print(geom.x)
     print(geom.index_map().size_local)
-    print(geom.dofmaps(0))
-    print(geom.dofmaps(1))
+    print(geom.dofmaps[0])
+    print(geom.dofmaps[1])
     set_log_level(LogLevel.WARNING)
 
 
@@ -252,8 +252,8 @@ def test_parallel_mixed_mesh(dtype):
         topology, [tri._cpp_object, quad._cpp_object], nodes, xdofs, x.flatten(), 2
     )
 
-    assert len(geom.dofmaps(0)) == 2
-    assert len(geom.dofmaps(1)) == 1
+    assert len(geom.dofmaps[0]) == 2
+    assert len(geom.dofmaps[1]) == 1
 
     mesh_t = Mesh_float64 if dtype == np.float64 else Mesh_float32
     mesh = mesh_t(MPI.COMM_WORLD, topology, geom)


### PR DESCRIPTION
Changes to the interface API for `geometry.cmap` and `geometry.dofmap` including deprecation messages.
In C++:
Now use - `geometry.cmaps().front()` or `geometry.cmaps().at(i)`
In Python:
Now use - `geometry.cmaps[0]` or `geometry.cmaps[i]`, with existing `geometry.cmap` deprecated (but retained for now).

The same transition for `dofmap` as for `cmap`.