### PR TITLE
Threading consistency fixes

### DIFF
--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -428,7 +428,7 @@ distribute_to_postoffice(MPI_Comm comm, const U& x,
   spdlog::debug("Completed send data to post offices.");
 
   // Convert to local indices
-  const std::int64_t r0 = dolfinx::common::local_range(rank, shape[0], size)[0];
+  const std::int64_t r0 = common::local_range(rank, shape[0], size)[0];
   std::vector<std::int32_t> index_local(recv_buffer_index.size());
   std::ranges::transform(recv_buffer_index, index_local.begin(),
                          [r0](auto idx) { return idx - r0; });
@@ -550,7 +550,7 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
   // data that was already on this rank and was therefore was not
   // sent/received via a postoffice.
   const std::array<std::int64_t, 2> postoffice_range
-      = dolfinx::common::local_range(rank, shape[0], size);
+      = common::local_range(rank, shape[0], size);
   std::vector<std::int32_t> post_indices_map(
       postoffice_range[1] - postoffice_range[0], -1);
   for (std::size_t i = 0; i < post_indices.size(); ++i)

--- a/cpp/dolfinx/geometry/gjk.h
+++ b/cpp/dolfinx/geometry/gjk.h
@@ -520,6 +520,7 @@ compute_distances_gjk(const std::vector<std::span<const T>>& bodies,
                       std::span<const T> q, size_t num_threads)
 {
   size_t total_size = bodies.size();
+  assert(num_threads > 0);
   num_threads = std::min(num_threads, total_size);
 
   std::vector<T> results(total_size * 3);
@@ -536,6 +537,7 @@ compute_distances_gjk(const std::vector<std::span<const T>>& bodies,
     }
   };
 
+  assert(num_threads > 0);
   std::vector<std::jthread> threads;
   for (size_t i = 1; i < num_threads; ++i)
   {

--- a/cpp/dolfinx/geometry/gjk.h
+++ b/cpp/dolfinx/geometry/gjk.h
@@ -536,20 +536,14 @@ compute_distances_gjk(const std::vector<std::span<const T>>& bodies,
     }
   };
 
-  if (num_threads > 1)
+  std::vector<std::jthread> threads;
+  for (size_t i = 1; i < num_threads; ++i)
   {
-    std::vector<std::jthread> threads;
-    for (size_t i = 1; i < num_threads; ++i)
-    {
-      auto [c0, c1] = common::local_range(i, total_size, num_threads);
-      threads.emplace_back(compute_chunk, c0, c1, q);
-    }
+    auto [c0, c1] = common::local_range(i, total_size, num_threads);
+    threads.emplace_back(compute_chunk, c0, c1, q);
   }
-  else
-  {
-    auto [c0, c1] = common::local_range(0, total_size, num_threads);
-    compute_chunk(c0, c1, q);
-  }
+  auto [c0, c1] = common::local_range(0, total_size, num_threads);
+  compute_chunk(c0, c1, q);
 
   return results;
 }

--- a/cpp/dolfinx/geometry/gjk.h
+++ b/cpp/dolfinx/geometry/gjk.h
@@ -519,7 +519,7 @@ std::vector<T>
 compute_distances_gjk(const std::vector<std::span<const T>>& bodies,
                       std::span<const T> q, size_t num_threads)
 {
-  size_t total_size = bodies.size();
+  std::size_t total_size = bodies.size();
   assert(num_threads > 0);
   num_threads = std::min(num_threads, total_size);
 

--- a/cpp/dolfinx/geometry/gjk.h
+++ b/cpp/dolfinx/geometry/gjk.h
@@ -506,7 +506,7 @@ std::array<T, 3> compute_distance_gjk(std::span<const T> p0,
 /// Row-major storage.
 /// @param[in] q Body 2 list of points, `shape=(num_points, 3)`. Row-major
 /// storage.
-/// @param[in] num_threads Thread count.
+/// @param[in] num_threads Number of threads to use.
 ///
 /// @tparam T Floating point type
 /// @tparam U Floating point type used for geometry computations internally,
@@ -536,18 +536,19 @@ compute_distances_gjk(const std::vector<std::span<const T>>& bodies,
     }
   };
 
-  if (num_threads > 0)
+  if (num_threads > 1)
   {
-    std::vector<std::jthread> threads(num_threads);
-    for (size_t i = 0; i < num_threads; ++i)
+    std::vector<std::jthread> threads;
+    for (size_t i = 1; i < num_threads; ++i)
     {
-      auto [c0, c1] = dolfinx::common::local_range(i, total_size, num_threads);
-      threads[i] = std::jthread(compute_chunk, c0, c1, q);
+      auto [c0, c1] = common::local_range(i, total_size, num_threads);
+      threads.emplace_back(compute_chunk, c0, c1, q);
     }
   }
   else
   {
-    compute_chunk(0, total_size, q);
+    auto [c0, c1] = common::local_range(0, total_size, num_threads);
+    compute_chunk(c0, c1, q);
   }
 
   return results;

--- a/cpp/dolfinx/geometry/gjk.h
+++ b/cpp/dolfinx/geometry/gjk.h
@@ -536,11 +536,7 @@ compute_distances_gjk(const std::vector<std::span<const T>>& bodies,
     }
   };
 
-  if (num_threads <= 1)
-  {
-    compute_chunk(0, total_size, q);
-  }
-  else
+  if (num_threads > 0)
   {
     std::vector<std::jthread> threads(num_threads);
     for (size_t i = 0; i < num_threads; ++i)
@@ -548,6 +544,10 @@ compute_distances_gjk(const std::vector<std::span<const T>>& bodies,
       auto [c0, c1] = dolfinx::common::local_range(i, total_size, num_threads);
       threads[i] = std::jthread(compute_chunk, c0, c1, q);
     }
+  }
+  else
+  {
+    compute_chunk(0, total_size, q);
   }
 
   return results;

--- a/cpp/dolfinx/geometry/gjk.h
+++ b/cpp/dolfinx/geometry/gjk.h
@@ -14,6 +14,7 @@
 #include <limits>
 #include <numeric>
 #include <span>
+#include <stdexcept>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -506,7 +507,7 @@ std::array<T, 3> compute_distance_gjk(std::span<const T> p0,
 /// Row-major storage.
 /// @param[in] q Body 2 list of points, `shape=(num_points, 3)`. Row-major
 /// storage.
-/// @param[in] num_threads Number of threads to use.
+/// @param[in] num_threads Number of threads to use. Must be >= 1.
 ///
 /// @tparam T Floating point type
 /// @tparam U Floating point type used for geometry computations internally,
