### PR TITLE
Convert FindKaHIP.cmake to create targets

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -581,7 +581,7 @@ endif()
 feature_summary(WHAT ALL)
 
 # Check that at least one graph partitioner has been found
-if(NOT SCOTCH_FOUND AND NOT PARMETIS_FOUND AND NOT KAHIP_FOUND)
+if(NOT SCOTCH_FOUND AND NOT PARMETIS_FOUND AND NOT KaHIP_FOUND)
   message(
     FATAL_ERROR
     "No graph partitioner found. SCOTCH, ParMETIS or KaHIP is required."

--- a/cpp/cmake/modules/FindKaHIP.cmake
+++ b/cpp/cmake/modules/FindKaHIP.cmake
@@ -56,7 +56,12 @@ if(MPI_CXX_FOUND)
       include(CheckCXXSourceRuns)
 
       set(CMAKE_REQUIRED_INCLUDES ${KAHIP_INCLUDE_DIR} ${MPI_CXX_INCLUDE_PATH})
-      set(CMAKE_REQUIRED_LIBRARIES ${PARHIP_LIBRARY} ${KAHIP_LIBRARY} ${MPI_CXX_LIBRARIES})
+      set(
+        CMAKE_REQUIRED_LIBRARIES
+        ${PARHIP_LIBRARY}
+        ${KAHIP_LIBRARY}
+        ${MPI_CXX_LIBRARIES}
+      )
       set(CMAKE_REQUIRED_FLAGS ${MPI_CXX_COMPILE_FLAGS})
       check_cxx_source_runs(
         "

--- a/cpp/cmake/modules/FindKaHIP.cmake
+++ b/cpp/cmake/modules/FindKaHIP.cmake
@@ -2,10 +2,10 @@
 # - Try to find KaHIP
 # Once done this will define
 #
-#  KAHIP_FOUND        - system has KaHIP
-#  KAHIP_INCLUDE_DIRS - include directories for KaHIP
-#  KAHIP_LIBRARIES    - libraries for KaHIP
-#  KAHIP_VERSION      - version for KaHIP
+#  KaHIP_FOUND        - system has KaHIP
+#  KaHIP::parhip      - imported target for parhip_interface library
+#  KaHIP::kahip       - imported target for kahip library (if found)
+#  KaHIP::KaHIP       - interface target linking all KaHIP components
 #
 #=============================================================================
 # Copyright (C) 2019 Igor A. Baratta
@@ -36,33 +36,27 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #=============================================================================
 
-set(KAHIP_FOUND FALSE)
-
 message(STATUS "Checking for package 'KaHIP'")
 
 if(MPI_CXX_FOUND)
-  find_path(KAHIP_INCLUDE_DIRS parhip_interface.h PATH_SUFFIXES kahip)
+  find_path(KAHIP_INCLUDE_DIR parhip_interface.h PATH_SUFFIXES kahip)
   find_library(PARHIP_LIBRARY parhip_interface)
   find_library(KAHIP_LIBRARY kahip)
-
-  set(KAHIP_LIBRARIES ${PARHIP_LIBRARY} ${KAHIP_LIBRARY})
 
   include(FindPackageHandleStandardArgs)
   if(DOLFINX_SKIP_BUILD_TESTS)
     find_package_handle_standard_args(
       KaHIP
       "KaHIP could not be found/configured."
-      KAHIP_INCLUDE_DIRS
-      KAHIP_LIBRARIES
+      KAHIP_INCLUDE_DIR
+      PARHIP_LIBRARY
     )
   else()
-    if(KAHIP_LIBRARIES AND KAHIP_LIBRARIES)
-      # Build and run test program
+    if(PARHIP_LIBRARY AND KAHIP_INCLUDE_DIR)
       include(CheckCXXSourceRuns)
 
-      # Set flags for building test program
-      set(CMAKE_REQUIRED_INCLUDES ${KAHIP_INCLUDE_DIRS} ${MPI_CXX_INCLUDE_PATH})
-      set(CMAKE_REQUIRED_LIBRARIES ${KAHIP_LIBRARIES} ${MPI_CXX_LIBRARIES})
+      set(CMAKE_REQUIRED_INCLUDES ${KAHIP_INCLUDE_DIR} ${MPI_CXX_INCLUDE_PATH})
+      set(CMAKE_REQUIRED_LIBRARIES ${PARHIP_LIBRARY} ${KAHIP_LIBRARY} ${MPI_CXX_LIBRARIES})
       set(CMAKE_REQUIRED_FLAGS ${MPI_CXX_COMPILE_FLAGS})
       check_cxx_source_runs(
         "
@@ -93,9 +87,37 @@ if(MPI_CXX_FOUND)
     find_package_handle_standard_args(
       KaHIP
       "KaHIP could not be found/configured."
-      KAHIP_INCLUDE_DIRS
-      KAHIP_LIBRARIES
+      KAHIP_INCLUDE_DIR
+      PARHIP_LIBRARY
       KAHIP_TEST_RUNS
     )
+  endif()
+
+  if(KaHIP_FOUND)
+    if(NOT TARGET KaHIP::parhip)
+      add_library(KaHIP::parhip UNKNOWN IMPORTED)
+      set_target_properties(
+        KaHIP::parhip
+        PROPERTIES
+          IMPORTED_LOCATION "${PARHIP_LIBRARY}"
+          INTERFACE_INCLUDE_DIRECTORIES "${KAHIP_INCLUDE_DIR}"
+      )
+    endif()
+
+    if(KAHIP_LIBRARY AND NOT TARGET KaHIP::kahip)
+      add_library(KaHIP::kahip UNKNOWN IMPORTED)
+      set_target_properties(
+        KaHIP::kahip
+        PROPERTIES IMPORTED_LOCATION "${KAHIP_LIBRARY}"
+      )
+    endif()
+
+    if(NOT TARGET KaHIP::KaHIP)
+      add_library(KaHIP::KaHIP INTERFACE IMPORTED)
+      target_link_libraries(KaHIP::KaHIP INTERFACE KaHIP::parhip)
+      if(TARGET KaHIP::kahip)
+        target_link_libraries(KaHIP::KaHIP INTERFACE KaHIP::kahip)
+      endif()
+    endif()
   endif()
 endif()

--- a/cpp/cmake/modules/FindKaHIP.cmake
+++ b/cpp/cmake/modules/FindKaHIP.cmake
@@ -42,6 +42,7 @@ if(MPI_CXX_FOUND)
   find_path(KAHIP_INCLUDE_DIR parhip_interface.h PATH_SUFFIXES kahip)
   find_library(PARHIP_LIBRARY parhip_interface)
   find_library(KAHIP_LIBRARY kahip)
+  mark_as_advanced(KAHIP_INCLUDE_DIR PARHIP_LIBRARY KAHIP_LIBRARY)
 
   include(FindPackageHandleStandardArgs)
   if(DOLFINX_SKIP_BUILD_TESTS)
@@ -54,14 +55,14 @@ if(MPI_CXX_FOUND)
   else()
     if(PARHIP_LIBRARY AND KAHIP_INCLUDE_DIR)
       include(CheckCXXSourceRuns)
+      include(CMakePushCheckState)
 
+      cmake_push_check_state(RESET)
       set(CMAKE_REQUIRED_INCLUDES ${KAHIP_INCLUDE_DIR} ${MPI_CXX_INCLUDE_PATH})
-      set(
-        CMAKE_REQUIRED_LIBRARIES
-        ${PARHIP_LIBRARY}
-        ${KAHIP_LIBRARY}
-        ${MPI_CXX_LIBRARIES}
-      )
+      set(CMAKE_REQUIRED_LIBRARIES ${PARHIP_LIBRARY} ${MPI_CXX_LIBRARIES})
+      if(KAHIP_LIBRARY)
+        list(APPEND CMAKE_REQUIRED_LIBRARIES ${KAHIP_LIBRARY})
+      endif()
       set(CMAKE_REQUIRED_FLAGS ${MPI_CXX_COMPILE_FLAGS})
       check_cxx_source_runs(
         "
@@ -78,16 +79,17 @@ if(MPI_CXX_FOUND)
           double imbalance = 0.03;
           int edge_cut = 0;
           int nparts = 2;
-          int *vwgt = nullptr;;
-          int *adjcwgt = nullptr;;
+          int *vwgt = nullptr;
+          int *adjcwgt = nullptr;
           kaffpa(&n, vwgt, xadj.data(), adjcwgt, adjncy.data(),
                  &nparts, &imbalance, false, 0, ECO, &edge_cut,
                  part.data());
-        return 0;
+          return 0;
         }
         "
         KAHIP_TEST_RUNS
       )
+      cmake_pop_check_state()
     endif()
     find_package_handle_standard_args(
       KaHIP
@@ -113,7 +115,9 @@ if(MPI_CXX_FOUND)
       add_library(KaHIP::kahip UNKNOWN IMPORTED)
       set_target_properties(
         KaHIP::kahip
-        PROPERTIES IMPORTED_LOCATION "${KAHIP_LIBRARY}"
+        PROPERTIES
+          IMPORTED_LOCATION "${KAHIP_LIBRARY}"
+          INTERFACE_INCLUDE_DIRECTORIES "${KAHIP_INCLUDE_DIR}"
       )
     endif()
 

--- a/cpp/cmake/modules/FindKaHIP.cmake
+++ b/cpp/cmake/modules/FindKaHIP.cmake
@@ -38,95 +38,96 @@
 
 message(STATUS "Checking for package 'KaHIP'")
 
-if(MPI_CXX_FOUND)
-  find_path(KAHIP_INCLUDE_DIR parhip_interface.h PATH_SUFFIXES kahip)
-  find_library(PARHIP_LIBRARY parhip_interface)
-  find_library(KAHIP_LIBRARY kahip)
-  mark_as_advanced(KAHIP_INCLUDE_DIR PARHIP_LIBRARY KAHIP_LIBRARY)
+find_package(MPI REQUIRED COMPONENTS CXX)
 
-  include(FindPackageHandleStandardArgs)
-  if(DOLFINX_SKIP_BUILD_TESTS)
-    find_package_handle_standard_args(
-      KaHIP
-      "KaHIP could not be found/configured."
-      KAHIP_INCLUDE_DIR
-      PARHIP_LIBRARY
-    )
-  else()
-    if(PARHIP_LIBRARY AND KAHIP_INCLUDE_DIR)
-      include(CheckCXXSourceRuns)
-      include(CMakePushCheckState)
+find_path(KAHIP_INCLUDE_DIR parhip_interface.h PATH_SUFFIXES kahip)
+find_library(PARHIP_LIBRARY parhip_interface)
+find_library(KAHIP_LIBRARY kahip)
+mark_as_advanced(KAHIP_INCLUDE_DIR PARHIP_LIBRARY KAHIP_LIBRARY)
 
-      cmake_push_check_state(RESET)
-      set(CMAKE_REQUIRED_INCLUDES ${KAHIP_INCLUDE_DIR} ${MPI_CXX_INCLUDE_PATH})
-      set(CMAKE_REQUIRED_LIBRARIES ${PARHIP_LIBRARY} ${MPI_CXX_LIBRARIES})
-      if(KAHIP_LIBRARY)
-        list(APPEND CMAKE_REQUIRED_LIBRARIES ${KAHIP_LIBRARY})
-      endif()
-      set(CMAKE_REQUIRED_FLAGS ${MPI_CXX_COMPILE_FLAGS})
-      check_cxx_source_runs(
-        "
-        #define MPICH_IGNORE_CXX_SEEK 1
-        #include <mpi.h>
-        #include <vector>
-        #include <kaHIP_interface.h>
-        int main()
-        {
-          int n = 5;
-          std::vector<int> xadj = {0, 2, 5, 7, 9, 12};
-          std::vector<int> adjncy = {1, 4, 0, 2, 4, 1, 3, 2, 4, 0, 1, 3};
-          std::vector<int> part(n);
-          double imbalance = 0.03;
-          int edge_cut = 0;
-          int nparts = 2;
-          int *vwgt = nullptr;
-          int *adjcwgt = nullptr;
-          kaffpa(&n, vwgt, xadj.data(), adjcwgt, adjncy.data(),
-                 &nparts, &imbalance, false, 0, ECO, &edge_cut,
-                 part.data());
-          return 0;
-        }
-        "
-        KAHIP_TEST_RUNS
-      )
-      cmake_pop_check_state()
+include(FindPackageHandleStandardArgs)
+if(DOLFINX_SKIP_BUILD_TESTS)
+  find_package_handle_standard_args(
+    KaHIP
+    "KaHIP could not be found/configured."
+    KAHIP_INCLUDE_DIR
+    PARHIP_LIBRARY
+  )
+else()
+  if(PARHIP_LIBRARY AND KAHIP_INCLUDE_DIR)
+    include(CheckCXXSourceRuns)
+    include(CMakePushCheckState)
+
+    cmake_push_check_state(RESET)
+    set(CMAKE_REQUIRED_INCLUDES ${KAHIP_INCLUDE_DIR} ${MPI_CXX_INCLUDE_PATH})
+    set(CMAKE_REQUIRED_LIBRARIES ${PARHIP_LIBRARY} ${MPI_CXX_LIBRARIES})
+    if(KAHIP_LIBRARY)
+      list(APPEND CMAKE_REQUIRED_LIBRARIES ${KAHIP_LIBRARY})
     endif()
-    find_package_handle_standard_args(
-      KaHIP
-      "KaHIP could not be found/configured."
-      KAHIP_INCLUDE_DIR
-      PARHIP_LIBRARY
+    set(CMAKE_REQUIRED_FLAGS ${MPI_CXX_COMPILE_FLAGS})
+    check_cxx_source_runs(
+      "
+      #define MPICH_IGNORE_CXX_SEEK 1
+      #include <mpi.h>
+      #include <vector>
+      #include <kaHIP_interface.h>
+      int main()
+      {
+        int n = 5;
+        std::vector<int> xadj = {0, 2, 5, 7, 9, 12};
+        std::vector<int> adjncy = {1, 4, 0, 2, 4, 1, 3, 2, 4, 0, 1, 3};
+        std::vector<int> part(n);
+        double imbalance = 0.03;
+        int edge_cut = 0;
+        int nparts = 2;
+        int *vwgt = nullptr;
+        int *adjcwgt = nullptr;
+        kaffpa(&n, vwgt, xadj.data(), adjcwgt, adjncy.data(),
+               &nparts, &imbalance, false, 0, ECO, &edge_cut,
+               part.data());
+        return 0;
+      }
+      "
       KAHIP_TEST_RUNS
+    )
+    cmake_pop_check_state()
+  endif()
+  find_package_handle_standard_args(
+    KaHIP
+    "KaHIP could not be found/configured."
+    KAHIP_INCLUDE_DIR
+    PARHIP_LIBRARY
+    KAHIP_TEST_RUNS
+  )
+endif()
+
+if(KaHIP_FOUND)
+  if(NOT TARGET KaHIP::parhip)
+    add_library(KaHIP::parhip UNKNOWN IMPORTED)
+    set_target_properties(
+      KaHIP::parhip
+      PROPERTIES
+        IMPORTED_LOCATION "${PARHIP_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${KAHIP_INCLUDE_DIR}"
+    )
+    target_link_libraries(KaHIP::parhip INTERFACE MPI::MPI_CXX)
+  endif()
+
+  if(KAHIP_LIBRARY AND NOT TARGET KaHIP::kahip)
+    add_library(KaHIP::kahip UNKNOWN IMPORTED)
+    set_target_properties(
+      KaHIP::kahip
+      PROPERTIES
+        IMPORTED_LOCATION "${KAHIP_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${KAHIP_INCLUDE_DIR}"
     )
   endif()
 
-  if(KaHIP_FOUND)
-    if(NOT TARGET KaHIP::parhip)
-      add_library(KaHIP::parhip UNKNOWN IMPORTED)
-      set_target_properties(
-        KaHIP::parhip
-        PROPERTIES
-          IMPORTED_LOCATION "${PARHIP_LIBRARY}"
-          INTERFACE_INCLUDE_DIRECTORIES "${KAHIP_INCLUDE_DIR}"
-      )
-    endif()
-
-    if(KAHIP_LIBRARY AND NOT TARGET KaHIP::kahip)
-      add_library(KaHIP::kahip UNKNOWN IMPORTED)
-      set_target_properties(
-        KaHIP::kahip
-        PROPERTIES
-          IMPORTED_LOCATION "${KAHIP_LIBRARY}"
-          INTERFACE_INCLUDE_DIRECTORIES "${KAHIP_INCLUDE_DIR}"
-      )
-    endif()
-
-    if(NOT TARGET KaHIP::KaHIP)
-      add_library(KaHIP::KaHIP INTERFACE IMPORTED)
-      target_link_libraries(KaHIP::KaHIP INTERFACE KaHIP::parhip)
-      if(TARGET KaHIP::kahip)
-        target_link_libraries(KaHIP::KaHIP INTERFACE KaHIP::kahip)
-      endif()
+  if(NOT TARGET KaHIP::KaHIP)
+    add_library(KaHIP::KaHIP INTERFACE IMPORTED)
+    target_link_libraries(KaHIP::KaHIP INTERFACE KaHIP::parhip)
+    if(TARGET KaHIP::kahip)
+      target_link_libraries(KaHIP::KaHIP INTERFACE KaHIP::kahip)
     endif()
   endif()
 endif()

--- a/cpp/cmake/modules/FindKaHIP.cmake
+++ b/cpp/cmake/modules/FindKaHIP.cmake
@@ -4,11 +4,11 @@
 #
 #  KaHIP_FOUND        - system has KaHIP
 #  KaHIP::parhip      - imported target for parhip_interface library
-#  KaHIP::kahip       - imported target for kahip library (if found)
+#  KaHIP::kahip       - imported target for kahip library
 #  KaHIP::KaHIP       - interface target linking all KaHIP components
 #
 #=============================================================================
-# Copyright (C) 2019 Igor A. Baratta
+# Copyright (C) 2026 Igor A. Baratta, Jack S. Hale
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -177,10 +177,9 @@ if(DOLFINX_ENABLE_PARMETIS AND PARMETIS_FOUND)
 endif()
 
 # KaHIP
-if(DOLFINX_ENABLE_KAHIP AND KAHIP_FOUND)
+if(DOLFINX_ENABLE_KAHIP AND KaHIP_FOUND)
   target_compile_definitions(dolfinx PUBLIC HAS_KAHIP)
-  target_link_libraries(dolfinx PRIVATE ${KAHIP_LIBRARIES})
-  target_include_directories(dolfinx SYSTEM PRIVATE ${KAHIP_INCLUDE_DIRS})
+  target_link_libraries(dolfinx PRIVATE KaHIP::KaHIP)
 endif()
 
 # SuperLU_DIST


### PR DESCRIPTION
Replaces bare `KAHIP_LIBRARIES/KAHIP_INCLUDE_DIRS` variables with `KaHIP::parhip`, `KaHIP::kahip`, and `KaHIP::KaHIP` (combined) imported targets. Consumers now link via `target_link_libraries(... KaHIP::KaHIP)`. `MPI::MPI_CXX` target is correctly set on `KaHIP::parhip`.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
