### PR TITLE
Unify num_threads meaning

### DIFF
--- a/cpp/dolfinx/geometry/gjk.h
+++ b/cpp/dolfinx/geometry/gjk.h
@@ -506,7 +506,8 @@ std::array<T, 3> compute_distance_gjk(std::span<const T> p0,
 /// Row-major storage.
 /// @param[in] q Body 2 list of points, `shape=(num_points, 3)`. Row-major
 /// storage.
-/// @param[in] num_threads Thread count.
+/// @param[in] num_threads Number of threads to use. Use 0 to not
+/// launch threads.
 ///
 /// @tparam T Floating point type
 /// @tparam U Floating point type used for geometry computations internally,
@@ -536,10 +537,8 @@ compute_distances_gjk(const std::vector<std::span<const T>>& bodies,
     }
   };
 
-  if (num_threads <= 1)
-  {
+  if (num_threads == 0)
     compute_chunk(0, total_size, q);
-  }
   else
   {
     std::vector<std::jthread> threads(num_threads);

--- a/cpp/dolfinx/graph/ordering.cpp
+++ b/cpp/dolfinx/graph/ordering.cpp
@@ -184,37 +184,39 @@ gps_reorder_unlabelled(const graph::AdjacencyList<std::int32_t>& graph,
 
     // C. Generate level structures rooted at vertices s in S selected
     // in order of increasing degree. Each candidate's level structure
-    // is independent of the others, so when num_threads > 1 they are
+    // is independent of the others, so when num_threads > 0 they are
     // computed concurrently. The decision of which candidate to use
     // is still made afterwards, sequentially, in the original order,
     // so the result is identical regardless of num_threads.
     std::vector<graph::AdjacencyList<int>> lstmps(S.size(),
                                                   graph::AdjacencyList<int>(0));
-    std::size_t nt = std::min(num_threads, S.size());
-    if (nt <= 1)
+    auto compute_lstmps = [&](std::size_t num_threads)
     {
-      for (std::size_t i = 0; i < S.size(); ++i)
-        lstmps[i] = create_level_structure(graph, S[i]);
-    }
-    else
-    {
-      std::vector<std::jthread> workers;
-      workers.reserve(nt);
-      std::size_t chunk = (S.size() + nt - 1) / nt;
-      for (std::size_t t = 0; t < nt; ++t)
+      if (num_threads == 0)
       {
-        std::size_t begin = t * chunk;
-        std::size_t end = std::min(S.size(), begin + chunk);
-        if (begin >= end)
-          break;
-        workers.emplace_back(
-            [&S, &lstmps, &graph, begin, end]()
-            {
-              for (std::size_t i = begin; i < end; ++i)
-                lstmps[i] = create_level_structure(graph, S[i]);
-            });
+        for (std::size_t i = 0; i < S.size(); ++i)
+          lstmps[i] = create_level_structure(graph, S[i]);
       }
-    }
+      else
+      {
+        std::vector<std::jthread> threads(num_threads);
+        std::size_t chunk = (S.size() + num_threads - 1) / num_threads;
+        for (std::size_t t = 0; t < num_threads; ++t)
+        {
+          std::size_t begin = t * chunk;
+          std::size_t end = std::min(S.size(), begin + chunk);
+          if (begin >= end)
+            break;
+          threads[t] = std::jthread(
+              [&S, &lstmps, &graph, begin, end]()
+              {
+                for (std::size_t i = begin; i < end; ++i)
+                  lstmps[i] = create_level_structure(graph, S[i]);
+              });
+        }
+      }
+    };
+    compute_lstmps(std::min(num_threads, S.size()));
 
     for (std::size_t i = 0; i < S.size(); ++i)
     {

--- a/cpp/dolfinx/graph/ordering.h
+++ b/cpp/dolfinx/graph/ordering.h
@@ -56,7 +56,7 @@ namespace dolfinx::graph
 /// `std::numeric_limits<std::size_t>::max()` for the original,
 /// exhaustive algorithm (see above).
 /// @param[in] num_threads Number of threads to use for the
-/// pseudo-diameter candidate search. `1` runs serially.
+/// pseudo-diameter candidate search. Use 0 to not launch threads.
 /// @return Reordering array `map`, where `map[i]` is the new index of
 /// node `i`.
 std::vector<std::int32_t>

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -65,7 +65,8 @@ public:
   /// in `cell_types`.
   /// @param[in] original_cell_index Original indices for each cell in
   /// `cells`.
-  /// @param[in] num_threads Number of threads to use for entity creation.
+  /// @param[in] num_threads Number of threads to use for entity
+  /// creation. Use 0 to not launch threads.
   Topology(
       std::vector<CellType> cell_types,
       std::shared_ptr<const common::IndexMap> vertex_map,
@@ -73,7 +74,7 @@ public:
       std::vector<std::shared_ptr<graph::AdjacencyList<std::int32_t>>> cells,
       const std::optional<std::vector<std::vector<std::int64_t>>>&
           original_cell_index = std::nullopt,
-      int num_threads = 1);
+      int num_threads = 0);
 
   /// Copy constructor
   Topology(const Topology& topology) = default;
@@ -199,10 +200,11 @@ public:
   /// @brief Create entities of given topological dimension.
   ///
   /// @param[in] dim Topological dimension of entities to compute.
-  /// @param[in] num_threads Number of threads to use for entity creation.
+  /// @param[in] num_threads Number of threads to use for entity
+  /// creation. Use 0 to not launch threads.
   /// @return True if entities are created, false if entities already
   /// existed.
-  bool create_entities(int dim, int num_threads = 1);
+  bool create_entities(int dim, int num_threads = 0);
 
   /// @brief Create connectivity between given pair of dimensions, `d0
   /// -> d1`.
@@ -211,7 +213,9 @@ public:
   void create_connectivity(int d0, int d1);
 
   /// @brief Compute entity permutations and reflections.
-  void create_entity_permutations(int num_threads = 1);
+  /// @param[in] num_threads Number of threads to use. Use 0 to not
+  /// launch threads.
+  void create_entity_permutations(int num_threads = 0);
 
   /// Original cell index for each cell type
   std::vector<std::vector<std::int64_t>> original_cell_index;

--- a/cpp/dolfinx/mesh/permutationcomputation.cpp
+++ b/cpp/dolfinx/mesh/permutationcomputation.cpp
@@ -170,7 +170,7 @@ compute_triangle_quad_face_permutations(const mesh::Topology& topology,
       spdlog::debug("Using {} threads for face permutation computation",
                     num_threads);
 
-      auto process_thread = [&](int i)
+      auto process_thread = [&](int i, int num_threads)
       {
         std::vector<std::int64_t> cell_vertices, vertices;
         std::vector<std::int32_t> e_vertices;
@@ -216,12 +216,14 @@ compute_triangle_quad_face_permutations(const mesh::Topology& topology,
         }
       };
 
-      // Launch threads for computing face permutations. The first thread is run
-      // in the main task.
-      std::vector<std::jthread> threads;
-      for (int i = 1; i < num_threads; ++i)
-        threads.emplace_back(process_thread, i);
-      process_thread(0);
+      if (num_threads > 0)
+      {
+        std::vector<std::jthread> threads(num_threads);
+        for (int i = 0; i < num_threads; ++i)
+          threads[i] = std::jthread(process_thread, i, num_threads);
+      }
+      else
+        process_thread(0, 1);
     }
   }
 
