### PR TITLE
Guard cloned-space BC assembly in C++

### DIFF
--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -40,6 +40,51 @@ class Form;
 template <std::floating_point T>
 class FunctionSpace;
 
+namespace impl
+{
+/// @brief Check that Dirichlet boundary conditions are supported for matrix
+/// assembly when test and trial spaces are distinct but share a dofmap.
+/// @param[in] a Bilinear form.
+/// @param[in] bcs Boundary conditions to check.
+/// @throws std::runtime_error If a boundary condition is applied to either
+/// space of a form whose distinct test and trial spaces share the same dofmap.
+template <dolfinx::scalar T, std::floating_point U>
+void check_bcs_for_dofmap_sharing_spaces(
+    const Form<T, U>& a,
+    const std::vector<std::reference_wrapper<const DirichletBC<T, U>>>& bcs)
+{
+  if (bcs.empty() or a.function_spaces().size() != 2)
+    return;
+
+  const auto& V0 = a.function_spaces().at(0);
+  const auto& V1 = a.function_spaces().at(1);
+  assert(V0);
+  assert(V1);
+  if (V0 == V1)
+    return;
+  if (V0->mesh() != V1->mesh())
+    return;
+  if (V0->dofmaps().size() != 1 or V1->dofmaps().size() != 1)
+    return;
+  if (V0->dofmap() != V1->dofmap())
+    return;
+  if (V0->element()->signature() != V1->element()->signature())
+    return;
+
+  for (auto& bc : bcs)
+  {
+    assert(bc.get().function_space());
+    if (V0->contains(*bc.get().function_space())
+        or V1->contains(*bc.get().function_space()))
+    {
+      throw std::runtime_error(
+          "DirichletBCs on distinct test and trial spaces that share a "
+          "dofmap are not supported by this matrix assembly function.");
+    }
+  }
+}
+} // namespace impl
+
 /// @brief Evaluate an Expression on cells or facets.
 ///
 /// This function accepts packed coefficient data, which allows it be
