### PR TITLE
Fix unchecked errors in SLEPcEigenSolver and trim its API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,12 @@ disclosure process.
   array memory traffic — so local indices must not be silently widened
   in storage or interfaces. Type a variable by the role of its value,
   not by the expression that initialises it.
+- **PETSc/SLEPc index types**: in the thin `la::petsc`/`la::slepc`
+  wrappers, an index or count passed straight through to a PETSc/SLEPc
+  call is `PetscInt`, matching the `PetscScalar`/`Mat`/`Vec` already in
+  those signatures. The fixed-width types above are for
+  DOLFINx-meaningful quantities, such as the sizes and ranges returned
+  by `petsc::Vector`.
 - **Iterator distances**: store `std::distance` results, a signed
   `difference_type`, in `std::size_t` when used as a container offset.
   They are non-negative by construction here, and `-Wsign-compare` is

--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -531,7 +531,7 @@ std::string petsc::Vector::get_options_prefix() const
   const char* prefix = nullptr;
   PetscErrorCode ierr = VecGetOptionsPrefix(_x, &prefix);
   CHECK_ERROR("VecGetOptionsPrefix");
-  return std::string(prefix);
+  return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
 void petsc::Vector::set_from_options()
@@ -677,7 +677,7 @@ std::string petsc::Matrix::get_options_prefix() const
   assert(_matA);
   const char* prefix = nullptr;
   MatGetOptionsPrefix(_matA, &prefix);
-  return std::string(prefix);
+  return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
 void petsc::Matrix::set_from_options()
@@ -811,7 +811,7 @@ std::string petsc::KrylovSolver::get_options_prefix() const
   PetscErrorCode ierr = KSPGetOptionsPrefix(_ksp, &prefix);
   if (ierr != 0)
     petsc::error(ierr, __FILE__, "KSPGetOptionsPrefix");
-  return std::string(prefix);
+  return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
 void petsc::KrylovSolver::set_from_options() const

--- a/cpp/dolfinx/la/slepc.cpp
+++ b/cpp/dolfinx/la/slepc.cpp
@@ -8,30 +8,39 @@
 
 #include "slepc.h"
 #include "petsc.h"
-#include "utils.h"
-#include <dolfinx/common/MPI.h>
+#include <cassert>
 #include <dolfinx/common/log.h>
 #include <format>
-#include <petscmat.h>
-#include <slepcversion.h>
+#include <stdexcept>
+#include <utility>
 
 using namespace dolfinx;
 using namespace dolfinx::la;
 
 //-----------------------------------------------------------------------------
-SLEPcEigenSolver::SLEPcEigenSolver(MPI_Comm comm) { EPSCreate(comm, &_eps); }
+#define CHECK_ERROR(NAME)                                                      \
+  do                                                                           \
+  {                                                                            \
+    if (ierr != 0)                                                             \
+      petsc::error(ierr, __FILE__, NAME);                                      \
+  } while (0)
+
+//-----------------------------------------------------------------------------
+SLEPcEigenSolver::SLEPcEigenSolver(MPI_Comm comm) : _eps(nullptr)
+{
+  PetscErrorCode ierr = EPSCreate(comm, &_eps);
+  CHECK_ERROR("EPSCreate");
+}
 //-----------------------------------------------------------------------------
 SLEPcEigenSolver::SLEPcEigenSolver(EPS eps, bool inc_ref_count) : _eps(eps)
 {
   if (!eps)
     throw std::runtime_error("SLEPc EPS must be initialised before wrapping");
 
-  PetscErrorCode ierr;
   if (inc_ref_count)
   {
-    ierr = PetscObjectReference((PetscObject)_eps);
-    if (ierr != 0)
-      petsc::error(ierr, __FILE__, "PetscObjectReference");
+    PetscErrorCode ierr = PetscObjectReference((PetscObject)_eps);
+    CHECK_ERROR("PetscObjectReference");
   }
 }
 //-----------------------------------------------------------------------------
@@ -56,111 +65,137 @@ SLEPcEigenSolver::operator=(SLEPcEigenSolver&& solver) noexcept
 //-----------------------------------------------------------------------------
 void SLEPcEigenSolver::set_operators(const Mat A, const Mat B)
 {
+  assert(A);
   assert(_eps);
-  EPSSetOperators(_eps, A, B);
+  PetscErrorCode ierr = EPSSetOperators(_eps, A, B);
+  CHECK_ERROR("EPSSetOperators");
 }
 //-----------------------------------------------------------------------------
 void SLEPcEigenSolver::solve()
 {
   // Get operators
-  Mat A, B;
   assert(_eps);
-  EPSGetOperators(_eps, &A, &B);
+  Mat A = nullptr;
+  PetscErrorCode ierr = EPSGetOperators(_eps, &A, nullptr);
+  CHECK_ERROR("EPSGetOperators");
+  if (!A)
+    throw std::runtime_error("Operators must be set before calling solve");
 
   PetscInt m(0), n(0);
-  MatGetSize(A, &m, &n);
-  solve(m);
+  ierr = MatGetSize(A, &m, &n);
+  CHECK_ERROR("MatGetSize");
+  solve(n);
 }
 //-----------------------------------------------------------------------------
 void SLEPcEigenSolver::solve(std::int64_t n)
 {
+  if (n <= 0)
+    throw std::runtime_error("Number of requested eigenpairs must be > 0");
+
+  assert(_eps);
+  PetscErrorCode ierr;
+
 #ifndef NDEBUG
   // Get operators
-  Mat A, B;
-  assert(_eps);
-  EPSGetOperators(_eps, &A, &B);
+  Mat A = nullptr;
+  ierr = EPSGetOperators(_eps, &A, nullptr);
+  CHECK_ERROR("EPSGetOperators");
+  if (!A)
+    throw std::runtime_error("Operators must be set before calling solve");
 
   PetscInt _m(0), _n(0);
-  MatGetSize(A, &_m, &_n);
+  ierr = MatGetSize(A, &_m, &_n);
+  CHECK_ERROR("MatGetSize");
   assert(n <= _n);
 #endif
 
   // Set number of eigenpairs to compute
-  assert(_eps);
-  EPSSetDimensions(_eps, n, PETSC_DECIDE, PETSC_DECIDE);
-
-  // Set any options from the PETSc database
-  EPSSetFromOptions(_eps);
+  ierr = EPSSetDimensions(_eps, static_cast<PetscInt>(n), PETSC_DECIDE,
+                          PETSC_DECIDE);
+  CHECK_ERROR("EPSSetDimensions");
 
   // Solve eigenvalue problem
-  EPSSolve(_eps);
+  ierr = EPSSolve(_eps);
+  CHECK_ERROR("EPSSolve");
 
   // Check for convergence
   EPSConvergedReason reason;
-  EPSGetConvergedReason(_eps, &reason);
+  ierr = EPSGetConvergedReason(_eps, &reason);
+  CHECK_ERROR("EPSGetConvergedReason");
   if (reason < 0)
     spdlog::warn("Eigenvalue solver did not converge");
 
   // Report solver status
   PetscInt num_iterations = 0;
-  EPSGetIterationNumber(_eps, &num_iterations);
+  ierr = EPSGetIterationNumber(_eps, &num_iterations);
+  CHECK_ERROR("EPSGetIterationNumber");
 
   EPSType eps_type = nullptr;
-  EPSGetType(_eps, &eps_type);
-  spdlog::info("Eigenvalue solver ({}) converged in {} iterations.", eps_type,
-               num_iterations);
+  ierr = EPSGetType(_eps, &eps_type);
+  CHECK_ERROR("EPSGetType");
+  spdlog::info("Eigenvalue solver ({}) converged in {} iterations.",
+               eps_type ? eps_type : "unknown", num_iterations);
 }
 //-----------------------------------------------------------------------------
