### PR TITLE
Fix circular namespaces with `common` and `graph`

### DIFF
--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -1016,7 +1016,8 @@ std::vector<std::int64_t> IndexMap::global_indices() const
 //-----------------------------------------------------------------------------
 MPI_Comm IndexMap::comm() const { return _comm.comm(); }
 //----------------------------------------------------------------------------
-graph::AdjacencyList<int> IndexMap::index_to_dest_ranks(int tag) const
+std::pair<std::vector<int>, std::vector<std::int32_t>>
+IndexMap::index_to_dest_ranks(int tag) const
 {
   const std::int64_t offset = _local_range[0];
 
@@ -1244,7 +1245,7 @@ graph::AdjacencyList<int> IndexMap::index_to_dest_ranks(int tag) const
   std::ranges::transform(idx_to_rank, data.begin(),
                          [&dest](auto x) { return dest[x.second]; });
 
-  return graph::AdjacencyList(std::move(data), std::move(offsets));
+  return {std::move(data), std::move(offsets)};
 }
 //-----------------------------------------------------------------------------
 std::vector<std::int32_t> IndexMap::shared_indices() const

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -8,7 +8,6 @@
 
 #include "MPI.h"
 #include <cstdint>
-#include <dolfinx/graph/AdjacencyList.h>
 #include <memory>
 #include <span>
 #include <tuple>
@@ -221,8 +220,8 @@ public:
 
   /// @todo Aim to remove this function?
   ///
-  /// @brief Compute map from each local (owned) index to the set of
-  /// ranks that have the index as a ghost.
+  /// @brief For each local (owned) index compute the set of ranks that
+  /// have the index as a ghost.
   ///
   /// @note Collective
   ///
@@ -231,7 +230,7 @@ public:
   /// std::int64_t>,std::span<const int>,int) for an explanation of when
   /// `tag` is required.
   /// @return Shared indices.
