### PR TITLE
Wrapping more return types as 'Python' types rather than nanobind types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,21 @@ disclosure process.
   already matches a callback/`std::function` parameter exactly, pass
   the function directly (e.g. `graph::reorder_rcm`) rather than
   wrapping it in a trivial forwarding lambda.
+- **Lambdas**: no `[=]`/`[&]` — list captures explicitly, e.g.
+  `[&v]`. Capture by reference for lambdas invoked in
+  place; by value (cheap scalars, or
+  `[v = std::move(v)]` to move a container) for lambdas that escape the
+  scope, where a captured reference or `span` into a local dangles
+  silently. `[this]` only if the lambda cannot outlive the object.
+  Never capture a container or `shared_ptr` by value for convenience:
+  the copy happens at capture and again whenever the lambda or its
+  `std::function` is copied.
+  Prefer explicit parameter types over `auto` (`auto&&` in generic
+  code); add an explicit return type when the deduced one is non-obvious
+  or must not decay. Avoid `mutable`. Promote long or reused lambdas to
+  a free function in an anonymous namespace. A by-reference capture is
+  `const` only if the captured variable is, so declare read-only locals
+  `const`.
 - **Algorithms**: prefer `<algorithm>`/`<ranges>` (`std::ranges::...`)
   over hand-written loops where it doesn't hurt clarity or
   performance; flattened row-major storage is the default convention

--- a/cpp/dolfinx/common/sort.h
+++ b/cpp/dolfinx/common/sort.h
@@ -64,7 +64,7 @@ inline constexpr _unsigned_projection unsigned_projection{};
 /// @code
 /// std::array<std::int16_t, 3> a{2, 3, 1};
 /// std::array<std::int16_t, 3> i{0, 1, 2};
-/// dolfinx::radix_sort(i, [&](auto i){ return a[i]; }); // yields i = {2, 0,
+/// dolfinx::radix_sort(i, [&a](auto i){ return a[i]; }); // yields i = {2, 0,
 /// 1} and a[i] = {1, 2, 3};
 /// @endcode
 /// @tparam BITS The number of bits to sort at a time.