@@ -475,13 +520,19 @@ void assemble_matrix(
 /// @param[in] coefficients Coefficients that appear in `a`.
 /// @param[in] bcs Boundary conditions to apply. For boundary condition
 /// dofs the row and column are zeroed. The diagonal  entry is not set.
+/// @param[in] check_bcs Check that the boundary conditions are supported by
+/// this assembly function.
 template <dolfinx::scalar T, std::floating_point U>
 void assemble_matrix(
     auto mat_add, const Form<T, U>& a, std::span<const T> constants,
     const std::map<std::pair<IntegralType, int>,
                    std::pair<std::span<const T>, int>>& coefficients,
-    const std::vector<std::reference_wrapper<const DirichletBC<T, U>>>& bcs)
+    const std::vector<std::reference_wrapper<const DirichletBC<T, U>>>& bcs,
+    bool check_bcs = true)
 {
+  if (check_bcs)
+    impl::check_bcs_for_dofmap_sharing_spaces(a, bcs);
+
   // Index maps for dof ranges
   // NOTE: For mixed-topology meshes, there will be multiple DOF maps,
   // but the index maps are the same.

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -1,4 +1,5 @@
 // Copyright (C) 2018-2026 Garth N. Wells and Jørgen S. Dokken
+// Copyright (C) 2026 Musawer Ahmad Saqif
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -40,6 +41,51 @@ template <dolfinx::scalar T, std::floating_point U>
 class Form;
 template <std::floating_point T>
 class FunctionSpace;
+
+namespace impl
+{
+/// @brief Check that Dirichlet boundary conditions are supported for matrix
+/// assembly when test and trial spaces are distinct but share a dofmap.
+/// @param[in] a Bilinear form.
+/// @param[in] bcs Boundary conditions to check.
+/// @throws std::runtime_error If a boundary condition is applied to either
+/// space of a form whose distinct test and trial spaces share the same dofmap.
+template <dolfinx::scalar T, std::floating_point U>
+void check_bcs_for_dofmap_sharing_spaces(
+    const Form<T, U>& a,
+    const std::vector<std::reference_wrapper<const DirichletBC<T, U>>>& bcs)
+{
+  if (bcs.empty() or a.function_spaces().size() != 2)
+    return;
+
+  const auto& V0 = a.function_spaces().at(0);
+  const auto& V1 = a.function_spaces().at(1);
+  assert(V0);
+  assert(V1);
+  if (V0 == V1)
+    return;
+  if (V0->mesh() != V1->mesh())
+    return;
+  if (V0->dofmaps().size() != 1 or V1->dofmaps().size() != 1)
+    return;
+  if (V0->dofmap() != V1->dofmap())
+    return;
+  if (V0->element()->signature() != V1->element()->signature())
+    return;
+
+  for (auto& bc : bcs)
+  {
+    assert(bc.get().function_space());
+    if (V0->contains(*bc.get().function_space())
+        or V1->contains(*bc.get().function_space()))
+    {
+      throw std::runtime_error(
+          "DirichletBCs on distinct test and trial spaces that share a "
+          "dofmap are not supported by this matrix assembly function.");
+    }
+  }
+}
+} // namespace impl
 
 /// @brief Evaluate an Expression on cells or facets.
 ///
@@ -540,13 +586,19 @@ void assemble_matrix(
 /// @param[in] coefficients Coefficients that appear in `a`.
 /// @param[in] bcs Boundary conditions to apply. For boundary condition
 /// dofs the row and column are zeroed. The diagonal  entry is not set.
+/// @param[in] check_bcs Check that the boundary conditions are supported by
+/// this assembly function.
 template <dolfinx::scalar T, std::floating_point U>
 void assemble_matrix(
     auto mat_add, const Form<T, U>& a, std::span<const T> constants,
     const std::map<std::pair<IntegralType, int>,
                    std::pair<std::span<const T>, int>>& coefficients,
-    const std::vector<std::reference_wrapper<const DirichletBC<T, U>>>& bcs)
+    const std::vector<std::reference_wrapper<const DirichletBC<T, U>>>& bcs,
+    bool check_bcs = true)
 {
+  if (check_bcs)
+    impl::check_bcs_for_dofmap_sharing_spaces(a, bcs);
+
   // Index maps for dof ranges
   // NOTE: For mixed-topology meshes, there will be multiple DOF maps,
   // but the index maps are the same.

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -433,6 +433,8 @@ def _assemble_matrix_petsc(  # type: ignore[misc]
         | Sequence[Sequence[dict[tuple[IntegralType, int], npt.NDArray]]]
         | None
     ) = None,
+    *,
+    _check_bcs: bool = True,
 ) -> PETSc.Mat:
     """Assemble bilinear form into a matrix.
 
@@ -443,6 +445,7 @@ def _assemble_matrix_petsc(  # type: ignore[misc]
     The returned matrix is not finalised, i.e. ghost values are not
     accumulated.
     """
+    bcs = [] if bcs is None else bcs
     if A.getType() == PETSc.Mat.Type.NEST:
         if not isinstance(a, Sequence):
             raise ValueError("Must provide a sequence of forms when assembling a nest matrix")
@@ -458,7 +461,7 @@ def _assemble_matrix_petsc(  # type: ignore[misc]
             ):
                 if a_block is not None:
                     Asub = A.getNestSubMatrix(i, j)
-                    _assemble_matrix_petsc(Asub, a_block, bcs, diag, const, coeff)
+                    _assemble_matrix_petsc(Asub, a_block, bcs, diag, const, coeff, _check_bcs=False)
                 elif i == j:
                     for bc in bcs:
                         row_forms = [row_form for row_form in a_row if row_form is not None]
@@ -502,6 +505,7 @@ def _assemble_matrix_petsc(  # type: ignore[misc]
                         coeffs[i][j],  # type: ignore[index]
                         _bcs,  # type: ignore[arg-type]
                         True,
+                        False,
                     )
                     A.restoreLocalSubMatrix(is0[i], is1[j], Asub)
                 elif i == j:
@@ -530,8 +534,8 @@ def _assemble_matrix_petsc(  # type: ignore[misc]
     else:  # Non-blocked
         constants = pack_constants(a) if constants is None else constants
         coeffs = pack_coefficients(a) if coeffs is None else coeffs
-        _bcs = [bc._cpp_object for bc in bcs] if bcs is not None else []
-        _cpp.fem.petsc.assemble_matrix(A, a._cpp_object, constants, coeffs, _bcs)  # type: ignore
+        _bcs = [bc._cpp_object for bc in bcs]
+        _cpp.fem.petsc.assemble_matrix(A, a._cpp_object, constants, coeffs, _bcs, False, _check_bcs)
         if a.function_spaces[0] is a.function_spaces[1]:
             A.assemblyBegin(PETSc.Mat.AssemblyType.FLUSH)  # type: ignore[arg-type]
             A.assemblyEnd(PETSc.Mat.AssemblyType.FLUSH)  # type: ignore[arg-type]

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2018-2026 Garth N. Wells, Nathan Sime and Jørgen S. Dokken
+# Copyright (C) 2026 Musawer Ahmad Saqif
 #
 # This file is part of DOLFINx (https://www.fenicsproject.org)
 #
@@ -488,6 +489,8 @@ def _assemble_matrix_petsc(
         | Sequence[Sequence[dict[tuple[dolfinx.fem.IntegralType, int], npt.NDArray]]]
         | None
     ) = None,
+    *,
+    _check_bcs: bool = True,
 ) -> PETSc.Mat:
     """Assemble bilinear form into a matrix.
 
@@ -515,7 +518,7 @@ def _assemble_matrix_petsc(
             ):
                 if a_block is not None:
                     Asub = A.getNestSubMatrix(i, j)
-                    _assemble_matrix_petsc(Asub, a_block, bcs, diag, const, coeff)
+                    _assemble_matrix_petsc(Asub, a_block, bcs, diag, const, coeff, _check_bcs=False)
                 elif i == j and bcs is not None:
                     for bc in bcs:
                         row_forms = [row_form for row_form in a_row if row_form is not None]
@@ -560,6 +563,7 @@ def _assemble_matrix_petsc(
                         coeffs[i][j],  # type: ignore[index]
                         _bcs,  # type: ignore[arg-type]
                         True,
+                        False,
                     )
                     A.restoreLocalSubMatrix(is0[i], is1[j], Asub)
                 elif i == j:
@@ -591,7 +595,7 @@ def _assemble_matrix_petsc(
         if coeffs is None:
             coeffs = pack_coefficients(a)
         _bcs = [bc._cpp_object for bc in bcs] if bcs is not None else []
-        _cpp.fem.petsc.assemble_matrix(A, a._cpp_object, constants, coeffs, _bcs)  # type: ignore
+        _cpp.fem.petsc.assemble_matrix(A, a._cpp_object, constants, coeffs, _bcs, False, _check_bcs)  # type: ignore
         if a.function_spaces[0] is a.function_spaces[1]:
             A.assemblyBegin(PETSc.Mat.AssemblyType.FLUSH)  # type: ignore[arg-type]
             A.assemblyEnd(PETSc.Mat.AssemblyType.FLUSH)  # type: ignore[arg-type]

--- a/python/dolfinx/wrappers/petsc.cpp
+++ b/python/dolfinx/wrappers/petsc.cpp
@@ -164,7 +164,7 @@ void petsc_fem_module(nb::module_& m)
                                     nb::c_contig>>& coefficients,
          const std::vector<
              const dolfinx::fem::DirichletBC<PetscScalar, PetscReal>*>& bcs,
-         bool unrolled)
+         bool unrolled, bool check_bcs)
       {
         std::vector<std::reference_wrapper<
             const dolfinx::fem::DirichletBC<PetscScalar, PetscReal>>>
@@ -183,18 +183,20 @@ void petsc_fem_module(nb::module_& m)
               a.function_spaces()[1]->dofmap()->bs(), ADD_VALUES);
           dolfinx::fem::assemble_matrix(
               set_fn, a, std::span(constants.data(), constants.size()),
-              dolfinx_wrappers::py_to_cpp_coeffs(coefficients), _bcs);
+              dolfinx_wrappers::py_to_cpp_coeffs(coefficients), _bcs,
+              check_bcs);
         }
         else
         {
           dolfinx::fem::assemble_matrix(
               dolfinx::la::petsc::Matrix::set_block_fn(A, ADD_VALUES), a,
               std::span(constants.data(), constants.size()),
-              dolfinx_wrappers::py_to_cpp_coeffs(coefficients), _bcs);
+              dolfinx_wrappers::py_to_cpp_coeffs(coefficients), _bcs,
+              check_bcs);
         }
       },
       nb::arg("A"), nb::arg("a"), nb::arg("constants"), nb::arg("coeffs"),
-      nb::arg("bcs"), nb::arg("unrolled") = false,
+      nb::arg("bcs"), nb::arg("unrolled") = false, nb::arg("check_bcs") = true,
       "Assemble bilinear form into an existing PETSc matrix");
   m.def(
       "assemble_matrix",

--- a/python/dolfinx/wrappers/petsc.cpp
+++ b/python/dolfinx/wrappers/petsc.cpp
@@ -1,4 +1,5 @@
 // Copyright (C) 2017-2026 Chris Richardson and Garth N. Wells
+// Copyright (C) 2026 Musawer Ahmad Saqif
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -171,7 +172,7 @@ void petsc_fem_module(nb::module_& m)
                                     nb::c_contig>>& coefficients,
          const std::vector<
              const dolfinx::fem::DirichletBC<PetscScalar, PetscReal>*>& bcs,
-         bool unrolled)
+         bool unrolled, bool check_bcs)
       {
         std::vector<std::reference_wrapper<
             const dolfinx::fem::DirichletBC<PetscScalar, PetscReal>>>
@@ -190,7 +191,8 @@ void petsc_fem_module(nb::module_& m)
               a.function_spaces()[1]->dofmap()->bs(), ADD_VALUES);
           dolfinx::fem::assemble_matrix(
               set_fn, a, std::span(constants.data(), constants.size()),
-              dolfinx_wrappers::py_to_cpp_coeffs(coefficients), _bcs);
+              dolfinx_wrappers::py_to_cpp_coeffs(coefficients), _bcs,
+              check_bcs);
         }
         else
         {
@@ -201,19 +203,21 @@ void petsc_fem_module(nb::module_& m)
             dolfinx::fem::assemble_matrix(
                 dolfinx::la::petsc::Matrix::set_fn(A, ADD_VALUES), a,
                 std::span(constants.data(), constants.size()),
-                dolfinx_wrappers::py_to_cpp_coeffs(coefficients), _bcs);
+                dolfinx_wrappers::py_to_cpp_coeffs(coefficients), _bcs,
+                check_bcs);
           }
           else
           {
             dolfinx::fem::assemble_matrix(
                 dolfinx::la::petsc::Matrix::set_block_fn(A, ADD_VALUES), a,
                 std::span(constants.data(), constants.size()),
-                dolfinx_wrappers::py_to_cpp_coeffs(coefficients), _bcs);
+                dolfinx_wrappers::py_to_cpp_coeffs(coefficients), _bcs,
+                check_bcs);
           }
         }
       },
       nb::arg("A"), nb::arg("a"), nb::arg("constants"), nb::arg("coeffs"),
-      nb::arg("bcs"), nb::arg("unrolled") = false,
+      nb::arg("bcs"), nb::arg("unrolled") = false, nb::arg("check_bcs") = true,
       "Assemble bilinear form into an existing PETSc matrix");
   m.def(
       "assemble_matrix",

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -179,6 +179,26 @@ def nest_matrix_norm(A):
     return math.sqrt(norm)
 
 
+def _shared_dofmap_distinct_space_form_and_bc():
+    msh = create_unit_square(MPI.COMM_WORLD, 4, 4)
+    U = functionspace(msh, ("Lagrange", 1))
+    V = U.clone()
+    u = ufl.TrialFunction(U)
+    v = ufl.TestFunction(V)
+    a = form(inner(u, v) * dx)
+
+    facets = locate_entities_boundary(msh, msh.topology.dim - 1, lambda x: np.isclose(x[0], 0.0))
+    dofs = locate_dofs_topological(V, msh.topology.dim - 1, facets)
+    bc = dirichletbc(default_scalar_type(0), dofs, V)
+    return a, bc
+
+
+def test_assembly_rejects_bcs_for_distinct_spaces_sharing_dofmap():
+    a, bc = _shared_dofmap_distinct_space_form_and_bc()
+    with pytest.raises(RuntimeError, match="distinct test and trial spaces that share a dofmap"):
+        assemble_matrix(a, bcs=[bc])
+
+
 @pytest.mark.petsc4py
 def test_vector_single_space_as_block():
     from dolfinx.fem.petsc import create_vector as petsc_create_vector
@@ -193,6 +213,16 @@ def test_vector_single_space_as_block():
 @pytest.mark.petsc4py
 class TestPETScAssemblers:
     """Test PETSc-based assemblers for matrices and vectors."""
+
+    def test_assembly_rejects_bcs_for_distinct_spaces_sharing_dofmap(self):
+        """Test that PETSc assembly rejects ambiguous standalone BCs."""
+        from dolfinx.fem.petsc import assemble_matrix as petsc_assemble_matrix
+
+        a, bc = _shared_dofmap_distinct_space_form_and_bc()
+        with pytest.raises(
+            RuntimeError, match="distinct test and trial spaces that share a dofmap"
+        ):
+            petsc_assemble_matrix(a, bcs=[bc])
 
     @pytest.mark.parametrize("mode", [GhostMode.none, GhostMode.shared_facet])
     def test_basic_assembly_petsc_matrixcsr(self, mode):

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2018-2025 Garth N. Wells, Jørgen S. Dokken and Paul T. Kühner
+# Copyright (C) 2026 Musawer Ahmad Saqif
 #
 # This file is part of DOLFINx (https://www.fenicsproject.org)
 #
@@ -179,6 +180,29 @@ def nest_matrix_norm(A):
     return math.sqrt(norm)
 
 
+def _shared_dofmap_distinct_space_form_and_bc(shape, bc_on_trial):
+    msh = create_unit_square(MPI.COMM_WORLD, 4, 4)
+    U = functionspace(msh, ("Lagrange", 1, shape))
+    V = U.clone()
+    u = ufl.TrialFunction(U)
+    v = ufl.TestFunction(V)
+    a = form(inner(u, v) * dx)
+
+    facets = locate_entities_boundary(msh, msh.topology.dim - 1, lambda x: np.isclose(x[0], 0.0))
+    bc_space = U if bc_on_trial else V
+    dofs = locate_dofs_topological(bc_space, msh.topology.dim - 1, facets)
+    bc = dirichletbc(Function(bc_space), dofs)
+    return a, bc
+
+
+@pytest.mark.parametrize("shape", [(), (2,)])
+@pytest.mark.parametrize("bc_on_trial", [False, True])
+def test_assembly_rejects_bcs_for_distinct_spaces_sharing_dofmap(shape, bc_on_trial):
+    a, bc = _shared_dofmap_distinct_space_form_and_bc(shape, bc_on_trial)
+    with pytest.raises(RuntimeError, match="distinct test and trial spaces that share a dofmap"):
+        assemble_matrix(a, bcs=[bc])
+
+
 @pytest.mark.petsc4py
 def test_vector_single_space_as_block():
     from dolfinx.fem.petsc import create_vector as petsc_create_vector
@@ -193,6 +217,18 @@ def test_vector_single_space_as_block():
 @pytest.mark.petsc4py
 class TestPETScAssemblers:
     """Test PETSc-based assemblers for matrices and vectors."""
+
+    @pytest.mark.parametrize("shape", [(), (2,)])
+    @pytest.mark.parametrize("bc_on_trial", [False, True])
+    def test_assembly_rejects_bcs_for_distinct_spaces_sharing_dofmap(self, shape, bc_on_trial):
+        """Test that PETSc assembly rejects ambiguous standalone BCs."""
+        from dolfinx.fem.petsc import assemble_matrix as petsc_assemble_matrix
+
+        a, bc = _shared_dofmap_distinct_space_form_and_bc(shape, bc_on_trial)
+        with pytest.raises(
+            RuntimeError, match="distinct test and trial spaces that share a dofmap"
+        ):
+            petsc_assemble_matrix(a, bcs=[bc])
 
     @pytest.mark.parametrize("mode", [GhostMode.none, GhostMode.shared_facet])
     def test_basic_assembly_petsc_matrixcsr(self, mode):


### PR DESCRIPTION
When a standalone bilinear form uses distinct cloned FunctionSpaces, Dirichlet boundary conditions can zero constrained rows or columns while diagonal insertion is skipped: the latter only runs when the test and trial spaces have the same identity. This can leave the constrained matrix without the expected diagonal entry.

Add validation in the shared C++ `assemble_matrix(..., bcs)` path for distinct spaces on the same mesh that share a single dofmap and element signature. If a boundary condition belongs to either space, standalone assembly raises an error before assembling the matrix. PETSc block and MatNest sub-assembly bypass this check because diagonal handling occurs at the block level.

Regression tests cover MatrixCSR and PETSc assembly, scalar and vector spaces, and boundary conditions on either the trial or test space.

Validation at `1df8c57`, rebased onto `700e977`:

- C++ library and Python bindings built in Developer mode in a Linux ARM64 container with PETSc 3.25.4 (`linux-gnu-real64-32`).
- `test_assembler.py`, `test_bcs.py`, and `test_assemble_submesh.py`: 366 passed, 1 xfailed in serial; 365 passed, 1 skipped, 1 xfailed per rank with three MPI ranks.
- clang-format, Ruff check/format, compileall, and `git diff --check` passed.
- Strict library mypy reports three identical diagnostics on this branch and unchanged upstream `700e977` in the local environment; no additional diagnostics from this PR.

Split from #4249 per maintainer request.

AI assistance: OpenAI Codex assisted with the implementation, rebase, testing, and PR text.
