### PR TITLE
Some Docker fixes

### DIFF
--- a/docker/Dockerfile.end-user
+++ b/docker/Dockerfile.end-user
@@ -36,14 +36,11 @@
 
 # Used to set the correct PYTHONPATH for the real and complex install of
 # DOLFINx
-ARG PYTHON_VERSION=3.12
 # Base image for end-user images
 ARG BASEIMAGE=ghcr.io/fenics/dolfinx/dev-env:current
 
 FROM ${BASEIMAGE} AS dolfinx-onbuild
 LABEL description="DOLFINx in 32-bit real and complex modes (onbuild)"
-
-ARG PYTHON_VERSION
 
 COPY dolfinx/docker/dolfinx-real-mode /usr/local/bin/dolfinx-real-mode
 COPY dolfinx/docker/dolfinx-complex-mode /usr/local/bin/dolfinx-complex-mode
@@ -94,7 +91,7 @@ ONBUILD RUN cd dolfinx && \
     cd ../python && \
     PETSC_ARCH=linux-gnu-real64-32 pip -v install \
       --config-settings=cmake.build-type="${DOLFINX_CMAKE_BUILD_TYPE}" --config-settings=install.strip=false --no-build-isolation --check-build-dependencies \
-      --target /usr/local/dolfinx-real/lib/python${PYTHON_VERSION}/dist-packages --no-dependencies --no-cache-dir '.' && \
+      --target /usr/local/dolfinx-real/lib/python/dist-packages --no-dependencies --no-cache-dir . && \
     git clean -fdx && \
     cd ../ && \
     mkdir -p build-complex && \
@@ -105,13 +102,13 @@ ONBUILD RUN cd dolfinx && \
     cd ../python && \
     PETSC_ARCH=linux-gnu-complex128-32 pip -v install \
       --config-settings=cmake.build-type="${DOLFINX_CMAKE_BUILD_TYPE}" --config-settings=install.strip=false --no-build-isolation --check-build-dependencies \
-      --target /usr/local/dolfinx-complex/lib/python${PYTHON_VERSION}/dist-packages --no-dependencies --no-cache-dir '.'
+      --target /usr/local/dolfinx-complex/lib/python/dist-packages --no-dependencies --no-cache-dir .
 
 # Real by default.
 ONBUILD ENV PKG_CONFIG_PATH=/usr/local/dolfinx-real/lib/pkgconfig:$PKG_CONFIG_PATH \
     CMAKE_PREFIX_PATH=/usr/local/dolfinx-real/lib/cmake:$CMAKE_PREFIX_PATH \
     PETSC_ARCH=linux-gnu-real64-32 \
-    PYTHONPATH=/usr/local/dolfinx-real/lib/python${PYTHON_VERSION}/dist-packages:$PYTHONPATH \
+    PYTHONPATH=/usr/local/dolfinx-real/lib/python/dist-packages:$PYTHONPATH \
     LD_LIBRARY_PATH=/usr/local/dolfinx-real/lib:$LD_LIBRARY_PATH
 
 ONBUILD WORKDIR /root
@@ -124,8 +121,6 @@ FROM dolfinx-onbuild AS intermediate
 
 FROM ${BASEIMAGE} AS dolfinx
 LABEL description="DOLFINx in 32-bit real and complex modes"
-
-ARG PYTHON_VERSION
 
 # This layer manually copies the build artifacts from intermediate into
 # dev-env to make the final image. This is a workaround for a well known
@@ -142,7 +137,7 @@ COPY --from=intermediate /dolfinx-env /dolfinx-env
 ENV PKG_CONFIG_PATH=/usr/local/dolfinx-real/lib/pkgconfig:$PKG_CONFIG_PATH \
     CMAKE_PREFIX_PATH=/usr/local/dolfinx-real/lib/cmake:$CMAKE_PREFIX_PATH \
     PETSC_ARCH=linux-gnu-real64-32 \
-    PYTHONPATH=/usr/local/dolfinx-real/lib/python${PYTHON_VERSION}/dist-packages:$PYTHONPATH \
+    PYTHONPATH=/usr/local/dolfinx-real/lib/python/dist-packages:$PYTHONPATH \
     LD_LIBRARY_PATH=/usr/local/dolfinx-real/lib:$LD_LIBRARY_PATH
 
 ########################################

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -12,7 +12,6 @@
 #    docker build --target dev-env --file dolfinx/docker/Dockerfile.test-env --build-arg PETSC_SLEPC_OPTFLAGS="-O2 -march=native" .
 #
 
-ARG ADIOS2_VERSION=2.12.1
 ARG DOXYGEN_VERSION=1_17_0
 ARG GMSH_VERSION=4_15_2
 ARG KAHIP_VERSION=3.25

--- a/docker/complex-kernel.json
+++ b/docker/complex-kernel.json
@@ -15,7 +15,7 @@
         "PKG_CONFIG_PATH": "/usr/local/dolfinx-complex/lib/pkgconfig:$PKG_CONFIG_PATH",
         "PETSC_DIR": "/usr/local/petsc/",
         "PETSC_ARCH": "linux-gnu-complex128-32",
