### PR TITLE
Deduplicate compile-time/runtime block-size loops in assembly and CSR spmv

### DIFF
--- a/cpp/demo/custom_kernel/main.cpp
+++ b/cpp/demo/custom_kernel/main.cpp
@@ -173,10 +173,10 @@ double assemble_vector1(const mesh::Geometry<T>& g, const fem::DofMap& dofmap,
   common::Timer timer("Assembler1 lambda (vector)");
   std::vector<T> cdofs_b(3 * g.dofmaps().front().extent(1));
   std::vector<T> be_b(dofmap.map().extent(1));
-  fem::impl::assemble_cells<1>([](auto, auto, auto, auto) {}, b.array(),
-                               g.dofmaps().front(), x, cells,
-                               {dofmap.map(), 1, cells}, kernel, {}, {}, {},
-                               std::span(be_b), std::span(cdofs_b));
+  fem::impl::assemble_cells(
+      [](auto, auto, auto, auto) {}, b.array(), g.dofmaps().front(), x, cells,
+      std::tuple{dofmap.map(), std::integral_constant<int, 1>{}, cells}, kernel,
+      {}, {}, {}, std::span(be_b), std::span(cdofs_b));
   b.scatter_rev(std::plus<T>());
   return la::squared_norm(b);
 }

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -74,7 +74,7 @@ template <typename V, std::floating_point U,
 void assemble_cells(
     const fem::DofTransformKernel<T> auto& P0, V&& b, mdspan2_t x_dofmap,
     md::mdspan<const U, md::extents<std::size_t, md::dynamic_extent, 3>> x,
-    std::span<const std::int32_t> cells, const auto& dofmap,
+    std::span<const std::int32_t> cells, const DofMapPackCells auto& dofmap,
     const FEkernel<T, U> auto& kernel, std::span<const T> constants,
     md::mdspan<const T, md::dextents<std::size_t, 2>> coeffs,
     std::span<const std::uint32_t> cell_info0, std::span<T> be_b,
@@ -91,7 +91,7 @@ void assemble_cells(
   // Iterate over active cells
   for (std::size_t index = 0; index < cells.size(); ++index)
   {
-    // Integration domain celland test function cell
+    // Integration domain cell and test function cell
     std::int32_t c = cells[index];
     std::int32_t c0 = cells0[index];
 
@@ -162,7 +162,7 @@ void assemble_entities(
     md::mdspan<const std::int32_t,
                std::extents<std::size_t, md::dynamic_extent, 2>>
         entities,
-    const auto& dofmap, const FEkernel<T, U> auto& kernel,
+    const DofMapPackEntities auto& dofmap, const FEkernel<T, U> auto& kernel,
     std::span<const T> constants,
     md::mdspan<const T, md::dextents<std::size_t, 2>> coeffs,
     std::span<const std::uint32_t> cell_info0,
@@ -250,7 +250,7 @@ void assemble_interior_facets(
     md::mdspan<const std::int32_t,
                std::extents<std::size_t, md::dynamic_extent, 2, 2>>
         facets,
-    const auto& dofmap, const FEkernel<T, U> auto& kernel,
+    const DofMapPackFacets auto& dofmap, const FEkernel<T, U> auto& kernel,
     std::span<const T> constants,
     md::mdspan<const T, md::extents<std::size_t, md::dynamic_extent, 2,
                                     md::dynamic_extent>>

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <optional>
 #include <span>
+#include <type_traits>
 #include <vector>
 
 namespace dolfinx::fem
@@ -113,18 +114,16 @@ void assemble_cells(
 
     // Scatter cell vector to 'global' vector array
     auto dofs = md::submdspan(dmap, c0, md::full_extent);
+    auto scatter = [&](auto n)
+    {
+      for (std::size_t i = 0; i < dofs.size(); ++i)
+        for (int k = 0; k < n; ++k)
+          b[n * dofs[i] + k] += be[n * i + k];
+    };
     if constexpr (_bs > 0)
-    {
-      for (std::size_t i = 0; i < dofs.size(); ++i)
-        for (int k = 0; k < _bs; ++k)
-          b[_bs * dofs[i] + k] += be[_bs * i + k];
-    }
+      scatter(std::integral_constant<int, _bs>());
     else
-    {
-      for (std::size_t i = 0; i < dofs.size(); ++i)
-        for (int k = 0; k < bs; ++k)
-          b[bs * dofs[i] + k] += be[bs * i + k];
-    }
+      scatter(bs);
   }
 }
 
@@ -225,18 +224,16 @@ void assemble_entities(
 
     // Add element vector to global vector
     auto dofs = md::submdspan(dmap, cell0, md::full_extent);
+    auto scatter = [&](auto n)
+    {
+      for (std::size_t i = 0; i < dofs.size(); ++i)
+        for (int k = 0; k < n; ++k)
+          b[n * dofs[i] + k] += be[n * i + k];
+    };
     if constexpr (_bs > 0)
-    {
-      for (std::size_t i = 0; i < dofs.size(); ++i)
-        for (int k = 0; k < _bs; ++k)
-          b[_bs * dofs[i] + k] += be[_bs * i + k];
-    }
+      scatter(std::integral_constant<int, _bs>());
     else
-    {
-      for (std::size_t i = 0; i < dofs.size(); ++i)
-        for (int k = 0; k < bs; ++k)
-          b[bs * dofs[i] + k] += be[bs * i + k];
-    }
+      scatter(bs);
   }
 }
 
@@ -355,24 +352,19 @@ void assemble_interior_facets(
     }
 
     // Add element vector to global vector
+    auto scatter = [&](auto n)
+    {
+      for (std::size_t i = 0; i < dmap0.size(); ++i)
+        for (int k = 0; k < n; ++k)
+          b[n * dmap0[i] + k] += be[n * i + k];
+      for (std::size_t i = 0; i < dmap1.size(); ++i)
+        for (int k = 0; k < n; ++k)
+          b[n * dmap1[i] + k] += be[n * (i + dmap_size) + k];
+    };
     if constexpr (_bs > 0)
-    {
-      for (std::size_t i = 0; i < dmap0.size(); ++i)
-        for (int k = 0; k < _bs; ++k)
-          b[_bs * dmap0[i] + k] += be[_bs * i + k];
-      for (std::size_t i = 0; i < dmap1.size(); ++i)
-        for (int k = 0; k < _bs; ++k)
-          b[_bs * dmap1[i] + k] += be[_bs * (i + dmap_size) + k];
-    }
+      scatter(std::integral_constant<int, _bs>());
     else
-    {
-      for (std::size_t i = 0; i < dmap0.size(); ++i)
-        for (int k = 0; k < bs; ++k)
-          b[bs * dmap0[i] + k] += be[bs * i + k];
-      for (std::size_t i = 0; i < dmap1.size(); ++i)
-        for (int k = 0; k < bs; ++k)
-          b[bs * dmap1[i] + k] += be[bs * (i + dmap_size) + k];
-    }
+      scatter(bs);
   }
 }
 

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -337,12 +337,12 @@ void assemble_interior_facets(
   }
 }
 
-/// @brief Apply boundary condition lifting using the matrix assembler.
+/// Modify RHS vector to account for boundary condition such that:
 ///
-/// @tparam T Scalar type.
-/// @tparam U Geometry scalar type.
-/// @param[in,out] b Vector to modify.
-/// @param[in] a The bilinear form.
+/// b <- b - alpha * A.(x_bc - x0)
+///
+/// @param[in,out] b Vector to be modified.
+/// @param[in] a Bilinear form that generates A.
 /// @param[in] bs0 Block size for the test function dofmap, as
 /// `std::integral_constant<int, BS0>` if known at compile time, or a
 /// plain `int` for the runtime-determined value.