-std::complex<PetscReal> SLEPcEigenSolver::get_eigenvalue(int i) const
+std::complex<PetscReal> SLEPcEigenSolver::get_eigenvalue(std::int64_t i) const
 {
   assert(_eps);
+  if (i < 0)
+    throw std::runtime_error("Requested eigenvalue index cannot be negative");
 
   // Get number of computed values
   PetscInt num_computed_eigenvalues;
-  EPSGetConverged(_eps, &num_computed_eigenvalues);
+  PetscErrorCode ierr = EPSGetConverged(_eps, &num_computed_eigenvalues);
+  CHECK_ERROR("EPSGetConverged");
 
-  if (i < num_computed_eigenvalues)
-  {
-#ifdef PETSC_USE_COMPLEX
-    PetscScalar l;
-    EPSGetEigenvalue(_eps, i, &l, nullptr);
-    return l;
-#else
-    PetscScalar lr, li;
-    EPSGetEigenvalue(_eps, i, &lr, &li);
-    return std::complex<PetscReal>(lr, li);
-#endif
-  }
-  else
+  if (i >= num_computed_eigenvalues)
   {
     throw std::runtime_error(
         std::format("Requested eigenvalue ({}) has not been computed", i));
   }
+
+  const PetscInt ii = static_cast<PetscInt>(i);
+#ifdef PETSC_USE_COMPLEX
+  PetscScalar l;
+  ierr = EPSGetEigenvalue(_eps, ii, &l, nullptr);
+  CHECK_ERROR("EPSGetEigenvalue");
+  return l;
+#else
+  PetscScalar lr, li;
+  ierr = EPSGetEigenvalue(_eps, ii, &lr, &li);
+  CHECK_ERROR("EPSGetEigenvalue");
+  return std::complex<PetscReal>(lr, li);
+#endif
 }
 //-----------------------------------------------------------------------------
 void SLEPcEigenSolver::get_eigenpair(PetscScalar& lr, PetscScalar& lc, Vec r,
-                                     Vec c, int i) const
+                                     Vec c, std::int64_t i) const
 {
   assert(_eps);
-  PetscInt ii = static_cast<PetscInt>(i);
+  if (i < 0)
+    throw std::runtime_error("Requested eigenpair index cannot be negative");
 
   // Get number of computed eigenvectors/values
   PetscInt num_computed_eigenvalues;
-  EPSGetConverged(_eps, &num_computed_eigenvalues);
-  if (ii < num_computed_eigenvalues)
-    EPSGetEigenpair(_eps, ii, &lr, &lc, r, c);
-  else
+  PetscErrorCode ierr = EPSGetConverged(_eps, &num_computed_eigenvalues);
+  CHECK_ERROR("EPSGetConverged");
+
+  if (i >= num_computed_eigenvalues)
   {
     throw std::runtime_error(
         std::format("Requested eigenpair ({}) has not been computed", i));
   }
+
+  ierr = EPSGetEigenpair(_eps, static_cast<PetscInt>(i), &lr, &lc, r, c);
+  CHECK_ERROR("EPSGetEigenpair");
 }
 //-----------------------------------------------------------------------------
 std::int64_t SLEPcEigenSolver::get_number_converged() const
 {
-  PetscInt num_conv;
   assert(_eps);
-  EPSGetConverged(_eps, &num_conv);
+  PetscInt num_conv;
+  PetscErrorCode ierr = EPSGetConverged(_eps, &num_conv);
+  CHECK_ERROR("EPSGetConverged");
   return num_conv;
 }
 //-----------------------------------------------------------------------------
@@ -169,8 +204,7 @@ void SLEPcEigenSolver::set_options_prefix(std::string_view options_prefix)
   assert(_eps);
   PetscErrorCode ierr
       = EPSSetOptionsPrefix(_eps, std::string(options_prefix).c_str());
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "EPSSetOptionsPrefix");
+  CHECK_ERROR("EPSSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string SLEPcEigenSolver::get_options_prefix() const
@@ -178,24 +212,23 @@ std::string SLEPcEigenSolver::get_options_prefix() const
   assert(_eps);
   const char* prefix = nullptr;
   PetscErrorCode ierr = EPSGetOptionsPrefix(_eps, &prefix);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "EPSGetOptionsPrefix");
-  return std::string(prefix);
+  CHECK_ERROR("EPSGetOptionsPrefix");
+  return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
 void SLEPcEigenSolver::set_from_options() const
 {
   assert(_eps);
   PetscErrorCode ierr = EPSSetFromOptions(_eps);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "EPSSetFromOptions");
+  CHECK_ERROR("EPSSetFromOptions");
 }
 //-----------------------------------------------------------------------------
 int SLEPcEigenSolver::get_iteration_number() const
 {
   assert(_eps);
   PetscInt num_iter;
-  EPSGetIterationNumber(_eps, &num_iter);
+  PetscErrorCode ierr = EPSGetIterationNumber(_eps, &num_iter);
+  CHECK_ERROR("EPSGetIterationNumber");
   return num_iter;
 }
 //-----------------------------------------------------------------------------
