### PR TITLE
Fix null-handle and dead operator checks in the PETSc wrappers

### DIFF
--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -747,7 +747,7 @@ void petsc::KrylovSolver::set_operators(const Mat A, const Mat P)
     petsc::error(ierr, __FILE__, "KSPSetOperators");
 }
 //-----------------------------------------------------------------------------
-int petsc::KrylovSolver::solve(Vec x, const Vec b, bool transpose) const
+PetscInt petsc::KrylovSolver::solve(Vec x, const Vec b, bool transpose) const
 {
   common::Timer timer("PETSc Krylov solver");
   assert(_ksp);

--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -451,9 +451,14 @@ petsc::Vector::Vector(const common::IndexMap& map, int bs)
 //-----------------------------------------------------------------------------
 petsc::Vector::Vector(Vec x, bool inc_ref_count) : _x(x)
 {
-  assert(x);
+  if (!_x)
+    throw std::runtime_error("PETSc Vec must be initialised before wrapping");
+
   if (inc_ref_count)
-    PetscObjectReference((PetscObject)_x);
+  {
+    PetscErrorCode ierr = PetscObjectReference((PetscObject)_x);
+    CHECK_ERROR("PetscObjectReference");
+  }
 }
 //-----------------------------------------------------------------------------
 petsc::Vector::Vector(Vector&& v) noexcept : _x(std::exchange(v._x, nullptr)) {}
@@ -546,9 +551,14 @@ Vec petsc::Vector::vec() const { return _x; }
 //-----------------------------------------------------------------------------
 petsc::Operator::Operator(Mat A, bool inc_ref_count) : _matA(A)
 {
-  assert(A);
+  if (!_matA)
+    throw std::runtime_error("PETSc Mat must be initialised before wrapping");
+
   if (inc_ref_count)
-    PetscObjectReference((PetscObject)_matA);
+  {
+    PetscErrorCode ierr = PetscObjectReference((PetscObject)_matA);
+    CHECK_ERROR("PetscObjectReference");
+  }
 }
 //-----------------------------------------------------------------------------
 petsc::Operator::Operator(Operator&& A) noexcept
@@ -697,12 +707,13 @@ petsc::KrylovSolver::KrylovSolver(MPI_Comm comm) : _ksp(nullptr)
 //-----------------------------------------------------------------------------
 petsc::KrylovSolver::KrylovSolver(KSP ksp, bool inc_ref_count) : _ksp(ksp)
 {
-  assert(_ksp);
+  if (!_ksp)
+    throw std::runtime_error("PETSc KSP must be initialised before wrapping");
+
   if (inc_ref_count)
   {
     PetscErrorCode ierr = PetscObjectReference((PetscObject)_ksp);
-    if (ierr != 0)
-      petsc::error(ierr, __FILE__, "PetscObjectReference");
+    CHECK_ERROR("PetscObjectReference");
   }
 }
 //-----------------------------------------------------------------------------
@@ -739,38 +750,31 @@ void petsc::KrylovSolver::set_operators(const Mat A, const Mat P)
 int petsc::KrylovSolver::solve(Vec x, const Vec b, bool transpose) const
 {
   common::Timer timer("PETSc Krylov solver");
+  assert(_ksp);
   assert(x);
   assert(b);
 
-  // Get PETSc operators
-  Mat _A, _P;
-  KSPGetOperators(_ksp, &_A, &_P);
-  assert(_A);
-
   PetscErrorCode ierr;
 
-  // Solve linear system
+  // Solve linear system. With no operator set, PCGetOperators creates an
+  // untyped Mat and setup fails on it, so KSPSolve errors rather than
+  // silently solving
   spdlog::info("PETSc Krylov solver starting to solve system.");
-
-  // Solve system
   if (!transpose)
   {
     ierr = KSPSolve(_ksp, b, x);
-    if (ierr != 0)
-      petsc::error(ierr, __FILE__, "KSPSolve");
+    CHECK_ERROR("KSPSolve");
   }
   else
   {
     ierr = KSPSolveTranspose(_ksp, b, x);
-    if (ierr != 0)
-      petsc::error(ierr, __FILE__, "KSPSolve");
+    CHECK_ERROR("KSPSolveTranspose");
   }
 
   // Get the number of iterations
   PetscInt num_iterations = 0;
   ierr = KSPGetIterationNumber(_ksp, &num_iterations);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "KSPGetIterationNumber");
+  CHECK_ERROR("KSPGetIterationNumber");
 
   // Check if the solution converged and warn if not. Note: this does
   // not throw on non-convergence -- the caller is responsible for

--- a/cpp/dolfinx/la/petsc.h
+++ b/cpp/dolfinx/la/petsc.h
@@ -509,7 +509,7 @@ public:
   /// = b if transpose is true). Non-convergence is not treated as an
   /// error by this function (a warning is logged); use ksp() and
   /// KSPGetConvergedReason to check the outcome if required.
-  int solve(Vec x, const Vec b, bool transpose = false) const;
+  PetscInt solve(Vec x, const Vec b, bool transpose = false) const;
 
   /// Sets the prefix used by PETSc when searching the PETSc options
   /// database

--- a/cpp/dolfinx/la/petsc.h
+++ b/cpp/dolfinx/la/petsc.h
@@ -252,7 +252,12 @@ private:
 class Operator
 {
 public:
-  /// Constructor
+  /// @brief Create operator wrapper of a PETSc Mat object.
+  /// @param[in] A PETSc Mat object, which must already have been
+  /// created. The reference count of `A` is always decreased when this
+  /// Operator is destroyed.
+  /// @param[in] inc_ref_count True if the reference count of `A` should
+  /// be incremented.
   Operator(Mat A, bool inc_ref_count);
 
   // Copy constructor (deleted)
@@ -467,13 +472,16 @@ public:
 class KrylovSolver
 {
 public:
-  /// Create Krylov solver for a particular method and named
-  /// preconditioner
+  /// @brief Create a Krylov solver.
+  /// @param[in] comm MPI communicator.
   explicit KrylovSolver(MPI_Comm comm);
 
-  /// Create solver wrapper of a PETSc KSP object
-  /// @param[in] ksp The PETSc KSP object. It should already have been created
-  /// @param[in] inc_ref_count Increment the reference count on `ksp` if true
+  /// @brief Create solver wrapper of a PETSc KSP object.
+  /// @param[in] ksp PETSc KSP object, which must already have been
+  /// created. The reference count of `ksp` is always decreased when this
+  /// KrylovSolver is destroyed.
+  /// @param[in] inc_ref_count True if the reference count of `ksp`
+  /// should be incremented.
   KrylovSolver(KSP ksp, bool inc_ref_count);
 
   // Copy constructor (deleted)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(
   graph.cpp
   vector.cpp
   matrix.cpp
+  petsc.cpp
   io.cpp
   common/CIFailure.cpp
   common/sub_systems_manager.cpp

--- a/cpp/test/petsc.cpp
+++ b/cpp/test/petsc.cpp
@@ -82,7 +82,7 @@ TEST_CASE("PETSc Krylov solver", "[petsc]")
     PetscReal norm = 0;
     VecAXPY(x, -1.0, b);
     VecNorm(x, NORM_2, &norm);
-    CHECK(static_cast<double>(norm) < 1e-10);
+    CHECK(norm < 100 * PETSC_SMALL);
 
     VecDestroy(&x);
     VecDestroy(&b);

--- a/cpp/test/petsc.cpp
+++ b/cpp/test/petsc.cpp
@@ -1,0 +1,124 @@
+// Copyright (C) 2026 Jack S. Hale
+//
+// This file is part of DOLFINx (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+//
+// Unit tests for the la::petsc wrappers
+
+#ifdef HAS_PETSC
+
+#include <catch2/catch_test_macros.hpp>
+#include <dolfinx/la/petsc.h>
+#include <petscksp.h>
+#include <petscmat.h>
+#include <petscvec.h>
+#include <stdexcept>
+#include <utility>
+
+using namespace dolfinx;
+
+namespace
+{
+/// PetscInitialize returns immediately if PETSc is already initialised
+void init_petsc()
+{
+  int argc = 0;
+  char** argv = nullptr;
+  REQUIRE(PetscInitialize(&argc, &argv, nullptr, nullptr) == 0);
+}
+} // namespace
+
+TEST_CASE("PETSc wrappers reject null handles", "[petsc]")
+{
+  init_petsc();
+
+  // Wrapping a null handle stored it and then dereferenced it in
+  // PetscObjectReference, where PetscValidHeaderSpecific is a no-op in
+  // optimised PETSc builds
+  CHECK_THROWS_AS(la::petsc::Vector(nullptr, true), std::runtime_error);
+  CHECK_THROWS_AS(la::petsc::Operator(nullptr, true), std::runtime_error);
+  CHECK_THROWS_AS(la::petsc::KrylovSolver(nullptr, true), std::runtime_error);
+
+  // inc_ref_count = false takes the same path
+  CHECK_THROWS_AS(la::petsc::KrylovSolver(nullptr, false), std::runtime_error);
+}
+
+TEST_CASE("PETSc Krylov solver", "[petsc]")
+{
+  init_petsc();
+
+  constexpr PetscInt N = 10;
+
+  // Identity matrix, so the solution of Ax = b is b
+  Mat A = nullptr;
+  MatCreate(MPI_COMM_WORLD, &A);
+  MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, N, N);
+  MatSetType(A, MATAIJ);
+  MatSetUp(A);
+  PetscInt r0 = 0, r1 = 0;
+  MatGetOwnershipRange(A, &r0, &r1);
+  for (PetscInt i = r0; i < r1; ++i)
+  {
+    PetscScalar v = 1.0;
+    MatSetValues(A, 1, &i, 1, &i, &v, INSERT_VALUES);
+  }
+  MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
+  MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
+
+  SECTION("Solve returns the iteration count")
+  {
+    la::petsc::KrylovSolver solver(MPI_COMM_WORLD);
+    solver.set_operator(A);
+
+    Vec x = nullptr, b = nullptr;
+    MatCreateVecs(A, &x, &b);
+    VecSet(b, 1.0);
+
+    int num_it = solver.solve(x, b, false);
+    CHECK(num_it >= 0);
+
+    // A is the identity, so x == b
+    PetscReal norm = 0;
+    VecAXPY(x, -1.0, b);
+    VecNorm(x, NORM_2, &norm);
+    CHECK(static_cast<double>(norm) < 1e-10);
+
+    VecDestroy(&x);
+    VecDestroy(&b);
+  }
+
+  SECTION("Solving before setting an operator throws")
+  {
+    // KSPGetOperators cannot detect this: PCGetOperators creates an
+    // empty Mat when none is set, so it never reports null. The error
+    // comes from KSPSolve failing on that untyped Mat
+    la::petsc::KrylovSolver solver(MPI_COMM_WORLD);
+    Vec x = nullptr, b = nullptr;
+    MatCreateVecs(A, &x, &b);
+    VecSet(b, 1.0);
+    CHECK_THROWS_AS(solver.solve(x, b, false), std::runtime_error);
+    VecDestroy(&x);
+    VecDestroy(&b);
+  }
+
+  SECTION("Options prefix round-trips")
+  {
+    la::petsc::KrylovSolver solver(MPI_COMM_WORLD);
+    solver.set_options_prefix("mysolver_");
+    CHECK(solver.get_options_prefix() == "mysolver_");
+  }
+
+  SECTION("Move leaves the source safe to destroy")
+  {
+    la::petsc::KrylovSolver a(MPI_COMM_WORLD);
+    KSP raw = a.ksp();
+    la::petsc::KrylovSolver b(std::move(a));
+    CHECK(b.ksp() == raw);
+    CHECK(a.ksp() == nullptr);
+  }
+
+  MatDestroy(&A);
+}
+
+#endif

--- a/cpp/test/petsc.cpp
+++ b/cpp/test/petsc.cpp
@@ -35,13 +35,95 @@ TEST_CASE("PETSc wrappers reject null handles", "[petsc]")
 
   // Wrapping a null handle stored it and then dereferenced it in
   // PetscObjectReference, where PetscValidHeaderSpecific is a no-op in
-  // optimised PETSc builds
+  // optimised PETSc builds. The null check happens before inc_ref_count
+  // is examined, so both values must be rejected.
   CHECK_THROWS_AS(la::petsc::Vector(nullptr, true), std::runtime_error);
+  CHECK_THROWS_AS(la::petsc::Vector(nullptr, false), std::runtime_error);
   CHECK_THROWS_AS(la::petsc::Operator(nullptr, true), std::runtime_error);
+  CHECK_THROWS_AS(la::petsc::Operator(nullptr, false), std::runtime_error);
   CHECK_THROWS_AS(la::petsc::KrylovSolver(nullptr, true), std::runtime_error);
-
-  // inc_ref_count = false takes the same path
   CHECK_THROWS_AS(la::petsc::KrylovSolver(nullptr, false), std::runtime_error);
+}
+
+TEST_CASE("PETSc wrappers manage reference counts", "[petsc]")
+{
+  init_petsc();
+
+  PetscInt refs = 0;
+
+  SECTION("Operator, inc_ref_count = true shares ownership")
+  {
+    Mat A = nullptr;
+    CHECK(MatCreate(MPI_COMM_WORLD, &A) == 0);
+    CHECK(MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, 1, 1) == 0);
+    CHECK(MatSetType(A, MATAIJ) == 0);
+    CHECK(MatSetUp(A) == 0);
+    CHECK(MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY) == 0);
+    CHECK(MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY) == 0);
+
+    {
+      la::petsc::Operator op(A, true);
+      CHECK(PetscObjectGetReference((PetscObject)A, &refs) == 0);
+      CHECK(refs == 2);
+    }
+
+    // Wrapper released its share; A must still be alive and usable
+    CHECK(PetscObjectGetReference((PetscObject)A, &refs) == 0);
+    CHECK(refs == 1);
+    CHECK(MatDestroy(&A) == 0);
+  }
+
+  SECTION("Operator, inc_ref_count = false takes ownership")
+  {
+    Mat A = nullptr;
+    CHECK(MatCreate(MPI_COMM_WORLD, &A) == 0);
+    CHECK(MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, 1, 1) == 0);
+    CHECK(MatSetType(A, MATAIJ) == 0);
+    CHECK(MatSetUp(A) == 0);
+    CHECK(MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY) == 0);
+    CHECK(MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY) == 0);
+
+    // No caller-side reference remains once the wrapper is constructed;
+    // destroying it must be the only thing that frees A (nothing left
+    // here to double-destroy).
+    la::petsc::Operator op(A, false);
+    CHECK(PetscObjectGetReference((PetscObject)op.mat(), &refs) == 0);
+    CHECK(refs == 1);
+  }
+
+  SECTION("Vector, inc_ref_count = true shares ownership")
+  {
+    Vec x = nullptr;
+    CHECK(VecCreate(MPI_COMM_WORLD, &x) == 0);
+    CHECK(VecSetSizes(x, PETSC_DECIDE, 1) == 0);
+    CHECK(VecSetFromOptions(x) == 0);
+
+    {
+      la::petsc::Vector v(x, true);
+      CHECK(PetscObjectGetReference((PetscObject)x, &refs) == 0);
+      CHECK(refs == 2);
+    }
+
+    CHECK(PetscObjectGetReference((PetscObject)x, &refs) == 0);
+    CHECK(refs == 1);
+    CHECK(VecDestroy(&x) == 0);
+  }
+
+  SECTION("KrylovSolver, inc_ref_count = true shares ownership")
+  {
+    KSP ksp = nullptr;
+    CHECK(KSPCreate(MPI_COMM_WORLD, &ksp) == 0);
+
+    {
+      la::petsc::KrylovSolver solver(ksp, true);
+      CHECK(PetscObjectGetReference((PetscObject)ksp, &refs) == 0);
+      CHECK(refs == 2);
+    }
+
+    CHECK(PetscObjectGetReference((PetscObject)ksp, &refs) == 0);
+    CHECK(refs == 1);
+    CHECK(KSPDestroy(&ksp) == 0);
+  }
 }
 
 TEST_CASE("PETSc Krylov solver", "[petsc]")
