### PR TITLE
Scatter.h const fix and consistent use of namespace dolfinx::MPI

### DIFF
--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -343,9 +343,9 @@ public:
       return;
 
     int ierr = MPI_Ineighbor_alltoallv(
-        send_buffer, _sizes_remote.data(), _displs_remote.data(), MPI::mpi_t<T>,
-        recv_buffer, _sizes_local.data(), _displs_local.data(), MPI::mpi_t<T>,
-        _comm1.comm(), &request);
+        send_buffer, _sizes_remote.data(), _displs_remote.data(),
+        dolfinx::MPI::mpi_t<T>, recv_buffer, _sizes_local.data(),
+        _displs_local.data(), dolfinx::MPI::mpi_t<T>, _comm1.comm(), &request);
     dolfinx::MPI::check_error(_comm1.comm(), ierr);
   }
 
@@ -489,7 +489,10 @@ public:
   /// communication.
   ///
   /// @return Number of required MPI request handles.
-  std::size_t num_p2p_requests() { return _dest.size() + _src.size(); }
+  std::size_t num_p2p_requests() const noexcept
+  {
+    return _dest.size() + _src.size();
+  }
 
 private:
   // Communicator where the source ranks own the indices in the callers


### PR DESCRIPTION
Very minor tweaks to Scatterer.h.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
