### PR TITLE
Fix: NumberOfEntities should be NumberOfCells

### DIFF
--- a/cpp/dolfinx/io/ADIOS2Writers.h
+++ b/cpp/dolfinx/io/ADIOS2Writers.h
@@ -413,7 +413,7 @@ vtx_write_mesh_from_space(adios2::IO& io, adios2::Engine& engine,
   adios2::Variable vertices = impl_adios2::define_variable<std::uint32_t>(
       io, "NumberOfNodes", {adios2::LocalValueDim});
   adios2::Variable elements = impl_adios2::define_variable<std::uint32_t>(
-      io, "NumberOfEntities", {adios2::LocalValueDim});
+      io, "NumberOfCells", {adios2::LocalValueDim});
 
   // Write mesh information to file
   spdlog::debug("vertices={}, elements={}, local_geom={}, local_cells={}",

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -233,7 +233,7 @@ class TestVTX:
         writer.write(2)
         writer.close()
 
-        reuse_variables = ["NumberOfEntities", "NumberOfNodes", "connectivity", "geometry", "types"]
+        reuse_variables = ["NumberOfCells", "NumberOfNodes", "connectivity", "geometry", "types"]
         target_all = 3  # For all other variables the step count is number of writes
         target_mesh = 1 if reuse else 3
         # For mesh variables the step count is 1 if reuse else number of writes


### PR DESCRIPTION
Vtk schema in `VTXWriter` is populated with `NumberOfCells` - however the `vtx_write_mesh_from_space` output instead wrote `NumberOfEntities` variable.

`vtx_write_mesh` correctly uses `NumberOfCells`, see https://github.com/FEniCS/dolfinx/blob/3309557c73827321db9d8c956f71156ba85611d2/cpp/dolfinx/io/ADIOS2Writers.h#L321-L323.

Not detected because never read back; triggered by pending tests of https://github.com/FEniCS/dolfinx/pull/4177. 