### PR TITLE
Spack CI: build the Basix Python bindings in Developer mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: fenics/spack-fenics
-          ref: 05ea6cd78f5fde9c580fe29cb6dbb040d05f74ee # main, 2026-08-12
+          ref: 55b14e0301eb64d4adc86c213046824f2b17e20c # main, 2026-08-15
           path: spack-fenics
 
       # Add FEniCS Spack packages on top of the upstream Spack packages
@@ -141,7 +141,7 @@ jobs:
         run: |
           # Ensure build provenance by adding manually and providing git sha
           spack -e ci add fenics-basix@main commit=$BASIX_SHA build_type=Developer
-          spack -e ci add py-fenics-basix@main commit=$BASIX_SHA
+          spack -e ci add py-fenics-basix@main commit=$BASIX_SHA build_type=Developer
           spack -e ci add py-fenics-ufl@main commit=$UFL_SHA
           spack -e ci add fenics-ufcx@main commit=$FFCX_SHA
           spack -e ci add py-fenics-ffcx@main commit=$FFCX_SHA


### PR DESCRIPTION
`py-fenics-basix` compiles the `_basixcpp` nanobind extension, but the Spack
package had no `build_type` variant, so the extension took scikit-build-core's
default while `libbasix` beside it was built `Developer`. AGENTS.md asks for
both the C++ and the Python parts to be built in Developer mode for test
builds.

FEniCS/spack-fenics#48 adds the variant, so this bumps the pin to pick it up
and asks for it:

```diff
-          ref: 05ea6cd78f5fde9c580fe29cb6dbb040d05f74ee # main, 2026-08-12
+          ref: 55b14e0301eb64d4adc86c213046824f2b17e20c # main, 2026-08-15
...
-          spack -e ci add py-fenics-basix@main commit=$BASIX_SHA
+          spack -e ci add py-fenics-basix@main commit=$BASIX_SHA build_type=Developer
```

I checked that the pinned commit carries the change, rather than assuming the
merge matched the pull request.

### What this changes at build time

Basix applies the Developer flags to the nanobind target as well as to the
library — `-Wall -Werror -Wextra -pedantic -Wno-comment`, `-g -O2`, and
`_GLIBCXX_ASSERTIONS` (see `python/CMakeLists.txt` in basix). So:

- a warning in the bindings under gcc 15.2 now **fails** the build where it
  previously passed. That is the point of the mode, and it is how DOLFINx
  builds its own bindings, but it is a new way for these legs to go red;
- the bindings gain the hardened libstdc++ assertions that the library
  already had, so the two halves of basix are consistent.

`py-fenics-basix` gets a new hash and rebuilds once per leg — a few seconds —
then comes from the cache.

---

AI assistance: I used Claude Code (Opus 5) to draft parts of this PR. I
reviewed, edited, tested, and take responsibility for the final contribution.
