### PR TITLE
Add bcs to P11 nested preconditioner of `demo_stokes.py` to make it a more extendible example

### DIFF
--- a/python/demo/demo_stokes.py
+++ b/python/demo/demo_stokes.py
@@ -301,7 +301,7 @@ def nested_iterative_solver_low_level():
     # Create a nested matrix P to use as the preconditioner. The
     # top-left block of P is shared with the top-left block of A. The
     # bottom-right diagonal entry is assembled from the form a_p11:
-    P11 = assemble_matrix(a_p11, [])
+    P11 = assemble_matrix(a_p11, bcs=bcs)
     P = PETSc.Mat().createNest([[A.getNestSubMatrix(0, 0), None], [None, P11]])
     P.assemble()
 

--- a/python/demo/demo_stokes.py
+++ b/python/demo/demo_stokes.py
@@ -301,6 +301,8 @@ def nested_iterative_solver_low_level():
     # Create a nested matrix P to use as the preconditioner. The
     # top-left block of P is shared with the top-left block of A. The
     # bottom-right diagonal entry is assembled from the form a_p11:
+    # Even if the Dirichlet conditions are only enforced on the velocity
+    # space, we pass it to the pressure assembler for consistency.
     P11 = assemble_matrix(a_p11, bcs=bcs)
     P = PETSc.Mat().createNest([[A.getNestSubMatrix(0, 0), None], [None, P11]])
     P.assemble()


### PR DESCRIPTION
As seen in: #4246 the fact that we didn't pass in the bcs (which in turn is ignored internally if the function spaces of the bc doesn't align with the form spaces) confuses users, leading to the wrong behaviour in demos extending the functionality presented in `demo_stokes.py`.

This PR adds the simple patch of passing in the `bcs`, even if they have no effect on the P11 block.