### PR TITLE
Fix exit()/quit() usage, dead-store reassignments, mixed returns, and a shadowed loop variable

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -336,7 +336,7 @@ jobs:
 
       - name: Update FEniCS Project simple503 repository
         run: |
-          python -m simple503 --base-url https://packages.fenicsproject.org/simple simple
+          python -m simple503 --base-url http://packages.fenicsproject.org/simple simple
 
       - name: Upload simple503 artifact
         uses: actions/upload-artifact@v7
@@ -367,7 +367,7 @@ jobs:
         run: find wheelhouse-artifacts/ -name "*.whl" -exec cp {} shared/ \;
 
       - name: Build simple503 repository
-        run: python -m simple503 --base-url https://packages.fenicsproject.org/simple-beta shared/
+        run: python -m simple503 --base-url http://packages.fenicsproject.org/simple-beta shared/
 
       - name: Upload combined repository artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -336,7 +336,7 @@ jobs:
 
       - name: Update FEniCS Project simple503 repository
         run: |
-          python -m simple503 --base-url http://packages.fenicsproject.org/simple simple
+          python -m simple503 --base-url https://packages.fenicsproject.org/simple simple
 
       - name: Upload simple503 artifact
         uses: actions/upload-artifact@v7
@@ -367,7 +367,7 @@ jobs:
         run: find wheelhouse-artifacts/ -name "*.whl" -exec cp {} shared/ \;
 
       - name: Build simple503 repository
-        run: python -m simple503 --base-url http://packages.fenicsproject.org/simple-beta shared/
+        run: python -m simple503 --base-url https://packages.fenicsproject.org/simple-beta shared/
 
       - name: Upload combined repository artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/docker-update-stable.yml
+++ b/.github/workflows/docker-update-stable.yml
@@ -48,20 +48,16 @@ jobs:
           chmod +x ./regctl
 
       - name: "Link :end-user-tag to :stable"
-        env:
-          END_USER_TAG: ${{ inputs.end-user-tag }}
         run: |
-           ./regctl image copy dolfinx/dolfinx:"$END_USER_TAG" dolfinx/dolfinx:stable
-           ./regctl image copy dolfinx/lab:"$END_USER_TAG" dolfinx/lab:stable
-           ./regctl image copy dolfinx/dolfinx-onbuild:"$END_USER_TAG" dolfinx/dolfinx-onbuild:stable
+           ./regctl image copy dolfinx/dolfinx:${{ inputs.end-user-tag }} dolfinx/dolfinx:stable
+           ./regctl image copy dolfinx/lab:${{ inputs.end-user-tag }} dolfinx/lab:stable
+           ./regctl image copy dolfinx/dolfinx-onbuild:${{ inputs.end-user-tag }} dolfinx/dolfinx-onbuild:stable
            # ghcr.io
-           ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx:"$END_USER_TAG" ghcr.io/fenics/dolfinx/dolfinx:stable
-           ./regctl image copy ghcr.io/fenics/dolfinx/lab:"$END_USER_TAG" ghcr.io/fenics/dolfinx/lab:stable
-           ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx-onbuild:"$END_USER_TAG" ghcr.io/fenics/dolfinx/dolfinx-onbuild:stable
+           ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx:${{ inputs.end-user-tag }} ghcr.io/fenics/dolfinx/dolfinx:stable
+           ./regctl image copy ghcr.io/fenics/dolfinx/lab:${{ inputs.end-user-tag }} ghcr.io/fenics/dolfinx/lab:stable
+           ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx-onbuild:${{ inputs.end-user-tag }} ghcr.io/fenics/dolfinx/dolfinx-onbuild:stable
 
       - name: "Link :dev-env-tag to :stable"
-        env:
-          DEV_ENV_TAG: ${{ inputs.dev-env-tag }}
         run: |
-           ./regctl image copy dolfinx/dev-env:"$DEV_ENV_TAG" dolfinx/dev-env:stable
-           ./regctl image copy ghcr.io/fenics/dolfinx/dev-env:"$DEV_ENV_TAG" ghcr.io/fenics/dolfinx/dev-env:stable
+           ./regctl image copy dolfinx/dev-env:${{ inputs.dev-env-tag }} dolfinx/dev-env:stable
+           ./regctl image copy ghcr.io/fenics/dolfinx/dev-env:${{ inputs.dev-env-tag }} ghcr.io/fenics/dolfinx/dev-env:stable

