### PR TITLE
Fix O(n^2) Debug-build regression in interpolate/eval cell loops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,15 +154,9 @@ disclosure process.
   not the legacy `LegacyRandomAccessIterator` (`operator*` returns a
   prvalue, not a reference), so their `iterator_category` degrades to
   `input_iterator_tag` and `std::distance` silently falls back to an
-  O(n) count instead of an O(1) subtraction — turning an O(n) per-cell
-  loop into O(n²), in unoptimised (Debug) builds only, since an
-  optimising compiler can inline the counting loop away. This is what
-  caused a 250x `Debug`-build-only slowdown in `fem::interpolate`/
-  `Function::eval` once they were generalised to accept any
-  `mesh::CellRange` and called with `std::ranges::iota_view` (#4347).
-  When indexing into a generic range parameter inside a loop (i.e.
-  anything constrained by a `CellRange`-like concept rather than a
-  concrete `std::vector`/`std::span`), track the index with a plain
+  O(n) count instead of an O(1) subtraction, turning an O(n) loop into
+  O(n²) in unoptimised (Debug) builds only. When indexing into a
+  generic range parameter inside a loop, track the index with a plain
   counter incremented alongside the iterator, or use
   `std::ranges::distance`/`std::ranges::advance`, which dispatch on
   the C++20 concept and stay O(1) for these views.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,10 +156,10 @@ disclosure process.
   `input_iterator_tag` and `std::distance` silently falls back to an
   O(n) count instead of an O(1) subtraction, turning an O(n) loop into
   O(n²) in unoptimised (Debug) builds only. When indexing into a
-  generic range parameter inside a loop, track the index with a plain
-  counter incremented alongside the iterator, or use
+  generic range parameter inside a loop, use
   `std::ranges::distance`/`std::ranges::advance`, which dispatch on
-  the C++20 concept and stay O(1) for these views.
+  the C++20 concept and stay O(1) for these views, or track the index
+  with a plain counter incremented alongside the iterator.
 - **Windows**: Windows is continuously tested on GitHub with the
   most important missing feature being the lack of C99 `_Complex`
   support denoted by existence of `DOLFINX_NO_STDC_COMPLEX_KERNELS`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,26 @@ disclosure process.
   over hand-written loops where it doesn't hurt clarity or
   performance; flattened row-major storage is the default convention
   for multi-dimensional data passed as flat buffers.
+- **`std::distance`/`std::advance`/`std::next`/`std::prev` on a
+  generic, template-parameterized range**: these legacy `<iterator>`
+  algorithms dispatch on `std::iterator_traits<It>::iterator_category`,
+  not the C++20 iterator concepts. Views such as
+  `std::ranges::iota_view` satisfy `std::random_access_iterator` but
+  not the legacy `LegacyRandomAccessIterator` (`operator*` returns a
+  prvalue, not a reference), so their `iterator_category` degrades to
+  `input_iterator_tag` and `std::distance` silently falls back to an
+  O(n) count instead of an O(1) subtraction — turning an O(n) per-cell
+  loop into O(n²), in unoptimised (Debug) builds only, since an
+  optimising compiler can inline the counting loop away. This is what
+  caused a 250x `Debug`-build-only slowdown in `fem::interpolate`/
+  `Function::eval` once they were generalised to accept any
+  `mesh::CellRange` and called with `std::ranges::iota_view` (#4347).
+  When indexing into a generic range parameter inside a loop (i.e.
+  anything constrained by a `CellRange`-like concept rather than a
+  concrete `std::vector`/`std::span`), track the index with a plain
+  counter incremented alongside the iterator, or use
+  `std::ranges::distance`/`std::ranges::advance`, which dispatch on
+  the C++20 concept and stay O(1) for these views.
 - **Windows**: Windows is continuously tested on GitHub with the
   most important missing feature being the lack of C99 `_Complex`
   support denoted by existence of `DOLFINX_NO_STDC_COMPLEX_KERNELS`

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -588,7 +588,7 @@ public:
           coord_dofs(i, j) = x_g[pos + j];
       }
 
-      std::size_t p = std::distance(cells.begin(), cell_it);
+      std::size_t p = std::ranges::distance(cells.begin(), cell_it);
       for (std::size_t j = 0; j < gdim; ++j)
         xp(0, j) = x[p * xshape[1] + j];
 
@@ -674,7 +674,7 @@ public:
 
       // Permute the reference basis function values to account for the
       // cell's orientation
-      std::size_t p = std::distance(cells.begin(), cell_it);
+      std::size_t p = std::ranges::distance(cells.begin(), cell_it);
       apply_dof_transformation(
           std::span(basis_derivatives_reference_values_b.data()
                         + p * num_basis_values,

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -92,7 +92,7 @@ std::vector<T> interpolation_coords(const fem::FiniteElement<T>& element,
     }
 
     // Push forward coordinates (X -> x)
-    std::size_t offset = std::distance(cells.begin(), cell_it);
+    std::size_t offset = std::ranges::distance(cells.begin(), cell_it);
     for (std::size_t p = 0; p < Xshape[0]; ++p)
     {
       for (std::size_t j = 0; j < gdim; ++j)
@@ -753,7 +753,7 @@ void point_evaluation(const FiniteElement<U>& element, bool symmetric,
       std::size_t row = 0;
       std::size_t rowstart = 0;
       std::span<const std::int32_t> dofs = dofmap.cell_dofs(*cell_it);
-      std::size_t offset = std::distance(cells.begin(), cell_it);
+      std::size_t offset = std::ranges::distance(cells.begin(), cell_it);
       for (int k = 0; k < element_bs; ++k)
       {
         if (k - rowstart > row)
@@ -791,7 +791,7 @@ void point_evaluation(const FiniteElement<U>& element, bool symmetric,
     // Loop over cells
     for (auto cell_it = cells.begin(); cell_it != cells.end(); ++cell_it)
     {
-      std::size_t offset = std::distance(cells.begin(), cell_it);
+      std::size_t offset = std::ranges::distance(cells.begin(), cell_it);
       std::span<const std::int32_t> dofs = dofmap.cell_dofs(*cell_it);
       for (int k = 0; k < element_bs; ++k)
       {
@@ -874,7 +874,7 @@ void identity_mapped_evaluation(const FiniteElement<U>& element, bool symmetric,
   std::vector<T> coeffs_b(num_scalar_dofs);
   for (auto cell_it = cells.begin(); cell_it != cells.end(); ++cell_it)
   {
-    std::size_t offset = std::distance(cells.begin(), cell_it);
+    std::size_t offset = std::ranges::distance(cells.begin(), cell_it);
     std::span<const std::int32_t> dofs = dofmap.cell_dofs(*cell_it);
     for (int k = 0; k < element_bs; ++k)
     {
@@ -1039,7 +1039,7 @@ void piola_mapped_evaluation(const FiniteElement<U>& element, bool symmetric,
       detJ[p] = cmap.compute_jacobian_determinant(_J, det_scratch);
     }
 
-    const std::size_t offset = std::distance(cells.begin(), cell_it);
+    const std::size_t offset = std::ranges::distance(cells.begin(), cell_it);
     std::span<const std::int32_t> dofs = dofmap.cell_dofs(*cell_it);
     for (int k = 0; k < element_bs; ++k)
     {


### PR DESCRIPTION
## Summary

PR #4049 rewrote the cell loops in `fem::interpolate` (and `Function::eval`) to
iterate generically over any `mesh::CellRange`, computing a per-cell offset via
`std::size_t offset = std::distance(cells.begin(), cell_it);`.

`Function::interpolate()`'s whole-domain overload passes
`std::ranges::iota_view(0, num_cells)` as the cell range. `iota_view`'s
iterator satisfies the C++20 `std::random_access_iterator` *concept*, but not
the legacy `LegacyRandomAccessIterator` named requirement, because
`operator*` returns a prvalue rather than a genuine reference. As a result
`std::iterator_traits<It>::iterator_category` resolves to `input_iterator_tag`,
and `std::distance` (which dispatches on that legacy tag, not the C++20
concept) silently falls back to its O(n) increment-and-count implementation
instead of an O(1) subtraction.

Since this call sits inside the per-cell loop, the whole interpolation
becomes **O(num_cells²)** instead of O(num_cells) in unoptimised (Debug)
builds — exactly the regression reported in #4347 (52s vs 0.2s for a
constant-field interpolation over ~162k cells). It disappears from `-O1`
onward because the compiler can inline through the loop and collapse the
trivial counting loop via strength reduction.

`std::ranges::distance` dispatches on the C++20 iterator concept rather than
the legacy category tag, and stays O(1) for `iota_view` and friends, so this
swaps all affected call sites to it.

Locally reproducing the issue's demo confirms the fix: n=30 (162,000 cells)
drops from 52s to 0.25s, matching the pre-regression `v0.10.0.post5` baseline
of ~0.2s, with clean linear scaling at smaller n.

Fixes #4347.

## Changes

- `cpp/dolfinx/fem/interpolate.h`: 5 call sites in `interpolation_coords`,
  `impl::point_evaluation` (x2), `impl::identity_mapped_evaluation`,
  `impl::piola_mapped_evaluation`.
- `cpp/dolfinx/fem/Function.h`: 2 call sites in `Function::eval`, which takes
  the same generic `mesh::CellRange auto&&` parameter and is public API, so
  it's exposed to the same pitfall if ever called with a view-typed range.

## Test plan

- [x] `clang-format --dry-run --Werror` clean on both files
- [x] `ninja` rebuild of `libdolfinx` (Developer/Debug build type) clean under `-Werror`
- [x] Full C++ Catch2 suite: 68 test cases / 27,210 assertions passing
- [x] Local reproducer from #4347 confirms O(n²) → O(n) and 52s → 0.25s at n=30

Supersedes #4351, which was accidentally auto-closed by GitHub when the
source branch was renamed (`garth/rangess-speed` → `garth/ranges-speed`) —
same commits, same branch, just the corrected name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)