### PR TITLE
Harden NBX consensus and streamline MPI post-office code

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -12,6 +12,7 @@
 #include <functional>
 #include <numeric>
 #include <ranges>
+#include <set>
 #include <span>
 #include <utility>
 #include <vector>

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -172,23 +172,20 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
       "of input edges: {}",
       static_cast<int>(edges.size()));
 
-  // Duplicate comm so this call's messages can't be confused with an
-  // overlapping call using the same tag.
+  // Duplicate comm so concurrent calls can't collide on messages.
   dolfinx::MPI::Comm nbx_comm(comm, true);
   const MPI_Comm comm0 = nbx_comm.comm();
 
-  // Post a persistent listener. Posting the receive ahead of arrival,
-  // rather than probing reactively, lets MPI treat it as an expected
-  // message and avoid unexpected-message buffering overhead.
+  // Post the receive before arrival (vs. probing reactively) so MPI
+  // treats it as an expected message, avoiding buffering overhead.
   std::byte buffer_recv;
   MPI_Request recv_request;
   int err = MPI_Irecv(&buffer_recv, 1, MPI_BYTE, MPI_ANY_SOURCE, tag, comm0,
                       &recv_request);
   dolfinx::MPI::check_error(comm0, err);
 
-  // Start non-blocking synchronised send. The message content is never
-  // inspected (only its arrival matters), so every send can share the
-  // same source buffer.
+  // Synchronised, non-blocking send; content is never inspected (only
+  // arrival matters), so every send shares one source buffer.
   std::vector<MPI_Request> send_requests(edges.size());
   std::byte send_buffer{0};
   for (std::size_t e = 0; e < edges.size(); ++e)
@@ -249,11 +246,9 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
     }
   }
 
-  // No more messages can arrive once the barrier has completed, so
-  // cancel the still-outstanding listener. A sender's Issend only
-  // requires the receive to be posted, not yet observed by this rank,
-  // so cancellation can race with a real match; if so, record it
-  // instead of discarding it.
+  // Cancel the listener once the barrier confirms no more messages can
+  // arrive. Issend only needs the receive posted, not yet observed, so
+  // cancellation can race with a real match -- record it if so.
   err = MPI_Cancel(&recv_request);
   dolfinx::MPI::check_error(comm0, err);
   MPI_Status cancel_status;

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -172,19 +172,14 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
       "of input edges: {}",
       static_cast<int>(edges.size()));
 
-  // Duplicate comm so this call's messages can't be confused with an
-  // overlapping call using the same tag.
-  dolfinx::MPI::Comm nbx_comm(comm, true);
-  const MPI_Comm comm0 = nbx_comm.comm();
-
   // Post a persistent listener. Posting the receive ahead of arrival,
   // rather than probing reactively, lets MPI treat it as an expected
   // message and avoid unexpected-message buffering overhead.
   std::byte buffer_recv;
   MPI_Request recv_request;
-  int err = MPI_Irecv(&buffer_recv, 1, MPI_BYTE, MPI_ANY_SOURCE, tag, comm0,
+  int err = MPI_Irecv(&buffer_recv, 1, MPI_BYTE, MPI_ANY_SOURCE, tag, comm,
                       &recv_request);
-  dolfinx::MPI::check_error(comm0, err);
+  dolfinx::MPI::check_error(comm, err);
 
   // Start non-blocking synchronised send. The message content is never
   // inspected (only its arrival matters), so every send can share the
@@ -193,9 +188,9 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
   std::byte send_buffer{0};
   for (std::size_t e = 0; e < edges.size(); ++e)
   {
-    int err = MPI_Issend(&send_buffer, 1, MPI_BYTE, edges[e], tag, comm0,
+    int err = MPI_Issend(&send_buffer, 1, MPI_BYTE, edges[e], tag, comm,
                          &send_requests[e]);
-    dolfinx::MPI::check_error(comm0, err);
+    dolfinx::MPI::check_error(comm, err);
   }
 
   // Vector to hold ranks that send data to this rank
@@ -211,16 +206,16 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
     int flag_recv;
     MPI_Status status;
     int err = MPI_Test(&recv_request, &flag_recv, &status);
-    dolfinx::MPI::check_error(comm0, err);
+    dolfinx::MPI::check_error(comm, err);
     while (flag_recv)
     {
       src_ranks.push_back(status.MPI_SOURCE);
-      int err = MPI_Irecv(&buffer_recv, 1, MPI_BYTE, MPI_ANY_SOURCE, tag, comm0,
+      int err = MPI_Irecv(&buffer_recv, 1, MPI_BYTE, MPI_ANY_SOURCE, tag, comm,
                           &recv_request);
-      dolfinx::MPI::check_error(comm0, err);
+      dolfinx::MPI::check_error(comm, err);
 
       err = MPI_Test(&recv_request, &flag_recv, &status);
-      dolfinx::MPI::check_error(comm0, err);
+      dolfinx::MPI::check_error(comm, err);
     }
 
     if (barrier_active)
@@ -228,7 +223,7 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
       // Check for barrier completion
       int flag = 0;
       int err = MPI_Test(&barrier_request, &flag, MPI_STATUS_IGNORE);
-      dolfinx::MPI::check_error(comm0, err);
+      dolfinx::MPI::check_error(comm, err);
       if (flag)
         comm_complete = true;
     }
@@ -238,12 +233,12 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
       int flag = 0;
       int err = MPI_Testall(send_requests.size(), send_requests.data(), &flag,
                             MPI_STATUSES_IGNORE);
-      dolfinx::MPI::check_error(comm0, err);
+      dolfinx::MPI::check_error(comm, err);
       if (flag)
       {
         // All sends have completed, start non-blocking barrier
-        int err = MPI_Ibarrier(comm0, &barrier_request);
-        dolfinx::MPI::check_error(comm0, err);
+        int err = MPI_Ibarrier(comm, &barrier_request);
+        dolfinx::MPI::check_error(comm, err);
         barrier_active = true;
       }
     }
@@ -255,10 +250,10 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
   // so cancellation can race with a real match; if so, record it
   // instead of discarding it.
   err = MPI_Cancel(&recv_request);
-  dolfinx::MPI::check_error(comm0, err);
+  dolfinx::MPI::check_error(comm, err);
   MPI_Status cancel_status;
   err = MPI_Wait(&recv_request, &cancel_status);
-  dolfinx::MPI::check_error(comm0, err);
+  dolfinx::MPI::check_error(comm, err);
   int cancelled;
   MPI_Test_cancelled(&cancel_status, &cancelled);
   if (!cancelled)

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -112,12 +112,11 @@ dolfinx::MPI::compute_graph_edges_pcx(MPI_Comm comm, std::span<const int> edges)
   // rank
   const int size = dolfinx::MPI::size(comm);
   std::vector<int> edge_count_send(size, 0);
-  for (auto e : edges)
+  for (int e : edges)
     edge_count_send[e] = 1;
 
-  // Determine how many in-edges this rank has. All ranks receive the
-  // same single-int block, so *_block avoids an O(size) recvcounts
-  // array of all-ones.
+  // Determine how many in-edges this rank has. All ranks get the same
+  // single-int block, so _block avoids an O(size) recvcounts array.
   int in_edges = 0;
   MPI_Request request_scatter;
   int err = MPI_Ireduce_scatter_block(edge_count_send.data(), &in_edges, 1,
@@ -136,10 +135,9 @@ dolfinx::MPI::compute_graph_edges_pcx(MPI_Comm comm, std::span<const int> edges)
     dolfinx::MPI::check_error(comm, err);
   }
 
-  // Receive exactly in_edges messages and record their source. A
-  // blocking recv is fine here (unlike NBX): the exact count is
-  // already known, so there is nothing to poll for and no risk of
-  // burning CPU cycles waiting on a message that may never arrive.
+  // Receive exactly in_edges messages, recording each source. A
+  // blocking recv is fine here (unlike NBX): the count is already
+  // known, so there is nothing to poll for.
   err = MPI_Wait(&request_scatter, MPI_STATUS_IGNORE);
   dolfinx::MPI::check_error(comm, err);
   std::vector<int> other_ranks;

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -5,10 +5,15 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "MPI.h"
+#include "sort.h"
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <dolfinx/common/log.h>
 #include <iostream>
+#include <iterator>
+#include <span>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -101,7 +106,7 @@ dolfinx::MPI::compute_graph_edges_pcx(MPI_Comm comm, std::span<const int> edges)
   spdlog::info(
       "Computing communication graph edges (using PCX algorithm). Number "
       "of input edges: {}",
-      static_cast<int>(edges.size()));
+      edges.size());
 
   // Build array with '0' for no outedge and '1' for an outedge for each
   // rank
@@ -162,7 +167,7 @@ dolfinx::MPI::compute_graph_edges_pcx(MPI_Comm comm, std::span<const int> edges)
 
   spdlog::info("Finished graph edge discovery using PCX algorithm. Number "
                "of discovered edges {}",
-               static_cast<int>(other_ranks.size()));
+               other_ranks.size());
 
   return other_ranks;
 }
@@ -297,14 +302,14 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
   spdlog::info(
       "Computing communication graph edges (using NBX algorithm). Number "
       "of input edges: {}",
-      static_cast<int>(edges.size()));
+      edges.size());
 
   std::array<std::vector<int>, 1> src_ranks
       = ::nbx_consensus_rounds<1>(comm, {edges}, {tag});
 
   spdlog::info("Finished graph edge discovery using NBX algorithm. Number "
                "of discovered edges {}",
-               static_cast<int>(src_ranks[0].size()));
+               src_ranks[0].size());
 
   return std::move(src_ranks[0]);
 }
@@ -318,16 +323,82 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
   spdlog::info(
       "Computing communication graph edges for two overlapped consensus "
       "rounds (using NBX algorithm). Number of input edges: {}, {}",
-      static_cast<int>(edges0.size()), static_cast<int>(edges1.size()));
+      edges0.size(), edges1.size());
 
   std::array<std::vector<int>, 2> src_ranks
       = ::nbx_consensus_rounds<2>(comm, {edges0, edges1}, {tag0, tag1});
 
   spdlog::info("Finished overlapped graph edge discovery using NBX "
                "algorithm. Number of discovered edges {}, {}",
-               static_cast<int>(src_ranks[0].size()),
-               static_cast<int>(src_ranks[1].size()));
+               src_ranks[0].size(), src_ranks[1].size());
 
   return {std::move(src_ranks[0]), std::move(src_ranks[1])};
+}
+//-----------------------------------------------------------------------------
+std::tuple<std::vector<int>, std::vector<std::int32_t>,
+           std::vector<std::int32_t>>
+dolfinx::MPI::impl::postoffice_plan(int size, int rank,
+                                    std::int32_t shape0_local,
+                                    std::int64_t shape0,
+                                    std::int64_t rank_offset)
+{
+  // Build list of (dest, positions) for each row that doesn't belong to
+  // this rank, then sort
+  std::vector<std::array<std::int32_t, 2>> dest_to_index;
+  dest_to_index.reserve(shape0_local);
+  for (std::int32_t i = 0; i < shape0_local; ++i)
+  {
+    std::size_t idx = i + rank_offset;
+    if (int dest = MPI::index_owner(size, idx, shape0); dest != rank)
+      dest_to_index.push_back({dest, i});
+  }
+
+  // Radix sort (not a comparison sort): dest_to_index can have
+  // hundreds of thousands of entries for a large mesh/problem.
+  {
+    std::span<const std::int32_t> flat(
+        reinterpret_cast<const std::int32_t*>(dest_to_index.data()),
+        2 * dest_to_index.size());
+    std::vector<std::int32_t> perm
+        = dolfinx::sort_by_perm<std::int32_t, 16>(flat, 2);
+    std::vector<std::array<std::int32_t, 2>> sorted(dest_to_index.size());
+    for (std::size_t i = 0; i < perm.size(); ++i)
+      sorted[i] = dest_to_index[perm[i]];
+    dest_to_index = std::move(sorted);
+  }
+
+  // Build list of neighbour src ranks and count number of items (rows
+  // of x) to receive from each src post office (by neighbourhood rank)
+  std::vector<int> dest;
+  std::vector<std::int32_t> num_items_per_dest,
+      pos_to_neigh_rank(shape0_local, -1);
+  {
+    auto it = dest_to_index.begin();
+    while (it != dest_to_index.end())
+    {
+      const int neigh_rank = dest.size();
+
+      // Store global rank
+      dest.push_back((*it)[0]);
+
+      // Find iterator to next global rank
+      auto it1
+          = std::find_if(it, dest_to_index.end(),
+                         [r = dest.back()](auto& idx) { return idx[0] != r; });
+
+      // Store number of items for current rank
+      num_items_per_dest.push_back(std::distance(it, it1));
+
+      // Map from local x index to local destination rank
+      for (auto e = it; e != it1; ++e)
+        pos_to_neigh_rank[(*e)[1]] = neigh_rank;
+
+      // Advance iterator
+      it = it1;
+    }
+  }
+
+  return {std::move(dest), std::move(num_items_per_dest),
+          std::move(pos_to_neigh_rank)};
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -249,8 +249,11 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
     }
   }
 