@@ -205,7 +238,8 @@ MPI_Comm SLEPcEigenSolver::comm() const
 {
   assert(_eps);
   MPI_Comm mpi_comm = MPI_COMM_NULL;
-  PetscObjectGetComm((PetscObject)_eps, &mpi_comm);
+  PetscErrorCode ierr = PetscObjectGetComm((PetscObject)_eps, &mpi_comm);
+  CHECK_ERROR("PetscObjectGetComm");
   return mpi_comm;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/la/slepc.cpp
+++ b/cpp/dolfinx/la/slepc.cpp
@@ -33,7 +33,7 @@ SLEPcEigenSolver::SLEPcEigenSolver(MPI_Comm comm) : _eps(nullptr)
 //-----------------------------------------------------------------------------
 SLEPcEigenSolver::SLEPcEigenSolver(EPS eps, bool inc_ref_count) : _eps(eps)
 {
-  if (!eps)
+  if (!_eps)
     throw std::runtime_error("SLEPc EPS must be initialised before wrapping");
 
   if (inc_ref_count)

--- a/cpp/dolfinx/la/slepc.cpp
+++ b/cpp/dolfinx/la/slepc.cpp
@@ -10,7 +10,6 @@
 #include "petsc.h"
 #include <cassert>
 #include <dolfinx/common/log.h>
-#include <format>
 #include <stdexcept>
 #include <utility>
 
@@ -75,15 +74,9 @@ void SLEPcEigenSolver::solve()
 {
   assert(_eps);
 
-  // EPSGetOperators returns a null Mat if no operators have been set
-  Mat A = nullptr;
-  PetscErrorCode ierr = EPSGetOperators(_eps, &A, nullptr);
-  CHECK_ERROR("EPSGetOperators");
-  if (!A)
-    throw std::runtime_error("Operators must be set before calling solve");
-
-  // Solve eigenvalue problem
-  ierr = EPSSolve(_eps);
+  // Solve eigenvalue problem. EPSSetUp errors if no operators have been
+  // set
+  PetscErrorCode ierr = EPSSolve(_eps);
   CHECK_ERROR("EPSSolve");
 
   // Check for convergence
@@ -108,20 +101,10 @@ void SLEPcEigenSolver::solve()
 std::complex<PetscReal> SLEPcEigenSolver::get_eigenvalue(PetscInt i) const
 {
   assert(_eps);
-  if (i < 0)
-    throw std::runtime_error("Requested eigenvalue index cannot be negative");
 
-  // Get number of computed values
-  PetscInt num_computed_eigenvalues;
-  PetscErrorCode ierr = EPSGetConverged(_eps, &num_computed_eigenvalues);
-  CHECK_ERROR("EPSGetConverged");
-
-  if (i >= num_computed_eigenvalues)
-  {
-    throw std::runtime_error(
-        std::format("Requested eigenvalue ({}) has not been computed", i));
-  }
-
+  // EPSGetEigenvalue checks that the problem has been solved and that i
+  // is in range
+  PetscErrorCode ierr;
 #ifdef PETSC_USE_COMPLEX
   PetscScalar l;
   ierr = EPSGetEigenvalue(_eps, i, &l, nullptr);
@@ -139,31 +122,11 @@ void SLEPcEigenSolver::get_eigenpair(PetscScalar& lr, PetscScalar& lc, Vec r,
                                      Vec c, PetscInt i) const
 {
   assert(_eps);
-  if (i < 0)
-    throw std::runtime_error("Requested eigenpair index cannot be negative");
 
-  // Get number of computed eigenvectors/values
-  PetscInt num_computed_eigenvalues;
-  PetscErrorCode ierr = EPSGetConverged(_eps, &num_computed_eigenvalues);
-  CHECK_ERROR("EPSGetConverged");
-
-  if (i >= num_computed_eigenvalues)
-  {
-    throw std::runtime_error(
-        std::format("Requested eigenpair ({}) has not been computed", i));
-  }
-
-  ierr = EPSGetEigenpair(_eps, i, &lr, &lc, r, c);
+  // EPSGetEigenpair checks that the problem has been solved and that i
+  // is in range
+  PetscErrorCode ierr = EPSGetEigenpair(_eps, i, &lr, &lc, r, c);
   CHECK_ERROR("EPSGetEigenpair");
-}
-//-----------------------------------------------------------------------------
-PetscInt SLEPcEigenSolver::get_number_converged() const
-{
-  assert(_eps);
-  PetscInt num_conv;
-  PetscErrorCode ierr = EPSGetConverged(_eps, &num_conv);
-  CHECK_ERROR("EPSGetConverged");
-  return num_conv;
 }
 //-----------------------------------------------------------------------------
 void SLEPcEigenSolver::set_options_prefix(std::string_view options_prefix)

--- a/cpp/dolfinx/la/slepc.cpp
+++ b/cpp/dolfinx/la/slepc.cpp
@@ -73,46 +73,14 @@ void SLEPcEigenSolver::set_operators(const Mat A, const Mat B)
 //-----------------------------------------------------------------------------
 void SLEPcEigenSolver::solve()
 {
-  // Get operators
   assert(_eps);
+
+  // EPSGetOperators returns a null Mat if no operators have been set
   Mat A = nullptr;
   PetscErrorCode ierr = EPSGetOperators(_eps, &A, nullptr);
   CHECK_ERROR("EPSGetOperators");
   if (!A)
     throw std::runtime_error("Operators must be set before calling solve");
-
-  PetscInt m(0), n(0);
-  ierr = MatGetSize(A, &m, &n);
-  CHECK_ERROR("MatGetSize");
-  solve(n);
-}
-//-----------------------------------------------------------------------------
-void SLEPcEigenSolver::solve(std::int64_t n)
-{
-  if (n <= 0)
-    throw std::runtime_error("Number of requested eigenpairs must be > 0");
-
-  assert(_eps);
-  PetscErrorCode ierr;
-
-#ifndef NDEBUG
-  // Get operators
-  Mat A = nullptr;
-  ierr = EPSGetOperators(_eps, &A, nullptr);
-  CHECK_ERROR("EPSGetOperators");
-  if (!A)
-    throw std::runtime_error("Operators must be set before calling solve");
-
-  PetscInt _m(0), _n(0);
-  ierr = MatGetSize(A, &_m, &_n);
-  CHECK_ERROR("MatGetSize");
-  assert(n <= _n);
-#endif
-
-  // Set number of eigenpairs to compute
-  ierr = EPSSetDimensions(_eps, static_cast<PetscInt>(n), PETSC_DECIDE,
-                          PETSC_DECIDE);
-  CHECK_ERROR("EPSSetDimensions");
 
   // Solve eigenvalue problem
   ierr = EPSSolve(_eps);
@@ -137,7 +105,7 @@ void SLEPcEigenSolver::solve(std::int64_t n)
                eps_type ? eps_type : "unknown", num_iterations);
 }
 //-----------------------------------------------------------------------------
-std::complex<PetscReal> SLEPcEigenSolver::get_eigenvalue(std::int64_t i) const
+std::complex<PetscReal> SLEPcEigenSolver::get_eigenvalue(PetscInt i) const
 {
   assert(_eps);
   if (i < 0)
@@ -154,22 +122,21 @@ std::complex<PetscReal> SLEPcEigenSolver::get_eigenvalue(std::int64_t i) const
         std::format("Requested eigenvalue ({}) has not been computed", i));
   }
 
-  const PetscInt ii = static_cast<PetscInt>(i);
 #ifdef PETSC_USE_COMPLEX
   PetscScalar l;
-  ierr = EPSGetEigenvalue(_eps, ii, &l, nullptr);
+  ierr = EPSGetEigenvalue(_eps, i, &l, nullptr);
   CHECK_ERROR("EPSGetEigenvalue");
   return l;
 #else
   PetscScalar lr, li;
-  ierr = EPSGetEigenvalue(_eps, ii, &lr, &li);
+  ierr = EPSGetEigenvalue(_eps, i, &lr, &li);
   CHECK_ERROR("EPSGetEigenvalue");
   return std::complex<PetscReal>(lr, li);
 #endif
 }
 //-----------------------------------------------------------------------------
 void SLEPcEigenSolver::get_eigenpair(PetscScalar& lr, PetscScalar& lc, Vec r,
-                                     Vec c, std::int64_t i) const
+                                     Vec c, PetscInt i) const
 {
   assert(_eps);
   if (i < 0)
@@ -186,11 +153,11 @@ void SLEPcEigenSolver::get_eigenpair(PetscScalar& lr, PetscScalar& lc, Vec r,
         std::format("Requested eigenpair ({}) has not been computed", i));
   }
 
