### PR TITLE
Remove package manager install for RH clone CI, use Spack

### DIFF
--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -21,6 +21,12 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
   PYTEST_ADDOPTS: "-W error"
+  # Spack environment activation does not add the view's library
+  # directories to the runtime linker search path, so packages that are
+  # only present in the environment (not linked via RPATH into a
+  # consuming package, e.g. mesa-glu's libGLU.so.1 for gmsh) are not
+  # found at runtime without this.
+  LD_LIBRARY_PATH: /opt/view/lib:/opt/view/lib64
 
 jobs:
   ci-spack-build:

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -21,6 +21,12 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
   PYTEST_ADDOPTS: "-W error"
+  # Spack environment activation does not add the view's library
+  # directories to the runtime linker search path, so packages that are
+  # only present in the environment (not linked via RPATH into a
+  # consuming package, e.g. mesa-glu's libGLU.so.1 for gmsh) are not
+  # found at runtime without this.
+  LD_LIBRARY_PATH: /opt/view/lib:/opt/view/lib64
 
 jobs:
   ci-spack-build:
@@ -62,15 +68,9 @@ jobs:
           # freetype@2.14.2 (2026-07). Re-check and drop once a fixed
           # freetype (2.14.3+) lands in the spack-packages recipe.
           spack -e py add openblas
-          # opencascade's visualization module (and application_framework,
-          # data_exchange, draw, which depend on it in turn) pulls in
-          # GLU/X11 libraries that gmsh cannot find at runtime in this
-          # container; disable it since this pipeline never needs OCCT
-          # rendering. draw is a conditional variant that only exists
-          # when +visualization, so it must not be set alongside ~visualization.
-          spack -e py add py-gmsh ^gmsh~fltk~med~mmg+external ^opencascade~visualization py-pyvista ^mesa~llvm ^freetype@2.13.3 \
+          spack -e py add py-gmsh ^gmsh~fltk~med~mmg+external ^opencascade~draw py-pyvista ^mesa~llvm ^freetype@2.13.3 \
             py-networkx py-matplotlib py-pyamg py-numba  ^llvm~clang~lldb~lld~offload~libomptarget~polly targets=x86 \
-            py-scipy
+            py-scipy mesa-glu libx11 libxcursor libxft libxinerama libxrender
 
       - if: matrix.compiler == 'oneapi'
         name: Add oneAPI compilers to environment

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -138,9 +138,9 @@ jobs:
           mkdir -p ~/.config/dolfinx
           echo '{ "cffi_extra_compile_args": ["-g0", "-O0" ] }' > ~/.config/dolfinx/dolfinx_jit_options.json
 
-      - name: Libraries that gmsh expects to find
-        run: |
-          dnf install -y mesa-libGLU libX11 libXrender mesa-libEGL libglvnd-glx libXcursor libXft libXinerama
+      # - name: Libraries that gmsh expects to find
+      #   run: |
+      #     dnf install -y mesa-libGLU libX11 libXrender mesa-libEGL libglvnd-glx libXcursor libXft libXinerama
 
       - name: Run demos (Python, serial and MPI)
         run: |

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -70,7 +70,7 @@ jobs:
           spack -e py add openblas
           spack -e py add py-gmsh ^gmsh~fltk~med~mmg+external ^opencascade~draw py-pyvista ^mesa~llvm ^freetype@2.13.3 \
             py-networkx py-matplotlib py-pyamg py-numba  ^llvm~clang~lldb~lld~offload~libomptarget~polly targets=x86 \
-            py-scipy mesa-glu
+            py-scipy mesa-glu libx11 libxcursor libxft libxinerama libxrender
 
       - if: matrix.compiler == 'oneapi'
         name: Add oneAPI compilers to environment

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -64,7 +64,7 @@ jobs:
           spack -e py add openblas
           spack -e py add py-gmsh ^gmsh~fltk~med~mmg+external ^opencascade~draw py-pyvista ^mesa~llvm ^freetype@2.13.3 \
             py-networkx py-matplotlib py-pyamg py-numba  ^llvm~clang~lldb~lld~offload~libomptarget~polly targets=x86 \
