### PR TITLE
Fix SparsityPattern insertion performance regression

### DIFF
--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -98,6 +98,18 @@ SparsityPattern::SparsityPattern(
 
   const std::int32_t num_rows_local_new = _index_maps[0]->size_local();
 
+  // Reserve the exact final cache size (sub-pattern cache sizes are
+  // already known, so this is a one-off reserve, not a per-call one)
+  {
+    std::size_t num_entries = 0;
+    for (std::size_t row = 0; row < patterns.size(); ++row)
+      for (std::size_t col = 0; col < patterns[row].size(); ++col)
+        if (const SparsityPattern* p = patterns[row][col]; p)
+          num_entries += p->_cache_rows.size() * bs[0][row] * bs[1][col];
+    _cache_rows.reserve(num_entries);
+    _cache_cols.reserve(num_entries);
+  }
+
   // Iterate over block rows
   for (std::size_t row = 0; row < patterns.size(); ++row)
   {
@@ -277,6 +289,11 @@ void SparsityPattern::finalize()
   const auto [cache_offsets, cache_cols]
       = bucket_by_row(_cache_rows, _cache_cols, num_rows0);
 
+  // Cache is now fully bucketed into cache_offsets/cache_cols; drop it
+  // early to reduce peak memory for the rest of finalize()
+  std::vector<std::int32_t>().swap(_cache_rows);
+  std::vector<std::int32_t>().swap(_cache_cols);
+
   // Neighbourhood rank of each ghost row's owner, looked up once
   std::vector<int> neighbour_rank(owners0.size());
   std::ranges::transform(owners0, neighbour_rank.begin(),
@@ -366,9 +383,11 @@ void SparsityPattern::finalize()
     MPI_Comm_free(&comm);
   }
 
-  // Global to local map for ghost column indices
+  // Global to local map for ghost column indices. Reserve for the
+  // worst case where every received entry is a new ghost column, to
+  // avoid rehashing while the map is populated below.
   std::unordered_map<std::int64_t, std::int32_t> global_to_local;
-  global_to_local.reserve(_col_ghosts.size());
+  global_to_local.reserve(_col_ghosts.size() + ghost_data_in.size() / 3);
   std::int32_t local_i = local_size1;
   for (std::int64_t global_i : _col_ghosts)
     global_to_local.insert({global_i, local_i++});
@@ -437,10 +456,6 @@ void SparsityPattern::finalize()
     _edges.insert(_edges.end(), row.begin(), it_end);
     _offsets.push_back(_offsets.back() + std::distance(row.begin(), it_end));
   }
-
-  // Clear cache
-  std::vector<std::int32_t>().swap(_cache_rows);
-  std::vector<std::int32_t>().swap(_cache_cols);
 
   _edges.shrink_to_fit();
 

--- a/cpp/dolfinx/la/SparsityPattern.cpp
+++ b/cpp/dolfinx/la/SparsityPattern.cpp
@@ -188,15 +188,6 @@ void SparsityPattern::insert(std::int32_t row, std::int32_t col)
   }
 
   assert(_index_maps[0]);
-  const std::int32_t max_row
-      = _index_maps[0]->size_local() + _index_maps[0]->num_ghosts() - 1;
-
-  if (row > max_row or row < 0)
-  {
-    throw std::runtime_error(
-        "Cannot insert rows that do not exist in the IndexMap.");
-  }
-
   _cache_rows.push_back(row);
   _cache_cols.push_back(col);
 }
@@ -211,18 +202,13 @@ void SparsityPattern::insert(std::span<const std::int32_t> rows,
   }
 
   assert(_index_maps[0]);
-  const std::int32_t max_row
-      = _index_maps[0]->size_local() + _index_maps[0]->num_ghosts() - 1;
 
-  _cache_rows.reserve(_cache_rows.size() + rows.size() * cols.size());
-  _cache_cols.reserve(_cache_cols.size() + rows.size() * cols.size());
+  // Note: no explicit reserve() here. reserve(n) allocates exactly n,
+  // not the amortised (e.g. doubled) capacity insert() itself would
+  // pick, so reserving to the current size on every call would turn
+  // the cache into an O(#insert calls^2) allocation pattern.
   for (std::int32_t row : rows)
   {
-    if (row > max_row or row < 0)
-    {
-      throw std::runtime_error(
-          "Cannot insert rows that do not exist in the IndexMap.");
-    }
     _cache_rows.insert(_cache_rows.end(), cols.size(), row);
     _cache_cols.insert(_cache_cols.end(), cols.begin(), cols.end());
   }
@@ -237,18 +223,6 @@ void SparsityPattern::insert_diagonal(std::span<const std::int32_t> rows)
   }
 
   assert(_index_maps[0]);
-  const std::int32_t max_row
-      = _index_maps[0]->size_local() + _index_maps[0]->num_ghosts() - 1;
-
-  for (std::int32_t row : rows)
-  {
-    if (row > max_row or row < 0)
-    {
-      throw std::runtime_error(
-          "Cannot insert rows that do not exist in the IndexMap.");
-    }
-  }
-
   _cache_rows.insert(_cache_rows.end(), rows.begin(), rows.end());
   _cache_cols.insert(_cache_cols.end(), rows.begin(), rows.end());
 }


### PR DESCRIPTION
Resolves #4356.

Issue was use of std::vector::reserve in a tight section of code.