-  ierr = EPSGetEigenpair(_eps, static_cast<PetscInt>(i), &lr, &lc, r, c);
+  ierr = EPSGetEigenpair(_eps, i, &lr, &lc, r, c);
   CHECK_ERROR("EPSGetEigenpair");
 }
 //-----------------------------------------------------------------------------
-std::int64_t SLEPcEigenSolver::get_number_converged() const
+PetscInt SLEPcEigenSolver::get_number_converged() const
 {
   assert(_eps);
   PetscInt num_conv;
@@ -221,15 +188,6 @@ void SLEPcEigenSolver::set_from_options() const
   assert(_eps);
   PetscErrorCode ierr = EPSSetFromOptions(_eps);
   CHECK_ERROR("EPSSetFromOptions");
-}
-//-----------------------------------------------------------------------------
-int SLEPcEigenSolver::get_iteration_number() const
-{
-  assert(_eps);
-  PetscInt num_iter;
-  PetscErrorCode ierr = EPSGetIterationNumber(_eps, &num_iter);
-  CHECK_ERROR("EPSGetIterationNumber");
-  return num_iter;
 }
 //-----------------------------------------------------------------------------
 EPS SLEPcEigenSolver::eps() const { return _eps; }

--- a/cpp/dolfinx/la/slepc.h
+++ b/cpp/dolfinx/la/slepc.h
@@ -8,8 +8,9 @@
 
 #ifdef HAS_SLEPC
 
-#include "dolfinx/common/MPI.h"
-#include <memory>
+#include <complex>
+#include <cstdint>
+#include <dolfinx/common/MPI.h>
 #include <petscmat.h>
 #include <petscvec.h>
 #include <slepceps.h>
@@ -24,13 +25,21 @@ namespace dolfinx::la
 class SLEPcEigenSolver
 {
 public:
-  /// Create eigenvalue solver
+  /// @brief Create eigenvalue solver.
+  /// @note SLEPc must have been initialised (`SlepcInitialize`) before
+  /// this is called.
+  /// @param[in] comm MPI communicator.
   explicit SLEPcEigenSolver(MPI_Comm comm);
 
-  /// Create eigenvalue solver from EPS object
+  /// @brief Create eigenvalue solver from an existing EPS object.
+  /// @param[in] eps SLEPc EPS object, which must already have been
+  /// created. The reference count of `eps` is always decreased when
+  /// this SLEPcEigenSolver is destroyed.
+  /// @param[in] inc_ref_count True if the reference count of `eps`
+  /// should be incremented.
   SLEPcEigenSolver(EPS eps, bool inc_ref_count);
 
-  // Delete copy constructor
+  // Copy constructor (deleted)
   SLEPcEigenSolver(const SLEPcEigenSolver&) = delete;
 
   /// Move constructor
@@ -39,34 +48,59 @@ public:
   /// Destructor
   ~SLEPcEigenSolver();
 
-  // Assignment operator (disabled)
+  // Assignment operator (deleted)
   SLEPcEigenSolver& operator=(const SLEPcEigenSolver&) = delete;
 
   /// Move assignment
   SLEPcEigenSolver& operator=(SLEPcEigenSolver&& solver) noexcept;
 
-  /// Set operators (B may be nullptr for regular eigenvalues
-  /// problems)
+  /// @brief Set the operators defining the eigenvalue problem.
+  /// @param[in] A Operator for the standard problem
+  /// \f$A x = \lambda x\f$, or the left-hand operator of the
+  /// generalised problem \f$A x = \lambda B x\f$. Must not be null.
+  /// @param[in] B Right-hand operator of the generalised problem, or
+  /// `nullptr` for a standard eigenvalue problem.
   void set_operators(const Mat A, const Mat B);
 
-  /// Compute all eigenpairs of the matrix A (solve \f$A x = \lambda x\f$)
+  /// @brief Compute all eigenpairs of \f$A\f$ (solve
+  /// \f$A x = \lambda x\f$).
+  /// @note Requests as many eigenpairs as the global dimension of
+  /// \f$A\f$. Prefer solve(std::int64_t) with the number of
+  /// eigenpairs actually required.
   void solve();
 
-  /// Compute the n first eigenpairs of the matrix A
-  /// (solve \f$A x = \lambda x\f$)
+  /// @brief Compute the `n` first eigenpairs of \f$A\f$ (solve
+  /// \f$A x = \lambda x\f$).
+  /// @param[in] n Number of eigenpairs to compute. Must be greater
+  /// than zero and at most the global dimension of \f$A\f$.
   void solve(std::int64_t n);
 
-  /// Get ith eigenvalue
-  std::complex<PetscReal> get_eigenvalue(int i) const;
+  /// @brief Get the ith eigenvalue.
+  /// @param[in] i Index of the eigenvalue, in
+  /// `[0, get_number_converged())`.
+  /// @return The eigenvalue.
+  std::complex<PetscReal> get_eigenvalue(std::int64_t i) const;
 
-  /// Get ith eigenpair
+  /// @brief Get the ith eigenpair.
+  /// @param[out] lr Real part of the eigenvalue.
+  /// @param[out] lc Imaginary part of the eigenvalue.
+  /// @param[out] r Real part of the eigenvector.
+  /// @param[out] c Imaginary part of the eigenvector.
+  /// @param[in] i Index of the eigenpair, in
+  /// `[0, get_number_converged())`.
+  /// @note For a complex PETSc scalar type the eigenvalue and
+  /// eigenvector are held entirely in `lr` and `r`, and `lc` and `c`
+  /// are set to zero.
   void get_eigenpair(PetscScalar& lr, PetscScalar& lc, Vec r, Vec c,
-                     int i) const;
+                     std::int64_t i) const;
 
-  /// Get the number of iterations used by the solver
+  /// @brief Get the number of iterations used by the solver.
+  /// @return Iteration count of the last solve.
   int get_iteration_number() const;
 
-  /// Get the number of converged eigenvalues
+  /// @brief Get the number of converged eigenvalues.
+  /// @return Number of converged eigenpairs available from
+  /// get_eigenvalue and get_eigenpair.
   std::int64_t get_number_converged() const;
 
   /// Sets the prefix used by PETSc when searching the PETSc options
@@ -77,7 +111,9 @@ public:
   /// database
   std::string get_options_prefix() const;
 
-  /// Set options from PETSc options database
+  /// @brief Set options from the PETSc options database.
+  /// @note Call after set_options_prefix and any settings the database
+  /// should override. `-eps_nev` has no effect; solve sets it.
   void set_from_options() const;
 
   /// Return SLEPc EPS pointer

--- a/cpp/dolfinx/la/slepc.h
+++ b/cpp/dolfinx/la/slepc.h
@@ -77,8 +77,9 @@ public:
   void solve();
 
   /// @brief Get the ith eigenvalue.
-  /// @param[in] i Index of the eigenvalue, in
-  /// `[0, get_number_converged())`.
+  /// @param[in] i Index of the eigenvalue, in `[0, nconv)`, where
+  /// `nconv` is the number of converged eigenpairs reported by
+  /// `EPSGetConverged(eps(), &nconv)`.
   /// @return The eigenvalue.
   std::complex<PetscReal> get_eigenvalue(PetscInt i) const;
 
