### PR TITLE
Wait after non-blocking send before function return

### DIFF
--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -151,6 +151,11 @@ dolfinx::MPI::compute_graph_edges_pcx(MPI_Comm comm, std::span<const int> edges)
     }
   }
 
+  // Complete sends before send_buffer is destroyed
+  err = MPI_Waitall(send_requests.size(), send_requests.data(),
+                    MPI_STATUSES_IGNORE);
+  dolfinx::MPI::check_error(comm, err);
+
   spdlog::info("Finished graph edge discovery using PCX algorithm. Number "
                "of discovered edges {}",
                static_cast<int>(other_ranks.size()));


### PR DESCRIPTION
The function posts `MPI_Isends` that read from `send_buffer`, a local vector destroyed on return. MPI requires the send buffer stay valid until the request completes. `MPI_Waitall` enforces local send completion before `return`.