### PR TITLE
Revert "Bump ubuntu from 24.04 to 26.04 in /docker (#4208)" and bump PETSc

### DIFF
--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -22,7 +22,7 @@ ARG KAHIP_VERSION=3.25
 # the most recent Numba release, see
 # https://numba.readthedocs.io/en/stable/user/installing.html#version-support-information
 ARG NUMPY_VERSION=2.4.6
-ARG PETSC_VERSION=3.25.3
+ARG PETSC_VERSION=3.25.4
 ARG SLEPC_VERSION=3.25.1
 ARG SPDLOG_VERSION=1.17.0
 

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -32,7 +32,7 @@ ARG OPENMPI_PATCH=10
 
 ########################################
 
-FROM ubuntu:26.04 AS dev-env
+FROM ubuntu:24.04 AS dev-env
 LABEL maintainer="FEniCS Steering Council <fenics-steering-council@googlegroups.com>"
 LABEL description="FEniCS testing and development environment with PETSc real, complex, 32-bit and 64-bit modes"
 


### PR DESCRIPTION
- This reverts commit 48d310d1fd3f9a45e6c436fbde96db7dbb665af0 ref https://github.com/FEniCS/dolfinx/pull/4208 (broken Docker images) - tested at https://github.com/FEniCS/dolfinx/actions/runs/30939304396
- Bumps PETSc to 3.25.4