### PR TITLE
Change args of `create_topology` to NDArray and introduce `dolfinx_wrappers::vec_of_spans`

### DIFF
--- a/python/dolfinx/wrappers/dolfinx_wrappers/array.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/array.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2025 Garth N. Wells
+// Copyright (C) 2021-2026 Garth N. Wells and Paul T. Kühner
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -13,6 +13,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <numeric>
+#include <span>
 #include <utility>
 
 namespace nb = nanobind;
@@ -93,6 +94,23 @@ template <typename V>
 auto as_nbarray(V&& x)
 {
   return as_nbarray(std::forward<V>(x), {x.size()});
+}
+
+/// @brief Convert a `std::vector<nb::ndarray>` to `std::vector<std::span>`.
+///
+/// This is used in the wrapper layer to convert lists of numpy arrays to the
+/// vector of spans used in the C++ interfaces.
+///
+/// @param[in] vec `std::vector` of `nd::array` to access as spans.
+/// @return Vector of spans to the underlying data.
+auto vec_of_spans(const auto& vec)
+{
+  using scalar_t = std::remove_cvref_t<decltype(vec)>::value_type::Scalar;
+  std::vector<std::span<scalar_t>> vec_span;
+  vec_span.reserve(vec.size());
+  for (auto& x : vec)
+    vec_span.emplace_back(x.data(), x.size());
+  return vec_span;
 }
 
 } // namespace dolfinx_wrappers

--- a/python/dolfinx/wrappers/dolfinx_wrappers/assemble.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/assemble.h
@@ -217,8 +217,7 @@ void declare_assembly_functions(nanobind::module_& m)
       {
         std::vector<int> coffsets = e.coefficient_offsets();
         const std::vector<std::shared_ptr<const dolfinx::fem::Function<T, U>>>&
-            coefficients
-            = e.coefficients();
+            coefficients = e.coefficients();
         std::vector<T> coeffs(entities.shape(0) * coffsets.back());
         std::size_t cstride = coffsets.back();
         std::vector<std::reference_wrapper<const dolfinx::fem::Function<T, U>>>

--- a/python/dolfinx/wrappers/dolfinx_wrappers/assemble.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/assemble.h
@@ -217,7 +217,8 @@ void declare_assembly_functions(nanobind::module_& m)
       {
         std::vector<int> coffsets = e.coefficient_offsets();
         const std::vector<std::shared_ptr<const dolfinx::fem::Function<T, U>>>&
-            coefficients = e.coefficients();
+            coefficients
+            = e.coefficients();
         std::vector<T> coeffs(entities.shape(0) * coffsets.back());
         std::size_t cstride = coffsets.back();
         std::vector<std::reference_wrapper<const dolfinx::fem::Function<T, U>>>
@@ -549,15 +550,8 @@ void declare_assembly_functions(nanobind::module_& m)
             _a.push_back(std::nullopt);
         }
 
-        std::vector<std::span<const T>> _x0;
-        _x0.reserve(x0.size());
-        for (auto& x : x0)
-          _x0.emplace_back(x.data(), x.size());
-
-        std::vector<std::span<const T>> _constants;
-        std::ranges::transform(
-            constants, std::back_inserter(_constants),
-            [](auto& c) { return std::span<const T>(c.data(), c.size()); });
+        std::vector<std::span<const T>> _x0 = vec_of_spans(x0);
+        std::vector<std::span<const T>> _constants = vec_of_spans(constants);
 
         std::vector<std::map<std::pair<dolfinx::fem::IntegralType, int>,
                              std::pair<std::span<const T>, int>>>

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -51,10 +51,7 @@ auto create_cell_partitioner_py(Functor&& p)
              const std::vector<dolfinx::mesh::CellType>& cell_types,
              std::vector<nb::ndarray<const std::int64_t, nb::numpy>> cells_nb)
   {
-    std::vector<std::span<const std::int64_t>> cells;
-    std::ranges::transform(
-        cells_nb, std::back_inserter(cells), [](auto& c)
-        { return std::span<const std::int64_t>(c.data(), c.size()); });
+    std::vector<std::span<const std::int64_t>> cells = vec_of_spans(cells_nb);
     return p(comm.get(), n, cell_types, cells);
   };
 }

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2025 Chris N. Richardson, Garth N. Wells, Jørgen S. Dokken
+// Copyright (C) 2017-2026 Chris N. Richardson, Garth N. Wells, Jørgen S. Dokken
 // and Paul T. Kühner
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -333,7 +333,6 @@ void mesh(nb::module_& m)
              ghost_owners,
          nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>
              boundary_vertices,
