### PR TITLE
Fix: gersemi discovery of `CMakeLists.txt` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,17 +83,6 @@ cpp/demo/**/**/*.h
 *.bp
 *.png
 
-# CMake files
-CMakeLists.txt
-!/CMakeLists.txt
-!dolfinx/CMakeLists.txt
-!dolfinx/*/CMakeLists.txt
-!doc/CMakeLists.txt
-!demo/CMakeLists.txt
-!test/unit/CMakeLists.txt
-!test/unit/cpp/CMakeLists.txt
-
-
 CMakeCache.txt
 CMakeFiles
 cmake_install.cmake

--- a/cpp/demo/biharmonic/CMakeLists.txt
+++ b/cpp/demo/biharmonic/CMakeLists.txt
@@ -41,7 +41,11 @@ add_custom_command(
   COMMENT "Compile biharmonic.py using FFCx"
 )
 
-add_executable(${PROJECT_NAME} main.cpp ${CMAKE_CURRENT_BINARY_DIR}/biharmonic.c)
+add_executable(
+  ${PROJECT_NAME}
+  main.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/biharmonic.c
+)
 target_link_libraries(${PROJECT_NAME} PRIVATE dolfinx::dolfinx)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -54,8 +58,13 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-Wno-comment" HAVE_NO_MULTLINE)
 target_compile_options(
-  ${PROJECT_NAME} PRIVATE
-  $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment -Wall -Wextra -pedantic -Werror>
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment
+    -Wall
+    -Wextra
+    -pedantic
+    -Werror>
 )
 
 # FFCx-generated C kernels have unused parameters fixed by the UFL ABI
@@ -65,10 +74,16 @@ set_source_files_properties(
 )
 
 # Test targets (used by DOLFINx testing system)
