### PR TITLE
Modernise FindUFCx.cmake to create target

### DIFF
--- a/cpp/cmake/modules/FindUFCx.cmake
+++ b/cpp/cmake/modules/FindUFCx.cmake
@@ -8,7 +8,7 @@
 #  UFCX_VERSION   - version for UFCx
 #
 #=============================================================================
-# Copyright (C) 2010-2021 Johannes Ring and Garth N. Wells
+# Copyright (C) 2010-2026 Johannes Ring, Garth N. Wells, Jack S. Hale
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/cpp/cmake/modules/FindUFCx.cmake
+++ b/cpp/cmake/modules/FindUFCx.cmake
@@ -2,10 +2,10 @@
 # - Try to find UFCx by interrogating the Python module FFCx
 # Once done this will define
 #
-#  UFCX_FOUND        - system has UFCx
-#  UFCX_INCLUDE_DIRS - include directories for UFCx
-#  UFCX_SIGNATURE    - signature for UFCx
-#  UFCX_VERSION      - version for UFCx
+#  UFCx_FOUND     - system has UFCx
+#  UFCx::UFCx     - imported interface target
+#  UFCX_SIGNATURE - SHA1 hash of ufcx.h
+#  UFCX_VERSION   - version for UFCx
 #
 #=============================================================================
 # Copyright (C) 2010-2021 Johannes Ring and Garth N. Wells
@@ -52,7 +52,6 @@ cmake_path(SET UFCX_INCLUDE_DIR "${UFCX_INCLUDE_DIR}")
 
 # Get ufcx.h version
 if(UFCX_INCLUDE_DIR)
-  set(UFCX_INCLUDE_DIRS ${UFCX_INCLUDE_DIR} CACHE STRING "Where to find ufcx.h")
   execute_process(
     COMMAND
       ${Python3_EXECUTABLE} -c
@@ -67,11 +66,19 @@ if(_UFCX_HEADER)
   file(SHA1 ${_UFCX_HEADER} UFCX_SIGNATURE)
 endif()
 
-mark_as_advanced(UFCX_VERSION UFCX_INCLUDE_DIRS UFCX_SIGNATURE)
+mark_as_advanced(UFCX_VERSION UFCX_INCLUDE_DIR UFCX_SIGNATURE)
 find_package_handle_standard_args(
   UFCx
-  REQUIRED_VARS UFCX_INCLUDE_DIRS UFCX_SIGNATURE UFCX_VERSION
+  REQUIRED_VARS UFCX_INCLUDE_DIR UFCX_SIGNATURE UFCX_VERSION
   VERSION_VAR UFCX_VERSION
   HANDLE_VERSION_RANGE
   REASON_FAILURE_MESSAGE "UFCx could not be found."
 )
+
+if(UFCx_FOUND AND NOT TARGET UFCx::UFCx)
+  add_library(UFCx::UFCx INTERFACE IMPORTED)
+  set_target_properties(
+    UFCx::UFCx
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${UFCX_INCLUDE_DIR}"
+  )
+endif()

--- a/cpp/cmake/modules/FindUFCx.cmake
+++ b/cpp/cmake/modules/FindUFCx.cmake
@@ -45,13 +45,13 @@ execute_process(
   COMMAND
     ${Python3_EXECUTABLE} -c
     "import ffcx.codegeneration, sys; sys.stdout.write(ffcx.codegeneration.get_include_path())"
-  OUTPUT_VARIABLE UFCX_INCLUDE_DIR
+  OUTPUT_VARIABLE _UFCX_INCLUDE_DIR
 )
 # Converts os native to cmake native path type
-cmake_path(SET UFCX_INCLUDE_DIR "${UFCX_INCLUDE_DIR}")
+cmake_path(SET _UFCX_INCLUDE_DIR "${_UFCX_INCLUDE_DIR}")
 
 # Get ufcx.h version
-if(UFCX_INCLUDE_DIR)
+if(_UFCX_INCLUDE_DIR)
   execute_process(
     COMMAND
       ${Python3_EXECUTABLE} -c
@@ -61,15 +61,15 @@ if(UFCX_INCLUDE_DIR)
 endif()
 
 # Compute hash of ufcx.h
-find_file(_UFCX_HEADER "ufcx.h" ${UFCX_INCLUDE_DIR})
+find_file(_UFCX_HEADER "ufcx.h" ${_UFCX_INCLUDE_DIR})
 if(_UFCX_HEADER)
   file(SHA1 ${_UFCX_HEADER} UFCX_SIGNATURE)
 endif()
 
-mark_as_advanced(UFCX_VERSION UFCX_INCLUDE_DIR UFCX_SIGNATURE)
+mark_as_advanced(UFCX_VERSION UFCX_SIGNATURE)
 find_package_handle_standard_args(
   UFCx
-  REQUIRED_VARS UFCX_INCLUDE_DIR UFCX_SIGNATURE UFCX_VERSION
+  REQUIRED_VARS _UFCX_INCLUDE_DIR UFCX_SIGNATURE UFCX_VERSION
   VERSION_VAR UFCX_VERSION
   HANDLE_VERSION_RANGE
   REASON_FAILURE_MESSAGE "UFCx could not be found."
@@ -79,6 +79,6 @@ if(UFCx_FOUND AND NOT TARGET UFCx::UFCx)
   add_library(UFCx::UFCx INTERFACE IMPORTED)
   set_target_properties(
     UFCx::UFCx
-    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${UFCX_INCLUDE_DIR}"
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_UFCX_INCLUDE_DIR}"
   )
 endif()

--- a/cpp/cmake/templates/DOLFINXConfig.cmake.in
+++ b/cpp/cmake/templates/DOLFINXConfig.cmake.in
@@ -29,6 +29,9 @@ find_package(Boost 1.70 REQUIRED)
 
 if(@ufcx_FOUND@)
   find_dependency(ufcx)
+elseif(@UFCx_FOUND@)
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+  find_dependency(UFCx MODULE)
 endif()
 
 # Basix

--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -260,6 +260,7 @@ install(
   FILES
     ${CMAKE_BINARY_DIR}/dolfinx/DOLFINXConfig.cmake
     ${CMAKE_BINARY_DIR}/dolfinx/DOLFINXConfigVersion.cmake
+    ${DOLFINX_SOURCE_DIR}/cmake/modules/FindUFCx.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/dolfinx
   COMPONENT Development
 )

--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -110,10 +110,10 @@ else()
 endif()
 
 # UFCx
-if(TARGET ufcx::ufcx)
+if(TARGET UFCx::UFCx)
+  target_link_libraries(dolfinx PUBLIC UFCx::UFCx)
+elseif(TARGET ufcx::ufcx)
   target_link_libraries(dolfinx PUBLIC ufcx::ufcx)
-else()
-  target_include_directories(dolfinx SYSTEM PUBLIC ${UFCX_INCLUDE_DIRS})
 endif()
 
 # Basix


### PR DESCRIPTION
Creates a target `UFCx::UFCx` with `INTERFACE_INCLUDE_DIRECTORIES` set.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
