### PR TITLE
Adapt to `nanobind@2.14.0`

### DIFF
--- a/python/dolfinx/fem/forms.py
+++ b/python/dolfinx/fem/forms.py
@@ -319,7 +319,10 @@ def mixed_topology_form(
 
     # TODO coeffs, constants, subdomains, entity_maps
     f = ftype(
-        [module.ffi.cast("uintptr_t", module.ffi.addressof(ufcx_form)) for ufcx_form in ufcx_forms],
+        [
+            int(module.ffi.cast("uintptr_t", module.ffi.addressof(ufcx_form)))
+            for ufcx_form in ufcx_forms
+        ],
         V,
         [],
         [],
@@ -471,7 +474,7 @@ def form(
             _entity_maps = [entity_map._cpp_object for entity_map in entity_maps]
 
         f = ftype(
-            [module.ffi.cast("uintptr_t", module.ffi.addressof(ufcx_form))],
+            [int(module.ffi.cast("uintptr_t", module.ffi.addressof(ufcx_form)))],
             V,
             coeffs,
             constants,
@@ -742,7 +745,7 @@ def create_form(
 
     ftype = form_cpp_creator(form.dtype)
     f = ftype(
-        form.module.ffi.cast("uintptr_t", form.module.ffi.addressof(form.ufcx_form)),
+        int(form.module.ffi.cast("uintptr_t", form.module.ffi.addressof(form.ufcx_form))),
         [fs._cpp_object for fs in V],
         coefficients,
         constants,

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -232,7 +232,7 @@ class Expression(Generic[Scalar]):
         )
         ffi = module.ffi
         self._cpp_object = create_expression(
-            ffi.cast("uintptr_t", ffi.addressof(self._ufcx_expression)),
+            int(ffi.cast("uintptr_t", ffi.addressof(self._ufcx_expression))),
             coeffs,
             constants,
             _entity_maps,

--- a/python/test/unit/fem/test_custom_jit_kernels.py
+++ b/python/test/unit/fem/test_custom_jit_kernels.py
@@ -272,7 +272,7 @@ def test_cffi_assembly():
 
     cells = np.arange(mesh.topology.index_map(mesh.topology.dim).size_local, dtype=np.int32)
 
-    ptrA = ffi.cast("intptr_t", ffi.addressof(lib, "tabulate_tensor_poissonA"))
+    ptrA = int(ffi.cast("intptr_t", ffi.addressof(lib, "tabulate_tensor_poissonA")))
     active_coeffs = np.array([], dtype=np.int8)
     integrals = {IntegralType.cell: [(0, ptrA, cells, active_coeffs)]}
     a = Form(
@@ -281,7 +281,7 @@ def test_cffi_assembly():
         )
     )
 
-    ptrL = ffi.cast("intptr_t", ffi.addressof(lib, "tabulate_tensor_poissonL"))
+    ptrL = int(ffi.cast("intptr_t", ffi.addressof(lib, "tabulate_tensor_poissonL")))
     integrals = {IntegralType.cell: [(0, ptrL, cells, active_coeffs)]}
     L = Form(
         _cpp.fem.Form_float64([V._cpp_object], integrals, [], [], False, [], mesh=mesh._cpp_object)

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -101,7 +101,7 @@ def test_incorrect_element():
     )
 
     f = ftype(
-        [module.ffi.cast("uintptr_t", module.ffi.addressof(ufcx_form))],
+        [int(module.ffi.cast("uintptr_t", module.ffi.addressof(ufcx_form)))],
         [space._cpp_object, space._cpp_object],
         [],
         [],
@@ -113,7 +113,7 @@ def test_incorrect_element():
 
     with pytest.raises(RuntimeError):
         f = ftype(
-            [module.ffi.cast("uintptr_t", module.ffi.addressof(ufcx_form))],
+            [int(module.ffi.cast("uintptr_t", module.ffi.addressof(ufcx_form)))],
             [incorrect_space._cpp_object, incorrect_space._cpp_object],
             [],
             [],


### PR DESCRIPTION
Nanobind version 2.14.0 no longer auto converts integers https://nanobind.readthedocs.io/en/latest/changelog.html#version-2-14-0-aug-7-2026 (bugfix upstream). 

Currently breaking all CI's.

Fixes #4373.