@@ -252,7 +254,7 @@ compute_edge_reflections(const mesh::Topology& topology, int num_threads)
 
   std::vector<std::bitset<BITSETSIZE>> edge_perm(num_cells, 0);
 
-  auto process_thread = [&](int i)
+  auto process_thread = [&](int i, int num_threads)
   {
     std::vector<std::int64_t> cell_vertices, vertices;
     auto range
@@ -281,12 +283,14 @@ compute_edge_reflections(const mesh::Topology& topology, int num_threads)
     }
   };
 
-  // Launch threads for computing edge reflections. The first thread is run in
-  // the main task.
-  std::vector<std::jthread> threads;
-  for (int i = 1; i < num_threads; ++i)
-    threads.emplace_back(process_thread, i);
-  process_thread(0);
+  if (num_threads > 0)
+  {
+    std::vector<std::jthread> threads(num_threads);
+    for (int i = 0; i < num_threads; ++i)
+      threads[i] = std::jthread(process_thread, i, num_threads);
+  }
+  else
+    process_thread(0, 1);
 
   return edge_perm;
 }

--- a/cpp/dolfinx/mesh/permutationcomputation.h
+++ b/cpp/dolfinx/mesh/permutationcomputation.h
@@ -66,6 +66,7 @@ class Topology;
 ///    This data is used to correct the direction of vector function
 ///    on permuted facets.
 ///