--- a/.github/workflows/docker-update-stable.yml
+++ b/.github/workflows/docker-update-stable.yml
@@ -48,16 +48,20 @@ jobs:
           chmod +x ./regctl
 
       - name: "Link :end-user-tag to :stable"
+        env:
+          END_USER_TAG: ${{ inputs.end-user-tag }}
         run: |
-           ./regctl image copy dolfinx/dolfinx:${{ inputs.end-user-tag }} dolfinx/dolfinx:stable
-           ./regctl image copy dolfinx/lab:${{ inputs.end-user-tag }} dolfinx/lab:stable
-           ./regctl image copy dolfinx/dolfinx-onbuild:${{ inputs.end-user-tag }} dolfinx/dolfinx-onbuild:stable
+           ./regctl image copy dolfinx/dolfinx:"$END_USER_TAG" dolfinx/dolfinx:stable
+           ./regctl image copy dolfinx/lab:"$END_USER_TAG" dolfinx/lab:stable
+           ./regctl image copy dolfinx/dolfinx-onbuild:"$END_USER_TAG" dolfinx/dolfinx-onbuild:stable
            # ghcr.io
-           ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx:${{ inputs.end-user-tag }} ghcr.io/fenics/dolfinx/dolfinx:stable
-           ./regctl image copy ghcr.io/fenics/dolfinx/lab:${{ inputs.end-user-tag }} ghcr.io/fenics/dolfinx/lab:stable
-           ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx-onbuild:${{ inputs.end-user-tag }} ghcr.io/fenics/dolfinx/dolfinx-onbuild:stable
+           ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx:"$END_USER_TAG" ghcr.io/fenics/dolfinx/dolfinx:stable
+           ./regctl image copy ghcr.io/fenics/dolfinx/lab:"$END_USER_TAG" ghcr.io/fenics/dolfinx/lab:stable
+           ./regctl image copy ghcr.io/fenics/dolfinx/dolfinx-onbuild:"$END_USER_TAG" ghcr.io/fenics/dolfinx/dolfinx-onbuild:stable
 
       - name: "Link :dev-env-tag to :stable"
+        env:
+          DEV_ENV_TAG: ${{ inputs.dev-env-tag }}
         run: |
-           ./regctl image copy dolfinx/dev-env:${{ inputs.dev-env-tag }} dolfinx/dev-env:stable
-           ./regctl image copy ghcr.io/fenics/dolfinx/dev-env:${{ inputs.dev-env-tag }} ghcr.io/fenics/dolfinx/dev-env:stable
+           ./regctl image copy dolfinx/dev-env:"$DEV_ENV_TAG" dolfinx/dev-env:stable
+           ./regctl image copy ghcr.io/fenics/dolfinx/dev-env:"$DEV_ENV_TAG" ghcr.io/fenics/dolfinx/dev-env:stable

--- a/python/demo/demo_axis.py
+++ b/python/demo/demo_axis.py
@@ -55,7 +55,7 @@ except ModuleNotFoundError:
 # therefore have been compiled with complex scalars.
 if not np.issubdtype(PETSc.ScalarType, np.complexfloating):
     print("Demo can only be executed when PETSc using complex scalars.")
-    exit(0)
+    sys.exit(0)
 
 # -
 

--- a/python/demo/demo_biharmonic.py
+++ b/python/demo/demo_biharmonic.py
@@ -154,6 +154,7 @@
 # We first import the modules and functions that the program uses:
 
 # +
+import sys
 from pathlib import Path
 
 from mpi4py import MPI
@@ -167,7 +168,7 @@ from dolfinx.mesh import CellType, GhostMode
 
 if np.issubdtype(default_real_type, np.float32):
     print("float32 not yet supported for this demo.")
-    exit(0)
+    sys.exit(0)
 # -
 
 

--- a/python/demo/demo_half-loaded-waveguide.py
+++ b/python/demo/demo_half-loaded-waveguide.py
@@ -40,6 +40,7 @@
 # problem:
 
 # +