@@ -87,18 +88,14 @@ public:
   /// @param[out] lc Imaginary part of the eigenvalue.
   /// @param[out] r Real part of the eigenvector.
   /// @param[out] c Imaginary part of the eigenvector.
-  /// @param[in] i Index of the eigenpair, in
-  /// `[0, get_number_converged())`.
+  /// @param[in] i Index of the eigenpair, in `[0, nconv)`, where
+  /// `nconv` is the number of converged eigenpairs reported by
+  /// `EPSGetConverged(eps(), &nconv)`.
   /// @note For a complex PETSc scalar type the eigenvalue and
   /// eigenvector are held entirely in `lr` and `r`, and `lc` and `c`
   /// are set to zero.
   void get_eigenpair(PetscScalar& lr, PetscScalar& lc, Vec r, Vec c,
                      PetscInt i) const;
-
-  /// @brief Get the number of converged eigenvalues.
-  /// @return Number of converged eigenpairs available from
-  /// get_eigenvalue and get_eigenpair.
-  PetscInt get_number_converged() const;
 
   /// Sets the prefix used by PETSc when searching the PETSc options
   /// database

--- a/cpp/dolfinx/la/slepc.h
+++ b/cpp/dolfinx/la/slepc.h
@@ -9,7 +9,6 @@
 #ifdef HAS_SLEPC
 
 #include <complex>
-#include <cstdint>
 #include <dolfinx/common/MPI.h>
 #include <petscmat.h>
 #include <petscvec.h>
@@ -62,24 +61,26 @@ public:
   /// `nullptr` for a standard eigenvalue problem.
   void set_operators(const Mat A, const Mat B);
 
-  /// @brief Compute all eigenpairs of \f$A\f$ (solve
-  /// \f$A x = \lambda x\f$).
-  /// @note Requests as many eigenpairs as the global dimension of
-  /// \f$A\f$. Prefer solve(std::int64_t) with the number of
-  /// eigenpairs actually required.
+  /// @brief Solve the eigenvalue problem \f$A x = \lambda x\f$ (or
+  /// \f$A x = \lambda B x\f$).
+  /// @note The number of eigenpairs to compute, and every other solver
+  /// setting, is applied to the EPS object returned by eps(). SLEPc
+  /// sizes its working subspace from the requested number, which
+  /// defaults to one, e.g.
+  /// @code
+  /// SLEPcEigenSolver solver(comm);
+  /// solver.set_operators(A, nullptr);
+  /// EPSSetDimensions(solver.eps(), 5, PETSC_DETERMINE, PETSC_DETERMINE);
+  /// EPSSetWhichEigenpairs(solver.eps(), EPS_SMALLEST_REAL);
+  /// solver.solve();
+  /// @endcode
   void solve();
-
-  /// @brief Compute the `n` first eigenpairs of \f$A\f$ (solve
-  /// \f$A x = \lambda x\f$).
-  /// @param[in] n Number of eigenpairs to compute. Must be greater
-  /// than zero and at most the global dimension of \f$A\f$.
-  void solve(std::int64_t n);
 
   /// @brief Get the ith eigenvalue.
   /// @param[in] i Index of the eigenvalue, in
   /// `[0, get_number_converged())`.
   /// @return The eigenvalue.
-  std::complex<PetscReal> get_eigenvalue(std::int64_t i) const;
+  std::complex<PetscReal> get_eigenvalue(PetscInt i) const;
 
   /// @brief Get the ith eigenpair.
   /// @param[out] lr Real part of the eigenvalue.
@@ -92,16 +93,12 @@ public:
   /// eigenvector are held entirely in `lr` and `r`, and `lc` and `c`
   /// are set to zero.
   void get_eigenpair(PetscScalar& lr, PetscScalar& lc, Vec r, Vec c,
-                     std::int64_t i) const;
-
-  /// @brief Get the number of iterations used by the solver.
-  /// @return Iteration count of the last solve.
-  int get_iteration_number() const;
+                     PetscInt i) const;
 
   /// @brief Get the number of converged eigenvalues.
   /// @return Number of converged eigenpairs available from
   /// get_eigenvalue and get_eigenpair.
-  std::int64_t get_number_converged() const;
+  PetscInt get_number_converged() const;
 
   /// Sets the prefix used by PETSc when searching the PETSc options
   /// database
@@ -112,8 +109,8 @@ public:
   std::string get_options_prefix() const;
 
   /// @brief Set options from the PETSc options database.
-  /// @note Call after set_options_prefix and any settings the database
-  /// should override. `-eps_nev` has no effect; solve sets it.
+  /// @note Call after set_options_prefix and after any settings the
+  /// database should override.
   void set_from_options() const;
 
   /// Return SLEPc EPS pointer

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(
   graph.cpp
   vector.cpp
   matrix.cpp
+  slepc.cpp
   io.cpp
   common/CIFailure.cpp
   common/sub_systems_manager.cpp

--- a/cpp/test/slepc.cpp
+++ b/cpp/test/slepc.cpp
@@ -114,7 +114,8 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
 
     solver.solve();
 
-    const PetscInt nconv = solver.get_number_converged();
+    PetscInt nconv = 0;
+    EPSGetConverged(solver.eps(), &nconv);
     REQUIRE(nconv >= 3);
 
     // Spectrum is {1, ..., N}, so the three largest are N, N-1, N-2
@@ -143,6 +144,8 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
       VecDestroy(&c);
     }
 