-  // No more messages can arrive once the barrier has completed;
-  // cancel the still-outstanding listener.
+  // No more messages can arrive once the barrier has completed, so
+  // cancel the still-outstanding listener. A sender's Issend only
+  // requires the receive to be posted, not yet observed by this rank,
+  // so cancellation can race with a real match; if so, record it
+  // instead of discarding it.
   err = MPI_Cancel(&recv_request);
   dolfinx::MPI::check_error(comm0, err);
   MPI_Status cancel_status;
@@ -258,7 +261,8 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
   dolfinx::MPI::check_error(comm0, err);
   int cancelled;
   MPI_Test_cancelled(&cancel_status, &cancelled);
-  assert(cancelled);
+  if (!cancelled)
+    src_ranks.push_back(cancel_status.MPI_SOURCE);
 
   spdlog::info("Finished graph edge discovery using NBX algorithm. Number "
                "of discovered edges {}",

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -5,8 +5,12 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "MPI.h"
+#include <array>
+#include <cstddef>
 #include <dolfinx/common/log.h>
 #include <iostream>
+#include <utility>
+#include <vector>
 
 //-----------------------------------------------------------------------------
 dolfinx::MPI::Comm::Comm(MPI_Comm comm, bool duplicate)
@@ -163,158 +167,65 @@ dolfinx::MPI::compute_graph_edges_pcx(MPI_Comm comm, std::span<const int> edges)
   return other_ranks;
 }
 //-----------------------------------------------------------------------------
-std::vector<int>
-dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
-                                      int tag)
+namespace
 {
-  spdlog::info(
-      "Computing communication graph edges (using NBX algorithm). Number "
-      "of input edges: {}",
-      static_cast<int>(edges.size()));
-
-  // Post the receive before arrival (vs. probing reactively) so MPI
-  // treats it as an expected message, avoiding buffering overhead.
-  std::byte buffer_recv;
-  MPI_Request recv_request;
-  int err = MPI_Irecv(&buffer_recv, 1, MPI_BYTE, MPI_ANY_SOURCE, tag, comm,
-                      &recv_request);
-  dolfinx::MPI::check_error(comm, err);
-
-  // Synchronised, non-blocking send; content is never inspected (only
-  // arrival matters), so every send shares one source buffer.
-  std::vector<MPI_Request> send_requests(edges.size());
-  std::byte send_buffer{0};
-  for (std::size_t e = 0; e < edges.size(); ++e)
+/// @brief Shared implementation behind both MPI::compute_graph_edges_nbx
+/// overloads: run K independent NBX consensus rounds concurrently
+/// behind a single shared barrier (K=1 for the plain, single-edge-set
+/// case).
+///
+/// Each edge set is distinguished by its own tag, so K persistent
+/// listeners can be posted up front and a message for one round is
+/// never mistaken for another.
+template <std::size_t K>
+std::array<std::vector<int>, K>
+nbx_consensus_rounds(MPI_Comm comm, std::array<std::span<const int>, K> edges,
+                     std::array<int, K> tags)
+{
+  // Post a persistent listener per edge set. Posting ahead of arrival
+  // (vs. probing reactively) lets MPI treat each as an expected
+  // message, avoiding buffering overhead.
+  std::array<std::byte, K> buffer_recv;
+  std::array<MPI_Request, K> recv_request;
+  for (std::size_t i = 0; i < K; ++i)
   {
-    int err = MPI_Issend(&send_buffer, 1, MPI_BYTE, edges[e], tag, comm,
-                         &send_requests[e]);
+    int err = MPI_Irecv(&buffer_recv[i], 1, MPI_BYTE, MPI_ANY_SOURCE, tags[i],
+                        comm, &recv_request[i]);
     dolfinx::MPI::check_error(comm, err);
   }
 
-  // Vector to hold ranks that send data to this rank
-  std::vector<int> src_ranks;
+  // Synchronised, non-blocking sends; content is never inspected (only
+  // arrival matters), so every send shares one source buffer. Pack all
+  // K sets into one flat request array so "have all sends completed"
+  // below is a single MPI_Testall call.
+  std::array<std::size_t, K + 1> send_offset{0};
+  for (std::size_t i = 0; i < K; ++i)
+    send_offset[i + 1] = send_offset[i] + edges[i].size();
+  std::vector<MPI_Request> send_requests(send_offset[K]);
+  std::byte send_buffer{0};
+  for (std::size_t i = 0; i < K; ++i)
+  {
+    for (std::size_t e = 0; e < edges[i].size(); ++e)
+    {
+      int err = MPI_Issend(&send_buffer, 1, MPI_BYTE, edges[i][e], tags[i],
+                           comm, &send_requests[send_offset[i] + e]);
+      dolfinx::MPI::check_error(comm, err);
+    }
+  }
 
-  // Start sending/receiving
+  // Ranks that send to this rank, per edge set
+  std::array<std::vector<int>, K> src_ranks;
+
+  // Start sending/receiving. A single barrier covers all K sets: it
+  // can only start once every send, across all sets, has completed.
   MPI_Request barrier_request;
   bool comm_complete = false;
   bool barrier_active = false;
   while (!comm_complete)
   {
-    // Drain all currently queued messages
-    int flag_recv;
-    MPI_Status status;
-    int err = MPI_Test(&recv_request, &flag_recv, &status);
-    dolfinx::MPI::check_error(comm, err);
-    while (flag_recv)
+    // Drain all currently queued messages, for each edge set
+    for (std::size_t i = 0; i < K; ++i)
     {
-      src_ranks.push_back(status.MPI_SOURCE);
-      int err = MPI_Irecv(&buffer_recv, 1, MPI_BYTE, MPI_ANY_SOURCE, tag, comm,
-                          &recv_request);
-      dolfinx::MPI::check_error(comm, err);
-
-      err = MPI_Test(&recv_request, &flag_recv, &status);
-      dolfinx::MPI::check_error(comm, err);
-    }
-
-    if (barrier_active)
-    {
-      // Check for barrier completion
-      int flag = 0;
-      int err = MPI_Test(&barrier_request, &flag, MPI_STATUS_IGNORE);
-      dolfinx::MPI::check_error(comm, err);
-      if (flag)
-        comm_complete = true;
-    }
-    else
-    {
-      // Check if all sends have completed
-      int flag = 0;
-      int err = MPI_Testall(send_requests.size(), send_requests.data(), &flag,
-                            MPI_STATUSES_IGNORE);
-      dolfinx::MPI::check_error(comm, err);
-      if (flag)
-      {
-        // All sends have completed, start non-blocking barrier
-        int err = MPI_Ibarrier(comm, &barrier_request);
-        dolfinx::MPI::check_error(comm, err);
-        barrier_active = true;
-      }
-    }
-  }
-
-  // Cancel the listener once the barrier confirms no more messages can
-  // arrive. Issend only needs the receive posted, not yet observed, so
-  // cancellation can race with a real match -- record it if so.
-  err = MPI_Cancel(&recv_request);
-  dolfinx::MPI::check_error(comm, err);
-  MPI_Status cancel_status;
-  err = MPI_Wait(&recv_request, &cancel_status);
-  dolfinx::MPI::check_error(comm, err);
-  int cancelled;
-  MPI_Test_cancelled(&cancel_status, &cancelled);
-  if (!cancelled)
-    src_ranks.push_back(cancel_status.MPI_SOURCE);
-
-  spdlog::info("Finished graph edge discovery using NBX algorithm. Number "
-               "of discovered edges {}",
-               static_cast<int>(src_ranks.size()));
-
-  return src_ranks;
-}
-//-----------------------------------------------------------------------------
-std::pair<std::vector<int>, std::vector<int>>
-dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
-                                      std::span<const int> edges0, int tag0,
-                                      std::span<const int> edges1, int tag1)
-{
-  assert(tag0 != tag1);
-  spdlog::info(
-      "Computing communication graph edges for two overlapped consensus "
-      "rounds (using NBX algorithm). Number of input edges: {}, {}",
-      static_cast<int>(edges0.size()), static_cast<int>(edges1.size()));
-
-  // One persistent listener per edge set (distinguished by tag), so
-  // that arrivals for one round are never mistaken for the other.
-  std::array<std::byte, 2> buffer_recv;
-  std::array<MPI_Request, 2> recv_request;
-  int err = MPI_Irecv(&buffer_recv[0], 1, MPI_BYTE, MPI_ANY_SOURCE, tag0, comm,
-                      &recv_request[0]);
-  dolfinx::MPI::check_error(comm, err);
-  err = MPI_Irecv(&buffer_recv[1], 1, MPI_BYTE, MPI_ANY_SOURCE, tag1, comm,
-                  &recv_request[1]);
-  dolfinx::MPI::check_error(comm, err);
-
-  std::array<std::vector<MPI_Request>, 2> send_requests
-      = {std::vector<MPI_Request>(edges0.size()),
-         std::vector<MPI_Request>(edges1.size())};
-  std::byte send_buffer{0};
-  for (std::size_t e = 0; e < edges0.size(); ++e)
-  {
-    int err = MPI_Issend(&send_buffer, 1, MPI_BYTE, edges0[e], tag0, comm,
-                         &send_requests[0][e]);
-    dolfinx::MPI::check_error(comm, err);
-  }
-  for (std::size_t e = 0; e < edges1.size(); ++e)
-  {
-    int err = MPI_Issend(&send_buffer, 1, MPI_BYTE, edges1[e], tag1, comm,
-                         &send_requests[1][e]);
-    dolfinx::MPI::check_error(comm, err);
-  }
-
-  // Ranks that send to this rank, for edge set 0 and edge set 1
-  std::array<std::vector<int>, 2> src_ranks;
-
-  // Start sending/receiving. A single barrier covers both edge sets:
-  // it can only start once every send in both sets has completed.
-  MPI_Request barrier_request;
-  bool comm_complete = false;
-  bool barrier_active = false;
-  while (!comm_complete)
-  {
-    // Drain all currently queued messages for each edge set
-    for (int i = 0; i < 2; ++i)
-    {
-      int tag = (i == 0) ? tag0 : tag1;
       int flag_recv;
       MPI_Status status;
       int err = MPI_Test(&recv_request[i], &flag_recv, &status);
@@ -322,8 +233,8 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
       while (flag_recv)
       {
         src_ranks[i].push_back(status.MPI_SOURCE);
-        int err = MPI_Irecv(&buffer_recv[i], 1, MPI_BYTE, MPI_ANY_SOURCE, tag,
-                            comm, &recv_request[i]);
+        int err = MPI_Irecv(&buffer_recv[i], 1, MPI_BYTE, MPI_ANY_SOURCE,
+                            tags[i], comm, &recv_request[i]);
         dolfinx::MPI::check_error(comm, err);
 
         err = MPI_Test(&recv_request[i], &flag_recv, &status);
@@ -342,15 +253,12 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
     }
     else
     {
-      // Check if all sends, in both edge sets, have completed
-      int flag0 = 0, flag1 = 0;
-      int err = MPI_Testall(send_requests[0].size(), send_requests[0].data(),
-                            &flag0, MPI_STATUSES_IGNORE);
+      // Check if all sends, across all K sets, have completed
+      int flag = 0;
+      int err = MPI_Testall(send_requests.size(), send_requests.data(), &flag,
+                            MPI_STATUSES_IGNORE);
       dolfinx::MPI::check_error(comm, err);
-      err = MPI_Testall(send_requests[1].size(), send_requests[1].data(),
-                        &flag1, MPI_STATUSES_IGNORE);
-      dolfinx::MPI::check_error(comm, err);
-      if (flag0 and flag1)
+      if (flag)
       {
         // All sends have completed, start non-blocking barrier
         int err = MPI_Ibarrier(comm, &barrier_request);
@@ -361,11 +269,13 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
   }
 
   // No more messages can arrive once the barrier has completed, so
-  // cancel the still-outstanding listeners (see single edge-set
-  // overload for the rationale on handling the cancellation race).
-  for (int i = 0; i < 2; ++i)
+  // cancel the still-outstanding listeners. A sender's Issend only
+  // requires the receive to be posted, not yet observed by this rank,
+  // so cancellation can race with a real match; if so, record it
+  // instead of discarding it.
+  for (std::size_t i = 0; i < K; ++i)
   {
-    err = MPI_Cancel(&recv_request[i]);
+    int err = MPI_Cancel(&recv_request[i]);
     dolfinx::MPI::check_error(comm, err);
     MPI_Status cancel_status;
     err = MPI_Wait(&recv_request[i], &cancel_status);
@@ -375,6 +285,42 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
     if (!cancelled)
       src_ranks[i].push_back(cancel_status.MPI_SOURCE);
   }
+
+  return src_ranks;
+}
+} // namespace
+//-----------------------------------------------------------------------------
+std::vector<int>
+dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
+                                      int tag)
+{
+  spdlog::info(
+      "Computing communication graph edges (using NBX algorithm). Number "
+      "of input edges: {}",
+      static_cast<int>(edges.size()));
+
+  auto src_ranks = ::nbx_consensus_rounds<1>(comm, {edges}, {tag});
+
+  spdlog::info("Finished graph edge discovery using NBX algorithm. Number "
+               "of discovered edges {}",
+               static_cast<int>(src_ranks[0].size()));
+
+  return std::move(src_ranks[0]);
+}
+//-----------------------------------------------------------------------------
+std::pair<std::vector<int>, std::vector<int>>
+dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
+                                      std::span<const int> edges0, int tag0,
+                                      std::span<const int> edges1, int tag1)
+{
+  assert(tag0 != tag1);
+  spdlog::info(
+      "Computing communication graph edges for two overlapped consensus "
+      "rounds (using NBX algorithm). Number of input edges: {}, {}",
+      static_cast<int>(edges0.size()), static_cast<int>(edges1.size()));
+
+  auto src_ranks
+      = ::nbx_consensus_rounds<2>(comm, {edges0, edges1}, {tag0, tag1});
 
   spdlog::info("Finished overlapped graph edge discovery using NBX "
                "algorithm. Number of discovered edges {}, {}",

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -115,49 +115,43 @@ dolfinx::MPI::compute_graph_edges_pcx(MPI_Comm comm, std::span<const int> edges)
   for (auto e : edges)
     edge_count_send[e] = 1;
 
-  // Determine how many in-edges this rank has
-  std::vector<int> recvcounts(size, 1);
+  // Determine how many in-edges this rank has. All ranks receive the
+  // same single-int block, so *_block avoids an O(size) recvcounts
+  // array of all-ones.
   int in_edges = 0;
   MPI_Request request_scatter;
-  int err = MPI_Ireduce_scatter(edge_count_send.data(), &in_edges,
-                                recvcounts.data(), MPI_INT, MPI_SUM, comm,
-                                &request_scatter);
+  int err = MPI_Ireduce_scatter_block(edge_count_send.data(), &in_edges, 1,
+                                      MPI_INT, MPI_SUM, comm, &request_scatter);
   dolfinx::MPI::check_error(comm, err);
 
+  // Synchronised, non-blocking send; content is never inspected (only
+  // arrival matters), so every send shares one source buffer.
   std::vector<MPI_Request> send_requests(edges.size());
-  std::vector<std::byte> send_buffer(edges.size());
+  std::byte send_buffer{0};
   for (std::size_t e = 0; e < edges.size(); ++e)
   {
-    int err = MPI_Isend(send_buffer.data() + e, 1, MPI_BYTE, edges[e],
+    int err = MPI_Isend(&send_buffer, 1, MPI_BYTE, edges[e],
                         static_cast<int>(tag::consensus_pcx), comm,
                         &send_requests[e]);
     dolfinx::MPI::check_error(comm, err);
   }
 
-  // Probe for incoming messages and store incoming rank
+  // Receive exactly in_edges messages and record their source. A
+  // blocking recv is fine here (unlike NBX): the exact count is
+  // already known, so there is nothing to poll for and no risk of
+  // burning CPU cycles waiting on a message that may never arrive.
   err = MPI_Wait(&request_scatter, MPI_STATUS_IGNORE);
   dolfinx::MPI::check_error(comm, err);
   std::vector<int> other_ranks;
-  while (in_edges > 0)
+  other_ranks.reserve(in_edges);
+  for (int i = 0; i < in_edges; ++i)
   {
-    // Check for message
-    int request_pending;
     MPI_Status status;
-    int err = MPI_Iprobe(MPI_ANY_SOURCE, static_cast<int>(tag::consensus_pcx),
-                         comm, &request_pending, &status);
+    std::byte buffer_recv;
+    int err = MPI_Recv(&buffer_recv, 1, MPI_BYTE, MPI_ANY_SOURCE,
+                       static_cast<int>(tag::consensus_pcx), comm, &status);
     dolfinx::MPI::check_error(comm, err);
-    if (request_pending)
-    {
-      // Receive message and store rank
-      int other_rank = status.MPI_SOURCE;
-      std::byte buffer_recv;
-      int err = MPI_Recv(&buffer_recv, 1, MPI_BYTE, other_rank,
-                         static_cast<int>(tag::consensus_pcx), comm,
-                         MPI_STATUS_IGNORE);
-      dolfinx::MPI::check_error(comm, err);
-      other_ranks.push_back(other_rank);
-      --in_edges;
-    }
+    other_ranks.push_back(status.MPI_SOURCE);
   }
 
   // Complete sends before send_buffer is destroyed

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -172,18 +172,34 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
       "of input edges: {}",
       static_cast<int>(edges.size()));
 
-  // Start non-blocking synchronised send
+  // Duplicate comm so this call's messages can't be confused with an
+  // overlapping call using the same tag.
+  dolfinx::MPI::Comm nbx_comm(comm, true);
+  const MPI_Comm comm0 = nbx_comm.comm();
+
+  // Post a persistent listener. Posting the receive ahead of arrival,
+  // rather than probing reactively, lets MPI treat it as an expected
+  // message and avoid unexpected-message buffering overhead.
+  std::byte buffer_recv;
+  MPI_Request recv_request;
+  int err = MPI_Irecv(&buffer_recv, 1, MPI_BYTE, MPI_ANY_SOURCE, tag, comm0,
+                      &recv_request);
+  dolfinx::MPI::check_error(comm0, err);
+
+  // Start non-blocking synchronised send. The message content is never
+  // inspected (only its arrival matters), so every send can share the
+  // same source buffer.
   std::vector<MPI_Request> send_requests(edges.size());
-  std::vector<std::byte> send_buffer(edges.size());
+  std::byte send_buffer{0};
   for (std::size_t e = 0; e < edges.size(); ++e)
   {
-    int err = MPI_Issend(send_buffer.data() + e, 1, MPI_BYTE, edges[e], tag,
-                         comm, &send_requests[e]);
-    dolfinx::MPI::check_error(comm, err);
+    int err = MPI_Issend(&send_buffer, 1, MPI_BYTE, edges[e], tag, comm0,
+                         &send_requests[e]);
+    dolfinx::MPI::check_error(comm0, err);
   }
 
   // Vector to hold ranks that send data to this rank
-  std::vector<int> other_ranks;
+  std::vector<int> src_ranks;
 
   // Start sending/receiving
   MPI_Request barrier_request;
@@ -191,22 +207,20 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
   bool barrier_active = false;
   while (!comm_complete)
   {
-    // Check for message
-    int request_pending;
+    // Drain all currently queued messages
+    int flag_recv;
     MPI_Status status;
-    int err = MPI_Iprobe(MPI_ANY_SOURCE, tag, comm, &request_pending, &status);
-    dolfinx::MPI::check_error(comm, err);
-
-    // Check if message is waiting to be processed
-    if (request_pending)
+    int err = MPI_Test(&recv_request, &flag_recv, &status);
+    dolfinx::MPI::check_error(comm0, err);
+    while (flag_recv)
     {
-      // Receive it
-      int other_rank = status.MPI_SOURCE;
-      std::byte buffer_recv;
-      int err = MPI_Recv(&buffer_recv, 1, MPI_BYTE, other_rank, tag, comm,
-                         MPI_STATUS_IGNORE);
-      dolfinx::MPI::check_error(comm, err);
-      other_ranks.push_back(other_rank);
+      src_ranks.push_back(status.MPI_SOURCE);
+      int err = MPI_Irecv(&buffer_recv, 1, MPI_BYTE, MPI_ANY_SOURCE, tag, comm0,
+                          &recv_request);
+      dolfinx::MPI::check_error(comm0, err);
+
+      err = MPI_Test(&recv_request, &flag_recv, &status);
+      dolfinx::MPI::check_error(comm0, err);
     }
 
     if (barrier_active)
@@ -214,7 +228,7 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
       // Check for barrier completion
       int flag = 0;
       int err = MPI_Test(&barrier_request, &flag, MPI_STATUS_IGNORE);
-      dolfinx::MPI::check_error(comm, err);
+      dolfinx::MPI::check_error(comm0, err);
       if (flag)
         comm_complete = true;
     }
@@ -224,21 +238,32 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
       int flag = 0;
       int err = MPI_Testall(send_requests.size(), send_requests.data(), &flag,
                             MPI_STATUSES_IGNORE);
-      dolfinx::MPI::check_error(comm, err);
+      dolfinx::MPI::check_error(comm0, err);
       if (flag)
       {
         // All sends have completed, start non-blocking barrier
-        int err = MPI_Ibarrier(comm, &barrier_request);
-        dolfinx::MPI::check_error(comm, err);
+        int err = MPI_Ibarrier(comm0, &barrier_request);
+        dolfinx::MPI::check_error(comm0, err);
         barrier_active = true;
       }
     }
   }
 
