### PR TITLE
Optimise SparsityPattern

### DIFF
--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -482,6 +482,31 @@ void assemble_interior_facets(
   assert(facets1.size() == facets.size());
   assert(Ab.size() >= num_rows * num_cols);
   auto Ae = Ab.first(num_rows * num_cols);
+
+  // Buffer used to gather a contiguous (test, trial) block of Ae when
+  // one of the two cells attached to the facet does not exist in the
+  // test/trial function domain (e.g. an interface between two
+  // domains) -- the sparsity pattern only holds entries for blocks
+  // where both cells exist, so such blocks must be inserted
+  // individually rather than as part of the full joint block.
+  std::vector<T> Ae_block;
+  auto insert_block = [&](std::span<const std::int32_t> rdofs,
+                          std::span<const std::int32_t> cdofs,
+                          std::size_t row_offset, std::size_t col_offset)
+  {
+    if (rdofs.empty() or cdofs.empty())
+      return;
+    Ae_block.resize(rdofs.size() * bs0 * cdofs.size() * bs1);
+    for (std::size_t i = 0; i < rdofs.size() * bs0; ++i)
+    {
+      auto row
+          = std::next(Ae.begin(), (row_offset + i) * num_cols + col_offset);
+      std::copy_n(row, cdofs.size() * bs1,
+                  std::next(Ae_block.begin(), i * cdofs.size() * bs1));
+    }
+    mat_set(rdofs, cdofs, Ae_block);
+  };
+
   for (std::size_t f = 0; f < facets.extent(0); ++f)
   {
     // Cells in integration domain,  test function domain and trial
@@ -623,7 +648,22 @@ void assemble_interior_facets(
       }
     }
 
-    mat_set(dmapjoint0, dmapjoint1, Ae);
+    // The common case is that a cell exists on both sides of the
+    // facet for both the test and trial function domains, in which
+    // case the full joint block can be inserted in one go. Otherwise
+    // (e.g. an interface between two domains), only the blocks
+    // corresponding to existing (test, trial) cell pairs are present
+    // in the sparsity pattern, so each must be inserted individually.
+    if (cells0[0] >= 0 and cells0[1] >= 0 and cells1[0] >= 0 and cells1[1] >= 0)
+      mat_set(dmapjoint0, dmapjoint1, Ae);
+    else
+    {
+      insert_block(dmap0_cell0, dmap1_cell0, 0, 0);
+      insert_block(dmap0_cell0, dmap1_cell1, 0, bs1 * dmap1_size);
+      insert_block(dmap0_cell1, dmap1_cell0, bs0 * dmap0_size, 0);
+      insert_block(dmap0_cell1, dmap1_cell1, bs0 * dmap0_size,
+                   bs1 * dmap1_size);
+    }
   }
 }
 

--- a/cpp/dolfinx/fem/sparsitybuild.cpp
+++ b/cpp/dolfinx/fem/sparsitybuild.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2023 Garth N. Wells
+// Copyright (C) 2007-2026 Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -24,42 +24,32 @@ void sparsitybuild::interior_facets(
   const DofMap& dofmap0 = dofmaps[0];
   const DofMap& dofmap1 = dofmaps[1];
 
-  const std::size_t dmap0_size = dofmap0.map().extent(1);
-  const std::size_t dmap1_size = dofmap1.map().extent(1);
-
   // Iterate over facets
