### PR TITLE
Fix O(n^2) Debug-build regression in interpolate/eval cell loops

### DIFF
--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -588,7 +588,7 @@ public:
           coord_dofs(i, j) = x_g[pos + j];
       }
 
-      std::size_t p = std::distance(cells.begin(), cell_it);
+      std::size_t p = std::ranges::distance(cells.begin(), cell_it);
       for (std::size_t j = 0; j < gdim; ++j)
         xp(0, j) = x[p * xshape[1] + j];
 
@@ -674,7 +674,7 @@ public:
 
       // Permute the reference basis function values to account for the
       // cell's orientation
-      std::size_t p = std::distance(cells.begin(), cell_it);
+      std::size_t p = std::ranges::distance(cells.begin(), cell_it);
       apply_dof_transformation(
           std::span(basis_derivatives_reference_values_b.data()
                         + p * num_basis_values,

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -92,7 +92,7 @@ std::vector<T> interpolation_coords(const fem::FiniteElement<T>& element,
     }
 
     // Push forward coordinates (X -> x)
-    std::size_t offset = std::distance(cells.begin(), cell_it);
+    std::size_t offset = std::ranges::distance(cells.begin(), cell_it);
     for (std::size_t p = 0; p < Xshape[0]; ++p)
     {
       for (std::size_t j = 0; j < gdim; ++j)
@@ -753,7 +753,7 @@ void point_evaluation(const FiniteElement<U>& element, bool symmetric,
       std::size_t row = 0;
       std::size_t rowstart = 0;
       std::span<const std::int32_t> dofs = dofmap.cell_dofs(*cell_it);
-      std::size_t offset = std::distance(cells.begin(), cell_it);
+      std::size_t offset = std::ranges::distance(cells.begin(), cell_it);
       for (int k = 0; k < element_bs; ++k)
       {
         if (k - rowstart > row)
@@ -791,7 +791,7 @@ void point_evaluation(const FiniteElement<U>& element, bool symmetric,
     // Loop over cells
     for (auto cell_it = cells.begin(); cell_it != cells.end(); ++cell_it)
     {
-      std::size_t offset = std::distance(cells.begin(), cell_it);
+      std::size_t offset = std::ranges::distance(cells.begin(), cell_it);
       std::span<const std::int32_t> dofs = dofmap.cell_dofs(*cell_it);
       for (int k = 0; k < element_bs; ++k)
       {
@@ -874,7 +874,7 @@ void identity_mapped_evaluation(const FiniteElement<U>& element, bool symmetric,
   std::vector<T> coeffs_b(num_scalar_dofs);
   for (auto cell_it = cells.begin(); cell_it != cells.end(); ++cell_it)
   {
-    std::size_t offset = std::distance(cells.begin(), cell_it);
+    std::size_t offset = std::ranges::distance(cells.begin(), cell_it);
     std::span<const std::int32_t> dofs = dofmap.cell_dofs(*cell_it);
     for (int k = 0; k < element_bs; ++k)
     {
@@ -1039,7 +1039,7 @@ void piola_mapped_evaluation(const FiniteElement<U>& element, bool symmetric,
       detJ[p] = cmap.compute_jacobian_determinant(_J, det_scratch);
     }
 
-    const std::size_t offset = std::distance(cells.begin(), cell_it);
+    const std::size_t offset = std::ranges::distance(cells.begin(), cell_it);
     std::span<const std::int32_t> dofs = dofmap.cell_dofs(*cell_it);
     for (int k = 0; k < element_bs; ++k)
     {


### PR DESCRIPTION
## Summary

PR #4049 rewrote the cell loops in `fem::interpolate` (and `Function::eval`) to
iterate generically over any `mesh::CellRange`, computing a per-cell offset via
`std::size_t offset = std::distance(cells.begin(), cell_it);`.

`Function::interpolate()`'s whole-domain overload passes
`std::ranges::iota_view(0, num_cells)` as the cell range. `iota_view`'s
iterator satisfies the C++20 `std::random_access_iterator` *concept*, but not
the legacy `LegacyRandomAccessIterator` named requirement, because
`operator*` returns a prvalue rather than a genuine reference. As a result
`std::iterator_traits<It>::iterator_category` resolves to `input_iterator_tag`,
and `std::distance` (which dispatches on that legacy tag, not the C++20
concept) silently falls back to its O(n) increment-and-count implementation
instead of an O(1) subtraction.

Since this call sits inside the per-cell loop, the whole interpolation
becomes **O(num_cells²)** instead of O(num_cells) in unoptimised (Debug)
builds — exactly the regression reported in #4347 (52s vs 0.2s for a
constant-field interpolation over ~162k cells). It disappears from `-O1`
onward because the compiler can inline through the loop and collapse the
trivial counting loop via strength reduction.

`std::ranges::distance` dispatches on the C++20 iterator concept rather than
the legacy category tag, and stays O(1) for `iota_view` and friends, so this
swaps all affected call sites to it.

Locally reproducing the issue's demo confirms the fix: n=30 (162,000 cells)
drops from 52s to 0.25s, matching the pre-regression `v0.10.0.post5` baseline
of ~0.2s, with clean linear scaling at smaller n.

Fixes #4347.

## Changes

- `cpp/dolfinx/fem/interpolate.h`: 5 call sites in `interpolation_coords`,
  `impl::point_evaluation` (x2), `impl::identity_mapped_evaluation`,
  `impl::piola_mapped_evaluation`.
- `cpp/dolfinx/fem/Function.h`: 2 call sites in `Function::eval`, which takes
  the same generic `mesh::CellRange auto&&` parameter and is public API, so
  it's exposed to the same pitfall if ever called with a view-typed range.

## Test plan

- [x] `clang-format --dry-run --Werror` clean on both files
- [x] `ninja` rebuild of `libdolfinx` (Developer/Debug build type) clean under `-Werror`
- [x] Full C++ Catch2 suite: 68 test cases / 27,210 assertions passing
- [x] Local reproducer from #4347 confirms O(n²) → O(n) and 52s → 0.25s at n=30

🤖 Generated with [Claude Code](https://claude.com/claude-code)