+import sys
 import typing
 from pathlib import Path
 
@@ -67,7 +68,7 @@ if PETSc.IntType == np.int64 and MPI.COMM_WORLD.size > 1:
     print("This solver fails with PETSc and 64-bit integers because of memory errors in MUMPS.")
     # Note: when PETSc.IntType == np.int32, superlu_dist is used
     # rather than MUMPS and does not trigger memory failures.
-    exit(0)
+    sys.exit(0)
 
 try:
     from dolfinx.io import VTXWriter

--- a/python/demo/demo_hdg.py
+++ b/python/demo/demo_hdg.py
@@ -24,6 +24,7 @@
 # - Assemble mixed systems with multiple, related meshes
 
 # +
+import sys
 import typing
 
 from mpi4py import MPI
@@ -253,7 +254,7 @@ except PETSc.Error as e:
     if e.ierr == 92:  # type: ignore[attr-defined]
         print("The required PETSc solver/preconditioner is not available. Exiting.")
         print(e)
-        exit(0)
+        sys.exit(0)
     else:
         raise e
 

--- a/python/demo/demo_mixed-topology.py
+++ b/python/demo/demo_mixed-topology.py
@@ -26,6 +26,7 @@
 # ```
 
 # +
+import sys
 import typing
 
 from mpi4py import MPI
@@ -56,7 +57,7 @@ from dolfinx.mesh import _create_cell_partitioner_from_ghost_mode as _cell_parti
 
 if MPI.COMM_WORLD.size > 1:
     print("Not yet running in parallel")
-    exit(0)
+    sys.exit(0)
 
 
 # ## Create a mixed-topology mesh

--- a/python/demo/demo_navier-stokes.py
+++ b/python/demo/demo_navier-stokes.py
@@ -177,6 +177,8 @@
 
 
 # +
+import sys
+
 from mpi4py import MPI
 from petsc4py import PETSc
 
@@ -188,7 +190,7 @@ from dolfinx.fem.petsc import LinearProblem
 
 if np.issubdtype(PETSc.ScalarType, np.complexfloating):
     print("Demo should only be executed with DOLFINx real mode")
-    exit(0)
+    sys.exit(0)
 
 
 # -
@@ -351,7 +353,7 @@ except PETSc.Error as e:
     if e.ierr == 92:  # type: ignore[attr-defined]
         print("The required PETSc solver/preconditioner is not available. Exiting.")
         print(e)
-        exit(0)
+        sys.exit(0)
     else:
         raise e
 # -

--- a/python/demo/demo_pml.py
+++ b/python/demo/demo_pml.py
@@ -41,7 +41,7 @@ try:
     from dolfinx.io import VTXWriter
 except ImportError:
     print("This demo requires DOLFINx to be configured with adios2.")
-    exit(0)
+    sys.exit(0)
 
 
 try:
@@ -58,7 +58,7 @@ except ModuleNotFoundError:
 
 if not np.issubdtype(default_scalar_type, np.complexfloating):
     print("Demo should only be executed with DOLFINx complex mode")
-    exit(0)
+    sys.exit(0)
 
 # # Mesh generation with GMSH
 # The mesh is made up by a central circle (the wire), and an external

--- a/python/demo/demo_pyamg.py
+++ b/python/demo/demo_pyamg.py
@@ -45,12 +45,12 @@ try:
     import pyamg
 except ImportError:
     print("This demo requires pyamg.")
-    exit(0)
+    sys.exit(0)
 
 
 if MPI.COMM_WORLD.size > 1:
     print("This demo works only in serial.")
-    exit(0)
+    sys.exit(0)
 # -
 
 

--- a/python/demo/demo_scattering-boundary-conditions.py
+++ b/python/demo/demo_scattering-boundary-conditions.py
@@ -62,7 +62,7 @@ if PETSc.IntType == np.int64 and MPI.COMM_WORLD.size > 1:
     print("This solver fails with PETSc and 64-bit integers becaude of memory errors in MUMPS.")
     # Note: when PETSc.IntType == np.int32, superlu_dist is used rather
     # than MUMPS and does not trigger memory failures.
-    exit(0)
+    sys.exit(0)
 
 # -
 
