### PR TITLE
Align Functionspace.dofmap(s) interface

### DIFF
--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -339,7 +339,7 @@ public:
           "Rank mismatch between Constant and function space in DirichletBC");
     }
 
-    if (g->value.size() != (std::size_t)_function_space->dofmaps(0)->bs())
+    if (g->value.size() != (std::size_t)_function_space->dofmaps()[0]->bs())
     {
       throw std::runtime_error(
           "Creating a DirichletBC using a Constant is not supported when the "
@@ -354,10 +354,10 @@ public:
     }
 
     // Unroll _dofs0 if dofmap block size > 1
-    if (const int bs = V->dofmaps(0)->bs(); bs > 1)
+    if (const int bs = V->dofmaps()[0]->bs(); bs > 1)
       _dofs0 = unroll_dofs(_dofs0, bs);
 
-    _owned_indices0 = num_owned(*_function_space->dofmaps(0), _dofs0);
+    _owned_indices0 = num_owned(*_function_space->dofmaps()[0], _dofs0);
   }
 
   /// @brief Create a representation of a Dirichlet boundary condition
@@ -382,10 +382,10 @@ public:
     assert(_function_space);
 
     // Unroll _dofs0 if dofmap block size > 1
-    if (const int bs = _function_space->dofmaps(0)->bs(); bs > 1)
+    if (const int bs = _function_space->dofmaps()[0]->bs(); bs > 1)
       _dofs0 = unroll_dofs(_dofs0, bs);
 
-    _owned_indices0 = num_owned(*_function_space->dofmaps(0), _dofs0);
+    _owned_indices0 = num_owned(*_function_space->dofmaps()[0], _dofs0);
   }
 
   /// @brief Create a representation of a Dirichlet boundary condition
@@ -549,7 +549,7 @@ public:
     {
       auto g = std::get<std::shared_ptr<const Constant<T>>>(_g);
       const std::vector<T>& value = g->value;
-      std::int32_t bs = _function_space->dofmaps(0)->bs();
+      std::int32_t bs = _function_space->dofmaps()[0]->bs();
       if (x0)
       {
         assert(x.size() <= x0->size());

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -339,7 +339,8 @@ public:
           "Rank mismatch between Constant and function space in DirichletBC");
     }
 
-    if (g->value.size() != (std::size_t)_function_space->dofmaps()[0]->bs())
+    if (g->value.size()
+        != (std::size_t)_function_space->dofmaps().front()->bs())
     {
       throw std::runtime_error(
           "Creating a DirichletBC using a Constant is not supported when the "
@@ -354,10 +355,10 @@ public:
     }
 
     // Unroll _dofs0 if dofmap block size > 1
-    if (const int bs = V->dofmaps()[0]->bs(); bs > 1)
+    if (const int bs = V->dofmaps().front()->bs(); bs > 1)
       _dofs0 = unroll_dofs(_dofs0, bs);
 
-    _owned_indices0 = num_owned(*_function_space->dofmaps()[0], _dofs0);
+    _owned_indices0 = num_owned(*_function_space->dofmaps().front(), _dofs0);
   }
 
   /// @brief Create a representation of a Dirichlet boundary condition
@@ -382,10 +383,10 @@ public:
     assert(_function_space);
 
     // Unroll _dofs0 if dofmap block size > 1
-    if (const int bs = _function_space->dofmaps()[0]->bs(); bs > 1)
+    if (const int bs = _function_space->dofmaps().front()->bs(); bs > 1)
       _dofs0 = unroll_dofs(_dofs0, bs);
 
-    _owned_indices0 = num_owned(*_function_space->dofmaps()[0], _dofs0);
+    _owned_indices0 = num_owned(*_function_space->dofmaps().front(), _dofs0);
   }
 
   /// @brief Create a representation of a Dirichlet boundary condition