+  // No more messages can arrive once the barrier has completed;
+  // cancel the still-outstanding listener.
+  err = MPI_Cancel(&recv_request);
+  dolfinx::MPI::check_error(comm0, err);
+  MPI_Status cancel_status;
+  err = MPI_Wait(&recv_request, &cancel_status);
+  dolfinx::MPI::check_error(comm0, err);
+  int cancelled;
+  MPI_Test_cancelled(&cancel_status, &cancelled);
+  assert(cancelled);
+
   spdlog::info("Finished graph edge discovery using NBX algorithm. Number "
                "of discovered edges {}",
-               static_cast<int>(other_ranks.size()));
+               static_cast<int>(src_ranks.size()));
 
-  return other_ranks;
+  return src_ranks;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -266,3 +266,125 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
   return src_ranks;
 }
 //-----------------------------------------------------------------------------
+std::pair<std::vector<int>, std::vector<int>>
+dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
+                                      std::span<const int> edges0, int tag0,
+                                      std::span<const int> edges1, int tag1)
+{
+  assert(tag0 != tag1);
+  spdlog::info(
+      "Computing communication graph edges for two overlapped consensus "
+      "rounds (using NBX algorithm). Number of input edges: {}, {}",
+      static_cast<int>(edges0.size()), static_cast<int>(edges1.size()));
+
+  // One persistent listener per edge set (distinguished by tag), so
+  // that arrivals for one round are never mistaken for the other.
+  std::array<std::byte, 2> buffer_recv;
+  std::array<MPI_Request, 2> recv_request;
+  int err = MPI_Irecv(&buffer_recv[0], 1, MPI_BYTE, MPI_ANY_SOURCE, tag0, comm,
+                      &recv_request[0]);
+  dolfinx::MPI::check_error(comm, err);
+  err = MPI_Irecv(&buffer_recv[1], 1, MPI_BYTE, MPI_ANY_SOURCE, tag1, comm,
+                  &recv_request[1]);
+  dolfinx::MPI::check_error(comm, err);
+
+  std::array<std::vector<MPI_Request>, 2> send_requests
+      = {std::vector<MPI_Request>(edges0.size()),
+         std::vector<MPI_Request>(edges1.size())};
+  std::byte send_buffer{0};
+  for (std::size_t e = 0; e < edges0.size(); ++e)
+  {
+    int err = MPI_Issend(&send_buffer, 1, MPI_BYTE, edges0[e], tag0, comm,
+                         &send_requests[0][e]);
+    dolfinx::MPI::check_error(comm, err);
+  }
+  for (std::size_t e = 0; e < edges1.size(); ++e)
+  {
+    int err = MPI_Issend(&send_buffer, 1, MPI_BYTE, edges1[e], tag1, comm,
+                         &send_requests[1][e]);
+    dolfinx::MPI::check_error(comm, err);
+  }
+
+  // Ranks that send to this rank, for edge set 0 and edge set 1
+  std::array<std::vector<int>, 2> src_ranks;
+
+  // Start sending/receiving. A single barrier covers both edge sets:
+  // it can only start once every send in both sets has completed.
+  MPI_Request barrier_request;
+  bool comm_complete = false;
+  bool barrier_active = false;
+  while (!comm_complete)
+  {
+    // Drain all currently queued messages for each edge set
+    for (int i = 0; i < 2; ++i)
+    {
+      int tag = (i == 0) ? tag0 : tag1;
+      int flag_recv;
+      MPI_Status status;
+      int err = MPI_Test(&recv_request[i], &flag_recv, &status);
+      dolfinx::MPI::check_error(comm, err);
+      while (flag_recv)
+      {
+        src_ranks[i].push_back(status.MPI_SOURCE);
+        int err = MPI_Irecv(&buffer_recv[i], 1, MPI_BYTE, MPI_ANY_SOURCE, tag,
+                            comm, &recv_request[i]);
+        dolfinx::MPI::check_error(comm, err);
+
+        err = MPI_Test(&recv_request[i], &flag_recv, &status);
+        dolfinx::MPI::check_error(comm, err);
+      }
+    }
+
+    if (barrier_active)
+    {
+      // Check for barrier completion
+      int flag = 0;
+      int err = MPI_Test(&barrier_request, &flag, MPI_STATUS_IGNORE);
+      dolfinx::MPI::check_error(comm, err);
+      if (flag)
+        comm_complete = true;
+    }
+    else
+    {
+      // Check if all sends, in both edge sets, have completed
+      int flag0 = 0, flag1 = 0;
+      int err = MPI_Testall(send_requests[0].size(), send_requests[0].data(),
+                            &flag0, MPI_STATUSES_IGNORE);
+      dolfinx::MPI::check_error(comm, err);
+      err = MPI_Testall(send_requests[1].size(), send_requests[1].data(),
+                        &flag1, MPI_STATUSES_IGNORE);
+      dolfinx::MPI::check_error(comm, err);
+      if (flag0 and flag1)
+      {
+        // All sends have completed, start non-blocking barrier
+        int err = MPI_Ibarrier(comm, &barrier_request);
+        dolfinx::MPI::check_error(comm, err);
+        barrier_active = true;
+      }
+    }
+  }
+
+  // No more messages can arrive once the barrier has completed, so
+  // cancel the still-outstanding listeners (see single edge-set
+  // overload for the rationale on handling the cancellation race).
+  for (int i = 0; i < 2; ++i)
+  {
+    err = MPI_Cancel(&recv_request[i]);
+    dolfinx::MPI::check_error(comm, err);
+    MPI_Status cancel_status;
+    err = MPI_Wait(&recv_request[i], &cancel_status);
+    dolfinx::MPI::check_error(comm, err);
+    int cancelled;
+    MPI_Test_cancelled(&cancel_status, &cancelled);
+    if (!cancelled)
+      src_ranks[i].push_back(cancel_status.MPI_SOURCE);
+  }
+
+  spdlog::info("Finished overlapped graph edge discovery using NBX "
+               "algorithm. Number of discovered edges {}, {}",
+               static_cast<int>(src_ranks[0].size()),
+               static_cast<int>(src_ranks[1].size()));
+
+  return {std::move(src_ranks[0]), std::move(src_ranks[1])};
+}
+//-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -299,7 +299,8 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
       "of input edges: {}",
       static_cast<int>(edges.size()));
 
