### PR TITLE
Fix aligned vs align inside $$ $$ rendering

### DIFF
--- a/python/demo/demo_axis.py
+++ b/python/demo/demo_axis.py
@@ -171,14 +171,14 @@ def generate_mesh_sphere_axis(
 # cylindrical harmonics:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # \mathbf{E}_s(\rho, z, \phi) &= \sum_m\mathbf{E}^{(m)}_s(\rho, z)
 #   e^{-jm\phi} \\
 # \mathbf{E}_b(\rho, z, \phi) &= \sum_m\mathbf{E}^{(m)}_b(\rho, z)
 #   e^{-jm\phi} \\
 # \bar{\mathbf{v}}(\rho, z, \phi) &=
 # \sum_m\bar{\mathbf{v}}^{(m)}(\rho, z)e^{+jm\phi}
-# \end{align}
+# \end{aligned}
 # $$
 #
 # The curl operator $\nabla\times$ in cylindrical coordinates becomes:
@@ -325,13 +325,13 @@ def background_field_p(theta: float, n_bkg: float, k0: float, m: int, x):
 # PML:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # &\rho^{\prime} = \rho\left[1 +j \alpha/k_0 \left(\frac{r
 # - r_{dom}}{r~r_{pml}}\right)\right] \\
 # &z^{\prime} = z\left[1 +j \alpha/k_0 \left(\frac{r
 # - r_{dom}}{r~r_{pml}}\right)\right] \\
 # &\phi^{\prime} = \phi
-# \end{align}
+# \end{aligned}
 # $$
 #
 # with $\alpha$ tuning the absorption inside the PML, and $r =
@@ -362,12 +362,12 @@ def background_field_p(theta: float, n_bkg: float, k0: float, m: int, x):
 # ${\boldsymbol{\mu}_{pml}}$:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # & {\boldsymbol{\varepsilon}_{pml}} =
 # A^{-1} \mathbf{A} {\boldsymbol{\varepsilon}_b}\mathbf{A}^{T}\\
 # & {\boldsymbol{\mu}_{pml}} =
 # A^{-1} \mathbf{A} {\boldsymbol{\mu}_b}\mathbf{A}^{T}
-# \end{align}
+# \end{aligned}
 # $$
 #
 # For doing these calculations, we define the `pml_coordinate` and
@@ -534,21 +534,21 @@ I0 = 0.5 * n_bkg / Z0  # Intensity
 # to few harmonic numbers, e.g., $m = -1, 0, 1$. Besides, we have that:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # &J_{-m}=(-1)^m J_m \\
 # &J_{-m}^{\prime}=(-1)^m J_m^{\prime} \\
 # &j^{-m}=(-1)^m j^m
-# \end{align}
+# \end{aligned}
 # $$
 #
 # and therefore:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # &E_{b, \rho}^{(m)}=E_{b, \rho}^{(-m)} \\
 # &E_{b, \phi}^{(m)}=-E_{b, \phi}^{(-m)} \\
 # &E_{b, z}^{(m)}=E_{b, z}^{(-m)}
-# \end{align}
+# \end{aligned}
 # $$
 #
 # In light of this, we can solve the problem for $m\geq 0$.
@@ -608,11 +608,11 @@ dS = ufl.Measure("dS", mesh_data.mesh, subdomain_data=mesh_data.facet_tags)
 # following way:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # &E_{s, \rho}^{(m)}(\phi)=E_{s, \rho}^{(m)}(e^{-jm\phi}+e^{jm\phi}) \\
 # &E_{s, \phi}^{(m)}(\phi)=E_{s, \phi}^{(m)}(e^{-jm\phi}-e^{jm\phi}) \\
 # &E_{s, z}^{(m)}(\phi)=E_{s, z}^{(m)}(e^{-jm\phi}+e^{jm\phi})
-# \end{align}
+# \end{aligned}
 # $$
 #
 # For this reason, we also add a `phase` constant for the above phase

--- a/python/demo/demo_biharmonic.py
+++ b/python/demo/demo_biharmonic.py
@@ -54,7 +54,7 @@
 # $$
 # \begin{aligned}
 # u =0 &\qquad \frac{\partial u}{\partial n} = 0
-# # \text{ on } \partial\Omega,\\
+# \text{ on } \partial\Omega,\\
 # u =0 &\qquad \Delta u = 0 \text{ on } \partial \Omega.
 # \end{aligned}
 # $$

--- a/python/demo/demo_cahn-hilliard.py
+++ b/python/demo/demo_cahn-hilliard.py
@@ -35,7 +35,7 @@
 # derivatives.  The equation reads:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # \frac{\partial c}{\partial t} -
 #   \nabla \cdot M \left(\nabla\left(\frac{d f}{dc}
 #   - \lambda \nabla^{2}c\right)\right) &= 0 \quad {\rm in} \ \Omega, \\
@@ -43,7 +43,7 @@
 #   \lambda \nabla^{2}c\right)\right) \cdot n
 #   &= 0 \quad {\rm on} \ \partial\Omega, \\
 # M \lambda \nabla c \cdot n &= 0 \quad {\rm on} \ \partial\Omega.
-# \end{align}
+# \end{aligned}
 # $$
 #
 # where $c$ is the unknown field, the function $f$ is usually non-convex
@@ -59,26 +59,26 @@
 # as two coupled second-order equations:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # \frac{\partial c}{\partial t} - \nabla \cdot M \nabla\mu
 #     &= 0 \quad {\rm in} \ \Omega, \\
 # \mu -  \frac{d f}{d c} + \lambda \nabla^{2}c &= 0 \quad {\rm in}
 #   \ \Omega.
-# \end{align}
+# \end{aligned}
 # $$
 #
 # The unknown fields are now $c$ and $\mu$. The weak (variational) form
 # of the problem reads: find $(c, \mu) \in V \times V$ such that
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # \int_{\Omega} \frac{\partial c}{\partial t} q \, {\rm d} x +
 #     \int_{\Omega} M \nabla\mu \cdot \nabla q \, {\rm d} x
 #     &= 0 \quad \forall \ q \in V,  \\
 # \int_{\Omega} \mu v \, {\rm d} x - \int_{\Omega} \frac{d f}{d c} v \,
 #   {\rm d} x - \int_{\Omega} \lambda \nabla c \cdot \nabla v \, {\rm d} x
 #    &= 0 \quad \forall \ v \in V.
-# \end{align}
+# \end{aligned}
 # $$
 #
 # ### Time discretisation
@@ -88,14 +88,14 @@
 # equation:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # \int_{\Omega} \frac{c_{n+1} - c_{n}}{dt} q \, {\rm d} x
 #   + \int_{\Omega} M \nabla \mu_{n+\theta} \cdot \nabla q \, {\rm d} x
 #   &= 0 \quad \forall \ q \in V  \\
 # \int_{\Omega} \mu_{n+1} v  \, {\rm d} x - \int_{\Omega}
 #   \frac{d f_{n+1}}{d c} v  \, {\rm d} x - \int_{\Omega} \lambda \nabla
 #   c_{n+1} \cdot \nabla v \, {\rm d} x &= 0 \quad \forall \ v \in V
-# \end{align}
+# \end{aligned}
 # $$
 #
 # where $dt = t_{n+1} - t_{n}$ and $\mu_{n+\theta} = (1-\theta) \mu_{n} +

--- a/python/demo/demo_half-loaded-waveguide.py
+++ b/python/demo/demo_half-loaded-waveguide.py
@@ -205,11 +205,11 @@ eps.x.array[cells_d] = eps_d
 # waveguide wall:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # &\nabla \times \frac{1}{\mu_{r}} \nabla \times \mathbf{E}-k_{o}^{2}
 # \epsilon_{r} \mathbf{E}=0 \quad &\text { in } \Omega\\
 # &\hat{n}\times\mathbf{E} = 0 &\text { on } \Gamma
-# \end{align}
+# \end{aligned}
 # $$
 #
 # with $k_0$ and $\lambda_0 = 2\pi/k_0$ being the wavevector and the
@@ -232,10 +232,10 @@ eps.x.array[cells_d] = eps_d
 # the following substitution:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # & \mathbf{e}_t = k_z\mathbf{E}_t\\
 # & e_z = -jE_z
-# \end{align}
+# \end{aligned}
 # $$
 #
 # The final weak form can be written as:

--- a/python/demo/demo_matrix-free-petsc.py
+++ b/python/demo/demo_matrix-free-petsc.py
@@ -25,11 +25,11 @@
 # Find $(u_h, p_h) \in V_h \times Q_h$ such that
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 #   \min_{u_h, p_h} J(u_h, p_h) &=
 #   \frac{1}{2} \int_\Omega \vert u_h - f\vert^2~\mathrm{d}x
 #   + \int_\Omega \vert p_h - g\vert^2~\mathrm{d}x
-# \end{align}
+# \end{aligned}
 # $$
 #
 # By considering the optimality conditions of this system we arrive at the
@@ -37,11 +37,11 @@
 # Find $(u_h, p_h) \in V_h \times Q_h$ such that
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 #   \int_\Omega (u_h-f) \cdot v~\mathrm{d}x + \int_\Omega (p_h-g) q
 #  ~\mathrm{d}x
 # &= 0 \quad \forall (v, q) \in V_h \times Q_h
-# \end{align}
+# \end{aligned}
 # $$
 #
 # We start by importing the necessary modules

--- a/python/demo/demo_mixed-poisson.py
+++ b/python/demo/demo_mixed-poisson.py
@@ -37,10 +37,10 @@
 # then read
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 #   \sigma - \nabla u &= 0 \quad {\rm in} \ \Omega, \\
 #   \nabla \cdot \sigma &= - f \quad {\rm in} \ \Omega,
-# \end{align}
+# \end{aligned}
 # $$
 # with boundary conditions
 #

--- a/python/demo/demo_navier-stokes.py
+++ b/python/demo/demo_navier-stokes.py
@@ -37,11 +37,11 @@
 # $(0, \infty)$, given by
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # \partial_t u - \nu \Delta u + (u \cdot \nabla)u + \nabla p &= f
 # \text{ in } \Omega_t, \\
 # \nabla \cdot u &= 0 \text{ in } \Omega_t,
-# \end{align}
+# \end{aligned}
 # $$
 #
 # where $u: \Omega_t \to \mathbb{R}^d$ is the velocity field, $p:
@@ -75,13 +75,13 @@
 # We begin by introducing the function spaces
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 #     V_h^g &:= \left\{v \in H(\text{div}; \Omega);
 #     v|_K \in V_h(K) \; \forall K \in \mathcal{T}, v \cdot n = g \cdot n
 #     \text{ on } \partial \Omega \right\} \\
 #     Q_h &:= \left\{q \in L^2_0(\Omega);
 #     q|_K \in Q_h(K) \; \forall K \in \mathcal{T} \right\}.
-# \end{align}
+# \end{aligned}
 # $$
 #
 # The local spaces $V_h(K)$ and $Q_h(K)$ should satisfy
@@ -141,12 +141,12 @@
 # $(u_h, p_h) \in V_h^{u_D} \times Q_h$ such that
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 #   \int_\Omega \partial_t u_h \cdot v + a_h(u_h, v_h) + c_h(u_h; u_h, v_h)
 #   + b_h(v_h, p_h) &= \int_\Omega f \cdot v_h + L_{a_h}(v_h) +
 #   L_{c_h}(v_h) \quad \forall v_h \in V_h^0, \\
 #   b_h(u_h, q_h) &= 0 \quad \forall q_h \in Q_h,
-# \end{align}
+# \end{aligned}
 # $$
 #
 # where
@@ -154,7 +154,7 @@
 # $\renewcommand{\sumF}[0]{\sum_{F \in \mathcal{F}_h}}$
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 #   a_h(u, v) &= Re^{-1} \left(\sumK \int_K \nabla u : \nabla v
 #   - \sumF \int_F \avg{\nabla u} : \jump{v}
 #   - \sumF \int_F \avg{\nabla v} : \jump{u} \\
@@ -167,7 +167,7 @@
 #   L_{c_h}(v_h) &= - \int_{\partial \Omega} u_D \cdot n \hat{u}_D \cdot
 #   v_h, \\
 #   b_h(v, q) &= - \int_K \nabla \cdot v q.
-# \end{align}
+# \end{aligned}
 # $$
 #
 #

--- a/python/demo/demo_pml.py
+++ b/python/demo/demo_pml.py
@@ -416,14 +416,14 @@ if have_pyvista:
 # specified here below:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # \text{PML}_\text{corners} \rightarrow \mathbf{r}^\prime &= (x^\prime,
 #   y^\prime) \\
 # \text{PML}_\text{rectangles along x} \rightarrow
 #   \mathbf{r}^\prime &= (x^\prime, y) \\
 # \text{PML}_\text{rectangles along y} \rightarrow
 #   \mathbf{r}^\prime &= (x, y^\prime).
-# \end{align}
+# \end{aligned}
 # $$
 #
 # Now we define some other problem specific parameters:
@@ -547,12 +547,12 @@ y_pml = ufl.as_vector((x[0], pml_coordinates(x[1], alpha, k0, l_dom, l_pml)))
 # https://www.tandfonline.com/doi/abs/10.1080/09500349608232782):
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # {\boldsymbol{\varepsilon}_{pml}} &=
 # A^{-1} \mathbf{A} {\boldsymbol{\varepsilon}_b}\mathbf{A}^{T},\\
 # {\boldsymbol{\mu}_{pml}} &=
 # A^{-1} \mathbf{A} {\boldsymbol{\mu}_b}\mathbf{A}^{T},
-# \end{align}
+# \end{aligned}
 # $$
 #
 # with $A^{-1}=\operatorname{det}(\mathbf{J})$.

--- a/python/demo/demo_poisson-matrix-free.py
+++ b/python/demo/demo_poisson-matrix-free.py
@@ -41,10 +41,10 @@
 # reads:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # - \nabla^{2} u &= f \quad {\rm in} \ \Omega, \\
 #       u &= u_{\rm D} \; {\rm on} \ \partial\Omega.
-# \end{align}
+# \end{aligned}
 # $$
 #
 # The variational problem reads: Given a suitable function space satisfying
@@ -59,10 +59,10 @@
 # where the bilinear and linear formulations are
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # a(u, v) &:= \int_{\Omega} \nabla u \cdot \nabla v \, {\rm d} x, \\
 # L(v)    &:= \int_{\Omega} f v \, {\rm d} x,
-# \end{align}
+# \end{aligned}
 # $$
 #
 # respectively. In this demo we select:

--- a/python/demo/demo_poisson.py
+++ b/python/demo/demo_poisson.py
@@ -27,11 +27,11 @@
 # particular boundary conditions reads:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 #   - \nabla^{2} u &= f \quad {\rm in} \ \Omega, \\
 #   u &= 0 \quad {\rm on} \ \Gamma_{D}, \\
 #   \nabla u \cdot n &= g \quad {\rm on} \ \Gamma_{N}. \\
-# \end{align}
+# \end{aligned}
 # $$
 #
 # where $f$ and $g$ are input data and $n$ denotes the outward directed
@@ -45,11 +45,11 @@
 # where $V$ is a suitable function space and
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 #   a(u, v) &:= \int_{\Omega} \nabla u \cdot \nabla v \, {\rm d} x, \\
 #   L(v)    &:= \int_{\Omega} f v \, {\rm d} x + \int_{\Gamma_{N}} g v \,
 #               {\rm d} s.
-# \end{align}
+# \end{aligned}
 # $$
 #
 # The expression $a(u, v)$ is the bilinear form and $L(v)$

--- a/python/demo/demo_scattering-boundary-conditions.py
+++ b/python/demo/demo_scattering-boundary-conditions.py
@@ -543,7 +543,7 @@ eps.x.scatter_forward()
 # integrate the terms over the corresponding domains:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # & \int_{\Omega}-\nabla \times( \nabla \times \mathbf{E}_s) \cdot
 # \bar{\mathbf{v}}+\varepsilon_{r} k_{0}^{2} \mathbf{E}_s \cdot
 # \bar{\mathbf{v}}+k_{0}^{2}\left(\varepsilon_{r}-\varepsilon_b\right)
@@ -552,7 +552,7 @@ eps.x.scatter_forward()
 # (\mathbf{n} \times \nabla \times \mathbf{E}_s) \cdot \bar{\mathbf{v}}
 # +\left(j n_bk_{0}+\frac{1}{2r}\right) (\mathbf{n} \times \mathbf{E}_s
 # \times \mathbf{n}) \cdot \bar{\mathbf{v}}~\mathrm{d}s=0
-# \end{align}
+# \end{aligned}
 # $$
 #
 # By using $(\nabla \times \mathbf{A}) \cdot \mathbf{B}=\mathbf{A}
@@ -560,7 +560,7 @@ eps.x.scatter_forward()
 # \mathbf{B}),$ we can change the first term into:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # & \int_{\Omega}-\nabla \cdot(\nabla\times\mathbf{E}_s \times
 # \bar{\mathbf{v}})-\nabla \times \mathbf{E}_s \cdot \nabla
 # \times\bar{\mathbf{v}}+\varepsilon_{r} k_{0}^{2} \mathbf{E}_s
@@ -570,7 +570,7 @@ eps.x.scatter_forward()
 # (\mathbf{n} \times \nabla \times \mathbf{E}_s) \cdot \bar{\mathbf{v}}
 # +\left(j n_bk_{0}+\frac{1}{2r}\right) (\mathbf{n} \times \mathbf{E}_s
 # \times \mathbf{n}) \cdot \bar{\mathbf{v}}~\mathrm{d}s=0,
-# \end{align}
+# \end{aligned}
 # $$
 #
 # using the divergence theorem
@@ -578,7 +578,7 @@ eps.x.scatter_forward()
 # \mathbf{F}\cdot\mathbf{n}~\mathrm{d}s$, we can write:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # & \int_{\Omega}-(\nabla \times \mathbf{E}_s) \cdot (\nabla \times
 # \bar{\mathbf{v}})+\varepsilon_{r} k_{0}^{2} \mathbf{E}_s \cdot
 # \bar{\mathbf{v}}+k_{0}^{2}\left(\varepsilon_{r}-\varepsilon_b\right)
@@ -588,7 +588,7 @@ eps.x.scatter_forward()
 # + (\mathbf{n} \times \nabla \times \mathbf{E}_s) \cdot \bar{\mathbf{v}}
 # +\left(j n_bk_{0}+\frac{1}{2r}\right) (\mathbf{n} \times \mathbf{E}_s
 # \times \mathbf{n}) \cdot \bar{\mathbf{v}}~\mathrm{d}s=0.
-# \end{align}
+# \end{aligned}
 # $$
 #
 # Cancelling $-(\nabla\times\mathbf{E}_s \times \bar{\mathbf{V}})
@@ -601,7 +601,7 @@ eps.x.scatter_forward()
 # \mathbf{A})=\mathbf{C} \cdot(\mathbf{A} \times \mathbf{B})$, we get:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # & \int_{\Omega}-(\nabla \times \mathbf{E}_s) \cdot (\nabla \times
 # \bar{\mathbf{v}})+\varepsilon_{r} k_{0}^{2} \mathbf{E}_s \cdot
 # \bar{\mathbf{v}}+k_{0}^{2}\left(\varepsilon_{r}-\varepsilon_b\right)
@@ -609,7 +609,7 @@ eps.x.scatter_forward()
 # +&\int_{\partial \Omega}
 # \left(j n_bk_{0}+\frac{1}{2r}\right)( \mathbf{n} \times \mathbf{E}_s
 # \times \mathbf{n}) \cdot \bar{\mathbf{v}} ~\mathrm{d} s = 0.
-# \end{align}
+# \end{aligned}
 # $$
 #
 # We use the [UFL](https://github.com/FEniCS/ufl/) to implement the
@@ -714,7 +714,7 @@ q_abs_analyt, q_sca_analyt, q_ext_analyt = calculate_analytical_efficiencies(
 # absorption, scattering and extinction are:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # & Q_{abs} = \operatorname{Re}\left(\int_{\Omega_{m}} \frac{1}{2}
 #   \frac{\operatorname{Im}(\varepsilon_m)k_0}{Z_0n_b}
 #   \mathbf{E}\cdot\hat{\mathbf{E}}~\mathrm{d}x\right) \\
@@ -722,7 +722,7 @@ q_abs_analyt, q_sca_analyt, q_ext_analyt = calculate_analytical_efficiencies(
 #   \left(\mathbf{E}_s\times\bar{\mathbf{H}}_s\right)
 #   \cdot\mathbf{n}~\mathrm{d}s\right)\\ \\
 # & Q_{ext} = Q_{abs} + Q_{sca},
-# \end{align}
+# \end{aligned}
 # $$
 #
 # with $Z_0 = \sqrt{\frac{\mu_0}{\varepsilon_0}}$ being the vacuum
@@ -733,11 +733,11 @@ q_abs_analyt, q_sca_analyt, q_ext_analyt = calculate_analytical_efficiencies(
 # of the wire, $\sigma_{gcs} = 2r_w$:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 # & q_{abs} = \frac{Q_{abs}}{I_0\sigma_{gcs}} \\
 # & q_{sca} = \frac{Q_{sca}}{I_0\sigma_{gcs}} \\
 # & q_{ext} = q_{abs} + q_{sca}.
-# \end{align}
+# \end{aligned}
 # $$
 #
 # We can calculate these values in the following way:

--- a/python/demo/demo_stokes.py
+++ b/python/demo/demo_stokes.py
@@ -35,20 +35,20 @@
 # ### Strong formulation
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 #   - \nabla \cdot (\nabla u + p I) &= f \quad {\rm in} \ \Omega,\\
 #   \nabla \cdot u &= 0 \quad {\rm in} \ \Omega.
-# \end{align}
+# \end{aligned}
 # $$
 #
 # with conditions on the boundary $\partial \Omega = \Gamma_{D} \cup
 # \Gamma_{N}$ of the form:
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 #   u &= u_0 \quad {\rm on} \ \Gamma_{D},\\
 #   \nabla u \cdot n + p n &= g \,   \quad\;\; {\rm on} \ \Gamma_{N}.
-# \end{align}
+# \end{aligned}
 # $$
 #
 # ```{note}
@@ -68,12 +68,12 @@
 # where
 #
 # $$
-# \begin{align}
+# \begin{aligned}
 #   a((u, p), (v, q)) &:= \int_{\Omega} \nabla u \cdot \nabla v -
 #            \nabla \cdot v \ p + \nabla \cdot u \ q \, {\rm d} x,\\
 #   L((v, q)) &:= \int_{\Omega} f \cdot v \, {\rm d} x + \int_{\partial
 #            \Omega_N} g \cdot v \, {\rm d} s.
-# \end{align}
+# \end{aligned}
 # $$
 #
 # ### Domain and boundary conditions


### PR DESCRIPTION
Closer inspection of the new documentation build showed that Mathjax no longer likes `$$\begin{align}\end{align}$$`. `$$\begin{aligned}\end{aligned}$$` is correct and works well. Will be backported to make `v0.11.0.post0` release of DOLFINx.

I used Claude Sonnet 4.6 to write the sed command from a textual description.