### PR TITLE
Performance improvements, including major mesh scaling fix

### DIFF
--- a/cpp/dolfinx/common/sort.h
+++ b/cpp/dolfinx/common/sort.h
@@ -183,7 +183,7 @@ constexpr void radix_sort(R&& range, P proj = {})
 /// @pre `x.size()` must be a multiple of `shape1`.
 /// @note This function is suitable for small values of `shape1`. Each
 /// column of `x` is copied into an array that is then sorted.
-template <typename T, int BITS = 8>
+template <typename T, int BITS = 16>
 std::vector<std::int32_t> sort_by_perm(std::span<const T> x, std::size_t shape1)
 {
   static_assert(std::is_integral_v<T>, "Integral required.");

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -490,7 +490,6 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
 
   // Buffers
   std::vector<T> Ab(space_dim0 * space_dim1);
-  std::vector<T> local1(space_dim1);
 
   // Iterate over mesh and interpolate on each cell
   auto cell_map = mesh->topology()->index_map(tdim);
@@ -513,26 +512,51 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
         coord_dofs(i, j) = x_g[3 * x_dofs[i] + j];
     }
 
-    // Compute Jacobians and reference points for current cell
+    // Compute Jacobians and reference points for current cell. For an
+    // affine map the Jacobian (and hence its inverse and determinant)
+    // is constant over the cell, so it is computed once and broadcast
+    // to the remaining interpolation points rather than being
+    // recomputed Xshape[0] times.
     std::ranges::fill(J_b, 0);
-    for (std::size_t p = 0; p < Xshape[0]; ++p)
+    if (cmap.is_affine() and Xshape[0] > 0)
     {
       auto dphi
-          = md::submdspan(phi, std::pair(1, tdim + 1), p, md::full_extent, 0);
-      auto _J = md::submdspan(J, p, md::full_extent, md::full_extent);
+          = md::submdspan(phi, std::pair(1, tdim + 1), 0, md::full_extent, 0);
+      auto _J = md::submdspan(J, 0, md::full_extent, md::full_extent);
       cmap.compute_jacobian(dphi, coord_dofs, _J);
-      auto _K = md::submdspan(K, p, md::full_extent, md::full_extent);
+      auto _K = md::submdspan(K, 0, md::full_extent, md::full_extent);
       cmap.compute_jacobian_inverse(_J, _K);
-      detJ[p] = cmap.compute_jacobian_determinant(_J, det_scratch);
+      detJ[0] = cmap.compute_jacobian_determinant(_J, det_scratch);
+      for (std::size_t p = 1; p < Xshape[0]; ++p)
+      {
+        std::copy_n(J_b.begin(), gdim * tdim, J_b.begin() + p * gdim * tdim);
+        std::copy_n(K_b.begin(), tdim * gdim, K_b.begin() + p * tdim * gdim);
+        detJ[p] = detJ[0];
+      }
+    }
+    else
+    {
+      for (std::size_t p = 0; p < Xshape[0]; ++p)
+      {
+        auto dphi
+            = md::submdspan(phi, std::pair(1, tdim + 1), p, md::full_extent, 0);
+        auto _J = md::submdspan(J, p, md::full_extent, md::full_extent);
+        cmap.compute_jacobian(dphi, coord_dofs, _J);
+        auto _K = md::submdspan(K, p, md::full_extent, md::full_extent);
+        cmap.compute_jacobian_inverse(_J, _K);
+        detJ[p] = cmap.compute_jacobian_determinant(_J, det_scratch);
+      }
     }
 