-            py-scipy
+            py-scipy mesa-glu
 
       - if: matrix.compiler == 'oneapi'
         name: Add oneAPI compilers to environment
@@ -137,10 +137,6 @@ jobs:
         run: |
           mkdir -p ~/.config/dolfinx
           echo '{ "cffi_extra_compile_args": ["-g0", "-O0" ] }' > ~/.config/dolfinx/dolfinx_jit_options.json
-
-      # - name: Libraries that gmsh expects to find
-      #   run: |
-      #     dnf install -y mesa-libGLU libX11 libXrender mesa-libEGL libglvnd-glx libXcursor libXft libXinerama
 
       - name: Run demos (Python, serial and MPI)
         run: |

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -70,7 +70,17 @@ jobs:
           spack -e py add openblas
           spack -e py add py-gmsh ^gmsh~fltk~med~mmg+external ^opencascade~draw py-pyvista ^mesa~llvm ^freetype@2.13.3 \
             py-networkx py-matplotlib py-pyamg py-numba  ^llvm~clang~lldb~lld~offload~libomptarget~polly targets=x86 \
-            py-scipy mesa-glu libx11 libxcursor libxft libxinerama libxrender
+            py-scipy
+          # gmsh's compiled library dlopens libGLU.so.1 and several X11
+          # libraries unconditionally at runtime (its native file-chooser
+          # and OpenGL-based drawing code are always built in), but the
+          # gmsh Spack recipe only declares depends_on("glu"/"gl") when
+          # +fltk is set. We build gmsh ~fltk, so Spack's dependency graph
+          # never gets these libraries, and none of them are RPATH-linked
+          # in by any package either — hence they must be added explicitly
+          # here and put on LD_LIBRARY_PATH (see env above) so gmsh can
+          # find them at runtime.
+          spack -e py add mesa-glu libx11 libxcursor libxft libxinerama libxrender
 
       - if: matrix.compiler == 'oneapi'
         name: Add oneAPI compilers to environment

--- a/.github/workflows/ci-spack.yml
+++ b/.github/workflows/ci-spack.yml
@@ -21,12 +21,6 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
   PYTEST_ADDOPTS: "-W error"
-  # Spack environment activation does not add the view's library
-  # directories to the runtime linker search path, so packages that are
-  # only present in the environment (not linked via RPATH into a
-  # consuming package, e.g. mesa-glu's libGLU.so.1 for gmsh) are not
-  # found at runtime without this.
-  LD_LIBRARY_PATH: /opt/view/lib:/opt/view/lib64
 
 jobs:
   ci-spack-build:
@@ -68,9 +62,15 @@ jobs:
           # freetype@2.14.2 (2026-07). Re-check and drop once a fixed
           # freetype (2.14.3+) lands in the spack-packages recipe.
           spack -e py add openblas
-          spack -e py add py-gmsh ^gmsh~fltk~med~mmg+external ^opencascade~draw py-pyvista ^mesa~llvm ^freetype@2.13.3 \
+          # opencascade's visualization module (and application_framework,
+          # data_exchange, draw, which depend on it in turn) pulls in
+          # GLU/X11 libraries that gmsh cannot find at runtime in this
+          # container; disable it since this pipeline never needs OCCT
+          # rendering. draw is a conditional variant that only exists
+          # when +visualization, so it must not be set alongside ~visualization.
+          spack -e py add py-gmsh ^gmsh~fltk~med~mmg+external ^opencascade~visualization py-pyvista ^mesa~llvm ^freetype@2.13.3 \
             py-networkx py-matplotlib py-pyamg py-numba  ^llvm~clang~lldb~lld~offload~libomptarget~polly targets=x86 \
-            py-scipy mesa-glu libx11 libxcursor libxft libxinerama libxrender
+            py-scipy
 
       - if: matrix.compiler == 'oneapi'
         name: Add oneAPI compilers to environment


### PR DESCRIPTION
py-gmsh dynamically loads some graphics libraries. These are not covered by the Spack spec. 