-
          int num_threads)
       {
         std::vector<std::span<const std::int64_t>> cells_span

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -340,25 +340,12 @@ void mesh(nb::module_& m)
 
          int num_threads)
       {
-        auto to_vec_of_spans
-            = []<typename T>(
-                  const std::vector<nb::ndarray<T, nb::ndim<1>, nb::c_contig>>&
-                      vec)
-        {
-          std::vector<std::span<T>> vec_span;
-          vec_span.reserve(vec.size());
-          std::ranges::transform(
-              vec, std::back_inserter(vec_span),
-              [](auto& nd) { return std::span<T>(nd.data(), nd.size()); });
-          return vec_span;
-        };
-
         std::vector<std::span<const std::int64_t>> cells_span
-            = to_vec_of_spans(cells);
+            = vec_of_spans(cells);
         std::vector<std::span<const std::int64_t>> original_cell_index_span
-            = to_vec_of_spans(original_cell_index);
+            = vec_of_spans(original_cell_index);
         std::vector<std::span<const int>> ghost_owners_span
-            = to_vec_of_spans(ghost_owners);
+            = vec_of_spans(ghost_owners);
 
         std::span<const std::int64_t> boundary_vertices_span(
             boundary_vertices.data(), boundary_vertices.size());

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -128,12 +128,8 @@ void mesh(nb::module_& m)
              nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>>& cells,
          std::optional<std::int32_t> max_facet_to_cell_links, int num_threads)
       {
-        std::vector<std::span<const std::int64_t>> cell_span(cells.size());
-        for (std::size_t i = 0; i < cells.size(); ++i)
-        {
-          cell_span[i]
-              = std::span<const std::int64_t>(cells[i].data(), cells[i].size());
-        }
+        std::vector<std::span<const std::int64_t>> cell_span
+            = vec_of_spans(cells);
         return dolfinx::mesh::build_dual_graph(
             comm.get(), cell_types, cell_span, max_facet_to_cell_links,
             num_threads);

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -366,6 +366,10 @@ void mesh(nb::module_& m)
             comm.get(), cell_type, cells_span, original_cell_index_span,
             ghost_owners_span, boundary_vertices_span, num_threads);
       },
+      nb::arg("comm"), nb::arg("cell_type"), nb::arg("cells").noconvert(),
+      nb::arg("original_cell_index").noconvert(),
+      nb::arg("ghost_owners").noconvert(),
+      nb::arg("boundary_vertices").noconvert(), nb::arg("num_threads"),
       "Create a Topology object.");
 
   m.def("compute_mixed_cell_pairs", &dolfinx::mesh::compute_mixed_cell_pairs);

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2017-2025 Chris N. Richardson, Garth N. Wells and Jørgen S.
-// Dokken
+// Copyright (C) 2017-2025 Chris N. Richardson, Garth N. Wells, Jørgen S. Dokken
+// and Paul T. Kühner
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -9,6 +9,7 @@
 #include "dolfinx_wrappers/MPICommWrapper.h"
 #include "dolfinx_wrappers/array.h"
 #include "dolfinx_wrappers/caster_mpi.h"
+#include <algorithm>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/fem/ElementDofLayout.h>
 #include <dolfinx/mesh/EntityMap.h>