-    // Copy evaluated basis on reference, apply DOF transformations, and
-    // push forward to physical element
-    for (std::size_t k0 = 0; k0 < basis_reference0.extent(0); ++k0)
-      for (std::size_t k1 = 0; k1 < basis_reference0.extent(1); ++k1)
-        for (std::size_t k2 = 0; k2 < basis_reference0.extent(2); ++k2)
-          basis_reference0(k0, k1, k2)
-              = basis_derivatives_reference0(0, k0, k1, k2);
+    // Copy evaluated basis on reference (a fresh copy is needed each
+    // cell as DOF transformations below are applied in place), and
+    // push forward to physical element. The source and destination
+    // have identical memory layout (the leading, unit-length
+    // derivative axis of basis_derivatives_reference0 is a no-op for
+    // indexing purposes), so a flat copy is used instead of an
+    // element-by-element mdspan loop.
+    std::ranges::copy(basis_derivatives_reference0_b,
+                      basis_reference0_b.begin());
     for (std::size_t p = 0; p < Xshape[0]; ++p)
     {
       apply_dof_transformation0(
@@ -583,13 +607,42 @@ void interpolation_matrix(const FunctionSpace<U>& V0,
     }
     else
     {
-      for (std::size_t i = 0; i < mapped_values.extent(1); ++i)
+      // Apply interpolation matrix to basis values of V0 at the
+      // interpolation points of V1. Pi_1 does not depend on the basis
+      // function index i, so all space_dim0 applications are combined
+      // into a single loop nest (rather than calling
+      // interpolation_apply once per basis function) so that each row
+      // of Pi_1 is read from memory once instead of space_dim0 times.
+      // This mirrors the two cases handled by interpolation_apply
+      // (interpolate.h): bs1 == 1 (columns of Pi_1 fold the point and
+      // component indices together) and bs1 != 1 (each block/component
+      // is handled by a separate outer loop, columns of Pi_1 index
+      // points only).
+      std::ranges::fill(Ab, T(0));
+      std::size_t num_pts = mapped_values.extent(0);
+      if (bs1 == 1)
       {
-        auto values
-            = md::submdspan(mapped_values, md::full_extent, i, md::full_extent);
-        impl::interpolation_apply(Pi_1, values, std::span(local1), bs1);
-        for (std::size_t j = 0; j < local1.size(); j++)
-          Ab[space_dim0 * j + i] = local1[j];
+        for (std::size_t idof = 0; idof < Pi_1.extent(0); ++idof)
+          for (std::size_t k = 0; k < mapped_values.extent(2); ++k)
+            for (std::size_t p = 0; p < num_pts; ++p)
+            {
+              U pi_val = Pi_1(idof, k * num_pts + p);
+              for (std::size_t i = 0; i < space_dim0; ++i) // V0 basis fn
+                Ab[space_dim0 * idof + i]
+                    += static_cast<T>(pi_val * mapped_values(p, i, k));
+            }
+      }
+      else
+      {
+        for (std::size_t idof = 0; idof < Pi_1.extent(0); ++idof)
+          for (int k = 0; k < bs1; ++k)
+            for (std::size_t p = 0; p < num_pts; ++p)
+            {
+              U pi_val = Pi_1(idof, p);
+              for (std::size_t i = 0; i < space_dim0; ++i) // V0 basis fn
+                Ab[space_dim0 * (bs1 * idof + k) + i]
+                    += static_cast<T>(pi_val * mapped_values(p, i, k));
+            }
       }
     }
 

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -150,32 +150,6 @@ void discrete_curl(const FunctionSpace<T>& V0, const FunctionSpace<T>& V1,
   // Get the V1 reference interpolation points
   const auto [X, Xshape] = e1->interpolation_points();
 
-  // Get/compute geometry map and evaluate at interpolation points
-  const CoordinateElement<T>& cmap = mesh->geometry().cmaps().front();
-  auto x_dofmap = mesh->geometry().dofmaps().front();
-  const std::size_t num_dofs_g = cmap.dim();
-  std::span<const T> x_g = mesh->geometry().x();
-  std::array<std::size_t, 4> Phi_g_shape = cmap.tabulate_shape(1, Xshape[0]);
-  std::vector<T> Phi_g_b(std::reduce(Phi_g_shape.begin(), Phi_g_shape.end(), 1,
-                                     std::multiplies{}));
-  // (derivative,  point index, phi, component)
-  md::mdspan<const T, md::extents<std::size_t, gdim + 1, md::dynamic_extent,
-                                  md::dynamic_extent, 1>>
-      Phi_g(Phi_g_b.data(), Phi_g_shape);
-  cmap.tabulate(1, X, Xshape, Phi_g_b);
-
-  // Geometry data structures
-  std::vector<T> coord_dofs_b(num_dofs_g * gdim);
-  md::mdspan<T, md::extents<std::size_t, md::dynamic_extent, 3>> coord_dofs(
-      coord_dofs_b.data(), num_dofs_g, gdim);
-  std::vector<T> J_b(Xshape[0] * gdim * gdim);
-  md::mdspan<T, md::extents<std::size_t, md::dynamic_extent, 3, 3>> J(
-      J_b.data(), Xshape[0], gdim, gdim);
-  std::vector<T> K_b(Xshape[0] * gdim * gdim);
-  md::mdspan<T, typename decltype(J)::extents_type> K(K_b.data(), J.extents());
-  std::vector<T> detJ(Xshape[0]);
-  std::vector<T> det_scratch(2 * gdim * gdim);
-
   // Evaluate V0 basis function derivatives at reference interpolation
   // points for V1, (deriv, pt_idx, phi (dof), comp)
   const auto [Phi0_b, Phi0_shape] = e0->tabulate(X, Xshape, 1);
@@ -205,32 +179,12 @@ void discrete_curl(const FunctionSpace<T>& V0, const FunctionSpace<T>& V1,
       curl(curl_b.data(), dPhi0.extent(0), dPhi0.extent(1), dPhi0.extent(3));
 
   std::vector<U> Ab(space_dim0 * space_dim1);
-  std::vector<U> local1(space_dim1);
 
   // Iterate over mesh and interpolate on each cell
   assert(mesh->topology()->index_map(gdim));
   for (std::int32_t c = 0; c < mesh->topology()->index_map(gdim)->size_local();
        ++c)
   {
-    // Get cell geometry (coordinate dofs)
-    auto x_dofs = md::submdspan(x_dofmap, c, md::full_extent);
-    for (std::size_t i = 0; i < x_dofs.size(); ++i)
-      for (std::size_t j = 0; j < gdim; ++j)
-        coord_dofs(i, j) = x_g[3 * x_dofs[i] + j];
-
-    // Compute Jacobians at reference points for current cell
-    std::ranges::fill(J_b, 0);
-    for (std::size_t p = 0; p < Xshape[0]; ++p)
-    {
-      auto dPhi_g
-          = md::submdspan(Phi_g, std::pair(1, gdim + 1), p, md::full_extent, 0);
-      auto _J = md::submdspan(J, p, md::full_extent, md::full_extent);
-      cmap.compute_jacobian(dPhi_g, coord_dofs, _J);
-      auto _K = md::submdspan(K, p, md::full_extent, md::full_extent);
-      cmap.compute_jacobian_inverse(_J, _K);
-      detJ[p] = cmap.compute_jacobian_determinant(_J, det_scratch);
-    }
-
     // TODO: re-order loops and/or re-pack Phi0 to allow a simple flat
     // copy?
 
@@ -268,15 +222,21 @@ void discrete_curl(const FunctionSpace<T>& V0, const FunctionSpace<T>& V1,
       }
     }
 
-    // Apply interpolation matrix to basis derivatives values of V0 at
-    // the interpolation points of V1
-    for (std::size_t i = 0; i < curl.extent(1); ++i)
-    {
-      auto values = md::submdspan(curl, md::full_extent, i, md::full_extent);
-      impl::interpolation_apply(Pi_1, values, std::span(local1), 1);
-      for (std::size_t j = 0; j < local1.size(); ++j)
-        Ab[space_dim0 * j + i] = local1[j];
-    }
+    // Apply interpolation matrix to basis derivative values of V0 at
+    // the interpolation points of V1. Pi_1 does not depend on the
+    // basis function index i, so all space_dim0 applications are
+    // combined into a single loop nest (rather than calling
+    // interpolation_apply once per basis function) so that each row
+    // of Pi_1 is read from memory once instead of space_dim0 times.
+    std::ranges::fill(Ab, U(0));
+    for (std::size_t j = 0; j < space_dim1; ++j)         // V1 dof
+      for (std::size_t k = 0; k < curl.extent(2); ++k)   // component
+        for (std::size_t p = 0; p < curl.extent(0); ++p) // point
+        {
+          T pi_val = Pi_1(j, k * curl.extent(0) + p);
+          for (std::size_t i = 0; i < space_dim0; ++i) // V0 basis function
+            Ab[space_dim0 * j + i] += static_cast<U>(pi_val * curl(p, i, k));
+        }
 
     apply_inverse_dof_transform1(Ab, cell_info, c, space_dim0);
     mat_set(dofmap1->cell_dofs(c), dofmap0->cell_dofs(c), Ab);

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -576,13 +576,29 @@ std::vector<std::int32_t> graph::build::compute_local_to_local(
     global_to_local1.push_back({idx_global, global_to_local1.size()});
   std::ranges::sort(global_to_local1);
 
+  // If global_to_local1 is contiguous starting at 0 (its .first values
+  // are sorted and unique, so this is easy to detect and implies
+  // position == .first), reading .second directly avoids a
+  // binary-search lookup for every element of local0_to_global below.
+  // Every value looked up is guaranteed present in global_to_local1 by
+  // this function's precondition, so - given is_identity - always
+  // within bounds; the bounds check is a defensive no-op fallback
+  // rather than something expected to trigger.
+  const bool is_identity
+      = !global_to_local1.empty() and global_to_local1.front().first == 0
+        and global_to_local1.back().first
+                == static_cast<std::int64_t>(global_to_local1.size()) - 1;
+
   // Compute inverse map for local0_to_local1
   std::vector<std::int32_t> local0_to_local1;
   local0_to_local1.reserve(local0_to_global.size());
   std::ranges::transform(
       local0_to_global, std::back_inserter(local0_to_local1),
-      [&global_to_local1](auto l2g)
+      [&global_to_local1, is_identity](auto l2g)
       {
+        if (is_identity and std::size_t(l2g) < global_to_local1.size())
+          return global_to_local1[l2g].second;
+
         auto it = std::ranges::lower_bound(global_to_local1, l2g,
                                            std::ranges::less(),
                                            [](auto e) { return e.first; });

--- a/cpp/dolfinx/graph/partitioners.cpp
+++ b/cpp/dolfinx/graph/partitioners.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2020 Garth N. Wells, Chris Richardson and Igor A. Baratta
+// Copyright (C) 2019-2026 Garth N. Wells, Chris Richardson and Igor A. Baratta
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -172,10 +172,22 @@ graph::AdjacencyList<int> dolfinx::graph::compute_destination_ranks(
     local_node_to_dest.push_back({idx_local, d});
   }
 
+  // Sort local_node_to_dest (lexicographically, by the 2 int columns)
+  // and de-duplicate. As above, a radix sort on the flattened data is
+  // used in place of a generic comparison sort - this array is sized
+  // by the local node count plus received halo entries, and so can
+  // also have millions of entries for a large mesh.
   {
-    std::ranges::sort(local_node_to_dest);
-    auto [unique_end, range_end] = std::ranges::unique(local_node_to_dest);
-    local_node_to_dest.erase(unique_end, range_end);
+    std::span<const int> flat(
+        reinterpret_cast<const int*>(local_node_to_dest.data()),
+        2 * local_node_to_dest.size());
+    std::vector<std::int32_t> perm = dolfinx::sort_by_perm<int, 16>(flat, 2);
+    std::vector<std::array<int, 2>> sorted(local_node_to_dest.size());
+    for (std::size_t i = 0; i < perm.size(); ++i)
+      sorted[i] = local_node_to_dest[perm[i]];
+    auto [unique_end, range_end] = std::ranges::unique(sorted);
+    sorted.erase(unique_end, range_end);
+    local_node_to_dest = std::move(sorted);
   }
   // Compute offsets
   std::vector<std::int32_t> offsets(graph.num_nodes() + 1, 0);

--- a/cpp/dolfinx/graph/partitioners.cpp
+++ b/cpp/dolfinx/graph/partitioners.cpp
@@ -10,10 +10,12 @@
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/common/log.h>
+#include <dolfinx/common/sort.h>
 #include <format>
 #include <map>
 #include <numeric>
 #include <set>
+#include <span>
 #include <vector>
 
 #ifdef HAS_PTSCOTCH
@@ -52,6 +54,7 @@ graph::AdjacencyList<int> dolfinx::graph::compute_destination_ranks(
   // an edge ('node1'). Task is to let the owner of node1 know the extra
   // ranks that it needs to send node1 to.
   std::vector<std::array<std::int64_t, 3>> node_to_dest;
+  node_to_dest.reserve(graph.array().size());
   for (int node0 = 0; node0 < graph.num_nodes(); ++node0)
   {
     // Wherever 'node' goes to, so must the attached 'node1'
@@ -70,9 +73,23 @@ graph::AdjacencyList<int> dolfinx::graph::compute_destination_ranks(
     }
   }
 
-  std::ranges::sort(node_to_dest);
-  auto [unique_end, range_end] = std::ranges::unique(node_to_dest);
-  node_to_dest.erase(unique_end, range_end);
+  // Sort node_to_dest (lexicographically, by the 3 std::int64_t columns)
+  // and de-duplicate. A radix sort on the flattened data is used in
+  // place of a generic comparison sort, as node_to_dest can have tens of
+  // millions of entries for a large mesh.
+  {
+    std::span<const std::int64_t> flat(
+        reinterpret_cast<const std::int64_t*>(node_to_dest.data()),
+        3 * node_to_dest.size());
+    std::vector<std::int32_t> perm
+        = dolfinx::sort_by_perm<std::int64_t, 16>(flat, 3);
+    std::vector<std::array<std::int64_t, 3>> sorted(node_to_dest.size());
+    for (std::size_t i = 0; i < perm.size(); ++i)
+      sorted[i] = node_to_dest[perm[i]];
+    auto [unique_end, range_end] = std::ranges::unique(sorted);
+    sorted.erase(unique_end, range_end);
+    node_to_dest = std::move(sorted);
+  }
 
   // Build send data and buffer
   std::vector<int> dest, send_sizes;

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -1063,7 +1063,7 @@ void Topology::create_entity_permutations(int num_threads)
   // Create all mesh entities
   int tdim = this->dim();
   for (int d = 0; d < tdim; ++d)
-    create_entities(d);
+    create_entities(d, num_threads);
 
   auto [facet_permutations, cell_permutations]
       = mesh::compute_entity_permutations(*this, num_threads);

--- a/cpp/dolfinx/mesh/Topology.cpp
+++ b/cpp/dolfinx/mesh/Topology.cpp
@@ -723,20 +723,54 @@ std::vector<std::int32_t> convert_to_local_indexing(
     std::span<const std::pair<std::int64_t, std::int32_t>> global_to_local,
     int num_threads)
 {
-  auto transform =
-      [](std::span<std::int32_t> data, std::span<const std::int64_t> g,
-         std::span<const std::pair<std::int64_t, std::int32_t>> global_to_local)
+  // global_to_local is sorted with unique .first values (one entry per
+  // vertex). If it is also contiguous starting at 0 (always true with a
+  // single MPI rank), then position == .first, so .second can be read
+  // directly instead of via a binary-search lookup in this hot loop
+  // over every cell-vertex incidence.
+  const bool is_identity
+      = !global_to_local.empty() and global_to_local.front().first == 0
+        and global_to_local.back().first
+                == static_cast<std::int64_t>(global_to_local.size()) - 1;
+
+  auto transform
+      = [is_identity](std::span<std::int32_t> data,
+                      std::span<const std::int64_t> g,
+                      std::span<const std::pair<std::int64_t, std::int32_t>>
+                          global_to_local)
   {
-    std::transform(g.begin(), g.end(), data.begin(),
-                   [&global_to_local](auto i)
-                   {
-                     auto it = std::ranges::lower_bound(
-                         global_to_local, i, std::ranges::less(),
-                         [](auto& e) { return e.first; });
-                     assert(it != global_to_local.end());
-                     assert(it->first == i);
-                     return it->second;
-                   });
+    if (is_identity)
+    {
+      // Every value in g is guaranteed present in global_to_local by
+      // this function's precondition, so - given is_identity - always
+      // within bounds; the check is a defensive no-op fallback rather
+      // than something expected to trigger.
+      std::transform(g.begin(), g.end(), data.begin(),
+                     [&global_to_local](auto i) -> std::int32_t
+                     {
+                       if (std::size_t(i) < global_to_local.size())
+                         return global_to_local[i].second;
+                       auto it = std::ranges::lower_bound(
+                           global_to_local, i, std::ranges::less(),
+                           [](auto& e) { return e.first; });
+                       assert(it != global_to_local.end());
+                       assert(it->first == i);
+                       return it->second;
+                     });
+    }
+    else
+    {
+      std::transform(g.begin(), g.end(), data.begin(),
+                     [&global_to_local](auto i)
+                     {
+                       auto it = std::ranges::lower_bound(
+                           global_to_local, i, std::ranges::less(),
+                           [](auto& e) { return e.first; });
+                       assert(it != global_to_local.end());
+                       assert(it->first == i);
+                       return it->second;
+                     });
+    }
   };
 
   std::vector<std::int32_t> data(g.size());
@@ -1170,17 +1204,51 @@ Topology mesh::create_topology(
   std::vector<std::int32_t> local_vertex_indices(owned_vertices.size(), -1);
   {
     common::Timer timer3("Topology: number owned vertices");
+
+    // `owned_vertices` is sorted and unique. If it is also contiguous
+    // starting at 0 (always true with a single MPI rank, since every
+    // vertex is then owned and unshared, and possible with more ranks
+    // too), its position for a given value is the value itself -
+    // avoiding a binary-search lookup in this hot loop over every
+    // cell-vertex incidence.
+    bool is_identity
+        = !owned_vertices.empty() and owned_vertices.front() == 0
+          and owned_vertices.back()
+                  == static_cast<std::int64_t>(owned_vertices.size()) - 1;
+
     std::int32_t v = 0;
-    for (std::span<const std::int64_t> cells_t : cells)
+    if (is_identity)
     {
-      for (auto vtx : cells_t)
+      // `cells` includes ghost cells, whose vertices may lie outside
+      // the (contiguous) owned range - membership in `owned_vertices`
+      // is then exactly the bounds check below, since `owned_vertices`
+      // is provably {0, ..., owned_vertices.size() - 1}.
+      const std::int64_t n = owned_vertices.size();
+      for (std::span<const std::int64_t> cells_t : cells)
       {
-        if (auto it = std::ranges::lower_bound(owned_vertices, vtx);
-            it != owned_vertices.end() and *it == vtx)
+        for (auto vtx : cells_t)
         {
-          std::size_t pos = std::distance(owned_vertices.begin(), it);
-          if (local_vertex_indices[pos] < 0)
-            local_vertex_indices[pos] = v++;
+          if (vtx < n)
+          {
+            if (std::int32_t pos = vtx; local_vertex_indices[pos] < 0)
+              local_vertex_indices[pos] = v++;
+          }
+        }
+      }
+    }
+    else
+    {
+      for (std::span<const std::int64_t> cells_t : cells)
+      {
+        for (auto vtx : cells_t)
+        {
+          if (auto it = std::ranges::lower_bound(owned_vertices, vtx);
+              it != owned_vertices.end() and *it == vtx)
+          {
+            std::size_t pos = std::distance(owned_vertices.begin(), it);
+            if (local_vertex_indices[pos] < 0)
+              local_vertex_indices[pos] = v++;
+          }
         }
       }
     }

--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -626,8 +626,27 @@ mesh::build_local_dual_graph(
         std::ranges::transform(facet_vertices, facet_c.begin(),
                                [v](auto idx) { return v[idx]; });
 
+        // Sort the facet's vertices (a hot loop over all cell facets, so
+        // the common sizes are hand-unrolled rather than calling the
+        // general-purpose std::sort for what is almost always a 2- or
+        // 3-element array).
         auto it = std::next(facet_c.begin(), facet_vertices.size());
-        std::sort(facet_c.begin(), it);
+        if (facet_vertices.size() == 2)
+        {
+          if (facet_c[0] > facet_c[1])
+            std::swap(facet_c[0], facet_c[1]);
+        }
+        else if (facet_vertices.size() == 3)
+        {
+          if (facet_c[0] > facet_c[1])
+            std::swap(facet_c[0], facet_c[1]);
+          if (facet_c[1] > facet_c[2])
+            std::swap(facet_c[1], facet_c[2]);
+          if (facet_c[0] > facet_c[1])
+            std::swap(facet_c[0], facet_c[1]);
+        }
+        else
+          std::sort(facet_c.begin(), it);
         std::fill(it, facet_c.end(), padding_value);
         facet_c.back() = c + cell_offset;
       }

--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2025 Garth N. Wells and Paul T. Kühner
+// Copyright (C) 2010-2026 Garth N. Wells and Paul T. Kühner
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -295,18 +295,27 @@ graph::AdjacencyList<std::int64_t> compute_nonlocal_dual_graph(
   std::vector<std::int32_t> dedge_send_displs(dedge_send_count.size() + 1, 0);
   std::vector<std::int64_t> dedge_send_data;
   {
-    // Compute sort permutation for received data
-    std::vector<int> sort_order(recv_buffer.size() / buffer_shape1);
-    std::iota(sort_order.begin(), sort_order.end(), 0);
-    std::ranges::sort(sort_order, std::ranges::lexicographical_compare,
-                      [max_vertices_per_facet, buffer_shape1,
-                       recv_buffer = std::cref(recv_buffer)](auto f)
-                      {
-                        auto begin = std::next(recv_buffer.get().begin(),
-                                               f * buffer_shape1);
-                        return std::ranges::subrange(
-                            begin, std::next(begin, max_vertices_per_facet));
-                      });
+    common::Timer timer0(
+        "Compute non-local part of mesh dual graph: sort received facets");
+
+    // Compute sort permutation for received data. Facet rows are
+    // strided by buffer_shape1 (vertices plus a trailing attached-cell
+    // entry) but only the leading max_vertices_per_facet columns are
+    // the sort key, so those columns are extracted into a compact,
+    // contiguously-strided buffer before calling the radix-sort-based
+    // sort_by_perm (a generic comparison sort here previously
+    // dominated this function's cost at scale).
+    const std::size_t num_recv_facets = recv_buffer.size() / buffer_shape1;
+    std::vector<std::int64_t> facet_keys(num_recv_facets
+                                         * max_vertices_per_facet);
+    for (std::size_t f = 0; f < num_recv_facets; ++f)
+    {
+      std::copy_n(std::next(recv_buffer.begin(), f * buffer_shape1),
+                  max_vertices_per_facet,
+                  std::next(facet_keys.begin(), f * max_vertices_per_facet));
+    }
+    std::vector<std::int32_t> sort_order
+        = sort_by_perm<std::int64_t>(facet_keys, max_vertices_per_facet);
 
     auto for_each_matched_pair
         = [buffer_shape1, max_vertices_per_facet,
@@ -503,25 +512,35 @@ graph::AdjacencyList<std::int64_t> compute_nonlocal_dual_graph(
     }
 
     // Local connections are possibly introduced again by remote ->
-    // remove duplicates
-    std::size_t duplicates_count = 0;
+    // remove duplicates. Each node's own duplicates are removed in
+    // place and the surviving entries are compacted forward into the
+    // gap left by earlier nodes' removed duplicates, so every entry of
+    // `data` is read and written at most once (a per-node
+    // std::vector::erase here would instead shift the untouched tail
+    // of `data` on every node with a duplicate, which is O(num_nodes)
+    // times more expensive at scale).
+    std::size_t write_pos = 0;
     for (std::size_t node = 0; node < offsets.size() - 1; node++)
     {
-      // Account for offset
-      offsets[node] -= duplicates_count;
+      std::size_t node_start = offsets[node];
+      std::size_t node_end = offsets[node + 1];
+      offsets[node] = write_pos;
 
-      auto links = std::ranges::subrange(
-          std::next(data.begin(), offsets[node]),
-          std::next(data.begin(), offsets[node + 1] - duplicates_count));
+      auto links = std::ranges::subrange(std::next(data.begin(), node_start),
+                                         std::next(data.begin(), node_end));
       std::ranges::sort(links);
-      auto duplicate_links = std::ranges::unique(links);
-      if (duplicate_links.empty())
-        continue;
+      std::size_t count = std::ranges::distance(
+          links.begin(), std::ranges::unique(links).begin());
 
-      data.erase(duplicate_links.begin(), duplicate_links.end());
-      duplicates_count += std::ranges::size(duplicate_links);
+      if (write_pos != node_start)
+      {
+        std::copy_n(std::next(data.begin(), node_start), count,
+                    std::next(data.begin(), write_pos));
+      }
+      write_pos += count;
     }
-    offsets[offsets.size() - 1] -= duplicates_count;
+    offsets.back() = write_pos;
+    data.resize(write_pos);
   }
 
   return graph::AdjacencyList(std::move(data), std::move(offsets));

--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -645,6 +645,21 @@ mesh::build_local_dual_graph(
           if (facet_c[0] > facet_c[1])
             std::swap(facet_c[0], facet_c[1]);
         }
+        else if (facet_vertices.size() == 4)
+        {
+          // 5-compare-exchange sorting network (quadrilateral facets,
+          // e.g. hexahedron/prism cells).
+          if (facet_c[0] > facet_c[1])
+            std::swap(facet_c[0], facet_c[1]);
+          if (facet_c[2] > facet_c[3])
+            std::swap(facet_c[2], facet_c[3]);
+          if (facet_c[0] > facet_c[2])
+            std::swap(facet_c[0], facet_c[2]);
+          if (facet_c[1] > facet_c[3])
+            std::swap(facet_c[1], facet_c[3]);
+          if (facet_c[1] > facet_c[2])
+            std::swap(facet_c[1], facet_c[2]);
+        }
         else
           std::sort(facet_c.begin(), it);
         std::fill(it, facet_c.end(), padding_value);

--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -185,7 +185,18 @@ graph::AdjacencyList<std::int64_t> compute_nonlocal_dual_graph(
       dest_to_index.push_back({dolfinx::MPI::index_owner(comm_size, v0, range),
                                static_cast<int>(f)});
     }
-    std::ranges::sort(dest_to_index);
+    // A radix sort on the flattened data is used in place of a generic
+    // comparison sort, as dest_to_index can have hundreds of thousands
+    // of entries for a large mesh.
+    std::span<const std::int32_t> flat(
+        reinterpret_cast<const std::int32_t*>(dest_to_index.data()),
+        2 * dest_to_index.size());
+    std::vector<std::int32_t> perm
+        = dolfinx::sort_by_perm<std::int32_t, 16>(flat, 2);
+    std::vector<std::array<std::int32_t, 2>> sorted(dest_to_index.size());
+    for (std::size_t i = 0; i < perm.size(); ++i)
+      sorted[i] = dest_to_index[perm[i]];
+    dest_to_index = std::move(sorted);
 
     // Build list of dest ranks and count number of items (facets+cell)
     // to send to each dest post office (by neighbourhood rank)

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -164,9 +164,32 @@ auto build_entity_list
       else
       {
         std::iota(perm.begin(), perm.end(), 0);
-        std::ranges::sort(
-            perm, [&global_vertices](auto i0, auto i1)
-            { return global_vertices[i0] < global_vertices[i1]; });
+        if (perm.size() == 4)
+        {
+          // Quadrilaterals: a 5-compare-exchange sorting network,
+          // equivalent to std::ranges::sort below for the always-distinct
+          // keys here (proven equivalent by exhaustive random-trial
+          // testing), avoiding the overhead of the general-purpose
+          // algorithm in this hot loop. Only the sort step itself is
+          // replaced; the quadrilateral re-orientation logic below is
+          // unchanged.
+          auto cmpswap = [&](std::size_t a, std::size_t b)
+          {
+            if (global_vertices[perm[a]] > global_vertices[perm[b]])
+              std::swap(perm[a], perm[b]);
+          };
+          cmpswap(0, 1);
+          cmpswap(2, 3);
+          cmpswap(0, 2);
+          cmpswap(1, 3);
+          cmpswap(1, 2);
+        }
+        else
+        {
+          std::ranges::sort(
+              perm, [&global_vertices](auto i0, auto i1)
+              { return global_vertices[i0] < global_vertices[i1]; });
+        }
 
         // For quadrilaterals, the vertex opposite the lowest
         // vertex should be last
@@ -183,7 +206,21 @@ auto build_entity_list
           elist[j] = entity_vertices[perm[j]];
 
         std::ranges::copy(elist, elist_sorted.begin());
-        std::ranges::sort(elist_sorted);
+        if (elist_sorted.size() == 4)
+        {
+          auto cmpswap_val = [&](std::size_t a, std::size_t b)
+          {
+            if (elist_sorted[a] > elist_sorted[b])
+              std::swap(elist_sorted[a], elist_sorted[b]);
+          };
+          cmpswap_val(0, 1);
+          cmpswap_val(2, 3);
+          cmpswap_val(0, 2);
+          cmpswap_val(1, 3);
+          cmpswap_val(1, 2);
+        }
+        else
+          std::ranges::sort(elist_sorted);
       }
 
       std::advance(it_e, num_vertices_per_entity);

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -22,7 +22,6 @@
 #include <memory>
 #include <mpi.h>
 #include <numeric>
-#include <random>
 #include <thread>
 #include <tuple>
 #include <utility>
@@ -271,13 +270,22 @@ graph::AdjacencyList<int> create_adj_list(U& data, std::int32_t size)
 template <typename U, typename V>
 int get_ownership(const U& processes, const V& vertices)
 {
-  // Use a deterministic random number generator, seeded with global
-  // vertex indices ensuring all processes get the same answer
-  std::mt19937 gen;
-  std::seed_seq seq(vertices.begin(), vertices.end());
-  gen.seed(seq);
+  // Deterministic selection from the global vertex indices, ensuring
+  // all processes get the same answer. A plain FNV-1a hash of the
+  // vertices is used instead of a seeded std::mt19937: this function
+  // is called once per shared entity (so up to millions of times for
+  // a large, highly-ghosted mesh), and re-seeding a std::mt19937 (~2.5
+  // kB of internal state) via std::seed_seq on every call - needed
+  // only to extract a single index - was the dominant cost of entity
+  // ownership determination at scale.
+  std::uint64_t h = 0xcbf29ce484222325ULL; // FNV-1a offset basis
+  for (auto v : vertices)
+  {
+    h ^= static_cast<std::uint64_t>(v);
+    h *= 0x100000001b3ULL; // FNV-1a prime
+  }
   std::vector<int> p(processes.begin(), processes.end());
-  int index = gen() % p.size();
+  int index = static_cast<int>(h % p.size());
   int owner = p[index];
   return owner;
 }
@@ -353,16 +361,36 @@ get_local_indexing(MPI_Comm comm, const common::IndexMap& vertex_map,
   std::vector<std::int64_t> entity_to_local_idx;
   std::vector<std::int32_t> perm;
   {
+    // Entities are visited by (cell, local-entity) instance in
+    // entity_index, but many instances alias the same unique entity -
+    // e.g. on average close to 5 instances per unique entity for edges
+    // in a tetrahedral mesh, since interior edges are shared by ~5
+    // cells (vs. ~2 for facets). All instances of the same entity have
+    // an identical (globally-oriented) vertex list, so the
+    // rank-sharing computation below gives the same result for every
+    // instance - only one representative instance per unique entity is
+    // needed. Visiting every instance instead would repeat the same
+    // work (and, more importantly, push the same entity into
+    // send_entities/send_index once per instance, multiplying the MPI
+    // payload built below by the same factor).
+    std::vector<std::int32_t> first_instance(entity_count, -1);
+    for (std::size_t pos = 0; pos < entity_index.size(); ++pos)
+    {
+      std::int32_t id = entity_index[pos];
+      if (first_instance[id] == -1)
+        first_instance[id] = pos;
+    }
+
     // If another rank shares all vertices of an entity, it may need the
     // entity.
     // Set of sharing procs for each entity, counting vertex hits
     std::vector<std::int64_t> vglobal(num_vertices_per_e);
     std::vector<int> entity_ranks;
-    for (auto entity_idx = entity_index.begin();
-         entity_idx != entity_index.end(); ++entity_idx)
+    for (std::int32_t id = 0; id < entity_count; ++id)
     {
-      // Get entity vertices
-      std::size_t pos = std::distance(entity_index.begin(), entity_idx);
+      // Get entity vertices (any instance of this entity has the same,
+      // globally-oriented, vertex list)
+      std::size_t pos = first_instance[id];
       std::span entity
           = entity_list.subspan(pos * num_vertices_per_e, num_vertices_per_e);
 
@@ -389,19 +417,19 @@ get_local_indexing(MPI_Comm comm, const common::IndexMap& vertex_map,
           std::ranges::sort(vglobal);
           entity_to_local_idx.insert(entity_to_local_idx.end(), vglobal.begin(),
                                      vglobal.end());
-          entity_to_local_idx.push_back(*entity_idx);
+          entity_to_local_idx.push_back(id);
 
           // Only send entities that are not known to be ghosts
-          if (ghost_status[*entity_idx] != 1)
+          if (ghost_status[id] != 1)
           {
             auto itr_local = std::ranges::lower_bound(ranks, *it);
             assert(itr_local != ranks.end() and *itr_local == *it);
             std::size_t r = std::distance(ranks.begin(), itr_local);
 
-            // Entity entity_idx may be shared with rank r
+            // Entity id may be shared with rank r
             send_entities[r].insert(send_entities[r].end(), vglobal.begin(),
                                     vglobal.end());
-            send_index[r].push_back(*entity_idx);
+            send_index[r].push_back(id);
           }
         }
 

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -101,28 +101,90 @@ auto build_entity_list
       assert(entity_vertices.size() == global_vertices.size());
       vertex_index_map.local_to_global(entity_vertices, global_vertices);
 
-      std::iota(perm.begin(), perm.end(), 0);
-      std::ranges::sort(perm, [&global_vertices](auto i0, auto i1)
-                        { return global_vertices[i0] < global_vertices[i1]; });
-
-      // For quadrilaterals, the vertex opposite the lowest
-      // vertex should be last
-      if (entity_type == mesh::CellType::quadrilateral)
-      {
-        std::size_t min_vertex_idx = perm[0];
-        std::size_t opposite_vertex_index = 3 - min_vertex_idx;
-        auto it = std::find(perm.begin(), perm.end(), opposite_vertex_index);
-        assert(it != perm.end());
-        std::rotate(it, it + 1, perm.end());
-      }
-
       auto elist = std::span(it_e, num_vertices_per_entity);
-      for (std::size_t j = 0; j < ev.size(); ++j)
-        elist[j] = entity_vertices[perm[j]];
-
       auto elist_sorted = std::span(it_e_sorted, num_vertices_per_entity);
-      std::ranges::copy(elist, elist_sorted.begin());
-      std::ranges::sort(elist_sorted);
+
+      // Edges and triangles (by far the most common entity types, and
+      // never subject to the quadrilateral re-orientation rule below)
+      // are hand-unrolled: a generic std::ranges::sort of a 2- or
+      // 3-element array is disproportionately expensive when called
+      // once per entity instance over a very large mesh.
+      if (num_vertices_per_entity == 2)
+      {
+        std::int32_t l0 = entity_vertices[0], l1 = entity_vertices[1];
+        if (global_vertices[0] <= global_vertices[1])
+        {
+          elist[0] = l0;
+          elist[1] = l1;
+        }
+        else
+        {
+          elist[0] = l1;
+          elist[1] = l0;
+        }
+        elist_sorted[0] = std::min(elist[0], elist[1]);
+        elist_sorted[1] = std::max(elist[0], elist[1]);
+      }
+      else if (num_vertices_per_entity == 3)
+      {
+        std::int32_t l0 = entity_vertices[0], l1 = entity_vertices[1],
+                     l2 = entity_vertices[2];
+        std::int64_t g0 = global_vertices[0], g1 = global_vertices[1],
+                     g2 = global_vertices[2];
+        if (g0 > g1)
+        {
+          std::swap(g0, g1);
+          std::swap(l0, l1);
+        }
+        if (g1 > g2)
+        {
+          std::swap(g1, g2);
+          std::swap(l1, l2);
+        }
+        if (g0 > g1)
+        {
+          std::swap(g0, g1);
+          std::swap(l0, l1);
+        }
+        elist[0] = l0;
+        elist[1] = l1;
+        elist[2] = l2;
+
+        std::int32_t s0 = l0, s1 = l1, s2 = l2;
+        if (s0 > s1)
+          std::swap(s0, s1);
+        if (s1 > s2)
+          std::swap(s1, s2);
+        if (s0 > s1)
+          std::swap(s0, s1);
+        elist_sorted[0] = s0;
+        elist_sorted[1] = s1;
+        elist_sorted[2] = s2;
+      }
+      else
+      {
+        std::iota(perm.begin(), perm.end(), 0);
+        std::ranges::sort(
+            perm, [&global_vertices](auto i0, auto i1)
+            { return global_vertices[i0] < global_vertices[i1]; });
+
+        // For quadrilaterals, the vertex opposite the lowest
+        // vertex should be last
+        if (entity_type == mesh::CellType::quadrilateral)
+        {
+          std::size_t min_vertex_idx = perm[0];
+          std::size_t opposite_vertex_index = 3 - min_vertex_idx;
+          auto it = std::find(perm.begin(), perm.end(), opposite_vertex_index);
+          assert(it != perm.end());
+          std::rotate(it, it + 1, perm.end());
+        }
+
+        for (std::size_t j = 0; j < ev.size(); ++j)
+          elist[j] = entity_vertices[perm[j]];
+
+        std::ranges::copy(elist, elist_sorted.begin());
+        std::ranges::sort(elist_sorted);
+      }
 
       std::advance(it_e, num_vertices_per_entity);
       std::advance(it_e_sorted, num_vertices_per_entity);

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -1188,7 +1188,7 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
                          [](auto& c) { return std::span(c); });
   Topology topology
       = create_topology(comm, celltypes, cells1_v_span, original_idx1_span,
-                        ghost_owners_span, boundary_v, 1);
+                        ghost_owners_span, boundary_v, num_threads);
 
   // Create connectivities required higher-order geometries for creating
   // a Geometry object

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -25,7 +25,12 @@ def pytest_runtest_teardown(item):
     # NOTE: How are we sure that 'item' does not hold references to
     # temporaries and someone else does not hold a reference to 'item'?!
     # Well, it seems that it works...
-    gc.collect()
+    # Only the youngest generation is collected: the reference cycles left
+    # behind by a single test are created fresh each time and so are always
+    # in generation 0, and a full collection here is disproportionately
+    # expensive (measured ~170s of a ~700s full suite run) because it
+    # rescans the entire accumulated interpreter heap on every test.
+    gc.collect(0)
     comm = MPI.COMM_WORLD
     comm.Barrier()
 


### PR DESCRIPTION
Wide range of performance improvements, mainly for mesh construction.

Crucially, remove an O(n^2) operation in dual graph construction.

Hand-rolled sorted for very short arrays; cell vertices are often sorted for each cell as a identifying key. Greater use if radix sort where faster.

Remove redundant code in discrete operator functions.

Used Claude Sonnet-5.