@@ -549,7 +550,7 @@ public:
     {
       auto g = std::get<std::shared_ptr<const Constant<T>>>(_g);
       const std::vector<T>& value = g->value;
-      std::int32_t bs = _function_space->dofmaps()[0]->bs();
+      std::int32_t bs = _function_space->dofmaps().front()->bs();
       if (x0)
       {
         assert(x.size() <= x0->size());

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -55,9 +55,9 @@ public:
   /// @brief Create function on given function space.
   /// @param[in] V The function space
   explicit Function(std::shared_ptr<const FunctionSpace<geometry_type>> V)
-      : _function_space(V),
-        _x(std::make_shared<la::Vector<value_type>>(
-            V->dofmaps()[0]->index_map, V->dofmaps()[0]->index_map_bs()))
+      : _function_space(V), _x(std::make_shared<la::Vector<value_type>>(
+                                V->dofmaps().front()->index_map,
+                                V->dofmaps().front()->index_map_bs()))
   {
     if (!V->component().empty())
     {

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -57,7 +57,7 @@ public:
   explicit Function(std::shared_ptr<const FunctionSpace<geometry_type>> V)
       : _function_space(V),
         _x(std::make_shared<la::Vector<value_type>>(
-            V->dofmaps(0)->index_map, V->dofmaps(0)->index_map_bs()))
+            V->dofmaps()[0]->index_map, V->dofmaps()[0]->index_map_bs()))
   {
     if (!V->component().empty())
     {

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -391,13 +391,13 @@ public:
           "FunctionSpace has multiple dofmaps, call `dofmaps` instead.");
     }
 
-    return dofmaps(0);
+    return dofmaps()[0];
   }
 
   /// The dofmaps
-  std::shared_ptr<const DofMap> dofmaps(int cell_type_idx) const
+  const std::vector<std::shared_ptr<const DofMap>>& dofmaps() const
   {
-    return _dofmaps.at(cell_type_idx);
+    return _dofmaps;
   }
 
 private:

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -391,7 +391,7 @@ public:
           "FunctionSpace has multiple dofmaps, call `dofmaps` instead.");
     }
 