@@ -517,17 +518,21 @@ template <std::floating_point T,
           typename U = boost::multiprecision::cpp_bin_float_double_extended>
 std::vector<T>
 compute_distances_gjk(const std::vector<std::span<const T>>& bodies,
-                      std::span<const T> q, size_t num_threads)
+                      std::span<const T> q, int num_threads)
 {
+  if (num_threads <= 0)
+    throw std::runtime_error("num_threads must be >= 1.");
+
   std::size_t total_size = bodies.size();
-  assert(num_threads > 0);
-  num_threads = std::min(num_threads, total_size);
+  num_threads
+      = std::max<std::size_t>(1, std::min(num_threads, (int)total_size));
 
   std::vector<T> results(total_size * 3);
-  auto compute_chunk
-      = [&results, &bodies](size_t c0, size_t c1, std::span<const T> q_ref)
+  auto compute_chunk =
+      [](std::vector<T>& results, const std::vector<std::span<const T>>& bodies,
+         std::size_t c0, std::size_t c1, std::span<const T> q_ref)
   {
-    for (size_t i = c0; i < c1; ++i)
+    for (std::size_t i = c0; i < c1; ++i)
     {
       // Using U explicitly as the internal precision type
       std::array<T, 3> dist = compute_distance_gjk<T, U>(bodies[i], q_ref);
@@ -537,15 +542,15 @@ compute_distances_gjk(const std::vector<std::span<const T>>& bodies,
     }
   };
 
-  assert(num_threads > 0);
   std::vector<std::jthread> threads;
-  for (size_t i = 1; i < num_threads; ++i)
+  for (int i = 1; i < num_threads; ++i)
   {
     auto [c0, c1] = common::local_range(i, total_size, num_threads);
-    threads.emplace_back(compute_chunk, c0, c1, q);
+    threads.emplace_back(compute_chunk, std::ref(results), std::ref(bodies), c0,
+                         c1, std::ref(q));
   }
   auto [c0, c1] = common::local_range(0, total_size, num_threads);
-  compute_chunk(c0, c1, q);
+  compute_chunk(std::ref(results), std::cref(bodies), c0, c1, q);
 
   return results;
 }

--- a/cpp/dolfinx/graph/ordering.h
+++ b/cpp/dolfinx/graph/ordering.h
@@ -56,7 +56,7 @@ namespace dolfinx::graph
 /// `std::numeric_limits<std::size_t>::max()` for the original,
 /// exhaustive algorithm (see above).
 /// @param[in] num_threads Number of threads to use for the
-/// pseudo-diameter candidate search. `1` runs serially.
+/// pseudo-diameter candidate search.
 /// @return Reordering array `map`, where `map[i]` is the new index of
 /// node `i`.
 std::vector<std::int32_t>

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -489,7 +489,8 @@ std::vector<std::int64_t> graph::build::compute_ghost_indices(
     old_to_new.push_back(
         {idx, static_cast<std::int64_t>(offset_local + old_to_new.size())});
   }
-  if (num_threads > 0)
+
+  if (num_threads > 1)
   {
     boost::sort::block_indirect_sort(old_to_new.begin(), old_to_new.end(),
                                      num_threads);

--- a/cpp/dolfinx/io/VTKFile.cpp
+++ b/cpp/dolfinx/io/VTKFile.cpp
@@ -39,8 +39,8 @@ constexpr std::array field_ext = {"_real", "_imag"};
 std::string get_counter(const pugi::xml_node& node, const std::string& name)
 {
   // Count number of entries
-  const size_t n = std::distance(node.children(name.c_str()).begin(),
-                                 node.children(name.c_str()).end());
+  const std::size_t n = std::distance(node.children(name.c_str()).begin(),
+                                      node.children(name.c_str()).end());
 
   // Compute counter string
   constexpr int num_digits = 6;

--- a/cpp/dolfinx/io/VTKHDF.h
+++ b/cpp/dolfinx/io/VTKHDF.h
@@ -323,7 +323,7 @@ mesh::Mesh<U> read_mesh(MPI_Comm comm, const std::filesystem::path& filename,
   int rank = dolfinx::MPI::rank(comm);
   int mpi_size = dolfinx::MPI::size(comm);
   std::array<std::int64_t, 2> local_cell_range
-      = dolfinx::common::local_range(rank, shape[0], mpi_size);
+      = common::local_range(rank, shape[0], mpi_size);
 
   hid_t dset_id = hdf5::open_dataset(h5file, "/VTKHDF/Types");
   std::vector<std::uint8_t> types
@@ -406,7 +406,7 @@ mesh::Mesh<U> read_mesh(MPI_Comm comm, const std::filesystem::path& filename,
   H5Dclose(dset_id);
   spdlog::info("Mesh with {} points", npoints[0]);
   std::array<std::int64_t, 2> local_point_range
-      = dolfinx::common::local_range(rank, npoints[0], mpi_size);
+      = common::local_range(rank, npoints[0], mpi_size);
 
   std::vector<std::int64_t> x_shape
       = hdf5::get_dataset_shape(h5file, "/VTKHDF/Points");

--- a/cpp/dolfinx/io/xdmf_utils.h
+++ b/cpp/dolfinx/io/xdmf_utils.h
@@ -214,8 +214,8 @@ std::vector<T> get_dataset(MPI_Comm comm, const pugi::xml_node& dataset_node,
     {
       if (shape_xml == shape_hdf5)
       {
-        range = dolfinx::common::local_range(mpi_rank, shape_hdf5[0],
-                                             dolfinx::MPI::size(comm));
+        range = common::local_range(mpi_rank, shape_hdf5[0],
+                                    dolfinx::MPI::size(comm));
       }
       else if (!shape_xml.empty() and shape_hdf5.size() == 1)
       {
@@ -231,8 +231,8 @@ std::vector<T> get_dataset(MPI_Comm comm, const pugi::xml_node& dataset_node,
         }
 
         // Compute data range to read
-        range = dolfinx::common::local_range(mpi_rank, shape_xml[0],
-                                             dolfinx::MPI::rank(comm));
+        range = common::local_range(mpi_rank, shape_xml[0],
+                                    dolfinx::MPI::rank(comm));
         range[0] *= d;
         range[1] *= d;
       }

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -1054,6 +1054,9 @@ Topology mesh::create_topology(
     std::vector<std::span<const int>> ghost_owners,
     std::span<const std::int64_t> boundary_vertices, int num_threads)
 {
+  if (num_threads < 1)
+    throw std::runtime_error("num_threads must be >= 1.");
+
   common::Timer timer("Topology: create");
 
   assert(cell_types.size() == cells.size());

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -709,22 +709,16 @@ std::vector<std::int32_t> convert_to_local_indexing(
   };
 
   std::vector<std::int32_t> data(g.size());
-  if (num_threads > 1)
+  std::vector<std::jthread> threads;
+  for (int i = 1; i < num_threads; ++i)
   {
-    std::vector<std::jthread> threads;
-    for (int i = 1; i < num_threads; ++i)
-    {
-      auto [c0, c1] = common::local_range(i, g.size(), num_threads);
-      threads.emplace_back(transform, std::span(data.data() + c0, c1 - c0),
-                           g.subspan(c0, c1 - c0), global_to_local);
-    }
+    auto [c0, c1] = common::local_range(i, g.size(), num_threads);
+    threads.emplace_back(transform, std::span(data.data() + c0, c1 - c0),
+                         g.subspan(c0, c1 - c0), global_to_local);
   }
-  else
-  {
-    auto [c0, c1] = common::local_range(0, g.size(), num_threads);
-    transform(std::span(data.data() + c0, c1 - c0), g.subspan(c0, c1 - c0),
-              global_to_local);
-  }
+  auto [c0, c1] = common::local_range(0, g.size(), num_threads);
+  transform(std::span(data.data() + c0, c1 - c0), g.subspan(c0, c1 - c0),
+            global_to_local);
 
   return data;
 }

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -709,6 +709,7 @@ std::vector<std::int32_t> convert_to_local_indexing(
   };
 
   std::vector<std::int32_t> data(g.size());
+  assert(num_threads > 0);
   std::vector<std::jthread> threads;
   for (int i = 1; i < num_threads; ++i)
   {

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -709,18 +709,22 @@ std::vector<std::int32_t> convert_to_local_indexing(
   };
 
   std::vector<std::int32_t> data(g.size());
-  if (num_threads > 0)
+  if (num_threads > 1)
   {
-    std::vector<std::jthread> threads(num_threads);
-    for (int i = 0; i < num_threads; ++i)
+    std::vector<std::jthread> threads;
+    for (int i = 1; i < num_threads; ++i)
     {
-      auto [c0, c1] = dolfinx::common::local_range(i, g.size(), num_threads);
-      threads[i] = std::jthread(transform, std::span(data.data() + c0, c1 - c0),
-                                g.subspan(c0, c1 - c0), global_to_local);
+      auto [c0, c1] = common::local_range(i, g.size(), num_threads);
+      threads.emplace_back(transform, std::span(data.data() + c0, c1 - c0),
+                           g.subspan(c0, c1 - c0), global_to_local);
     }
   }
   else
-    transform(data, g, global_to_local);
+  {
+    auto [c0, c1] = common::local_range(0, g.size(), num_threads);
+    transform(std::span(data.data() + c0, c1 - c0), g.subspan(c0, c1 - c0),
+              global_to_local);
+  }
 
   return data;
 }

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -65,7 +65,7 @@ public:
   /// in `cell_types`.
   /// @param[in] original_cell_index Original indices for each cell in
   /// `cells`.
-  /// @param[in] num_threads Number of threads to use.
+  /// @param[in] num_threads Number of threads to use. Must be >= 1.
   Topology(
       std::vector<CellType> cell_types,
       std::shared_ptr<const common::IndexMap> vertex_map,
@@ -199,7 +199,7 @@ public:
   /// @brief Create entities of given topological dimension.
   ///
   /// @param[in] dim Topological dimension of entities to compute.
-  /// @param[in] num_threads Number of threads to use.
+  /// @param[in] num_threads Number of threads to use. Must be >= 1.
   /// @return True if entities are created, false if entities already
   /// existed.
   bool create_entities(int dim, int num_threads = 1);
@@ -211,6 +211,7 @@ public:
   void create_connectivity(int d0, int d1);
 
   /// @brief Compute entity permutations and reflections.
+  /// @param[in] num_threads Number of threads to use. Must be >= 1.
   void create_entity_permutations(int num_threads = 1);
 
   /// Original cell index for each cell type
@@ -283,7 +284,7 @@ private:
 /// @param[in] boundary_vertices Vertices on the 'exterior' (boundary)
 /// of the local topology. These vertices might appear on other
 /// processes.
-/// @param[in] num_threads Number of threads to use.
+/// @param[in] num_threads Number of threads to use. Must be >= 1.
 /// @return A distributed mesh topology.
 Topology
 create_topology(MPI_Comm comm, const std::vector<CellType>& cell_types,
@@ -315,7 +316,7 @@ create_topology(MPI_Comm comm, const std::vector<CellType>& cell_types,
 /// @param[in] boundary_vertices Vertices on the 'exterior' (boundary)
 /// of the local topology. These vertices might appear on other
 /// processes.
-/// @param[in] num_threads Number of threads to use.
+/// @param[in] num_threads Number of threads to use. Must be >= 1.
 /// @return A distributed mesh topology.
 Topology create_topology(MPI_Comm comm, std::span<const std::int64_t> cells,
                          std::span<const std::int64_t> original_cell_index,

--- a/cpp/dolfinx/mesh/Topology.h
+++ b/cpp/dolfinx/mesh/Topology.h
@@ -65,7 +65,7 @@ public:
   /// in `cell_types`.
   /// @param[in] original_cell_index Original indices for each cell in
   /// `cells`.
-  /// @param[in] num_threads Number of threads to use for entity creation.
+  /// @param[in] num_threads Number of threads to use.
   Topology(
       std::vector<CellType> cell_types,
       std::shared_ptr<const common::IndexMap> vertex_map,
@@ -199,7 +199,7 @@ public:
   /// @brief Create entities of given topological dimension.
   ///
   /// @param[in] dim Topological dimension of entities to compute.
-  /// @param[in] num_threads Number of threads to use for entity creation.
+  /// @param[in] num_threads Number of threads to use.
   /// @return True if entities are created, false if entities already
   /// existed.
   bool create_entities(int dim, int num_threads = 1);
@@ -283,8 +283,7 @@ private:
 /// @param[in] boundary_vertices Vertices on the 'exterior' (boundary)
 /// of the local topology. These vertices might appear on other
 /// processes.
-/// @param[in] num_threads Number of threads to use. Use 0 to not launch
-/// threads.
+/// @param[in] num_threads Number of threads to use.
 /// @return A distributed mesh topology.
 Topology
 create_topology(MPI_Comm comm, const std::vector<CellType>& cell_types,
@@ -316,8 +315,7 @@ create_topology(MPI_Comm comm, const std::vector<CellType>& cell_types,
 /// @param[in] boundary_vertices Vertices on the 'exterior' (boundary)
 /// of the local topology. These vertices might appear on other
 /// processes.
-/// @param[in] num_threads Number of threads to use. Use 0 to not launch
-/// threads.
+/// @param[in] num_threads Number of threads to use.
 /// @return A distributed mesh topology.
 Topology create_topology(MPI_Comm comm, std::span<const std::int64_t> cells,
                          std::span<const std::int64_t> original_cell_index,

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -356,7 +356,7 @@ std::vector<T> create_geom(MPI_Comm comm, std::array<std::array<T, 3>, 2> p,
   }
 
   const std::int64_t n_points = (nx + 1) * (ny + 1) * (nz + 1);
-  const auto [range_begin, range_end] = dolfinx::common::local_range(
+  const auto [range_begin, range_end] = common::local_range(
       dolfinx::MPI::rank(comm), n_points, dolfinx::MPI::size(comm));
 
   std::vector<T> geom;
@@ -394,7 +394,7 @@ Mesh<T> build_tet(MPI_Comm comm, MPI_Comm subcomm,
     const auto [nx, ny, nz] = n;
     const std::int64_t n_cells = nx * ny * nz;
 
-    std::array range_c = dolfinx::common::local_range(
+    std::array range_c = common::local_range(
         dolfinx::MPI::rank(subcomm), n_cells, dolfinx::MPI::size(subcomm));
     cells.reserve(6 * (range_c[1] - range_c[0]) * 4);
 
@@ -444,7 +444,7 @@ build_hex(MPI_Comm comm, MPI_Comm subcomm, std::array<std::array<T, 3>, 2> p,
     // Create cuboids
     const auto [nx, ny, nz] = n;
     const std::int64_t n_cells = nx * ny * nz;
-    std::array range_c = dolfinx::common::local_range(
+    std::array range_c = common::local_range(
         dolfinx::MPI::rank(subcomm), n_cells, dolfinx::MPI::size(subcomm));
     cells.reserve((range_c[1] - range_c[0]) * 8);
     for (std::int64_t i = range_c[0]; i < range_c[1]; ++i)
@@ -488,8 +488,8 @@ Mesh<T> build_prism(MPI_Comm comm, MPI_Comm subcomm,
     const std::int64_t ny = n[1];
     const std::int64_t nz = n[2];
     const std::int64_t n_cells = nx * ny * nz;
-    std::array range_c = dolfinx::common::local_range(
-        dolfinx::MPI::rank(comm), n_cells, dolfinx::MPI::size(comm));
+    std::array range_c = common::local_range(dolfinx::MPI::rank(comm), n_cells,
+                                             dolfinx::MPI::size(comm));
     const std::int64_t cell_range = range_c[1] - range_c[0];
 
     // Create cuboids

--- a/cpp/dolfinx/mesh/permutationcomputation.cpp
+++ b/cpp/dolfinx/mesh/permutationcomputation.cpp
@@ -284,7 +284,7 @@ compute_edge_reflections(const mesh::Topology& topology, int num_threads)
 
         // The number of reflections. Comparing iterators directly instead
         // of values they point to is sufficient here.
-        edge_perm[c][edge] = (it1 < it0) == (vertices[1] > vertices[0]);
+        edge_perm.get()[c][edge] = (it1 < it0) == (vertices[1] > vertices[0]);
       }
     }
   };
@@ -298,12 +298,13 @@ compute_edge_reflections(const mesh::Topology& topology, int num_threads)
   {
     std::array<std::int64_t, 2> range
         = common::local_range(i, c_to_v->num_nodes(), num_threads);
-    threads.emplace_back(process_thread, range, im, edge_perm, c_to_v, e_to_v,
-                         c_to_e, edges_per_cell);
+    threads.emplace_back(process_thread, range, im, std::ref(edge_perm), c_to_v,
+                         e_to_v, c_to_e, edges_per_cell);
   }
   std::array<std::int64_t, 2> range
       = common::local_range(0, c_to_v->num_nodes(), num_threads);
-  process_thread(range, im, edge_perm, c_to_v, e_to_v, c_to_e, edges_per_cell);
+  process_thread(range, im, std::ref(edge_perm), c_to_v, e_to_v, c_to_e,
+                 edges_per_cell);
 
   return edge_perm;
 }

--- a/cpp/dolfinx/mesh/permutationcomputation.cpp
+++ b/cpp/dolfinx/mesh/permutationcomputation.cpp
@@ -217,6 +217,7 @@ compute_triangle_quad_face_permutations(const mesh::Topology& topology,
       auto compute_refl_rots = (mesh_face_types[t] == mesh::CellType::triangle)
                                    ? compute_triangle_rot_reflect
                                    : compute_quad_rot_reflect;
+      assert(num_threads > 0);
       std::vector<std::jthread> threads;
       for (int i : std::ranges::iota_view(1, num_threads))
       {
@@ -292,6 +293,7 @@ compute_edge_reflections(const mesh::Topology& topology, int num_threads)
   // the main task.
 
   std::vector<std::jthread> threads;
+  assert(num_threads > 0);
   for (int i : std::ranges::iota_view(1, num_threads))
   {
     std::array<std::int64_t, 2> range
@@ -334,6 +336,8 @@ mesh::compute_entity_permutations(const mesh::Topology& topology,
                                   int num_threads)
 {
   common::Timer t_perm("Compute entity permutations");
+  assert(num_threads > 0);
+
   const int tdim = topology.dim();
   CellType cell_type = topology.cell_type();
   const std::int32_t num_cells = topology.connectivity(tdim, 0)->num_nodes();

--- a/cpp/dolfinx/mesh/permutationcomputation.cpp
+++ b/cpp/dolfinx/mesh/permutationcomputation.cpp
@@ -167,27 +167,27 @@ compute_triangle_quad_face_permutations(const mesh::Topology& topology,
       auto compute_refl_rots = (mesh_face_types[t] == mesh::CellType::triangle)
                                    ? compute_triangle_rot_reflect
                                    : compute_quad_rot_reflect;
-      spdlog::debug("Using {} threads for face permutation computation",
-                    num_threads);
 
-      auto process_thread = [&](int i)
+      auto process_thread
+          = [im, c_to_v, &face_perm, t, &face_type_indices](
+                std::array<std::int64_t, 2> range, auto&& f_to_v, auto&& c_to_f,
+                auto&& compute_refl_rots)
       {
         std::vector<std::int64_t> cell_vertices, vertices;
         std::vector<std::int32_t> e_vertices;
-        auto range = dolfinx::common::local_range(i, num_cells, num_threads);
-        for (int c = range[0]; c < range[1]; ++c)
+        for (std::int64_t c = range[0]; c < range[1]; ++c)
         {
           cell_vertices.resize(c_to_v->links(c).size());
           im->local_to_global(c_to_v->links(c), cell_vertices);
 
-          auto cell_faces = c_to_f[t]->links(c);
+          auto cell_faces = c_to_f->links(c);
           for (std::size_t j = 0; j < cell_faces.size(); ++j)
           {
             // Get the face
             const int face = cell_faces[j];
-            e_vertices.resize(f_to_v[t]->num_links(face));
-            vertices.resize(f_to_v[t]->num_links(face));
-            im->local_to_global(f_to_v[t]->links(face), vertices);
+            e_vertices.resize(f_to_v->num_links(face));
+            vertices.resize(f_to_v->num_links(face));
+            im->local_to_global(f_to_v->links(face), vertices);
 
             // Orient that triangle or quadrilateral so the lowest
             // numbered vertex is the origin, and the next vertex
@@ -218,10 +218,19 @@ compute_triangle_quad_face_permutations(const mesh::Topology& topology,
 
       // Launch threads for computing face permutations. The first thread is run
       // in the main task.
-      std::vector<std::jthread> threads;
-      for (int i = 1; i < num_threads; ++i)
-        threads.emplace_back(process_thread, i);
-      process_thread(0);
+      if (num_threads > 0)
+      {
+        std::vector<std::jthread> threads;
+        for (int i = 1; i < num_threads; ++i)
+        {
+          std::array<std::int64_t, 2> range
+              = common::local_range(i, num_cells, num_threads);
+          threads.emplace_back(process_thread, range, f_to_v[t], c_to_f[t],
+                               compute_refl_rots);
+        }
+      }
+      else
+        process_thread({0, num_cells}, f_to_v[t], c_to_f[t], compute_refl_rots);
     }
   }
 
@@ -251,12 +260,11 @@ compute_edge_reflections(const mesh::Topology& topology, int num_threads)
   assert(im);
 
   std::vector<std::bitset<BITSETSIZE>> edge_perm(num_cells, 0);
-
-  auto process_thread = [&](int i)
+  auto process_thread = [&im, &c_to_v, &e_to_v, &c_to_e, &edge_perm,
+                         edges_per_cell](std::array<std::int64_t, 2> range)
   {
     std::vector<std::int64_t> cell_vertices, vertices;
-    auto range
-        = dolfinx::common::local_range(i, c_to_v->num_nodes(), num_threads);
+
     for (int c = range[0]; c < range[1]; ++c)
     {
       cell_vertices.resize(c_to_v->num_links(c));
@@ -283,10 +291,21 @@ compute_edge_reflections(const mesh::Topology& topology, int num_threads)
 
   // Launch threads for computing edge reflections. The first thread is run in
   // the main task.
-  std::vector<std::jthread> threads;
-  for (int i = 1; i < num_threads; ++i)
-    threads.emplace_back(process_thread, i);
-  process_thread(0);
+
+  if (num_threads > 0)
+  {
+    std::vector<std::jthread> threads;
+    for (int i = 0; i < num_threads; ++i)
+    {
+      std::array<std::int64_t, 2> range
+          = common::local_range(i, c_to_v->num_nodes(), num_threads);
+      threads.emplace_back(process_thread, range);
+    }
+  }
+  else
+  {
+    process_thread({0, c_to_v->num_nodes()});
+  }
 
   return edge_perm;
 }

--- a/cpp/dolfinx/mesh/permutationcomputation.cpp
+++ b/cpp/dolfinx/mesh/permutationcomputation.cpp
@@ -171,7 +171,6 @@ compute_triangle_quad_face_permutations(const mesh::Topology& topology,
     {
       cell_vertices.resize(c_to_v->links(c).size());
       im->local_to_global(c_to_v->links(c), cell_vertices);
-
       auto cell_faces = c_to_f->links(c);
       for (std::size_t j = 0; j < cell_faces.size(); ++j)
       {
@@ -192,6 +191,7 @@ compute_triangle_quad_face_permutations(const mesh::Topology& topology,
         for (std::size_t k = 0; k < vertices.size(); ++k)
         {
           auto it = std::ranges::find(cell_vertices, vertices[k]);
+          assert(it != cell_vertices.end());
 
           // Get the actual local vertex indices
           e_vertices[k] = std::distance(cell_vertices.begin(), it);
@@ -218,8 +218,6 @@ compute_triangle_quad_face_permutations(const mesh::Topology& topology,
                                    ? compute_triangle_rot_reflect
                                    : compute_quad_rot_reflect;
 
-      // Launch threads for computing face permutations. The first thread is run
-      // in the main task.
       if (num_threads > 1)
       {
         std::vector<std::jthread> threads;
@@ -313,8 +311,10 @@ compute_edge_reflections(const mesh::Topology& topology, int num_threads)
   }
   else
   {
-    process_thread({0, c_to_v->num_nodes()}, im, edge_perm, c_to_v, e_to_v,
-                   c_to_e, edges_per_cell);
+    std::array<std::int64_t, 2> range
+        = common::local_range(0, c_to_v->num_nodes(), num_threads);
+    process_thread(range, im, edge_perm, c_to_v, e_to_v, c_to_e,
+                   edges_per_cell);
   }
 
   return edge_perm;

--- a/cpp/dolfinx/mesh/permutationcomputation.cpp
+++ b/cpp/dolfinx/mesh/permutationcomputation.cpp
@@ -217,25 +217,18 @@ compute_triangle_quad_face_permutations(const mesh::Topology& topology,
       auto compute_refl_rots = (mesh_face_types[t] == mesh::CellType::triangle)
                                    ? compute_triangle_rot_reflect
                                    : compute_quad_rot_reflect;
-
-      if (num_threads > 1)
+      std::vector<std::jthread> threads;
+      for (int i : std::ranges::iota_view(1, num_threads))
       {
-        std::vector<std::jthread> threads;
-        for (int i : std::ranges::iota_view(1, num_threads))
-        {
-          std::array range = common::local_range(i, num_cells, num_threads);
-          threads.emplace_back(process_thread, range, im, std::ref(face_perm),
-                               std::cref(face_type_indices[t]), c_to_v,
-                               f_to_v[t], c_to_f[t], compute_refl_rots);
-        }
+        std::array range = common::local_range(i, num_cells, num_threads);
+        threads.emplace_back(process_thread, range, im, std::ref(face_perm),
+                             std::cref(face_type_indices[t]), c_to_v, f_to_v[t],
+                             c_to_f[t], compute_refl_rots);
       }
-      else
-      {
-        std::array range = common::local_range(0, num_cells, num_threads);
-        process_thread(range, im, std::ref(face_perm),
-                       std::cref(face_type_indices[t]), c_to_v, f_to_v[t],
-                       c_to_f[t], compute_refl_rots);
-      }
+      std::array range = common::local_range(0, num_cells, num_threads);
+      process_thread(range, im, std::ref(face_perm),
+                     std::cref(face_type_indices[t]), c_to_v, f_to_v[t],
+                     c_to_f[t], compute_refl_rots);
     }
   }
 
@@ -298,24 +291,17 @@ compute_edge_reflections(const mesh::Topology& topology, int num_threads)
   // Launch threads for computing edge reflections. The first thread is run in
   // the main task.
 
-  if (num_threads > 1)
-  {
-    std::vector<std::jthread> threads;
-    for (int i : std::ranges::iota_view(1, num_threads))
-    {
-      std::array<std::int64_t, 2> range
-          = common::local_range(i, c_to_v->num_nodes(), num_threads);
-      threads.emplace_back(process_thread, range, im, edge_perm, c_to_v, e_to_v,
-                           c_to_e, edges_per_cell);
-    }
-  }
-  else
+  std::vector<std::jthread> threads;
+  for (int i : std::ranges::iota_view(1, num_threads))
   {
     std::array<std::int64_t, 2> range
-        = common::local_range(0, c_to_v->num_nodes(), num_threads);
-    process_thread(range, im, edge_perm, c_to_v, e_to_v, c_to_e,
-                   edges_per_cell);
+        = common::local_range(i, c_to_v->num_nodes(), num_threads);
+    threads.emplace_back(process_thread, range, im, edge_perm, c_to_v, e_to_v,
+                         c_to_e, edges_per_cell);
   }
+  std::array<std::int64_t, 2> range
+      = common::local_range(0, c_to_v->num_nodes(), num_threads);
+  process_thread(range, im, edge_perm, c_to_v, e_to_v, c_to_e, edges_per_cell);
 
   return edge_perm;
 }

--- a/cpp/dolfinx/mesh/permutationcomputation.cpp
+++ b/cpp/dolfinx/mesh/permutationcomputation.cpp
@@ -13,6 +13,7 @@
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/common/log.h>
 #include <dolfinx/graph/AdjacencyList.h>
+#include <ranges>
 
 namespace
 {
@@ -159,6 +160,55 @@ compute_triangle_quad_face_permutations(const mesh::Topology& topology,
   std::vector<std::bitset<BITSETSIZE>> face_perm(num_cells, 0);
   auto im = topology.index_map(0);
 
+  auto process_thread
+      = [](std::array<std::int64_t, 2> range, auto&& im, auto&& face_perm,
+           auto&& face_type_indices, auto&& c_to_v, auto&& f_to_v,
+           auto&& c_to_f, auto&& compute_refl_rots)
+  {
+    std::vector<std::int64_t> cell_vertices, vertices;
+    std::vector<std::int32_t> e_vertices;
+    for (std::int64_t c = range[0]; c < range[1]; ++c)
+    {
+      cell_vertices.resize(c_to_v->links(c).size());
+      im->local_to_global(c_to_v->links(c), cell_vertices);
+
+      auto cell_faces = c_to_f->links(c);
+      for (std::size_t j = 0; j < cell_faces.size(); ++j)
+      {
+        // Get the face
+        const int face = cell_faces[j];
+        e_vertices.resize(f_to_v->num_links(face));
+        vertices.resize(f_to_v->num_links(face));
+        im->local_to_global(f_to_v->links(face), vertices);
+
+        // Orient that triangle or quadrilateral so the lowest
+        // numbered vertex is the origin, and the next vertex
+        // anticlockwise from the lowest has a lower number than the
+        // next vertex clockwise. Find the index of the lowest
+        // numbered vertex.
+
+        // Find iterators pointing to cell vertex given a vertex on
+        // facet
+        for (std::size_t k = 0; k < vertices.size(); ++k)
+        {
+          auto it = std::ranges::find(cell_vertices, vertices[k]);
+
+          // Get the actual local vertex indices
+          e_vertices[k] = std::distance(cell_vertices.begin(), it);
+        }
+
+        // Compute reflections and rotations for this face type
+        auto [refl, rots] = compute_refl_rots(e_vertices, vertices);
+
+        // Store bits for this face
+        int fi = face_type_indices.get()[j];
+        face_perm.get()[c][3 * fi] = refl;
+        face_perm.get()[c][3 * fi + 1] = rots % 2;
+        face_perm.get()[c][3 * fi + 2] = rots / 2;
+      }
+    }
+  };
+
   for (std::size_t t = 0; t < face_type_indices.size(); ++t)
   {
     spdlog::info("Computing permutations for face type {}", t);
@@ -168,69 +218,26 @@ compute_triangle_quad_face_permutations(const mesh::Topology& topology,
                                    ? compute_triangle_rot_reflect
                                    : compute_quad_rot_reflect;
 
-      auto process_thread
-          = [im, c_to_v, &face_perm, t, &face_type_indices](
-                std::array<std::int64_t, 2> range, auto&& f_to_v, auto&& c_to_f,
-                auto&& compute_refl_rots)
-      {
-        std::vector<std::int64_t> cell_vertices, vertices;
-        std::vector<std::int32_t> e_vertices;
-        for (std::int64_t c = range[0]; c < range[1]; ++c)
-        {
-          cell_vertices.resize(c_to_v->links(c).size());
-          im->local_to_global(c_to_v->links(c), cell_vertices);
-
-          auto cell_faces = c_to_f->links(c);
-          for (std::size_t j = 0; j < cell_faces.size(); ++j)
-          {
-            // Get the face
-            const int face = cell_faces[j];
-            e_vertices.resize(f_to_v->num_links(face));
-            vertices.resize(f_to_v->num_links(face));
-            im->local_to_global(f_to_v->links(face), vertices);
-
-            // Orient that triangle or quadrilateral so the lowest
-            // numbered vertex is the origin, and the next vertex
-            // anticlockwise from the lowest has a lower number than the
-            // next vertex clockwise. Find the index of the lowest
-            // numbered vertex.
-
-            // Find iterators pointing to cell vertex given a vertex on
-            // facet
-            for (std::size_t k = 0; k < vertices.size(); ++k)
-            {
-              auto it = std::ranges::find(cell_vertices, vertices[k]);
-              // Get the actual local vertex indices
-              e_vertices[k] = std::distance(cell_vertices.begin(), it);
-            }
-
-            // Compute reflections and rotations for this face type
-            auto [refl, rots] = compute_refl_rots(e_vertices, vertices);
-
-            // Store bits for this face
-            int fi = face_type_indices[t][j];
-            face_perm[c][3 * fi] = refl;
-            face_perm[c][3 * fi + 1] = rots % 2;
-            face_perm[c][3 * fi + 2] = rots / 2;
-          }
-        }
-      };
-
       // Launch threads for computing face permutations. The first thread is run
       // in the main task.
-      if (num_threads > 0)
+      if (num_threads > 1)
       {
         std::vector<std::jthread> threads;
-        for (int i = 1; i < num_threads; ++i)
+        for (int i : std::ranges::iota_view(1, num_threads))
         {
-          std::array<std::int64_t, 2> range
-              = common::local_range(i, num_cells, num_threads);
-          threads.emplace_back(process_thread, range, f_to_v[t], c_to_f[t],
-                               compute_refl_rots);
+          std::array range = common::local_range(i, num_cells, num_threads);
+          threads.emplace_back(process_thread, range, im, std::ref(face_perm),
+                               std::cref(face_type_indices[t]), c_to_v,
+                               f_to_v[t], c_to_f[t], compute_refl_rots);
         }
       }
       else
-        process_thread({0, num_cells}, f_to_v[t], c_to_f[t], compute_refl_rots);
+      {
+        std::array range = common::local_range(0, num_cells, num_threads);
+        process_thread(range, im, std::ref(face_perm),
+                       std::cref(face_type_indices[t]), c_to_v, f_to_v[t],
+                       c_to_f[t], compute_refl_rots);
+      }
     }
   }
 
@@ -260,11 +267,12 @@ compute_edge_reflections(const mesh::Topology& topology, int num_threads)
   assert(im);
 
   std::vector<std::bitset<BITSETSIZE>> edge_perm(num_cells, 0);
-  auto process_thread = [&im, &c_to_v, &e_to_v, &c_to_e, &edge_perm,
-                         edges_per_cell](std::array<std::int64_t, 2> range)
+  auto process_thread
+      = [](std::array<std::int64_t, 2> range, auto&& im, auto&& edge_perm,
+           auto&& c_to_v, auto&& e_to_v, auto&& c_to_e, int edges_per_cell)
   {
-    std::vector<std::int64_t> cell_vertices, vertices;
-
+    std::vector<std::int64_t> cell_vertices;
+    std::vector<std::int64_t> vertices;
     for (int c = range[0]; c < range[1]; ++c)
     {
       cell_vertices.resize(c_to_v->num_links(c));
@@ -292,19 +300,21 @@ compute_edge_reflections(const mesh::Topology& topology, int num_threads)
   // Launch threads for computing edge reflections. The first thread is run in
   // the main task.
 
-  if (num_threads > 0)
+  if (num_threads > 1)
   {
     std::vector<std::jthread> threads;
-    for (int i = 0; i < num_threads; ++i)
+    for (int i : std::ranges::iota_view(1, num_threads))
     {
       std::array<std::int64_t, 2> range
           = common::local_range(i, c_to_v->num_nodes(), num_threads);
-      threads.emplace_back(process_thread, range);
+      threads.emplace_back(process_thread, range, im, edge_perm, c_to_v, e_to_v,
+                           c_to_e, edges_per_cell);
     }
   }
   else
   {
-    process_thread({0, c_to_v->num_nodes()});
+    process_thread({0, c_to_v->num_nodes()}, im, edge_perm, c_to_v, e_to_v,
+                   c_to_e, edges_per_cell);
   }
 
   return edge_perm;

--- a/cpp/dolfinx/mesh/permutationcomputation.cpp
+++ b/cpp/dolfinx/mesh/permutationcomputation.cpp
@@ -336,8 +336,10 @@ std::pair<std::vector<std::uint8_t>, std::vector<std::uint32_t>>
 mesh::compute_entity_permutations(const mesh::Topology& topology,
                                   int num_threads)
 {
+  if (num_threads < 1)
+    throw std::runtime_error("num_threads must be >= 1.");
+
   common::Timer t_perm("Compute entity permutations");
-  assert(num_threads > 0);
 
   const int tdim = topology.dim();
   CellType cell_type = topology.cell_type();

--- a/cpp/dolfinx/mesh/permutationcomputation.h
+++ b/cpp/dolfinx/mesh/permutationcomputation.h
@@ -68,6 +68,6 @@ class Topology;
 ///
 /// @return Facet permutation and cells permutations
 std::pair<std::vector<std::uint8_t>, std::vector<std::uint32_t>>
-compute_entity_permutations(const Topology& topology, int num_threads = 1);
+compute_entity_permutations(const Topology& topology, int num_threads);
 
 } // namespace dolfinx::mesh

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -675,8 +675,9 @@ compute_entities_by_key_matching(
     };
 
     // Sort the list and label uniquely
+    assert(num_threads > 0);
     const std::vector<std::int32_t> sort_order
-        = num_threads == 0
+        = num_threads == 1
               ? dolfinx::sort_by_perm<std::int32_t, 16>(entity_list_sorted,
                                                         num_vertices_per_entity)
               : sort_threaded(entity_list_sorted, num_vertices_per_entity,

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -572,6 +572,7 @@ compute_entities_by_key_matching(
   }
 
   assert(cell_dim(entity_type) == dim);
+  assert(num_threads > 0);
 
   // Start timer
   common::Timer timer("Compute entities of dim = " + std::to_string(dim));
@@ -615,7 +616,6 @@ compute_entities_by_key_matching(
     int num_entities_per_cell = cell_type_entities[k].size();
     std::size_t num_cells = cells.size() / num_cell_vertices(cell_type);
 
-    assert(num_threads > 0);
     std::vector<std::jthread> threads;
     for (int i = 1; i < num_threads; ++i)
     {
@@ -675,7 +675,6 @@ compute_entities_by_key_matching(
     };
 
     // Sort the list and label uniquely
-    assert(num_threads > 0);
     const std::vector<std::int32_t> sort_order
         = num_threads == 1
               ? dolfinx::sort_by_perm<std::int32_t, 16>(entity_list_sorted,
@@ -871,6 +870,9 @@ std::tuple<std::vector<std::shared_ptr<graph::AdjacencyList<std::int32_t>>>,
 mesh::compute_entities(const Topology& topology, int dim, CellType entity_type,
                        int num_threads)
 {
+  if (num_threads < 1)
+    throw std::runtime_error("num_threads must be >= 1.");
+
   spdlog::info("Computing mesh entities of dimension {}", dim);
 
   // Vertices must always exist

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -614,29 +614,11 @@ compute_entities_by_key_matching(
     std::span<const std::int32_t> cells = std::get<1>(cell_lists[k]);
     int num_entities_per_cell = cell_type_entities[k].size();
     std::size_t num_cells = cells.size() / num_cell_vertices(cell_type);
-    if (num_threads > 1)
+
+    std::vector<std::jthread> threads;
+    for (int i = 1; i < num_threads; ++i)
     {
-      std::vector<std::jthread> threads;
-      for (int i = 1; i < num_threads; ++i)
-      {
-        auto [c0, c1] = common::local_range(i, num_cells, num_threads);
-        std::size_t offset
-            = cell_type_offsets[k] * num_vertices_per_entity
-              + c0 * num_vertices_per_entity * num_entities_per_cell;
-        std::size_t count
-            = (c1 - c0) * num_vertices_per_entity * num_entities_per_cell;
-        auto cells_i = cells.subspan(c0 * num_vertices_per_cell,
-                                     (c1 - c0) * num_vertices_per_cell);
-        threads.emplace_back(
-            build_entity_list, std::span(entity_list.data() + offset, count),
-            std::span(entity_list_sorted.data() + offset, count), cells_i,
-            num_vertices_per_cell, std::cref(e_vertices), entity_type,
-            std::cref(cell_type_entities[k]), std::cref(vertex_index_map));
-      }
-    }
-    else
-    {
-      auto [c0, c1] = common::local_range(0, num_cells, num_threads);
+      auto [c0, c1] = common::local_range(i, num_cells, num_threads);
       std::size_t offset
           = cell_type_offsets[k] * num_vertices_per_entity
             + c0 * num_vertices_per_entity * num_entities_per_cell;
@@ -644,12 +626,24 @@ compute_entities_by_key_matching(
           = (c1 - c0) * num_vertices_per_entity * num_entities_per_cell;
       auto cells_i = cells.subspan(c0 * num_vertices_per_cell,
                                    (c1 - c0) * num_vertices_per_cell);
-      build_entity_list(std::span(entity_list.data() + offset, count),
-                        std::span(entity_list_sorted.data() + offset, count),
-                        cells_i, num_vertices_per_cell, std::cref(e_vertices),
-                        entity_type, std::cref(cell_type_entities[k]),
-                        std::cref(vertex_index_map));
+      threads.emplace_back(
+          build_entity_list, std::span(entity_list.data() + offset, count),
+          std::span(entity_list_sorted.data() + offset, count), cells_i,
+          num_vertices_per_cell, std::cref(e_vertices), entity_type,
+          std::cref(cell_type_entities[k]), std::cref(vertex_index_map));
     }
+    auto [c0, c1] = common::local_range(0, num_cells, num_threads);
+    std::size_t offset = cell_type_offsets[k] * num_vertices_per_entity
+                         + c0 * num_vertices_per_entity * num_entities_per_cell;
+    std::size_t count
+        = (c1 - c0) * num_vertices_per_entity * num_entities_per_cell;
+    auto cells_i = cells.subspan(c0 * num_vertices_per_cell,
+                                 (c1 - c0) * num_vertices_per_cell);
+    build_entity_list(std::span(entity_list.data() + offset, count),
+                      std::span(entity_list_sorted.data() + offset, count),
+                      cells_i, num_vertices_per_cell, std::cref(e_vertices),
+                      entity_type, std::cref(cell_type_entities[k]),
+                      std::cref(vertex_index_map));
   }
 
   // Start numbering entities

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -615,6 +615,7 @@ compute_entities_by_key_matching(
     int num_entities_per_cell = cell_type_entities[k].size();
     std::size_t num_cells = cells.size() / num_cell_vertices(cell_type);
 
+    assert(num_threads > 0);
     std::vector<std::jthread> threads;
     for (int i = 1; i < num_threads; ++i)
     {

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -614,12 +614,12 @@ compute_entities_by_key_matching(
     std::span<const std::int32_t> cells = std::get<1>(cell_lists[k]);
     int num_entities_per_cell = cell_type_entities[k].size();
     std::size_t num_cells = cells.size() / num_cell_vertices(cell_type);
-    if (num_threads > 0)
+    if (num_threads > 1)
     {
-      std::vector<std::jthread> threads(num_threads);
-      for (int i = 0; i < num_threads; ++i)
+      std::vector<std::jthread> threads;
+      for (int i = 1; i < num_threads; ++i)
       {
-        auto [c0, c1] = dolfinx::common::local_range(i, num_cells, num_threads);
+        auto [c0, c1] = common::local_range(i, num_cells, num_threads);
         std::size_t offset
             = cell_type_offsets[k] * num_vertices_per_entity
               + c0 * num_vertices_per_entity * num_entities_per_cell;
@@ -627,7 +627,7 @@ compute_entities_by_key_matching(
             = (c1 - c0) * num_vertices_per_entity * num_entities_per_cell;
         auto cells_i = cells.subspan(c0 * num_vertices_per_cell,
                                      (c1 - c0) * num_vertices_per_cell);
-        threads[i] = std::jthread(
+        threads.emplace_back(
             build_entity_list, std::span(entity_list.data() + offset, count),
             std::span(entity_list_sorted.data() + offset, count), cells_i,
             num_vertices_per_cell, std::cref(e_vertices), entity_type,
@@ -636,12 +636,17 @@ compute_entities_by_key_matching(
     }
     else
     {
-      std::size_t offset = cell_type_offsets[k] * num_vertices_per_entity;
+      auto [c0, c1] = common::local_range(0, num_cells, num_threads);
+      std::size_t offset
+          = cell_type_offsets[k] * num_vertices_per_entity
+            + c0 * num_vertices_per_entity * num_entities_per_cell;
       std::size_t count
-          = num_cells * num_vertices_per_entity * num_entities_per_cell;
+          = (c1 - c0) * num_vertices_per_entity * num_entities_per_cell;
+      auto cells_i = cells.subspan(c0 * num_vertices_per_cell,
+                                   (c1 - c0) * num_vertices_per_cell);
       build_entity_list(std::span(entity_list.data() + offset, count),
                         std::span(entity_list_sorted.data() + offset, count),
-                        cells, num_vertices_per_cell, std::cref(e_vertices),
+                        cells_i, num_vertices_per_cell, std::cref(e_vertices),
                         entity_type, std::cref(cell_type_entities[k]),
                         std::cref(vertex_index_map));
     }

--- a/cpp/dolfinx/mesh/topologycomputation.h
+++ b/cpp/dolfinx/mesh/topologycomputation.h
@@ -36,6 +36,7 @@ enum class CellType : std::int8_t;
 /// @param[in] entity_type Entity type in dimension `dim` to create.
 /// Entity type must be in the list returned by Topology::entity_types.
 /// @param[in] num_threads Number of threads to use for entity creation.
+/// Must be >= 1.
 ///
 /// @return Tuple of (cell->entity connectivity, entity->vertex
 /// connectivity, index map for created entities, list of interprocess

--- a/cpp/dolfinx/mesh/topologycomputation.h
+++ b/cpp/dolfinx/mesh/topologycomputation.h
@@ -47,7 +47,7 @@ std::tuple<std::vector<std::shared_ptr<graph::AdjacencyList<std::int32_t>>>,
            std::shared_ptr<graph::AdjacencyList<std::int32_t>>,
            std::shared_ptr<common::IndexMap>, std::vector<std::int32_t>>
 compute_entities(const Topology& topology, int dim, CellType entity_type,
-                 int num_threads = 0);
+                 int num_threads = 1);
 
 /// @brief Compute connectivity (d0 -> d1) for given pair of entity
 /// types, given by topological dimension and index, as found in

--- a/cpp/dolfinx/mesh/topologycomputation.h
+++ b/cpp/dolfinx/mesh/topologycomputation.h
@@ -36,7 +36,6 @@ enum class CellType : std::int8_t;
 /// @param[in] entity_type Entity type in dimension `dim` to create.
 /// Entity type must be in the list returned by Topology::entity_types.
 /// @param[in] num_threads Number of threads to use for entity creation.
-/// Set to zero to not spawn threads.
 ///
 /// @return Tuple of (cell->entity connectivity, entity->vertex
 /// connectivity, index map for created entities, list of interprocess

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -1174,7 +1174,7 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
                          [](auto& c) { return std::span(c); });
   Topology topology
       = create_topology(comm, celltypes, cells1_v_span, original_idx1_span,
-                        ghost_owners_span, boundary_v, 0);
+                        ghost_owners_span, boundary_v, 1);
 
   // Create connectivities required higher-order geometries for creating
   // a Geometry object

--- a/cpp/test/mesh/refinement/rectangle.cpp
+++ b/cpp/test/mesh/refinement/rectangle.cpp
@@ -95,7 +95,8 @@ plotter.show()
       MPI_COMM_SELF, {{{0, 0}, {1, 1}}}, {1, 1}, mesh::CellType::triangle);
 
   // plaza requires the edges to be pre initialized!
-  mesh.topology()->create_entities(1, std::thread::hardware_concurrency());
+  mesh.topology()->create_entities(
+      1, std::max(1, static_cast<int>(std::thread::hardware_concurrency())));
 
   auto [mesh_fine, parent_cell, parent_facet] = refinement::refine(
       mesh, std::nullopt,

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -184,8 +184,7 @@ class Topology:
 
         Args:
             dim: Topological dimension of entities to create.
-            num_threads: Number of CPU threads to use when creating. If
-                0, threads are not spawned.
+            num_threads: Number of CPU threads to use. Must be >= 1.
 
         Returns:
             ``True` is entities are created, ``False`` is if entities
@@ -194,7 +193,11 @@ class Topology:
         return self._cpp_object.create_entities(dim, num_threads)
 
     def create_entity_permutations(self, num_threads: int = 1):
-        """Compute entity permutations and reflections."""
+        """Compute entity permutations and reflections.
+
+        Args:
+            num_threads: Number of CPU threads to use. Must be >= 1.
+        """
         self._cpp_object.create_entity_permutations(num_threads)
 
     @property

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -179,7 +179,7 @@ class Topology:
         """
         self._cpp_object.create_connectivity(d0, d1)
 
-    def create_entities(self, dim: int, num_threads: int = 0) -> bool:
+    def create_entities(self, dim: int, num_threads: int = 1) -> bool:
         """Create entities of given topological dimension.
 
         Args:

--- a/python/dolfinx/wrappers/dolfinx_wrappers/geometry.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/geometry.h
@@ -221,7 +221,7 @@ void declare_bbtree(nb::module_& m, const std::string& type)
   m.def(
       gjks_name.c_str(),
       [](const std::vector<nb::ndarray<const T, nb::c_contig>>& bodies,
-         nb::ndarray<const T, nb::c_contig> q, size_t num_threads)
+         nb::ndarray<const T, nb::c_contig> q, int num_threads)
       {
         std::size_t q_s0 = num_points_3d(q, "q");
         std::span<const T> _q(q.data(), 3 * q_s0);

--- a/python/test/unit/fem/test_mixed_mesh_dofmap.py
+++ b/python/test/unit/fem/test_mixed_mesh_dofmap.py
@@ -39,7 +39,7 @@ def test_dofmap_mixed_topology():
         orig_index,
         ghost_owners,
         boundary_vertices,
-        0,
+        1,
     )
     # Create dofmaps for Geometry
     tri = coordinate_element(CellType.triangle, 1)
@@ -93,7 +93,7 @@ def test_dofmap_prism_mesh():
 
     topology = Topology(
         create_topology(
-            MPI.COMM_SELF, [CellType.prism], cells, orig_index, ghost_owners, boundary_vertices, 0
+            MPI.COMM_SELF, [CellType.prism], cells, orig_index, ghost_owners, boundary_vertices, 1
         )
     )
     topology.create_entities(2)

--- a/python/test/unit/mesh/test_mixed_topology.py
+++ b/python/test/unit/mesh/test_mixed_topology.py
@@ -45,7 +45,7 @@ def test_mixed_topology_mesh(dtype):
             orig_index,
             ghost_owners,
             boundary_vertices,
-            0,
+            1,
         )
     )
 
@@ -111,7 +111,7 @@ def test_mixed_topology_mesh_3d():
             orig_index,
             ghost_owners,
             boundary_vertices,
-            0,
+            1,
         )
     )
 
@@ -225,7 +225,7 @@ def test_parallel_mixed_mesh(dtype):
         orig_index,
         ghost_owners,
         boundary_vertices,
-        0,
+        1,
     )
 
     # Cell types appear in order as in create_topology


### PR DESCRIPTION
- `num_threads == 1`: Run on calling process
- `num_threads == n` (`n>1`): Spawn `n-1` threads *and* run on calling process
- `num_threads < 1`: Raise exception

And avoid clobbering by capturing reference to all objects.