-  auto src_ranks = ::nbx_consensus_rounds<1>(comm, {edges}, {tag});
+  std::array<std::vector<int>, 1> src_ranks
+      = ::nbx_consensus_rounds<1>(comm, {edges}, {tag});
 
   spdlog::info("Finished graph edge discovery using NBX algorithm. Number "
                "of discovered edges {}",
@@ -319,7 +320,7 @@ dolfinx::MPI::compute_graph_edges_nbx(MPI_Comm comm,
       "rounds (using NBX algorithm). Number of input edges: {}, {}",
       static_cast<int>(edges0.size()), static_cast<int>(edges1.size()));
 
-  auto src_ranks
+  std::array<std::vector<int>, 2> src_ranks
       = ::nbx_consensus_rounds<2>(comm, {edges0, edges1}, {tag0, tag1});
 
   spdlog::info("Finished overlapped graph edge discovery using NBX "

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -374,9 +374,9 @@ dolfinx::MPI::impl::postoffice_plan(int size, int rank,
       dest.push_back((*it)[0]);
 
       // Find iterator to next global rank
-      auto it1
-          = std::find_if(it, dest_to_index.end(),
-                         [r = dest.back()](auto& idx) { return idx[0] != r; });
+      auto it1 = std::ranges::find_if(it, dest_to_index.end(),
+                                      [r = dest.back()](auto& idx)
+                                      { return idx[0] != r; });
 
       // Store number of items for current rank
       num_items_per_dest.push_back(std::distance(it, it1));

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -15,10 +15,11 @@
 #include <array>
 #include <cassert>
 #include <complex>
+#include <concepts>
 #include <cstdint>
+#include <iterator>
 #include <numeric>
 #include <ranges>
-#include <set>
 #include <span>
 #include <tuple>
 #include <type_traits>
@@ -251,29 +252,29 @@ struct dependent_false : std::false_type
 template <typename T>
 MPI_Datatype mpi_datatype()
 {
-  if constexpr (std::is_same_v<T, float>)
+  if constexpr (std::same_as<T, float>)
     return MPI_FLOAT;
-  else if constexpr (std::is_same_v<T, double>)
+  else if constexpr (std::same_as<T, double>)
     return MPI_DOUBLE;
-  else if constexpr (std::is_same_v<T, std::complex<float>>)
+  else if constexpr (std::same_as<T, std::complex<float>>)
     return MPI_C_FLOAT_COMPLEX;
-  else if constexpr (std::is_same_v<T, std::complex<double>>)
+  else if constexpr (std::same_as<T, std::complex<double>>)
     return MPI_C_DOUBLE_COMPLEX;
-  else if constexpr (std::is_same_v<T, std::int8_t>)
+  else if constexpr (std::same_as<T, std::int8_t>)
     return MPI_INT8_T;
-  else if constexpr (std::is_same_v<T, std::int16_t>)
+  else if constexpr (std::same_as<T, std::int16_t>)
     return MPI_INT16_T;
-  else if constexpr (std::is_same_v<T, std::int32_t>)
+  else if constexpr (std::same_as<T, std::int32_t>)
     return MPI_INT32_T;
-  else if constexpr (std::is_same_v<T, std::int64_t>)
+  else if constexpr (std::same_as<T, std::int64_t>)
     return MPI_INT64_T;
-  else if constexpr (std::is_same_v<T, std::uint8_t>)
+  else if constexpr (std::same_as<T, std::uint8_t>)
     return MPI_UINT8_T;
-  else if constexpr (std::is_same_v<T, std::uint16_t>)
+  else if constexpr (std::same_as<T, std::uint16_t>)
     return MPI_UINT16_T;
-  else if constexpr (std::is_same_v<T, std::uint32_t>)
+  else if constexpr (std::same_as<T, std::uint32_t>)
     return MPI_UINT32_T;
-  else if constexpr (std::is_same_v<T, std::uint64_t>)
+  else if constexpr (std::same_as<T, std::uint64_t>)
     return MPI_UINT64_T;
   else
     static_assert(dependent_false<T>::value,
@@ -313,9 +314,8 @@ distribute_to_postoffice(MPI_Comm comm, const U& x,
       dest_to_index.push_back({dest, i});
   }
 
-  // Radix sort (rather than a generic comparison sort), since
-  // dest_to_index can have hundreds of thousands of entries for a
-  // large mesh/problem.
+  // Radix sort (not a comparison sort): dest_to_index can have
+  // hundreds of thousands of entries for a large mesh/problem.
   {
     std::span<const std::int32_t> flat(
         reinterpret_cast<const std::int32_t*>(dest_to_index.data()),
@@ -438,7 +438,7 @@ distribute_to_postoffice(MPI_Comm comm, const U& x,
   const std::int64_t r0 = common::local_range(rank, shape[0], size)[0];
   std::vector<std::int32_t> index_local(recv_buffer_index.size());
   std::ranges::transform(recv_buffer_index, index_local.begin(),
-                         [r0](auto idx) { return idx - r0; });
+                         [r0](std::int64_t idx) { return idx - r0; });
 
   return {index_local, recv_buffer_data};
 }
@@ -470,12 +470,9 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
 
   // 1. Send request to post office ranks for data
 
-  // Build list of (src, global index, position) for each entry in
-  // 'indices' that doesn't belong to this rank, then sort.
-  // Entries already held locally in `x` (before any post office
-  // communication) are skipped -- they are read directly from `x`
-  // below, so routing them through a (possibly unrelated) post office
-  // rank would only add unnecessary communication.
+  // Build (src, global index, position) for each entry in 'indices'
+  // not held locally, then sort. Locally-held entries are read
+  // directly below -- skipping them here avoids a wasted round trip.
   std::vector<std::tuple<int, std::int64_t, std::int32_t>> src_to_index;
   for (std::size_t i = 0; i < indices.size(); ++i)
   {
@@ -486,9 +483,8 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
       src_to_index.push_back({src, idx, i});
   }
 
-  // Group by source rank using a radix sort on the rank alone (rather
-  // than a generic comparison sort of the full tuple) -- only grouping
-  // by rank matters below, entry order within a group is irrelevant.
+  // Radix sort on the rank alone (not the full tuple) -- only
+  // grouping by rank matters below; order within a group doesn't.
   {
     std::vector<std::int32_t> perm(src_to_index.size());
     std::iota(perm.begin(), perm.end(), 0);
@@ -601,7 +597,7 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
     else
     {
       // Take from my 'post bag'
-      auto local_index = index - postoffice_range[0];
+      std::int64_t local_index = index - postoffice_range[0];
       std::int32_t pos = post_indices_map[local_index];
       assert(pos != -1);
       std::copy_n(std::next(post_x.begin(), shape[1] * pos), shape[1],
@@ -642,23 +638,22 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
     if (index >= rank_offset and index < (rank_offset + shape0_local))
     {
       // Had data from the start in x
-      auto local_index = index - rank_offset;
+      std::int64_t local_index = index - rank_offset;
       std::copy_n(std::next(x.begin(), shape[1] * local_index), shape[1],
                   std::next(x_new.begin(), shape[1] * i));
     }
     else if (std::int32_t pos = index_pos_to_buffer[i]; pos != -1)
     {
-      // In my received post. `index_pos_to_buffer[i] != -1` iff `index`
-      // was in `src_to_index`, i.e. iff its post office owner is not
-      // this rank -- this avoids recomputing the owner with
-      // index_owner.
+      // In my received post: index_pos_to_buffer[i] != -1 iff
+      // index_owner would say this rank isn't the owner -- avoids
+      // recomputing it.
       std::copy_n(std::next(recv_buffer_data.begin(), shape[1] * pos), shape[1],
                   std::next(x_new.begin(), shape[1] * i));
     }
     else
     {
       // In my post office bag
-      auto local_index = index - postoffice_range[0];
+      std::int64_t local_index = index - postoffice_range[0];
       std::int32_t bag_pos = post_indices_map[local_index];
       assert(bag_pos != -1);
       std::copy_n(std::next(post_x.begin(), shape[1] * bag_pos), shape[1],

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -131,6 +131,10 @@ constexpr int index_owner(int size, std::size_t index, std::size_t N)
 ///
 /// @param[in] comm MPI communicator
 /// @param[in] edges Edges (ranks) from this rank (the caller).
+/// @pre `edges` must not contain duplicate ranks: a duplicate makes
+/// the sender emit more messages than the reduce-scatter-based
+/// receive count expects, leaving a message unconsumed on the shared
+/// PCX tag that can corrupt a later, unrelated call.
 /// @return Ranks that have defined edges from them to this rank.
 std::vector<int> compute_graph_edges_pcx(MPI_Comm comm,
                                          std::span<const int> edges);

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -131,10 +131,9 @@ constexpr int index_owner(int size, std::size_t index, std::size_t N)
 ///
 /// @param[in] comm MPI communicator
 /// @param[in] edges Edges (ranks) from this rank (the caller).
-/// @pre `edges` must not contain duplicate ranks: a duplicate makes
-/// the sender emit more messages than the reduce-scatter-based
-/// receive count expects, leaving a message unconsumed on the shared
-/// PCX tag that can corrupt a later, unrelated call.
+/// @pre `edges` must not contain duplicate ranks (a duplicate can
+/// leave a message unconsumed on the shared PCX tag, corrupting a
+/// later call).
 /// @return Ranks that have defined edges from them to this rank.
 std::vector<int> compute_graph_edges_pcx(MPI_Comm comm,
                                          std::span<const int> edges);

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -152,12 +152,11 @@ std::vector<int> compute_graph_edges_pcx(MPI_Comm comm,
 ///
 /// @param[in] comm MPI communicator
 /// @param[in] edges Edges (ranks) from this rank (the caller).
-/// @param[in] tag Tag used in non-blocking MPI calls. A tag can be
-/// required when this function is called a second time on some ranks
-/// before a previous call has completed on all other ranks. @return
-/// Ranks that have defined edges from them to this rank. @note An
-/// alternative to passing a tag is to ensure that there is an implicit
-/// or explicit barrier before and after the call to this function.
+/// @pre `edges` must not contain duplicate ranks.
+/// @param[in] tag Tag used in non-blocking MPI calls. `comm` is
+/// duplicated internally, so concurrent calls cannot interfere with
+/// each other regardless of `tag`.
+/// @return Ranks that have defined edges from them to this rank.
 std::vector<int>
 compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
                         int tag = static_cast<int>(tag::consensus_nbx));

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -9,6 +9,7 @@
 #include "Timer.h"
 #include "local_range.h"
 #include "log.h"
+#include "sort.h"
 #include "types.h"
 #include <algorithm>
 #include <array>
@@ -300,14 +301,6 @@ distribute_to_postoffice(MPI_Comm comm, const U& x,
 
   spdlog::debug("Sending data to post offices (distribute_to_postoffice)");
 
-  // Post office ranks will receive data from this rank
-  std::vector<int> row_to_dest(shape0_local);
-  for (std::int32_t i = 0; i < shape0_local; ++i)
-  {
-    int dest = MPI::index_owner(size, i + rank_offset, shape[0]);
-    row_to_dest[i] = dest;
-  }
-
   // Build list of (dest, positions) for each row that doesn't belong to
   // this rank, then sort
   std::vector<std::array<std::int32_t, 2>> dest_to_index;
@@ -318,7 +311,21 @@ distribute_to_postoffice(MPI_Comm comm, const U& x,
     if (int dest = MPI::index_owner(size, idx, shape[0]); dest != rank)
       dest_to_index.push_back({dest, i});
   }
-  std::ranges::sort(dest_to_index);
+
+  // Radix sort (rather than a generic comparison sort), since
+  // dest_to_index can have hundreds of thousands of entries for a
+  // large mesh/problem.
+  {
+    std::span<const std::int32_t> flat(
+        reinterpret_cast<const std::int32_t*>(dest_to_index.data()),
+        2 * dest_to_index.size());
+    std::vector<std::int32_t> perm
+        = dolfinx::sort_by_perm<std::int32_t, 16>(flat, 2);
+    std::vector<std::array<std::int32_t, 2>> sorted(dest_to_index.size());
+    for (std::size_t i = 0; i < perm.size(); ++i)
+      sorted[i] = dest_to_index[perm[i]];
+    dest_to_index = std::move(sorted);
+  }
 
   // Build list of neighbour src ranks and count number of items (rows
   // of x) to receive from each src post office (by neighbourhood rank)
@@ -463,15 +470,35 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
   // 1. Send request to post office ranks for data
 
   // Build list of (src, global index, global, index position) for each
-  // entry in 'indices' that doesn't belong to this rank, then sort
+  // entry in 'indices' that doesn't belong to this rank, then sort.
+  // Entries already held locally in `x` (before any post office
+  // communication) are skipped -- they are read directly from `x`
+  // below, so routing them through a (possibly unrelated) post office
+  // rank would only add unnecessary communication.
   std::vector<std::tuple<int, std::int64_t, std::int32_t>> src_to_index;
   for (std::size_t i = 0; i < indices.size(); ++i)
   {
-    std::size_t idx = indices[i];
+    std::int64_t idx = indices[i];
+    if (idx >= rank_offset and idx < rank_offset + shape0_local)
+      continue;
     if (int src = dolfinx::MPI::index_owner(size, idx, shape[0]); src != rank)
       src_to_index.push_back({src, idx, i});
   }
-  std::ranges::sort(src_to_index);
+
+  // Group by source rank using a radix sort on the rank alone (rather
+  // than a generic comparison sort of the full tuple) -- only grouping
+  // by rank matters below, entry order within a group is irrelevant.
+  {
+    std::vector<std::int32_t> perm(src_to_index.size());
+    std::iota(perm.begin(), perm.end(), 0);
+    dolfinx::radix_sort(perm, [&src_to_index](std::int32_t i)
+                        { return std::get<0>(src_to_index[i]); });
+    std::vector<std::tuple<int, std::int64_t, std::int32_t>> sorted(
+        src_to_index.size());
+    for (std::size_t i = 0; i < perm.size(); ++i)
+      sorted[i] = src_to_index[perm[i]];
+    src_to_index = std::move(sorted);
+  }
 
   // Build list is neighbour src ranks and count number of items (rows
   // of x) to receive from each src post office (by neighbourhood rank)

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -562,9 +562,9 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
     while (it != src_to_index.end())
     {
       src.push_back(std::get<0>(*it));
-      auto it1
-          = std::find_if(it, src_to_index.end(), [r = src.back()](auto& idx)
-                         { return std::get<0>(idx) != r; });
+      auto it1 = std::ranges::find_if(it, src_to_index.end(),
+                                      [r = src.back()](auto& idx)
+                                      { return std::get<0>(idx) != r; });
       num_items_per_src.push_back(std::distance(it, it1));
       it = it1;
     }

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -469,8 +469,8 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
 
   // 1. Send request to post office ranks for data
 
-  // Build list of (src, global index, global, index position) for each
-  // entry in 'indices' that doesn't belong to this rank, then sort.
+  // Build list of (src, global index, position) for each entry in
+  // 'indices' that doesn't belong to this rank, then sort.
   // Entries already held locally in `x` (before any post office
   // communication) are skipped -- they are read directly from `x`
   // below, so routing them through a (possibly unrelated) post office
@@ -500,7 +500,7 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
     src_to_index = std::move(sorted);
   }
 
-  // Build list is neighbour src ranks and count number of items (rows
+  // Build list of neighbour src ranks and count number of items (rows
   // of x) to receive from each src post office (by neighbourhood rank)
   std::vector<std::int32_t> num_items_per_src;
   std::vector<int> src;
@@ -553,7 +553,7 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
 
   // Pack my requested indices (global) in send buffer ready to send to
   // post offices
-  assert(send_disp.back() == (int)src_to_index.size());
+  assert(send_disp.back() == static_cast<int>(src_to_index.size()));
   std::vector<std::int64_t> send_buffer_index(src_to_index.size());
   std::ranges::transform(src_to_index, send_buffer_index.begin(),
                          [](auto x) { return std::get<1>(x); });
@@ -581,36 +581,30 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
       postoffice_range[1] - postoffice_range[0], -1);
   for (std::size_t i = 0; i < post_indices.size(); ++i)
   {
-    assert(post_indices[i] < (int)post_indices_map.size());
+    assert(post_indices[i] < static_cast<int>(post_indices_map.size()));
     post_indices_map[post_indices[i]] = i;
   }
 
   // Build send buffer
   std::vector<T> send_buffer_data(shape[1] * recv_disp.back());
-  for (std::size_t p = 0; p < recv_disp.size() - 1; ++p)
+  for (std::int32_t i = 0; i < recv_disp.back(); ++i)
   {
-    int offset = recv_disp[p];
-    for (std::int32_t i = recv_disp[p]; i < recv_disp[p + 1]; ++i)
+    std::int64_t index = recv_buffer_index[i];
+    if (index >= rank_offset and index < (rank_offset + shape0_local))
     {
-      std::int64_t index = recv_buffer_index[i];
-      if (index >= rank_offset and index < (rank_offset + shape0_local))
-      {
-        // I already had this index before any communication
-        std::int32_t local_index = index - rank_offset;
-        std::copy_n(std::next(x.begin(), shape[1] * local_index), shape[1],
-                    std::next(send_buffer_data.begin(), shape[1] * offset));
-      }
-      else
-      {
-        // Take from my 'post bag'
-        auto local_index = index - postoffice_range[0];
-        std::int32_t pos = post_indices_map[local_index];
-        assert(pos != -1);
-        std::copy_n(std::next(post_x.begin(), shape[1] * pos), shape[1],
-                    std::next(send_buffer_data.begin(), shape[1] * offset));
-      }
-
-      ++offset;
+      // I already had this index before any communication
+      std::int32_t local_index = index - rank_offset;
+      std::copy_n(std::next(x.begin(), shape[1] * local_index), shape[1],
+                  std::next(send_buffer_data.begin(), shape[1] * i));
+    }
+    else
+    {
+      // Take from my 'post bag'
+      auto local_index = index - postoffice_range[0];
+      std::int32_t pos = post_indices_map[local_index];
+      assert(pos != -1);
+      std::copy_n(std::next(post_x.begin(), shape[1] * pos), shape[1],
+                  std::next(send_buffer_data.begin(), shape[1] * i));
     }
   }
 
@@ -651,26 +645,23 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
       std::copy_n(std::next(x.begin(), shape[1] * local_index), shape[1],
                   std::next(x_new.begin(), shape[1] * i));
     }
+    else if (std::int32_t pos = index_pos_to_buffer[i]; pos != -1)
+    {
+      // In my received post. `index_pos_to_buffer[i] != -1` iff `index`
+      // was in `src_to_index`, i.e. iff its post office owner is not
+      // this rank -- this avoids recomputing the owner with
+      // index_owner.
+      std::copy_n(std::next(recv_buffer_data.begin(), shape[1] * pos), shape[1],
+                  std::next(x_new.begin(), shape[1] * i));
+    }
     else
     {
-      if (int src = dolfinx::MPI::index_owner(size, index, shape[0]);
-          src == rank)
-      {
-        // In my post office bag
-        auto local_index = index - postoffice_range[0];
-        std::int32_t pos = post_indices_map[local_index];
-        assert(pos != -1);
-        std::copy_n(std::next(post_x.begin(), shape[1] * pos), shape[1],
-                    std::next(x_new.begin(), shape[1] * i));
-      }
-      else
-      {
-        // In my received post
-        std::int32_t pos = index_pos_to_buffer[i];
-        assert(pos != -1);
-        std::copy_n(std::next(recv_buffer_data.begin(), shape[1] * pos),
-                    shape[1], std::next(x_new.begin(), shape[1] * i));
-      }
+      // In my post office bag
+      auto local_index = index - postoffice_range[0];
+      std::int32_t bag_pos = post_indices_map[local_index];
+      assert(bag_pos != -1);
+      std::copy_n(std::next(post_x.begin(), shape[1] * bag_pos), shape[1],
+                  std::next(x_new.begin(), shape[1] * i));
     }
   }
 
@@ -686,9 +677,9 @@ distribute_data(MPI_Comm comm0, std::span<const std::int64_t> indices,
   assert(x.size() % shape1 == 0);
   const std::int64_t shape0_local = x.size() / shape1;
 
-  int err;
   std::int64_t shape0 = 0;
-  err = MPI_Allreduce(&shape0_local, &shape0, 1, MPI_INT64_T, MPI_SUM, comm0);
+  int err
+      = MPI_Allreduce(&shape0_local, &shape0, 1, MPI_INT64_T, MPI_SUM, comm0);
   dolfinx::MPI::check_error(comm0, err);
 
   std::int64_t rank_offset = -1;
@@ -699,12 +690,8 @@ distribute_data(MPI_Comm comm0, std::span<const std::int64_t> indices,
                      dolfinx::MPI::mpi_t<std::int64_t>, MPI_SUM, comm1);
     dolfinx::MPI::check_error(comm1, err);
   }
-  else
-  {
-    rank_offset = -1;
-    if (!x.empty())
-      throw std::runtime_error("Non-empty data on null MPI communicator");
-  }
+  else if (!x.empty())
+    throw std::runtime_error("Non-empty data on null MPI communicator");
 
   return distribute_from_postoffice(comm0, indices, x, {shape0, shape1},
                                     rank_offset);

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -17,6 +17,7 @@
 #include <complex>
 #include <cstdint>
 #include <numeric>
+#include <ranges>
 #include <set>
 #include <span>
 #include <tuple>
@@ -180,9 +181,8 @@ compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
 /// post-office partition of `[0, shape[0])`, and (1) the received row
 /// data (row-major). Rows for which the caller is itself the post
 /// office are not included.
-template <typename U>
-std::pair<std::vector<std::int32_t>,
-          std::vector<typename std::remove_reference_t<typename U::value_type>>>
+template <std::ranges::contiguous_range U>
+std::pair<std::vector<std::int32_t>, std::vector<std::ranges::range_value_t<U>>>
 distribute_to_postoffice(MPI_Comm comm, const U& x,
                          std::array<std::int64_t, 2> shape,
                          std::int64_t rank_offset);
@@ -208,8 +208,8 @@ distribute_to_postoffice(MPI_Comm comm, const U& x,
 /// @return The row for each entry of `indices`, in the same order
 /// (row-major storage).
 /// @pre `shape[1] > 0`.
-template <typename U>
-std::vector<typename std::remove_reference_t<typename U::value_type>>
+template <std::ranges::contiguous_range U>
+std::vector<std::ranges::range_value_t<U>>
 distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
                            const U& x, std::array<std::int64_t, 2> shape,
                            std::int64_t rank_offset);
@@ -233,8 +233,8 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
 /// @return The row for each entry of `indices`, in the same order
 /// (row-major storage).
 /// @pre `shape1 > 0`.
-template <typename U>
-std::vector<typename std::remove_reference_t<typename U::value_type>>
+template <std::ranges::contiguous_range U>
+std::vector<std::ranges::range_value_t<U>>
 distribute_data(MPI_Comm comm0, std::span<const std::int64_t> indices,
                 MPI_Comm comm1, const U& x, int shape1);
 
@@ -282,15 +282,14 @@ MAP_TO_MPI_TYPE(std::uint64_t, MPI_UINT64_T)
 /// @}
 
 //---------------------------------------------------------------------------
-template <typename U>
-std::pair<std::vector<std::int32_t>,
-          std::vector<typename std::remove_reference_t<typename U::value_type>>>
+template <std::ranges::contiguous_range U>
+std::pair<std::vector<std::int32_t>, std::vector<std::ranges::range_value_t<U>>>
 distribute_to_postoffice(MPI_Comm comm, const U& x,
                          std::array<std::int64_t, 2> shape,
                          std::int64_t rank_offset)
 {
   assert(rank_offset >= 0 or x.empty());
-  using T = typename std::remove_reference_t<typename U::value_type>;
+  using T = std::ranges::range_value_t<U>;
 
   const int size = dolfinx::MPI::size(comm);
   const int rank = dolfinx::MPI::rank(comm);
@@ -440,14 +439,14 @@ distribute_to_postoffice(MPI_Comm comm, const U& x,
   return {index_local, recv_buffer_data};
 }
 //---------------------------------------------------------------------------
-template <typename U>
-std::vector<typename std::remove_reference_t<typename U::value_type>>
+template <std::ranges::contiguous_range U>
+std::vector<std::ranges::range_value_t<U>>
 distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
                            const U& x, std::array<std::int64_t, 2> shape,
                            std::int64_t rank_offset)
 {
   assert(rank_offset >= 0 or x.empty());
-  using T = typename std::remove_reference_t<typename U::value_type>;
+  using T = std::ranges::range_value_t<U>;
 
   common::Timer timer("Distribute row-wise data (scalable)");
   assert(shape[1] > 0);
@@ -666,8 +665,8 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
   return x_new;
 }
 //---------------------------------------------------------------------------
-template <typename U>
-std::vector<typename std::remove_reference_t<typename U::value_type>>
+template <std::ranges::contiguous_range U>
+std::vector<std::ranges::range_value_t<U>>
 distribute_data(MPI_Comm comm0, std::span<const std::int64_t> indices,
                 MPI_Comm comm1, const U& x, int shape1)
 {

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -162,25 +162,24 @@ std::vector<int>
 compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
                         int tag = static_cast<int>(tag::consensus_nbx));
 
-/// @brief Distribute row data to 'post office' ranks.
+/// @brief Send row data to its 'post office' rank.
 ///
-/// This function takes row-wise data that is distributed across
-/// processes. Data is not duplicated across ranks. The global index of
-/// a row is its local row position plus the offset for the calling
-/// process. The post office rank for a row is determined by applying
-/// dolfinx::MPI::index_owner to the global index, and the row is then
-/// sent to the post office rank. The function returns that row data for
-/// which the caller is the post office.
+/// `x` is a contiguous local block of a larger row-major array
+/// distributed over `comm`, with local row `i` at global index
+/// `rank_offset + i`. Each row is sent to its post office rank
+/// (dolfinx::MPI::index_owner applied to the row's global index and
+/// `shape[0]`), except rows for which the caller is itself the post
+/// office, which are left in place.
 ///
 /// @param[in] comm MPI communicator.
-/// @param[in] x Data to distribute (2D, row-major layout).
-/// @param[in] shape The global shape of `x`.
-/// @param[in] rank_offset The rank offset such that global index of
-/// local row `i` in `x` is `rank_offset + i`. It is usually computed
-/// using `MPI_Exscan`.
-/// @returns (0) local indices of my post office data and (1) the data
-/// (row-major). It **does not** include rows that are in `x`, i.e. rows
-/// for which the calling process is the post office.
+/// @param[in] x Local block of the array to distribute (row-major).
+/// @param[in] shape Global shape of the array, `{num_rows, num_cols}`.
+/// @param[in] rank_offset Global row index of local row 0 in `x`,
+/// usually computed with `MPI_Exscan`.
+/// @return (0) position of each received row within the caller's
+/// post-office partition of `[0, shape[0])`, and (1) the received row
+/// data (row-major). Rows for which the caller is itself the post
+/// office are not included.
 template <typename U>
 std::pair<std::vector<std::int32_t>,
           std::vector<typename std::remove_reference_t<typename U::value_type>>>
@@ -188,53 +187,52 @@ distribute_to_postoffice(MPI_Comm comm, const U& x,
                          std::array<std::int64_t, 2> shape,
                          std::int64_t rank_offset);
 
-/// @brief Distribute rows of a rectangular data array from post office
-/// ranks to ranks where they are required.
+/// @brief Fetch rows of a distributed row-major array via their post
+/// office ranks.
 ///
-/// This function determines local neighborhoods for communication, and
-/// then using MPI neighbourhood collectives to exchange data. It is
-/// scalable if the neighborhoods are relatively small, i.e. each
-/// process communicated with a modest number of other processes.
+/// `x` is a contiguous local block of a larger row-major array
+/// distributed over `comm`, with local row `i` at global index
+/// `rank_offset + i`. For each global row index in `indices` (which
+/// may contain repeats), returns that row -- read directly from `x` if
+/// already local, otherwise requested from its post office rank via
+/// MPI neighbourhood collectives. Scalable provided each rank
+/// exchanges with only a modest number of others.
 ///
-/// @param[in] comm The MPI communicator.
-/// @param[in] indices Global indices of the data (row indices) required
-/// by calling process.
-/// @param[in] x Data (2D array, row-major) on calling process which may
-/// be distributed (by row). The global index for the `[0, ..., n)`
-/// local rows is assumed to be the local index plus the offset for this
-/// rank.
-/// @param[in] shape The global shape of `x`.
-/// @param[in] rank_offset The rank offset such that global index of
-/// local row `i` in `x` is `rank_offset + i`. It is usually computed
-/// using `MPI_Exscan` on `comm1` from MPI::distribute_data.
-/// @return The data for each index in `indices` (row-major storage).
-/// @pre `shape1 > 0`.
+/// @param[in] comm MPI communicator.
+/// @param[in] indices Global row indices required by the caller.
+/// @param[in] x Local block of the array to distribute (row-major).
+/// @param[in] shape Global shape of the array, `{num_rows, num_cols}`.
+/// @param[in] rank_offset Global row index of local row 0 in `x`
+/// (usually an exclusive scan of row counts over the communicator `x`
+/// is distributed across, which may differ from `comm`).
+/// @return The row for each entry of `indices`, in the same order
+/// (row-major storage).
+/// @pre `shape[1] > 0`.
 template <typename U>
 std::vector<typename std::remove_reference_t<typename U::value_type>>
 distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
                            const U& x, std::array<std::int64_t, 2> shape,
                            std::int64_t rank_offset);
 
-/// @brief Distribute rows of a rectangular data array to ranks where
-/// they are required (scalable version).
+/// @brief Distribute rows of a row-major array to the ranks that
+/// require them, via the post office pattern.
 ///
-/// This function determines local neighborhoods for communication, and
-/// then uses MPI neighbourhood collectives to exchange data. It is
-/// scalable if the neighborhoods are relatively small, i.e. each
-/// process communicated with a modest number of other processes.
+/// Scalable provided each rank exchanges with only a modest number of
+/// others.
 ///
-/// @param[in] comm0 Communicator to distribute data across.
-/// @param[in] indices Global indices of the data (row indices) required
-/// by the calling process.
-/// @param[in] comm1 Communicator across which x is distributed. Can be
+/// @param[in] comm0 Communicator over which `indices` are resolved and
+/// the result is returned.
+/// @param[in] indices Global row indices required by the calling rank.
+/// @param[in] comm1 Communicator across which `x` is distributed --
+/// typically `comm0` itself or a sub-communicator of it, and
 /// `MPI_COMM_NULL` on ranks where `x` is empty.
-/// @param[in] x Data (2D array, row-major) on calling process to be
-/// distributed (by row). The global index for the `[0, ..., n)` local
-/// rows is assumed to be the local index plus the offset for this rank
-/// on `comm1`.
-/// @param[in] shape1 The number of columns of the data array `x`.
-/// @return The data for each index in `indices` (row-major storage).
-/// @pre `shape1 > 0`
+/// @param[in] x Local block of rows to distribute (row-major); local
+/// row `i` has global index given by an exclusive scan of local row
+/// counts over `comm1`.
+/// @param[in] shape1 Number of columns of `x`.
+/// @return The row for each entry of `indices`, in the same order
+/// (row-major storage).
+/// @pre `shape1 > 0`.
 template <typename U>
 std::vector<typename std::remove_reference_t<typename U::value_type>>
 distribute_data(MPI_Comm comm0, std::span<const std::int64_t> indices,

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -164,6 +164,34 @@ std::vector<int>
 compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
                         int tag = static_cast<int>(tag::consensus_nbx));
 
+/// @brief Determine incoming graph edges for two independent edge
+/// sets using a single, overlapped NBX consensus round.
+///
+/// Equivalent to calling MPI::compute_graph_edges_nbx independently
+/// for `edges0` and `edges1`, but runs both consensus rounds
+/// concurrently behind a single shared barrier rather than one after
+/// the other, halving the number of global barrier round-trips when
+/// the two edge sets can be computed without waiting on one another.
+///
+/// @note `tag0` and `tag1` must differ from one another, and from any
+/// tag used by another consensus round that may be in flight
+/// concurrently on `comm`.
+///
+/// @note Collective.
+///
+/// @param[in] comm MPI communicator
+/// @param[in] edges0 Edges (ranks) from this rank (the caller) for
+/// the first edge set.
+/// @param[in] tag0 Tag used for `edges0`'s messages.
+/// @param[in] edges1 Edges (ranks) from this rank (the caller) for
+/// the second edge set.
+/// @param[in] tag1 Tag used for `edges1`'s messages.
+/// @return Ranks with defined edges to this rank, for (0) `edges0`
+/// and (1) `edges1`.
+std::pair<std::vector<int>, std::vector<int>>
+compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges0, int tag0,
+                        std::span<const int> edges1, int tag1);
+
 /// @brief Distribute row data to 'post office' ranks.
 ///
 /// This function takes row-wise data that is distributed across
@@ -286,22 +314,21 @@ MAP_TO_MPI_TYPE(std::uint64_t, MPI_UINT64_T)
 /// @}
 
 //---------------------------------------------------------------------------
-template <typename U>
-std::pair<std::vector<std::int32_t>,
-          std::vector<typename std::remove_reference_t<typename U::value_type>>>
-distribute_to_postoffice(MPI_Comm comm, const U& x,
-                         std::array<std::int64_t, 2> shape,
-                         std::int64_t rank_offset)
+namespace impl
 {
-  assert(rank_offset >= 0 or x.empty());
-  using T = typename std::remove_reference_t<typename U::value_type>;
-
+/// @brief Local (non-communicating) part of distribute_to_postoffice:
+/// group the local rows of `x` that do not belong to this rank by
+/// their post office (destination) rank.
+/// @return (0) unique destination ranks, (1) number of rows destined
+/// for each rank in (0), and (2) a map from local row index to
+/// position in (0), or -1 if the row is already owned by this rank.
+inline std::tuple<std::vector<int>, std::vector<std::int32_t>,
+                  std::vector<std::int32_t>>
+postoffice_plan(MPI_Comm comm, std::int32_t shape0_local, std::int64_t shape0,
+                std::int64_t rank_offset)
+{
   const int size = dolfinx::MPI::size(comm);
   const int rank = dolfinx::MPI::rank(comm);
-  assert(x.size() % shape[1] == 0);
-  const std::int32_t shape0_local = x.size() / shape[1];
-
-  spdlog::debug("Sending data to post offices (distribute_to_postoffice)");
 
   // Build list of (dest, positions) for each row that doesn't belong to
   // this rank, then sort
@@ -310,7 +337,7 @@ distribute_to_postoffice(MPI_Comm comm, const U& x,
   for (std::int32_t i = 0; i < shape0_local; ++i)
   {
     std::size_t idx = i + rank_offset;
-    if (int dest = MPI::index_owner(size, idx, shape[0]); dest != rank)
+    if (int dest = MPI::index_owner(size, idx, shape0); dest != rank)
       dest_to_index.push_back({dest, i});
   }
 
@@ -360,11 +387,29 @@ distribute_to_postoffice(MPI_Comm comm, const U& x,
     }
   }
 
-  // Determine source ranks
-  const std::vector<int> src = MPI::compute_graph_edges_nbx(comm, dest);
-  spdlog::info(
-      "Number of neighbourhood source ranks in distribute_to_postoffice: {}",
-      static_cast<int>(src.size()));
+  return {std::move(dest), std::move(num_items_per_dest),
+          std::move(pos_to_neigh_rank)};
+}
+
+/// @brief Neighbourhood data exchange step of distribute_to_postoffice,
+/// given an already-resolved `src` (e.g. from a single or overlapped
+/// NBX consensus round).
+template <typename U>
+std::pair<std::vector<std::int32_t>,
+          std::vector<typename std::remove_reference_t<typename U::value_type>>>
+postoffice_exchange(MPI_Comm comm, const U& x,
+                    std::array<std::int64_t, 2> shape, std::int64_t rank_offset,
+                    std::span<const int> dest,
+                    std::span<const std::int32_t> num_items_per_dest0,
+                    std::span<const std::int32_t> pos_to_neigh_rank,
+                    std::span<const int> src)
+{
+  using T = typename std::remove_reference_t<typename U::value_type>;
+
+  const int size = dolfinx::MPI::size(comm);
+  const int rank = dolfinx::MPI::rank(comm);
+  assert(x.size() % shape[1] == 0);
+  const std::int32_t shape0_local = x.size() / shape[1];
 
   // Create neighbourhood communicator for sending data to post offices
   MPI_Comm neigh_comm;
@@ -374,6 +419,8 @@ distribute_to_postoffice(MPI_Comm comm, const U& x,
   dolfinx::MPI::check_error(comm, err);
 
   // Compute send displacements
+  std::vector<std::int32_t> num_items_per_dest(num_items_per_dest0.begin(),
+                                               num_items_per_dest0.end());
   std::vector<std::int32_t> send_disp{0};
   std::partial_sum(num_items_per_dest.begin(), num_items_per_dest.end(),
                    std::back_inserter(send_disp));
@@ -433,8 +480,6 @@ distribute_to_postoffice(MPI_Comm comm, const U& x,
   err = MPI_Comm_free(&neigh_comm);
   dolfinx::MPI::check_error(comm, err);
 
-  spdlog::debug("Completed send data to post offices.");
-
   // Convert to local indices
   const std::int64_t r0 = common::local_range(rank, shape[0], size)[0];
   std::vector<std::int32_t> index_local(recv_buffer_index.size());
@@ -442,6 +487,36 @@ distribute_to_postoffice(MPI_Comm comm, const U& x,
                          [r0](auto idx) { return idx - r0; });
 
   return {index_local, recv_buffer_data};
+}
+} // namespace impl
+
+template <typename U>
+std::pair<std::vector<std::int32_t>,
+          std::vector<typename std::remove_reference_t<typename U::value_type>>>
+distribute_to_postoffice(MPI_Comm comm, const U& x,
+                         std::array<std::int64_t, 2> shape,
+                         std::int64_t rank_offset)
+{
+  assert(rank_offset >= 0 or x.empty());
+  assert(x.size() % shape[1] == 0);
+  const std::int32_t shape0_local = x.size() / shape[1];
+
+  spdlog::debug("Sending data to post offices (distribute_to_postoffice)");
+
+  auto [dest, num_items_per_dest, pos_to_neigh_rank]
+      = impl::postoffice_plan(comm, shape0_local, shape[0], rank_offset);
+
+  // Determine source ranks
+  const std::vector<int> src = MPI::compute_graph_edges_nbx(comm, dest);
+  spdlog::info(
+      "Number of neighbourhood source ranks in distribute_to_postoffice: {}",
+      static_cast<int>(src.size()));
+
+  auto result
+      = impl::postoffice_exchange(comm, x, shape, rank_offset, dest,
+                                  num_items_per_dest, pos_to_neigh_rank, src);
+  spdlog::debug("Completed send data to post offices.");
+  return result;
 }
 //---------------------------------------------------------------------------
 template <typename U>
@@ -461,15 +536,14 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
   assert(x.size() % shape[1] == 0);
   const std::int64_t shape0_local = x.size() / shape[1];
 
-  // 0. Send x data to/from post offices
+  // 0. Send x data to/from post offices, and 1. determine which post
+  //    office ranks hold the data I need (indices) -- these are
+  //    independent local computations, so the two NBX consensus
+  //    rounds they each need (below) are run concurrently in a single
+  //    overlapped round rather than back-to-back.
 
-  // Send receive x data to post office (only for rows that need to be
-  // communicated)
-  auto [post_indices, post_x] = dolfinx::MPI::distribute_to_postoffice(
-      comm, x, {shape[0], shape[1]}, rank_offset);
-  assert(post_indices.size() == post_x.size() / shape[1]);
-
-  // 1. Send request to post office ranks for data
+  auto [send_dest, num_items_per_send_dest, pos_to_neigh_rank]
+      = impl::postoffice_plan(comm, shape0_local, shape[0], rank_offset);
 
   // Build list of (src, global index, position) for each entry in
   // 'indices' that doesn't belong to this rank, then sort.
@@ -519,15 +593,25 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
     }
   }
 
-  // Determine 'delivery' destination ranks (ranks that want data from
-  // me)
-  const std::vector<int> dest
-      = dolfinx::MPI::compute_graph_edges_nbx(comm, src);
+  // Determine, in one overlapped NBX round, (0) the post office ranks
+  // that hold data for me to receive (post office send round) and (1)
+  // the 'delivery' destination ranks that want data from me (my
+  // request round)
+  auto [post_src, dest] = dolfinx::MPI::compute_graph_edges_nbx(
+      comm, send_dest, static_cast<int>(tag::consensus_nbx), src,
+      static_cast<int>(tag::consensus_nbx) + 1);
   spdlog::info(
       "Neighbourhood destination ranks from post office in "
       "distribute_data (rank, num dests, num dests/mpi_size): {}, {}, {}",
       rank, static_cast<int>(dest.size()),
       static_cast<double>(dest.size()) / size);
+
+  // Send receive x data to post office (only for rows that need to be
+  // communicated)
+  auto [post_indices, post_x] = impl::postoffice_exchange(
+      comm, x, {shape[0], shape[1]}, rank_offset, send_dest,
+      num_items_per_send_dest, pos_to_neigh_rank, post_src);
+  assert(post_indices.size() == post_x.size() / shape[1]);
 
   // Create neighbourhood communicator for sending data to post offices
   // (src), and receiving data form my send my post office

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -238,48 +238,52 @@ std::vector<std::ranges::range_value_t<U>>
 distribute_data(MPI_Comm comm0, std::span<const std::int64_t> indices,
                 MPI_Comm comm1, const U& x, int shape1);
 
+/// @private Type-dependent `false` for use in a `static_assert` that
+/// should only fire when a template is actually instantiated (a bare
+/// `static_assert(false, ...)` would fire unconditionally).
 template <typename T>
 struct dependent_false : std::false_type
 {
 };
 
-/// MPI Type
-
-/// @brief Type trait for MPI type conversions.
+/// @private Map a C++ scalar type to its MPI_Datatype. New types are
+/// added here as another `else if constexpr` branch.
 template <typename T>
-struct mpi_type_mapping;
+MPI_Datatype mpi_datatype()
+{
+  if constexpr (std::is_same_v<T, float>)
+    return MPI_FLOAT;
+  else if constexpr (std::is_same_v<T, double>)
+    return MPI_DOUBLE;
+  else if constexpr (std::is_same_v<T, std::complex<float>>)
+    return MPI_C_FLOAT_COMPLEX;
+  else if constexpr (std::is_same_v<T, std::complex<double>>)
+    return MPI_C_DOUBLE_COMPLEX;
+  else if constexpr (std::is_same_v<T, std::int8_t>)
+    return MPI_INT8_T;
+  else if constexpr (std::is_same_v<T, std::int16_t>)
+    return MPI_INT16_T;
+  else if constexpr (std::is_same_v<T, std::int32_t>)
+    return MPI_INT32_T;
+  else if constexpr (std::is_same_v<T, std::int64_t>)
+    return MPI_INT64_T;
+  else if constexpr (std::is_same_v<T, std::uint8_t>)
+    return MPI_UINT8_T;
+  else if constexpr (std::is_same_v<T, std::uint16_t>)
+    return MPI_UINT16_T;
+  else if constexpr (std::is_same_v<T, std::uint32_t>)
+    return MPI_UINT32_T;
+  else if constexpr (std::is_same_v<T, std::uint64_t>)
+    return MPI_UINT64_T;
+  else
+    static_assert(dependent_false<T>::value,
+                  "No MPI datatype registered for this type.");
+}
 
 /// @brief Retrieves the MPI data type associated to the provided type.
 /// @tparam T cpp type to map
 template <typename T>
-MPI_Datatype mpi_t = mpi_type_mapping<T>::type;
-
-/// @brief Registers for cpp_t the corresponding mpi_t which can then be
-/// retrieved with mpi_t<cpp_t> from here on.
-#define MAP_TO_MPI_TYPE(cpp_t, mpi_t)                                          \
-  template <>                                                                  \
-  struct mpi_type_mapping<cpp_t>                                               \
-  {                                                                            \
-    static inline MPI_Datatype type = mpi_t;                                   \
-  };
-
-/// @defgroup MPI type mappings
-/// @{
-/// @cond
-MAP_TO_MPI_TYPE(float, MPI_FLOAT)
-MAP_TO_MPI_TYPE(double, MPI_DOUBLE)
-MAP_TO_MPI_TYPE(std::complex<float>, MPI_C_FLOAT_COMPLEX)
-MAP_TO_MPI_TYPE(std::complex<double>, MPI_C_DOUBLE_COMPLEX)
-MAP_TO_MPI_TYPE(std::int8_t, MPI_INT8_T)
-MAP_TO_MPI_TYPE(std::int16_t, MPI_INT16_T)
-MAP_TO_MPI_TYPE(std::int32_t, MPI_INT32_T)
-MAP_TO_MPI_TYPE(std::int64_t, MPI_INT64_T)
-MAP_TO_MPI_TYPE(std::uint8_t, MPI_UINT8_T)
-MAP_TO_MPI_TYPE(std::uint16_t, MPI_UINT16_T)
-MAP_TO_MPI_TYPE(std::uint32_t, MPI_UINT32_T)
-MAP_TO_MPI_TYPE(std::uint64_t, MPI_UINT64_T)
-/// @endcond
-/// @}
+MPI_Datatype mpi_t = mpi_datatype<T>();
 
 //---------------------------------------------------------------------------
 template <std::ranges::contiguous_range U>

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -33,7 +33,7 @@
 namespace dolfinx::MPI
 {
 /// MPI communication tags
-enum class tag : std::uint16_t
+enum class tag : int
 {
   consensus_pcx = 1200,
   consensus_pex = 1201,
@@ -158,10 +158,11 @@ std::vector<int> compute_graph_edges_pcx(MPI_Comm comm,
 /// @pre `edges` must not contain duplicate ranks.
 /// @param[in] tag Tag used in non-blocking MPI calls. A tag can be
 /// required when this function is called a second time on some ranks
-/// before a previous call has completed on all other ranks. @return
-/// Ranks that have defined edges from them to this rank. @note An
-/// alternative to passing a tag is to ensure that there is an implicit
-/// or explicit barrier before and after the call to this function.
+/// before a previous call has completed on all other ranks.
+/// @return Ranks that have defined edges from them to this rank.
+/// @note An alternative to passing a tag is to ensure that there is
+/// an implicit or explicit barrier before and after the call to this
+/// function.
 std::vector<int>
 compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
                         int tag = static_cast<int>(tag::consensus_nbx));
@@ -319,83 +320,59 @@ MPI_Datatype mpi_t = mpi_datatype<T>();
 //---------------------------------------------------------------------------
 namespace impl
 {
-/// @private Local (non-communicating) part of distribute_to_postoffice:
-/// group the local rows of `x` that do not belong to this rank by
-/// their post office (destination) rank.
+/// @private Local (non-communicating) part of distribute_to_postoffice.
+///
+/// For each local row of `x`, determines its post office (destination)
+/// rank by applying dolfinx::MPI::index_owner to the row's global
+/// index and `shape0`, skipping rows already owned by this rank (which
+/// never need to be sent anywhere). The remaining (destination,
+/// position) pairs are grouped by destination with a radix sort --
+/// this list can have hundreds of thousands of entries for a large
+/// mesh/problem, too many for a generic comparison sort -- producing
+/// the compact per-neighbour form (unique destination ranks, row
+/// count per destination, and a local-row-to-neighbour-rank map)
+/// that postoffice_exchange needs to drive MPI neighbourhood
+/// collectives without a further per-row lookup during packing.
+///
+/// Factored out of distribute_to_postoffice so distribute_from_postoffice
+/// can reuse the same planning step when it overlaps this push with
+/// the NBX round that resolves who is requesting data from it.
+///
+/// @param[in] size Number of ranks in the communicator `x` is
+/// distributed/required across.
+/// @param[in] rank Rank of the caller in that communicator.
+/// @param[in] shape0_local Number of local rows of `x` (before any
+/// post-office redistribution).
+/// @param[in] shape0 Global number of rows (row count summed over all
+/// ranks).
+/// @param[in] rank_offset Global row index of local row 0 in `x`.
 /// @return (0) unique destination ranks, (1) number of rows destined
 /// for each rank in (0), and (2) a map from local row index to
 /// position in (0), or -1 if the row is already owned by this rank.
-inline std::tuple<std::vector<int>, std::vector<std::int32_t>,
-                  std::vector<std::int32_t>>
-postoffice_plan(MPI_Comm comm, std::int32_t shape0_local, std::int64_t shape0,
-                std::int64_t rank_offset)
-{
-  const int size = dolfinx::MPI::size(comm);
-  const int rank = dolfinx::MPI::rank(comm);
-
-  // Build list of (dest, positions) for each row that doesn't belong to
-  // this rank, then sort
-  std::vector<std::array<std::int32_t, 2>> dest_to_index;
-  dest_to_index.reserve(shape0_local);
-  for (std::int32_t i = 0; i < shape0_local; ++i)
-  {
-    std::size_t idx = i + rank_offset;
-    if (int dest = MPI::index_owner(size, idx, shape0); dest != rank)
-      dest_to_index.push_back({dest, i});
-  }
-
-  // Radix sort (not a comparison sort): dest_to_index can have
-  // hundreds of thousands of entries for a large mesh/problem.
-  {
-    std::span<const std::int32_t> flat(
-        reinterpret_cast<const std::int32_t*>(dest_to_index.data()),
-        2 * dest_to_index.size());
-    std::vector<std::int32_t> perm
-        = dolfinx::sort_by_perm<std::int32_t, 16>(flat, 2);
-    std::vector<std::array<std::int32_t, 2>> sorted(dest_to_index.size());
-    for (std::size_t i = 0; i < perm.size(); ++i)
-      sorted[i] = dest_to_index[perm[i]];
-    dest_to_index = std::move(sorted);
-  }
-
-  // Build list of neighbour src ranks and count number of items (rows
-  // of x) to receive from each src post office (by neighbourhood rank)
-  std::vector<int> dest;
-  std::vector<std::int32_t> num_items_per_dest,
-      pos_to_neigh_rank(shape0_local, -1);
-  {
-    auto it = dest_to_index.begin();
-    while (it != dest_to_index.end())
-    {
-      const int neigh_rank = dest.size();
-
-      // Store global rank
-      dest.push_back((*it)[0]);
-
-      // Find iterator to next global rank
-      auto it1
-          = std::find_if(it, dest_to_index.end(),
-                         [r = dest.back()](auto& idx) { return idx[0] != r; });
-
-      // Store number of items for current rank
-      num_items_per_dest.push_back(std::distance(it, it1));
-
-      // Map from local x index to local destination rank
-      for (auto e = it; e != it1; ++e)
-        pos_to_neigh_rank[(*e)[1]] = neigh_rank;
-
-      // Advance iterator
-      it = it1;
-    }
-  }
-
-  return {std::move(dest), std::move(num_items_per_dest),
-          std::move(pos_to_neigh_rank)};
-}
+std::tuple<std::vector<int>, std::vector<std::int32_t>,
+           std::vector<std::int32_t>>
+postoffice_plan(int size, int rank, std::int32_t shape0_local,
+                std::int64_t shape0, std::int64_t rank_offset);
 
 /// @private Neighbourhood data exchange step of distribute_to_postoffice,
 /// given an already-resolved `src` (e.g. from a single or overlapped
 /// NBX consensus round).
+/// @param[in] comm MPI communicator.
+/// @param[in] x Local block of the array to distribute (row-major).
+/// @param[in] shape Global shape of the array, `{num_rows, num_cols}`.
+/// @param[in] rank_offset Global row index of local row 0 in `x`.
+/// @param[in] dest Destination (post office) ranks, from
+/// `postoffice_plan`.
+/// @param[in] num_items_per_dest0 Number of rows destined for each
+/// rank in `dest`, from `postoffice_plan`.
+/// @param[in] pos_to_neigh_rank Map from local row index to position
+/// in `dest`, from `postoffice_plan`.
+/// @param[in] src Ranks that will send this rank data, i.e. the
+/// incoming edges resolved from `dest` (e.g. via
+/// `compute_graph_edges_nbx`).
+/// @return (0) position of each received row within the caller's
+/// post-office partition of `[0, shape[0])`, and (1) the received row
+/// data (row-major).
 template <std::ranges::contiguous_range U>
 std::pair<std::vector<std::int32_t>, std::vector<std::ranges::range_value_t<U>>>
 postoffice_exchange(MPI_Comm comm, const U& x,
@@ -503,14 +480,16 @@ distribute_to_postoffice(MPI_Comm comm, const U& x,
 
   spdlog::debug("Sending data to post offices (distribute_to_postoffice)");
 
+  const int size = dolfinx::MPI::size(comm);
+  const int rank = dolfinx::MPI::rank(comm);
   auto [dest, num_items_per_dest, pos_to_neigh_rank]
-      = impl::postoffice_plan(comm, shape0_local, shape[0], rank_offset);
+      = impl::postoffice_plan(size, rank, shape0_local, shape[0], rank_offset);
 
   // Determine source ranks
   const std::vector<int> src = MPI::compute_graph_edges_nbx(comm, dest);
   spdlog::info(
       "Number of neighbourhood source ranks in distribute_to_postoffice: {}",
-      static_cast<int>(src.size()));
+      src.size());
 
   auto result
       = impl::postoffice_exchange(comm, x, shape, rank_offset, dest,
@@ -543,7 +522,7 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
   //    overlapped round rather than back-to-back.
 
   auto [send_dest, num_items_per_send_dest, pos_to_neigh_rank]
-      = impl::postoffice_plan(comm, shape0_local, shape[0], rank_offset);
+      = impl::postoffice_plan(size, rank, shape0_local, shape[0], rank_offset);
 
   // Build (src, global index, position) for each entry in 'indices'
   // not held locally, then sort. Locally-held entries are read
@@ -599,8 +578,7 @@ distribute_from_postoffice(MPI_Comm comm, std::span<const std::int64_t> indices,
   spdlog::info(
       "Neighbourhood destination ranks from post office in "
       "distribute_data (rank, num dests, num dests/mpi_size): {}, {}, {}",
-      rank, static_cast<int>(dest.size()),
-      static_cast<double>(dest.size()) / size);
+      rank, dest.size(), static_cast<double>(dest.size()) / size);
 
   // Send receive x data to post office (only for rows that need to be
   // communicated)

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -153,10 +153,12 @@ std::vector<int> compute_graph_edges_pcx(MPI_Comm comm,
 /// @param[in] comm MPI communicator
 /// @param[in] edges Edges (ranks) from this rank (the caller).
 /// @pre `edges` must not contain duplicate ranks.
-/// @param[in] tag Tag used in non-blocking MPI calls. `comm` is
-/// duplicated internally, so concurrent calls cannot interfere with
-/// each other regardless of `tag`.
-/// @return Ranks that have defined edges from them to this rank.
+/// @param[in] tag Tag used in non-blocking MPI calls. A tag can be
+/// required when this function is called a second time on some ranks
+/// before a previous call has completed on all other ranks. @return
+/// Ranks that have defined edges from them to this rank. @note An
+/// alternative to passing a tag is to ensure that there is an implicit
+/// or explicit barrier before and after the call to this function.
 std::vector<int>
 compute_graph_edges_nbx(MPI_Comm comm, std::span<const int> edges,
                         int tag = static_cast<int>(tag::consensus_nbx));

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -36,7 +36,6 @@ namespace dolfinx::MPI
 enum class tag : int
 {
   consensus_pcx = 1200,
-  consensus_pex = 1201,
   consensus_nbx = 1202,
 };
 


### PR DESCRIPTION
## Summary

- Harden `MPI::compute_graph_edges_nbx`: duplicate the communicator internally
  (matching the codebase's own `Comm` RAII idiom), replace the reactive
  `Iprobe`+`Recv` pattern with a persistent `Irecv` to avoid unexpected-message
  overhead, and fix a Release-build correctness gap where an `assert()` used to
  guard a legitimate send/cancellation race compiled out under `NDEBUG`,
  silently dropping a valid source rank.
- Speed up the MPI "post office" data-distribution functions
  (`distribute_to_postoffice`/`distribute_from_postoffice`/`distribute_data`
  in `common/MPI.h`):
  - Replace an `O(n log n)` comparison sort used to group rows by
    destination/source rank with the radix-sort pattern already used for the
    same problem shape in `mesh/graphbuild.cpp` (1.6–2.4x on a naive
    even-split benchmark).
  - Skip post-office round trips for indices the caller already holds
    locally, rather than routing them through an unrelated post-office rank
    and discarding the reply (2.4–2.9x on a request-heavy gather/scatter
    benchmark).
  - Remove a dead computation, a redundant `index_owner` recomputation, and a
    vestigial doubly-nested loop where the "offset" cursor was always equal
    to the inner loop index.
- Constrain the post-office function templates with
  `std::ranges::contiguous_range` (previously unconstrained `typename U`),
  matching the `concepts`-over-SFINAE precedent in `mesh::Topology.h`'s
  `CellRange`, and drop the repeated
  `typename std::remove_reference_t<typename U::value_type>` boilerplate in
  favour of `std::ranges::range_value_t<U>`.
- Simplify the MPI type-mapping machinery: replace the
  `mpi_type_mapping`-struct + `MAP_TO_MPI_TYPE` macro (12 explicit
  specializations) with a single `if constexpr` dispatch function. The public
  `dolfinx::MPI::mpi_t<T>` interface is unchanged. This also puts the
  previously-unused `dependent_false` to work, turning a generic "implicit
  instantiation of undefined template" error for an unregistered type into a
  clear `static_assert` message.
- Fix stale/inaccurate docstrings on the post-office functions (a `@pre`
  referencing a nonexistent `shape1` parameter, a misleading claim about
  which communicator `rank_offset` is scanned over, grammar and typos) and
  tighten the wording.

## AI assistance

AI assistance: I used Claude Code (Claude Sonnet 5) to draft this PR,
including the benchmarking used to validate the performance claims above. I
reviewed, tested, and take responsibility for the final contribution.

## Test plan

- [x] `clang-format --dry-run --Werror` clean
- [x] `ninja` build of `libdolfinx` clean under `-Wall -Wextra -pedantic
      -Werror` (exercises all 16 files across the codebase that consume
      `mpi_t<T>`)
- [x] Python bindings (`nanobind` wrappers) rebuild clean
- [x] C++ Catch2 suite passes at 1/2/3 MPI ranks with unchanged assertion
      counts
- [x] Standalone benchmark harness exercising `MPI::distribute_data`
      confirms both the performance improvements above and correctness (a
      per-row self-check against expected values, zero mismatches, up to 8
      ranks) against the pre-change baseline