-    return dofmaps()[0];
+    return dofmaps().front();
   }
 
   /// The dofmaps

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -646,9 +646,9 @@ void assemble_matrix(
 
     // Get dofmap data
     std::shared_ptr<const fem::DofMap> dofmap0
-        = a.function_spaces().at(0)->dofmaps(cell_type_idx);
+        = a.function_spaces().at(0)->dofmaps()[cell_type_idx];
     std::shared_ptr<const fem::DofMap> dofmap1
-        = a.function_spaces().at(1)->dofmaps(cell_type_idx);
+        = a.function_spaces().at(1)->dofmaps()[cell_type_idx];
     assert(dofmap0);
     assert(dofmap1);
     auto dofs0 = dofmap0->map();

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -646,9 +646,9 @@ void assemble_matrix(
 
     // Get dofmap data
     std::shared_ptr<const fem::DofMap> dofmap0
-        = a.function_spaces().at(0)->dofmaps()[cell_type_idx];
+        = a.function_spaces().at(0)->dofmaps().at(cell_type_idx);
     std::shared_ptr<const fem::DofMap> dofmap1
-        = a.function_spaces().at(1)->dofmaps()[cell_type_idx];
+        = a.function_spaces().at(1)->dofmaps().at(cell_type_idx);
     assert(dofmap0);
     assert(dofmap1);
     auto dofs0 = dofmap0->map();

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -382,8 +382,8 @@ void lift_bc_impl(
   // Deduce runtime block sizes as fallback when compile-time sizes not given.
   // The block size of the dofmap and indexmap is the same on all
   // sub-topologies.
-  const int bs0 = BS0 > 0 ? BS0 : a.function_spaces()[0]->dofmaps(0)->bs();
-  const int bs1 = BS1 > 0 ? BS1 : a.function_spaces()[1]->dofmaps(0)->bs();
+  const int bs0 = BS0 > 0 ? BS0 : a.function_spaces()[0]->dofmaps()[0]->bs();
+  const int bs1 = BS1 > 0 ? BS1 : a.function_spaces()[1]->dofmaps()[0]->bs();
 
   // Use default [=] capture for bs0, bs1 which may be compile-time constants
   auto lifting_fn
@@ -450,8 +450,8 @@ void lift_bc(V&& b, const Form<T, U>& a, std::span<const T> constants,
   // Get dofmap for columns and rows of a
   assert(a.function_spaces().at(0));
   assert(a.function_spaces().at(1));
-  const int bs0 = a.function_spaces()[0]->dofmaps(0)->bs();
-  const int bs1 = a.function_spaces()[1]->dofmaps(0)->bs();
+  const int bs0 = a.function_spaces()[0]->dofmaps()[0]->bs();
+  const int bs1 = a.function_spaces()[1]->dofmaps()[0]->bs();
 
   spdlog::debug("lifting: bs0={}, bs1={}", bs0, bs1);
 
@@ -531,7 +531,7 @@ void apply_lifting(
         _x0 = x0[j];
 
       assert(V1);
-      const auto& dofmap = V1->dofmaps(0);
+      const auto& dofmap = V1->dofmaps()[0];
       auto map1 = dofmap->index_map;
       const int bs1 = dofmap->index_map_bs();
       assert(map1);
@@ -588,7 +588,7 @@ void assemble_vector(
     auto element = L.function_spaces().at(0)->elements(cell_type_idx);
     assert(element);
     std::shared_ptr<const fem::DofMap> dofmap
-        = L.function_spaces().at(0)->dofmaps(cell_type_idx);
+        = L.function_spaces().at(0)->dofmaps()[cell_type_idx];
     assert(dofmap);
     auto dofs = dofmap->map();
     const int bs = dofmap->bs();

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -382,8 +382,10 @@ void lift_bc_impl(
   // Deduce runtime block sizes as fallback when compile-time sizes not given.
   // The block size of the dofmap and indexmap is the same on all
   // sub-topologies.
-  const int bs0 = BS0 > 0 ? BS0 : a.function_spaces()[0]->dofmaps()[0]->bs();
-  const int bs1 = BS1 > 0 ? BS1 : a.function_spaces()[1]->dofmaps()[0]->bs();
+  const int bs0
+      = BS0 > 0 ? BS0 : a.function_spaces()[0]->dofmaps().front()->bs();
+  const int bs1
+      = BS1 > 0 ? BS1 : a.function_spaces()[1]->dofmaps().front()->bs();
 
   // Use default [=] capture for bs0, bs1 which may be compile-time constants
   auto lifting_fn
@@ -450,8 +452,8 @@ void lift_bc(V&& b, const Form<T, U>& a, std::span<const T> constants,
   // Get dofmap for columns and rows of a
   assert(a.function_spaces().at(0));
   assert(a.function_spaces().at(1));
-  const int bs0 = a.function_spaces()[0]->dofmaps()[0]->bs();
-  const int bs1 = a.function_spaces()[1]->dofmaps()[0]->bs();
+  const int bs0 = a.function_spaces()[0]->dofmaps().front()->bs();
+  const int bs1 = a.function_spaces()[1]->dofmaps().front()->bs();
 
   spdlog::debug("lifting: bs0={}, bs1={}", bs0, bs1);
 
@@ -531,7 +533,7 @@ void apply_lifting(
         _x0 = x0[j];
 
       assert(V1);
-      const auto& dofmap = V1->dofmaps()[0];
+      const auto& dofmap = V1->dofmaps().front();
       auto map1 = dofmap->index_map;
       const int bs1 = dofmap->index_map_bs();
       assert(map1);
@@ -588,7 +590,7 @@ void assemble_vector(
     auto element = L.function_spaces().at(0)->elements(cell_type_idx);
     assert(element);
     std::shared_ptr<const fem::DofMap> dofmap
-        = L.function_spaces().at(0)->dofmaps()[cell_type_idx];
+        = L.function_spaces().at(0)->dofmaps().at(cell_type_idx);
     assert(dofmap);
     auto dofs = dofmap->map();
     const int bs = dofmap->bs();

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -507,10 +507,10 @@ void assemble_matrix(
   // Index maps for dof ranges
   // NOTE: For mixed-topology meshes, there will be multiple DOF maps,
   // but the index maps are the same.
-  auto map0 = a.function_spaces().at(0)->dofmaps(0)->index_map;
-  auto map1 = a.function_spaces().at(1)->dofmaps(0)->index_map;
-  auto bs0 = a.function_spaces().at(0)->dofmaps(0)->index_map_bs();
-  auto bs1 = a.function_spaces().at(1)->dofmaps(0)->index_map_bs();
+  auto map0 = a.function_spaces().at(0)->dofmaps()[0]->index_map;
+  auto map1 = a.function_spaces().at(1)->dofmaps()[0]->index_map;
+  auto bs0 = a.function_spaces().at(0)->dofmaps()[0]->index_map_bs();
+  auto bs1 = a.function_spaces().at(1)->dofmaps()[0]->index_map_bs();
 
   // Build dof markers
   std::vector<std::int8_t> dof_marker0, dof_marker1;

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -507,10 +507,10 @@ void assemble_matrix(
   // Index maps for dof ranges
   // NOTE: For mixed-topology meshes, there will be multiple DOF maps,
   // but the index maps are the same.
-  auto map0 = a.function_spaces().at(0)->dofmaps()[0]->index_map;
-  auto map1 = a.function_spaces().at(1)->dofmaps()[0]->index_map;
-  auto bs0 = a.function_spaces().at(0)->dofmaps()[0]->index_map_bs();
-  auto bs1 = a.function_spaces().at(1)->dofmaps()[0]->index_map_bs();
+  auto map0 = a.function_spaces().at(0)->dofmaps().front()->index_map;
+  auto map1 = a.function_spaces().at(1)->dofmaps().front()->index_map;
+  auto bs0 = a.function_spaces().at(0)->dofmaps().front()->index_map_bs();
+  auto bs1 = a.function_spaces().at(1)->dofmaps().front()->index_map_bs();
 
   // Build dof markers
   std::vector<std::int8_t> dof_marker0, dof_marker1;

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -1132,7 +1132,7 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
 
   // Get dofmap
   spdlog::debug("Interpolate: get dofmap");
-  const auto dofmap = u.function_space()->dofmaps()[index];
+  const auto dofmap = u.function_space()->dofmaps().at(index);
   assert(dofmap);
 
   // Result will be stored to coeffs

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -1132,7 +1132,7 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
 
   // Get dofmap
   spdlog::debug("Interpolate: get dofmap");
-  const auto dofmap = u.function_space()->dofmaps(index);
+  const auto dofmap = u.function_space()->dofmaps()[index];
   assert(dofmap);
 
   // Result will be stored to coeffs

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -204,8 +204,8 @@ la::SparsityPattern create_sparsity_pattern(const Form<T, U>& a)
   // mixed-topology meshes, despite there being multiple DOF maps, the
   // index maps and block sizes are the same.
   std::array<std::reference_wrapper<const DofMap>, 2> dofmaps{
-      *a.function_spaces().at(0)->dofmaps()[0],
-      *a.function_spaces().at(1)->dofmaps()[0]};
+      *a.function_spaces().at(0)->dofmaps().front(),
+      *a.function_spaces().at(1)->dofmaps().front()};
 
   const std::array index_maps{dofmaps[0].get().index_map,
                               dofmaps[1].get().index_map};
@@ -264,8 +264,8 @@ void build_sparsity_pattern(la::SparsityPattern& pattern, const Form<T, U>& a)
   for (int cell_type_idx = 0; cell_type_idx < num_cell_types; ++cell_type_idx)
   {
     std::array<std::reference_wrapper<const DofMap>, 2> dofmaps{
-        *a.function_spaces().at(0)->dofmaps()[cell_type_idx],
-        *a.function_spaces().at(1)->dofmaps()[cell_type_idx]};
+        *a.function_spaces().at(0)->dofmaps().at(cell_type_idx),
+        *a.function_spaces().at(1)->dofmaps().at(cell_type_idx)};
 
     // Create and build sparsity pattern
     for (auto type : types)
@@ -926,7 +926,8 @@ FunctionSpace<T> create_functionspace(
     std::shared_ptr<mesh::Mesh<T>> mesh,
     std::shared_ptr<const fem::FiniteElement<T>> e,
     std::function<std::vector<int>(const graph::AdjacencyList<std::int32_t>&)>
-        reorder_fn = nullptr)
+        reorder_fn
+    = nullptr)
 {
   // TODO: check cell type of e (need to add method to fem::FiniteElement)
   assert(e);
@@ -1070,10 +1071,12 @@ Expression<T, U> create_expression(
 /// @return A new mesh sharing the topology of `mesh` and with a
 /// geometry described by `new_cmap`.
 template <std::floating_point T>
-mesh::Mesh<T> interpolate_geometry(
-    std::shared_ptr<mesh::Mesh<T>> mesh, const CoordinateElement<T>& new_cmap,
-    const std::function<std::vector<int>(
-        const graph::AdjacencyList<std::int32_t>&)>& reorder_fn = nullptr)
+mesh::Mesh<T>
+interpolate_geometry(std::shared_ptr<mesh::Mesh<T>> mesh,
+                     const CoordinateElement<T>& new_cmap,
+                     const std::function<std::vector<int>(
+                         const graph::AdjacencyList<std::int32_t>&)>& reorder_fn
+                     = nullptr)
 {
   assert(mesh);
   const CoordinateElement<T>& old_cmap = mesh->geometry().cmaps().front();

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -204,8 +204,8 @@ la::SparsityPattern create_sparsity_pattern(const Form<T, U>& a)
   // mixed-topology meshes, despite there being multiple DOF maps, the
   // index maps and block sizes are the same.
   std::array<std::reference_wrapper<const DofMap>, 2> dofmaps{
-      *a.function_spaces().at(0)->dofmaps(0),
-      *a.function_spaces().at(1)->dofmaps(0)};
+      *a.function_spaces().at(0)->dofmaps()[0],
+      *a.function_spaces().at(1)->dofmaps()[0]};
 
   const std::array index_maps{dofmaps[0].get().index_map,
                               dofmaps[1].get().index_map};
@@ -264,8 +264,8 @@ void build_sparsity_pattern(la::SparsityPattern& pattern, const Form<T, U>& a)
   for (int cell_type_idx = 0; cell_type_idx < num_cell_types; ++cell_type_idx)
   {
     std::array<std::reference_wrapper<const DofMap>, 2> dofmaps{
-        *a.function_spaces().at(0)->dofmaps(cell_type_idx),
-        *a.function_spaces().at(1)->dofmaps(cell_type_idx)};
+        *a.function_spaces().at(0)->dofmaps()[cell_type_idx],
+        *a.function_spaces().at(1)->dofmaps()[cell_type_idx]};
 
     // Create and build sparsity pattern
     for (auto type : types)

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -926,8 +926,7 @@ FunctionSpace<T> create_functionspace(
     std::shared_ptr<mesh::Mesh<T>> mesh,
     std::shared_ptr<const fem::FiniteElement<T>> e,
     std::function<std::vector<int>(const graph::AdjacencyList<std::int32_t>&)>
-        reorder_fn
-    = nullptr)
+        reorder_fn = nullptr)
 {
   // TODO: check cell type of e (need to add method to fem::FiniteElement)
   assert(e);
@@ -1071,12 +1070,10 @@ Expression<T, U> create_expression(
 /// @return A new mesh sharing the topology of `mesh` and with a
 /// geometry described by `new_cmap`.
 template <std::floating_point T>
-mesh::Mesh<T>
-interpolate_geometry(std::shared_ptr<mesh::Mesh<T>> mesh,
-                     const CoordinateElement<T>& new_cmap,
-                     const std::function<std::vector<int>(
-                         const graph::AdjacencyList<std::int32_t>&)>& reorder_fn
-                     = nullptr)
+mesh::Mesh<T> interpolate_geometry(
+    std::shared_ptr<mesh::Mesh<T>> mesh, const CoordinateElement<T>& new_cmap,
+    const std::function<std::vector<int>(
+        const graph::AdjacencyList<std::int32_t>&)>& reorder_fn = nullptr)
 {
   assert(mesh);
   const CoordinateElement<T>& old_cmap = mesh->geometry().cmaps().front();

--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -107,7 +107,7 @@ def create_vector(V: FunctionSpace, dtype: npt.DTypeLike = default_scalar_type) 
     """
     # Can just take the first dofmap here, since all dof maps have the same
     # index map in mixed-topology meshes
-    dofmap = V.dofmaps(0)  # type: ignore[attr-defined]
+    dofmap = V.dofmaps[0]  # type: ignore[attr-defined]
     return la.vector(dofmap.index_map, dofmap.index_map_bs, dtype=dtype)
 
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -830,12 +830,7 @@ class FunctionSpace(ufl.FunctionSpace, Generic[Real]):
     @property
     def dofmap(self) -> DofMap:
         """Degree-of-freedom map associated with the function space."""
-        warnings.warn(
-            "dofmap is deprecated. Use dofmaps[0] instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.dofmaps[0]
+        return DofMap(self._cpp_object.dofmap)
 
     @property
     def dofmaps(self) -> list[DofMap]:

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import typing
+import warnings
 from collections.abc import Callable, Sequence
 from functools import cached_property, singledispatch
 from typing import Generic
@@ -829,11 +830,17 @@ class FunctionSpace(ufl.FunctionSpace, Generic[Real]):
     @property
     def dofmap(self) -> DofMap:
         """Degree-of-freedom map associated with the function space."""
-        return DofMap(self._cpp_object.dofmap)
+        warnings.warn(
+            "dofmap is deprecated. Use dofmaps[0] instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.dofmaps[0]
 
-    def dofmaps(self, idx: int) -> DofMap:
-        """Dof maps."""
-        return DofMap(self._cpp_object.dofmaps(idx))
+    @property
+    def dofmaps(self) -> list[DofMap]:
+        """The geometry dofmaps, one per cell type."""
+        return [DofMap(_o) for _o in self._cpp_object.dofmaps]
 
     @property
     def mesh(self) -> Mesh[Real]:

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -9,7 +9,6 @@
 from __future__ import annotations
 
 import typing
-import warnings
 from collections.abc import Callable, Sequence
 from functools import cached_property, singledispatch
 from typing import Generic

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -456,10 +456,10 @@ def _(
                     "Cannot have a entire {'row' if index == 0 else 'column'} of a full of None"
                 )
         is0 = _cpp.la.petsc.create_index_sets(
-            [(Vsub.dofmaps(0).index_map, Vsub.dofmaps(0).index_map_bs) for Vsub in V[0]]  # type: ignore[union-attr]
+            [(Vsub.dofmaps[0].index_map, Vsub.dofmaps[0].index_map_bs) for Vsub in V[0]]  # type: ignore[union-attr]
         )
         is1 = _cpp.la.petsc.create_index_sets(
-            [(Vsub.dofmaps(0).index_map, Vsub.dofmaps(0).index_map_bs) for Vsub in V[1]]  # type: ignore[union-attr]
+            [(Vsub.dofmaps[0].index_map, Vsub.dofmaps[0].index_map_bs) for Vsub in V[1]]  # type: ignore[union-attr]
         )
 
         _bcs = [bc._cpp_object for bc in bcs] if bcs is not None else []

--- a/python/dolfinx/wrappers/dolfinx_wrappers/assemble.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/assemble.h
@@ -217,8 +217,7 @@ void declare_assembly_functions(nanobind::module_& m)
       {
         std::vector<int> coffsets = e.coefficient_offsets();
         const std::vector<std::shared_ptr<const dolfinx::fem::Function<T, U>>>&
-            coefficients
-            = e.coefficients();
+            coefficients = e.coefficients();
         std::vector<T> coeffs(entities.shape(0) * coffsets.back());
         std::size_t cstride = coffsets.back();
         std::vector<std::reference_wrapper<const dolfinx::fem::Function<T, U>>>

--- a/python/dolfinx/wrappers/dolfinx_wrappers/assemble.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/assemble.h
@@ -365,8 +365,8 @@ void declare_assembly_functions(nanobind::module_& m)
         // Get index map block size. Note that mixed-topology meshes
         // will have multiple DOF maps, but the block sizes are the same.
         const std::array<int, 2> data_bs
-            = {a.function_spaces().at(0)->dofmaps(0)->index_map_bs(),
-               a.function_spaces().at(1)->dofmaps(0)->index_map_bs()};
+            = {a.function_spaces().at(0)->dofmaps()[0]->index_map_bs(),
+               a.function_spaces().at(1)->dofmaps()[0]->index_map_bs()};
 
         if (data_bs[0] != data_bs[1])
         {

--- a/python/dolfinx/wrappers/dolfinx_wrappers/assemble.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/assemble.h
@@ -217,7 +217,8 @@ void declare_assembly_functions(nanobind::module_& m)
       {
         std::vector<int> coffsets = e.coefficient_offsets();
         const std::vector<std::shared_ptr<const dolfinx::fem::Function<T, U>>>&
-            coefficients = e.coefficients();
+            coefficients
+            = e.coefficients();
         std::vector<T> coeffs(entities.shape(0) * coffsets.back());
         std::size_t cstride = coffsets.back();
         std::vector<std::reference_wrapper<const dolfinx::fem::Function<T, U>>>
@@ -365,8 +366,8 @@ void declare_assembly_functions(nanobind::module_& m)
         // Get index map block size. Note that mixed-topology meshes
         // will have multiple DOF maps, but the block sizes are the same.
         const std::array<int, 2> data_bs
-            = {a.function_spaces().at(0)->dofmaps()[0]->index_map_bs(),
-               a.function_spaces().at(1)->dofmaps()[0]->index_map_bs()};
+            = {a.function_spaces().at(0)->dofmaps().front()->index_map_bs(),
+               a.function_spaces().at(1)->dofmaps().front()->index_map_bs()};
 
         if (data_bs[0] != data_bs[1])
         {

--- a/python/dolfinx/wrappers/dolfinx_wrappers/fem.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/fem.h
@@ -125,8 +125,7 @@ void declare_function_space(nb::module_& m, std::string type)
         .def("elements", &dolfinx::fem::FunctionSpace<T>::elements)
         .def_prop_ro("mesh", &dolfinx::fem::FunctionSpace<T>::mesh)
         .def_prop_ro("dofmap", &dolfinx::fem::FunctionSpace<T>::dofmap)
-        .def("dofmaps", &dolfinx::fem::FunctionSpace<T>::dofmaps,
-             nb::arg("cell_type_index"))
+        .def("dofmaps", &dolfinx::fem::FunctionSpace<T>::dofmaps)
         .def("sub", &dolfinx::fem::FunctionSpace<T>::sub, nb::arg("component"))
         .def("tabulate_dof_coordinates",
              [](const dolfinx::fem::FunctionSpace<T>& self)

--- a/python/dolfinx/wrappers/dolfinx_wrappers/fem.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/fem.h
@@ -125,7 +125,7 @@ void declare_function_space(nb::module_& m, std::string type)
         .def("elements", &dolfinx::fem::FunctionSpace<T>::elements)
         .def_prop_ro("mesh", &dolfinx::fem::FunctionSpace<T>::mesh)
         .def_prop_ro("dofmap", &dolfinx::fem::FunctionSpace<T>::dofmap)
-        .def("dofmaps", &dolfinx::fem::FunctionSpace<T>::dofmaps)
+        .def_prop_ro("dofmaps", &dolfinx::fem::FunctionSpace<T>::dofmaps)
         .def("sub", &dolfinx::fem::FunctionSpace<T>::sub, nb::arg("component"))
         .def("tabulate_dof_coordinates",
              [](const dolfinx::fem::FunctionSpace<T>& self)


### PR DESCRIPTION
Aligns `Functionspace.dofmaps` interface to geometry access patter, ref https://github.com/FEniCS/dolfinx/pull/4227. Otherwise current access patterns of `mesh.geometry.dofmaps` and `functionspace.dofmaps` do confusingly not align anymore.

- does not deprecate (python) `FunctionSpace.dofmap`, since also c++ layer still relies on it.