### PR TITLE
Remove venv based typing checks from PETSc CI

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -270,7 +270,7 @@ jobs:
       - name: Run mypy
         run: |
           pip install mypy types-cffi scipy-stubs
-          mypy --config-file python/pyproject.toml -p dolfinx
+          mypy --config-file python/pyproject.toml -p dolfinx --exclude superlu_dist.py
           mypy -p dolfinx
         # cd python/
         # mypy test

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -263,12 +263,17 @@ jobs:
         run: cmake --build . --target test
 
       - name: Build Python interface
-        run: |
-          pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Developer" 'python/[test,mypy]'
-          python -c "from mpi4py import MPI; import dolfinx; assert dolfinx.has_adios2; assert dolfinx.has_kahip; assert not dolfinx.has_parmetis; assert dolfinx.has_petsc; assert dolfinx.has_petsc4py; assert dolfinx.has_ptscotch; assert dolfinx.has_slepc; assert dolfinx.has_complex_ufcx_kernels"
+        run: >
+          pip install 'python/[test,mypy]'
+          --check-build-dependencies
+          --no-build-isolation
+          --config-settings=cmake.build-type="Developer"
+
+      - name: Check Python configuration
+        run: python -c "from mpi4py import MPI; import dolfinx; assert dolfinx.has_adios2; assert dolfinx.has_kahip; assert not dolfinx.has_parmetis; assert dolfinx.has_petsc; assert dolfinx.has_petsc4py; assert dolfinx.has_ptscotch; assert dolfinx.has_slepc; assert dolfinx.has_complex_ufcx_kernels"
 
       - name: Run mypy
-        run: | # numpy-typing-compat needs to be pinned tp latest numba compatible numpy version to avoid auto upgrade
+        run: |
           mypy --config-file python/pyproject.toml -p dolfinx --exclude superlu_dist.py
           cd python/
           mypy test

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -273,7 +273,7 @@ jobs:
           mypy --config-file python/pyproject.toml -p dolfinx --exclude superlu_dist.py
           cd python/
           mypy test
-          mypy demo
+        # mypy demo
 
       - name: Numpy version
         run: python -c "import numpy; print(numpy.__version__)"

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -270,7 +270,7 @@ jobs:
       - name: Run mypy
         run: |
           pip install mypy types-cffi scipy-stubs numpy-typing-compat==20260602.2.4
-          mypy --config-file python/pyproject.toml -p dolfinx --exclude superlu_dist.py
+          mypy --config-file python/pyproject.toml -p dolfinx --exclude dolfinx/la/superlu_dist.py
           mypy -p dolfinx
         # cd python/
         # mypy test

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -264,12 +264,11 @@ jobs:
 
       - name: Build Python interface
         run: |
-          pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Developer" 'python/[test]'
+          pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Developer" 'python/[test,mypy]'
           python -c "from mpi4py import MPI; import dolfinx; assert dolfinx.has_adios2; assert dolfinx.has_kahip; assert not dolfinx.has_parmetis; assert dolfinx.has_petsc; assert dolfinx.has_petsc4py; assert dolfinx.has_ptscotch; assert dolfinx.has_slepc; assert dolfinx.has_complex_ufcx_kernels"
 
       - name: Run mypy
         run: | # numpy-typing-compat needs to be pinned tp latest numba compatible numpy version to avoid auto upgrade
-          pip install mypy types-cffi scipy-stubs numpy-typing-compat==20260602.2.4
           mypy --config-file python/pyproject.toml -p dolfinx --exclude superlu_dist.py
           cd python/
           mypy test

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -270,8 +270,7 @@ jobs:
       - name: Run mypy
         run: |
           pip install mypy types-cffi scipy-stubs numpy-typing-compat==20260602.2.4
-          mypy --config-file python/pyproject.toml -p dolfinx --exclude '(^|/)dolfinx/la/superlu_dist\.py$'
-          mypy -p dolfinx
+          mypy --config-file python/pyproject.toml -p dolfinx --exclude superlu_dist.py
         # cd python/
         # mypy test
         # mypy demo

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -268,7 +268,7 @@ jobs:
           python -c "from mpi4py import MPI; import dolfinx; assert dolfinx.has_adios2; assert dolfinx.has_kahip; assert not dolfinx.has_parmetis; assert dolfinx.has_petsc; assert dolfinx.has_petsc4py; assert dolfinx.has_ptscotch; assert dolfinx.has_slepc; assert dolfinx.has_complex_ufcx_kernels"
 
       - name: Run mypy
-        run: |
+        run: | # numpy-typing-compat needs to be pinned tp latest numba compatible numpy version to avoid auto upgrade
           pip install mypy types-cffi scipy-stubs numpy-typing-compat==20260602.2.4
           mypy --config-file python/pyproject.toml -p dolfinx --exclude superlu_dist.py
           cd python/

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -270,7 +270,7 @@ jobs:
       - name: Run mypy
         run: |
           pip install mypy types-cffi scipy-stubs numpy-typing-compat==20260602.2.4