-  graph::AdjacencyList<int> index_to_dest_ranks(
+  std::pair<std::vector<int>, std::vector<std::int32_t>> index_to_dest_ranks(
       int tag = static_cast<int>(dolfinx::MPI::tag::consensus_nbx)) const;
 
   /// @brief Build a list of owned indices that are ghosted by another

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "MPI.h"
+#include "log.h"
 #include "sort.h"
 #include <algorithm>
 #include <array>
 #include <cstddef>
-#include <dolfinx/common/log.h>
 #include <iostream>
 #include <iterator>
 #include <span>

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -21,7 +21,6 @@
 
 namespace dolfinx::common
 {
-
 /// @brief A Scatterer supports the scattering and gathering of
 /// distributed data that is associated with a common::IndexMap, using
 /// MPI.

--- a/cpp/dolfinx/common/Table.h
+++ b/cpp/dolfinx/common/Table.h
@@ -16,7 +16,6 @@
 
 namespace dolfinx
 {
-
 /// @brief This class provides storage and pretty-printing for tables.
 ///
 /// Example usage:

--- a/cpp/dolfinx/common/defines.h
+++ b/cpp/dolfinx/common/defines.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <string>
+#include <string_view>
 
 namespace dolfinx
 {

--- a/cpp/dolfinx/common/types.h
+++ b/cpp/dolfinx/common/types.h
@@ -14,10 +14,10 @@
 
 namespace dolfinx
 {
-/// @private This concept is used to constrain the a template type to floating
-/// point real or complex types. Note that this concept is different to
-/// std::floating_point which does not include std::complex.
-
+/// @private This concept is used to constrain the a template type to
+/// floating point real or complex types. Note that this concept is
+/// different to std::floating_point which does not include
+/// std::complex.
 template <class T>
 struct is_custom_scalar : std::false_type
 {

--- a/cpp/dolfinx/common/utils.h
+++ b/cpp/dolfinx/common/utils.h
@@ -11,12 +11,10 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <cstdint>
-#include <dolfinx/graph/AdjacencyList.h>
 #include <iterator>
 #include <mpi.h>
 #include <ranges>
 #include <stdexcept>
-#include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -116,20 +114,4 @@ std::size_t hash_global(MPI_Comm comm, const T& x)
   return global_hash;
 }
 
-/// @brief Build communication graph data as a JSON string.
-///
-/// The data string can be decoded (loaded) to create a Python object
-/// from which a [NetworkX](https://networkx.org/) graph can be
-/// constructed.
-///
-/// See ::comm_graph for a description of the data.
-///
-/// @param[in] g Communication graph.
-/// @return JSON string representing the communication graph. Edge
-/// data is data volume (`weight`) and local/remote memory indicator
-/// (`local==1` is an edge to an shared memory process/rank, other
-/// wise the target node is a remote memory rank).
-std::string comm_to_json(
-    const graph::AdjacencyList<std::tuple<int, std::size_t, std::int8_t>,
-                               std::pair<std::int32_t, std::int32_t>>& g);
 } // namespace dolfinx::common

--- a/cpp/dolfinx/mesh/MeshTags.h
+++ b/cpp/dolfinx/mesh/MeshTags.h
@@ -12,7 +12,6 @@
 #include <dolfinx/common/log.h>
 #include <dolfinx/common/utils.h>
 #include <dolfinx/graph/AdjacencyList.h>
-#include <dolfinx/io/cells.h>
 #include <memory>
 #include <span>
 #include <utility>

--- a/cpp/dolfinx/mesh/topologycomputation.cpp
+++ b/cpp/dolfinx/mesh/topologycomputation.cpp
@@ -336,7 +336,8 @@ get_local_indexing(MPI_Comm comm, const common::IndexMap& vertex_map,
   // Create a symmetric neighbor_comm from vertex_ranks
 
   // Get sharing ranks for each vertex
-  graph::AdjacencyList<int> vertex_ranks = vertex_map.index_to_dest_ranks();
+  auto [data, offsets] = vertex_map.index_to_dest_ranks();
+  graph::AdjacencyList<int> vertex_ranks(std::move(data), std::move(offsets));
 
   // Create unique list of ranks that share vertices (owners of)
   std::vector<int> ranks(vertex_ranks.array().begin(),

--- a/cpp/dolfinx/refinement/interval.h
+++ b/cpp/dolfinx/refinement/interval.h
@@ -55,8 +55,8 @@ compute_refinement_data(const mesh::Mesh<T>& mesh,
   // TODO: creation of sharing ranks in external function? Also same
   // code in use for plaza
   // Get sharing ranks for each cell
-  auto [data, offsets_g] = map_c->index_to_dest_ranks();
-  graph::AdjacencyList<int> cell_ranks(std::move(data), std::move(offsets_g));
+  auto [_data, _offsets_g] = map_c->index_to_dest_ranks();
+  graph::AdjacencyList<int> cell_ranks(std::move(_data), std::move(_offsets_g));
 
   // Create unique list of ranks that share cells (owners of ghosts plus
   // ranks that ghost owned indices)

--- a/cpp/dolfinx/refinement/interval.h
+++ b/cpp/dolfinx/refinement/interval.h
@@ -55,7 +55,8 @@ compute_refinement_data(const mesh::Mesh<T>& mesh,
   // TODO: creation of sharing ranks in external function? Also same
   // code in use for plaza
   // Get sharing ranks for each cell
-  graph::AdjacencyList<int> cell_ranks = map_c->index_to_dest_ranks();
+  auto [data, offsets_g] = map_c->index_to_dest_ranks();
+  graph::AdjacencyList<int> cell_ranks(std::move(data), std::move(offsets_g));
 
   // Create unique list of ranks that share cells (owners of ghosts plus
   // ranks that ghost owned indices)
@@ -181,7 +182,6 @@ compute_refinement_data(const mesh::Mesh<T>& mesh,
 
   std::vector<std::int32_t> offsets(refined_cell_count + 1);
   std::ranges::generate(offsets, [i = 0]() mutable { return 2 * i++; });
-
   graph::AdjacencyList cell_adj(std::move(cell_topology), std::move(offsets));
 
   return {std::move(cell_adj), std::move(new_vertex_coords), xshape,

--- a/cpp/dolfinx/refinement/plaza.h
+++ b/cpp/dolfinx/refinement/plaza.h
@@ -478,8 +478,8 @@ compute_refinement_data(const mesh::Mesh<T>& mesh,
     throw std::runtime_error("Edges must be initialised");
 
   // Get sharing ranks for each edge
-  auto [data, offsets] = map_e->index_to_dest_ranks();
-  graph::AdjacencyList<int> edge_ranks(std::move(data), std::move(offsets));
+  auto [_data, _offsets] = map_e->index_to_dest_ranks();
+  graph::AdjacencyList<int> edge_ranks(std::move(_data), std::move(_offsets));
 
   // Create unique list of ranks that share edges (owners of ghosts plus
   // ranks that ghost owned indices)

--- a/cpp/dolfinx/refinement/plaza.h
+++ b/cpp/dolfinx/refinement/plaza.h
@@ -478,7 +478,8 @@ compute_refinement_data(const mesh::Mesh<T>& mesh,
     throw std::runtime_error("Edges must be initialised");
 
   // Get sharing ranks for each edge
-  graph::AdjacencyList<int> edge_ranks = map_e->index_to_dest_ranks();
+  auto [data, offsets] = map_e->index_to_dest_ranks();
+  graph::AdjacencyList<int> edge_ranks(std::move(data), std::move(offsets));
 
   // Create unique list of ranks that share edges (owners of ghosts plus
   // ranks that ghost owned indices)

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -129,8 +129,14 @@ void common(nb::module_& m)
       .def_prop_ro("num_ghosts", &dolfinx::common::IndexMap::num_ghosts)
       .def_prop_ro("local_range", &dolfinx::common::IndexMap::local_range,
                    "Range of indices owned by this map")
-      .def("index_to_dest_ranks",
-           &dolfinx::common::IndexMap::index_to_dest_ranks)
+      .def(
+          "index_to_dest_ranks",
+          [](const dolfinx::common::IndexMap& self, int tag)
+          {
+            auto [data, offsets] = self.index_to_dest_ranks(tag);
+            return std::pair(std::move(data), std::move(offsets));
+          },
+          nb::arg("tag"))
       .def_prop_ro(
           "ghosts",
           [](const dolfinx::common::IndexMap& self)

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -140,7 +140,8 @@ void common(nb::module_& m)
           [](const dolfinx::common::IndexMap& self, int tag)
           {
             auto [data, offsets] = self.index_to_dest_ranks(tag);
-            return std::pair(std::move(data), std::move(offsets));
+            return std::pair{dolfinx_wrappers::as_nbarray(std::move(data)),
+                             dolfinx_wrappers::as_nbarray(std::move(offsets))};
           },
           nb::arg("tag"))
       .def_prop_ro(

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -84,7 +84,6 @@ ci = [
 wheel.packages = ["dolfinx"]
 sdist.exclude = ["*.cpp"]
 cmake.build-type = "Release"
-editable.rebuild = true
 
 [tool.scikit-build.cmake.define]
 # Set to FALSE to disable automatic RPATH adjustments

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -84,6 +84,7 @@ ci = [
 wheel.packages = ["dolfinx"]
 sdist.exclude = ["*.cpp"]
 cmake.build-type = "Release"
+editable.rebuild = true
 
 [tool.scikit-build.cmake.define]
 # Set to FALSE to disable automatic RPATH adjustments

--- a/python/test/unit/la/test_matrix_csr.py
+++ b/python/test/unit/la/test_matrix_csr.py
@@ -222,9 +222,9 @@ def test_set_diagonal_distributed(dtype):
     nlocal = index_map.size_local
     assert (diag[nlocal:] == dtype(0.0)).all()
 
-    shared_dofs = index_map.index_to_dest_ranks(0)
+    data, offsets = index_map.index_to_dest_ranks(0)
     for dof in range(nlocal):
-        owners = shared_dofs.links(dof)
+        owners = data[offsets[dof] : offsets[dof + 1]]
         assert diag[dof] == len(owners) + 1
 
     # create matrix


### PR DESCRIPTION
Code in the namespace `common` should not depend on code in `graph`. The relationship should be strictly `graph <- common`.