### PR TITLE
Fix typo in `real_element`

### DIFF
--- a/python/doc/source/release_notes.md
+++ b/python/doc/source/release_notes.md
@@ -49,7 +49,7 @@ core libraries. Users can now call
 import basix.ufl
 import dolfinx.fem
 
-el = basix.ufl.real_element(mesh.basix_cell(), dtype=dtype, shape=(N, ))
+el = basix.ufl.real_element(mesh.basix_cell(), dtype=dtype, value_shape=(N, ))
 R = dolfinx.fem.functionspace(mesh, el)
 ```
 


### PR DESCRIPTION
Updated the parameter name from 'shape' to 'value_shape' in the example code.