### PR TITLE
Defer message formatting in TimeLogger::register_timing

### DIFF
--- a/cpp/dolfinx/common/TimeLogger.cpp
+++ b/cpp/dolfinx/common/TimeLogger.cpp
@@ -25,8 +25,7 @@ void TimeLogger::register_timing(
     std::string_view task, std::chrono::duration<double, std::ratio<1>> time)
 {
   // Print a message
-  std::string line = std::format("Elapsed time: {} ({})", time.count(), task);
-  spdlog::debug(line.c_str());
+  spdlog::debug("Elapsed time: {} ({})", time.count(), task);
 
   // Store values for summary
   if (auto it = _timings.find(task); it != _timings.end())


### PR DESCRIPTION
## Summary
- `TimeLogger::register_timing` built its debug message with `std::format` before handing it to `spdlog::debug`, so the formatting cost was paid on every `common::Timer` destruction/`stop()` regardless of whether debug-level logging is enabled (the default level is `warn`).
- Passes the format string and arguments directly to `spdlog::debug` so spdlog only formats when the debug sink is active.

## Test plan
- [x] `clang-format --dry-run --Werror` passes on the changed file
- [x] Syntax-checked with the project's include paths (mpicxx + basix/spdlog headers); compiles cleanly aside from a pre-existing fmt/spdlog deprecation warning unrelated to this change