@@ -52,19 +134,19 @@ TEST_CASE("PETSc Krylov solver", "[petsc]")
 
   // Identity matrix, so the solution of Ax = b is b
   Mat A = nullptr;
-  MatCreate(MPI_COMM_WORLD, &A);
-  MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, N, N);
-  MatSetType(A, MATAIJ);
-  MatSetUp(A);
+  CHECK(MatCreate(MPI_COMM_WORLD, &A) == 0);
+  CHECK(MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, N, N) == 0);
+  CHECK(MatSetType(A, MATAIJ) == 0);
+  CHECK(MatSetUp(A) == 0);
   PetscInt r0 = 0, r1 = 0;
-  MatGetOwnershipRange(A, &r0, &r1);
+  CHECK(MatGetOwnershipRange(A, &r0, &r1) == 0);
   for (PetscInt i = r0; i < r1; ++i)
   {
     PetscScalar v = 1.0;
-    MatSetValues(A, 1, &i, 1, &i, &v, INSERT_VALUES);
+    CHECK(MatSetValues(A, 1, &i, 1, &i, &v, INSERT_VALUES) == 0);
   }
-  MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
-  MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
+  CHECK(MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY) == 0);
+  CHECK(MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY) == 0);
 
   SECTION("Solve returns the iteration count")
   {
@@ -72,20 +154,117 @@ TEST_CASE("PETSc Krylov solver", "[petsc]")
     solver.set_operator(A);
 
     Vec x = nullptr, b = nullptr;
-    MatCreateVecs(A, &x, &b);
-    VecSet(b, 1.0);
+    CHECK(MatCreateVecs(A, &x, &b) == 0);
+    CHECK(VecSet(b, 1.0) == 0);
 
     PetscInt num_it = solver.solve(x, b, false);
     CHECK(num_it >= 0);
 
     // A is the identity, so x == b
     PetscReal norm = 0;
-    VecAXPY(x, -1.0, b);
-    VecNorm(x, NORM_2, &norm);
+    CHECK(VecAXPY(x, -1.0, b) == 0);
+    CHECK(VecNorm(x, NORM_2, &norm) == 0);
     CHECK(norm < 100 * PETSC_SMALL);
 
-    VecDestroy(&x);
-    VecDestroy(&b);
+    CHECK(VecDestroy(&x) == 0);
+    CHECK(VecDestroy(&b) == 0);
+  }
+
+  SECTION("ksp() exposes a handle usable with the raw PETSc API")
+  {
+    // Bypass the class entirely and drive ksp() with the raw PETSc API
+    la::petsc::KrylovSolver solver(MPI_COMM_WORLD);
+    CHECK(KSPSetOperators(solver.ksp(), A, A) == 0);
+
+    Vec x = nullptr, b = nullptr;
+    CHECK(MatCreateVecs(A, &x, &b) == 0);
+    CHECK(VecSet(b, 1.0) == 0);
+
+    CHECK(KSPSolve(solver.ksp(), b, x) == 0);
+
+    KSPConvergedReason reason;
+    CHECK(KSPGetConvergedReason(solver.ksp(), &reason) == 0);
+    CHECK(reason > 0);
+
+    // A is the identity, so x == b
+    PetscReal norm = 0;
+    CHECK(VecAXPY(x, -1.0, b) == 0);
+    CHECK(VecNorm(x, NORM_2, &norm) == 0);
+    CHECK(norm < 100 * PETSC_SMALL);
+
+    CHECK(VecDestroy(&x) == 0);
+    CHECK(VecDestroy(&b) == 0);
+  }
+
+  SECTION("Solving the transpose system")
+  {
+    // A is symmetric (identity), so the transpose solve has the same
+    // solution and exercises the KSPSolveTranspose path in solve()
+    la::petsc::KrylovSolver solver(MPI_COMM_WORLD);
+    solver.set_operator(A);
+
+    Vec x = nullptr, b = nullptr;
+    CHECK(MatCreateVecs(A, &x, &b) == 0);
+    CHECK(VecSet(b, 1.0) == 0);
+
+    PetscInt num_it = solver.solve(x, b, true);
+    CHECK(num_it >= 0);
+
+    PetscReal norm = 0;
+    CHECK(VecAXPY(x, -1.0, b) == 0);
+    CHECK(VecNorm(x, NORM_2, &norm) == 0);
+    CHECK(norm < 100 * PETSC_SMALL);
+
+    CHECK(VecDestroy(&x) == 0);
+    CHECK(VecDestroy(&b) == 0);
+  }
+
+  SECTION("Solving with a distinct preconditioner matrix")
+  {
+    la::petsc::KrylovSolver solver(MPI_COMM_WORLD);
+    solver.set_operators(A, A);
+
+    Vec x = nullptr, b = nullptr;
+    CHECK(MatCreateVecs(A, &x, &b) == 0);
+    CHECK(VecSet(b, 1.0) == 0);
+
+    PetscInt num_it = solver.solve(x, b, false);
+    CHECK(num_it >= 0);
+
+    CHECK(VecDestroy(&x) == 0);
+    CHECK(VecDestroy(&b) == 0);
+  }
+
+  SECTION("Solving through a wrapped external KSP handle")
+  {
+    // KrylovSolver(ksp, inc_ref_count) must produce a wrapper that is
+    // fully usable via solve(), not just safe to destroy
+    for (bool inc_ref_count : {true, false})
+    {
+      KSP ksp = nullptr;
+      CHECK(KSPCreate(MPI_COMM_WORLD, &ksp) == 0);
+      CHECK(KSPSetOperators(ksp, A, A) == 0);
+
+      la::petsc::KrylovSolver solver(ksp, inc_ref_count);
+
+      Vec x = nullptr, b = nullptr;
+      CHECK(MatCreateVecs(A, &x, &b) == 0);
+      CHECK(VecSet(b, 1.0) == 0);
+
+      PetscInt num_it = solver.solve(x, b, false);
+      CHECK(num_it >= 0);
+
+      PetscReal norm = 0;
+      CHECK(VecAXPY(x, -1.0, b) == 0);
+      CHECK(VecNorm(x, NORM_2, &norm) == 0);
+      CHECK(norm < 100 * PETSC_SMALL);
+
+      CHECK(VecDestroy(&x) == 0);
+      CHECK(VecDestroy(&b) == 0);
+
+      if (inc_ref_count)
+        CHECK(KSPDestroy(&ksp) == 0);
+    }
   }
 
   SECTION("Solving before setting an operator throws")