+/// @param[in] topology Mesh topology.
 /// @param[in] num_threads Number of threads to use. Use 0 to not
 /// launch threads.
 /// @return Facet permutation and cells permutations

--- a/cpp/dolfinx/mesh/permutationcomputation.h
+++ b/cpp/dolfinx/mesh/permutationcomputation.h
@@ -66,8 +66,10 @@ class Topology;
 ///    This data is used to correct the direction of vector function
 ///    on permuted facets.
 ///
+/// @param[in] num_threads Number of threads to use. Use 0 to not
+/// launch threads.
 /// @return Facet permutation and cells permutations
 std::pair<std::vector<std::uint8_t>, std::vector<std::uint32_t>>
-compute_entity_permutations(const Topology& topology, int num_threads = 1);
+compute_entity_permutations(const Topology& topology, int num_threads = 0);
 
 } // namespace dolfinx::mesh

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -193,8 +193,13 @@ class Topology:
         """
         return self._cpp_object.create_entities(dim, num_threads)
 
-    def create_entity_permutations(self, num_threads: int = 1):
-        """Compute entity permutations and reflections."""
+    def create_entity_permutations(self, num_threads: int = 0):
+        """Compute entity permutations and reflections.
+
+        Args:
+            num_threads: Number of threads to use. If 0, threads
+                are not spawned.
+        """
         self._cpp_object.create_entity_permutations(num_threads)
 
     @property

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -149,7 +149,7 @@ void mesh(nb::module_& m)
                                                num_threads);
       },
       nb::arg("topology"), nb::arg("dim"), nb::arg("entity_type"),
-      nb::arg("num_threads") = 1);
+      nb::arg("num_threads") = 0);
   m.def("compute_connectivity", &dolfinx::mesh::compute_connectivity,
         nb::arg("topology"), nb::arg("d0"), nb::arg("d1"));
 
@@ -217,10 +217,10 @@ void mesh(nb::module_& m)
           nb::arg("cell_type"), nb::arg("vertex_map"), nb::arg("cell_map"),
           nb::arg("cells"), nb::arg("original_index").none())
       .def("create_entities", &dolfinx::mesh::Topology::create_entities,
-           nb::arg("dim"), nb::arg("num_threads") = 1)
+           nb::arg("dim"), nb::arg("num_threads") = 0)
       .def("create_entity_permutations",
            &dolfinx::mesh::Topology::create_entity_permutations,
-           nb::arg("num_threads"))
+           nb::arg("num_threads") = 0)
       .def("create_connectivity", &dolfinx::mesh::Topology::create_connectivity,
            nb::arg("d0"), nb::arg("d1"))
       .def(


### PR DESCRIPTION
@garth-wells This unifies meaning of all num_threads to
- num_threads=0: serial codepath, no spawning,
- num_threads=n: there are n threads spawned, while main, caller "thread" waits for the `std::jthread` block to join.

I've also run a quick benchmark using 
[num_threads_speedup.py](https://github.com/user-attachments/files/30169779/num_threads_speedup.py)

`python3 num_threads_speedup.py --repeats 3 --mesh-n 60 --num-bodies 50000 --max-threads 10 --out num_threads_speedup_test.png`

My M4 CPU only has 4 performance cores, so the scaling of entity permutations and GJK looks good. But also, this was run inside the docker container and not the best build flags, so take with a pinch of salt.

<img width="2250" height="630" alt="num_threads_speedup_test" src="https://github.com/user-attachments/assets/e46beceb-a342-470c-ae10-dcb81b0db865" />

Used Claude Code Opus 4.8.
