### PR TITLE
Fix demo_stokes.py MUMPS crash on parallel direct solves

### DIFF
--- a/python/demo/demo_stokes.py
+++ b/python/demo/demo_stokes.py
@@ -520,6 +520,7 @@ def block_direct_solver():
     pc.setType("lu")
     use_superlu = PETSc.IntType == np.int64
     if PETSc.Sys().hasExternalPackage("mumps") and not use_superlu:
+        PETSc.Options()["mat_mumps_icntl_20"] = 0
         pc.setFactorSolverType("mumps")
         pc.setFactorSetUpSolverType()
         pc.getFactorMatrix().setMumpsIcntl(icntl=24, ival=1)
@@ -611,6 +612,7 @@ def mixed_direct():
     pc.setType("lu")
     use_superlu = PETSc.IntType == np.int64
     if PETSc.Sys().hasExternalPackage("mumps") and not use_superlu:
+        PETSc.Options()["mat_mumps_icntl_20"] = 0
         pc.setFactorSolverType("mumps")
         pc.setFactorSetUpSolverType()
         pc.getFactorMatrix().setMumpsIcntl(icntl=24, ival=1)

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -854,8 +854,20 @@ class TestPETScAssemblers:
             pc.setFieldSplitIS(["u", nested_IS[0][0]], ["p", nested_IS[1][1]])
             ksp_u, ksp_p = pc.getFieldSplitSubKSP()
             ksp_u.setType("preonly")
-            ksp_u.getPC().setType("lu")
+            pc_u = ksp_u.getPC()
+            pc_u.setType("lu")
+            use_superlu = PETSc.IntType == np.int64
+            if PETSc.Sys().hasExternalPackage("mumps") and not use_superlu:
+                # Avoid a longstanding PETSc/MUMPS bug triggered by the
+                # default distributed dense RHS (ICNTL(20)=10) in parallel
+                # solves; must be set via the options database as
+                # MatSolve_MUMPS re-derives ICNTL(20) from it on every solve.
+                PETSc.Options()[f"{ksp_u.getOptionsPrefix()}mat_mumps_icntl_20"] = 0
+                pc_u.setFactorSolverType("mumps")
+            else:
+                pc_u.setFactorSolverType("superlu_dist")
             ksp_p.setType("preonly")
+            ksp_p.getPC().setType("jacobi")
 
             def monitor(ksp, its, rnorm):
                 pass
@@ -892,6 +904,16 @@ class TestPETScAssemblers:
             ksp.setType("minres")
             pc = ksp.getPC()
             pc.setType("lu")
+            use_superlu = PETSc.IntType == np.int64
+            if PETSc.Sys().hasExternalPackage("mumps") and not use_superlu:
+                # Avoid a longstanding PETSc/MUMPS bug triggered by the
+                # default distributed dense RHS (ICNTL(20)=10) in parallel
+                # solves; must be set via the options database as
+                # MatSolve_MUMPS re-derives ICNTL(20) from it on every solve.
+                PETSc.Options()["mat_mumps_icntl_20"] = 0
+                pc.setFactorSolverType("mumps")
+            else:
+                pc.setFactorSolverType("superlu_dist")
             ksp.setTolerances(rtol=1.0e-8, max_it=50)
             ksp.setFromOptions()
             x = A.createVecRight()
@@ -952,6 +974,16 @@ class TestPETScAssemblers:
             ksp.setType("minres")
             pc = ksp.getPC()
             pc.setType("lu")
+            use_superlu = PETSc.IntType == np.int64
+            if PETSc.Sys().hasExternalPackage("mumps") and not use_superlu:
+                # Avoid a longstanding PETSc/MUMPS bug triggered by the
+                # default distributed dense RHS (ICNTL(20)=10) in parallel
+                # solves; must be set via the options database as
+                # MatSolve_MUMPS re-derives ICNTL(20) from it on every solve.
+                PETSc.Options()["mat_mumps_icntl_20"] = 0
+                pc.setFactorSolverType("mumps")
+            else:
+                pc.setFactorSolverType("superlu_dist")
 
             def monitor(ksp, its, rnorm):
                 # print("Num it, rnorm:", its, rnorm)


### PR DESCRIPTION
## Summary

`block_direct_solver()` and `mixed_direct()` in `demo_stokes.py` crash with a bus error (`SIGBUS`/`EXC_BAD_ACCESS`) in parallel (n>=2 MPI ranks), inside MUMPS's `dmumps_scatter_dist_rhs_`.

This is a known, longstanding upstream PETSc/MUMPS bug -- reports trace the root cause to PETSc's MUMPS interface since v3.14.0, occurring whenever PETSc drives MUMPS with a **distributed** dense right-hand-side vector (`ICNTL(20)=10`, PETSc's default in parallel) rather than a centralized one. It's not MUMPS-version-specific and remains open upstream.

## Fix

Set `PETSc.Options()["mat_mumps_icntl_20"] = 0` before configuring the MUMPS factorization, forcing PETSc to scatter the RHS to a centralized vector on rank 0 instead of using the buggy distributed-RHS path. This keeps MUMPS for the actual factorization (no need to fall back to SuperLU_DIST) and completely avoids the crash.

Note: setting `ICNTL(20)` directly via `pc.getFactorMatrix().setMumpsIcntl(icntl=20, ival=0)` (the same pattern already used for `icntl=24/25`) does **not** work -- PETSc's `MatSolve_MUMPS` re-derives `ICNTL(20)` from its own internal, options-database-backed flag on every solve call and overwrites whatever was set directly on the MUMPS struct. The options-database route is the only one that sticks.

## Test plan

- [x] `mpirun -n 1/2/3 python3 demo_stokes.py` -- all four solvers (`(A)`-`(D)`) now produce matching norms at every rank count; previously `n>=2` crashed with `SIGBUS` in `block_direct_solver()` and `mixed_direct()`.
- [x] `ruff format --check` / `ruff check` clean.

AI assistance: I used Claude to root-cause this crash (bisecting against v0.11.0, reading PETSc's MUMPS interface source, and confirming via a targeted fix) and draft the change. I reviewed and tested the final contribution.