@@ -95,11 +274,11 @@ TEST_CASE("PETSc Krylov solver", "[petsc]")
     // comes from KSPSolve failing on that untyped Mat
     la::petsc::KrylovSolver solver(MPI_COMM_WORLD);
     Vec x = nullptr, b = nullptr;
-    MatCreateVecs(A, &x, &b);
-    VecSet(b, 1.0);
+    CHECK(MatCreateVecs(A, &x, &b) == 0);
+    CHECK(VecSet(b, 1.0) == 0);
     CHECK_THROWS_AS(solver.solve(x, b, false), std::runtime_error);
-    VecDestroy(&x);
-    VecDestroy(&b);
+    CHECK(VecDestroy(&x) == 0);
+    CHECK(VecDestroy(&b) == 0);
   }
 
   SECTION("Options prefix round-trips")
@@ -118,7 +297,28 @@ TEST_CASE("PETSc Krylov solver", "[petsc]")
     CHECK(a.ksp() == nullptr);
   }
 
-  MatDestroy(&A);
+  SECTION("Move assignment releases the target's prior handle")
+  {
+    la::petsc::KrylovSolver a(MPI_COMM_WORLD);
+    la::petsc::KrylovSolver b(MPI_COMM_WORLD);
+    KSP raw_a = a.ksp();
+    KSP raw_b = b.ksp();
+
+    PetscInt refs = 0;
+    CHECK(PetscObjectGetReference((PetscObject)raw_b, &refs) == 0);
+    CHECK(refs == 1);
+
+    b = std::move(a);
+    CHECK(b.ksp() == raw_a);
+    CHECK(a.ksp() == raw_b);
+
+    // a now holds b's former handle and destroys it going out of scope;
+    // nothing else references raw_b, so it must not leak
+    CHECK(PetscObjectGetReference((PetscObject)raw_b, &refs) == 0);
+    CHECK(refs == 1);
+  }
+
+  CHECK(MatDestroy(&A) == 0);
 }
 
 #endif

