### PR TITLE
Add missing include

### DIFF
--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -30,7 +30,7 @@ target_include_directories(
   dolfinx
   PUBLIC
     $<INSTALL_INTERFACE:include>
-    "$<BUILD_INTERFACE:${DOLFINX_SOURCE_DIR};${DOLFINX_SOURCE_DIR}/dolfinx;${CMAKE_CURRENT_BINARY_DIR}/..>"
+    "$<BUILD_INTERFACE:${DOLFINX_SOURCE_DIR};${DOLFINX_SOURCE_DIR}/dolfinx>"
 )
 
 # ------------------------------------------------------------------------------

--- a/cpp/dolfinx/CMakeLists.txt
+++ b/cpp/dolfinx/CMakeLists.txt
@@ -30,7 +30,7 @@ target_include_directories(
   dolfinx
   PUBLIC
     $<INSTALL_INTERFACE:include>
-    "$<BUILD_INTERFACE:${DOLFINX_SOURCE_DIR};${DOLFINX_SOURCE_DIR}/dolfinx>"
+    "$<BUILD_INTERFACE:${DOLFINX_SOURCE_DIR};${DOLFINX_SOURCE_DIR}/dolfinx;${CMAKE_CURRENT_BINARY_DIR}/..>"
 )
 
 # ------------------------------------------------------------------------------
@@ -38,7 +38,7 @@ target_include_directories(
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/common/version.h.in
-  common/version.h
+  ${CMAKE_CURRENT_BINARY_DIR}/common/version.h
   @ONLY
 )
 

--- a/cpp/dolfinx/common/defines.h
+++ b/cpp/dolfinx/common/defines.h
@@ -8,9 +8,6 @@
 
 #include <string>
 
-// Created by Cmake from version.h.in
-#include "version.h"
-
 namespace dolfinx
 {
 

--- a/cpp/dolfinx/common/defines.h
+++ b/cpp/dolfinx/common/defines.h
@@ -8,6 +8,9 @@
 
 #include <string>
 
+// Created by Cmake from version.h.in
+#include "version.h"
+
 namespace dolfinx
 {
 


### PR DESCRIPTION
Bit mysterious; there is no way that defines.h can build without including version.h, but this only appeared after the recent CMake changes.
