### PR TITLE
Fix type annotation in `create_point_mesh`

### DIFF
--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -1459,7 +1459,7 @@ def transfer_meshtags_to_submesh(
     return MeshTags(cpp_tag)
 
 
-def create_point_mesh(comm: _MPI.Intracomm, points: npt.NDArray[np.float32 | np.float64]) -> Mesh:
+def create_point_mesh(comm: _MPI.Comm, points: npt.NDArray[np.float32 | np.float64]) -> Mesh:
     """Create a mesh consisting of points only.
 
     Note:


### PR DESCRIPTION
Type should be `MPI.Comm` and not `MPI.Intracomm`.

See e.g https://github.com/scientificcomputing/dolfinx-adjoint/actions/runs/31804604322/job/94780374748?pr=60