### PR TITLE
Unpin cffi and fix stale complex skip condition

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,7 +28,7 @@ authors = [
 ]
 dependencies = [
       "numpy>=2",
-      "cffi<2.1",
+      "cffi",
       "mpi4py",
       "fenics-basix>=0.12.0.dev0",
       "fenics-ffcx>=0.12.0.dev0",

--- a/python/test/unit/fem/test_custom_assembler.py
+++ b/python/test/unit/fem/test_custom_assembler.py
@@ -116,8 +116,10 @@ def assemble_vector_ufc(b, kernel, mesh, dofmap, num_cells, dtype):
             marks=[
                 pytest.mark.xfail_win32_complex,
                 pytest.mark.skipif(
-                    cffi.__version_info__ > (1, 16, 99) and cffi.__version_info__ <= (2, 0, 0),
-                    reason="bug in cffi 1.17.0/1 and 2.0.0 for complex",
+                    cffi.__version_info__ >= (1, 17),
+                    reason="Numba cannot type CFFI complex arguments, see map_type in "
+                    "numba/core/typing/cffi_utils.py. From cffi 1.17 the complex ctypes "
+                    "are named _cffi_{float,double}_complex_t.",
                 ),
             ],
         ),
@@ -126,8 +128,10 @@ def assemble_vector_ufc(b, kernel, mesh, dofmap, num_cells, dtype):
             marks=[
                 pytest.mark.xfail_win32_complex,
                 pytest.mark.skipif(
-                    cffi.__version_info__ > (1, 16, 99) and cffi.__version_info__ <= (2, 0, 0),
-                    reason="bug in cffi 1.17.0/1 and 2.0.0 for complex",
+                    cffi.__version_info__ >= (1, 17),
+                    reason="Numba cannot type CFFI complex arguments, see map_type in "
+                    "numba/core/typing/cffi_utils.py. From cffi 1.17 the complex ctypes "
+                    "are named _cffi_{float,double}_complex_t.",
                 ),
             ],
         ),


### PR DESCRIPTION
Related to https://github.com/FEniCS/dolfinx/issues/4273.

This is not a fix, but does apply and give a reason for the skip. The fix will need to be done in Numba, rather than cffi.
