### PR TITLE
Scale pull_back Newton tolerance with dtype precision

### DIFF
--- a/python/dolfinx/fem/element.py
+++ b/python/dolfinx/fem/element.py
@@ -91,7 +91,7 @@ class CoordinateElement(Generic[Real]):
         x: npt.NDArray[Real],
         cell_geometry: npt.NDArray[Real],
         *,
-        tol: float = 1.0e-6,
+        tol: float | None = None,
         maxit: int = 15,
         working_array: npt.NDArray[Real] | None = None,
     ) -> npt.NDArray[Real]:
@@ -107,7 +107,10 @@ class CoordinateElement(Generic[Real]):
                 geometrical_dimension)``. They can be created by accessing
                 ``geometry.x[geometry.dofmaps[0].cell_dofs(i)]``,
             tol: Tolerance for convergence in Newton method for
-                nonaffine pullbacks.
+                nonaffine pullbacks. If not provided, it is set from
+                the square root of the machine epsilon of ``x``'s
+                dtype, since a fixed value tuned for ``float64`` is
+                often unreachable in ``float32`` arithmetic.
             maxit: Maximum number of Newton iterations for
                 nonaffine pullbacks.
             working_array: Working memory for the pull-back operation.
@@ -118,6 +121,8 @@ class CoordinateElement(Generic[Real]):
         Returns:
             Reference coordinates of the physical points ``x``.
         """
+        if tol is None:
+            tol = float(np.sqrt(np.finfo(x.dtype).eps))
         if working_array is None:
             working_array = np.zeros(self.pull_back_working_size(x.shape[1]), dtype=x.dtype)
         return self._cpp_object.pull_back(x, cell_geometry, tol, maxit, working_array)  # type: ignore[arg-type,return-value]

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -484,7 +484,8 @@ def test_push_forward_pull_back(gdim: int, is_affine: bool):
         )
         # Pull back
         x_pullback = mesh.geometry.cmaps[0].pull_back(x, cell_geometry, working_array=working_array)
-        assert np.allclose(x_pullback, ref_point, rtol=np.sqrt(np.finfo(dtype).eps))
+        tol = np.sqrt(np.finfo(dtype).eps)
+        assert np.allclose(x_pullback, ref_point, rtol=tol, atol=tol)
 
 
 @pytest.mark.parametrize("gdim", [2, 3])


### PR DESCRIPTION
## Summary
- `CoordinateElement.pull_back`'s default `tol=1.0e-6` is tuned for `float64` and is often unreachable in `float32` arithmetic, causing the Newton iteration used for non-affine geometry pull-back to spuriously raise `RuntimeError: Newton method failed to converge for non-affine geometry`.
- `test_push_forward_pull_back` (added in #4126) additionally only scaled `rtol` by dtype precision in its `np.allclose` check, leaving `atol` at numpy's `float64` default of `1e-8` — too tight for `float32` residuals of a few epsilons at reference points that are exactly 0 or 1.
- Surfaced by basix's cross-repo "Run DOLFINx tests" CI job, which builds DOLFINx with `PETSC_ARCH=linux-gnu-complex64-32` (single precision); reproduced locally by explicitly constructing `float32` meshes.

Fix: `pull_back`'s `tol` now defaults to `sqrt(finfo(x.dtype).eps)` when not given explicitly, and the test's `atol` is scaled the same way as `rtol`.

## Test plan
- [x] Reproduced the failure locally with `float32` meshes for `gdim in (2, 3)` and both affine/non-affine cell types; confirmed all cases pass after the fix.
- [x] `pytest python/test/unit/fem/test_dofmap.py` passes (27 tests, incl. `test_push_forward_pull_back` and `test_undersized_working_array`).
- [x] `ruff check` / `ruff format --check` pass on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)