@@ -256,7 +256,7 @@ def calculate_analytical_efficiencies(
 
 if not np.issubdtype(default_scalar_type, np.complexfloating):
     print("Demo should only be executed with DOLFINx complex mode.")
-    exit(0)
+    sys.exit(0)
 
 
 # Now, let's consider an infinite metallic wire immersed in a background

--- a/python/demo/demo_static-condensation.py
+++ b/python/demo/demo_static-condensation.py
@@ -34,6 +34,7 @@
 # efficient static condensation.
 
 # +
+import sys
 import typing
 from pathlib import Path
 
@@ -75,7 +76,7 @@ rtype = default_real_type
 dtype = default_scalar_type
 if np.issubdtype(rtype, np.float32):
     print("float32 not yet supported for this demo.")
-    exit(0)
+    sys.exit(0)
 
 # We start by reading in the Cook's mesh [cooks_tri_mesh.xdmf](
 # https://github.com/FEniCS/dolfinx/blob/main/python/demo/data/cooks_tri_mesh.xdmf)
@@ -183,7 +184,7 @@ if np.issubdtype(dtype, np.complexfloating):
             "CFFI 1.17.0 and 1.17.1 has a bug for complex type."
             "See https://github.com/FEniCS/dolfinx/pull/3635. Exiting."
         )
-        exit(0)
+        sys.exit(0)
     cffi_support.register_type(ffi.typeof("double _Complex"), numba.types.complex128)
 
 # Get local dofmap sizes for later local tensor tabulations

--- a/python/demo/demo_stokes.py
+++ b/python/demo/demo_stokes.py
@@ -92,6 +92,8 @@
 # The required modules are first imported:
 
 # +
+import sys
+
 from mpi4py import MPI
 from petsc4py import PETSc
 
@@ -631,7 +633,7 @@ def mixed_direct():
         if e.ierr == 92:  # type: ignore[attr-defined]
             print("The required PETSc solver/preconditioner is not available. Exiting.")
             print(e)
-            exit(0)
+            sys.exit(0)
         else:
             raise e
 

--- a/python/demo/demo_types.py
+++ b/python/demo/demo_types.py
@@ -231,18 +231,18 @@ def elasticity(dtype) -> fem.Function:
 # Solve problems for different types
 
 
-uh = poisson(dtype=np.float32)
+poisson(dtype=np.float32)
 uh = poisson(dtype=np.float64)
 if not sys.platform.startswith("win32"):
-    uh = poisson(dtype=np.complex64)
+    poisson(dtype=np.complex64)
     uh = poisson(dtype=np.complex128)
 display_scalar(uh, "poisson", np.real)
 display_scalar(uh, "poisson", np.imag)
 
 
-uh = elasticity(dtype=np.float32)
+elasticity(dtype=np.float32)
 uh = elasticity(dtype=np.float64)
 if not sys.platform.startswith("win32"):
-    uh = elasticity(dtype=np.complex64)
+    elasticity(dtype=np.complex64)
     uh = elasticity(dtype=np.complex128)
 display_vector(uh, "elasticity", np.real)

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -1912,7 +1912,6 @@ def test_vertex_integral_rank_1(cell_type, ghost_mode, dtype):
         comm, x[0] * v * ufl.dP, form_compiler_options={"scalar_type": dtype}
     )
     form = fem.create_form(compiled_form, [V], msh, subdomains, {}, {}, [])
-    expected_value_l = np.sum(msh.geometry.x[vertices, 0])
     expected_value_l = np.zeros(num_vertices, dtype=rdtype)
     expected_value_l[vertices] = msh.geometry.x[vertices, 0]
     value_l = fem.assemble_vector(form)
@@ -1952,7 +1951,6 @@ def test_ridge_integrals_rank1_2D(cell_type, ghost_mode, dtype):
     comm = MPI.COMM_WORLD
     rdtype = np.real(dtype(0)).dtype
 
-    msh = None
     msh = mesh.create_unit_square(
         comm, 4, 4, cell_type=cell_type, ghost_mode=ghost_mode, dtype=rdtype
     )

