### PR TITLE
Use wheel.exclude rather than sdist.exclude for wrapper sources

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -87,7 +87,7 @@ ci = [
 
 [tool.scikit-build]
 wheel.packages = ["dolfinx"]
-sdist.exclude = ["*.cpp"]
+wheel.exclude = ["*.cpp"]
 cmake.build-type = "Release"
 
 [tool.scikit-build.cmake.define]


### PR DESCRIPTION
`sdist.exclude = ["*.cpp"]` removed the twelve nanobind wrapper sources from the sdist, not just from the wheel. Since `nanobind_add_module()` refers to them by name, an sdist built this way cannot be compiled. No sdist has ever been shipped, so nothing already published is affected — this is latent rather than live. `wheel.exclude` keeps the sources out of the wheel, which is what was intended, while leaving the sdist buildable.

Verified by building both artefacts before and after: the sdist goes from 0 to all 12 `dolfinx/wrappers/*.cpp`, the wheel still ships none, and the 16 `dolfinx_wrappers/*.h` headers are present in both as before.

Found while making the equivalent split in Basix (FEniCS/basix#1064).

🤖 Generated with [Claude Code](https://claude.com/claude-code)