@@ -328,19 +329,39 @@ void mesh(nb::module_& m)
       "create_topology",
       [](MPICommWrapper comm,
          const std::vector<dolfinx::mesh::CellType>& cell_type,
-         const std::vector<std::vector<std::int64_t>>& cells,
-         const std::vector<std::vector<std::int64_t>>& original_cell_index,
-         const std::vector<std::vector<int>>& ghost_owners,
-         const std::vector<std::int64_t>& boundary_vertices, int num_threads)
+         std::vector<nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>>
+             cells,
+         std::vector<nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>>
+             original_cell_index,
+         std::vector<nb::ndarray<const int, nb::ndim<1>, nb::c_contig>>
+             ghost_owners,
+         nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig>
+             boundary_vertices,
+
+         int num_threads)
       {
-        std::vector<std::span<const std::int64_t>> cells_span(cells.begin(),
-                                                              cells.end());
-        std::vector<std::span<const std::int64_t>> original_cell_index_span(
-            original_cell_index.begin(), original_cell_index.end());
-        std::vector<std::span<const int>> ghost_owners_span(
-            ghost_owners.begin(), ghost_owners.end());
+        auto to_vec_of_spans
+            = []<typename T>(
+                  const std::vector<nb::ndarray<T, nb::ndim<1>, nb::c_contig>>&
+                      vec)
+        {
+          std::vector<std::span<T>> vec_span;
+          vec_span.reserve(vec.size());
+          std::ranges::transform(
+              vec, std::back_inserter(vec_span),
+              [](auto& nd) { return std::span<T>(nd.data(), nd.size()); });
+          return vec_span;
+        };
+
+        std::vector<std::span<const std::int64_t>> cells_span
+            = to_vec_of_spans(cells);
+        std::vector<std::span<const std::int64_t>> original_cell_index_span
+            = to_vec_of_spans(original_cell_index);
+        std::vector<std::span<const int>> ghost_owners_span
+            = to_vec_of_spans(ghost_owners);
+
         std::span<const std::int64_t> boundary_vertices_span(
-            boundary_vertices.begin(), boundary_vertices.end());
+            boundary_vertices.data(), boundary_vertices.size());
         return dolfinx::mesh::create_topology(
             comm.get(), cell_type, cells_span, original_cell_index_span,
             ghost_owners_span, boundary_vertices_span, num_threads);

--- a/python/dolfinx/wrappers/petsc.cpp
+++ b/python/dolfinx/wrappers/petsc.cpp
@@ -87,10 +87,8 @@ void petsc_la_module(nb::module_& m)
          const std::vector<std::pair<
              std::shared_ptr<const dolfinx::common::IndexMap>, int>>& maps)
       {
-        std::vector<std::span<const PetscScalar>> _x_b;
-        std::ranges::transform(x_b, std::back_inserter(_x_b), [](auto& x)
-                               { return std::span(x.data(), x.size()); });
-
+        std::vector<std::span<const PetscScalar>> _x_b
+            = dolfinx_wrappers::vec_of_spans(x_b);
         auto _maps = to_index_map_refs(maps);
         dolfinx::la::petsc::scatter_local_vectors(x, _x_b, _maps);
       },

--- a/python/test/unit/fem/test_mixed_mesh_dofmap.py
+++ b/python/test/unit/fem/test_mixed_mesh_dofmap.py
@@ -25,12 +25,18 @@ def test_dofmap_mixed_topology():
     tri = [0, 1, 4, 0, 3, 4]
     quad = [1, 4, 2, 5]
     # cells with global indexing
-    cells = [np.array([t + 3 * rank for t in tri]), np.array([q + 3 * rank for q in quad])]
-    orig_index = [np.array([3 * rank, 1 + 3 * rank]), np.array([2 + 3 * rank])]
+    cells = [
+        np.array([t + 3 * rank for t in tri], dtype=np.int64),
+        np.array([q + 3 * rank for q in quad], dtype=np.int64),
+    ]
+    orig_index = [
+        np.array([3 * rank, 1 + 3 * rank], dtype=np.int64),
+        np.array([2 + 3 * rank], dtype=np.int64),
+    ]
     # No ghosting