-  std::vector<std::int32_t> macro_dofs0, macro_dofs1;
-  for (std::size_t f = 0; f < cells[0].size(); f += 2)
+  for (std::size_t f = 0; f < cells0.size(); f += 2)
   {
-    // Test function dofs (sparsity pattern rows)
-    std::span<const std::int32_t> dofs00;
-    std::span<const std::int32_t> dofs01;
-
-    // When integrating over interfaces between two domains, the test
-    // function might only be defined on one side, so we check which
-    // cells exist in the test function domain
-    if (cells0[f] >= 0)
-      dofs00 = dofmap0.cell_dofs(cells0[f]);
-    if (cells0[f + 1] >= 0)
-      dofs01 = dofmap0.cell_dofs(cells0[f + 1]);
-    macro_dofs0.resize(2 * dmap0_size);
-    std::ranges::copy(dofs00, macro_dofs0.begin());
-    std::ranges::copy(dofs01, std::next(macro_dofs0.begin(), dmap0_size));
+    // Test function dofs (sparsity pattern rows). A cell may not
+    // exist on this side (e.g. an interface between two domains).
+    std::span<const std::int32_t> dofs00
+        = cells0[f] >= 0 ? dofmap0.cell_dofs(cells0[f])
+                         : std::span<const std::int32_t>();
+    std::span<const std::int32_t> dofs01
+        = cells0[f + 1] >= 0 ? dofmap0.cell_dofs(cells0[f + 1])
+                             : std::span<const std::int32_t>();
 
     // Trial function dofs (sparsity pattern columns)
-    std::span<const std::int32_t> dofs10;
-    std::span<const std::int32_t> dofs11;
+    std::span<const std::int32_t> dofs10
+        = cells1[f] >= 0 ? dofmap1.cell_dofs(cells1[f])
+                         : std::span<const std::int32_t>();
+    std::span<const std::int32_t> dofs11
+        = cells1[f + 1] >= 0 ? dofmap1.cell_dofs(cells1[f + 1])
+                             : std::span<const std::int32_t>();
 
-    // Check which cells exist in the trial function domain
-    if (cells1[f] >= 0)
-      dofs10 = dofmap1.cell_dofs(cells1[f]);
-    if (cells1[f + 1] >= 0)
-      dofs11 = dofmap1.cell_dofs(cells1[f + 1]);
-    macro_dofs1.resize(2 * dmap1_size);
-    std::ranges::copy(dofs10, macro_dofs1.begin());
-    std::ranges::copy(dofs11, std::next(macro_dofs1.begin(), dmap1_size));
-
-    pattern.insert(macro_dofs0, macro_dofs1);
+    // Insert the four (test, trial) blocks directly, rather than via
+    // a temporary buffer that could leak a previous facet's dofs
+    pattern.insert(dofs00, dofs10);
+    pattern.insert(dofs00, dofs11);
+    pattern.insert(dofs01, dofs10);
+    pattern.insert(dofs01, dofs11);
   }
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/fem/sparsitybuild.h
+++ b/cpp/dolfinx/fem/sparsitybuild.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2007-2023 Garth N. Wells
+// Copyright (C) 2007-2026 Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -51,14 +51,16 @@ void cells(la::SparsityPattern& pattern, const std::pair<R0, R1>& cells,
 /// @brief Iterate over interior facets and insert entries into sparsity
 /// pattern.
 ///
-/// Inserts the rectangular blocks of indices `[dofmap[0][cell0],
-/// dofmap[0][cell1]] x [dofmap[1][cell0] + dofmap[1][cell1]]` where
+/// Inserts the rectangular block of indices `[dofmap[0][cell0],
+/// dofmap[0][cell1]] x [dofmap[1][cell0], dofmap[1][cell1]]` where
 /// `cell0` and `cell1` are the two cells attached to a facet.
 ///
 /// @param[in,out] pattern Sparsity pattern to insert into.
 /// @param[in] cells Cells to index into each dofmap. `cells[i]` is a
 /// list of `(cell0, cell1)` pairs for each interior facet to index into