+    // SLEPc rejects these itself; the point is that the return code is
+    // checked, so they throw rather than leaving the outputs untouched
     SECTION("Out-of-range indices throw rather than return garbage")
     {
       PetscScalar lr = 0, lc = 0;
@@ -169,7 +172,9 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
     EPSSetDimensions(solver.eps(), 2, PETSC_DETERMINE, PETSC_DETERMINE);
 
     solver.solve();
-    REQUIRE(solver.get_number_converged() >= 2);
+    PetscInt nconv = 0;
+    EPSGetConverged(solver.eps(), &nconv);
+    REQUIRE(nconv >= 2);
 
     // get_eigenvalue is independent of the PETSc scalar type: the pair
     // of largest magnitude is num_blocks(1 +/- i) in both real and
@@ -214,8 +219,8 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
 
   SECTION("Solving before setting operators throws")
   {
-    // Collective-safe: every rank evaluates the same condition and
-    // throws before entering any collective
+    // EPSSetUp raises the error on the EPS communicator, so every rank
+    // throws
     la::SLEPcEigenSolver solver(MPI_COMM_WORLD);
     CHECK_THROWS_AS(solver.solve(), std::runtime_error);
   }

--- a/cpp/test/slepc.cpp
+++ b/cpp/test/slepc.cpp
@@ -1,0 +1,253 @@
+// Copyright (C) 2026 Jack S. Hale
+//
+// This file is part of DOLFINx (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+//
+// Unit tests for la::SLEPcEigenSolver
+
+#ifdef HAS_SLEPC
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <dolfinx/la/slepc.h>
+#include <petscmat.h>
+#include <slepceps.h>
+#include <stdexcept>
+#include <utility>
+
+using namespace dolfinx;
+
+namespace
+{
+/// Create a distributed diagonal matrix with entries 1, 2, ..., N, so
+/// that the spectrum is known exactly.
+Mat create_diagonal_matrix(PetscInt N)
+{
+  Mat A = nullptr;
+  MatCreate(MPI_COMM_WORLD, &A);
+  MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, N, N);
+  MatSetType(A, MATAIJ);
+  MatSetUp(A);
+
+  PetscInt r0 = 0, r1 = 0;
+  MatGetOwnershipRange(A, &r0, &r1);
+  for (PetscInt i = r0; i < r1; ++i)
+  {
+    PetscScalar v = static_cast<PetscReal>(i + 1);
+    MatSetValues(A, 1, &i, 1, &i, &v, INSERT_VALUES);
+  }
+
+  MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
+  MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
+  return A;
+}
+
+/// Create a real non-symmetric block-diagonal matrix built from 2x2
+/// blocks [[a, -a], [a, a]] for a = 1, ..., num_blocks. Block a has the
+/// complex conjugate eigenvalue pair a(1 +/- i), so the spectrum is
+/// known exactly and the pair of largest magnitude is num_blocks(1 +/- i).
+Mat create_conjugate_pair_matrix(PetscInt num_blocks)
+{
+  const PetscInt N = 2 * num_blocks;
+  Mat A = nullptr;
+  MatCreate(MPI_COMM_WORLD, &A);
+  MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, N, N);
+  MatSetType(A, MATAIJ);
+  MatSeqAIJSetPreallocation(A, 2, nullptr);
+  MatMPIAIJSetPreallocation(A, 2, nullptr, 2, nullptr);
+
+  PetscInt r0 = 0, r1 = 0;
+  MatGetOwnershipRange(A, &r0, &r1);
+  for (PetscInt i = r0; i < r1; ++i)
+  {
+    const PetscInt block = i / 2;
+    const PetscScalar a = static_cast<PetscReal>(block + 1);
+    if (i % 2 == 0)
+    {
+      const PetscInt cols[2] = {i, i + 1};
+      const PetscScalar vals[2] = {a, -a};
+      MatSetValues(A, 1, &i, 2, cols, vals, INSERT_VALUES);
+    }
+    else
+    {
+      const PetscInt cols[2] = {i - 1, i};
+      const PetscScalar vals[2] = {a, a};
+      MatSetValues(A, 1, &i, 2, cols, vals, INSERT_VALUES);
+    }
+  }
+
+  MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
+  MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
+  return A;
+}
+} // namespace
+
+TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
+{
+  int argc = 0;
+  char** argv = nullptr;
+  REQUIRE(SlepcInitialize(&argc, &argv, nullptr, nullptr) == 0);
+
+  constexpr PetscInt N = 20;
+
+  SECTION("Solve a standard Hermitian eigenvalue problem")
+  {
+    Mat A = create_diagonal_matrix(N);
+    la::SLEPcEigenSolver solver(MPI_COMM_WORLD);
+    solver.set_operators(A, nullptr);
+
+    // Diagonal matrix is Hermitian; ask for the largest eigenvalues,
+    // which Krylov methods recover first
+    EPSSetProblemType(solver.eps(), EPS_HEP);
+    EPSSetWhichEigenpairs(solver.eps(), EPS_LARGEST_MAGNITUDE);
+
+    solver.solve(3);
+
+    const std::int64_t nconv = solver.get_number_converged();
+    REQUIRE(nconv >= 3);
+    CHECK(solver.get_iteration_number() > 0);
+
+    // Spectrum is {1, ..., N}, so the three largest are N, N-1, N-2
+    for (std::int64_t i = 0; i < 3; ++i)
+    {
+      std::complex<PetscReal> l = solver.get_eigenvalue(i);
+      CHECK_THAT(static_cast<double>(l.real()),
+                 Catch::Matchers::WithinAbs(static_cast<double>(N - i), 1e-8));
+      CHECK_THAT(static_cast<double>(l.imag()),
+                 Catch::Matchers::WithinAbs(0.0, 1e-8));
+    }
+
+    SECTION("Eigenpair matches eigenvalue")
+    {
+      Vec r = nullptr, c = nullptr;
+      MatCreateVecs(A, nullptr, &r);
+      MatCreateVecs(A, nullptr, &c);
+
+      PetscScalar lr = 0, lc = 0;
+      solver.get_eigenpair(lr, lc, r, c, 0);
+      CHECK_THAT(static_cast<double>(PetscRealPart(lr)),
+                 Catch::Matchers::WithinAbs(static_cast<double>(N), 1e-8));
+
+      VecDestroy(&r);
+      VecDestroy(&c);
+    }
+
+    SECTION("Out-of-range indices throw rather than return garbage")
+    {
+      PetscScalar lr = 0, lc = 0;
+      CHECK_THROWS_AS(solver.get_eigenvalue(-1), std::runtime_error);
+      CHECK_THROWS_AS(solver.get_eigenvalue(nconv), std::runtime_error);
+      CHECK_THROWS_AS(solver.get_eigenpair(lr, lc, nullptr, nullptr, -1),
+                      std::runtime_error);
+      CHECK_THROWS_AS(solver.get_eigenpair(lr, lc, nullptr, nullptr, nconv),
+                      std::runtime_error);
+    }
+
+    MatDestroy(&A);
+  }
+
+  SECTION("Complex conjugate eigenpair of a non-symmetric operator")
+  {
+    constexpr PetscInt num_blocks = 3;
+    Mat A = create_conjugate_pair_matrix(num_blocks);
+    la::SLEPcEigenSolver solver(MPI_COMM_WORLD);
+    solver.set_operators(A, nullptr);
+
+    EPSSetProblemType(solver.eps(), EPS_NHEP);
+    EPSSetWhichEigenpairs(solver.eps(), EPS_LARGEST_MAGNITUDE);
+
+    solver.solve(2);
+    REQUIRE(solver.get_number_converged() >= 2);
+
+    // get_eigenvalue is independent of the PETSc scalar type: the pair
+    // of largest magnitude is num_blocks(1 +/- i) in both real and
+    // complex builds
+    constexpr double expected = static_cast<double>(num_blocks);
+    std::complex<PetscReal> l0 = solver.get_eigenvalue(0);
+    std::complex<PetscReal> l1 = solver.get_eigenvalue(1);
+    for (std::complex<PetscReal> l : {l0, l1})
+    {
+      CHECK_THAT(static_cast<double>(l.real()),
+                 Catch::Matchers::WithinAbs(expected, 1e-8));
+      CHECK_THAT(std::abs(static_cast<double>(l.imag())),
+                 Catch::Matchers::WithinAbs(expected, 1e-8));
+    }
+
+    // A conjugate pair, so the imaginary parts have opposite signs
+    CHECK(l0.imag() * l1.imag() < 0);
+
+    SECTION("Raw eigenpair storage follows the PETSc scalar type")
+    {
+      PetscScalar lr = 0, lc = 0;
+      solver.get_eigenpair(lr, lc, nullptr, nullptr, 0);
+#ifdef PETSC_USE_COMPLEX
+      // Eigenvalue held entirely in lr, and lc set to zero
+      CHECK_THAT(std::abs(static_cast<double>(PetscImaginaryPart(lr))),
+                 Catch::Matchers::WithinAbs(expected, 1e-8));
+      CHECK_THAT(static_cast<double>(PetscRealPart(lc)),
+                 Catch::Matchers::WithinAbs(0.0, 1e-12));
+      CHECK_THAT(static_cast<double>(PetscImaginaryPart(lc)),
+                 Catch::Matchers::WithinAbs(0.0, 1e-12));
+#else
+      // Real scalars split the pair across lr and lc
+      CHECK_THAT(static_cast<double>(lr),
+                 Catch::Matchers::WithinAbs(expected, 1e-8));
+      CHECK_THAT(std::abs(static_cast<double>(lc)),
+                 Catch::Matchers::WithinAbs(expected, 1e-8));
+#endif
+    }
+
+    MatDestroy(&A);
+  }
+
+  SECTION("Requesting a non-positive number of eigenpairs throws")
+  {
+    Mat A = create_diagonal_matrix(N);
+    la::SLEPcEigenSolver solver(MPI_COMM_WORLD);
+    solver.set_operators(A, nullptr);
+
+    // Collective-safe: every rank evaluates the same condition and
+    // throws before entering any collective
+    CHECK_THROWS_AS(solver.solve(0), std::runtime_error);
+    CHECK_THROWS_AS(solver.solve(-1), std::runtime_error);
+
+    MatDestroy(&A);
+  }
+
+  SECTION("Solving before setting operators throws")
+  {
+    la::SLEPcEigenSolver solver(MPI_COMM_WORLD);
+    CHECK_THROWS_AS(solver.solve(), std::runtime_error);
+  }
+
+  SECTION("Options prefix round-trips and is empty when unset")
+  {
+    la::SLEPcEigenSolver solver(MPI_COMM_WORLD);
+
+    // Must not dereference a null prefix
+    CHECK(solver.get_options_prefix().empty());
+
+    solver.set_options_prefix("mysolver_");
+    CHECK(solver.get_options_prefix() == "mysolver_");
+  }
+
+  SECTION("Wrapping a null EPS throws")
+  {
+    CHECK_THROWS_AS(la::SLEPcEigenSolver(nullptr, true), std::runtime_error);
+  }
+
+  SECTION("Move leaves the source safe to destroy")
+  {
+    la::SLEPcEigenSolver a(MPI_COMM_WORLD);
+    EPS raw = a.eps();
+    la::SLEPcEigenSolver b(std::move(a));
+    CHECK(b.eps() == raw);
+    CHECK(a.eps() == nullptr);
+  }
+}
+
+#endif