@@ -351,20 +351,21 @@ void assemble_interior_facets(
 /// plain `int` for the runtime-determined value.
 /// @param[in] constants Constants that appear in `a`.
 /// @param[in] coefficients Coefficients that appear in `a`.
-/// @param[in] bc_values1 The boundary condition values.
-/// @param[in] bc_markers1 Marker to identify which DOFs have boundary
-/// conditions applied.
-/// @param[in] x0 Vector used in the lifting.
+/// @param[in] bc_values1 Boundary condition 'values'.
+/// @param[in] bc_markers1 Indices (columns of A, rows of x) to
+/// which bcs belong.
+/// @param[in] x0 Array used in the lifting, typically a 'current
+/// solution' in a Newton method.
 /// @param[in] alpha Scaling to apply.
 template <dolfinx::scalar T, std::floating_point U, typename V>
   requires std::is_same_v<typename std::remove_cvref_t<V>::value_type, T>
-void lift_bc_impl(
-    V&& b, const Form<T, U>& a, auto bs0, auto bs1,
-    std::span<const T> constants,
-    const std::map<std::pair<IntegralType, int>,
-                   std::pair<std::span<const T>, int>>& coefficients,
-    std::span<const T> bc_values1, std::span<const std::int8_t> bc_markers1,
-    std::span<const T> x0, T alpha)
+void lift_bc(V&& b, const Form<T, U>& a, auto bs0, auto bs1,
+             std::span<const T> constants,
+             const std::map<std::pair<IntegralType, int>,
+                            std::pair<std::span<const T>, int>>& coefficients,
+             std::span<const T> bc_values1,
+             std::span<const std::int8_t> bc_markers1, std::span<const T> x0,
+             T alpha)
 {
   // Deduce runtime block sizes as fallback when compile-time sizes
   // not given. The block size of the dofmap and indexmap is the same
@@ -404,54 +405,6 @@ void lift_bc_impl(
   // cells that have BC-constrained DOFs in the column space.
   assemble_matrix<T, U, true>(lifting_fn, a, constants, coefficients, {},
                               bc_markers1);
-}
-
-/// Modify RHS vector to account for boundary condition such that:
-///
-/// b <- b - alpha * A.(x_bc - x0)
-///
-/// @param[in,out] b The vector to be modified
-/// @param[in] a The bilinear form that generates A
-/// @param[in] constants Constants that appear in `a`
-/// @param[in] coefficients Coefficients that appear in `a`
-/// @param[in] bc_values1 The boundary condition 'values'
-/// @param[in] bc_markers1 The indices (columns of A, rows of x) to
-/// which bcs belong
-/// @param[in] x0 The array used in the lifting, typically a 'current
-/// solution' in a Newton method
-/// @param[in] alpha Scaling to apply
-template <typename V, std::floating_point U,
-          dolfinx::scalar T = typename std::remove_cvref_t<V>::value_type>
-  requires std::is_same_v<typename std::remove_cvref_t<V>::value_type, T>
-void lift_bc(V&& b, const Form<T, U>& a, std::span<const T> constants,
-             const std::map<std::pair<IntegralType, int>,
-                            std::pair<std::span<const T>, int>>& coefficients,
-             std::span<const T> bc_values1,
-             std::span<const std::int8_t> bc_markers1, std::span<const T> x0,
-             T alpha)
-{
-  // Get dofmap for columns and rows of a
-  assert(a.function_spaces().at(0));
-  assert(a.function_spaces().at(1));
-  const int bs0 = a.function_spaces()[0]->dofmaps().front()->bs();
-  const int bs1 = a.function_spaces()[1]->dofmaps().front()->bs();
-  if (bs0 == 1 and bs1 == 1)
-  {
-    lift_bc_impl<T, U>(std::forward<V>(b), a, std::integral_constant<int, 1>{},
-                       std::integral_constant<int, 1>{}, constants,
-                       coefficients, bc_values1, bc_markers1, x0, alpha);
-  }
-  else if (bs0 == 3 and bs1 == 3)
-  {
-    lift_bc_impl<T, U>(std::forward<V>(b), a, std::integral_constant<int, 3>{},
-                       std::integral_constant<int, 3>{}, constants,
-                       coefficients, bc_values1, bc_markers1, x0, alpha);
-  }
-  else
-  {
-    lift_bc_impl<T, U>(std::forward<V>(b), a, bs0, bs1, constants, coefficients,
-                       bc_values1, bc_markers1, x0, alpha);
-  }
 }
 
 /// Modify b such that:
@@ -508,17 +461,20 @@ void apply_lifting(
     {
       assert(a[j]->get().function_spaces().at(0));
       auto V1 = a[j]->get().function_spaces()[1];
+      assert(V1);
+
+      const int bs0 = a[j]->get().function_spaces()[0]->dofmaps().front()->bs();
+      const int bs1 = V1->dofmaps().front()->bs();
 
       std::span<const T> _x0;
       if (!x0.empty())
         _x0 = x0[j];
 
-      assert(V1);
       std::shared_ptr<const DofMap> dofmap = V1->dofmaps().front();
       auto map1 = dofmap->index_map;
-      const int bs1 = dofmap->index_map_bs();
+      const int map_bs1 = dofmap->index_map_bs();
       assert(map1);
-      const int crange = bs1 * (map1->size_local() + map1->num_ghosts());
+      const int crange = map_bs1 * (map1->size_local() + map1->num_ghosts());
       bc_markers1.assign(crange, false);
       bc_values1.assign(crange, 0);
       for (auto& bc : bcs1[j])
@@ -527,7 +483,7 @@ void apply_lifting(
         bc.get().set(bc_values1, std::nullopt, 1);
       }
 
-      lift_bc(b, a[j]->get(), constants[j], coeffs[j],
+      lift_bc(b, a[j]->get(), bs0, bs1, constants[j], coeffs[j],
               std::span<const T>(bc_values1), bc_markers1, _x0, alpha);
     }
   }

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -341,10 +341,6 @@ void assemble_interior_facets(
 ///
 /// @tparam T Scalar type.
 /// @tparam U Geometry scalar type.
-/// @tparam BS0 Compile-time block size for test function dofmap. Use -1
-/// for runtime block size.
-/// @tparam BS1 Compile-time block size for trial function dofmap. Use -1
-/// for runtime block size.
 /// @param[in,out] b Vector to modify.
 /// @param[in] a The bilinear form.
 /// @param[in] bs0 Block size for the test function dofmap, as

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -114,7 +114,7 @@ void assemble_cells(
 
     // Scatter cell vector to 'global' vector array
     auto dofs = md::submdspan(dmap, c0, md::full_extent);
-    auto scatter = [&](auto n)
+    auto scatter = [&b, be, dofs](auto n)
     {
       for (std::size_t i = 0; i < dofs.size(); ++i)
         for (int k = 0; k < n; ++k)
@@ -224,7 +224,7 @@ void assemble_entities(
 
     // Add element vector to global vector
     auto dofs = md::submdspan(dmap, cell0, md::full_extent);
-    auto scatter = [&](auto n)
+    auto scatter = [&b, be, dofs](auto n)
     {
       for (std::size_t i = 0; i < dofs.size(); ++i)
         for (int k = 0; k < n; ++k)
@@ -352,7 +352,7 @@ void assemble_interior_facets(
     }
 
     // Add element vector to global vector
-    auto scatter = [&](auto n)
+    auto scatter = [&b, be, dmap0, dmap1, dmap_size](auto n)
     {
       for (std::size_t i = 0; i < dmap0.size(); ++i)
         for (int k = 0; k < n; ++k)

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -238,7 +238,7 @@ void assemble_entities(
 /// @param[in] perms Facet permutation integer. Empty if facet
 /// permutations are not required.
 /// @param[in] be_b Buffer for local element vector. Size must be at
-/// least `2 * bs * dmap.map().extent(1)`.
+/// least `2 * bs * dmap.extent(1)`.
 /// @param[in] cdofs_b Buffer for local element geometry. Size must be
 /// at least `2 * 3 * x_dofmap.extent(1)`.
 template <typename V, std::floating_point U,

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <optional>
 #include <span>
+#include <stdexcept>
 #include <type_traits>
 #include <vector>
 
@@ -45,10 +46,6 @@ using mdspan2_t = md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>;
 /// a per-call allocation would not be amortized. Buffers must be
 /// sized by the caller and passed in via `be_b`/`cdofs_b`.
 ///
-/// @tparam _bs Block size of the form test function dof map. If less
-/// than zero the block size is determined at runtime. If `_bs` is
-/// positive the block size is used as a compile-time constant, which
-/// has performance benefits.
 /// @tparam V Vector container type (i.e. the type of `b`).
 /// @tparam T Scalar type.
 /// @param[in] P0 Function that applies transformation `P0.b` in-place
@@ -71,14 +68,13 @@ using mdspan2_t = md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>;
 /// least `bs * dmap.extent(1)`.
 /// @param[in] cdofs_b Buffer for local element geometry. Size must be
 /// at least `3 * x_dofmap.extent(1)`.
-template <int _bs = -1, typename V, std::floating_point U,
+template <typename V, std::floating_point U,
           dolfinx::scalar T = typename std::remove_cvref_t<V>::value_type>
   requires std::is_same_v<typename std::remove_cvref_t<V>::value_type, T>
 void assemble_cells(
     const fem::DofTransformKernel<T> auto& P0, V&& b, mdspan2_t x_dofmap,
     md::mdspan<const U, md::extents<std::size_t, md::dynamic_extent, 3>> x,
-    std::span<const std::int32_t> cells,
-    std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap,
+    std::span<const std::int32_t> cells, const auto& dofmap,
     const FEkernel<T, U> auto& kernel, std::span<const T> constants,
     md::mdspan<const T, md::dextents<std::size_t, 2>> coeffs,
     std::span<const std::uint32_t> cell_info0, std::span<T> be_b,
@@ -88,10 +84,8 @@ void assemble_cells(
     return;
 
   const auto [dmap, bs, cells0] = dofmap;
-  assert(_bs < 0 or _bs == bs);
-
   assert(cdofs_b.size() >= 3 * x_dofmap.extent(1));
-  assert(be_b.size() >= static_cast<std::size_t>(bs) * dmap.extent(1));
+  assert(be_b.size() >= bs * dmap.extent(1));
   auto be = be_b.first(bs * dmap.extent(1));
 
   // Iterate over active cells
@@ -114,16 +108,9 @@ void assemble_cells(
 
     // Scatter cell vector to 'global' vector array
     auto dofs = md::submdspan(dmap, c0, md::full_extent);
-    auto scatter = [&b, be, dofs](auto n)
-    {
-      for (std::size_t i = 0; i < dofs.size(); ++i)
-        for (int k = 0; k < n; ++k)
-          b[n * dofs[i] + k] += be[n * i + k];
-    };
-    if constexpr (_bs > 0)
-      scatter(std::integral_constant<int, _bs>());
-    else
-      scatter(bs);
+    for (std::size_t i = 0; i < dofs.size(); ++i)
+      for (int k = 0; k < bs; ++k)
+        b[bs * dofs[i] + k] += be[bs * i + k];
   }
 }
 
@@ -143,10 +130,6 @@ void assemble_cells(
 /// entities, so a per-call allocation would not be amortized. Buffers
 /// must be sized by the caller and passed in via `be_b`/`cdofs_b`.
 ///
-/// @tparam _bs The block size of the form test function dof map. If
-/// less than zero the block size is determined at runtime. If `_bs` is
-/// positive the block size is used as a compile-time constant, which
-/// has performance benefits.
 /// @tparam V Vector container type (i.e. the type of `b`).
 /// @tparam T Scalar type.
 /// @param P0 Function that applies transformation `P0.b` in-place to
@@ -170,7 +153,7 @@ void assemble_cells(
 /// least `bs * dmap.extent(1)`.
 /// @param[in] cdofs_b Buffer for local element geometry. Size must be
 /// at least `3 * x_dofmap.extent(1)`.
-template <int _bs = -1, typename V, std::floating_point U,
+template <typename V, std::floating_point U,
           dolfinx::scalar T = typename std::remove_cvref_t<V>::value_type>
   requires std::is_same_v<typename std::remove_cvref_t<V>::value_type, T>
 void assemble_entities(
@@ -179,11 +162,8 @@ void assemble_entities(
     md::mdspan<const std::int32_t,
                std::extents<std::size_t, md::dynamic_extent, 2>>
         entities,
-    std::tuple<mdspan2_t, int,
-               md::mdspan<const std::int32_t,
-                          std::extents<std::size_t, md::dynamic_extent, 2>>>
-        dofmap,
-    const FEkernel<T, U> auto& kernel, std::span<const T> constants,
+    const auto& dofmap, const FEkernel<T, U> auto& kernel,
+    std::span<const T> constants,
     md::mdspan<const T, md::dextents<std::size_t, 2>> coeffs,
     std::span<const std::uint32_t> cell_info0,
     md::mdspan<const std::uint8_t, md::dextents<std::size_t, 2>> perms,
@@ -193,7 +173,6 @@ void assemble_entities(
     return;
 
   const auto [dmap, bs, entities0] = dofmap;
-  assert(_bs < 0 or _bs == bs);
 
   const int num_dofs = dmap.extent(1);
   assert(cdofs_b.size() >= 3 * x_dofmap.extent(1));
@@ -224,16 +203,9 @@ void assemble_entities(
 
     // Add element vector to global vector
     auto dofs = md::submdspan(dmap, cell0, md::full_extent);
-    auto scatter = [&b, be, dofs](auto n)
-    {
-      for (std::size_t i = 0; i < dofs.size(); ++i)
-        for (int k = 0; k < n; ++k)
-          b[n * dofs[i] + k] += be[n * i + k];
-    };
-    if constexpr (_bs > 0)
-      scatter(std::integral_constant<int, _bs>());
-    else
-      scatter(bs);
+    for (std::size_t i = 0; i < dofs.size(); ++i)
+      for (int k = 0; k < bs; ++k)
+        b[bs * dofs[i] + k] += be[bs * i + k];
   }
 }
 
@@ -244,10 +216,6 @@ void assemble_entities(
 /// so a per-call allocation would not be amortized. Buffers must be
 /// sized by the caller and passed in via `be_b`/`cdofs_b`.
 ///
-/// @tparam _bs Block size of the form test function dof map. If less
-/// than zero the block size is determined at runtime. If `_bs` is
-/// positive the block size is used as a compile-time constant, which
-/// has performance benefits.
 /// @tparam V Vector container type (i.e. the type of `b`).
 /// @tparam T Scalar type.
 /// @param P0 Function that applies transformation P0.A in-place to
@@ -273,7 +241,7 @@ void assemble_entities(
 /// least `2 * bs * dmap.map().extent(1)`.
 /// @param[in] cdofs_b Buffer for local element geometry. Size must be
 /// at least `2 * 3 * x_dofmap.extent(1)`.
-template <int _bs = -1, typename V, std::floating_point U,
+template <typename V, std::floating_point U,
           dolfinx::scalar T = typename std::remove_cvref_t<V>::value_type>
   requires std::is_same_v<typename std::remove_cvref_t<V>::value_type, T>
 void assemble_interior_facets(
@@ -282,11 +250,8 @@ void assemble_interior_facets(
     md::mdspan<const std::int32_t,
                std::extents<std::size_t, md::dynamic_extent, 2, 2>>
         facets,
-    std::tuple<const DofMap&, int,
-               md::mdspan<const std::int32_t,
-                          std::extents<std::size_t, md::dynamic_extent, 2, 2>>>
-        dofmap,
-    const FEkernel<T, U> auto& kernel, std::span<const T> constants,
+    const auto& dofmap, const FEkernel<T, U> auto& kernel,
+    std::span<const T> constants,
     md::mdspan<const T, md::extents<std::size_t, md::dynamic_extent, 2,
                                     md::dynamic_extent>>
         coeffs,
@@ -298,13 +263,12 @@ void assemble_interior_facets(
     return;
 
   const auto [dmap, bs, facets0] = dofmap;
-  assert(_bs < 0 or _bs == bs);
 
   assert(cdofs_b.size() >= 2 * x_dofmap.extent(1) * 3);
   auto cdofs0 = cdofs_b.first(x_dofmap.extent(1) * 3);
   auto cdofs1 = cdofs_b.subspan(x_dofmap.extent(1) * 3, x_dofmap.extent(1) * 3);
 
-  const std::size_t dmap_size = dmap.map().extent(1);
+  const std::size_t dmap_size = dmap.extent(1);
   assert(be_b.size() >= static_cast<std::size_t>(bs) * 2 * dmap_size);
   auto be = be_b.first(bs * 2 * dmap_size);
 
@@ -329,9 +293,9 @@ void assemble_interior_facets(
     // Get dofmaps for cells. When integrating over interfaces between
     // two domains, the test function might only be defined on one side,
     // so we check which cells exist in the test function domain.
-    std::span dmap0 = cells0[0] >= 0 ? dmap.cell_dofs(cells0[0])
+    std::span dmap0 = cells0[0] >= 0 ? std::span(&dmap(cells0[0], 0), dmap_size)
                                      : std::span<const std::int32_t>();
-    std::span dmap1 = cells0[1] >= 0 ? dmap.cell_dofs(cells0[1])
+    std::span dmap1 = cells0[1] >= 0 ? std::span(&dmap(cells0[1], 0), dmap_size)
                                      : std::span<const std::int32_t>();
 
     // Tabulate element vector
@@ -352,19 +316,12 @@ void assemble_interior_facets(
     }
 
     // Add element vector to global vector
-    auto scatter = [&b, be, dmap0, dmap1, dmap_size](auto n)
-    {
-      for (std::size_t i = 0; i < dmap0.size(); ++i)
-        for (int k = 0; k < n; ++k)
-          b[n * dmap0[i] + k] += be[n * i + k];
-      for (std::size_t i = 0; i < dmap1.size(); ++i)
-        for (int k = 0; k < n; ++k)
-          b[n * dmap1[i] + k] += be[n * (i + dmap_size) + k];
-    };
-    if constexpr (_bs > 0)
-      scatter(std::integral_constant<int, _bs>());
-    else
-      scatter(bs);
+    for (std::size_t i = 0; i < dmap0.size(); ++i)
+      for (int k = 0; k < bs; ++k)
+        b[bs * dmap0[i] + k] += be[bs * i + k];
+    for (std::size_t i = 0; i < dmap1.size(); ++i)
+      for (int k = 0; k < bs; ++k)
+        b[bs * dmap1[i] + k] += be[bs * (i + dmap_size) + k];
   }
 }
 
@@ -634,24 +591,26 @@ void assemble_vector(
       assert(cells.size() * cstride == coeffs.size());
       if (bs == 1)
       {
-        impl::assemble_cells<1>(
-            P0, b, x_dofmap, x, cells, {dofs, bs, cells0}, fn, constants,
-            md::mdspan(coeffs.data(), cells.size(), cstride), cell_info0,
-            std::span(be_buffer), std::span(cdofs_buffer));
+        impl::assemble_cells(
+            P0, b, x_dofmap, x, cells,
+            std::tuple{dofs, std::integral_constant<int, 1>{}, cells0}, fn,
+            constants, md::mdspan(coeffs.data(), cells.size(), cstride),
+            cell_info0, std::span(be_buffer), std::span(cdofs_buffer));
       }
       else if (bs == 3)
       {
-        impl::assemble_cells<3>(
-            P0, b, x_dofmap, x, cells, {dofs, bs, cells0}, fn, constants,
-            md::mdspan(coeffs.data(), cells.size(), cstride), cell_info0,
-            std::span(be_buffer), std::span(cdofs_buffer));
+        impl::assemble_cells(
+            P0, b, x_dofmap, x, cells,
+            std::tuple{dofs, std::integral_constant<int, 3>(), cells0}, fn,
+            constants, md::mdspan(coeffs.data(), cells.size(), cstride),
+            cell_info0, std::span(be_buffer), std::span(cdofs_buffer));
       }
       else
       {
         impl::assemble_cells(
-            P0, b, x_dofmap, x, cells, {dofs, bs, cells0}, fn, constants,
-            md::mdspan(coeffs.data(), cells.size(), cstride), cell_info0,
-            std::span(be_buffer), std::span(cdofs_buffer));
+            P0, b, x_dofmap, x, cells, std::tuple{dofs, bs, cells0}, fn,
+            constants, md::mdspan(coeffs.data(), cells.size(), cstride),
+            cell_info0, std::span(be_buffer), std::span(cdofs_buffer));
       }
     }
 
@@ -688,13 +647,14 @@ void assemble_vector(
       std::span facets = L.domain(IntegralType::interior_facet, i, 0);
       std::span facets1 = L.domain_arg(IntegralType::interior_facet, 0, i, 0);
       assert((facets.size() / 4) * 2 * cstride == coeffs.size());
+
+      mdspanx22_t facets_mdspan(facets.data(), facets.size() / 4, 2, 2);
+      mdspanx22_t facets1_mdspan(facets1.data(), facets1.size() / 4, 2, 2);
       if (bs == 1)
       {
-        impl::assemble_interior_facets<1>(
-            P0, b, x_dofmap, x,
-            mdspanx22_t(facets.data(), facets.size() / 4, 2, 2),
-            {*dofmap, bs,
-             mdspanx22_t(facets1.data(), facets1.size() / 4, 2, 2)},
+        impl::assemble_interior_facets(
+            P0, b, x_dofmap, x, facets_mdspan,
+            std::tuple{dofs, std::integral_constant<int, 1>{}, facets1_mdspan},
             fn, constants,
             mdspanx2x_t(coeffs.data(), facets.size() / 4, 2, cstride),
             cell_info0, facet_perms, std::span(be_buffer),
@@ -702,11 +662,9 @@ void assemble_vector(
       }
       else if (bs == 3)
       {
-        impl::assemble_interior_facets<3>(
-            P0, b, x_dofmap, x,
-            mdspanx22_t(facets.data(), facets.size() / 4, 2, 2),
-            {*dofmap, bs,
-             mdspanx22_t(facets1.data(), facets1.size() / 4, 2, 2)},
+        impl::assemble_interior_facets(
+            P0, b, x_dofmap, x, facets_mdspan,
+            std::tuple{dofs, std::integral_constant<int, 3>{}, facets1_mdspan},
             fn, constants,
             mdspanx2x_t(coeffs.data(), facets.size() / 4, 2, cstride),
             cell_info0, facet_perms, std::span(be_buffer),
@@ -715,11 +673,8 @@ void assemble_vector(
       else
       {
         impl::assemble_interior_facets(
-            P0, b, x_dofmap, x,
-            mdspanx22_t(facets.data(), facets.size() / 4, 2, 2),
-            {*dofmap, bs,
-             mdspanx22_t(facets1.data(), facets1.size() / 4, 2, 2)},
-            fn, constants,
+            P0, b, x_dofmap, x, facets_mdspan,
+            std::tuple{dofs, bs, facets1_mdspan}, fn, constants,
             mdspanx2x_t(coeffs.data(), facets.size() / 4, 2, cstride),
             cell_info0, facet_perms, std::span(be_buffer),
             std::span(cdofs_buffer));
@@ -746,15 +701,17 @@ void assemble_vector(
         assert((entities.size() / 2) * cstride == coeffs.size());
         if (bs == 1)
         {
-          impl::assemble_entities<1>(
-              P0, b, x_dofmap, x, entities, {dofs, bs, entities1}, fn,
+          impl::assemble_entities(
+              P0, b, x_dofmap, x, entities,
+              std::tuple{dofs, std::integral_constant<int, 1>{}, entities1}, fn,
               constants, md::mdspan(coeffs.data(), entities.extent(0), cstride),
               cell_info0, perms, std::span(be_buffer), std::span(cdofs_buffer));
         }
         else if (bs == 3)
         {
-          impl::assemble_entities<3>(
-              P0, b, x_dofmap, x, entities, {dofs, bs, entities1}, fn,
+          impl::assemble_entities(
+              P0, b, x_dofmap, x, entities,
+              std::tuple{dofs, std::integral_constant<int, 3>{}, entities1}, fn,
               constants,
               md::mdspan(coeffs.data(), entities.size() / 2, cstride),
               cell_info0, perms, std::span(be_buffer), std::span(cdofs_buffer));
@@ -762,7 +719,7 @@ void assemble_vector(
         else
         {
           impl::assemble_entities(
-              P0, b, x_dofmap, x, entities, {dofs, bs, entities1}, fn,
+              P0, b, x_dofmap, x, entities, std::tuple{dofs, bs, entities1}, fn,
               constants,
               md::mdspan(coeffs.data(), entities.size() / 2, cstride),
               cell_info0, perms, std::span(be_buffer), std::span(cdofs_buffer));

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -201,11 +201,15 @@ void assemble_entities(
            &local_entity, &perm, nullptr);
     P0(be, cell_info0, cell0, 1);
 
-    // Add element vector to global vector
+    // Add to global vector
     auto dofs = md::submdspan(dmap, cell0, md::full_extent);
     for (std::size_t i = 0; i < dofs.size(); ++i)
+    {
+      std::int32_t dof = bs * dofs[i];
+      std::int32_t offset = bs * i;
       for (int k = 0; k < bs; ++k)
-        b[bs * dofs[i] + k] += be[bs * i + k];
+        b[dof + k] += be[offset + k];
+    }
   }
 }
 
@@ -317,11 +321,19 @@ void assemble_interior_facets(
 
     // Add element vector to global vector
     for (std::size_t i = 0; i < dmap0.size(); ++i)
+    {
+      std::int32_t dof = bs * dmap0[i];
+      std::int32_t offset = bs * i;
       for (int k = 0; k < bs; ++k)
-        b[bs * dmap0[i] + k] += be[bs * i + k];
+        b[dof + k] += be[offset + k];
+    }
     for (std::size_t i = 0; i < dmap1.size(); ++i)
+    {
+      std::int32_t dof = bs * dmap1[i];
+      std::int32_t offset = bs * (i + dmap_size);
       for (int k = 0; k < bs; ++k)
-        b[bs * dmap1[i] + k] += be[bs * (i + dmap_size) + k];
+        b[dof + k] += be[offset + k];
+    }
   }
 }
 
@@ -335,6 +347,12 @@ void assemble_interior_facets(
 /// for runtime block size.
 /// @param[in,out] b Vector to modify.
 /// @param[in] a The bilinear form.
+/// @param[in] bs0 Block size for the test function dofmap, as
+/// `std::integral_constant<int, BS0>` if known at compile time, or a
+/// plain `int` for the runtime-determined value.
+/// @param[in] bs1 Block size for the trial function dofmap, as
+/// `std::integral_constant<int, BS1>` if known at compile time, or a
+/// plain `int` for the runtime-determined value.
 /// @param[in] constants Constants that appear in `a`.
 /// @param[in] coefficients Coefficients that appear in `a`.
 /// @param[in] bc_values1 The boundary condition values.
@@ -342,31 +360,24 @@ void assemble_interior_facets(
 /// conditions applied.
 /// @param[in] x0 Vector used in the lifting.
 /// @param[in] alpha Scaling to apply.
-template <dolfinx::scalar T, std::floating_point U, int BS0 = -1, int BS1 = -1,
-          typename V>
+template <dolfinx::scalar T, std::floating_point U, typename V>
   requires std::is_same_v<typename std::remove_cvref_t<V>::value_type, T>
 void lift_bc_impl(
-    V&& b, const Form<T, U>& a, std::span<const T> constants,
+    V&& b, const Form<T, U>& a, auto bs0, auto bs1,
+    std::span<const T> constants,
     const std::map<std::pair<IntegralType, int>,
                    std::pair<std::span<const T>, int>>& coefficients,
     std::span<const T> bc_values1, std::span<const std::int8_t> bc_markers1,
     std::span<const T> x0, T alpha)
 {
-  // Deduce runtime block sizes as fallback when compile-time sizes not given.
-  // The block size of the dofmap and indexmap is the same on all
-  // sub-topologies.
-  const int bs0
-      = BS0 > 0 ? BS0 : a.function_spaces()[0]->dofmaps().front()->bs();
-  const int bs1
-      = BS1 > 0 ? BS1 : a.function_spaces()[1]->dofmaps().front()->bs();
+  // Deduce runtime block sizes as fallback when compile-time sizes
+  // not given. The block size of the dofmap and indexmap is the same
+  // on all sub-topologies.
+  assert(bs0 == a.function_spaces()[0]->dofmaps().front()->bs());
+  assert(bs1 == a.function_spaces()[1]->dofmaps().front()->bs());
 
-  // Default capture is required for bs0/bs1: when BS0/BS1 are
-  // compile-time constants they are constant-initialised and an
-  // explicit capture is rejected by -Wunused-lambda-capture
-  auto lifting_fn
-      = [=, &b, &bc_values1, &bc_markers1,
-         &x0](std::span<const std::int32_t> rows,
-              std::span<const std::int32_t> cols, std::span<const T> Ae)
+  auto lifting_fn = [bs0, bs1, alpha, &b, &bc_values1, &bc_markers1,
+                     &x0](auto rows, auto cols, auto Ae)
   {
     const std::size_t nc = cols.size() * bs1;
     for (std::size_t i = 0; i < cols.size(); ++i)
@@ -392,9 +403,9 @@ void lift_bc_impl(
     }
   };
 
-  // Repurpose the assemble_matrix assembler to work on the vector b instead.
-  // Use LiftingMode=true so the kernel is only called on cells that have
-  // BC-constrained DOFs in the column space.
+  // Repurpose the assemble_matrix assembler to work on the vector b
+  // instead. Use LiftingMode=true so the kernel is only called on
+  // cells that have BC-constrained DOFs in the column space.
   assemble_matrix<T, U, true>(lifting_fn, a, constants, coefficients, {},
                               bc_markers1);
 }
@@ -423,28 +434,26 @@ void lift_bc(V&& b, const Form<T, U>& a, std::span<const T> constants,
              std::span<const std::int8_t> bc_markers1, std::span<const T> x0,
              T alpha)
 {
-
   // Get dofmap for columns and rows of a
   assert(a.function_spaces().at(0));
   assert(a.function_spaces().at(1));
   const int bs0 = a.function_spaces()[0]->dofmaps().front()->bs();
   const int bs1 = a.function_spaces()[1]->dofmaps().front()->bs();
-
-  spdlog::debug("lifting: bs0={}, bs1={}", bs0, bs1);
-
-  if (bs0 == 1 && bs1 == 1)
+  if (bs0 == 1 and bs1 == 1)
   {
-    lift_bc_impl<T, U, 1, 1>(std::forward<V>(b), a, constants, coefficients,
-                             bc_values1, bc_markers1, x0, alpha);
+    lift_bc_impl<T, U>(std::forward<V>(b), a, std::integral_constant<int, 1>{},
+                       std::integral_constant<int, 1>{}, constants,
+                       coefficients, bc_values1, bc_markers1, x0, alpha);
   }
-  else if (bs0 == 3 && bs1 == 3)
+  else if (bs0 == 3 and bs1 == 3)
   {
-    lift_bc_impl<T, U, 3, 3>(std::forward<V>(b), a, constants, coefficients,
-                             bc_values1, bc_markers1, x0, alpha);
+    lift_bc_impl<T, U>(std::forward<V>(b), a, std::integral_constant<int, 3>{},
+                       std::integral_constant<int, 3>{}, constants,
+                       coefficients, bc_values1, bc_markers1, x0, alpha);
   }
   else
   {
-    lift_bc_impl<T, U>(std::forward<V>(b), a, constants, coefficients,
+    lift_bc_impl<T, U>(std::forward<V>(b), a, bs0, bs1, constants, coefficients,
                        bc_values1, bc_markers1, x0, alpha);
   }
 }
@@ -474,7 +483,8 @@ template <typename V, std::floating_point U,
   requires std::is_same_v<typename std::remove_cvref_t<V>::value_type, T>
 void apply_lifting(
     V&& b,
-    std::vector<std::optional<std::reference_wrapper<const Form<T, U>>>> a,
+    const std::vector<std::optional<std::reference_wrapper<const Form<T, U>>>>&
+        a,
     const std::vector<std::span<const T>>& constants,
     const std::vector<std::map<std::pair<IntegralType, int>,
                                std::pair<std::span<const T>, int>>>& coeffs,
@@ -508,7 +518,7 @@ void apply_lifting(
         _x0 = x0[j];
 
       assert(V1);
-      const auto& dofmap = V1->dofmaps().front();
+      std::shared_ptr<const DofMap> dofmap = V1->dofmaps().front();
       auto map1 = dofmap->index_map;
       const int bs1 = dofmap->index_map_bs();
       assert(map1);
@@ -528,6 +538,7 @@ void apply_lifting(
 }
 
 /// @brief Assemble linear form into a vector.
+///
 /// @param[in,out] b Array to be accumulated into. It will not be zeroed
 /// before assembly.
 /// @param[in] L Linear forms to assemble into b.

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -31,8 +31,8 @@ namespace dolfinx::fem
 {
 template <dolfinx::scalar T, std::floating_point U>
 class DirichletBC;
-
 }
+
 namespace dolfinx::fem::impl
 {
 /// @cond
@@ -453,10 +453,12 @@ void apply_lifting(
         "Mismatch in size between a and bcs in assembler.");
   }
 
+  // Reused across iterations so `assign` below can recycle the
+  // existing buffer instead of reallocating for every block.
+  std::vector<std::int8_t> bc_markers1;
+  std::vector<T> bc_values1;
   for (std::size_t j = 0; j < a.size(); ++j)
   {
-    std::vector<std::int8_t> bc_markers1;
-    std::vector<T> bc_values1;
     if (a[j] and !bcs1[j].empty())
     {
       assert(a[j]->get().function_spaces().at(0));
@@ -483,8 +485,23 @@ void apply_lifting(
         bc.get().set(bc_values1, std::nullopt, 1);
       }
 
-      lift_bc(b, a[j]->get(), bs0, bs1, constants[j], coeffs[j],
-              std::span<const T>(bc_values1), bc_markers1, _x0, alpha);
+      if (bs0 == 1 and bs1 == 1)
+      {
+        lift_bc(b, a[j]->get(), std::integral_constant<int, 1>{},
+                std::integral_constant<int, 1>{}, constants[j], coeffs[j],
+                std::span<const T>(bc_values1), bc_markers1, _x0, alpha);
+      }
+      else if (bs0 == 3 and bs1 == 3)
+      {
+        lift_bc(b, a[j]->get(), std::integral_constant<int, 3>{},
+                std::integral_constant<int, 3>{}, constants[j], coeffs[j],
+                std::span<const T>(bc_values1), bc_markers1, _x0, alpha);
+      }
+      else
+      {
+        lift_bc(b, a[j]->get(), bs0, bs1, constants[j], coeffs[j],
+                std::span<const T>(bc_values1), bc_markers1, _x0, alpha);
+      }
     }
   }
 }
@@ -535,6 +552,8 @@ void assemble_vector(
     // sized for the worst case (interior facets, which touch two cells).
     std::vector<T> be_buffer(2 * bs * dofs.extent(1));
     std::vector<U> cdofs_buffer(2 * 3 * x_dofmap.extent(1));
+    std::span be_b(be_buffer);
+    std::span cdofs_b(cdofs_buffer);
 
     const fem::DofTransformKernel<T> auto P0
         = element->template dof_transformation_fn<T>(doftransform::standard);
@@ -560,7 +579,7 @@ void assemble_vector(
             P0, b, x_dofmap, x, cells,
             std::tuple{dofs, std::integral_constant<int, 1>{}, cells0}, fn,
             constants, md::mdspan(coeffs.data(), cells.size(), cstride),
-            cell_info0, std::span(be_buffer), std::span(cdofs_buffer));
+            cell_info0, be_b, cdofs_b);
       }
       else if (bs == 3)
       {
@@ -568,14 +587,14 @@ void assemble_vector(
             P0, b, x_dofmap, x, cells,
             std::tuple{dofs, std::integral_constant<int, 3>(), cells0}, fn,
             constants, md::mdspan(coeffs.data(), cells.size(), cstride),
-            cell_info0, std::span(be_buffer), std::span(cdofs_buffer));
+            cell_info0, be_b, cdofs_b);
       }
       else
       {
-        impl::assemble_cells(
-            P0, b, x_dofmap, x, cells, std::tuple{dofs, bs, cells0}, fn,
-            constants, md::mdspan(coeffs.data(), cells.size(), cstride),
-            cell_info0, std::span(be_buffer), std::span(cdofs_buffer));
+        impl::assemble_cells(P0, b, x_dofmap, x, cells,
+                             std::tuple{dofs, bs, cells0}, fn, constants,
+                             md::mdspan(coeffs.data(), cells.size(), cstride),
+                             cell_info0, be_b, cdofs_b);
       }
     }
 
@@ -595,16 +614,15 @@ void assemble_vector(
     using mdspanx2_t
         = md::mdspan<const std::int32_t,
                      md::extents<std::size_t, md::dynamic_extent, 2>>;
+    using mdspanx22_t
+        = md::mdspan<const std::int32_t,
+                     md::extents<std::size_t, md::dynamic_extent, 2, 2>>;
+    using mdspanx2x_t
+        = md::mdspan<const T, md::extents<std::size_t, md::dynamic_extent, 2,
+                                          md::dynamic_extent>>;
 
     for (int i = 0; i < L.num_integrals(IntegralType::interior_facet, 0); ++i)
     {
-      using mdspanx22_t
-          = md::mdspan<const std::int32_t,
-                       md::extents<std::size_t, md::dynamic_extent, 2, 2>>;
-      using mdspanx2x_t
-          = md::mdspan<const T, md::extents<std::size_t, md::dynamic_extent, 2,
-                                            md::dynamic_extent>>;
-
       auto fn = L.kernel(IntegralType::interior_facet, i, 0);
       assert(fn);
       auto& [coeffs, cstride]
@@ -622,8 +640,7 @@ void assemble_vector(
             std::tuple{dofs, std::integral_constant<int, 1>{}, facets1_mdspan},
             fn, constants,
             mdspanx2x_t(coeffs.data(), facets.size() / 4, 2, cstride),
-            cell_info0, facet_perms, std::span(be_buffer),
-            std::span(cdofs_buffer));
+            cell_info0, facet_perms, be_b, cdofs_b);
       }
       else if (bs == 3)
       {
@@ -632,8 +649,7 @@ void assemble_vector(
             std::tuple{dofs, std::integral_constant<int, 3>{}, facets1_mdspan},
             fn, constants,
             mdspanx2x_t(coeffs.data(), facets.size() / 4, 2, cstride),
-            cell_info0, facet_perms, std::span(be_buffer),
-            std::span(cdofs_buffer));
+            cell_info0, facet_perms, be_b, cdofs_b);
       }
       else
       {
@@ -641,8 +657,7 @@ void assemble_vector(
             P0, b, x_dofmap, x, facets_mdspan,
             std::tuple{dofs, bs, facets1_mdspan}, fn, constants,
             mdspanx2x_t(coeffs.data(), facets.size() / 4, 2, cstride),
-            cell_info0, facet_perms, std::span(be_buffer),
-            std::span(cdofs_buffer));
+            cell_info0, facet_perms, be_b, cdofs_b);
       }
     }
 
@@ -670,24 +685,22 @@ void assemble_vector(
               P0, b, x_dofmap, x, entities,
               std::tuple{dofs, std::integral_constant<int, 1>{}, entities1}, fn,
               constants, md::mdspan(coeffs.data(), entities.extent(0), cstride),
-              cell_info0, perms, std::span(be_buffer), std::span(cdofs_buffer));
+              cell_info0, perms, be_b, cdofs_b);
         }
         else if (bs == 3)
         {
           impl::assemble_entities(
               P0, b, x_dofmap, x, entities,
               std::tuple{dofs, std::integral_constant<int, 3>{}, entities1}, fn,
-              constants,
-              md::mdspan(coeffs.data(), entities.size() / 2, cstride),
-              cell_info0, perms, std::span(be_buffer), std::span(cdofs_buffer));
+              constants, md::mdspan(coeffs.data(), entities.extent(0), cstride),
+              cell_info0, perms, be_b, cdofs_b);
         }
         else
         {
           impl::assemble_entities(
               P0, b, x_dofmap, x, entities, std::tuple{dofs, bs, entities1}, fn,
-              constants,
-              md::mdspan(coeffs.data(), entities.size() / 2, cstride),
-              cell_info0, perms, std::span(be_buffer), std::span(cdofs_buffer));
+              constants, md::mdspan(coeffs.data(), entities.extent(0), cstride),
+              cell_info0, perms, be_b, cdofs_b);
         }
       }
     }

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -340,7 +340,8 @@ template <typename V,
   requires std::is_same_v<typename std::remove_cvref_t<V>::value_type, T>
 void apply_lifting(
     V&& b,
-    std::vector<std::optional<std::reference_wrapper<const Form<T, U>>>> a,
+    const std::vector<std::optional<std::reference_wrapper<const Form<T, U>>>>&
+        a,
     const std::vector<std::span<const T>>& constants,
     const std::vector<std::map<std::pair<IntegralType, int>,
                                std::pair<std::span<const T>, int>>>& coeffs,
@@ -391,7 +392,8 @@ template <typename V,
   requires std::is_same_v<typename std::remove_cvref_t<V>::value_type, T>
 void apply_lifting(
     V&& b,
-    std::vector<std::optional<std::reference_wrapper<const Form<T, U>>>> a,
+    const std::vector<std::optional<std::reference_wrapper<const Form<T, U>>>>&
+        a,
     const std::vector<
         std::vector<std::reference_wrapper<const DirichletBC<T, U>>>>& bcs1,
     const std::vector<std::span<const T>>& x0, T alpha)
@@ -400,7 +402,7 @@ void apply_lifting(
       std::map<std::pair<IntegralType, int>, std::pair<std::vector<T>, int>>>
       coeffs;
   std::vector<std::vector<T>> constants;
-  for (auto _a : a)
+  for (const auto& _a : a)
   {
     if (_a)
     {

--- a/cpp/dolfinx/fem/traits.h
+++ b/cpp/dolfinx/fem/traits.h
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <dolfinx/common/types.h>
 #include <span>
+#include <tuple>
 #include <type_traits>
 
 namespace dolfinx::fem
@@ -40,19 +41,48 @@ concept MDSpan2
           md::mdspan<const std::int32_t, md::dextents<std::size_t, 1>>>;
 
 /// @cond
+/// Common part of the `DofMapPack*` concepts: a 3-tuple whose (0)
+/// entry is the dofmap (a rank-2 `const std::int32_t` mdspan) and (1)
+/// entry is the block size, as a run-time `int` or a compile-time
+/// `std::integral_constant<int, N>`. The (2) entry (cell/entity
+/// indices) is constrained separately by each `DofMapPack*` concept,
+/// since its shape differs between the cell, entity and facet
+/// assembly kernels.
 template <class T>
-struct is_integral_constant : std::false_type
-{
-};
-template <class T, T v>
-struct is_integral_constant<std::integral_constant<T, v>> : std::true_type
-{
+concept DofMapPackBase = requires(const std::remove_cvref_t<T>& t) {
+  requires std::tuple_size_v<std::remove_cvref_t<T>> == 3;
+  requires std::is_convertible_v<
+      std::remove_cvref_t<decltype(std::get<0>(t))>,
+      md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>>;
+  { std::get<1>(t) } -> std::convertible_to<int>;
 };
 /// @endcond
 
-/// @brief Concept satisfied by specializations of
-/// `std::integral_constant`.
+/// @brief Concept for the degree-of-freedom map data passed to the
+/// cell assembly kernel, whose (2) entry is a flat, integer-indexable
+/// list of cell indices.
 template <class T>
-concept IntegralConstant = is_integral_constant<std::remove_cvref_t<T>>::value;
+concept DofMapPackCells
+    = DofMapPackBase<T> and requires(const std::remove_cvref_t<T>& t) {
+        { std::get<2>(t)[0] } -> std::convertible_to<std::int32_t>;
+      };
+
+/// @brief Concept for the degree-of-freedom map data passed to the
+/// entity assembly kernel, whose (2) entry is indexed by (entity,
+/// local index).
+template <class T>
+concept DofMapPackEntities
+    = DofMapPackBase<T> and requires(const std::remove_cvref_t<T>& t) {
+        { std::get<2>(t)(0, 0) } -> std::convertible_to<std::int32_t>;
+      };
+
+/// @brief Concept for the degree-of-freedom map data passed to the
+/// interior facet assembly kernel, whose (2) entry is indexed by
+/// (facet, side, local index).
+template <class T>
+concept DofMapPackFacets
+    = DofMapPackBase<T> and requires(const std::remove_cvref_t<T>& t) {
+        { std::get<2>(t)(0, 0, 0) } -> std::convertible_to<std::int32_t>;
+      };
 
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/traits.h
+++ b/cpp/dolfinx/fem/traits.h
@@ -15,7 +15,6 @@
 
 namespace dolfinx::fem
 {
-
 /// @brief DOF transform kernel concept.
 template <class U, class T>
 concept DofTransformKernel
@@ -84,5 +83,4 @@ concept DofMapPackFacets
     = DofMapPackBase<T> and requires(const std::remove_cvref_t<T>& t) {
         { std::get<2>(t)(0, 0, 0) } -> std::convertible_to<std::int32_t>;
       };
-
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/traits.h
+++ b/cpp/dolfinx/fem/traits.h
@@ -39,4 +39,20 @@ concept MDSpan2
           std::remove_cvref_t<T>,
           md::mdspan<const std::int32_t, md::dextents<std::size_t, 1>>>;
 
+/// @cond
+template <class T>
+struct is_integral_constant : std::false_type
+{
+};
+template <class T, T v>
+struct is_integral_constant<std::integral_constant<T, v>> : std::true_type
+{
+};
+/// @endcond
+
+/// @brief Concept satisfied by specializations of
+/// `std::integral_constant`.
+template <class T>
+concept IntegralConstant = is_integral_constant<std::remove_cvref_t<T>>::value;
+
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -898,13 +898,13 @@ void MatrixCSR<Scalar, V, W, X>::mult(la::Vector<Scalar>& x,
   // yi[0] += Ai[0] * xi[0]
   if (_bs[1] == 1)
   {
-    impl::spmv<Scalar, 1>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x, _y,
-                          _bs[0], 1);
+    impl::spmv<Scalar>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x, _y,
+                       _bs[0], std::integral_constant<int, 1>{});
   }
   else
   {
-    impl::spmv<Scalar, -1>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x, _y,
-                           _bs[0], _bs[1]);
+    impl::spmv<Scalar>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x, _y,
+                       _bs[0], _bs[1]);
   }
 
   // finalize ghost update
@@ -914,13 +914,13 @@ void MatrixCSR<Scalar, V, W, X>::mult(la::Vector<Scalar>& x,
   // yi[0] += Ai[1] * xi[1]
   if (_bs[1] == 1)
   {
-    impl::spmv<Scalar, 1>(Avalues, Aoff_diag_offset, Arow_end, Acols, _x, _y,
-                          _bs[0], 1);
+    impl::spmv<Scalar>(Avalues, Aoff_diag_offset, Arow_end, Acols, _x, _y,
+                       _bs[0], std::integral_constant<int, 1>{});
   }
   else
   {
-    impl::spmv<Scalar, -1>(Avalues, Aoff_diag_offset, Arow_end, Acols, _x, _y,
-                           _bs[0], _bs[1]);
+    impl::spmv<Scalar>(Avalues, Aoff_diag_offset, Arow_end, Acols, _x, _y,
+                       _bs[0], _bs[1]);
   }
 }
 
@@ -947,23 +947,30 @@ void MatrixCSR<Scalar, V, W, X>::multT(la::Vector<Scalar>& x,
   // Compute ghost region contribution and scatter back. Zero only the
   // ghost portion of y so the caller's owned values are preserved (multT
   // accumulates).
-  int ncolslocal = index_map(1)->size_local();
+  std::int32_t ncolslocal = index_map(1)->size_local();
   std::fill(std::next(_y.begin(), ncolslocal * _bs[1]), _y.end(), Scalar(0));
   if (_bs[1] == 1)
-    impl::spmvT<Scalar, 1>(Avalues, Aoff_diag_offset, Arow_end, Acols, _x, _y,
-                           _bs[0], 1);
+  {
+    impl::spmvT<Scalar>(Avalues, Aoff_diag_offset, Arow_end, Acols, _x, _y,
+                        _bs[0], std::integral_constant<int, 1>{});
+  }
   else
-    impl::spmvT<Scalar, -1>(Avalues, Aoff_diag_offset, Arow_end, Acols, _x, _y,
-                            _bs[0], _bs[1]);
-
+  {
+    impl::spmvT<Scalar>(Avalues, Aoff_diag_offset, Arow_end, Acols, _x, _y,
+                        _bs[0], _bs[1]);
+  }
   y.scatter_rev(std::plus<Scalar>{});
 
   if (_bs[1] == 1)
-    impl::spmvT<Scalar, 1>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x, _y,
-                           _bs[0], 1);
+  {
+    impl::spmvT<Scalar>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x, _y,
+                        _bs[0], std::integral_constant<int, 1>{});
+  }
   else
-    impl::spmvT<Scalar, -1>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x,
-                            _y, _bs[0], _bs[1]);
+  {
+    impl::spmvT<Scalar>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x, _y,
+                        _bs[0], _bs[1]);
+  }
 }
 
 } // namespace dolfinx::la

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -50,7 +50,8 @@ enum class BlockMode : int
                /// matrix has a block size of (1, 1).
 };
 
-/// @brief Distributed sparse matrix using compressed sparse row storage.
+/// @brief Distributed sparse matrix using compressed sparse row
+/// storage.
 ///
 /// @warning The class is experimental and subject to change.
 ///
@@ -901,6 +902,16 @@ void MatrixCSR<Scalar, V, W, X>::mult(la::Vector<Scalar>& x,
     impl::spmv<Scalar>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x, _y,
                        _bs[0], std::integral_constant<int, 1>{});
   }
+  else if (_bs[1] == 2)
+  {
+    impl::spmv<Scalar>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x, _y,
+                       _bs[0], std::integral_constant<int, 2>{});
+  }
+  else if (_bs[1] == 3)
+  {
+    impl::spmv<Scalar>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x, _y,
+                       _bs[0], std::integral_constant<int, 3>{});
+  }
   else
   {
     impl::spmv<Scalar>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x, _y,
@@ -916,6 +927,16 @@ void MatrixCSR<Scalar, V, W, X>::mult(la::Vector<Scalar>& x,
   {
     impl::spmv<Scalar>(Avalues, Aoff_diag_offset, Arow_end, Acols, _x, _y,
                        _bs[0], std::integral_constant<int, 1>{});
+  }
+  else if (_bs[1] == 2)
+  {
+    impl::spmv<Scalar>(Avalues, Aoff_diag_offset, Arow_end, Acols, _x, _y,
+                       _bs[0], std::integral_constant<int, 2>{});
+  }
+  else if (_bs[1] == 3)
+  {
+    impl::spmv<Scalar>(Avalues, Aoff_diag_offset, Arow_end, Acols, _x, _y,
+                       _bs[0], std::integral_constant<int, 3>{});
   }
   else
   {
@@ -954,11 +975,22 @@ void MatrixCSR<Scalar, V, W, X>::multT(la::Vector<Scalar>& x,
     impl::spmvT<Scalar>(Avalues, Aoff_diag_offset, Arow_end, Acols, _x, _y,
                         _bs[0], std::integral_constant<int, 1>{});
   }
+  else if (_bs[1] == 2)
+  {
+    impl::spmvT<Scalar>(Avalues, Aoff_diag_offset, Arow_end, Acols, _x, _y,
+                        _bs[0], std::integral_constant<int, 2>{});
+  }
+  else if (_bs[1] == 3)
+  {
+    impl::spmvT<Scalar>(Avalues, Aoff_diag_offset, Arow_end, Acols, _x, _y,
+                        _bs[0], std::integral_constant<int, 3>{});
+  }
   else
   {
     impl::spmvT<Scalar>(Avalues, Aoff_diag_offset, Arow_end, Acols, _x, _y,
                         _bs[0], _bs[1]);
   }
+
   y.scatter_rev(std::plus<Scalar>{});
 
   if (_bs[1] == 1)
@@ -966,11 +998,20 @@ void MatrixCSR<Scalar, V, W, X>::multT(la::Vector<Scalar>& x,
     impl::spmvT<Scalar>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x, _y,
                         _bs[0], std::integral_constant<int, 1>{});
   }
+  else if (_bs[1] == 2)
+  {
+    impl::spmvT<Scalar>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x, _y,
+                        _bs[0], std::integral_constant<int, 2>{});
+  }
+  else if (_bs[1] == 3)
+  {
+    impl::spmvT<Scalar>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x, _y,
+                        _bs[0], std::integral_constant<int, 3>{});
+  }
   else
   {
     impl::spmvT<Scalar>(Avalues, Arow_begin, Aoff_diag_offset, Acols, _x, _y,
                         _bs[0], _bs[1]);
   }
 }
-
 } // namespace dolfinx::la

--- a/cpp/dolfinx/la/matrix_csr_impl.h
+++ b/cpp/dolfinx/la/matrix_csr_impl.h
@@ -212,17 +212,31 @@ void insert_nonblocked_csr(U&& data, const V& cols, const W& row_ptr,
   }
 }
 
-/// @brief  Sparse matrix-vector product implementation.
-/// @tparam T
-/// @tparam BS1
-/// @param values
-/// @param row_begin
-/// @param row_end
-/// @param indices
-/// @param x
-/// @param y
-/// @param bs0
-/// @param bs1
+/// @brief Sparse matrix-vector product implementation.
+///
+/// Computes `y += A x` where A is given in CSR format.
+///
+/// @note The value block layout is row-major within each block: for
+/// block entry `j` the element at row-offset `k0` and column-offset `k1`
+/// is stored at `values[j * bs0 * bs1 + k0 * bs1 + k1]`.
+///
+/// @tparam T Scalar type of the matrix and vector entries.
+/// @param[in] values Nonzero values of A, stored block-row-major.
+/// Length: `nnz * bs0 * bs1`.
+/// @param[in] row_begin Start positions in `values`/`indices` for each
+/// row of A. Length: number of rows of A.
+/// @param[in] row_end End positions in `values`/`indices` for each row
+/// of A. Length: number of rows of A.
+/// @param[in] indices Column indices of each nonzero block entry of A.
+/// Length: `nnz`.
+/// @param[in] x Input vector, indexed by the *columns* of A.
+/// Length: `num_cols * bs1`.
+/// @param[in,out] y Output vector, indexed by the *rows* of A,
+/// accumulated into. Length: `num_rows * bs0`.
+/// @param[in] bs0 Row block size. Either a runtime `int` or a
+/// `std::integral_constant<int, N>`.
+/// @param[in] bs1 Column block size. Either a runtime `int` or a
+/// `std::integral_constant<int, N>`.
 template <typename T>
 void spmv(std::span<const T> values, std::span<const std::int64_t> row_begin,
           std::span<const std::int64_t> row_end,
@@ -265,9 +279,7 @@ void spmv(std::span<const T> values, std::span<const std::int64_t> row_begin,
 /// block entry `j` the element at row-offset `k0` and column-offset `k1`
 /// is stored at `values[j * bs0 * bs1 + k0 * bs1 + k1]`.
 ///
-/// @tparam T   Scalar type of the matrix and vector entries.
-/// @tparam BS1 Compile-time column block size.  Pass `-1` to use the
-///             runtime value `bs1` instead.
+/// @tparam T Scalar type of the matrix and vector entries.
 ///
 /// @param[in]  values    Nonzero values of A, stored block-row-major.
 ///                       Length: `nnz * bs0 * bs1`.
@@ -282,9 +294,10 @@ void spmv(std::span<const T> values, std::span<const std::int64_t> row_begin,
 /// @param[in,out] y      Output vector, indexed by the *columns* of A,
 ///                       accumulated into.
 ///                       Length: `num_cols * bs1`.
-/// @param[in]  bs0       Row block size (runtime value).
-/// @param[in]  bs1       Column block size (runtime value, used when
-///                       `BS1 == -1`).
+/// @param[in]  bs0       Row block size. Either a runtime `int` or a
+///                       `std::integral_constant<int, N>`.
+/// @param[in]  bs1       Column block size. Either a runtime `int` or a
+///                       `std::integral_constant<int, N>`.
 template <typename T>
 void spmvT(std::span<const T> values, std::span<const std::int64_t> row_begin,
            std::span<const std::int64_t> row_end,

--- a/cpp/dolfinx/la/matrix_csr_impl.h
+++ b/cpp/dolfinx/la/matrix_csr_impl.h
@@ -8,6 +8,7 @@
 
 #include <numeric>
 #include <span>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -237,24 +238,17 @@ void spmv(std::span<const T> values, std::span<const std::int64_t> row_begin,
     for (std::size_t i = 0; i < row_begin.size(); i++)
     {
       T vi{0};
+      auto accumulate = [&](auto n, std::int64_t j)
+      {
+        for (int k1 = 0; k1 < n; ++k1)
+          vi += values[j * bs0 * n + k0 * n + k1] * x[indices[j] * n + k1];
+      };
       for (std::int64_t j = row_begin[i]; j < row_end[i]; j++)
       {
         if constexpr (BS1 == -1)
-        {
-          for (int k1 = 0; k1 < bs1; ++k1)
-          {
-            vi += values[j * bs0 * bs1 + k0 * bs1 + k1]
-                  * x[indices[j] * bs1 + k1];
-          }
-        }
+          accumulate(bs1, j);
         else
-        {
-          for (int k1 = 0; k1 < BS1; ++k1)
-          {
-            vi += values[j * bs0 * BS1 + k0 * BS1 + k1]
-                  * x[indices[j] * BS1 + k1];
-          }
-        }
+          accumulate(std::integral_constant<int, BS1>(), j);
       }
 
       y[i * bs0 + k0] += vi;
@@ -309,24 +303,17 @@ void spmvT(std::span<const T> values, std::span<const std::int64_t> row_begin,
     for (std::size_t i = 0; i < row_begin.size(); i++)
     {
       const T xval = x[i * bs0 + k0];
+      auto accumulate = [&](auto n, std::int64_t j)
+      {
+        for (int k1 = 0; k1 < n; ++k1)
+          y[indices[j] * n + k1] += values[j * bs0 * n + k0 * n + k1] * xval;
+      };
       for (std::int64_t j = row_begin[i]; j < row_end[i]; j++)
       {
         if constexpr (BS1 == -1)
-        {
-          for (int k1 = 0; k1 < bs1; ++k1)
-          {
-            y[indices[j] * bs1 + k1]
-                += values[j * bs0 * bs1 + k0 * bs1 + k1] * xval;
-          }
-        }
+          accumulate(bs1, j);
         else
-        {
-          for (int k1 = 0; k1 < BS1; ++k1)
-          {
-            y[indices[j] * BS1 + k1]
-                += values[j * bs0 * BS1 + k0 * BS1 + k1] * xval;
-          }
-        }
+          accumulate(std::integral_constant<int, BS1>(), j);
       }
     }
   }

--- a/cpp/dolfinx/la/matrix_csr_impl.h
+++ b/cpp/dolfinx/la/matrix_csr_impl.h
@@ -238,7 +238,8 @@ void spmv(std::span<const T> values, std::span<const std::int64_t> row_begin,
     for (std::size_t i = 0; i < row_begin.size(); i++)
     {
       T vi{0};
-      auto accumulate = [&](auto n, std::int64_t j)
+      auto accumulate
+          = [&vi, values, bs0, k0, x, indices](auto n, std::int64_t j)
       {
         for (int k1 = 0; k1 < n; ++k1)
           vi += values[j * bs0 * n + k0 * n + k1] * x[indices[j] * n + k1];
@@ -303,7 +304,8 @@ void spmvT(std::span<const T> values, std::span<const std::int64_t> row_begin,
     for (std::size_t i = 0; i < row_begin.size(); i++)
     {
       const T xval = x[i * bs0 + k0];
-      auto accumulate = [&](auto n, std::int64_t j)
+      auto accumulate
+          = [y, values, indices, bs0, k0, xval](auto n, std::int64_t j)
       {
         for (int k1 = 0; k1 < n; ++k1)
           y[indices[j] * n + k1] += values[j * bs0 * n + k0 * n + k1] * xval;

--- a/cpp/dolfinx/la/matrix_csr_impl.h
+++ b/cpp/dolfinx/la/matrix_csr_impl.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <numeric>
 #include <span>
 #include <type_traits>
@@ -16,6 +17,24 @@ namespace dolfinx::la
 {
 namespace impl
 {
+/// @cond
+template <typename T>
+struct is_integral_constant : std::false_type
+{
+};
+template <std::integral U, U N>
+struct is_integral_constant<std::integral_constant<U, N>> : std::true_type
+{
+};
+
+/// Concept for a block size argument: a run-time integral value or a
+/// compile-time `std::integral_constant<U, N>` for some integral type
+/// `U`.
+template <typename T>
+concept BlockSizeArg = std::integral<std::remove_cvref_t<T>>
+                       or is_integral_constant<std::remove_cvref_t<T>>::value;
+/// @endcond
+
 /// @brief Incorporate data into a CSR matrix.
 ///
 /// @tparam BS0 Row block size (of both matrix and data).
@@ -233,28 +252,28 @@ void insert_nonblocked_csr(U&& data, const V& cols, const W& row_ptr,
 /// Length: `num_cols * bs1`.
 /// @param[in,out] y Output vector, indexed by the *rows* of A,
 /// accumulated into. Length: `num_rows * bs0`.
-/// @param[in] bs0 Row block size. Either a runtime `int` or a
-/// `std::integral_constant<int, N>`.
-/// @param[in] bs1 Column block size. Either a runtime `int` or a
-/// `std::integral_constant<int, N>`.
+/// @param[in] bs0 Row block size. Either a runtime integral value or a
+/// `std::integral_constant<U, N>` for some integral type `U`.
+/// @param[in] bs1 Column block size. Either a runtime integral value
+/// or a `std::integral_constant<U, N>` for some integral type `U`.
 template <typename T>
 void spmv(std::span<const T> values, std::span<const std::int64_t> row_begin,
           std::span<const std::int64_t> row_end,
           std::span<const std::int32_t> indices, std::span<const T> x,
-          std::span<T> y, auto bs0, auto bs1)
+          std::span<T> y, BlockSizeArg auto bs0, BlockSizeArg auto bs1)
 {
   assert(row_begin.size() == row_end.size());
   // Block layout: row-major within each block. The element at row-offset
   // k0 (∈ [0, bs0)) and column-offset k1 (∈ [0, bs1)) of block entry j
   // is stored at values[j * bs0 * bs1 + k0 * bs1 + k1].
-  for (int k0 = 0; k0 < bs0; ++k0)
+  for (decltype(+bs0) k0 = 0; k0 < bs0; ++k0)
   {
     for (std::size_t i = 0; i < row_begin.size(); i++)
     {
       T vi{0};
       for (std::int64_t j = row_begin[i]; j < row_end[i]; j++)
       {
-        for (int k1 = 0; k1 < bs1; ++k1)
+        for (decltype(+bs1) k1 = 0; k1 < bs1; ++k1)
         {
           vi += values[j * bs0 * bs1 + k0 * bs1 + k1]
                 * x[indices[j] * bs1 + k1];
@@ -276,45 +295,44 @@ void spmv(std::span<const T> values, std::span<const std::int64_t> row_begin,
 /// zero `y` before the first call if a fresh result is required.
 ///
 /// @note The value block layout is row-major within each block: for
-/// block entry `j` the element at row-offset `k0` and column-offset `k1`
-/// is stored at `values[j * bs0 * bs1 + k0 * bs1 + k1]`.
+/// block entry `j` the element at row-offset `k0` and column-offset
+/// `k1` is stored at `values[j * bs0 * bs1 + k0 * bs1 + k1]`.
 ///
 /// @tparam T Scalar type of the matrix and vector entries.
 ///
-/// @param[in]  values    Nonzero values of A, stored block-row-major.
-///                       Length: `nnz * bs0 * bs1`.
-/// @param[in]  row_begin Start positions in `values`/`indices` for each
-///                       row of A.  Length: number of rows of A.
-/// @param[in]  row_end   End positions in `values`/`indices` for each
-///                       row of A.  Length: number of rows of A.
-/// @param[in]  indices   Column indices of each nonzero block entry of A.
-///                       Length: `nnz`.
-/// @param[in]  x         Input vector, indexed by the *rows* of A.
-///                       Length: `num_rows * bs0`.
-/// @param[in,out] y      Output vector, indexed by the *columns* of A,
-///                       accumulated into.
-///                       Length: `num_cols * bs1`.
-/// @param[in]  bs0       Row block size. Either a runtime `int` or a
-///                       `std::integral_constant<int, N>`.
-/// @param[in]  bs1       Column block size. Either a runtime `int` or a
-///                       `std::integral_constant<int, N>`.
+/// @param[in] values Nonzero values of A, stored block-row-major.
+/// Length: `nnz * bs0 * bs1`.
+/// @param[in] row_begin Start positions in `values`/`indices` for each
+/// row of A.  Length: number of rows of A.
+/// @param[in] row_end End positions in `values`/`indices` for each row
+/// of A.  Length: number of rows of A.
+/// @param[in] indices Column indices of each nonzero block entry of A.
+/// Length: `nnz`.
+/// @param[in] x Input vector, indexed by the *rows* of A. Length:
+/// `num_rows * bs0`.
+/// @param[in,out] y Output vector, indexed by the *columns* of A,
+/// accumulated into. Length: `num_cols * bs1`.
+/// @param[in] bs0 Row block size. Either a runtime integral value or a
+/// `std::integral_constant<U, N>` for some integral type `U`.
+/// @param[in] bs1 Column block size. Either a runtime integral value
+/// or a `std::integral_constant<U, N>` for some integral type `U`.
 template <typename T>
 void spmvT(std::span<const T> values, std::span<const std::int64_t> row_begin,
            std::span<const std::int64_t> row_end,
            std::span<const std::int32_t> indices, std::span<const T> x,
-           std::span<T> y, auto bs0, auto bs1)
+           std::span<T> y, BlockSizeArg auto bs0, BlockSizeArg auto bs1)
 {
   assert(row_begin.size() == row_end.size());
 
   // Block layout: row-major within each block.
-  for (int k0 = 0; k0 < bs0; ++k0)
+  for (decltype(+bs0) k0 = 0; k0 < bs0; ++k0)
   {
     for (std::size_t i = 0; i < row_begin.size(); i++)
     {
       const T xval = x[i * bs0 + k0];
       for (std::int64_t j = row_begin[i]; j < row_end[i]; j++)
       {
-        for (int k1 = 0; k1 < bs1; ++k1)
+        for (decltype(+bs1) k1 = 0; k1 < bs1; ++k1)
         {
           y[indices[j] * bs1 + k1]
               += values[j * bs0 * bs1 + k0 * bs1 + k1] * xval;

--- a/cpp/dolfinx/la/matrix_csr_impl.h
+++ b/cpp/dolfinx/la/matrix_csr_impl.h
@@ -223,11 +223,11 @@ void insert_nonblocked_csr(U&& data, const V& cols, const W& row_ptr,
 /// @param y
 /// @param bs0
 /// @param bs1
-template <typename T, int BS1>
+template <typename T>
 void spmv(std::span<const T> values, std::span<const std::int64_t> row_begin,
           std::span<const std::int64_t> row_end,
           std::span<const std::int32_t> indices, std::span<const T> x,
-          std::span<T> y, int bs0, int bs1)
+          std::span<T> y, auto bs0, auto bs1)
 {
   assert(row_begin.size() == row_end.size());
   // Block layout: row-major within each block. The element at row-offset
@@ -238,18 +238,13 @@ void spmv(std::span<const T> values, std::span<const std::int64_t> row_begin,
     for (std::size_t i = 0; i < row_begin.size(); i++)
     {
       T vi{0};
-      auto accumulate
-          = [&vi, values, bs0, k0, x, indices](auto n, std::int64_t j)
-      {
-        for (int k1 = 0; k1 < n; ++k1)
-          vi += values[j * bs0 * n + k0 * n + k1] * x[indices[j] * n + k1];
-      };
       for (std::int64_t j = row_begin[i]; j < row_end[i]; j++)
       {
-        if constexpr (BS1 == -1)
-          accumulate(bs1, j);
-        else
-          accumulate(std::integral_constant<int, BS1>(), j);
+        for (int k1 = 0; k1 < bs1; ++k1)
+        {
+          vi += values[j * bs0 * bs1 + k0 * bs1 + k1]
+                * x[indices[j] * bs1 + k1];
+        }
       }
 
       y[i * bs0 + k0] += vi;
@@ -290,11 +285,11 @@ void spmv(std::span<const T> values, std::span<const std::int64_t> row_begin,
 /// @param[in]  bs0       Row block size (runtime value).
 /// @param[in]  bs1       Column block size (runtime value, used when
 ///                       `BS1 == -1`).
-template <typename T, int BS1>
+template <typename T>
 void spmvT(std::span<const T> values, std::span<const std::int64_t> row_begin,
            std::span<const std::int64_t> row_end,
            std::span<const std::int32_t> indices, std::span<const T> x,
-           std::span<T> y, int bs0, int bs1)
+           std::span<T> y, auto bs0, auto bs1)
 {
   assert(row_begin.size() == row_end.size());
 
@@ -304,18 +299,13 @@ void spmvT(std::span<const T> values, std::span<const std::int64_t> row_begin,
     for (std::size_t i = 0; i < row_begin.size(); i++)
     {
       const T xval = x[i * bs0 + k0];
-      auto accumulate
-          = [y, values, indices, bs0, k0, xval](auto n, std::int64_t j)
-      {
-        for (int k1 = 0; k1 < n; ++k1)
-          y[indices[j] * n + k1] += values[j * bs0 * n + k0 * n + k1] * xval;
-      };
       for (std::int64_t j = row_begin[i]; j < row_end[i]; j++)
       {
-        if constexpr (BS1 == -1)
-          accumulate(bs1, j);
-        else
-          accumulate(std::integral_constant<int, BS1>(), j);
+        for (int k1 = 0; k1 < bs1; ++k1)
+        {
+          y[indices[j] * bs1 + k1]
+              += values[j * bs0 * bs1 + k0 * bs1 + k1] * xval;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

An alternative, smaller-footprint way to address the code-duplication objective of #3716 (`Introduce BlockSize`), without introducing the generic `ConstexprType`/`BlockSize` concept machinery.

The `if constexpr (_bs > 0) { ... } else { ... }` branches in `assemble_cells`, `assemble_entities`, `assemble_interior_facets` (`fem/assemble_vector_impl.h`) and `spmv`/`spmvT` (`la/matrix_csr_impl.h`) duplicated the entire scatter/accumulate loop body for the compile-time and runtime block-size paths.

Rather than retaining the `if constexpr` dispatch inside each function (factoring only the loop body into a shared lambda), the block size is now carried as a single value that is either a runtime `int` or a compile-time `std::integral_constant<int, N>`, and the scatter/accumulate loop is written once, unconditionally, in terms of that value:

```cpp
for (std::size_t i = 0; i < dofs.size(); ++i)
  for (int k = 0; k < bs; ++k)
    b[bs * dofs[i] + k] += be[bs * i + k];
```

`std::integral_constant<int, N>` converts implicitly to `int`, so this single loop is valid for both cases, and the compiler can still constant-fold/unroll it for the `bs = 1, 3` fast paths since `bs` is a literal `std::integral_constant` there — the unrolling guarantee is preserved by the type system, not left to the optimizer to reconstruct from a plain `int`, which was the concern that motivated moving away from #3716's `consteval`-accessor approach in the first place (see [my review comment on #3716](https://github.com/FEniCS/dolfinx/pull/3716#issuecomment-5124163026)). The dispatch between the two now happens once, at the call site (`if (bs == 1) ... else if (bs == 3) ... else ...`), rather than being re-checked with `if constexpr` inside every function.

The same treatment is applied to `la::impl::spmv`/`spmvT`: the `template <typename T, int BS1>` non-type template parameter and its `if constexpr (BS1 == -1)` branch are replaced by plain `auto bs0, auto bs1` parameters, with `MatrixCSR::mult`/`multT` passing either `std::integral_constant<int, 1>{}` or the runtime `_bs[1]`.

Since `assemble_cells`/`assemble_entities`/`assemble_interior_facets` now take the dofmap/block-size/index data as an unconstrained `const auto& dofmap`, three concepts (`DofMapPackCells`, `DofMapPackEntities`, `DofMapPackFacets`) were added to `fem/traits.h` to give this parameter a real, checked type constraint again. They share a common base (`DofMapPackBase`: a 3-tuple whose first entry is a rank-2 `const std::int32_t` dofmap mdspan and second entry is convertible to `int`) and differ only in how the third entry (cell/entity/facet indices) is indexed, since that shape genuinely differs between the three assembly kernels — a flat span for cells, a rank-2 mdspan for entities, a rank-3 mdspan for interior facets.

This does not address #3716's secondary objective (block size specified twice — once as a template parameter, once via the runtime dofmap tuple, checked only by `assert`); that's a separate, independent concern.

## Test plan
- [x] `clang-format --dry-run --Werror` clean on all touched files
- [x] Full `libdolfinx` rebuild (`-Werror`) clean
- [x] `cpp/test` unittests: 68/68 passed, 27210/27210 assertions, including `[la_matrix]` (exercises `spmv`/`spmvT` directly)
- [x] Python bindings rebuilt; smoke-tested vector assembly and matrix-vector product (`A.mult`) at bs=1, bs=2, bs=3 — results match expected sums in each case

🤖 Generated with [Claude Code](https://claude.com/claude-code)
