### PR TITLE
Correct stated Boost minimum version to 1.81

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -259,7 +259,9 @@ if(DEFINED ENV{BOOST_USE_MULTITHREADED})
   set(Boost_USE_MULTITHREADED $ENV{BOOST_USE_MULTITHREADED})
 endif()
 set(Boost_VERBOSE TRUE)
-find_package(Boost 1.70 REQUIRED)
+# 1.81 is required for boost/unordered/unordered_flat_set.hpp, used by
+# dolfinx::graph::partitioners.
+find_package(Boost 1.81 REQUIRED)
 set_package_properties(
   Boost
   PROPERTIES

--- a/cpp/cmake/templates/DOLFINXConfig.cmake.in
+++ b/cpp/cmake/templates/DOLFINXConfig.cmake.in
@@ -25,7 +25,7 @@ if(DEFINED ENV{BOOST_ROOT} OR DEFINED BOOST_ROOT)
 endif()
 set(Boost_USE_MULTITHREADED $ENV{BOOST_USE_MULTITHREADED})
 set(Boost_VERBOSE TRUE)
-find_package(Boost 1.70 REQUIRED)
+find_package(Boost 1.81 REQUIRED)
 
 # CONFIG mode is explicit, otherwise the FindUFCx.cmake installed alongside this
 # file is picked up as Findufcx.cmake on case-insensitive filesystems.


### PR DESCRIPTION
find_package(Boost 1.70 REQUIRED) understated the real minimum: `dolfinx::graph::partitioners` uses `boost/unordered/unordered_flat_set.hpp`, added in Boost 1.81.

Documents the real requirement only; does not fix beta `wheel-build.yml` with an older Boost (e.g. manylinux's system packages top out at 1.78) — left for a follow-up.

🤖 Generated with [Claude Code Sonnet 5.0](https://claude.com/claude-code)