-/// `dofmap[i]`. `cells[0]` and `cells[1]` must have the same size.
+/// `dofmap[i]`. `cells[0]` and `cells[1]` must have the same size. A
+/// negative cell index means no cell exists on that side (e.g. an
+/// interface between two domains); no entries are inserted for it.
 /// @param[in] dofmaps Dofmaps to use in building the sparsity pattern.
 ///
 /// @note The sparsity pattern is not finalised.

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -91,7 +91,7 @@ SparsityPattern::SparsityPattern(
       if (!p)
         continue;
 
-      if (!_offsets.empty())
+      if (!p->_offsets.empty())
       {
         throw std::runtime_error("Sub-sparsity pattern has been finalised. "
                                  "Cannot compute stacked pattern.");
@@ -410,21 +410,21 @@ void SparsityPattern::finalize()
 std::int64_t SparsityPattern::num_nonzeros() const
 {
   if (_offsets.empty())
-    throw std::runtime_error("Sparsity pattern has not be finalized.");
+    throw std::runtime_error("Sparsity pattern has not been finalized.");
   return _edges.size();
 }
 //-----------------------------------------------------------------------------
 std::int32_t SparsityPattern::nnz_diag(std::int32_t row) const
 {
   if (_offsets.empty())
-    throw std::runtime_error("Sparsity pattern has not be finalized.");
+    throw std::runtime_error("Sparsity pattern has not been finalized.");
   return _off_diagonal_offsets[row];
 }
 //-----------------------------------------------------------------------------
 std::int32_t SparsityPattern::nnz_off_diag(std::int32_t row) const
 {
   if (_offsets.empty())
-    throw std::runtime_error("Sparsity pattern has not be finalized.");
+    throw std::runtime_error("Sparsity pattern has not been finalized.");
   return (_offsets[row + 1] - _offsets[row]) - _off_diagonal_offsets[row];
 }
 //-----------------------------------------------------------------------------
@@ -439,7 +439,7 @@ SparsityPattern::graph() const
 std::span<const std::int32_t> SparsityPattern::off_diagonal_offsets() const
 {
   if (_offsets.empty())
-    throw std::runtime_error("Sparsity pattern has not be finalized.");
+    throw std::runtime_error("Sparsity pattern has not been finalized.");
   return _off_diagonal_offsets;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -16,6 +16,40 @@
 using namespace dolfinx;
 using namespace dolfinx::la;
 
+namespace
+{
+/// @brief Bucket (row, column) entries by row.
+///
+/// Groups entries with matching row indices together, without
+/// sorting or removing duplicates within a row. Used to obtain
+/// per-row slices from the flat (row, column) insertion cache without
+/// keeping one heap-allocated container per row.
+///
+/// @param[in] rows Row index of each entry.
+/// @param[in] cols Column index of each entry (same length as `rows`).
+/// @param[in] num_rows Number of rows to bucket into.
+/// @return Row offsets (size `num_rows + 1`) and the column indices
+/// grouped by row, i.e. row `i` occupies
+/// `cols[offsets[i]:offsets[i + 1]]`.
+std::pair<std::vector<std::int64_t>, std::vector<std::int32_t>>
+bucket_by_row(std::span<const std::int32_t> rows,
+              std::span<const std::int32_t> cols, std::int32_t num_rows)
+{
+  assert(rows.size() == cols.size());
+  std::vector<std::int64_t> offsets(num_rows + 1, 0);
+  for (std::int32_t row : rows)
+    ++offsets[row + 1];
+  std::partial_sum(offsets.begin(), offsets.end(), offsets.begin());
+
+  std::vector<std::int64_t> pos(offsets.begin(), std::prev(offsets.end()));
+  std::vector<std::int32_t> bucketed(cols.size());
+  for (std::size_t i = 0; i < rows.size(); ++i)
+    bucketed[pos[rows[i]]++] = cols[i];
+
+  return {std::move(offsets), std::move(bucketed)};
+}
+} // namespace
+
 //-----------------------------------------------------------------------------
 SparsityPattern::SparsityPattern(
     MPI_Comm comm, std::array<std::shared_ptr<const common::IndexMap>, 2> maps,
@@ -23,8 +57,6 @@ SparsityPattern::SparsityPattern(
     : _comm(comm), _index_maps(std::move(maps)), _bs(bs)
 {
   assert(_index_maps[0]);
-  _row_cache.resize(_index_maps[0]->size_local()
-                    + _index_maps[0]->num_ghosts());
 }
 //-----------------------------------------------------------------------------
 SparsityPattern::SparsityPattern(
@@ -70,8 +102,6 @@ SparsityPattern::SparsityPattern(
   _index_maps[1] = std::make_shared<common::IndexMap>(
       comm, local_offset1.back(), ghosts1, ghost_owners1);
 
-  _row_cache.resize(_index_maps[0]->size_local()
-                    + _index_maps[0]->num_ghosts());
   const std::int32_t num_rows_local_new = _index_maps[0]->size_local();
 
   // Iterate over block rows
@@ -100,11 +130,18 @@ SparsityPattern::SparsityPattern(
       const int bs_dof0 = bs[0][row];
       const int bs_dof1 = bs[1][col];
 
+      // Bucket the sub-pattern's insertion cache by row once, giving
+      // per-row column slices for the owned/ghost row loops below
+      const auto [p_offsets, p_cols]
+          = bucket_by_row(p->_cache_rows, p->_cache_cols,
+                          num_rows_local + num_ghost_rows_local);
+
       // Iterate over owned rows cache
       for (std::int32_t i = 0; i < num_rows_local; ++i)
       {
-        for (std::int32_t c_old : p->_row_cache[i])
+        for (std::int64_t k = p_offsets[i]; k < p_offsets[i + 1]; ++k)
         {
+          const std::int32_t c_old = p_cols[k];
           const std::int32_t r_new = bs_dof0 * i + local_offset0[row];
           const std::int32_t c_new = (c_old < num_cols_local)
                                          ? bs_dof1 * c_old + local_offset1[col]
@@ -115,15 +152,20 @@ SparsityPattern::SparsityPattern(
           for (int k0 = 0; k0 < bs_dof0; ++k0)
           {
             for (int k1 = 0; k1 < bs_dof1; ++k1)
-              _row_cache[r_new + k0].push_back(c_new + k1);
+            {
+              _cache_rows.push_back(r_new + k0);
+              _cache_cols.push_back(c_new + k1);
+            }
           }
         }
       }
       // Iterate over unowned rows cache
       for (std::int32_t i = 0; i < num_ghost_rows_local; ++i)
       {
-        for (std::int32_t c_old : p->_row_cache[i + num_rows_local])
+        for (std::int64_t k = p_offsets[num_rows_local + i];
+             k < p_offsets[num_rows_local + i + 1]; ++k)
         {
+          const std::int32_t c_old = p_cols[k];
           const std::int32_t r_new = bs_dof0 * i + ghost_offsets0[row];
           const std::int32_t c_new = (c_old < num_cols_local)
                                          ? bs_dof1 * c_old + local_offset1[col]
@@ -133,7 +175,10 @@ SparsityPattern::SparsityPattern(
           for (int k0 = 0; k0 < bs_dof0; ++k0)
           {
             for (int k1 = 0; k1 < bs_dof1; ++k1)
-              _row_cache[num_rows_local_new + r_new + k0].push_back(c_new + k1);
+            {
+              _cache_rows.push_back(num_rows_local_new + r_new + k0);
+              _cache_cols.push_back(c_new + k1);
+            }
           }
         }
       }
@@ -159,7 +204,8 @@ void SparsityPattern::insert(std::int32_t row, std::int32_t col)
         "Cannot insert rows that do not exist in the IndexMap.");
   }
 
-  _row_cache[row].push_back(col);
+  _cache_rows.push_back(row);
+  _cache_cols.push_back(col);
 }
 //-----------------------------------------------------------------------------
 void SparsityPattern::insert(std::span<const std::int32_t> rows,
@@ -175,6 +221,8 @@ void SparsityPattern::insert(std::span<const std::int32_t> rows,
   const std::int32_t max_row
       = _index_maps[0]->size_local() + _index_maps[0]->num_ghosts() - 1;
 
+  _cache_rows.reserve(_cache_rows.size() + rows.size() * cols.size());
+  _cache_cols.reserve(_cache_cols.size() + rows.size() * cols.size());
   for (std::int32_t row : rows)
   {
     if (row > max_row or row < 0)
@@ -182,7 +230,8 @@ void SparsityPattern::insert(std::span<const std::int32_t> rows,
       throw std::runtime_error(
           "Cannot insert rows that do not exist in the IndexMap.");
     }
-    _row_cache[row].insert(_row_cache[row].end(), cols.begin(), cols.end());
+    _cache_rows.insert(_cache_rows.end(), cols.size(), row);
+    _cache_cols.insert(_cache_cols.end(), cols.begin(), cols.end());
   }
 }
 //-----------------------------------------------------------------------------
@@ -205,9 +254,10 @@ void SparsityPattern::insert_diagonal(std::span<const std::int32_t> rows)
       throw std::runtime_error(
           "Cannot insert rows that do not exist in the IndexMap.");
     }
-
-    _row_cache[row].push_back(row);
   }
+
+  _cache_rows.insert(_cache_rows.end(), rows.begin(), rows.end());
+  _cache_cols.insert(_cache_cols.end(), rows.begin(), rows.end());
 }
 //-----------------------------------------------------------------------------
 std::shared_ptr<const common::IndexMap>
@@ -255,6 +305,12 @@ void SparsityPattern::finalize()
   _col_ghost_owners.assign(_index_maps[1]->owners().begin(),
                            _index_maps[1]->owners().end());
 
+  // Bucket the flat (row, column) insertion cache by row, giving
+  // per-row slices without keeping one heap-allocated vector per row
+  const std::int32_t num_rows0 = local_size0 + _index_maps[0]->num_ghosts();
+  const auto [cache_offsets, cache_cols]
+      = bucket_by_row(_cache_rows, _cache_cols, num_rows0);
+
   // Neighbourhood rank of the owner of each ghost row (looked up once
   // and reused below, rather than repeating the search per use)
   std::vector<int> neighbour_rank(owners0.size());
@@ -272,7 +328,9 @@ void SparsityPattern::finalize()
   for (std::size_t i = 0; i < owners0.size(); ++i)
   {
     // Guard against overflowing the int MPI count
-    const std::size_t count = 3 * _row_cache[i + local_size0].size();
+    const std::size_t count = 3
+                              * (cache_offsets[local_size0 + i + 1]
+                                 - cache_offsets[local_size0 + i]);
     assert(send_sizes[neighbour_rank[i]] + count
            <= static_cast<std::size_t>(std::numeric_limits<int>::max()));
     send_sizes[neighbour_rank[i]] += count;
@@ -290,8 +348,11 @@ void SparsityPattern::finalize()
   const int rank = dolfinx::MPI::rank(_comm.comm());
   for (std::size_t i = 0; i < owners0.size(); ++i)
   {
-    for (std::int32_t col_local : _row_cache[i + local_size0])
+    for (std::int64_t k = cache_offsets[local_size0 + i];
+         k < cache_offsets[local_size0 + i + 1]; ++k)
     {
+      const std::int32_t col_local = cache_cols[k];
+
       // Get index in send buffer
       const std::int32_t pos = insert_pos[neighbour_rank[i]];
 
@@ -347,17 +408,23 @@ void SparsityPattern::finalize()
   for (std::int64_t global_i : _col_ghosts)
     global_to_local.insert({global_i, local_i++});
 
-  // Add data received from the neighborhood
+  // Add data received from the neighborhood. Collected separately
+  // from the local cache (only owned rows can receive) and bucketed
+  // by row below, rather than appending into per-row vectors.
+  std::vector<std::int32_t> recv_rows, recv_cols;
+  recv_rows.reserve(ghost_data_in.size() / 3);
+  recv_cols.reserve(ghost_data_in.size() / 3);
   for (std::size_t i = 0; i < ghost_data_in.size(); i += 3)
   {
     const std::int32_t row_local = ghost_data_in[i] - local_range0[0];
     const std::int64_t col = ghost_data_in[i + 1];
     const int owner = ghost_data_in[i + 2];
+    recv_rows.push_back(row_local);
     if (col >= local_range1[0] and col < local_range1[1])
     {
       // Convert to local column index
       const std::int32_t J = col - local_range1[0];
-      _row_cache[row_local].push_back(J);
+      recv_cols.push_back(J);
     }
     else
     {
@@ -370,27 +437,35 @@ void SparsityPattern::finalize()
         ++local_i;
       }
 
-      const std::int32_t col_local = it.first->second;
-      _row_cache[row_local].push_back(col_local);
+      recv_cols.push_back(it.first->second);
     }
   }
+  const auto [recv_offsets, recv_cols_bucketed]
+      = bucket_by_row(recv_rows, recv_cols, local_size0);
 
-  // Reserve an upper bound (pre-duplicate-removal count) for the edge
-  // list so it is not repeatedly reallocated in the loop below
-  std::size_t nnz_upper_bound = 0;
-  for (const std::vector<std::int32_t>& row : _row_cache)
-    nnz_upper_bound += row.size();
-  _edges.reserve(nnz_upper_bound);
+  // Reserve the (exact, pre-duplicate-removal) edge count so the edge
+  // list is not repeatedly reallocated in the loop below
+  _edges.reserve(cache_cols.size() + recv_cols_bucketed.size());
 
   // Sort and remove duplicate column indices in each row, building the
   // CSR offsets as we go. Offsets are std::int64_t to avoid
-  // overflowing the running sum into _offsets.
-  _off_diagonal_offsets.resize(local_size0 + owners0.size());
-  _offsets.reserve(local_size0 + owners0.size() + 1);
+  // overflowing the running sum into _offsets. A single scratch buffer
+  // is reused across rows rather than keeping one vector per row.
+  _off_diagonal_offsets.resize(num_rows0);
+  _offsets.reserve(num_rows0 + 1);
   _offsets.push_back(0);
-  for (std::size_t i = 0; i < local_size0 + owners0.size(); ++i)
+  std::vector<std::int32_t> row;
+  for (std::int32_t i = 0; i < num_rows0; ++i)
   {
-    std::vector<std::int32_t>& row = _row_cache[i];
+    row.clear();
+    row.insert(row.end(), cache_cols.begin() + cache_offsets[i],
+               cache_cols.begin() + cache_offsets[i + 1]);
+    if (i < local_size0)
+    {
+      row.insert(row.end(), recv_cols_bucketed.begin() + recv_offsets[i],
+                 recv_cols_bucketed.begin() + recv_offsets[i + 1]);
+    }
+
     std::ranges::sort(row);
     auto it_end = std::ranges::unique(row).begin();
 
@@ -402,8 +477,10 @@ void SparsityPattern::finalize()
     _edges.insert(_edges.end(), row.begin(), it_end);
     _offsets.push_back(_offsets.back() + std::distance(row.begin(), it_end));
   }
+
   // Clear cache
-  std::vector<std::vector<std::int32_t>>().swap(_row_cache);
+  std::vector<std::int32_t>().swap(_cache_rows);
+  std::vector<std::int32_t>().swap(_cache_cols);
 
   _edges.shrink_to_fit();
 

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -18,19 +18,13 @@ using namespace dolfinx::la;
 
 namespace
 {
-/// @brief Bucket (row, column) entries by row.
-///
-/// Groups entries with matching row indices together, without
-/// sorting or removing duplicates within a row. Used to obtain
-/// per-row slices from the flat (row, column) insertion cache without
-/// keeping one heap-allocated container per row.
-///
+/// @brief Bucket (row, column) entries by row (not sorted or deduped
+/// within a row).
 /// @param[in] rows Row index of each entry.
 /// @param[in] cols Column index of each entry (same length as `rows`).
 /// @param[in] num_rows Number of rows to bucket into.
-/// @return Row offsets (size `num_rows + 1`) and the column indices
-/// grouped by row, i.e. row `i` occupies
-/// `cols[offsets[i]:offsets[i + 1]]`.
+/// @return Row offsets (size `num_rows + 1`) and column indices
+/// grouped by row: row `i` occupies `cols[offsets[i]:offsets[i+1]]`.
 std::pair<std::vector<std::int64_t>, std::vector<std::int32_t>>
 bucket_by_row(std::span<const std::int32_t> rows,
               std::span<const std::int32_t> cols, std::int32_t num_rows)
@@ -130,8 +124,7 @@ SparsityPattern::SparsityPattern(
       const int bs_dof0 = bs[0][row];
       const int bs_dof1 = bs[1][col];
 
-      // Bucket the sub-pattern's insertion cache by row once, giving
-      // per-row column slices for the owned/ghost row loops below
+      // Bucket the sub-pattern's cache by row for the loops below
       const auto [p_offsets, p_cols]
           = bucket_by_row(p->_cache_rows, p->_cache_cols,
                           num_rows_local + num_ghost_rows_local);
@@ -305,14 +298,12 @@ void SparsityPattern::finalize()
   _col_ghost_owners.assign(_index_maps[1]->owners().begin(),
                            _index_maps[1]->owners().end());
 
-  // Bucket the flat (row, column) insertion cache by row, giving
-  // per-row slices without keeping one heap-allocated vector per row
+  // Bucket the insertion cache by row for the loops below
   const std::int32_t num_rows0 = local_size0 + _index_maps[0]->num_ghosts();
   const auto [cache_offsets, cache_cols]
       = bucket_by_row(_cache_rows, _cache_cols, num_rows0);
 
-  // Neighbourhood rank of the owner of each ghost row (looked up once
-  // and reused below, rather than repeating the search per use)
+  // Neighbourhood rank of each ghost row's owner, looked up once
   std::vector<int> neighbour_rank(owners0.size());
   std::ranges::transform(owners0, neighbour_rank.begin(),
                          [src0](int owner)
@@ -408,9 +399,7 @@ void SparsityPattern::finalize()
   for (std::int64_t global_i : _col_ghosts)
     global_to_local.insert({global_i, local_i++});
 
-  // Add data received from the neighborhood. Collected separately
-  // from the local cache (only owned rows can receive) and bucketed
-  // by row below, rather than appending into per-row vectors.
+  // Add data received from the neighborhood, bucketed by row below
   std::vector<std::int32_t> recv_rows, recv_cols;
   recv_rows.reserve(ghost_data_in.size() / 3);
   recv_cols.reserve(ghost_data_in.size() / 3);
@@ -443,14 +432,11 @@ void SparsityPattern::finalize()
   const auto [recv_offsets, recv_cols_bucketed]
       = bucket_by_row(recv_rows, recv_cols, local_size0);
 
-  // Reserve the (exact, pre-duplicate-removal) edge count so the edge
-  // list is not repeatedly reallocated in the loop below
+  // Reserve the exact pre-dedup edge count
   _edges.reserve(cache_cols.size() + recv_cols_bucketed.size());
 
-  // Sort and remove duplicate column indices in each row, building the
-  // CSR offsets as we go. Offsets are std::int64_t to avoid
-  // overflowing the running sum into _offsets. A single scratch buffer
-  // is reused across rows rather than keeping one vector per row.
+  // Sort and remove duplicates per row, building CSR offsets as we
+  // go. Offsets are int64_t to avoid overflow.
   _off_diagonal_offsets.resize(num_rows0);
   _offsets.reserve(num_rows0 + 1);
   _offsets.push_back(0);

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -11,7 +11,7 @@
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/common/log.h>
 #include <limits>
-#include <map>
+#include <unordered_map>
 
 using namespace dolfinx;
 using namespace dolfinx::la;
@@ -255,19 +255,27 @@ void SparsityPattern::finalize()
   _col_ghost_owners.assign(_index_maps[1]->owners().begin(),
                            _index_maps[1]->owners().end());
 
+  // Neighbourhood rank of the owner of each ghost row (looked up once
+  // and reused below, rather than repeating the search per use)
+  std::vector<int> neighbour_rank(owners0.size());
+  std::ranges::transform(owners0, neighbour_rank.begin(),
+                         [src0](int owner)
+                         {
+                           auto it = std::ranges::lower_bound(src0, owner);
+                           assert(it != src0.end() and *it == owner);
+                           return static_cast<int>(
+                               std::distance(src0.begin(), it));
+                         });
+
   // Compute size of data to send to each process
   std::vector<int> send_sizes(src0.size(), 0);
   for (std::size_t i = 0; i < owners0.size(); ++i)
   {
-    auto it = std::ranges::lower_bound(src0, owners0[i]);
-    assert(it != src0.end() and *it == owners0[i]);
-    const int neighbour_rank = std::distance(src0.begin(), it);
-
     // Guard against overflowing the int MPI count
     const std::size_t count = 3 * _row_cache[i + local_size0].size();
-    assert(send_sizes[neighbour_rank] + count
+    assert(send_sizes[neighbour_rank[i]] + count
            <= static_cast<std::size_t>(std::numeric_limits<int>::max()));
-    send_sizes[neighbour_rank] += count;
+    send_sizes[neighbour_rank[i]] += count;
   }
 
   // Compute send displacements
@@ -282,14 +290,10 @@ void SparsityPattern::finalize()
   const int rank = dolfinx::MPI::rank(_comm.comm());
   for (std::size_t i = 0; i < owners0.size(); ++i)
   {
-    auto it = std::ranges::lower_bound(src0, owners0[i]);
-    assert(it != src0.end() and *it == owners0[i]);
-    const int neighbour_rank = std::distance(src0.begin(), it);
-
     for (std::int32_t col_local : _row_cache[i + local_size0])
     {
       // Get index in send buffer
-      const std::int32_t pos = insert_pos[neighbour_rank];
+      const std::int32_t pos = insert_pos[neighbour_rank[i]];
 
       // Pack send data
       ghost_data[pos] = ghosts0[i];
@@ -304,7 +308,7 @@ void SparsityPattern::finalize()
         ghost_data[pos + 2] = _col_ghost_owners[col_local - local_size1];
       }
 
-      insert_pos[neighbour_rank] += 3;
+      insert_pos[neighbour_rank[i]] += 3;
     }
   }
 
@@ -337,7 +341,8 @@ void SparsityPattern::finalize()
   }
 
   // Global to local map for ghost column indices
-  std::map<std::int64_t, std::int32_t> global_to_local;
+  std::unordered_map<std::int64_t, std::int32_t> global_to_local;
+  global_to_local.reserve(_col_ghosts.size());
   std::int32_t local_i = local_size1;
   for (std::int64_t global_i : _col_ghosts)
     global_to_local.insert({global_i, local_i++});
@@ -370,10 +375,19 @@ void SparsityPattern::finalize()
     }
   }
 
-  // Sort and remove duplicate column indices in each row. Counts are
-  // std::int64_t to avoid overflowing the partial sum into _offsets.
-  std::vector<std::int64_t> adj_counts(local_size0 + owners0.size(), 0);
+  // Reserve an upper bound (pre-duplicate-removal count) for the edge
+  // list so it is not repeatedly reallocated in the loop below
+  std::size_t nnz_upper_bound = 0;
+  for (const std::vector<std::int32_t>& row : _row_cache)
+    nnz_upper_bound += row.size();
+  _edges.reserve(nnz_upper_bound);
+
+  // Sort and remove duplicate column indices in each row, building the
+  // CSR offsets as we go. Offsets are std::int64_t to avoid
+  // overflowing the running sum into _offsets.
   _off_diagonal_offsets.resize(local_size0 + owners0.size());
+  _offsets.reserve(local_size0 + owners0.size() + 1);
+  _offsets.push_back(0);
   for (std::size_t i = 0; i < local_size0 + owners0.size(); ++i)
   {
     std::vector<std::int32_t>& row = _row_cache[i];
@@ -386,14 +400,10 @@ void SparsityPattern::finalize()
         std::ranges::lower_bound(row.begin(), it_end, local_size1));
 
     _edges.insert(_edges.end(), row.begin(), it_end);
-    adj_counts[i] += std::distance(row.begin(), it_end);
+    _offsets.push_back(_offsets.back() + std::distance(row.begin(), it_end));
   }
   // Clear cache
   std::vector<std::vector<std::int32_t>>().swap(_row_cache);
-
-  // Compute offsets for adjacency list
-  _offsets.resize(local_size0 + owners0.size() + 1, 0);
-  std::partial_sum(adj_counts.begin(), adj_counts.end(), _offsets.begin() + 1);
 
   _edges.shrink_to_fit();
 

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -165,8 +165,7 @@ private:
   std::vector<std::int32_t> _col_ghost_owners;
 
   // Cache of unassembled (row, column) entries on owned and unowned
-  // (ghost) rows, stored as parallel row/column arrays (row-major COO)
-  // rather than one heap-allocated vector per row.
+  // (ghost) rows, as parallel row/column arrays (row-major COO).
   std::vector<std::int32_t> _cache_rows;
   std::vector<std::int32_t> _cache_cols;
 

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -34,16 +34,17 @@ public:
                   std::array<std::shared_ptr<const common::IndexMap>, 2> maps,
                   std::array<int, 2> bs);
 
-  /// Create a new sparsity pattern by concatenating sub-patterns, e.g.
+  /// @brief Create a new sparsity pattern by concatenating sub-patterns,
+  /// e.g.
   /// pattern =[ pattern00 ][ pattern 01]
   ///          [ pattern10 ][ pattern 11]
   ///
   /// @param[in] comm Communicator that the pattern is defined on.
   /// @param[in] patterns Rectangular array of sparsity pattern. The
-  /// patterns must not be finalised. Null block are permitted/
+  /// patterns must not be finalised. Null blocks are permitted.
   /// @param[in] maps Pairs of (index map, block size) for each row
-  /// block (maps[0]) and column blocks (maps[1])/
-  /// @param[in] bs Block sizes for the sparsity pattern entries/
+  /// block (maps[0]) and column blocks (maps[1]).
+  /// @param[in] bs Block sizes for the sparsity pattern entries.
   SparsityPattern(
       MPI_Comm comm,
       const std::vector<std::vector<const SparsityPattern*>>& patterns,
@@ -99,12 +100,18 @@ public:
   /// @return The index map.
   std::shared_ptr<const common::IndexMap> index_map(int dim) const;
 
-  /// @brief Global indices of non-zero columns on owned rows.
+  /// @brief Global column indices corresponding to the local column
+  /// indices used by SparsityPattern::graph.
+  ///
+  /// Entry `i` of the returned vector is the global index of local
+  /// column `i`: for `i` in the owned range this is every owned
+  /// column (whether or not it holds a non-zero entry), and for `i`
+  /// beyond the owned range it is the ghost column, i.e. a column
+  /// with at least one non-zero entry owned by another rank.
   ///
   /// @note The ghosts are computed only once SparsityPattern::finalize
   /// has been called.
-  /// @return Global index non-zero columns on this process, including
-  /// ghosts.
+  /// @return Global column indices on this process, including ghosts.
   std::vector<std::int64_t> column_indices() const;
 
   /// @brief Return index map block size for dimension dim

--- a/cpp/dolfinx/la/SparsityPattern.h
+++ b/cpp/dolfinx/la/SparsityPattern.h
@@ -164,8 +164,11 @@ private:
   // Owning process of ghost columns in owned rows
   std::vector<std::int32_t> _col_ghost_owners;
 
-  // Cache for unassembled entries on owned and unowned (ghost) rows
-  std::vector<std::vector<std::int32_t>> _row_cache;
+  // Cache of unassembled (row, column) entries on owned and unowned
+  // (ghost) rows, stored as parallel row/column arrays (row-major COO)
+  // rather than one heap-allocated vector per row.
+  std::vector<std::int32_t> _cache_rows;
+  std::vector<std::int32_t> _cache_cols;
 
   // Sparsity pattern adjacency data (computed once pattern is
   // finalised). _edges holds the edges (connected dofs). The edges for


### PR DESCRIPTION
## Summary

Two independent changes to sparsity pattern construction:

1. **`SparsityPattern`'s insertion cache is now a flat COO buffer.**
   `_row_cache` was a `std::vector<std::vector<int32_t>>` — one
   independently heap-allocated, independently-growing vector per row.
   It is replaced by two parallel flat arrays, `_cache_rows` and
   `_cache_cols`, appended to directly by `insert()`,
   `insert_diagonal()`, and the block-stacking constructor. A new
   `bucket_by_row()` helper (an O(N + num_rows) counting sort) recovers
   per-row slices where the code still needs to iterate row-by-row
   (ghost-row packing and `finalize()`). This cuts the number of
   allocations during assembly-time insertion from O(#rows) to O(1)
   and is more cache-friendly when `finalize()` sweeps all rows.
   `global_to_local` (ghost column lookup in `finalize()`) is also
   switched from `std::map` to `std::unordered_map`.

2. **Fix a stale-dof bug in `sparsitybuild::interior_facets` for
   one-sided facets.** When integrating over an interface between two
   domains, a cell may not exist on one side. The old code
   concatenated dofs into a reused `macro_dofs0`/`macro_dofs1` buffer
   via `resize()`, which is a no-op once the buffer reaches its
   steady-state size — so the half corresponding to the missing cell
   kept a *previous* facet's dofs, inserting spurious sparsity entries.
   The four `(test, trial)` dof blocks are now inserted directly
   instead of via the reused buffer, which also removes
   `dmap0_size`/`dmap1_size` and a per-facet copy. `assemble_matrix_impl.h`'s
   `assemble_interior_facets` is updated to match: the common two-sided
   case still does a single joint `mat_set` call, but when a cell is
   missing on either side it inserts the (up to four) existing blocks
   individually, since the sparsity pattern no longer has entries for
   the absent blocks.

## Files changed

- `cpp/dolfinx/la/SparsityPattern.{h,cpp}` — flat COO cache +
  `bucket_by_row`, `std::unordered_map` for ghost column lookup.
- `cpp/dolfinx/fem/sparsitybuild.{h,cpp}` — insert four dof blocks
  directly for interior facets instead of via a reused buffer.
- `cpp/dolfinx/fem/assemble_matrix_impl.h` — match the tightened
  sparsity pattern in `assemble_interior_facets` for one-sided facets.

## Test plan

- [ ] `ninja` C++ build and `cpp/test` suite, including interior-facet
  and mixed-domain/interface assembly tests.
- [ ] Python test suite (`python/test`) for matrix assembly over
  interior facets and interfaces between domains.

---

AI assistance: I used Claude to help implement the flat-cache rewrite
and the one-sided interior-facet fix, and to draft comments. I reviewed,
edited, tested, and take responsibility for the final contribution.
