### PR TITLE
Set pressure PC in Taylor-Hood assembly test

### DIFF
--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -856,6 +856,7 @@ class TestPETScAssemblers:
             ksp_u.setType("preonly")
             ksp_u.getPC().setType("lu")
             ksp_p.setType("preonly")
+            ksp_p.getPC().setType("lu")
 
             def monitor(ksp, its, rnorm):
                 pass


### PR DESCRIPTION
The Taylor-Hood nested assembly test explicitly selects LU for the velocity sub-KSP but leaves the pressure preconditioner at PETSc's default. This change also selects `lu` for the pressure sub-KSP, making both sub-solves explicit.

Related to #4359. The reported macOS hang was resolved with PETSc's `--download-mumps-avoid-mpi-in-place` build option, as confirmed in that issue. This PR is a test-configuration proposal; it does not establish an ILU defect or claim to fix the macOS build issue.

Validation:

- The previously reported Linux-container run at `974f756` passed all four Taylor-Hood cases with three MPI ranks, `PETSC_ARCH=linux-gnu-real32-32`, and `nanobind==2.13.0`.
- After rebasing to `717a15f` following #4371, all executed CI checks passed, including real32/OpenMPI and macOS. SonarCloud was skipped.

AI assistance: OpenAI Codex assisted with the code change, testing, and PR text.