--- a/cpp/test/petsc.cpp
+++ b/cpp/test/petsc.cpp
@@ -75,7 +75,7 @@ TEST_CASE("PETSc Krylov solver", "[petsc]")
     MatCreateVecs(A, &x, &b);
     VecSet(b, 1.0);
 
-    int num_it = solver.solve(x, b, false);
+    PetscInt num_it = solver.solve(x, b, false);
     CHECK(num_it >= 0);
 
     // A is the identity, so x == b


### PR DESCRIPTION
Three defects in the `la::petsc` wrappers, found while reviewing
`SLEPcEigenSolver` in #4425 and checking what carried over.

### Null handles guarded by `assert`

`petsc::Vector`, `petsc::Operator` and `petsc::KrylovSolver` all validate the
handle passed to their wrapping constructor with `assert`, then pass it to
`PetscObjectReference`. `PetscValidHeaderSpecific` compiles to a no-op in
optimised PETSc builds, so in a release build a null handle is stored and
dereferenced rather than reported. All three now throw `std::runtime_error`.

`Vector` and `Operator` also dropped the `PetscObjectReference` return code
entirely; it is now checked.

### A check that can never fire

`KrylovSolver::solve` did:

```cpp
Mat _A, _P;
KSPGetOperators(_ksp, &_A, &_P);
assert(_A);
```

