### PR TITLE
Use RelWithDebInfo rather than RelWithDebug when building wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -201,7 +201,7 @@ jobs:
             cmake -G Ninja -S dolfinx/cpp -B dolfinx-build-dir/ \
               -DPython3_EXECUTABLE=$(which python) \
               -DCMAKE_PREFIX_PATH=/usr/lib64/mpich \
-              -DCMAKE_BUILD_TYPE=RelWithDebug \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               -DDOLFINX_ENABLE_SUPERLU_DIST=ON \
               -DDOLFINX_ENABLE_SCOTCH=ON \
               -DDOLFINX_ENABLE_PARMETIS=OFF &&
@@ -240,7 +240,7 @@ jobs:
               -DDOLFINX_ENABLE_SCOTCH=ON \
               -DDOLFINX_ENABLE_PARMETIS=OFF \
               -DDOLFINX_ENABLE_SUPERLU_DIST=ON \
-              -DCMAKE_BUILD_TYPE=RelWithDebug &&
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo &&
             cmake --build $GITHUB_WORKSPACE/dolfinx-build-dir/ &&
             sudo cmake --install dolfinx-build-dir/
           # As of 6/26 DOLFINx uses std::jthread which is only officially


### PR DESCRIPTION
`RelWithDebug` is not a CMake build type — the standard name is `RelWithDebInfo`. Because `CMAKE_CXX_FLAGS_RELWITHDEBUG` does not exist, the C++ library has been built for the Linux (`build-wheels.yml:204`) and macOS (`:243`) wheels with no optimisation flags at all.

Worth a second opinion on the target: `RelWithDebInfo` is the faithful reading of the original intent, but it adds `-g` and will noticeably grow the wheels. If the intent was simply "optimised", plain `Release` is the better choice — a one-word change either way.

Found while fixing the same mistake in Basix's install docs (FEniCS/basix#1065).

🤖 Generated with [Claude Code](https://claude.com/claude-code)