### PR TITLE
Add non-blocking ty and pyrefly type checks to CI

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -33,7 +33,7 @@ jobs:
         run: cat .github/workflows/fenicsx-refs.env >> $GITHUB_ENV
 
       - name: Install linting tools
-        run: pip install clang-format gersemi mypy ruff
+        run: pip install clang-format gersemi mypy pyrefly ruff ty
       - name: ruff .py files in C++ code
         run: |
           cd cpp/
@@ -64,6 +64,16 @@ jobs:
           mypy $MYPY_FLAGS demo
           mypy $MYPY_FLAGS test
 
+      - name: ty checks (not installed, non-blocking)
+        continue-on-error: true
+        run: |
+          cd python/
+          ty check dolfinx demo test
+      - name: pyrefly checks (not installed, non-blocking)
+        continue-on-error: true
+        run: |
+          cd python/
+          pyrefly check dolfinx demo test
 
   ccpp-build:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- Adds `ty` and `pyrefly` as additional Python type checkers in the `lint` job of `ccpp.yml`, run alongside the existing `mypy` checks.
- Both steps use `continue-on-error: true` so they report diagnostics without blocking the pipeline.

## Test plan
- [ ] Confirm the `ty checks` and `pyrefly checks` steps run in the `lint` job on this PR and show as non-blocking (yellow/warning) even with diagnostics present.
- [ ] Confirm the rest of the `lint` job (ruff, clang-format, gersemi, mypy) is unaffected.