--- a/cpp/test/slepc.cpp
+++ b/cpp/test/slepc.cpp
@@ -14,6 +14,7 @@
 #include <complex>
 #include <cstdint>
 #include <dolfinx/la/slepc.h>
+#include <limits>
 #include <petscmat.h>
 #include <slepceps.h>
 #include <stdexcept>
@@ -23,6 +24,12 @@ using namespace dolfinx;
 
 namespace
 {
+/// Relative tolerance on computed eigenvalues. Both test matrices are
+/// normal, so the eigenvalue error is bounded by the residual the
+/// solver stops at, which is looser in single precision.
+constexpr double eig_rtol
+    = std::numeric_limits<PetscReal>::epsilon() < 1e-10 ? 1e-8 : 1e-5;
+
 /// Create a distributed diagonal matrix with entries 1, 2, ..., N, so
 /// that the spectrum is known exactly.
 Mat create_diagonal_matrix(PetscInt N)
@@ -115,10 +122,11 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
     for (std::int64_t i = 0; i < 3; ++i)
     {
       std::complex<PetscReal> l = solver.get_eigenvalue(i);
-      CHECK_THAT(static_cast<double>(l.real()),
-                 Catch::Matchers::WithinAbs(static_cast<double>(N - i), 1e-8));
+      CHECK_THAT(
+          static_cast<double>(l.real()),
+          Catch::Matchers::WithinRel(static_cast<double>(N - i), eig_rtol));
       CHECK_THAT(static_cast<double>(l.imag()),
-                 Catch::Matchers::WithinAbs(0.0, 1e-8));
+                 Catch::Matchers::WithinAbs(0.0, 1e-12));
     }
 
     SECTION("Eigenpair matches eigenvalue")
@@ -130,7 +138,7 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
       PetscScalar lr = 0, lc = 0;
       solver.get_eigenpair(lr, lc, r, c, 0);
       CHECK_THAT(static_cast<double>(PetscRealPart(lr)),
-                 Catch::Matchers::WithinAbs(static_cast<double>(N), 1e-8));
+                 Catch::Matchers::WithinRel(static_cast<double>(N), eig_rtol));
 
       VecDestroy(&r);
       VecDestroy(&c);
@@ -172,9 +180,9 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
     for (std::complex<PetscReal> l : {l0, l1})
     {
       CHECK_THAT(static_cast<double>(l.real()),
-                 Catch::Matchers::WithinAbs(expected, 1e-8));
+                 Catch::Matchers::WithinRel(expected, eig_rtol));
       CHECK_THAT(std::abs(static_cast<double>(l.imag())),
-                 Catch::Matchers::WithinAbs(expected, 1e-8));
+                 Catch::Matchers::WithinRel(expected, eig_rtol));
     }
 
     // A conjugate pair, so the imaginary parts have opposite signs
@@ -187,7 +195,7 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
 #ifdef PETSC_USE_COMPLEX
       // Eigenvalue held entirely in lr, and lc set to zero
       CHECK_THAT(std::abs(static_cast<double>(PetscImaginaryPart(lr))),
-                 Catch::Matchers::WithinAbs(expected, 1e-8));
+                 Catch::Matchers::WithinRel(expected, eig_rtol));
       CHECK_THAT(static_cast<double>(PetscRealPart(lc)),
                  Catch::Matchers::WithinAbs(0.0, 1e-12));
       CHECK_THAT(static_cast<double>(PetscImaginaryPart(lc)),
@@ -195,9 +203,9 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
 #else
       // Real scalars split the pair across lr and lc
       CHECK_THAT(static_cast<double>(lr),
-                 Catch::Matchers::WithinAbs(expected, 1e-8));
+                 Catch::Matchers::WithinRel(expected, eig_rtol));
       CHECK_THAT(std::abs(static_cast<double>(lc)),
-                 Catch::Matchers::WithinAbs(expected, 1e-8));
+                 Catch::Matchers::WithinRel(expected, eig_rtol));
 #endif
     }
 

--- a/cpp/test/slepc.cpp
+++ b/cpp/test/slepc.cpp
@@ -12,7 +12,6 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <cmath>
 #include <complex>
-#include <cstdint>
 #include <dolfinx/la/slepc.h>
 #include <limits>
 #include <petscmat.h>