-          mypy --config-file python/pyproject.toml -p dolfinx --exclude dolfinx/la/superlu_dist.py
+          mypy --config-file python/pyproject.toml -p dolfinx --exclude '(^|/)dolfinx/la/superlu_dist\.py$'
           mypy -p dolfinx
         # cd python/
         # mypy test

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -271,9 +271,9 @@ jobs:
         run: |
           pip install mypy types-cffi scipy-stubs numpy-typing-compat==20260602.2.4
           mypy --config-file python/pyproject.toml -p dolfinx --exclude superlu_dist.py
-        # cd python/
-        # mypy test
-        # mypy demo
+          cd python/
+          mypy test
+          mypy demo
 
       - name: Numpy version
         run: python -c "import numpy; print(numpy.__version__)"

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -148,9 +148,14 @@ jobs:
         run: cmake --build . --target test
 
       - name: Build Python interface
-        run: |
-          pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Developer" 'python/[test,mypy]'
-          python -c "from mpi4py import MPI; import dolfinx; assert not dolfinx.has_petsc; assert not dolfinx.has_petsc4py; assert dolfinx.has_superlu_dist"
+        run: >
+          pip install  'python/[test,mypy]'
+          --check-build-dependencies
+          --no-build-isolation
+          --config-settings=cmake.build-type="Developer"
+
+      - name: Check Python configuration
+        run: python -c "from mpi4py import MPI; import dolfinx; assert not dolfinx.has_petsc; assert not dolfinx.has_petsc4py; assert dolfinx.has_superlu_dist"
 
       - name: Run mypy
         run: |
@@ -340,8 +345,10 @@ jobs:
           cmake --install build
 
       - name: Build Python interface
-        run: |
-          pip install --check-build-dependencies --no-build-isolation 'python/[docs]'
+        run: >
+          pip install 'python/[docs]'
+          --check-build-dependencies
+          --no-build-isolation
 
       - name: Build C++ interface documentation
         run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -267,13 +267,12 @@ jobs:
           pip install --check-build-dependencies --no-build-isolation --config-settings=cmake.build-type="Developer" 'python/[test]'
           python -c "from mpi4py import MPI; import dolfinx; assert dolfinx.has_adios2; assert dolfinx.has_kahip; assert not dolfinx.has_parmetis; assert dolfinx.has_petsc; assert dolfinx.has_petsc4py; assert dolfinx.has_ptscotch; assert dolfinx.has_slepc; assert dolfinx.has_complex_ufcx_kernels"
 
-      - name: Run mypy  # Use a venv to avoid NumPy upgrades that are incompatible with numba
-        working-directory: python
+      - name: Run mypy
         run: |
-          python -m venv mypy-env
-          . ./mypy-env/bin/activate
           pip install mypy types-cffi scipy-stubs
+          mypy --config-file python/pyproject.toml -p dolfinx
           mypy -p dolfinx
+        # cd python/
         # mypy test
         # mypy demo
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -269,7 +269,7 @@ jobs:
 
       - name: Run mypy
         run: |
-          pip install mypy types-cffi scipy-stubs
+          pip install mypy types-cffi scipy-stubs numpy-typing-compat==20260602.2.4
           mypy --config-file python/pyproject.toml -p dolfinx --exclude superlu_dist.py
           mypy -p dolfinx
         # cd python/

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -1538,7 +1538,7 @@ class NewtonSolverNonlinearProblem:
         F: ufl.form.Form,
         u: _Function,
         bcs: Sequence[DirichletBC] | None = None,
-        J: ufl.form.Form = None,
+        J: ufl.form.Form | None = None,
         form_compiler_options: dict | None = None,
         jit_options: dict | None = None,
     ):
@@ -1812,7 +1812,7 @@ class numba_utils:
     try:
         import petsc4py.PETSc as _PETSc
 
-        import llvmlite as _llvmlite
+        import llvmlite as _llvmlite  # type: ignore[import-untyped]
         import numba as _numba
 
         _llvmlite.binding.load_library_permanently(str(get_petsc_lib()))

--- a/python/dolfinx/io/gmsh.py
+++ b/python/dolfinx/io/gmsh.py
@@ -536,7 +536,7 @@ def read_from_msh(
 
     """
     try:
-        import gmsh
+        import gmsh  # type: ignore[import-untyped]
     except ModuleNotFoundError as err:
         # Python 3.11+ adds the add_note method to exceptions
         # e.add_note("Gmsh must be installed to import dolfinx.io.gmsh")


### PR DESCRIPTION
Breaks typing checks (installed libraries not discoverable in venv).

- installation of typing dependencies changed form manual to `[mypy]` optional dependency based (avoids hacks to avoid incompatible `numpy` version installation)
- `superlu_dist` needs to be ignored since (optional) cpp bindings not importable here.
- checks extended to also run over `test/`

Part of https://github.com/FEniCS/dolfinx/issues/4059.