### PR TITLE
Adapt to FFCx numba relocation

### DIFF
--- a/.github/workflows/fenicsx-refs.env
+++ b/.github/workflows/fenicsx-refs.env
@@ -3,4 +3,4 @@ basix_ref=main
 ufl_repository=FEniCS/ufl
 ufl_ref=main
 ffcx_repository=FEniCS/ffcx
-ffcx_ref=main
+ffcx_ref=schnellerhase/numba-opt

--- a/.github/workflows/fenicsx-refs.env
+++ b/.github/workflows/fenicsx-refs.env
@@ -3,4 +3,4 @@ basix_ref=main
 ufl_repository=FEniCS/ufl
 ufl_ref=main
 ffcx_repository=FEniCS/ffcx
-ffcx_ref=schnellerhase/numba-opt
+ffcx_ref=main

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -61,8 +61,8 @@ from dolfinx.fem.petsc import apply_lifting, assemble_matrix, assemble_vector
 from dolfinx.io import XDMFFile
 from dolfinx.jit import ffcx_jit
 from dolfinx.mesh import locate_entities_boundary, meshtags
-from ffcx.codegeneration.utils import empty_void_pointer
-from ffcx.codegeneration.utils import numba_ufcx_kernel_signature as ufcx_signature
+from ffcx.numba import empty_void_pointer
+from ffcx.numba import numba_ufcx_kernel_signature as ufcx_signature
 
 # -
 

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -61,8 +61,8 @@ from dolfinx.fem.petsc import apply_lifting, assemble_matrix, assemble_vector
 from dolfinx.io import XDMFFile
 from dolfinx.jit import ffcx_jit
 from dolfinx.mesh import locate_entities_boundary, meshtags
-from ffcx.codegeneration.numba import empty_void_pointer
-from ffcx.codegeneration.numba import ufcx_kernel_signature as ufcx_signature
+from ffcx.codegeneration.numba.utils import empty_void_pointer
+from ffcx.codegeneration.numba.utils import ufcx_kernel_signature as ufcx_signature
 
 # -
 

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -61,8 +61,8 @@ from dolfinx.fem.petsc import apply_lifting, assemble_matrix, assemble_vector
 from dolfinx.io import XDMFFile
 from dolfinx.jit import ffcx_jit
 from dolfinx.mesh import locate_entities_boundary, meshtags
-from ffcx.numba import empty_void_pointer
-from ffcx.numba import numba_ufcx_kernel_signature as ufcx_signature
+from ffcx.codegeneration.numba import empty_void_pointer
+from ffcx.codegeneration.numba import ufcx_kernel_signature as ufcx_signature
 
 # -
 

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -22,7 +22,7 @@ cffi = pytest.importorskip("cffi")
 cffi_support = pytest.importorskip("numba.core.typing.cffi_utils")
 numba = pytest.importorskip("numba")
 
-from ffcx.codegeneration.numba import get_void_pointer  # noqa: E402
+from ffcx.codegeneration.numba.utils import get_void_pointer  # noqa: E402
 
 ffi = cffi.FFI()
 

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -10,13 +10,6 @@ import time
 
 from mpi4py import MPI
 
-try:
-    import numba
-
-    from ffcx.codegeneration.utils import get_void_pointer
-except ImportError:
-    pass
-
 import numpy as np
 import pytest
 
@@ -28,6 +21,8 @@ from dolfinx.mesh import create_unit_square
 cffi = pytest.importorskip("cffi")
 cffi_support = pytest.importorskip("numba.core.typing.cffi_utils")
 numba = pytest.importorskip("numba")
+
+from ffcx.numba import get_void_pointer  # noqa: E402
 
 ffi = cffi.FFI()
 

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -22,7 +22,7 @@ cffi = pytest.importorskip("cffi")
 cffi_support = pytest.importorskip("numba.core.typing.cffi_utils")
 numba = pytest.importorskip("numba")
 
-from ffcx.numba import get_void_pointer  # noqa: E402
+from ffcx.codegeneration.numba import get_void_pointer  # noqa: E402
 
 ffi = cffi.FFI()
 

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -22,7 +22,7 @@ from dolfinx.fem import Form, Function, IntegralType, form_cpp_class, functionsp
 from dolfinx.mesh import create_unit_square
 
 numba = pytest.importorskip("numba")
-from ffcx.numba import numba_ufcx_kernel_signature as ufcx_signature  # noqa: E402
+from ffcx.codegeneration.numba import ufcx_kernel_signature as ufcx_signature  # noqa: E402
 
 sys.path.append(os.getcwd())
 

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -15,7 +15,6 @@ import numpy as np
 import pytest
 
 import dolfinx
-import ffcx.codegeneration.utils
 from dolfinx import cpp as _cpp
 from dolfinx import fem, la
 from dolfinx.common import list_timings
@@ -23,7 +22,7 @@ from dolfinx.fem import Form, Function, IntegralType, form_cpp_class, functionsp
 from dolfinx.mesh import create_unit_square
 
 numba = pytest.importorskip("numba")
-ufcx_signature = ffcx.codegeneration.utils.numba_ufcx_kernel_signature
+from ffcx.numba import numba_ufcx_kernel_signature as ufcx_signature  # noqa: E402
 
 sys.path.append(os.getcwd())
 

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -22,7 +22,7 @@ from dolfinx.fem import Form, Function, IntegralType, form_cpp_class, functionsp
 from dolfinx.mesh import create_unit_square
 
 numba = pytest.importorskip("numba")
-from ffcx.codegeneration.numba import ufcx_kernel_signature as ufcx_signature  # noqa: E402
+from ffcx.codegeneration.numba.utils import ufcx_kernel_signature as ufcx_signature  # noqa: E402
 
 sys.path.append(os.getcwd())
 


### PR DESCRIPTION
`FFCx` moved the `numba` related (optional) functionality to `ffcx.codegeneation.numba.utils` - adapt.

Accompanies https://github.com/FEniCS/ffcx/pull/849.