--- a/python/test/unit/fem/test_custom_basix_element.py
+++ b/python/test/unit/fem/test_custom_basix_element.py
@@ -31,7 +31,6 @@ from ufl import SpatialCoordinate, TestFunction, TrialFunction, div, dx, grad, i
 def run_scalar_test(V, degree, dtype, cg_solver, rtol=None):
     mesh = V.mesh
     u, v = TrialFunction(V), TestFunction(V)
-    a = inner(grad(u), grad(v)) * dx
 
     # Get quadrature degree for bilinear form integrand (ignores effect of non-affine map)
     a = inner(grad(u), grad(v)) * dx(metadata={"quadrature_degree": -1})

--- a/python/test/unit/fem/test_dof_permuting.py
+++ b/python/test/unit/fem/test_dof_permuting.py
@@ -27,6 +27,8 @@ def randomly_ordered_mesh(cell_type):
         gdim = 2
     elif cell_type == "tetrahedron" or cell_type == "hexahedron":
         gdim = 3
+    else:
+        raise ValueError(f"Unsupported {cell_type=}")
 
     domain = ufl.Mesh(element("Lagrange", cell_type, 1, shape=(gdim,), dtype=default_real_type))
     # Create a mesh
@@ -138,6 +140,8 @@ def randomly_ordered_mesh(cell_type):
                 domain,
                 np.ndarray((0, 3), dtype=default_real_type),
             )
+        else:
+            raise ValueError(f"Unsupported {cell_type=}")
 
 
 @pytest.mark.parametrize("space_type", [("P", 1), ("P", 2), ("P", 3), ("P", 4)])

--- a/python/test/unit/fem/test_element_integrals.py
+++ b/python/test/unit/fem/test_element_integrals.py
@@ -86,6 +86,8 @@ def unit_cell_points(cell_type, dtype):
             ],
             dtype=dtype,
         )
+    else:
+        raise ValueError(f"Unsupported {cell_type=}")
 
 
 def unit_cell(cell_type, dtype, random_order=True):

--- a/python/test/unit/fem/test_expression.py
+++ b/python/test/unit/fem/test_expression.py
@@ -112,9 +112,9 @@ def test_rank1_hdiv(dtype):
             rows = dofmap0[i, :]
             cols = dofmap1[i, :]
             A_local = array_evaluated[i, :].reshape(len(rows), len(cols))
-            for i, row in enumerate(rows):
-                for j, col in enumerate(cols):
-                    A[row, col] = A_local[i, j]
+            for local_row, row in enumerate(rows):
+                for local_col, col in enumerate(cols):
+                    A[row, col] = A_local[local_row, local_col]
 
     dofmap_col = RT1.dofmap.list
     dofmap_row = vdP1.dofmap.list