-        "PYTHONPATH": "/usr/local/dolfinx-complex/lib/python3.12/dist-packages:$PYTHONPATH",
+        "PYTHONPATH": "/usr/local/dolfinx-complex/lib/python/dist-packages:$PYTHONPATH",
         "LD_LIBRARY_PATH": "/usr/local/dolfinx-complex/lib:$LD_LIBRARY_PATH"
     }
 }

--- a/docker/dolfinx-complex-mode
+++ b/docker/dolfinx-complex-mode
@@ -1,7 +1,6 @@
 #!/bin/bash
-PYV=`python3 -c "import sys;t='{v[0]}.{v[1]}'.format(v=list(sys.version_info[:2]));sys.stdout.write(t)";`
 export PKG_CONFIG_PATH=/usr/local/dolfinx-complex/lib/pkgconfig:$PKG_CONFIG_PATH
 export CMAKE_PREFIX_PATH=/usr/local/dolfinx-complex/lib/cmake:$CMAKE_PREFIX_PATH
 export PETSC_ARCH=linux-gnu-complex128-32
-export PYTHONPATH=/usr/local/dolfinx-complex/lib/python$PYV/dist-packages:$PYTHONPATH
+export PYTHONPATH=/usr/local/dolfinx-complex/lib/python/dist-packages:$PYTHONPATH
 export LD_LIBRARY_PATH=/usr/local/dolfinx-complex/lib:$LD_LIBRARY_PATH

--- a/docker/dolfinx-real-mode
+++ b/docker/dolfinx-real-mode
@@ -1,7 +1,6 @@
 #!/bin/bash
-PYV=`python3 -c "import sys;t='{v[0]}.{v[1]}'.format(v=list(sys.version_info[:2]));sys.stdout.write(t)";`
 export PKG_CONFIG_PATH=/usr/local/dolfinx-real/lib/pkgconfig:$PKG_CONFIG_PATH
 export CMAKE_PREFIX_PATH=/usr/local/dolfinx-real/lib/cmake:$CMAKE_PREFIX_PATH
 export PETSC_ARCH=linux-gnu-real64-32
-export PYTHONPATH=/usr/local/dolfinx-real/lib/python$PYV/dist-packages:$PYTHONPATH
+export PYTHONPATH=/usr/local/dolfinx-real/lib/python/dist-packages:$PYTHONPATH
 export LD_LIBRARY_PATH=/usr/local/dolfinx-real/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
This works fine now, but I think there is probably still a fair amount of stuff that can be trimmed here if we are moving away from this being a CI image.

Some notes:

```
# Install dependencies available via apt-get.
# - First set of packages are required to build and run FEniCS.
# - Second set of packages are recommended and/or required to build
#   documentation or tests.
# - Third set of packages are optional, but required to run gmsh
#   pre-built binaries.
RUN export DEBIAN_FRONTEND=noninteractive && \
    apt-get -qq update && \
    apt-get -yq --with-new-pkgs -o Dpkg::Options::="--force-confold" upgrade && \
    apt-get -y install --no-install-recommends \
    cmake \
    g++ \
    gfortran \
    libadios2-mpi-c++-dev \
    libboost-dev \
    libhdf5-mpi-dev \
    liblapack-dev \
    libopenblas-dev \
    libpugixml-dev \
    mpi-default-dev \
    ninja-build \
    pkg-config \
    python3-dev \
    python3-pip \
    python3-venv && \
    #
    apt-get -y install \
    #catch2 \
    #git \
    #graphviz \
    #libeigen3-dev \
    #valgrind \
    #wget && \
    #apt-get -y install \
    #libglu1 \
    #libxcursor-dev \
    #libxft2 \
    #libxinerama1 \
    #libfltk1.3-dev \
    #libfreetype6-dev  \
    #libgl1-mesa-dev \
    #libocct-foundation-dev \
    #libocct-data-exchange-dev && \
    apt-get clean && \
    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
```

Do we need the `linux-gnu-real64-64` PETSc build?

gmsh can also be built without a GUI, sketch using LLM:

```
cmake -G Ninja \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX=/usr/local \
    -DENABLE_BUILD_DYNAMIC=ON \
    -DENABLE_BAMG=ON \
    -DENABLE_CGNS=OFF \
    -DENABLE_CAIRO=OFF \
    -DENABLE_DINTEGRATION=OFF \
    -DENABLE_DOMHEX=ON \
    -DENABLE_FLTK=OFF \
    -DENABLE_GEOMETRYCENTRAL=OFF \
    -DENABLE_GETDP=OFF \
    -DENABLE_GMM=OFF \
    -DENABLE_GMP=OFF \
    -DENABLE_KBIPACK=OFF \
    -DENABLE_MED=OFF \
    -DENABLE_MMG=OFF \
    -DENABLE_MPEG_ENCODE=OFF \
    -DENABLE_NETGEN=OFF \
    -DENABLE_OCC_CAF=OFF \
    -DENABLE_ONELAB=OFF \
    -DENABLE_ONELAB_METAMODEL=OFF \
    -DENABLE_PLUGINS=OFF \
    -DENABLE_POST=OFF \
    -DENABLE_PRO=OFF \
    -DENABLE_QUADMESHINGTOOLS=ON \
    -DENABLE_QUADTRI=ON \
    -DENABLE_TOUCHBAR=OFF \
    -DENABLE_VOROPP=OFF \
    ..
```