-add_test(NAME ${PROJECT_NAME}_mpi_2
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
-add_test(NAME ${PROJECT_NAME}_mpi_3
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
+add_test(
+  NAME ${PROJECT_NAME}_mpi_2
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
+add_test(
+  NAME ${PROJECT_NAME}_mpi_3
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
 add_test(NAME ${PROJECT_NAME}_serial COMMAND $<TARGET_FILE:${PROJECT_NAME}>)

--- a/cpp/demo/codim_0_assembly/CMakeLists.txt
+++ b/cpp/demo/codim_0_assembly/CMakeLists.txt
@@ -41,7 +41,11 @@ add_custom_command(
   COMMENT "Compile mixed_codim0.py using FFCx"
 )
 
-add_executable(${PROJECT_NAME} main.cpp ${CMAKE_CURRENT_BINARY_DIR}/mixed_codim0.c)
+add_executable(
+  ${PROJECT_NAME}
+  main.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/mixed_codim0.c
+)
 target_link_libraries(${PROJECT_NAME} PRIVATE dolfinx::dolfinx)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -54,8 +58,13 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-Wno-comment" HAVE_NO_MULTLINE)
 target_compile_options(
-  ${PROJECT_NAME} PRIVATE
-  $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment -Wall -Wextra -pedantic -Werror>
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment
+    -Wall
+    -Wextra
+    -pedantic
+    -Werror>
 )
 
 # FFCx-generated C kernels have unused parameters fixed by the UFL ABI
@@ -65,10 +74,16 @@ set_source_files_properties(
 )
 
 # Test targets (used by DOLFINx testing system)
-add_test(NAME ${PROJECT_NAME}_mpi_2
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
-add_test(NAME ${PROJECT_NAME}_mpi_3
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
+add_test(
+  NAME ${PROJECT_NAME}_mpi_2
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
+add_test(
+  NAME ${PROJECT_NAME}_mpi_3
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
 add_test(NAME ${PROJECT_NAME}_serial COMMAND $<TARGET_FILE:${PROJECT_NAME}>)

--- a/cpp/demo/custom_kernel/CMakeLists.txt
+++ b/cpp/demo/custom_kernel/CMakeLists.txt
@@ -24,15 +24,26 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-Wno-comment" HAVE_NO_MULTLINE)
 target_compile_options(
-  ${PROJECT_NAME} PRIVATE
-  $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment -Wall -Wextra -pedantic -Werror>
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment
+    -Wall
+    -Wextra
+    -pedantic
+    -Werror>
 )
 
 # Test targets (used by DOLFINx testing system)
-add_test(NAME ${PROJECT_NAME}_mpi_2
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
-add_test(NAME ${PROJECT_NAME}_mpi_3
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
+add_test(
+  NAME ${PROJECT_NAME}_mpi_2
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
+add_test(
+  NAME ${PROJECT_NAME}_mpi_3
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
 add_test(NAME ${PROJECT_NAME}_serial COMMAND $<TARGET_FILE:${PROJECT_NAME}>)

--- a/cpp/demo/hyperelasticity/CMakeLists.txt
+++ b/cpp/demo/hyperelasticity/CMakeLists.txt
@@ -42,9 +42,16 @@ else()
     COMMENT "Compile hyperelasticity.py using FFCx"
   )
 
-  add_executable(${PROJECT_NAME} main.cpp ${CMAKE_CURRENT_BINARY_DIR}/hyperelasticity.c)
+  add_executable(
+    ${PROJECT_NAME}
+    main.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/hyperelasticity.c
+  )
   target_link_libraries(${PROJECT_NAME} PRIVATE dolfinx::dolfinx)
-  target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+  target_include_directories(
+    ${PROJECT_NAME}
+    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+  )
 
   # Set C++20 standard
   target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
@@ -55,8 +62,13 @@ else()
   include(CheckCXXCompilerFlag)
   check_cxx_compiler_flag("-Wno-comment" HAVE_NO_MULTLINE)
   target_compile_options(
-    ${PROJECT_NAME} PRIVATE
-    $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment -Wall -Wextra -pedantic -Werror>
+    ${PROJECT_NAME}
+    PRIVATE
+      $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment
+      -Wall
+      -Wextra
+      -pedantic
+      -Werror>
   )
 
   # FFCx-generated C kernels have unused parameters fixed by the UFL ABI
@@ -66,11 +78,17 @@ else()
   )
 
   # Test targets (used by DOLFINx testing system)
-  add_test(NAME ${PROJECT_NAME}_mpi_2
-           COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
-                   ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
-  add_test(NAME ${PROJECT_NAME}_mpi_3
-           COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3
-                   ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
+  add_test(
+    NAME ${PROJECT_NAME}_mpi_2
+    COMMAND
+      ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS}
+      $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+  )
+  add_test(
+    NAME ${PROJECT_NAME}_mpi_3
+    COMMAND
+      ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 ${MPIEXEC_PREFLAGS}
+      $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+  )
   add_test(NAME ${PROJECT_NAME}_serial COMMAND $<TARGET_FILE:${PROJECT_NAME}>)
 endif()

--- a/cpp/demo/interpolation-io/CMakeLists.txt
+++ b/cpp/demo/interpolation-io/CMakeLists.txt
@@ -24,15 +24,26 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-Wno-comment" HAVE_NO_MULTLINE)
 target_compile_options(
-  ${PROJECT_NAME} PRIVATE
-  $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment -Wall -Wextra -pedantic -Werror>
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment
+    -Wall
+    -Wextra
+    -pedantic
+    -Werror>
 )
 
 # Test targets (used by DOLFINx testing system)
-add_test(NAME ${PROJECT_NAME}_mpi_2
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
-add_test(NAME ${PROJECT_NAME}_mpi_3
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
+add_test(
+  NAME ${PROJECT_NAME}_mpi_2
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
+add_test(
+  NAME ${PROJECT_NAME}_mpi_3
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
 add_test(NAME ${PROJECT_NAME}_serial COMMAND $<TARGET_FILE:${PROJECT_NAME}>)

--- a/cpp/demo/interpolation_different_meshes/CMakeLists.txt
+++ b/cpp/demo/interpolation_different_meshes/CMakeLists.txt
@@ -24,15 +24,26 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-Wno-comment" HAVE_NO_MULTLINE)
 target_compile_options(
-  ${PROJECT_NAME} PRIVATE
-  $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment -Wall -Wextra -pedantic -Werror>
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment
+    -Wall
+    -Wextra
+    -pedantic
+    -Werror>
 )
 
 # Test targets (used by DOLFINx testing system)
-add_test(NAME ${PROJECT_NAME}_mpi_2
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
-add_test(NAME ${PROJECT_NAME}_mpi_3
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
+add_test(
+  NAME ${PROJECT_NAME}_mpi_2
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
+add_test(
+  NAME ${PROJECT_NAME}_mpi_3
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
 add_test(NAME ${PROJECT_NAME}_serial COMMAND $<TARGET_FILE:${PROJECT_NAME}>)

--- a/cpp/demo/mixed_poisson/CMakeLists.txt
+++ b/cpp/demo/mixed_poisson/CMakeLists.txt
@@ -41,7 +41,11 @@ add_custom_command(
   COMMENT "Compile mixed_poisson.py using FFCx"
 )
 
-add_executable(${PROJECT_NAME} main.cpp ${CMAKE_CURRENT_BINARY_DIR}/mixed_poisson.c)
+add_executable(
+  ${PROJECT_NAME}
+  main.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/mixed_poisson.c
+)
 target_link_libraries(${PROJECT_NAME} PRIVATE dolfinx::dolfinx)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -54,8 +58,13 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-Wno-comment" HAVE_NO_MULTLINE)
 target_compile_options(
-  ${PROJECT_NAME} PRIVATE
-  $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment -Wall -Wextra -pedantic -Werror>
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment
+    -Wall
+    -Wextra
+    -pedantic
+    -Werror>
 )
 
 # FFCx-generated C kernels have unused parameters fixed by the UFL ABI
@@ -65,10 +74,16 @@ set_source_files_properties(
 )
 
 # Test targets (used by DOLFINx testing system)
-add_test(NAME ${PROJECT_NAME}_mpi_2
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
-add_test(NAME ${PROJECT_NAME}_mpi_3
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
+add_test(
+  NAME ${PROJECT_NAME}_mpi_2
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
+add_test(
+  NAME ${PROJECT_NAME}_mpi_3
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
 add_test(NAME ${PROJECT_NAME}_serial COMMAND $<TARGET_FILE:${PROJECT_NAME}>)

--- a/cpp/demo/poisson/CMakeLists.txt
+++ b/cpp/demo/poisson/CMakeLists.txt
@@ -54,8 +54,13 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-Wno-comment" HAVE_NO_MULTLINE)
 target_compile_options(
-  ${PROJECT_NAME} PRIVATE
-  $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment -Wall -Wextra -pedantic -Werror>
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment
+    -Wall
+    -Wextra
+    -pedantic
+    -Werror>
 )
 
 # FFCx-generated C kernels have unused parameters fixed by the UFL ABI
@@ -65,10 +70,16 @@ set_source_files_properties(
 )
 
 # Test targets (used by DOLFINx testing system)
-add_test(NAME ${PROJECT_NAME}_mpi_2
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
-add_test(NAME ${PROJECT_NAME}_mpi_3
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
+add_test(
+  NAME ${PROJECT_NAME}_mpi_2
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
+add_test(
+  NAME ${PROJECT_NAME}_mpi_3
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
 add_test(NAME ${PROJECT_NAME}_serial COMMAND $<TARGET_FILE:${PROJECT_NAME}>)

--- a/cpp/demo/poisson_matrix_free/CMakeLists.txt
+++ b/cpp/demo/poisson_matrix_free/CMakeLists.txt
@@ -54,8 +54,13 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-Wno-comment" HAVE_NO_MULTLINE)
 target_compile_options(
-  ${PROJECT_NAME} PRIVATE
-  $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment -Wall -Wextra -pedantic -Werror>
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${HAVE_NO_MULTLINE}>:-Wno-comment
+    -Wall
+    -Wextra
+    -pedantic
+    -Werror>
 )
 
 # FFCx-generated C kernels have unused parameters fixed by the UFL ABI
@@ -65,10 +70,16 @@ set_source_files_properties(
 )
 
 # Test targets (used by DOLFINx testing system)
-add_test(NAME ${PROJECT_NAME}_mpi_2
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
-add_test(NAME ${PROJECT_NAME}_mpi_3
-         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3
-                 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS})
+add_test(
+  NAME ${PROJECT_NAME}_mpi_2
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
+add_test(
+  NAME ${PROJECT_NAME}_mpi_3
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 ${MPIEXEC_PREFLAGS}
+    $<TARGET_FILE:${PROJECT_NAME}> ${MPIEXEC_POSTFLAGS}
+)
 add_test(NAME ${PROJECT_NAME}_serial COMMAND $<TARGET_FILE:${PROJECT_NAME}>)

--- a/cpp/dolfinx/common/CMakeLists.txt
+++ b/cpp/dolfinx/common/CMakeLists.txt
@@ -1,28 +1,30 @@
-set(HEADERS_common
-    ${CMAKE_CURRENT_SOURCE_DIR}/defines.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_common.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_doc.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/IndexMap.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/log.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/sort.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/types.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/math.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/MPI.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/Scatterer.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/Table.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/Timer.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/TimeLogger.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/timing.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
-    PARENT_SCOPE
+set(
+  HEADERS_common
+  ${CMAKE_CURRENT_SOURCE_DIR}/defines.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_common.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_doc.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/IndexMap.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/log.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/sort.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/types.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/math.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/MPI.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/Scatterer.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/Table.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/Timer.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/TimeLogger.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/timing.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
+  PARENT_SCOPE
 )
 
 target_sources(
   dolfinx
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/IndexMap.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/log.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/MPI.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/Table.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/TimeLogger.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/timing.cpp
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/IndexMap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/log.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/MPI.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Table.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/TimeLogger.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/timing.cpp
 )

--- a/cpp/dolfinx/fem/CMakeLists.txt
+++ b/cpp/dolfinx/fem/CMakeLists.txt
@@ -1,41 +1,43 @@
-set(HEADERS_fem
-    ${CMAKE_CURRENT_SOURCE_DIR}/Constant.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/CoordinateElement.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/DirichletBC.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/DofMap.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/ElementDofLayout.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/Expression.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/FiniteElement.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/Form.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/Function.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/FunctionSpace.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/assembler.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/assemble_expression_impl.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/assemble_matrix_impl.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/assemble_scalar_impl.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/assemble_vector_impl.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/discreteoperators.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/dofmapbuilder.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_fem.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/interpolate.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/kernel.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/petsc.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/pack.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/sparsitybuild.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/traits.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
-    PARENT_SCOPE
+set(
+  HEADERS_fem
+  ${CMAKE_CURRENT_SOURCE_DIR}/Constant.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/CoordinateElement.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/DirichletBC.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/DofMap.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/ElementDofLayout.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/Expression.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/FiniteElement.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/Form.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/Function.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/FunctionSpace.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/assembler.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/assemble_expression_impl.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/assemble_matrix_impl.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/assemble_scalar_impl.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/assemble_vector_impl.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/discreteoperators.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/dofmapbuilder.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_fem.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/interpolate.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/kernel.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/petsc.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/pack.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/sparsitybuild.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/traits.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
+  PARENT_SCOPE
 )
 
 target_sources(
   dolfinx
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/DirichletBC.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/CoordinateElement.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/DofMap.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/ElementDofLayout.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/FiniteElement.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/dofmapbuilder.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/petsc.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/sparsitybuild.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/DirichletBC.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CoordinateElement.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/DofMap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ElementDofLayout.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/FiniteElement.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dofmapbuilder.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/petsc.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sparsitybuild.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
 )

--- a/cpp/dolfinx/geometry/CMakeLists.txt
+++ b/cpp/dolfinx/geometry/CMakeLists.txt
@@ -1,7 +1,8 @@
-set(HEADERS_geometry
-    ${CMAKE_CURRENT_SOURCE_DIR}/BoundingBoxTree.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/gjk.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_geometry.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
-    PARENT_SCOPE
+set(
+  HEADERS_geometry
+  ${CMAKE_CURRENT_SOURCE_DIR}/BoundingBoxTree.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/gjk.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_geometry.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
+  PARENT_SCOPE
 )

--- a/cpp/dolfinx/graph/CMakeLists.txt
+++ b/cpp/dolfinx/graph/CMakeLists.txt
@@ -1,17 +1,19 @@
-set(HEADERS_graph
-    ${CMAKE_CURRENT_SOURCE_DIR}/AdjacencyList.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_graph.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/ordering.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/partitioners.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/partition.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
-    PARENT_SCOPE
+set(
+  HEADERS_graph
+  ${CMAKE_CURRENT_SOURCE_DIR}/AdjacencyList.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_graph.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/ordering.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/partitioners.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/partition.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
+  PARENT_SCOPE
 )
 
 target_sources(
   dolfinx
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ordering.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/partitioners.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/partition.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/ordering.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/partitioners.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/partition.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
 )

--- a/cpp/dolfinx/io/CMakeLists.txt
+++ b/cpp/dolfinx/io/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(HEADERS_io
+set(
+  HEADERS_io
   ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_io.h
   ${CMAKE_CURRENT_SOURCE_DIR}/ADIOS2Writers.h
   ${CMAKE_CURRENT_SOURCE_DIR}/cells.h
@@ -16,13 +17,14 @@ set(HEADERS_io
 
 target_sources(
   dolfinx
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ADIOS2Writers.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/cells.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/HDF5Interface.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/VTKFile.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/vtk_utils.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/XDMFFile.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/xdmf_function.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/xdmf_mesh.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/xdmf_utils.cpp
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/ADIOS2Writers.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cells.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/HDF5Interface.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/VTKFile.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/vtk_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/XDMFFile.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xdmf_function.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xdmf_mesh.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xdmf_utils.cpp
 )

--- a/cpp/dolfinx/la/CMakeLists.txt
+++ b/cpp/dolfinx/la/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(HEADERS_la
+set(
+  HEADERS_la
   ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_la.h
   ${CMAKE_CURRENT_SOURCE_DIR}/MatrixCSR.h
   ${CMAKE_CURRENT_SOURCE_DIR}/matrix_csr_impl.h
@@ -15,8 +16,9 @@ set(HEADERS_la
 
 target_sources(
   dolfinx
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/SparsityPattern.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/superlu_dist.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/petsc.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/slepc.cpp
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/SparsityPattern.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/superlu_dist.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/petsc.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/slepc.cpp
 )

--- a/cpp/dolfinx/mesh/CMakeLists.txt
+++ b/cpp/dolfinx/mesh/CMakeLists.txt
@@ -1,26 +1,28 @@
-set(HEADERS_mesh
-    ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_mesh.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/Mesh.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/Geometry.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/Topology.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/MeshTags.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/cell_types.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/generation.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/graphbuild.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/permutationcomputation.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/topologycomputation.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/EntityMap.h
-    PARENT_SCOPE
+set(
+  HEADERS_mesh
+  ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_mesh.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/Mesh.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/Geometry.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/Topology.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/MeshTags.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/cell_types.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/generation.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/graphbuild.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/permutationcomputation.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/topologycomputation.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/EntityMap.h
+  PARENT_SCOPE
 )
 
 target_sources(
   dolfinx
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Topology.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/EntityMap.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/cell_types.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/graphbuild.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/permutationcomputation.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/topologycomputation.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/Topology.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/EntityMap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cell_types.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/graphbuild.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/permutationcomputation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/topologycomputation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
 )

--- a/cpp/dolfinx/nls/CMakeLists.txt
+++ b/cpp/dolfinx/nls/CMakeLists.txt
@@ -1,7 +1,8 @@
-set(HEADERS_nls
-    ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_nls.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/NewtonSolver.h
-    PARENT_SCOPE
+set(
+  HEADERS_nls
+  ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_nls.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/NewtonSolver.h
+  PARENT_SCOPE
 )
 
 target_sources(dolfinx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/NewtonSolver.cpp)

--- a/cpp/dolfinx/refinement/CMakeLists.txt
+++ b/cpp/dolfinx/refinement/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(HEADERS_refinement
+set(
+  HEADERS_refinement
   ${CMAKE_CURRENT_SOURCE_DIR}/dolfinx_refinement.h
   ${CMAKE_CURRENT_SOURCE_DIR}/interval.h
   ${CMAKE_CURRENT_SOURCE_DIR}/mark.h
@@ -11,7 +12,9 @@ set(HEADERS_refinement
 )
 
 target_sources(
-  dolfinx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/plaza.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/uniform.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
+  dolfinx
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/plaza.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/uniform.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils.cpp
 )

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -56,7 +56,11 @@ if(CMAKE_BUILD_TYPE STREQUAL "Developer")
   set_target_properties(dolfinx::dolfinx PROPERTIES SYSTEM OFF)
 endif()
 
-get_target_property(_dolfinx_defs dolfinx::dolfinx INTERFACE_COMPILE_DEFINITIONS)
+get_target_property(
+  _dolfinx_defs
+  dolfinx::dolfinx
+  INTERFACE_COMPILE_DEFINITIONS
+)
 if("HAS_SUPERLU_DIST" IN_LIST _dolfinx_defs)
   # SuperLU_DIST Python interface requires the superlu_defs.h header for int_t.
   find_package(PkgConfig)


### PR DESCRIPTION
`gersemi` respects `.gitignore` during file system traversal, see https://github.com/BlankSpruce/gersemi#usage `--respect-ignore-files` (on by default). Therefore all `CMakeLists.txt` files have not been formatted, due to ignore config.

This removes the explicit CMakeLists ignore in the `.gitignore`, if we want to keep that, we can also toggle the `gersemi` flag.