### PR TITLE
Convert `list[int]` to `npt.NDArray[np.uint16]` in nanobind interface for `perm_vtk` and `perm_gmsh`

### DIFF
--- a/python/dolfinx/io/gmsh.py
+++ b/python/dolfinx/io/gmsh.py
@@ -151,7 +151,7 @@ def ufl_mesh(gmsh_cell: int, gdim: int, dtype: npt.DTypeLike) -> ufl.Mesh:
     return ufl.Mesh(element)
 
 
-def cell_perm_array(cell_type: CellType, num_nodes: int) -> list[int]:
+def cell_perm_array(cell_type: CellType, num_nodes: int) -> npt.NDArray[np.uint16]:
     """Array for permuting Gmsh ordering to DOLFINx ordering.
 
     Args:

--- a/python/dolfinx/io/vtkhdf.py
+++ b/python/dolfinx/io/vtkhdf.py
@@ -21,7 +21,7 @@ from dolfinx.cpp.io import (
     write_vtkhdf_data,
     write_vtkhdf_mesh,
 )
-from dolfinx.mesh import Mesh
+from dolfinx.mesh import CellType, Mesh
 
 __all__ = ["read_mesh", "write_cell_data", "write_mesh", "write_point_data"]
 
@@ -107,3 +107,17 @@ def write_cell_data(filename: str | Path, mesh: Mesh, data: npt.NDArray, time: f
         time: Timestamp.
     """
     write_vtkhdf_data("Cell", filename, mesh._cpp_object, data, time)  # type: ignore[call-overload]
+
+
+def cell_perm_array(cell_type: CellType, num_nodes: int) -> npt.NDArray[np.uint16]:
+    """Array for permuting VTK ordering to DOLFINx ordering.
+
+    Args:
+        cell_type: DOLFINx cell type.
+        num_nodes: Number of nodes in the cell.
+
+    Returns:
+        An array ``p`` such that ``a_dolfinx[i] = a_vtk[p[i]]``.
+
+    """
+    return _cpp.io.perm_vtk(cell_type, num_nodes)

--- a/python/dolfinx/io/vtkhdf.py
+++ b/python/dolfinx/io/vtkhdf.py
@@ -23,7 +23,7 @@ from dolfinx.cpp.io import (
 )
 from dolfinx.mesh import CellType, Mesh
 
-__all__ = ["read_mesh", "write_cell_data", "write_mesh", "write_point_data"]
+__all__ = ["cell_perm_array", "read_mesh", "write_cell_data", "write_mesh", "write_point_data"]
 
 
 def read_mesh(

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -91,7 +91,7 @@ void io(nb::module_& m)
       {
         std::vector<std::uint16_t> perm
             = dolfinx::io::cells::perm_vtk(type, num_nodes);
-        return dolfinx_wrappers::as_nbarray(std::move(perm), {perm.size()});
+        return dolfinx_wrappers::as_nbarray(std::move(perm));
       },
       nb::arg("type"), nb::arg("num_nodes"),
       "Permutation array to map from VTK to DOLFINx node ordering");

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -101,7 +101,7 @@ void io(nb::module_& m)
       {
         std::vector<std::uint16_t> perm
             = dolfinx::io::cells::perm_gmsh(type, num_nodes);
-        return dolfinx_wrappers::as_nbarray(std::move(perm), {perm.size()});
+        return dolfinx_wrappers::as_nbarray(std::move(perm));
       },
       nb::arg("type"), nb::arg("num_nodes"),
       "Permutation array to map from Gmsh to DOLFINx node ordering");

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -85,12 +85,26 @@ void io(nb::module_& m)
         });
 
   // dolfinx::io::cell permutation functions
-  m.def("perm_vtk", &dolfinx::io::cells::perm_vtk, nb::arg("type"),
-        nb::arg("num_nodes"),
-        "Permutation array to map from VTK to DOLFINx node ordering");
-  m.def("perm_gmsh", &dolfinx::io::cells::perm_gmsh, nb::arg("type"),
-        nb::arg("num_nodes"),
-        "Permutation array to map from Gmsh to DOLFINx node ordering");
+  m.def(
+      "perm_vtk",
+      [](dolfinx::mesh::CellType type, int num_nodes)
+      {
+        std::vector<std::uint16_t> perm
+            = dolfinx::io::cells::perm_vtk(type, num_nodes);
+        return dolfinx_wrappers::as_nbarray(std::move(perm), {perm.size()});
+      },
+      nb::arg("type"), nb::arg("num_nodes"),
+      "Permutation array to map from VTK to DOLFINx node ordering");
+  m.def(
+      "perm_gmsh",
+      [](dolfinx::mesh::CellType type, int num_nodes)
+      {
+        std::vector<std::uint16_t> perm
+            = dolfinx::io::cells::perm_gmsh(type, num_nodes);
+        return dolfinx_wrappers::as_nbarray(std::move(perm), {perm.size()});
+      },
+      nb::arg("type"), nb::arg("num_nodes"),
+      "Permutation array to map from Gmsh to DOLFINx node ordering");
 
   // dolfinx::io::XDMFFile
   nb::class_<dolfinx::io::XDMFFile> xdmf_file(m, "XDMFFile");


### PR DESCRIPTION
Conserve data-type from C++ and convert perm_vtk/perm_gmsh to numpy array.