--- a/python/test/unit/fem/test_fem_pipeline.py
+++ b/python/test/unit/fem/test_fem_pipeline.py
@@ -58,7 +58,6 @@ def run_scalar_test(mesh, V, degree, cg_solver):
     """
     dtype = mesh.geometry.x.dtype
     u, v = TrialFunction(V), TestFunction(V)
-    a = inner(grad(u), grad(v)) * dx
 
     # Get quadrature degree for bilinear form integrand (ignores effect of non-affine map)
     a = inner(grad(u), grad(v)) * dx(metadata={"quadrature_degree": -1})

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -74,6 +74,8 @@ def random_point_in_reference(cell_type):
         return (x, y)
     elif cell_type == CellType.hexahedron:
         return (random.random(), random.random(), random.random())
+    else:
+        raise ValueError(f"Unsupported {cell_type=}")
 
 
 def random_point_in_cell(mesh):

--- a/python/test/unit/io/test_vtk.py
+++ b/python/test/unit/io/test_vtk.py
@@ -129,10 +129,6 @@ def test_save_2d_vector(tempdir, cell_type):
 @pytest.mark.skip_in_parallel
 def test_save_2d_vector_CG2(tempdir):
     points = np.array(
-        [[0, 0], [1, 0], [1, 2], [0, 2], [1 / 2, 0], [1, 1], [1 / 2, 2], [0, 1], [1 / 2, 1]],
-        dtype=default_real_type,
-    )
-    points = np.array(
         [[0, 0], [1, 0], [0, 2], [0.5, 1], [0, 1], [0.5, 0], [1, 2], [0.5, 2], [1, 1]],
         dtype=default_real_type,
     )

--- a/python/test/unit/io/test_xdmf_function.py
+++ b/python/test/unit/io/test_xdmf_function.py
@@ -34,6 +34,8 @@ def mesh_factory(tdim, n):
         return create_unit_square(MPI.COMM_WORLD, n, n)
     elif tdim == 3:
         return create_unit_cube(MPI.COMM_WORLD, n, n, n)
+    else:
+        raise ValueError(f"Unsupported {tdim=}")
 
 
 # --- Function

--- a/python/test/unit/io/test_xdmf_mesh.py
+++ b/python/test/unit/io/test_xdmf_mesh.py
@@ -43,6 +43,8 @@ def mesh_factory(tdim, n, ghost_mode=GhostMode.shared_facet, dtype=default_real_
         return create_unit_square(MPI.COMM_WORLD, n, n, ghost_mode=ghost_mode, dtype=dtype)
     elif tdim == 3:
         return create_unit_cube(MPI.COMM_WORLD, n, n, n, ghost_mode=ghost_mode, dtype=dtype)
+    else:
+        raise ValueError(f"Unsupported {tdim=}")
 
 
 @pytest.mark.skipif(default_real_type != np.float64, reason="float32 not supported yet")

--- a/python/test/unit/io/test_xdmf_meshdata.py
+++ b/python/test/unit/io/test_xdmf_meshdata.py
@@ -32,6 +32,8 @@ def mesh_factory(tdim, n):
         return create_unit_square(MPI.COMM_WORLD, n, n)
     elif tdim == 3:
         return create_unit_cube(MPI.COMM_WORLD, n, n, n)
+    else:
+        raise ValueError(f"Unsupported {tdim=}")
 
 
 @pytest.mark.skipif(default_real_type != np.float64, reason="float32 not supported yet")


### PR DESCRIPTION
## Summary
Addresses findings from the [security/quality](https://github.com/FEniCS/dolfinx/security/quality) scan:

- `py/use-of-exit-or-quit`: replaced bare `exit()`/`quit()` calls with `sys.exit()` across demo scripts. `exit`/`quit` are injected into builtins by the `site` module for interactive use only and are not guaranteed to exist when Python is run non-interactively (e.g. `python -S`), embedded, or frozen.
- `py/multiple-definition`: removed dead-store variable reassignments, where a name was assigned and then immediately reassigned before the first value was ever read (`demo_types.py`, `test_fem_pipeline.py`, `test_custom_basix_element.py`, `test_assembler.py`, `test_vtk.py`).
- `py/mixed-returns`: several test helpers had an `if`/`elif` chain over a closed set of cell types or topological dimensions with no `else`, so an unrecognized value silently returned `None` instead of failing clearly. Now raise `ValueError` instead, matching the style already used elsewhere in the test suite (`test_dof_permuting.py`, `test_interpolation.py`, `test_element_integrals.py`, `test_xdmf_meshdata.py`, `test_xdmf_function.py`, `test_xdmf_mesh.py`).
- `py/nested-loops-with-same-variable`: `test_expression.py`'s `scatter()` helper reused the outer cell-index loop variable `i` as the inner `enumerate(rows)` loop variable, so `i` meant different things in different parts of the function. Renamed the inner loop variables to `local_row`/`local_col`; behaviour is unchanged.

Also checked `py/redundant-comparison`: found nothing to fix. The only self-comparisons in the codebase (`V == V`, `W == W` in `test_function_space.py`) are intentional reflexivity assertions already marked `# /NOSONAR`.

Other function/class "redefinitions" the scanner also flags (`@typing.overload` stub groups, `@property`/`@x.setter` pairs, `functools.singledispatch.register` variants) are legitimate, standard idioms — confirmed clean by `ruff --select F811` — and were left as-is.

## Test plan
- [x] `ruff check` / `ruff format --check` pass on all modified files
- [x] `pytest` passes for all modified test modules (828 passed, 22 skipped for the mixed-returns batch; 54 passed for test_expression.py)
- [ ] CI run on this PR (build/test workflows)