@@ -90,7 +90,7 @@ constexpr void radix_sort(R&& range, P proj = {})
 
   if constexpr (!std::is_same_v<uI, I>)
   {
-    radix_sort<_BITS>(std::forward<R>(range), [&](const T& e) -> uI
+    radix_sort<_BITS>(std::forward<R>(range), [&proj](const T& e) -> uI
                       { return unsigned_projection(proj(e)); });
     return;
   }

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -497,7 +497,7 @@ public:
   {
     // set_fn is a lambda which gets evaluated for every index in [0,
     // _dofs0.size()) and its result is assigned to x[_dofs0[i]].
-    auto apply = [&](std::invocable<std::int32_t> auto set_fn)
+    auto apply = [this, &x](std::invocable<std::int32_t> auto set_fn)
     {
       static_assert(
           std::is_same_v<std::invoke_result_t<decltype(set_fn), std::int32_t>,

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -585,8 +585,10 @@ FiniteElement<T>::dof_permutation_fn(bool inverse, bool scalar_element) const
         dims.push_back(_sub_elements[i]->space_dimension());
       }
 
-      return [dims, sub_element_functions](std::span<std::int32_t> doflist,
-                                           std::uint32_t cell_permutation)
+      return
+          [dims = std::move(dims),
+           sub_element_functions = std::move(sub_element_functions)](
+              std::span<std::int32_t> doflist, std::uint32_t cell_permutation)
       {
         std::size_t start = 0;
         for (std::size_t e = 0; e < sub_element_functions.size(); ++e)
@@ -605,10 +607,10 @@ FiniteElement<T>::dof_permutation_fn(bool inverse, bool scalar_element) const
           = _sub_elements.front()->dof_permutation_fn(inverse);
       int dim = _sub_elements.front()->space_dimension();
       int bs = _bs;
-      return
-          [sub_element_function, bs, subdofs = std::vector<std::int32_t>(dim)](
-              std::span<std::int32_t> doflist,
-              std::uint32_t cell_permutation) mutable
+      return [sub_element_function = std::move(sub_element_function), bs,
+              subdofs = std::vector<std::int32_t>(dim)](
+                 std::span<std::int32_t> doflist,
+                 std::uint32_t cell_permutation) mutable
       {
         for (int k = 0; k < bs; ++k)
         {

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -458,9 +458,10 @@ public:
           dims.push_back(_sub_elements[i]->space_dimension());
         }
 
-        return [dims, sub_element_fns](std::span<U> data,
-                                       std::span<const std::uint32_t> cell_info,
-                                       std::int32_t cell, int block_size)
+        return [dims = std::move(dims),
+                sub_element_fns = std::move(sub_element_fns)](
+                   std::span<U> data, std::span<const std::uint32_t> cell_info,
+                   std::int32_t cell, int block_size)
         {
           std::size_t offset = 0;
           for (std::size_t e = 0; e < sub_element_fns.size(); ++e)
@@ -480,9 +481,9 @@ public:
             sub_fn
             = _sub_elements.front()->template dof_transformation_fn<U>(ttype);
         const int ebs = _bs;
-        return [ebs, sub_fn](std::span<U> data,
-                             std::span<const std::uint32_t> cell_info,
-                             std::int32_t cell, int data_block_size)
+        return [ebs, sub_fn = std::move(sub_fn)](
+                   std::span<U> data, std::span<const std::uint32_t> cell_info,
+                   std::int32_t cell, int data_block_size)
         { sub_fn(data, cell_info, cell, ebs * data_block_size); };
       }
     }
@@ -562,9 +563,10 @@ public:
           dims.push_back(_sub_elements[i]->space_dimension());
         }
 
-        return [dims, sub_element_fns](std::span<U> data,
-                                       std::span<const std::uint32_t> cell_info,
-                                       std::int32_t cell, int block_size)
+        return [dims = std::move(dims),
+                sub_element_fns = std::move(sub_element_fns)](
+                   std::span<U> data, std::span<const std::uint32_t> cell_info,
+                   std::int32_t cell, int block_size)
         {
           std::size_t offset = 0;
           for (std::size_t e = 0; e < sub_element_fns.size(); ++e)
@@ -586,9 +588,9 @@ public:
                            std::int32_t, int)>
             sub_fn
             = _sub_elements.front()->template dof_transformation_fn<U>(ttype);
-        return [this, sub_fn](std::span<U> data,
-                              std::span<const std::uint32_t> cell_info,
-                              std::int32_t cell, int data_block_size)
+        return [this, sub_fn = std::move(sub_fn)](
+                   std::span<U> data, std::span<const std::uint32_t> cell_info,
+                   std::int32_t cell, int data_block_size)
         {
           const int ebs = block_size();
           const std::size_t dof_count = data.size() / data_block_size;

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -122,7 +122,7 @@ void assemble_cells_matrix(
     // In "LiftingMode" only execute kernel if there are BCs on column space
     if constexpr (LiftingMode)
     {
-      auto has_bc = [&]()
+      auto has_bc = [&dofs1, &bc1, &bs1]()
       {
         for (std::int32_t dof : dofs1)
         {
@@ -307,7 +307,7 @@ void assemble_entities(
     // Check for BCs on column space
     if constexpr (LiftingMode)
     {
-      auto has_bc = [&]()
+      auto has_bc = [&dofs1, &bc1, &bs1]()
       {
         for (std::int32_t dof : dofs1)
         {
@@ -490,9 +490,10 @@ void assemble_interior_facets(
   // where both cells exist, so such blocks must be inserted
   // individually rather than as part of the full joint block.
   std::vector<T> Ae_block;
-  auto insert_block = [&](std::span<const std::int32_t> rdofs,
-                          std::span<const std::int32_t> cdofs,
-                          std::size_t row_offset, std::size_t col_offset)
+  auto insert_block = [&Ae_block, &Ae, &bs0, &bs1, &num_cols,
+                       &mat_set](std::span<const std::int32_t> rdofs,
+                                 std::span<const std::int32_t> cdofs,
+                                 std::size_t row_offset, std::size_t col_offset)
   {
     if (rdofs.empty() or cdofs.empty())
       return;
@@ -554,7 +555,7 @@ void assemble_interior_facets(
     // Check for BCs on column space
     if constexpr (LiftingMode)
     {
-      auto has_bc = [&]()
+      auto has_bc = [&dmapjoint1, &bc1, &bs1]()
       {
         for (std::int32_t dof : dmapjoint1)
         {

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -411,7 +411,9 @@ void lift_bc_impl(
   const int bs1
       = BS1 > 0 ? BS1 : a.function_spaces()[1]->dofmaps().front()->bs();
 
-  // Use default [=] capture for bs0, bs1 which may be compile-time constants
+  // Default capture is required for bs0/bs1: when BS0/BS1 are
+  // compile-time constants they are constant-initialised and an
+  // explicit capture is rejected by -Wunused-lambda-capture
   auto lifting_fn
       = [=, &b, &bc_values1, &bc_markers1,
          &x0](std::span<const std::int32_t> rows,

--- a/cpp/dolfinx/fem/pack.h
+++ b/cpp/dolfinx/fem/pack.h
@@ -144,7 +144,8 @@ void pack_coefficient_entity(std::span<T> c, int cstride,
   // and 3, rather than looping `bs` times at runtime for every cell.
   // `bs_c` is a `std::integral_constant<int, N>`, converted to `N` via
   // `bs_c()` where `pack_impl`'s `_bs` template parameter is needed.
-  auto pack_for_bs = [&](auto bs_c)
+  auto pack_for_bs = [&cells, &c, &cstride, &offset, &space_dim, &bs, &v,
+                      &cell_info, &dofmap, &transformation](auto bs_c)
   {
     for (std::size_t e = 0; e < cells.extent(0); ++e)
     {

--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -652,7 +652,7 @@ public:
         // Write a single mesh for functions as they share finite
         // element
         std::tie(_x_id, _x_ghost) = std::visit(
-            [&](auto& u)
+            [this](auto& u)
             {
               spdlog::debug("ADIOS2: write_mesh_from_space");
               return impl_vtx::vtx_write_mesh_from_space(*_io, *_engine,
@@ -677,8 +677,8 @@ public:
     // Write function data for each function to file
     for (auto& v : _u)
     {
-      std::visit([&](auto& u) { impl_vtx::vtx_write_data(*_io, *_engine, *u); },
-                 v);
+      std::visit([this](auto& u)
+                 { impl_vtx::vtx_write_data(*_io, *_engine, *u); }, v);
     }
 
     _engine->EndStep();

--- a/cpp/dolfinx/io/VTKFile.cpp
+++ b/cpp/dolfinx/io/VTKFile.cpp
@@ -663,7 +663,8 @@ void write_function(
       if (num_components < std::pow(3, rank))
         num_components = std::pow(3, rank);
 
-      auto add_field = [&](const std::string& name, int size)
+      auto add_field
+          = [&data_pnode, &num_components](const std::string& name, int size)
       {
         std::string type = std::format("Float{}", size);
         pugi::xml_node data_node = data_pnode.append_child("PDataArray");

--- a/cpp/dolfinx/la/MatrixCSR.h
+++ b/cpp/dolfinx/la/MatrixCSR.h
@@ -121,9 +121,9 @@ public:
           "Cannot insert blocks of different size than matrix block size");
     }
 
-    return [&](std::span<const std::int32_t> rows,
-               std::span<const std::int32_t> cols,
-               std::span<const value_type> data) -> int
+    return [this](std::span<const std::int32_t> rows,
+                  std::span<const std::int32_t> cols,
+                  std::span<const value_type> data) -> int
     {
       this->set<BS0, BS1>(data, rows, cols);
       return 0;
@@ -163,9 +163,9 @@ public:
           "Cannot insert blocks of different size than matrix block size");
     }
 
-    return [&](std::span<const std::int32_t> rows,
-               std::span<const std::int32_t> cols,
-               std::span<const value_type> data) -> int
+    return [this](std::span<const std::int32_t> rows,
+                  std::span<const std::int32_t> cols,
+                  std::span<const value_type> data) -> int
     {
       this->add<BS0, BS1>(data, rows, cols);
       return 0;

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -172,7 +172,7 @@ auto build_entity_list
           // algorithm in this hot loop. Only the sort step itself is
           // replaced; the quadrilateral re-orientation logic below is
           // unchanged.
-          auto cmpswap = [&](std::size_t a, std::size_t b)
+          auto cmpswap = [&perm, &global_vertices](std::size_t a, std::size_t b)
           {
             if (global_vertices[perm[a]] > global_vertices[perm[b]])
               std::swap(perm[a], perm[b]);
@@ -207,7 +207,7 @@ auto build_entity_list
         std::ranges::copy(elist, elist_sorted.begin());
         if (elist_sorted.size() == 4)
         {
-          auto cmpswap_val = [&](std::size_t a, std::size_t b)
+          auto cmpswap_val = [&elist_sorted](std::size_t a, std::size_t b)
           {
             if (elist_sorted[a] > elist_sorted[b])
               std::swap(elist_sorted[a], elist_sorted[b]);

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -22,6 +22,7 @@
 #include <optional>
 #include <span>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 using namespace dolfinx;
@@ -99,10 +100,10 @@ std::vector<std::int32_t> mesh::exterior_facet_indices(const Topology& topology)
 }
 //------------------------------------------------------------------------------
 mesh::CellPartitionFunction mesh::create_cell_partitioner(
-    mesh::GhostMode ghost_mode, const graph::partition_fn& partfn,
+    mesh::GhostMode ghost_mode, graph::partition_fn partfn,
     std::optional<std::int32_t> max_facet_to_cell_links)
 {
-  return [partfn, ghost_mode, max_facet_to_cell_links](
+  return [partfn = std::move(partfn), ghost_mode, max_facet_to_cell_links](
              MPI_Comm comm, int nparts, const std::vector<CellType>& cell_types,
              const std::vector<std::span<const std::int64_t>>& cells)
              -> graph::AdjacencyList<std::int32_t>

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -972,8 +972,7 @@ entities_to_geometry(const Mesh<T>& mesh, int dim,
 /// boundary for non-branching meshes).
 /// @return Function that computes the destination ranks for each cell.
 CellPartitionFunction
-create_cell_partitioner(mesh::GhostMode ghost_mode,
-                        const graph::partition_fn& partfn,
+create_cell_partitioner(mesh::GhostMode ghost_mode, graph::partition_fn partfn,
                         std::optional<std::int32_t> max_facet_to_cell_links);
 
 /// @brief Create a function that computes destination rank for mesh
@@ -1619,7 +1618,7 @@ MeshTags<T> transfer_meshtags_to_submesh(
           // parent entity
           bool entity_matches = std::ranges::all_of(
               parent_vertices,
-              [&](auto p_v)
+              [&entity_vertices](auto p_v)
               {
                 // With C++23 this can use std::ranges::contains
                 return std::ranges::find(entity_vertices, p_v)

--- a/cpp/dolfinx/refinement/mark.h
+++ b/cpp/dolfinx/refinement/mark.h
@@ -39,7 +39,7 @@ std::vector<std::int32_t> mark_maximum(std::span<const T> marker, T theta,
                          : std::ranges::max(marker);
   MPI_Allreduce(MPI_IN_PLACE, &max, 1, dolfinx::MPI::mpi_t<T>, MPI_MAX, comm);
 
-  auto mark = [=](T e) { return e > theta * max; };
+  auto mark = [&theta, &max](T e) { return e > theta * max; };
 
   std::vector<std::int32_t> indices;
   indices.reserve(std::ranges::count_if(marker, mark));

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -73,8 +73,8 @@ void test_scatter_fwd(int n)
     }
     CHECK((int)data_ghost.size() == n * num_ghosts);
     CHECK(std::ranges::all_of(
-        data_ghost,
-        [=](auto i) { return i == val * ((mpi_rank + 1) % mpi_size); }));
+        data_ghost, [&val, &mpi_rank, &mpi_size](auto i)
+        { return i == val * ((mpi_rank + 1) % mpi_size); }));
   }
 
   {

--- a/cpp/test/common/sort.cpp
+++ b/cpp/test/common/sort.cpp
@@ -70,7 +70,7 @@ TEMPLATE_TEST_CASE("Test radix sort (projection)", "[radix]", std::int16_t,
     std::vector<TestType> indices(vec.size());
     std::iota(indices.begin(), indices.end(), 0);
 
-    auto proj = [&](auto index) { return vec[index]; };
+    auto proj = [&vec](auto index) { return vec[index]; };
     dolfinx::radix_sort(indices, proj);
     CHECK(std::ranges::is_sorted(indices, std::less{}, proj));
   }

--- a/cpp/test/matrix.cpp
+++ b/cpp/test/matrix.cpp
@@ -154,7 +154,7 @@ void test_matrix()
   md::mdspan<T, md::extents<std::size_t, 8, md::dynamic_extent>> Aref(
       Aref_data.data(), 8, A.index_map(1)->size_global());
 
-  auto to_global_col = [&](auto col)
+  auto to_global_col = [&A](auto col)
   {
     std::array<std::int64_t, 1> tmp;
     A.index_map(1)->local_to_global(std::vector<std::int32_t>{col}, tmp);

--- a/cpp/test/mesh/generation.cpp
+++ b/cpp/test/mesh/generation.cpp
@@ -96,10 +96,10 @@ TEMPLATE_TEST_CASE("Interval mesh (parallel)", "[mesh][interval]", float,
   //   auto part
   //       = mesh::create_cell_partitioner(ghost_mode,
   //       graph::scotch::partitioner());
-  mesh::CellPartitionFunction part
-      = [&](MPI_Comm /* comm */, int /* nparts */,
-            const std::vector<mesh::CellType>& /* cell_types */,
-            const std::vector<std::span<const std::int64_t>>& /* cells */)
+  mesh::CellPartitionFunction part =
+      [comm_size](MPI_Comm /* comm */, int /* nparts */,
+                  const std::vector<mesh::CellType>& /* cell_types */,
+                  const std::vector<std::span<const std::int64_t>>& /* cells */)
   {
     std::vector<std::vector<std::int32_t>> data;
     if (comm_size == 1)

--- a/cpp/test/mesh/refinement/interval.cpp
+++ b/cpp/test/mesh/refinement/interval.cpp
@@ -123,7 +123,7 @@ TEMPLATE_TEST_CASE("Interval Refinement (parallel)",
   if (comm_size == 1)
     SKIP("Only runs in parallel");
 
-  auto create_mesh = [&]()
+  auto create_mesh = [&rank, &comm_size]()
   {
     std::vector<T> x;
     std::vector<std::int64_t> cells;

--- a/cpp/test/mesh/refinement/mark.cpp
+++ b/cpp/test/mesh/refinement/mark.cpp
@@ -35,11 +35,11 @@ TEMPLATE_TEST_CASE("Mark maximum", "[refinement][mark][maximum]", double, float)
   auto indices = mark_maximum<TestType>(marker, theta, comm);
 
   CHECK(std::ranges::all_of(
-      indices, [&](auto e)
+      indices, [&marker](auto e)
       { return (0 <= e) && (e <= static_cast<std::int32_t>(marker.size())); }));
 
   TestType max = dolfinx::MPI::size(comm) * 10 - 1;
-  auto mark = [=](auto e) { return e > theta * max; };
+  auto mark = [&theta, &max](auto e) { return e > theta * max; };
 
   CHECK(std::ranges::count_if(marker, mark)
         == static_cast<std::int32_t>(indices.size()));

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -245,7 +245,8 @@ formtype = form_cpp_class(dtype)
 cells = np.arange(msh.topology.index_map(msh.topology.dim).size_local)
 integrals = {IntegralType.cell: [(0, tabulate_A.address, cells, np.array([], dtype=np.int8))]}
 a_cond = Form(
-    formtype([U._cpp_object, U._cpp_object], integrals, [], [], False, [], mesh=msh._cpp_object)  # type: ignore
+    formtype([U._cpp_object, U._cpp_object], integrals, [], [], False, [], mesh=msh._cpp_object),  # type: ignore
+    msh,
 )
 
 # Next, we pass the compiled kernel to the standard {py:func}`

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -25,7 +25,7 @@ from dolfinx import cpp as _cpp
 from dolfinx import default_scalar_type, jit
 from dolfinx.fem import IntegralType
 from dolfinx.fem.function import Constant, Function, FunctionSpace
-from dolfinx.typing import Real, Scalar
+from dolfinx.typing import Scalar
 
 if typing.TYPE_CHECKING:
     # import dolfinx.mesh just when doing type checking to avoid
@@ -51,7 +51,7 @@ class Form(typing.Generic[Scalar]):
         | _cpp.fem.Form_float32
         | _cpp.fem.Form_float64
     )
-    _mesh: Mesh[Real]
+    _mesh: Mesh
     _code: str | list[str] | None
 
     def __init__(
@@ -60,7 +60,7 @@ class Form(typing.Generic[Scalar]):
         | _cpp.fem.Form_complex128
         | _cpp.fem.Form_float32
         | _cpp.fem.Form_float64,
-        msh: Mesh[Real],
+        msh: Mesh,
         ufcx_form=None,
         code: str | list[str] | None = None,
         module: types.ModuleType | list[types.ModuleType] | None = None,

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -25,7 +25,7 @@ from dolfinx import cpp as _cpp
 from dolfinx import default_scalar_type, jit
 from dolfinx.fem import IntegralType
 from dolfinx.fem.function import Constant, Function, FunctionSpace
-from dolfinx.typing import Scalar
+from dolfinx.typing import Real, Scalar
 
 if typing.TYPE_CHECKING:
     # import dolfinx.mesh just when doing type checking to avoid
@@ -51,6 +51,7 @@ class Form(typing.Generic[Scalar]):
         | _cpp.fem.Form_float32
         | _cpp.fem.Form_float64
     )
+    _mesh: Mesh[Real]
     _code: str | list[str] | None
 
     def __init__(
@@ -59,6 +60,7 @@ class Form(typing.Generic[Scalar]):
         | _cpp.fem.Form_complex128
         | _cpp.fem.Form_float32
         | _cpp.fem.Form_float64,
+        msh: Mesh[Real]
         ufcx_form=None,
         code: str | list[str] | None = None,
         module: types.ModuleType | list[types.ModuleType] | None = None,
@@ -77,10 +79,12 @@ class Form(typing.Generic[Scalar]):
             code: Form C++ code.
             module: CFFI module.
         """
+        self._cpp_object = form
+        self._mesh = msh
         self._code = code
         self._ufcx_form = ufcx_form
-        self._cpp_object = form
         self._module = module
+
 
     @property
     def ufcx_form(self):
@@ -105,7 +109,8 @@ class Form(typing.Generic[Scalar]):
     @property
     def function_spaces(self) -> list[FunctionSpace]:
         """Function spaces on which this form is defined."""
-        return self._cpp_object.function_spaces  # type: ignore[return-value]
+        # return [FunctionSpace(fs) for fs in self._cpp_object.function_spaces]
+        # return self._cpp_object.function_spaces  # type: ignore[return-value]
 
     @property
     def dtype(self) -> np.dtype:
@@ -218,13 +223,26 @@ def form_cpp_class(
     | type[_cpp.fem.Form_complex64]
     | type[_cpp.fem.Form_complex128]
 ):
-    """Wrapped C++ class of a variational form of a specific scalar type.
+    """Look up the wrapped C++ ``Form`` class for a given scalar type.
+
+    DOLFINx's C++ ``Form`` is templated on the scalar type and, for
+    complex scalars, on the geometry (coordinate) type. This resolves
+    ``dtype`` to the matching entry in :attr:`Form.cpp_types`, using
+    matched precision between the scalar and geometry types, e.g.
+    ``np.complex64`` maps to the class with ``np.float32`` geometry
+    and ``np.complex128`` to the class with ``np.float64`` geometry.
 
     Args:
-        dtype: Scalar type of the required form class.
+        dtype: Scalar type of the required form class, e.g.
+            ``np.float64`` or ``np.complex128``.
 
     Returns:
-        Wrapped C++ form class of the requested type.
+        Wrapped C++ form class matching ``dtype``.
+
+    Raises:
+        KeyError: If ``dtype`` is not one of the supported scalar
+            types (``np.float32``, ``np.float64``, ``np.complex64``,
+            ``np.complex128``).
 
     Note:
         This function is for advanced usage, typically when writing
@@ -291,13 +309,13 @@ def mixed_topology_form(
         if not all(d is data[0] for d in data if d is not None):
             raise ValueError("Subdomain data must be the same for each integral type.")
 
-    mesh = domain.ufl_cargo()
-    if mesh is None:
+    msh = domain.ufl_cargo()
+    if msh is None:
         raise RuntimeError("Expecting to find a Mesh in the form.")
-    comm = mesh.comm if jit_comm is None else jit_comm
+    comm = msh.comm if jit_comm is None else jit_comm
 
     # Geometry type is fixed by the mesh.
-    ftype = Form.cpp_types[np.dtype(dtype), mesh.geometry.x.dtype]
+    ftype = Form.cpp_types[np.dtype(dtype), msh.geometry.x.dtype]
 
     ufcx_forms = []
     modules = []
@@ -325,9 +343,9 @@ def mixed_topology_form(
         [],
         {},
         [],
-        mesh,
+        msh,
     )
-    return Form(f, ufcx_forms, codes, modules)
+    return Form(f, msh, ufcx_forms, codes, modules)
 
 
 def form(
@@ -386,7 +404,7 @@ def form(
             raise RuntimeError("Expecting to find a Mesh in the form.")
         comm = msh.comm if jit_comm is None else jit_comm
 
-        # Geometry type is fixed by the mesh.
+        # Geometry type is fixed by the mesh
         ftype = Form.cpp_types[np.dtype(dtype), msh.geometry.x.dtype]
 
         ufcx_form, module, code = jit.ffcx_jit(
@@ -440,7 +458,7 @@ def form(
             _entity_maps,
             msh,
         )
-        return Form(f, ufcx_form, code, module)
+        return Form(f, msh, ufcx_form, code, module)
 
     def _zero_form(form):
         """Compile a single 'zero' UFL form.
@@ -463,7 +481,7 @@ def form(
             entity_maps=[],
             mesh=msh,
         )
-        return Form(f)
+        return Form(f, msh)
 
     def _create_form(form):
         """Recursively convert ufl.Forms to dolfinx.fem.Form.

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -109,8 +109,7 @@ class Form(typing.Generic[Scalar]):
     @property
     def function_spaces(self) -> list[FunctionSpace]:
         """Function spaces on which this form is defined."""
-        # return [FunctionSpace(fs) for fs in self._cpp_object.function_spaces]
-        # return self._cpp_object.function_spaces  # type: ignore[return-value]
+        return self._cpp_object.function_spaces  # type: ignore[return-value]
 
     @property
     def dtype(self) -> np.dtype:
@@ -728,7 +727,7 @@ def create_form(
         _entity_maps,
         msh._cpp_object,
     )
-    return Form(f, form.ufcx_form, form.code)
+    return Form(f, msh, form.ufcx_form, form.code)
 
 
 def _derive_univariate_residual(

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -75,6 +75,7 @@ class Form(typing.Generic[Scalar]):
 
         Args:
             form: Compiled form object.
+            msh: Mesh that form is defined on.
             ufcx_form: UFCx form.
             code: Form C++ code.
             module: CFFI module.

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -60,7 +60,7 @@ class Form(typing.Generic[Scalar]):
         | _cpp.fem.Form_complex128
         | _cpp.fem.Form_float32
         | _cpp.fem.Form_float64,
-        msh: Mesh[Real]
+        msh: Mesh[Real],
         ufcx_form=None,
         code: str | list[str] | None = None,
         module: types.ModuleType | list[types.ModuleType] | None = None,
@@ -84,7 +84,6 @@ class Form(typing.Generic[Scalar]):
         self._code = code
         self._ufcx_form = ufcx_form
         self._module = module
-
 
     @property
     def ufcx_form(self):

--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -358,8 +358,11 @@ def form(
     """Create a Form or list of Forms.
 
     Args:
-        form: A UFL form or iterable of UFL forms. ``None`` is passed
-            through unchanged.
+        form: A UFL form, or a nested sequence of UFL forms (e.g. for
+            a block form). Any entry may be ``None``, e.g. to indicate
+            a zero block in a block form; each ``None`` entry is
+            returned as ``None`` in the corresponding position of the
+            result, rather than being compiled.
         dtype: Scalar type to use for the compiled form.
         form_compiler_options: See :func:`ffcx_jit <dolfinx.jit.ffcx_jit>`
         jit_options: See :func:`ffcx_jit <dolfinx.jit.ffcx_jit>`.

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -701,6 +701,7 @@ def functionspace(
     # Check that element and mesh cell types match
     if ((domain := mesh.ufl_domain()) is None) or ufl_e.cell != domain.ufl_cell():
         raise ValueError("Non-matching UFL cell and mesh cell shapes.")
+
     # Create DOLFINx objects
     dolfinx_element = finiteelement(mesh.topology.cell_type, ufl_e, dtype)
 

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -848,15 +848,15 @@ class FunctionSpace(ufl.FunctionSpace, Generic[Real]):
         """Function space finite element."""
         return FiniteElement(self._cpp_object.element)
 
-    @property
+    @cached_property
     def dofmap(self) -> DofMap:
         """Degree-of-freedom map associated with the function space."""
         return DofMap(self._cpp_object.dofmap)
 
-    @property
+    @cached_property
     def dofmaps(self) -> list[DofMap]:
         """The geometry dofmaps, one per cell type."""
-        return [DofMap(_o) for _o in self._cpp_object.dofmaps]
+        return [DofMap(map) for map in self._cpp_object.dofmaps]
 
     @property
     def mesh(self) -> Mesh[Real]:

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -101,10 +101,11 @@ def test_numba_assembly(dtype):
     a = Form(
         formtype(
             [V._cpp_object, V._cpp_object], integrals, [], [], False, [], mesh=mesh._cpp_object
-        )
+        ),
+        mesh,
     )
     integrals = {IntegralType.cell: [(0, k1.address, cells, active_coeffs)]}
-    L = Form(formtype([V._cpp_object], integrals, [], [], False, [], mesh=mesh._cpp_object))
+    L = Form(formtype([V._cpp_object], integrals, [], [], False, [], mesh=mesh._cpp_object), mesh)
 
     A = dolfinx.fem.assemble_matrix(a)
     A.scatter_reverse()
@@ -140,7 +141,8 @@ def test_coefficient(dtype):
     L = Form(
         formtype(
             [V._cpp_object], integrals, [vals._cpp_object], [], False, [], mesh=mesh._cpp_object
-        )
+        ),
+        mesh,
     )
 
     b = dolfinx.fem.assemble_vector(L)
@@ -278,13 +280,15 @@ def test_cffi_assembly():
     a = Form(
         _cpp.fem.Form_float64(
             [V._cpp_object, V._cpp_object], integrals, [], [], False, [], mesh=mesh._cpp_object
-        )
+        ),
+        mesh,
     )
 
     ptrL = ffi.cast("intptr_t", ffi.addressof(lib, "tabulate_tensor_poissonL"))
     integrals = {IntegralType.cell: [(0, ptrL, cells, active_coeffs)]}
     L = Form(
-        _cpp.fem.Form_float64([V._cpp_object], integrals, [], [], False, [], mesh=mesh._cpp_object)
+        _cpp.fem.Form_float64([V._cpp_object], integrals, [], [], False, [], mesh=mesh._cpp_object),
+        mesh,
     )
     A = fem.assemble_matrix(a)
     A.scatter_reverse()

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -35,9 +35,9 @@ def test_extract_forms():
     """Test extraction on unique function spaces for rows and columns of
     a block system.
     """
-    mesh = create_unit_square(MPI.COMM_WORLD, 32, 31)
-    V0 = functionspace(mesh, ("Lagrange", 1))
-    V1 = functionspace(mesh, ("Lagrange", 2))
+    msh = create_unit_square(MPI.COMM_WORLD, 32, 31)
+    V0 = functionspace(msh, ("Lagrange", 1))
+    V1 = functionspace(msh, ("Lagrange", 2))
     V2 = V0.clone()
     V3 = V1.clone()
 
@@ -69,7 +69,7 @@ def test_extract_forms():
 
 def test_incorrect_element():
     """Test that an error is raised if an incorrect element is used."""
-    mesh = create_unit_square(MPI.COMM_WORLD, 32, 31)
+    msh = create_unit_square(MPI.COMM_WORLD, 32, 31)
     element = basix.ufl.element(
         "Lagrange",
         "triangle",
@@ -85,8 +85,8 @@ def test_incorrect_element():
         dtype=dolfinx.default_real_type,
     )
 
-    space = functionspace(mesh, element)
-    incorrect_space = functionspace(mesh, incorrect_element)
+    space = functionspace(msh, element)
+    incorrect_space = functionspace(msh, incorrect_element)
 
     u = TrialFunction(space)
     v = TestFunction(space)
@@ -97,7 +97,7 @@ def test_incorrect_element():
     ftype = form_cpp_class(dtype)
 
     ufcx_form, module, code = dolfinx.jit.ffcx_jit(
-        mesh.comm, a, form_compiler_options={"scalar_type": dtype}
+        msh.comm, a, form_compiler_options={"scalar_type": dtype}
     )
 
     f = ftype(
@@ -107,9 +107,9 @@ def test_incorrect_element():
         [],
         {IntegralType.cell: []},
         [],
-        mesh._cpp_object,
+        msh._cpp_object,
     )
-    dolfinx.fem.Form(f, mesh, ufcx_form, code)
+    dolfinx.fem.Form(f, msh, ufcx_form, code)
 
     with pytest.raises(RuntimeError):
         f = ftype(
@@ -119,25 +119,25 @@ def test_incorrect_element():
             [],
             {IntegralType.cell: []},
             [],
-            mesh._cpp_object,
+            msh._cpp_object,
         )
-        dolfinx.fem.Form(f, mesh, ufcx_form, code)
+        dolfinx.fem.Form(f, msh, ufcx_form, code)
 
 
 def test_multiple_measures_one_subdomain_data():
     comm = MPI.COMM_WORLD
-    mesh = dolfinx.mesh.create_unit_interval(comm, 10)
-    x = SpatialCoordinate(mesh)
-    num_cells_local = mesh.topology.index_map(mesh.topology.dim).size_local
+    msh = dolfinx.mesh.create_unit_interval(comm, 10)
+    x = SpatialCoordinate(msh)
+    num_cells_local = msh.topology.index_map(msh.topology.dim).size_local
     ct = dolfinx.mesh.meshtags(
-        mesh,
-        mesh.topology.dim,
+        msh,
+        msh.topology.dim,
         np.arange(num_cells_local, dtype=np.int32),
         np.arange(num_cells_local, dtype=np.int32),
     )
 
-    dx = Measure("dx", domain=mesh, subdomain_data=ct)
-    dx_stand = Measure("dx", domain=mesh)
+    dx = Measure("dx", domain=msh, subdomain_data=ct)
+    dx_stand = Measure("dx", domain=msh)
 
     J = dolfinx.fem.form(x[0] ** 2 * dx + x[0] * dx_stand)
     J_local = dolfinx.fem.assemble_scalar(J)
@@ -147,9 +147,9 @@ def test_multiple_measures_one_subdomain_data():
 
 def test_derivative_block():
     """Test the function derivative_block."""
-    mesh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, 10)
-    V0 = functionspace(mesh, ("Lagrange", 1))
-    V1 = functionspace(mesh, ("Lagrange", 2))
+    msh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, 10)
+    V0 = functionspace(msh, ("Lagrange", 1))
+    V1 = functionspace(msh, ("Lagrange", 2))
     V = MixedFunctionSpace(V0, V1)
 
     f0, f1 = dolfinx.fem.Function(V0), dolfinx.fem.Function(V1)

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -109,7 +109,7 @@ def test_incorrect_element():
         [],
         mesh._cpp_object,
     )
-    dolfinx.fem.Form(f, ufcx_form, code)
+    dolfinx.fem.Form(f, mesh, ufcx_form, code)
 
     with pytest.raises(RuntimeError):
         f = ftype(
@@ -121,7 +121,7 @@ def test_incorrect_element():
             [],
             mesh._cpp_object,
         )
-        dolfinx.fem.Form(f, ufcx_form, code)
+        dolfinx.fem.Form(f, mesh, ufcx_form, code)
 
 
 def test_multiple_measures_one_subdomain_data():


### PR DESCRIPTION
There are places where methods return 'raw' nanobind wrapped types when we have a Python class that holds the nanobind wrapped object. Returning raw types leads to some inconsistencies in behaviour, missing docs and less effective type hints.

This PR tidies up a number of these return types, and adds Python wrappers where one was missing. All changes are in the Python interface; the C++ library is untouched.

### Return types now wrapped

- `Form.mesh` returns a `mesh.Mesh`, and `Form.function_spaces` a tuple of `fem.FunctionSpace`. Both were annotated as the Python types but returned the C++ objects. The Python objects are now stored on the `Form`, as is done for the mesh, so identity is preserved (`a.mesh is msh`).
- `Topology.connectivity` and `MeshTags.topology` return `graph.AdjacencyList` and `mesh.Topology`. `connectivity` also accepts the mixed-topology `(dim, entity type index)` pairs that the C++ method already supported. A dimension is anything integer-like, a NumPy integer included; the two arguments must be both dimensions or both pairs.
- `DofMap.dof_layout` and `CoordinateElement.create_dof_layout` return the new `fem.ElementDofLayout`.
- `fem.create_sparsity_pattern` returns the new `la.SparsityPattern`.
- `mesh.build_dual_graph` and `fem.transpose_dofmap` were bare `dolfinx.cpp` re-exports returning a C++ adjacency list. Both are now Python functions returning `graph.AdjacencyList`.

### New Python wrappers

- `la.SparsityPattern`, wrapping `index_map`, `num_nonzeros`, `insert`, `insert_diagonal`, `finalize` and `graph`, with `la.sparsity_pattern` and `la.sparsity_pattern_blocked` factories covering the two C++ constructors. This was the most visible gap: the standard create/insert/finalize/`matrix_csr` sequence called C++ methods directly, and constructing a pattern at all required importing from `dolfinx.cpp.la`.
- `fem.ElementDofLayout`, wrapping `num_dofs`, `block_size`, `entity_dofs` and `entity_closure_dofs`.

### Arguments that required `dolfinx.cpp` objects

- `graph.distribute`'s `destinations` argument and `mesh.create_mesh`'s `reorder_fn` callback took/passed raw C++ adjacency lists, so user code could not avoid `dolfinx.cpp`. Both now use `graph.AdjacencyList`.
- `graph.reorder_rcm` gains a Python counterpart (the default cell reordering, and the natural thing to pass as `reorder_fn`), and `mesh.cell_num_entities` is re-exported.
- `la.matrix_csr` and `fem.build_sparsity_pattern` take a `la.SparsityPattern`.

### Wrapper identity and caching

The wrappers are thin handles around a shared C++ object, and several are rebuilt on each access, so comparing two of them fell back to identity and silently returned `False` — including the 'both dofmaps have the same index map' check that `demo_mixed-topology.py` documents.

- `AdjacencyList`, `DofMap`, `ElementDofLayout`, `Topology` and `Geometry` define `__eq__`/`__hash__` delegating to the wrapped object. nanobind hands back the same Python object for a given C++ pointer, so delegating is exact and the hash stays consistent with equality.
- `DofMap.dof_layout` and `Geometry.cmaps` are `functools.cached_property`, next to the existing `FunctionSpace.element`/`.dofmap`, rather than building a wrapper per access.
- Collections that are fixed by the object they are derived from are returned as tuples: `FunctionSpace.dofmaps`, `Geometry.cmaps` and `Form.function_spaces`. Each was a list copied out of a cached tuple on every access, purely to stop callers mutating the cache; a tuple says that directly and drops the copy. Every caller in the library and the tests only indexes them.

### API changes for callers

- `Form.__init__` takes the mesh and the argument function spaces (`Form(form, msh, spaces, ...)`). Forms are normally built with `fem.form`; the custom-kernel route in `demo_static-condensation.py` shows the updated call.
- Callers that relied on `Form.function_spaces` returning C++ spaces now take `._cpp_object` explicitly. The normalise-either-type branch in `bcs_by_block`, added for that leak, is removed.
- `FunctionSpace.dofmaps`, `Geometry.cmaps` and `Form.function_spaces` return tuples rather than lists.
- `Mesh.__init__` attaches the Python `Mesh` to the UFL domain rather than the C++ mesh, so `ufl.Mesh.ufl_cargo` returns the Python object. `Mesh` and `ufl.Mesh` then reference each other. The link has to be strong — `fem.form` needs `ufl_cargo` to give back that same `Mesh` — so a mesh is now reclaimed by the cyclic garbage collector rather than by reference counting. Where a mesh, and the MPI communicator it holds, must be released at a known point, `gc.collect()` is the lever; it matters because `~Comm` frees the communicator collectively.

### Fixes

- `get_integration_domains` mixed `subdomain.topology` and `subdomain._cpp_object.topology`.
- The docstrings of `create_sparsity_pattern` and `build_sparsity_pattern` told callers to call `assemble` on the pattern; the method is `finalize`.

### Still to do

- `SparsityPattern.index_map` returns a C++ `IndexMap`, which has no Python wrapper yet. #4496, stacked on this PR, adds one and closes the gap.
- `demo_mixed-topology.py` still imports the mixed-topology `create_mesh` and `FunctionSpace_float64` from `dolfinx.cpp`, which have no pure-Python equivalent yet. Other demos no longer import from `dolfinx.cpp`.

### AGENTS.md

Two conventions that came up while doing this: Python demos must not import from `dolfinx.cpp`, and Python tests needing PETSc must live in a file with `petsc` in the name.

---

AI assistance: I used Claude Code (Opus 5) to draft parts of this PR. I
reviewed, edited, tested, and take responsibility for the final contribution.