@@ -111,15 +110,15 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
     // which Krylov methods recover first
     EPSSetProblemType(solver.eps(), EPS_HEP);
     EPSSetWhichEigenpairs(solver.eps(), EPS_LARGEST_MAGNITUDE);
+    EPSSetDimensions(solver.eps(), 3, PETSC_DETERMINE, PETSC_DETERMINE);
 
-    solver.solve(3);
+    solver.solve();
 
-    const std::int64_t nconv = solver.get_number_converged();
+    const PetscInt nconv = solver.get_number_converged();
     REQUIRE(nconv >= 3);
-    CHECK(solver.get_iteration_number() > 0);
 
     // Spectrum is {1, ..., N}, so the three largest are N, N-1, N-2
-    for (std::int64_t i = 0; i < 3; ++i)
+    for (PetscInt i = 0; i < 3; ++i)
     {
       std::complex<PetscReal> l = solver.get_eigenvalue(i);
       CHECK_THAT(
@@ -167,8 +166,9 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
 
     EPSSetProblemType(solver.eps(), EPS_NHEP);
     EPSSetWhichEigenpairs(solver.eps(), EPS_LARGEST_MAGNITUDE);
+    EPSSetDimensions(solver.eps(), 2, PETSC_DETERMINE, PETSC_DETERMINE);
 
-    solver.solve(2);
+    solver.solve();
     REQUIRE(solver.get_number_converged() >= 2);
 
     // get_eigenvalue is independent of the PETSc scalar type: the pair
@@ -212,22 +212,10 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
     MatDestroy(&A);
   }
 
-  SECTION("Requesting a non-positive number of eigenpairs throws")
-  {
-    Mat A = create_diagonal_matrix(N);
-    la::SLEPcEigenSolver solver(MPI_COMM_WORLD);
-    solver.set_operators(A, nullptr);
-
-    // Collective-safe: every rank evaluates the same condition and
-    // throws before entering any collective
-    CHECK_THROWS_AS(solver.solve(0), std::runtime_error);
-    CHECK_THROWS_AS(solver.solve(-1), std::runtime_error);
-
-    MatDestroy(&A);
-  }
-
   SECTION("Solving before setting operators throws")
   {
+    // Collective-safe: every rank evaluates the same condition and
+    // throws before entering any collective
     la::SLEPcEigenSolver solver(MPI_COMM_WORLD);
     CHECK_THROWS_AS(solver.solve(), std::runtime_error);
   }


### PR DESCRIPTION
`la::SLEPcEigenSolver` dropped the return code of nearly every SLEPc call. SLEPc
signals failure through the return code and leaves its output arguments
untouched, so each dropped code turned a diagnosable error into an indeterminate
value:

- `get_eigenvalue`, `get_eigenpair` and `get_number_converged` read an
  uninitialised `PetscInt` when `EPSGetConverged` failed, which it does via
  `EPSCheckSolved` if `EPSSolve` has not been called.
- `solve()` called `MatGetSize` on the null `Mat` that `EPSGetOperators` returns
  when no operators have been set (`if (k<1) *A = NULL;`).
  `PetscValidHeaderSpecific` compiles to a no-op in optimised PETSc builds, so
  this was a null dereference rather than a clean error.
- The `EPSType` from `EPSGetType` was formatted without a null check; it is null
  until `EPSSetUp` has run.
- `get_options_prefix` constructed a `std::string` from the null pointer
  `PetscObjectGetOptionsPrefix` returns when no prefix is set (`*prefix =
  obj->prefix;`, null by default).

Every return code is now checked with the `CHECK_ERROR` macro already used in
`petsc.cpp`, which routes the code to `petsc::error` and throws
`std::runtime_error`. The null-prefix bug is fixed in `petsc::Vector`,
`petsc::Matrix` and `petsc::KrylovSolver` too.

Checking the return code is sufficient for the argument errors SLEPc already
detects, so the class does not add its own guards:
`EPSGetEigenvalue`/`EPSGetEigenpair` call `EPSCheckSolved` and bounds check the
index, and `EPSSetUp` errors with "EPSSetOperators must be called first". These
use `PetscCheck`, which — unlike `PetscValidHeaderSpecific` — is unconditional,
so they hold in optimised builds.

### Behaviour change

`solve()` no longer calls `EPSSetFromOptions`. It ran *after* all user
configuration, so the options database overrode anything applied between
construction and the solve — and because `EPSSetFromOptions` applies `-eps_nev`
via `EPSSetDimensions`, `-eps_nev 10` silently overrode a requested three
eigenpairs. Callers wanting database options call `set_from_options()`
themselves, after `set_options_prefix()` and after any settings the database
should override.

### API changes

Following review, the class is trimmed to what actually earns a wrapper: `EPS`
lifetime management, hiding `char*` behind `std::string`, and normalising the
real/complex split in `get_eigenvalue`.

- `get_eigenvalue` and `get_eigenpair` take `PetscInt` rather than `int`, and
  `solve` no longer takes a count. `PetscInt` removes a `static_cast` at every
  SLEPc call and matches the `PetscScalar`/`Mat`/`Vec` already in these
  signatures. The fixed-width rule in `AGENTS.md` governs DOLFINx entity indices,
  not arguments handed straight to PETSc; `AGENTS.md` now records the
  distinction.
- `get_iteration_number` is removed — a passthrough to `EPSGetIterationNumber`
  that manages nothing and saves no boilerplate. The iteration count is still
  logged after a solve.
- `get_number_converged` is removed. It existed to bound a loop over
  `get_eigenvalue`; `EPSGetConverged(solver.eps(), &nconv)` does that directly,
  and the accessor documentation points at it.
- `solve(n)` is removed in favour of a bare `solve()`. Setting `nev` behind the
  caller's back clobbered a programmatic `EPSSetDimensions` on `eps()`, and the
  no-argument overload requested as many eigenpairs as the global dimension of
  `A`, which sized SLEPc's working subspace to match. Dimensions are now set on
  `eps()` like every other solver option:

  ```cpp
  SLEPcEigenSolver solver(comm);
  solver.set_operators(A, nullptr);
  EPSSetDimensions(solver.eps(), 5, PETSC_DETERMINE, PETSC_DETERMINE);
  EPSSetWhichEigenpairs(solver.eps(), EPS_SMALLEST_REAL);
  solver.solve();
  ```

The class has no in-tree callers, no Python binding and no demo, so the practical
impact of the removals is nil. Exposing it through nanobind is not proposed —
`slepc4py` covers Python.

### Testing

Adds `cpp/test/slepc.cpp`, the first test coverage for this class: a Hermitian
problem with a known spectrum, a non-symmetric operator with a known complex
conjugate pair (checking that `get_eigenvalue` is independent of the PETSc scalar
type while raw `get_eigenpair` storage is not), and the error paths above. Passes
at np = 1, 2, 3, and on the real and complex CI legs.

Reverting `slepc.h`/`slepc.cpp` to their previous state fails six assertions and
aborts in `get_options_prefix` with libc++'s
`basic_string(const char*) detected nullptr` hardening assertion, so the test does
exercise the fixes.

---

AI assistance: I used Claude Opus 5 (Claude Code) to draft parts of this PR. I
reviewed, edited, tested, and take responsibility for the final contribution.