The return code is dropped, so a failure leaves the uninitialised `Mat` locals to
be read by the `assert`. More importantly the `assert` is unreachable:
`KSPGetOperators` defers to `PCGetOperators`, which *creates* an empty `Mat` when
none has been set (`precon.c:1421-1430`) rather than reporting null. Unlike
SLEPc's `EPSGetOperators`, it never returns null, so there is nothing to detect.
The block is removed.

Solving with no operator still errors — `KSPSolve` fails on the untyped `Mat`
that `PCGetOperators` fabricated, with "Object is in wrong state / Mat object's
type is not set". Covered by a new test.

### Wrong function name in an error path

The transpose branch reported a failure as `KSPSolve` rather than
`KSPSolveTranspose`, in both the exception message and the log line.

### Also

`KrylovSolver::solve` returns `PetscInt` rather than `int`. The count comes
straight from `KSPGetIterationNumber` and was narrowed on the way out; this
follows the same convention as the `PetscInt` change to `SLEPcEigenSolver` in
#4425. `NewtonSolver` accumulates into an `int` and is unaffected.

The touched call sites now use the `CHECK_ERROR` macro already defined at the top
of `petsc.cpp`, rather than open-coding `if (ierr != 0) petsc::error(...)`. The
null checks test the member (`_ksp`) rather than the constructor argument, since
the member is what gets dereferenced. Doxygen is filled in on the three
constructors, including that the reference count is always decreased on
destruction; the `KrylovSolver(MPI_Comm)` comment claimed it took "a particular
method and named preconditioner", which it does not.

### Testing

Adds `cpp/test/petsc.cpp` — there was no direct coverage of these wrappers, only
indirect use through `NewtonSolver`. Covers the null-handle rejections, a solve
against an identity operator, solving before setting an operator, the options
prefix, and move safety. Passes at np = 1, 2, 3.

Against the unpatched `petsc.cpp` the null-handle test aborts in the `assert`
rather than passing, so it does exercise the change.

### Not included

The null options-prefix fix for these classes is in #4425 and is deliberately not
duplicated here.

---

AI assistance: I used Claude Opus 5 (Claude Code) to draft parts of this PR. I
reviewed, edited, tested, and take responsibility for the final contribution.