-    ghost_owners = [np.array([]), np.array([])]
+    ghost_owners = [np.array([], dtype=np.int32), np.array([], dtype=np.int32)]
     # All vertices are on boundary
-    boundary_vertices = np.array([3 * rank + i for i in range(6)])
+    boundary_vertices = np.array([3 * rank + i for i in range(6)], dtype=np.int64)
 
     topology = create_topology(
         MPI.COMM_WORLD,
@@ -83,13 +89,13 @@ def test_dofmap_mixed_topology():
 
 def test_dofmap_prism_mesh():
     # Prism mesh
-    cells = [np.array([0, 1, 2, 3, 4, 5])]
+    cells = [np.array([0, 1, 2, 3, 4, 5], dtype=np.int64)]
     # cells with global indexing
-    orig_index = [np.array([0, 1, 2, 3, 4, 5])]
+    orig_index = [np.array([0, 1, 2, 3, 4, 5], dtype=np.int64)]
     # No ghosting
-    ghost_owners = [np.array([])]
+    ghost_owners = [np.array([], dtype=np.int32)]
     # All vertices are on boundary
-    boundary_vertices = np.array([0, 1, 2, 3, 4, 5])
+    boundary_vertices = np.array([0, 1, 2, 3, 4, 5], dtype=np.int64)
 
     topology = Topology(
         create_topology(

--- a/python/test/unit/fem/test_mixed_mesh_dofmap.py
+++ b/python/test/unit/fem/test_mixed_mesh_dofmap.py
@@ -25,12 +25,12 @@ def test_dofmap_mixed_topology():
     tri = [0, 1, 4, 0, 3, 4]
     quad = [1, 4, 2, 5]
     # cells with global indexing
-    cells = [[t + 3 * rank for t in tri], [q + 3 * rank for q in quad]]
-    orig_index = [[3 * rank, 1 + 3 * rank], [2 + 3 * rank]]
+    cells = [np.array([t + 3 * rank for t in tri]), np.array([q + 3 * rank for q in quad])]
+    orig_index = [np.array([3 * rank, 1 + 3 * rank]), np.array([2 + 3 * rank])]
     # No ghosting
-    ghost_owners = [[], []]
+    ghost_owners = [np.array([]), np.array([])]
     # All vertices are on boundary
-    boundary_vertices = [3 * rank + i for i in range(6)]
+    boundary_vertices = np.array([3 * rank + i for i in range(6)])
 
     topology = create_topology(
         MPI.COMM_WORLD,
@@ -83,13 +83,13 @@ def test_dofmap_mixed_topology():
 
 def test_dofmap_prism_mesh():
     # Prism mesh
-    cells = [[0, 1, 2, 3, 4, 5]]
+    cells = [np.array([0, 1, 2, 3, 4, 5])]
     # cells with global indexing
-    orig_index = [[0, 1, 2, 3, 4, 5]]
+    orig_index = [np.array([0, 1, 2, 3, 4, 5])]
     # No ghosting
-    ghost_owners = [[]]
+    ghost_owners = [np.array([])]
     # All vertices are on boundary
-    boundary_vertices = [0, 1, 2, 3, 4, 5]
+    boundary_vertices = np.array([0, 1, 2, 3, 4, 5])
 
     topology = Topology(
         create_topology(

--- a/python/test/unit/mesh/test_mixed_topology.py
+++ b/python/test/unit/mesh/test_mixed_topology.py
@@ -32,10 +32,10 @@ from dolfinx.mesh import CellType, GhostMode, Mesh, Topology, create_unit_cube
 def test_mixed_topology_mesh(dtype):
     set_log_level(LogLevel.INFO)
 
-    cells = [[0, 1, 2, 1, 2, 3], [2, 3, 4, 5]]
-    orig_index = [[0, 1], [2]]
-    ghost_owners = [[], []]
-    boundary_vertices = []
+    cells = [np.array([0, 1, 2, 1, 2, 3]), np.array([2, 3, 4, 5])]
+    orig_index = [np.array([0, 1]), np.array([2])]
+    ghost_owners = [np.array([]), np.array([])]
+    boundary_vertices = np.array([])
 
     topology = Topology(
         create_topology(
@@ -98,10 +98,14 @@ def test_mixed_topology_mesh(dtype):
 
 def test_mixed_topology_mesh_3d():
     # Mesh = 2 tets, 1 prism, 1 hex, joined.
-    cells = [[0, 1, 2, 3, 1, 2, 3, 4], [2, 3, 4, 5, 6, 7], [3, 4, 6, 7, 8, 9, 10, 11]]
-    orig_index = [[0, 1], [2], [3]]
-    ghost_owners = [[], [], []]
-    boundary_vertices = []
+    cells = [
+        np.array([0, 1, 2, 3, 1, 2, 3, 4]),
+        np.array([2, 3, 4, 5, 6, 7]),
+        np.array([3, 4, 6, 7, 8, 9, 10, 11]),
+    ]
+    orig_index = [np.array([0, 1]), np.array([2]), np.array([3])]
+    ghost_owners = [np.array([]), np.array([]), np.array([])]
+    boundary_vertices = np.array([])
 
     topology = Topology(
         create_topology(
@@ -211,12 +215,12 @@ def test_parallel_mixed_mesh(dtype):
     tri = np.array([0, 1, 4, 0, 3, 4], dtype=np.int64)
     quad = np.array([1, 4, 2, 5], dtype=np.int64)
     # cells with global indexing
-    cells = [[t + 3 * rank for t in tri], [q + 3 * rank for q in quad]]
-    orig_index = [[3 * rank, 1 + 3 * rank], [2 + 3 * rank]]
+    cells = [np.array([t + 3 * rank for t in tri]), np.array([q + 3 * rank for q in quad])]
+    orig_index = [np.array([3 * rank, 1 + 3 * rank]), np.array([2 + 3 * rank])]
     # No ghosting
-    ghost_owners = [[], []]
+    ghost_owners = [np.array([]), np.array([])]
     # All vertices are on boundary
-    boundary_vertices = [3 * rank + i for i in range(6)]
+    boundary_vertices = np.array([3 * rank + i for i in range(6)])
 
     topology = create_topology(
         MPI.COMM_WORLD,

--- a/python/test/unit/mesh/test_mixed_topology.py
+++ b/python/test/unit/mesh/test_mixed_topology.py
@@ -32,10 +32,10 @@ from dolfinx.mesh import CellType, GhostMode, Mesh, Topology, create_unit_cube
 def test_mixed_topology_mesh(dtype):
     set_log_level(LogLevel.INFO)
 
-    cells = [np.array([0, 1, 2, 1, 2, 3]), np.array([2, 3, 4, 5])]
-    orig_index = [np.array([0, 1]), np.array([2])]
-    ghost_owners = [np.array([]), np.array([])]
-    boundary_vertices = np.array([])
+    cells = [np.array([0, 1, 2, 1, 2, 3], dtype=np.int64), np.array([2, 3, 4, 5], dtype=np.int64)]
+    orig_index = [np.array([0, 1], dtype=np.int64), np.array([2], dtype=np.int64)]
+    ghost_owners = [np.array([], dtype=np.int32), np.array([], dtype=np.int32)]
+    boundary_vertices = np.array([], dtype=np.int64)
 
     topology = Topology(
         create_topology(
@@ -99,13 +99,21 @@ def test_mixed_topology_mesh(dtype):
 def test_mixed_topology_mesh_3d():
     # Mesh = 2 tets, 1 prism, 1 hex, joined.
     cells = [
-        np.array([0, 1, 2, 3, 1, 2, 3, 4]),
-        np.array([2, 3, 4, 5, 6, 7]),
-        np.array([3, 4, 6, 7, 8, 9, 10, 11]),
+        np.array([0, 1, 2, 3, 1, 2, 3, 4], dtype=np.int64),
+        np.array([2, 3, 4, 5, 6, 7], dtype=np.int64),
+        np.array([3, 4, 6, 7, 8, 9, 10, 11], dtype=np.int64),
     ]
-    orig_index = [np.array([0, 1]), np.array([2]), np.array([3])]
-    ghost_owners = [np.array([]), np.array([]), np.array([])]
-    boundary_vertices = np.array([])
+    orig_index = [
+        np.array([0, 1], dtype=np.int64),
+        np.array([2], dtype=np.int64),
+        np.array([3], dtype=np.int64),
+    ]
+    ghost_owners = [
+        np.array([], dtype=np.int32),
+        np.array([], dtype=np.int32),
+        np.array([], dtype=np.int32),
+    ]
+    boundary_vertices = np.array([], dtype=np.int64)
 
     topology = Topology(
         create_topology(
@@ -215,12 +223,18 @@ def test_parallel_mixed_mesh(dtype):
     tri = np.array([0, 1, 4, 0, 3, 4], dtype=np.int64)
     quad = np.array([1, 4, 2, 5], dtype=np.int64)
     # cells with global indexing
-    cells = [np.array([t + 3 * rank for t in tri]), np.array([q + 3 * rank for q in quad])]
-    orig_index = [np.array([3 * rank, 1 + 3 * rank]), np.array([2 + 3 * rank])]
+    cells = [
+        np.array([t + 3 * rank for t in tri], dtype=np.int64),
+        np.array([q + 3 * rank for q in quad], dtype=np.int64),
+    ]
+    orig_index = [
+        np.array([3 * rank, 1 + 3 * rank], dtype=np.int64),
+        np.array([2 + 3 * rank], dtype=np.int64),
+    ]
     # No ghosting
-    ghost_owners = [np.array([]), np.array([])]
+    ghost_owners = [np.array([], dtype=np.int32), np.array([], dtype=np.int32)]
     # All vertices are on boundary
-    boundary_vertices = np.array([3 * rank + i for i in range(6)])
+    boundary_vertices = np.array([3 * rank + i for i in range(6)], dtype=np.int64)
 
     topology = create_topology(
         MPI.COMM_WORLD,


### PR DESCRIPTION
Caught by `mypy` check on downstream usage of `create_topology`, while possible due to implicit conversions, we should stick to the `NDArray` in the interface.

Previously this implied the (non numpy compatible signature):
```python
def create_topology(arg0: mpi4py.MPI.Comm, arg1: Sequence[CellType], arg2: Sequence[Sequence[int]], arg3: Sequence[Sequence[int]], arg4: Sequence[Sequence[int]], arg5: Sequence[int], arg6: int, /) -> Topology:
    """Create a Topology object."""
```
now
```python
def create_topology(arg0: mpi4py.MPI.Comm, arg1: Sequence[CellType], arg2: Sequence[Annotated[NDArray[numpy.int64], dict(shape=(None,), order='C', writable=False)]], arg3: Sequence[Annotated[NDArray[numpy.int64], dict(shape=(None,), order='C', writable=False)]], arg4: Sequence[Annotated[NDArray[numpy.int32], dict(shape=(None,), order='C', writable=False)]], arg5: Annotated[NDArray[numpy.int64], dict(shape=(None,), order='C', writable=False)], arg6: int, /) -> Topology:
    """Create a Topology object."""
```

- Introduced common wrapper functionality `dolfinx_wrappers::vec_of_spans` to facilitate `std::vector<nb::ndarray>` to `std::vector<std::span>` conversions.