### PR TITLE
Guard VTXWriter use when ADIOS2 is unavailable

### DIFF
--- a/python/demo/demo_scattering-boundary-conditions.py
+++ b/python/demo/demo_scattering-boundary-conditions.py
@@ -47,7 +47,7 @@ from scipy.special import h2vp, hankel2, jv, jvp
 
 import ufl
 from basix.ufl import element
-from dolfinx import default_real_type, default_scalar_type, fem, io, plot
+from dolfinx import default_real_type, default_scalar_type, fem, has_adios2, io, plot
 from dolfinx.fem.petsc import LinearProblem
 
 try:
@@ -655,8 +655,11 @@ Esh_dg = fem.Function(V_dg)
 assert isinstance(Esh, fem.Function)
 Esh_dg.interpolate(Esh)
 
-with io.VTXWriter(mesh_data.mesh.comm, out_folder / "Esh.bp", Esh_dg) as vtx:
-    vtx.write(0.0)
+if has_adios2:
+    with io.VTXWriter(mesh_data.mesh.comm, out_folder / "Esh.bp", Esh_dg) as vtx:
+        vtx.write(0.0)
+else:
+    print("VTXWriter is unavailable, Esh.bp will not be saved.")
 # -
 
 # We visualize the solution using PyVista. For more information about
@@ -694,8 +697,11 @@ E = fem.Function(V)
 E.x.array[:] = Eb.x.array[:] + Esh.x.array[:]
 E_dg = fem.Function(V_dg)
 E_dg.interpolate(E)
-with io.VTXWriter(mesh_data.mesh.comm, "E.bp", E_dg) as vtx:
-    vtx.write(0.0)
+if has_adios2:
+    with io.VTXWriter(mesh_data.mesh.comm, "E.bp", E_dg) as vtx:
+        vtx.write(0.0)
+else:
+    print("VTXWriter is unavailable, E.bp will not be saved.")
 # -
 
 # We validate our numerical solution by computing the absorption,

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -14,10 +14,12 @@ import pytest
 
 import ufl
 from basix.ufl import element
-from dolfinx import default_real_type
+from dolfinx import default_real_type, has_adios2
 from dolfinx.fem import Function, functionspace
 from dolfinx.graph import adjacencylist
 from dolfinx.mesh import CellType, create_mesh, create_unit_cube, create_unit_square
+
+pytestmark = pytest.mark.skipif(not has_adios2, reason="DOLFINx has been built without ADIOS2")
 
 
 def import_adios2():
@@ -251,9 +253,9 @@ class TestVTX:
 
     def test_dg_0_data(self, tempdir):
         """Test that we can mix DG-0 and other Lagrange functions."""
+        adios2 = import_adios2()
         from dolfinx.io import VTXWriter
 
-        adios2 = import_adios2()
         mesh = generate_mesh(2, False)
         v = Function(functionspace(mesh, ("Lagrange", 2, (2,))))
         filename = Path(tempdir, "v.bp")


### PR DESCRIPTION
Skip the ADIOS2 VTXWriter test module when DOLFINx itself is built without ADIOS2 support, while still using the Python adios2 import check for tests that inspect BP output.\n\nAlso guard VTXWriter output in the scattering boundary conditions demo so the demo can continue when ADIOS2-backed VTX output is unavailable.\n\nFixes #3995.\n\nSplit out from #4249 per maintainer request.