### PR TITLE
Add weight options to mesh partitioners

### DIFF
--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -22,12 +22,15 @@ using namespace dolfinx;
 graph::AdjacencyList<std::int32_t>
 graph::partition_graph(MPI_Comm comm, int nparts,
                        const AdjacencyList<std::int64_t>& local_graph,
-                       bool ghosting)
+                       std::span<std::int32_t> node_weights,
+                       std::span<std::int32_t> edge_weights, bool ghosting)
 {
 #if HAS_PARMETIS
-  return graph::parmetis::partitioner()(comm, nparts, local_graph, ghosting);
+  return graph::parmetis::partitioner()(comm, nparts, local_graph, node_weights,
+                                        edge_weights, ghosting);
 #elif HAS_PTSCOTCH
-  return graph::scotch::partitioner()(comm, nparts, local_graph, ghosting);
+  return graph::scotch::partitioner()(comm, nparts, local_graph, node_weights,
+                                      edge_weights, ghosting);
 #elif HAS_KAHIP
   return graph::kahip::partitioner()(comm, nparts, local_graph, ghosting);
 #else

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -22,8 +22,9 @@ using namespace dolfinx;
 graph::AdjacencyList<std::int32_t>
 graph::partition_graph(MPI_Comm comm, int nparts,
                        const AdjacencyList<std::int64_t>& local_graph,
-                       std::span<std::int32_t> node_weights,
-                       std::span<std::int32_t> edge_weights, bool ghosting)
+                       std::span<const std::int32_t> node_weights,
+                       std::span<const std::int32_t> edge_weights,
+                       bool ghosting)
 {
 #if HAS_PARMETIS
   return graph::parmetis::partitioner()(comm, nparts, local_graph, node_weights,
@@ -32,6 +33,8 @@ graph::partition_graph(MPI_Comm comm, int nparts,
   return graph::scotch::partitioner()(comm, nparts, local_graph, node_weights,
                                       edge_weights, ghosting);
 #elif HAS_KAHIP
+  if (!node_weights.empty() or !edge_weights.empty())
+    spdlog::warn("KaHIP does not support node or edge weights");
   return graph::kahip::partitioner()(comm, nparts, local_graph, ghosting);
 #else
 // Should never reach this point

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -33,9 +33,8 @@ graph::partition_graph(MPI_Comm comm, int nparts,
   return graph::scotch::partitioner()(comm, nparts, local_graph, node_weights,
                                       edge_weights, ghosting);
 #elif HAS_KAHIP
-  if (!node_weights.empty() or !edge_weights.empty())
-    spdlog::warn("KaHIP does not support node or edge weights");
-  return graph::kahip::partitioner()(comm, nparts, local_graph, ghosting);
+  return graph::kahip::partitioner()(comm, nparts, local_graph, node_weights,
+                                     edge_weights, ghosting);
 #else
 // Should never reach this point
 #endif

--- a/cpp/dolfinx/graph/partition.cpp
+++ b/cpp/dolfinx/graph/partition.cpp
@@ -19,12 +19,10 @@
 using namespace dolfinx;
 
 //-----------------------------------------------------------------------------
-graph::AdjacencyList<std::int32_t>
-graph::partition_graph(MPI_Comm comm, int nparts,
-                       const AdjacencyList<std::int64_t>& local_graph,
-                       std::span<const std::int32_t> node_weights,
-                       std::span<const std::int32_t> edge_weights,
-                       bool ghosting)
+graph::AdjacencyList<std::int32_t> graph::partition_graph(
+    MPI_Comm comm, int nparts, const AdjacencyList<std::int64_t>& local_graph,
+    std::span<const std::int32_t> node_weights,
+    std::span<const std::int32_t> edge_weights, bool ghosting)
 {
 #if HAS_PARMETIS
   return graph::parmetis::partitioner()(comm, nparts, local_graph, node_weights,

--- a/cpp/dolfinx/graph/partition.h
+++ b/cpp/dolfinx/graph/partition.h
@@ -30,8 +30,8 @@ namespace dolfinx::graph
 /// distribution
 /// @return Destination rank for each input node
 using partition_fn = std::function<graph::AdjacencyList<std::int32_t>(
-    MPI_Comm, int, const AdjacencyList<std::int64_t>&, std::span<std::int32_t>,
-    std::span<std::int32_t>, bool)>;
+    MPI_Comm, int, const AdjacencyList<std::int64_t>&,
+    std::span<const std::int32_t>, std::span<const std::int32_t>, bool)>;
 
 /// @brief Partition graph across processes using the default graph
 /// partitioner.
@@ -40,15 +40,18 @@ using partition_fn = std::function<graph::AdjacencyList<std::int32_t>(
 /// across.
 /// @param[in] nparts Number of partitions to divide graph nodes into.
 /// @param[in] local_graph Node connectivity graph.
-/// @param[in] node_weights Node weights.
+/// @param[in] node_weights Node weights. Each partition aims to have the same
+/// sum of node weights.
+/// @param[in] edge_weights Edge weights. Higher values increase the likelihood
+/// that adjacent cells will be on the same partition.
 /// @param[in] ghosting Flag to enable ghosting of the output node
 /// distribution.
 /// @return Destination rank for each input node.
 AdjacencyList<std::int32_t>
 partition_graph(MPI_Comm comm, int nparts,
                 const AdjacencyList<std::int64_t>& local_graph,
-                std::span<std::int32_t> node_weights,
-                std::span<std::int32_t> edge_weights, bool ghosting);
+                std::span<const std::int32_t> node_weights,
+                std::span<const std::int32_t> edge_weights, bool ghosting);
 
 /// Tools for distributed graphs
 ///

--- a/cpp/dolfinx/graph/partition.h
+++ b/cpp/dolfinx/graph/partition.h
@@ -25,11 +25,13 @@ namespace dolfinx::graph
 /// across
 /// @param[in] nparts Number of partitions to divide graph nodes into
 /// @param[in] local_graph Node connectivity graph
+/// @param[in] node_weights Node weights
 /// @param[in] ghosting Flag to enable ghosting of the output node
 /// distribution
 /// @return Destination rank for each input node
 using partition_fn = std::function<graph::AdjacencyList<std::int32_t>(
-    MPI_Comm, int, const AdjacencyList<std::int64_t>&, bool)>;
+    MPI_Comm, int, const AdjacencyList<std::int64_t>&, std::span<std::int32_t>,
+    std::span<std::int32_t>, bool)>;
 
 /// @brief Partition graph across processes using the default graph
 /// partitioner.
@@ -38,12 +40,15 @@ using partition_fn = std::function<graph::AdjacencyList<std::int32_t>(
 /// across.
 /// @param[in] nparts Number of partitions to divide graph nodes into.
 /// @param[in] local_graph Node connectivity graph.
+/// @param[in] node_weights Node weights.
 /// @param[in] ghosting Flag to enable ghosting of the output node
 /// distribution.
 /// @return Destination rank for each input node.
 AdjacencyList<std::int32_t>
 partition_graph(MPI_Comm comm, int nparts,
-                const AdjacencyList<std::int64_t>& local_graph, bool ghosting);
+                const AdjacencyList<std::int64_t>& local_graph,
+                std::span<std::int32_t> node_weights,
+                std::span<std::int32_t> edge_weights, bool ghosting);
 
 /// Tools for distributed graphs
 ///

--- a/cpp/dolfinx/graph/partition.h
+++ b/cpp/dolfinx/graph/partition.h
@@ -26,6 +26,7 @@ namespace dolfinx::graph
 /// @param[in] nparts Number of partitions to divide graph nodes into
 /// @param[in] local_graph Node connectivity graph
 /// @param[in] node_weights Node weights
+/// @param[in] edge_weights Edge weights
 /// @param[in] ghosting Flag to enable ghosting of the output node
 /// distribution
 /// @return Destination rank for each input node

--- a/cpp/dolfinx/graph/partitioners.cpp
+++ b/cpp/dolfinx/graph/partitioners.cpp
@@ -565,12 +565,11 @@ graph::partition_fn graph::scotch::partitioner(graph::scotch::strategy strategy,
 graph::partition_fn graph::parmetis::partitioner(double imbalance,
                                                  std::array<int, 3> options)
 {
-  return
-      [imbalance, options](MPI_Comm comm, idx_t nparts,
-                           const graph::AdjacencyList<std::int64_t>& graph,
-                           std::span<const std::int32_t> node_weights,
-                           std::span<const std::int32_t> edge_weights,
-                           bool ghosting)
+  return [imbalance, options](MPI_Comm comm, idx_t nparts,
+                              const graph::AdjacencyList<std::int64_t>& graph,
+                              std::span<const std::int32_t> node_weights,
+                              std::span<const std::int32_t> edge_weights,
+                              bool ghosting)
   {
     spdlog::info("Compute graph partition using ParMETIS");
     common::Timer timer("Compute graph partition (ParMETIS)");

--- a/cpp/dolfinx/graph/partitioners.cpp
+++ b/cpp/dolfinx/graph/partitioners.cpp
@@ -351,8 +351,8 @@ graph::partition_fn graph::scotch::partitioner(graph::scotch::strategy strategy,
 {
   return [imbalance, strategy, seed](MPI_Comm comm, int nparts,
                                      const AdjacencyList<std::int64_t>& graph,
-                                     std::span<std::int32_t> node_weights,
-                                     std::span<std::int32_t> edge_weights,
+                                     std::span<const std::int32_t> node_weights,
+                                     std::span<const std::int32_t> edge_weights,
                                      bool ghosting)
   {
     spdlog::info("Compute graph partition using PT-SCOTCH");
@@ -568,8 +568,9 @@ graph::partition_fn graph::parmetis::partitioner(double imbalance,
   return
       [imbalance, options](MPI_Comm comm, idx_t nparts,
                            const graph::AdjacencyList<std::int64_t>& graph,
-                           std::span<std::int32_t> node_weights,
-                           std::span<std::int32_t> edge_weights, bool ghosting)
+                           std::span<const std::int32_t> node_weights,
+                           std::span<const std::int32_t> edge_weights,
+                           bool ghosting)
   {
     spdlog::info("Compute graph partition using ParMETIS");
     common::Timer timer("Compute graph partition (ParMETIS)");

--- a/cpp/dolfinx/graph/partitioners.cpp
+++ b/cpp/dolfinx/graph/partitioners.cpp
@@ -351,6 +351,8 @@ graph::partition_fn graph::scotch::partitioner(graph::scotch::strategy strategy,
 {
   return [imbalance, strategy, seed](MPI_Comm comm, int nparts,
                                      const AdjacencyList<std::int64_t>& graph,
+                                     std::span<std::int32_t> node_weights,
+                                     std::span<std::int32_t> edge_weights,
                                      bool ghosting)
   {
     spdlog::info("Compute graph partition using PT-SCOTCH");
@@ -380,11 +382,15 @@ graph::partition_fn graph::scotch::partitioner(graph::scotch::strategy strategy,
     // FIXME: If the nodes have weights but this rank has no nodes, then
     //        SCOTCH may deadlock since vload.data() will be nullptr on
     //        this rank but not null on all other ranks.
-    // Handle node weights (disabled for now)
-    std::vector<SCOTCH_Num> node_weights;
+    // Handle node weights
     std::vector<SCOTCH_Num> vload;
     if (!node_weights.empty())
       vload.assign(node_weights.begin(), node_weights.end());
+
+    // Handle edge weights
+    std::vector<SCOTCH_Num> edload;
+    if (!edge_weights.empty())
+      edload.assign(edge_weights.begin(), edge_weights.end());
 
     // Set seed and reset SCOTCH random number generator to produce
     // deterministic partitions on repeated calls
@@ -397,7 +403,7 @@ graph::partition_fn graph::scotch::partitioner(graph::scotch::strategy strategy,
     err = SCOTCH_dgraphBuild(
         &dgrafdat, baseval, graph.num_nodes(), graph.num_nodes(),
         vertloctab.data(), nullptr, vload.data(), nullptr, edgeloctab.size(),
-        edgeloctab.size(), edgeloctab.data(), nullptr, nullptr);
+        edgeloctab.size(), edgeloctab.data(), nullptr, edload.data());
     if (err != 0)
       throw std::runtime_error("Error building SCOTCH graph");
     timer1.stop();
@@ -559,9 +565,11 @@ graph::partition_fn graph::scotch::partitioner(graph::scotch::strategy strategy,
 graph::partition_fn graph::parmetis::partitioner(double imbalance,
                                                  std::array<int, 3> options)
 {
-  return [imbalance, options](MPI_Comm comm, idx_t nparts,
-                              const graph::AdjacencyList<std::int64_t>& graph,
-                              bool ghosting)
+  return
+      [imbalance, options](MPI_Comm comm, idx_t nparts,
+                           const graph::AdjacencyList<std::int64_t>& graph,
+                           std::span<std::int32_t> node_weights,
+                           std::span<std::int32_t> edge_weights, bool ghosting)
   {
     spdlog::info("Compute graph partition using ParMETIS");
     common::Timer timer("Compute graph partition (ParMETIS)");
@@ -575,7 +583,7 @@ graph::partition_fn graph::parmetis::partitioner(double imbalance,
 
     // Note: ParMETIS fails (crashes) if a rank does not have any graph
     // data. Therefore we split the communicator such that ParMETIS
-    // partitioning happens only on ranks that have data. Ideallt we
+    // partitioning happens only on ranks that have data. Ideally we
     // wouldn't need to do this.
     constexpr bool split_comm = true;
     MPI_Comm pcomm = MPI_COMM_NULL;
@@ -607,8 +615,21 @@ graph::partition_fn graph::parmetis::partitioner(double imbalance,
       // Options and data for ParMETIS
       std::array<idx_t, 3> opts = {options[0], options[1], options[2]};
       idx_t ncon = 1;
-      idx_t* elmwgt = nullptr;
       idx_t wgtflag(0), edgecut(0), numflag(0);
+      std::vector<idx_t> elmwgt(node_weights.begin(), node_weights.end());
+      std::vector<idx_t> edgwgt(edge_weights.begin(), edge_weights.end());
+
+      if (!elmwgt.empty())
+      {
+        spdlog::info("ParMETIS: applying node weights");
+        wgtflag += 2;
+      }
+      if (!edgwgt.empty())
+      {
+        spdlog::info("ParMETIS: applying edge weights");
+        wgtflag += 1;
+      }
+
       std::vector<real_t> tpwgts(ncon * nparts,
                                  1.0 / static_cast<real_t>(nparts));
       real_t ubvec = static_cast<real_t>(imbalance);
@@ -616,9 +637,9 @@ graph::partition_fn graph::parmetis::partitioner(double imbalance,
       // Partition
       common::Timer timer1("ParMETIS: call ParMETIS_V3_PartKway");
       int err = ParMETIS_V3_PartKway(
-          node_disp.data(), offsets.data(), array.data(), elmwgt, nullptr,
-          &wgtflag, &numflag, &ncon, &nparts, tpwgts.data(), &ubvec,
-          opts.data(), &edgecut, part.data(), &pcomm);
+          node_disp.data(), offsets.data(), array.data(), elmwgt.data(),
+          edgwgt.data(), &wgtflag, &numflag, &ncon, &nparts, tpwgts.data(),
+          &ubvec, opts.data(), &edgecut, part.data(), &pcomm);
       if (err != METIS_OK)
       {
         throw std::runtime_error(

--- a/cpp/dolfinx/graph/partitioners.cpp
+++ b/cpp/dolfinx/graph/partitioners.cpp
@@ -678,7 +678,9 @@ graph::partition_fn graph::kahip::partitioner(int mode, int seed,
 {
   return [mode, seed, imbalance, suppress_output](
              MPI_Comm comm, int nparts,
-             const graph::AdjacencyList<std::int64_t>& graph, bool ghosting)
+             const graph::AdjacencyList<std::int64_t>& graph,
+             std::span<const std::int32_t> node_weights,
+             std::span<const std::int32_t> edge_weights, bool ghosting)
   {
     spdlog::info("Compute graph partition using (parallel) KaHIP");
 
@@ -687,9 +689,8 @@ graph::partition_fn graph::kahip::partitioner(int mode, int seed,
 
     common::Timer timer("Compute graph partition (KaHIP)");
 
-    // Graph does not have vertex or adjacency weights, so we use null
-    // pointers as arguments
-    T *vwgt(nullptr), *adjcwgt(nullptr);
+    std::vector<T> vwgt(node_weights.begin(), node_weights.end());
+    std::vector<T> adjcwgt(edge_weights.begin(), edge_weights.end());
 
     // Build adjacency list data
     common::Timer timer1("KaHIP: build adjacency data");
@@ -712,9 +713,10 @@ graph::partition_fn graph::kahip::partitioner(int mode, int seed,
     std::vector<T> part(graph.num_nodes());
     int edgecut = 0;
     double _imbalance = imbalance;
-    ParHIPPartitionKWay(node_disp.data(), offsets.data(), array.data(), vwgt,
-                        adjcwgt, &nparts, &_imbalance, suppress_output, seed,
-                        mode, &edgecut, part.data(), &comm);
+    ParHIPPartitionKWay(node_disp.data(), offsets.data(), array.data(),
+                        vwgt.data(), adjcwgt.data(), &nparts, &_imbalance,
+                        suppress_output, seed, mode, &edgecut, part.data(),
+                        &comm);
     timer2.stop();
 
     if (ghosting)

--- a/cpp/dolfinx/io/VTKHDF.h
+++ b/cpp/dolfinx/io/VTKHDF.h
@@ -467,7 +467,7 @@ mesh::Mesh<U> read_mesh(MPI_Comm comm, const std::filesystem::path& filename,
       });
 
   auto part = create_cell_partitioner(mesh::GhostMode::none,
-                                      dolfinx::graph::partition_graph,
+                                      dolfinx::graph::partition_graph, nullptr,
                                       max_facet_to_cell_links);
   std::vector<std::span<const std::int64_t>> cells_span(cells_local.begin(),
                                                         cells_local.end());

--- a/cpp/dolfinx/io/VTKHDF.h
+++ b/cpp/dolfinx/io/VTKHDF.h
@@ -467,12 +467,13 @@ mesh::Mesh<U> read_mesh(MPI_Comm comm, const std::filesystem::path& filename,
       });
 
   auto part = create_cell_partitioner(mesh::GhostMode::none,
-                                      dolfinx::graph::partition_graph, nullptr,
+                                      dolfinx::graph::partition_graph,
                                       max_facet_to_cell_links);
   std::vector<std::span<const std::int64_t>> cells_span(cells_local.begin(),
                                                         cells_local.end());
-  return mesh::create_mesh(comm, comm, cells_span, coordinate_elements, comm,
-                           points_pruned, {(std::size_t)x_shape[0], gdim}, part,
-                           max_facet_to_cell_links, 1);
+  return mesh::create_mesh(comm, comm, cells_span,
+                           std::span<const std::int32_t>(), coordinate_elements,
+                           comm, points_pruned, {(std::size_t)x_shape[0], gdim},
+                           part, max_facet_to_cell_links, 1);
 }
 } // namespace dolfinx::io::VTKHDF

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -184,20 +184,53 @@ void XDMFFile::write_geometry(const mesh::Geometry<double>& geometry,
     _xml_doc->save_file(_filename.c_str(), "  ");
 }
 //-----------------------------------------------------------------------------
-mesh::Mesh<double>
-XDMFFile::read_mesh(const fem::CoordinateElement<double>& element,
-                    mesh::GhostMode mode, std::string_view name,
-                    std::string_view xpath,
-                    std::optional<std::int32_t> max_facet_to_cell_links) const
+mesh::Mesh<double> XDMFFile::read_mesh(
+    const fem::CoordinateElement<double>& element, mesh::GhostMode mode,
+    std::string_view name, std::string_view xpath,
+    std::function<void(std::vector<std::int64_t>&)> facet_intercept,
+    std::optional<std::int32_t> max_facet_to_cell_links) const
 {
   // Read mesh data
   auto [cells, cshape] = XDMFFile::read_topology_data(name, xpath);
   auto [x, xshape] = XDMFFile::read_geometry_data(name, xpath);
 
+  std::vector<std::int32_t> cell_weights;
+  if (_h5_id)
+  {
+    std::string cwname = "/Mesh/mesh/cell_weights";
+    if (io::hdf5::has_dataset(_h5_id, cwname))
+    {
+      std::cout << "Has dataset cell_weights\n";
+
+      // Get data shape from HDF5 file
+      const std::vector shape_hdf5
+          = io::hdf5::get_dataset_shape(_h5_id, cwname);
+      auto range
+          = common::local_range(dolfinx::MPI::rank(_comm.comm()), shape_hdf5[0],
+                                dolfinx::MPI::size(_comm.comm()));
+
+      // read_dataset() needs an open *dataset* identifier, not the file
+      // identifier -- open it here and close it once we're done
+      hid_t dset_id = io::hdf5::open_dataset(_h5_id, cwname);
+      cell_weights = io::hdf5::read_dataset<std::int32_t>(dset_id, range, true);
+      H5Dclose(dset_id);
+      std::cout << "Read cell weights (" << cell_weights.size() << ")\n";
+      std::cout << "Cells (" << cells.size() / 4 << ")\n";
+    }
+  }
+
   // Create mesh
   const std::vector<double>& _x = std::get<std::vector<double>>(x);
+  // mesh::Mesh<double> mesh = mesh::create_mesh(
+  //    _comm.comm(), cells, element, _x, xshape, mode,
+  //    max_facet_to_cell_links);
+
+  auto part = create_cell_partitioner(mode, dolfinx::graph::partition_graph,
+                                      facet_intercept, max_facet_to_cell_links);
   mesh::Mesh<double> mesh = mesh::create_mesh(
-      _comm.comm(), cells, element, _x, xshape, mode, max_facet_to_cell_links);
+      _comm.comm(), _comm.comm(), cells, cell_weights, {element}, _comm.comm(),
+      _x, xshape, part, max_facet_to_cell_links, 1);
+
   mesh.name = name;
   return mesh;
 }

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -184,11 +184,11 @@ void XDMFFile::write_geometry(const mesh::Geometry<double>& geometry,
     _xml_doc->save_file(_filename.c_str(), "  ");
 }
 //-----------------------------------------------------------------------------
-mesh::Mesh<double> XDMFFile::read_mesh(
-    const fem::CoordinateElement<double>& element, mesh::GhostMode mode,
-    std::string_view name, std::string_view xpath,
-    std::function<void(std::vector<std::int64_t>&)> facet_intercept,
-    std::optional<std::int32_t> max_facet_to_cell_links) const
+mesh::Mesh<double>
+XDMFFile::read_mesh(const fem::CoordinateElement<double>& element,
+                    mesh::GhostMode mode, std::string_view name,
+                    std::string_view xpath,
+                    std::optional<std::int32_t> max_facet_to_cell_links) const
 {
   // Read mesh data
   auto [cells, cshape] = XDMFFile::read_topology_data(name, xpath);
@@ -221,12 +221,8 @@ mesh::Mesh<double> XDMFFile::read_mesh(
 
   // Create mesh
   const std::vector<double>& _x = std::get<std::vector<double>>(x);
-  // mesh::Mesh<double> mesh = mesh::create_mesh(
-  //    _comm.comm(), cells, element, _x, xshape, mode,
-  //    max_facet_to_cell_links);
-
   auto part = create_cell_partitioner(mode, dolfinx::graph::partition_graph,
-                                      facet_intercept, max_facet_to_cell_links);
+                                      max_facet_to_cell_links);
   mesh::Mesh<double> mesh = mesh::create_mesh(
       _comm.comm(), _comm.comm(), cells, cell_weights, {element}, _comm.comm(),
       _x, xshape, part, max_facet_to_cell_links, 1);

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -194,13 +194,14 @@ XDMFFile::read_mesh(const fem::CoordinateElement<double>& element,
   auto [cells, cshape] = XDMFFile::read_topology_data(name, xpath);
   auto [x, xshape] = XDMFFile::read_geometry_data(name, xpath);
 
+  // TODO: formalise how this should work with XDMFFile
   std::vector<std::int32_t> cell_weights;
   if (_h5_id)
   {
     std::string cwname = "/Mesh/mesh/cell_weights";
     if (io::hdf5::has_dataset(_h5_id, cwname))
     {
-      std::cout << "Has dataset cell_weights\n";
+      std::cout << "Reading cell weight dataset /Mesh/mesh/cell_weights\n";
 
       // Get data shape from HDF5 file
       const std::vector shape_hdf5
@@ -209,13 +210,13 @@ XDMFFile::read_mesh(const fem::CoordinateElement<double>& element,
           = common::local_range(dolfinx::MPI::rank(_comm.comm()), shape_hdf5[0],
                                 dolfinx::MPI::size(_comm.comm()));
 
-      // read_dataset() needs an open *dataset* identifier, not the file
-      // identifier -- open it here and close it once we're done
       hid_t dset_id = io::hdf5::open_dataset(_h5_id, cwname);
       cell_weights = io::hdf5::read_dataset<std::int32_t>(dset_id, range, true);
       H5Dclose(dset_id);
-      std::cout << "Read cell weights (" << cell_weights.size() << ")\n";
-      std::cout << "Cells (" << cells.size() / 4 << ")\n";
+
+      if (cell_weights.size() != cshape[0])
+        throw std::runtime_error(
+            "Cell weights size mismatch with number of local cells");
     }
   }
 

--- a/cpp/dolfinx/io/XDMFFile.cpp
+++ b/cpp/dolfinx/io/XDMFFile.cpp
@@ -194,31 +194,8 @@ XDMFFile::read_mesh(const fem::CoordinateElement<double>& element,
   auto [cells, cshape] = XDMFFile::read_topology_data(name, xpath);
   auto [x, xshape] = XDMFFile::read_geometry_data(name, xpath);
 
-  // TODO: formalise how this should work with XDMFFile
+  // TODO: figure out how to include this data with XDMFFile
   std::vector<std::int32_t> cell_weights;
-  if (_h5_id)
-  {
-    std::string cwname = "/Mesh/mesh/cell_weights";
-    if (io::hdf5::has_dataset(_h5_id, cwname))
-    {
-      std::cout << "Reading cell weight dataset /Mesh/mesh/cell_weights\n";
-
-      // Get data shape from HDF5 file
-      const std::vector shape_hdf5
-          = io::hdf5::get_dataset_shape(_h5_id, cwname);
-      auto range
-          = common::local_range(dolfinx::MPI::rank(_comm.comm()), shape_hdf5[0],
-                                dolfinx::MPI::size(_comm.comm()));
-
-      hid_t dset_id = io::hdf5::open_dataset(_h5_id, cwname);
-      cell_weights = io::hdf5::read_dataset<std::int32_t>(dset_id, range, true);
-      H5Dclose(dset_id);
-
-      if (cell_weights.size() != cshape[0])
-        throw std::runtime_error(
-            "Cell weights size mismatch with number of local cells");
-    }
-  }
 
   // Create mesh
   const std::vector<double>& _x = std::get<std::vector<double>>(x);

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -111,8 +111,6 @@ public:
   mesh::Mesh<double>
   read_mesh(const fem::CoordinateElement<double>& element, mesh::GhostMode mode,
             std::string_view name, std::string_view xpath = "/Xdmf/Domain",
-            std::function<void(std::vector<std::int64_t>&)> facet_intercept
-            = nullptr,
             std::optional<std::int32_t> max_facet_to_cell_links = 2) const;
 
   /// Read Topology data for Mesh

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -111,6 +111,8 @@ public:
   mesh::Mesh<double>
   read_mesh(const fem::CoordinateElement<double>& element, mesh::GhostMode mode,
             std::string_view name, std::string_view xpath = "/Xdmf/Domain",
+            std::function<void(std::vector<std::int64_t>&)> facet_intercept
+            = nullptr,
             std::optional<std::int32_t> max_facet_to_cell_links = 2) const;
 
   /// Read Topology data for Mesh

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -284,18 +284,17 @@ create_interval(MPI_Comm comm, std::int64_t n, std::array<T, 2> p,
     std::size_t npts = x1d.size();
     if (gdim == 1)
     {
-      return create_mesh(comm, MPI_COMM_SELF, cells,
-                         std::span<const std::int32_t>(), element,
-                         MPI_COMM_SELF, x1d, {npts, 1}, partitioner, 2, 1,
-                         reorder_fn);
+      return create_mesh(
+          comm, MPI_COMM_SELF, cells, std::span<const std::int32_t>(), element,
+          MPI_COMM_SELF, x1d, {npts, 1}, partitioner, 2, 1, reorder_fn);
     }
     std::vector<T> x(npts * gdim, T(0));
     for (std::size_t i = 0; i < npts; i++)
       x[i * gdim] = x1d[i];
     return create_mesh(comm, MPI_COMM_SELF, cells,
-                       std::span<const std::int32_t>(), element,
-                       MPI_COMM_SELF, x, {npts, static_cast<std::size_t>(gdim)},
-                       partitioner, 2, 1, reorder_fn);
+                       std::span<const std::int32_t>(), element, MPI_COMM_SELF,
+                       x, {npts, static_cast<std::size_t>(gdim)}, partitioner,
+                       2, 1, reorder_fn);
   }
   else
   {
@@ -678,10 +677,9 @@ Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
     std::size_t npts = x.size() / 2;
     if (gdim == 2)
     {
-      return create_mesh(comm, MPI_COMM_SELF, cells,
-                         std::span<const std::int32_t>(), element,
-                         MPI_COMM_SELF, x, {npts, 2}, partitioner, 2, 1,
-                         reorder_fn);
+      return create_mesh(
+          comm, MPI_COMM_SELF, cells, std::span<const std::int32_t>(), element,
+          MPI_COMM_SELF, x, {npts, 2}, partitioner, 2, 1, reorder_fn);
     }
     std::vector<T> xg(npts * gdim, T(0));
     for (std::size_t i = 0; i < npts; i++)
@@ -690,10 +688,9 @@ Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
       xg[i * gdim + 1] = x[2 * i + 1];
     }
     return create_mesh(comm, MPI_COMM_SELF, cells,
-                       std::span<const std::int32_t>(), element,
-                       MPI_COMM_SELF, xg,
-                       {npts, static_cast<std::size_t>(gdim)}, partitioner, 2,
-                       1, reorder_fn);
+                       std::span<const std::int32_t>(), element, MPI_COMM_SELF,
+                       xg, {npts, static_cast<std::size_t>(gdim)}, partitioner,
+                       2, 1, reorder_fn);
   }
   else
   {
@@ -749,10 +746,9 @@ Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
     std::size_t npts = x.size() / 2;
     if (gdim == 2)
     {
-      return create_mesh(comm, MPI_COMM_SELF, cells,
-                         std::span<const std::int32_t>(), element,
-                         MPI_COMM_SELF, x, {npts, 2}, partitioner, 2, 1,
-                         reorder_fn);
+      return create_mesh(
+          comm, MPI_COMM_SELF, cells, std::span<const std::int32_t>(), element,
+          MPI_COMM_SELF, x, {npts, 2}, partitioner, 2, 1, reorder_fn);
     }
     std::vector<T> xg(npts * gdim, T(0));
     for (std::size_t i = 0; i < npts; i++)
@@ -761,10 +757,9 @@ Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
       xg[i * gdim + 1] = x[2 * i + 1];
     }
     return create_mesh(comm, MPI_COMM_SELF, cells,
-                       std::span<const std::int32_t>(), element,
-                       MPI_COMM_SELF, xg,
-                       {npts, static_cast<std::size_t>(gdim)}, partitioner, 2,
-                       1, reorder_fn);
+                       std::span<const std::int32_t>(), element, MPI_COMM_SELF,
+                       xg, {npts, static_cast<std::size_t>(gdim)}, partitioner,
+                       2, 1, reorder_fn);
   }
   else
   {

--- a/cpp/dolfinx/mesh/generation.h
+++ b/cpp/dolfinx/mesh/generation.h
@@ -284,21 +284,25 @@ create_interval(MPI_Comm comm, std::int64_t n, std::array<T, 2> p,
     std::size_t npts = x1d.size();
     if (gdim == 1)
     {
-      return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF,
-                         x1d, {npts, 1}, partitioner, 2, 1, reorder_fn);
+      return create_mesh(comm, MPI_COMM_SELF, cells,
+                         std::span<const std::int32_t>(), element,
+                         MPI_COMM_SELF, x1d, {npts, 1}, partitioner, 2, 1,
+                         reorder_fn);
     }
     std::vector<T> x(npts * gdim, T(0));
     for (std::size_t i = 0; i < npts; i++)
       x[i * gdim] = x1d[i];
-    return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
-                       {npts, static_cast<std::size_t>(gdim)}, partitioner, 2,
-                       1, reorder_fn);
+    return create_mesh(comm, MPI_COMM_SELF, cells,
+                       std::span<const std::int32_t>(), element,
+                       MPI_COMM_SELF, x, {npts, static_cast<std::size_t>(gdim)},
+                       partitioner, 2, 1, reorder_fn);
   }
   else
   {
-    return create_mesh(comm, MPI_COMM_NULL, {}, element, MPI_COMM_NULL,
-                       std::vector<T>{}, {0, static_cast<std::size_t>(gdim)},
-                       partitioner, 2, 1, reorder_fn);
+    return create_mesh(comm, MPI_COMM_NULL, {}, std::span<const std::int32_t>(),
+                       element, MPI_COMM_NULL, std::vector<T>{},
+                       {0, static_cast<std::size_t>(gdim)}, partitioner, 2, 1,
+                       reorder_fn);
   }
 }
 
@@ -421,8 +425,9 @@ Mesh<T> build_tet(MPI_Comm comm, MPI_Comm subcomm,
     }
   }
 
-  return create_mesh(comm, subcomm, cells, element, subcomm, x,
-                     {x.size() / 3, 3}, partitioner, 2, 1, reorder_fn);
+  return create_mesh(comm, subcomm, cells, std::span<const std::int32_t>(),
+                     element, subcomm, x, {x.size() / 3, 3}, partitioner, 2, 1,
+                     reorder_fn);
 }
 
 template <std::floating_point T>
@@ -466,8 +471,9 @@ build_hex(MPI_Comm comm, MPI_Comm subcomm, std::array<std::array<T, 3>, 2> p,
     }
   }
 
-  return create_mesh(comm, subcomm, cells, element, subcomm, x,
-                     {x.size() / 3, 3}, partitioner, 2, 1, reorder_fn);
+  return create_mesh(comm, subcomm, cells, std::span<const std::int32_t>(),
+                     element, subcomm, x, {x.size() / 3, 3}, partitioner, 2, 1,
+                     reorder_fn);
 }
 
 template <std::floating_point T>
@@ -514,8 +520,9 @@ Mesh<T> build_prism(MPI_Comm comm, MPI_Comm subcomm,
     }
   }
 
-  return create_mesh(comm, subcomm, cells, element, subcomm, x,
-                     {x.size() / 3, 3}, partitioner, 2, 1, reorder_fn);
+  return create_mesh(comm, subcomm, cells, std::span<const std::int32_t>(),
+                     element, subcomm, x, {x.size() / 3, 3}, partitioner, 2, 1,
+                     reorder_fn);
 }
 
 template <std::floating_point T>
@@ -671,8 +678,10 @@ Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
     std::size_t npts = x.size() / 2;
     if (gdim == 2)
     {
-      return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
-                         {npts, 2}, partitioner, 2, 1, reorder_fn);
+      return create_mesh(comm, MPI_COMM_SELF, cells,
+                         std::span<const std::int32_t>(), element,
+                         MPI_COMM_SELF, x, {npts, 2}, partitioner, 2, 1,
+                         reorder_fn);
     }
     std::vector<T> xg(npts * gdim, T(0));
     for (std::size_t i = 0; i < npts; i++)
@@ -680,15 +689,18 @@ Mesh<T> build_tri(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
       xg[i * gdim] = x[2 * i];
       xg[i * gdim + 1] = x[2 * i + 1];
     }
-    return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, xg,
+    return create_mesh(comm, MPI_COMM_SELF, cells,
+                       std::span<const std::int32_t>(), element,
+                       MPI_COMM_SELF, xg,
                        {npts, static_cast<std::size_t>(gdim)}, partitioner, 2,
                        1, reorder_fn);
   }
   else
   {
-    return create_mesh(comm, MPI_COMM_NULL, {}, element, MPI_COMM_NULL,
-                       std::vector<T>{}, {0, static_cast<std::size_t>(gdim)},
-                       partitioner, 2, 1, reorder_fn);
+    return create_mesh(comm, MPI_COMM_NULL, {}, std::span<const std::int32_t>(),
+                       element, MPI_COMM_NULL, std::vector<T>{},
+                       {0, static_cast<std::size_t>(gdim)}, partitioner, 2, 1,
+                       reorder_fn);
   }
 }
 
@@ -737,8 +749,10 @@ Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
     std::size_t npts = x.size() / 2;
     if (gdim == 2)
     {
-      return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
-                         {npts, 2}, partitioner, 2, 1, reorder_fn);
+      return create_mesh(comm, MPI_COMM_SELF, cells,
+                         std::span<const std::int32_t>(), element,
+                         MPI_COMM_SELF, x, {npts, 2}, partitioner, 2, 1,
+                         reorder_fn);
     }
     std::vector<T> xg(npts * gdim, T(0));
     for (std::size_t i = 0; i < npts; i++)
@@ -746,15 +760,18 @@ Mesh<T> build_quad(MPI_Comm comm, std::array<std::array<T, 2>, 2> p,
       xg[i * gdim] = x[2 * i];
       xg[i * gdim + 1] = x[2 * i + 1];
     }
-    return create_mesh(comm, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, xg,
+    return create_mesh(comm, MPI_COMM_SELF, cells,
+                       std::span<const std::int32_t>(), element,
+                       MPI_COMM_SELF, xg,
                        {npts, static_cast<std::size_t>(gdim)}, partitioner, 2,
                        1, reorder_fn);
   }
   else
   {
-    return create_mesh(comm, MPI_COMM_NULL, {}, element, MPI_COMM_NULL,
-                       std::vector<T>{}, {0, static_cast<std::size_t>(gdim)},
-                       partitioner, 2, 1, reorder_fn);
+    return create_mesh(comm, MPI_COMM_NULL, {}, std::span<const std::int32_t>(),
+                       element, MPI_COMM_NULL, std::vector<T>{},
+                       {0, static_cast<std::size_t>(gdim)}, partitioner, 2, 1,
+                       reorder_fn);
   }
 }
 } // namespace impl

--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -38,7 +38,7 @@ namespace
 /// before this function is called.
 ///
 /// @param[in] comm MPI communicator
-/// @param[in] facets Facets on this rank that are shared by only on
+/// @param[in] facets Facets on this rank that are shared by only one
 /// cell on this rank, i.e. candidates for possibly residing on other
 /// processes. Each row in `facets` corresponds to a facet, and the row
 /// data has the form `[v0, ..., v_{n-1}, -1, -1]`, where `v_i` are the
@@ -303,7 +303,7 @@ graph::AdjacencyList<std::int64_t> compute_nonlocal_dual_graph(
   // Search for consecutive facets (-> dual graph edge between cells)
   // and pack into send buffer. We store for every cell the number of
   // matches, the offsets of each cell and the continuous data. Note:
-  // 'deges' is short for dual edges.
+  // 'dedges' is short for dual edges.
   std::vector<int> dedge_send_count(recv_disp.back());
   std::vector<std::int32_t> dedge_send_displs(dedge_send_count.size() + 1, 0);
   std::vector<std::int64_t> dedge_send_data;
@@ -419,46 +419,40 @@ graph::AdjacencyList<std::int64_t> compute_nonlocal_dual_graph(
                           num_items_per_dest.data(), send_disp.data(), MPI_INT,
                           comm_po_receive, &dedge_recv_count_request);
 
+  // Collapse per-facet-slot counts into per-neighbour-rank totals and
+  // the corresponding displacements. `counts` is indexed by facet
+  // slot (flat across all neighbours' facets); `group_sizes[i]` is
+  // the number of facet slots sent to/received from neighbour `i`.
+  // Note: pp in variable names is short for per-process.
+  auto collapse_counts_to_pp
+      = [](std::span<const int> counts, const auto& group_sizes)
+      -> std::pair<std::vector<int>, std::vector<std::int32_t>>
+  {
+    std::vector<int> pp_count(group_sizes.size(), 0);
+    std::vector<std::int32_t> pp_displs(pp_count.size() + 1, 0);
+    int index = 0;
+    for (std::size_t i = 0; i < group_sizes.size(); i++)
+    {
+      for (int j = 0; j < group_sizes[i]; j++)
+        pp_count[i] += counts[index++];
+    }
+
+    std::partial_sum(pp_count.begin(), pp_count.end(),
+                     std::next(pp_displs.begin()));
+    return {std::move(pp_count), std::move(pp_displs)};
+  };
+
   // Prepare send data for matched facets. Note, we have prepared
   // adjacency information for all cells. Here we retrieve the offset
   // and displacement data corresponding to the per process adjacency
   // lists.
-  // Note: pp in variable names is short for per-process.
-  std::vector<int> dedge_send_count_pp(num_items_recv.size(), 0);
-  std::vector<std::int32_t> dedge_send_displs_pp(dedge_send_count_pp.size() + 1,
-                                                 0);
-  {
-    int index = 0;
-    for (std::size_t i = 0; i < num_items_recv.size(); i++)
-    {
-      for (int j = 0; j < num_items_recv[i]; j++)
-        dedge_send_count_pp[i] += dedge_send_count[index + j];
-
-      index += num_items_recv[i];
-    }
-
-    std::partial_sum(dedge_send_count_pp.begin(), dedge_send_count_pp.end(),
-                     std::next(dedge_send_displs_pp.begin()));
-  }
+  auto [dedge_send_count_pp, dedge_send_displs_pp]
+      = collapse_counts_to_pp(dedge_send_count, num_items_recv);
 
   // Compute matched facet receive counts and displacements.
-  std::vector<int> dedge_recv_count_pp(num_items_per_dest.size(), 0);
-  std::vector<std::int32_t> dedge_recv_displs_pp(dedge_recv_count_pp.size() + 1,
-                                                 0);
   MPI_Wait(&dedge_recv_count_request, MPI_STATUS_IGNORE);
-  {
-    int index = 0;
-    for (std::size_t i = 0; i < num_items_per_dest.size(); i++)
-    {
-      for (int j = 0; j < num_items_per_dest[i]; j++)
-        dedge_recv_count_pp[i] += dedge_recv_count[index + j];
-
-      index += num_items_per_dest[i];
-    }
-
-    std::partial_sum(dedge_recv_count_pp.begin(), dedge_recv_count_pp.end(),
-                     std::next(dedge_recv_displs_pp.begin()));
-  }
+  auto [dedge_recv_count_pp, dedge_recv_displs_pp]
+      = collapse_counts_to_pp(dedge_recv_count, num_items_per_dest);
   // Exchange flattened list of matched facets
   std::vector<std::int64_t> recv_dual_edges(dedge_recv_displs_pp.back());
   MPI_Neighbor_alltoallv(dedge_send_data.data(), dedge_send_count_pp.data(),
@@ -899,11 +893,12 @@ mesh::build_local_dual_graph(
           std::move(local_cells)};
 }
 //-----------------------------------------------------------------------------
-graph::AdjacencyList<std::int64_t>
-mesh::build_dual_graph(MPI_Comm comm, std::span<const CellType> celltypes,
-                       const std::vector<std::span<const std::int64_t>>& cells,
-                       std::optional<std::int32_t> max_facet_to_cell_links,
-                       int num_threads)
+graph::AdjacencyList<std::int64_t> mesh::build_dual_graph(
+    MPI_Comm comm, std::span<const CellType> celltypes,
+    const std::vector<std::span<const std::int64_t>>& cells,
+    std::optional<std::int32_t> max_facet_to_cell_links,
+    std::function<void(std::vector<std::int64_t>&)> facet_intercept,
+    int num_threads)
 {
   spdlog::info("Building mesh dual graph");
 
@@ -911,6 +906,11 @@ mesh::build_dual_graph(MPI_Comm comm, std::span<const CellType> celltypes,
   // are connections by facet)
   auto [local_graph, facets, shape1, fcells] = mesh::build_local_dual_graph(
       celltypes, cells, max_facet_to_cell_links, num_threads);
+
+  // Run custom function to change certain exterior facets before sending to the
+  // nonlocal dual graph computation.
+  if (facet_intercept)
+    facet_intercept(facets);
 
   // Extend with nonlocal edges and convert to global indices
   graph::AdjacencyList graph

--- a/cpp/dolfinx/mesh/graphbuild.cpp
+++ b/cpp/dolfinx/mesh/graphbuild.cpp
@@ -893,12 +893,11 @@ mesh::build_local_dual_graph(
           std::move(local_cells)};
 }
 //-----------------------------------------------------------------------------
-graph::AdjacencyList<std::int64_t> mesh::build_dual_graph(
-    MPI_Comm comm, std::span<const CellType> celltypes,
-    const std::vector<std::span<const std::int64_t>>& cells,
-    std::optional<std::int32_t> max_facet_to_cell_links,
-    std::function<void(std::vector<std::int64_t>&)> facet_intercept,
-    int num_threads)
+graph::AdjacencyList<std::int64_t>
+mesh::build_dual_graph(MPI_Comm comm, std::span<const CellType> celltypes,
+                       const std::vector<std::span<const std::int64_t>>& cells,
+                       std::optional<std::int32_t> max_facet_to_cell_links,
+                       int num_threads)
 {
   spdlog::info("Building mesh dual graph");
 
@@ -906,11 +905,6 @@ graph::AdjacencyList<std::int64_t> mesh::build_dual_graph(
   // are connections by facet)
   auto [local_graph, facets, shape1, fcells] = mesh::build_local_dual_graph(
       celltypes, cells, max_facet_to_cell_links, num_threads);
-
-  // Run custom function to change certain exterior facets before sending to the
-  // nonlocal dual graph computation.
-  if (facet_intercept)
-    facet_intercept(facets);
 
   // Extend with nonlocal edges and convert to global indices
   graph::AdjacencyList graph

--- a/cpp/dolfinx/mesh/graphbuild.h
+++ b/cpp/dolfinx/mesh/graphbuild.h
@@ -102,6 +102,8 @@ graph::AdjacencyList<std::int64_t>
 build_dual_graph(MPI_Comm comm, std::span<const CellType> celltypes,
                  const std::vector<std::span<const std::int64_t>>& cells,
                  std::optional<std::int32_t> max_facet_to_cell_links,
+                 std::function<void(std::vector<std::int64_t>&)> facet_intercept
+                 = nullptr,
                  int num_threads = 1);
 
 } // namespace dolfinx::mesh

--- a/cpp/dolfinx/mesh/graphbuild.h
+++ b/cpp/dolfinx/mesh/graphbuild.h
@@ -102,8 +102,6 @@ graph::AdjacencyList<std::int64_t>
 build_dual_graph(MPI_Comm comm, std::span<const CellType> celltypes,
                  const std::vector<std::span<const std::int64_t>>& cells,
                  std::optional<std::int32_t> max_facet_to_cell_links,
-                 std::function<void(std::vector<std::int64_t>&)> facet_intercept
-                 = nullptr,
                  int num_threads = 1);
 
 } // namespace dolfinx::mesh

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -101,22 +101,20 @@ std::vector<std::int32_t> mesh::exterior_facet_indices(const Topology& topology)
 //------------------------------------------------------------------------------
 mesh::CellPartitionFunction mesh::create_cell_partitioner(
     mesh::GhostMode ghost_mode, graph::partition_fn partfn,
-    std::function<void(std::vector<std::int64_t>&)> facet_intercept,
     std::optional<std::int32_t> max_facet_to_cell_links)
 {
-  return [partfn = std::move(partfn), facet_intercept, ghost_mode,
-          max_facet_to_cell_links](
+  return [partfn = std::move(partfn), ghost_mode, max_facet_to_cell_links](
              MPI_Comm comm, int nparts, const std::vector<CellType>& cell_types,
              const std::vector<std::span<const std::int64_t>>& cells,
-             std::span<std::int32_t> cell_weights,
-             std::span<std::int32_t> edge_weights)
+             std::span<const std::int32_t> cell_weights,
+             std::span<const std::int32_t> edge_weights)
              -> graph::AdjacencyList<std::int32_t>
   {
     spdlog::info("Compute partition of cells across ranks");
 
     // Compute distributed dual graph (for the cells on this process)
-    graph::AdjacencyList dual_graph = build_dual_graph(
-        comm, cell_types, cells, max_facet_to_cell_links, facet_intercept);
+    graph::AdjacencyList dual_graph
+        = build_dual_graph(comm, cell_types, cells, max_facet_to_cell_links);
 
     // Just flag any kind of ghosting for now
     bool ghosting = (ghost_mode != GhostMode::none);
@@ -131,7 +129,7 @@ mesh::CellPartitionFunction mesh::create_cell_partitioner(
     mesh::GhostMode ghost_mode,
     std::optional<std::int32_t> max_facet_to_cell_links)
 {
-  return create_cell_partitioner(ghost_mode, &graph::partition_graph, nullptr,
+  return create_cell_partitioner(ghost_mode, &graph::partition_graph,
                                  max_facet_to_cell_links);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/mesh/utils.cpp
+++ b/cpp/dolfinx/mesh/utils.cpp
@@ -101,24 +101,29 @@ std::vector<std::int32_t> mesh::exterior_facet_indices(const Topology& topology)
 //------------------------------------------------------------------------------
 mesh::CellPartitionFunction mesh::create_cell_partitioner(
     mesh::GhostMode ghost_mode, graph::partition_fn partfn,
+    std::function<void(std::vector<std::int64_t>&)> facet_intercept,
     std::optional<std::int32_t> max_facet_to_cell_links)
 {
-  return [partfn = std::move(partfn), ghost_mode, max_facet_to_cell_links](
+  return [partfn = std::move(partfn), facet_intercept, ghost_mode,
+          max_facet_to_cell_links](
              MPI_Comm comm, int nparts, const std::vector<CellType>& cell_types,
-             const std::vector<std::span<const std::int64_t>>& cells)
+             const std::vector<std::span<const std::int64_t>>& cells,
+             std::span<std::int32_t> cell_weights,
+             std::span<std::int32_t> edge_weights)
              -> graph::AdjacencyList<std::int32_t>
   {
     spdlog::info("Compute partition of cells across ranks");
 
     // Compute distributed dual graph (for the cells on this process)
-    graph::AdjacencyList dual_graph
-        = build_dual_graph(comm, cell_types, cells, max_facet_to_cell_links);
+    graph::AdjacencyList dual_graph = build_dual_graph(
+        comm, cell_types, cells, max_facet_to_cell_links, facet_intercept);
 
     // Just flag any kind of ghosting for now
     bool ghosting = (ghost_mode != GhostMode::none);
 
     // Compute partition
-    return partfn(comm, nparts, dual_graph, ghosting);
+    return partfn(comm, nparts, dual_graph, cell_weights, edge_weights,
+                  ghosting);
   };
 }
 //-----------------------------------------------------------------------------
@@ -126,7 +131,7 @@ mesh::CellPartitionFunction mesh::create_cell_partitioner(
     mesh::GhostMode ghost_mode,
     std::optional<std::int32_t> max_facet_to_cell_links)
 {
-  return create_cell_partitioner(ghost_mode, &graph::partition_graph,
+  return create_cell_partitioner(ghost_mode, &graph::partition_graph, nullptr,
                                  max_facet_to_cell_links);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -212,7 +212,9 @@ std::vector<std::int32_t> exterior_facet_indices(const Topology& topology);
 /// @note Cells can have multiple destination ranks, when ghosted.
 using CellPartitionFunction = std::function<graph::AdjacencyList<std::int32_t>(
     MPI_Comm comm, int nparts, const std::vector<CellType>& cell_types,
-    const std::vector<std::span<const std::int64_t>>& cells)>;
+    const std::vector<std::span<const std::int64_t>>& cells,
+    std::span<std::int32_t> cell_weights,
+    std::span<std::int32_t> edge_weights)>;
 
 /// @brief Function that reorders (locally) cells that
 /// are owned by this process. It takes the local mesh dual graph as an
@@ -996,9 +998,10 @@ entities_to_geometry(const Mesh<T>& mesh, int dim,
 /// facet needs to be connected to to be considered *matched* (not on
 /// boundary for non-branching meshes).
 /// @return Function that computes the destination ranks for each cell.
-CellPartitionFunction
-create_cell_partitioner(mesh::GhostMode ghost_mode, graph::partition_fn partfn,
-                        std::optional<std::int32_t> max_facet_to_cell_links);
+CellPartitionFunction create_cell_partitioner(
+    mesh::GhostMode ghost_mode, graph::partition_fn partfn,
+    std::function<void(std::vector<std::int64_t>&)> facet_intercept,
+    std::optional<std::int32_t> max_facet_to_cell_links);
 
 /// @brief Create a function that computes destination rank for mesh
 /// cells on this rank by applying the default graph partitioner to the
@@ -1074,6 +1077,7 @@ template <typename U>
 Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
     MPI_Comm comm, MPI_Comm commt,
     std::vector<std::span<const std::int64_t>> cells,
+    std::span<std::int32_t> cell_weights,
     const std::vector<fem::CoordinateElement<
         typename std::remove_reference_t<typename U::value_type>>>& elements,
     MPI_Comm commg, const U& x, std::array<std::size_t, 2> xshape,
@@ -1118,7 +1122,9 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
         t[i] = extract_topology(celltypes[i], doflayouts[i], cells[i]);
         tspan[i] = std::span(t[i]);
       }
-      dest = partitioner(commt, size, celltypes, tspan);
+      std::vector<std::int32_t> edge_weights;
+      dest = partitioner(commt, size, celltypes, tspan, cell_weights,
+                         edge_weights);
     }
 
     std::int32_t cell_offset = 0;
@@ -1300,6 +1306,7 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
 template <typename U>
 Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
     MPI_Comm comm, MPI_Comm commt, std::span<const std::int64_t> cells,
+    std::span<std::int32_t> cell_weights,
     const fem::CoordinateElement<
         typename std::remove_reference_t<typename U::value_type>>& element,
     MPI_Comm commg, const U& x, std::array<std::size_t, 2> xshape,
@@ -1307,9 +1314,9 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
     std::optional<std::int32_t> max_facet_to_cell_links, int num_threads,
     const CellReorderFunction& reorder_fn = graph::reorder_rcm)
 {
-  return create_mesh(comm, commt, std::vector{cells}, std::vector{element},
-                     commg, x, xshape, partitioner, max_facet_to_cell_links,
-                     num_threads, reorder_fn);
+  return create_mesh(comm, commt, std::vector{cells}, cell_weights,
+                     std::vector{element}, commg, x, xshape, partitioner,
+                     max_facet_to_cell_links, num_threads, reorder_fn);
 }
 
 /// @brief Create a distributed mesh from mesh data using the default

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -208,6 +208,13 @@ std::vector<std::int32_t> exterior_facet_indices(const Topology& topology);
 /// globally, i.e. the maximum index across all processes can be greater
 /// than the number of vertices. High-order 'nodes', e.g. mid-side
 /// points, should not be included.
+/// @param[in] cell_weights Weights associated with each cell in `cells`
+/// (flattened across cell types in the same order as `cells`), e.g. for
+/// use by the graph partitioner. If empty, cells are treated as having
+/// equal weight.
+/// @param[in] edge_weights Weights associated with each edge of the
+/// dual graph built from `cells`, e.g. for use by the graph partitioner.
+/// If empty, edges are treated as having equal weight.
 /// @return Destination ranks for each cell on this process.
 /// @note Cells can have multiple destination ranks, when ghosted.
 using CellPartitionFunction = std::function<graph::AdjacencyList<std::int32_t>(
@@ -1052,6 +1059,10 @@ compute_incident_entities(const Topology& topology,
 /// cells this will be just the cell vertices. For higher-order geometry
 /// cells, other cell 'nodes' will be included. See io::cells for
 /// examples of the Basix ordering.
+/// @param[in] cell_weights Weights associated with each cell in `cells`
+/// (flattened across cell types in the same order as `cells`), e.g. for
+/// use by the graph partitioner. If empty, cells are treated as having
+/// equal weight.
 /// @param[in] elements Coordinate elements for the cells, where
 /// `elements[i]` is the coordinate element for the cells in `cells[i]`.
 /// **The list of elements must be the same on all calling parallel
@@ -1286,6 +1297,9 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
 /// will be just the cell vertices. For higher-order cells, other cells
 /// 'nodes' will be included. See dolfinx::io::cells for examples of the
 /// Basix ordering.
+/// @param[in] cell_weights Weights associated with each cell in `cells`,
+/// e.g. for use by the graph partitioner. If empty, cells are treated
+/// as having equal weight.
 /// @param[in] element Coordinate element for the cells.
 /// @param[in] commg Communicator for geometry.
 /// @param[in] x Geometry data ('node' coordinates). Row-major storage.
@@ -1348,13 +1362,15 @@ create_mesh(MPI_Comm comm, std::span<const std::int64_t> cells,
 {
   if (dolfinx::MPI::size(comm) == 1)
   {
-    return create_mesh(comm, comm, std::vector{cells}, std::vector{elements},
+    return create_mesh(comm, comm, std::vector{cells},
+                       std::span<const std::int32_t>(), std::vector{elements},
                        comm, x, xshape, nullptr, max_facet_to_cell_links, 1);
   }
   else
   {
     return create_mesh(
-        comm, comm, std::vector{cells}, std::vector{elements}, comm, x, xshape,
+        comm, comm, std::vector{cells}, std::span<const std::int32_t>(),
+        std::vector{elements}, comm, x, xshape,
         create_cell_partitioner(ghost_mode, max_facet_to_cell_links),
         max_facet_to_cell_links, 1);
   }

--- a/cpp/dolfinx/mesh/utils.h
+++ b/cpp/dolfinx/mesh/utils.h
@@ -213,8 +213,8 @@ std::vector<std::int32_t> exterior_facet_indices(const Topology& topology);
 using CellPartitionFunction = std::function<graph::AdjacencyList<std::int32_t>(
     MPI_Comm comm, int nparts, const std::vector<CellType>& cell_types,
     const std::vector<std::span<const std::int64_t>>& cells,
-    std::span<std::int32_t> cell_weights,
-    std::span<std::int32_t> edge_weights)>;
+    std::span<const std::int32_t> cell_weights,
+    std::span<const std::int32_t> edge_weights)>;
 
 /// @brief Function that reorders (locally) cells that
 /// are owned by this process. It takes the local mesh dual graph as an
@@ -998,10 +998,9 @@ entities_to_geometry(const Mesh<T>& mesh, int dim,
 /// facet needs to be connected to to be considered *matched* (not on
 /// boundary for non-branching meshes).
 /// @return Function that computes the destination ranks for each cell.
-CellPartitionFunction create_cell_partitioner(
-    mesh::GhostMode ghost_mode, graph::partition_fn partfn,
-    std::function<void(std::vector<std::int64_t>&)> facet_intercept,
-    std::optional<std::int32_t> max_facet_to_cell_links);
+CellPartitionFunction
+create_cell_partitioner(mesh::GhostMode ghost_mode, graph::partition_fn partfn,
+                        std::optional<std::int32_t> max_facet_to_cell_links);
 
 /// @brief Create a function that computes destination rank for mesh
 /// cells on this rank by applying the default graph partitioner to the
@@ -1077,7 +1076,7 @@ template <typename U>
 Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
     MPI_Comm comm, MPI_Comm commt,
     std::vector<std::span<const std::int64_t>> cells,
-    std::span<std::int32_t> cell_weights,
+    std::span<const std::int32_t> cell_weights,
     const std::vector<fem::CoordinateElement<
         typename std::remove_reference_t<typename U::value_type>>>& elements,
     MPI_Comm commg, const U& x, std::array<std::size_t, 2> xshape,
@@ -1306,7 +1305,7 @@ Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
 template <typename U>
 Mesh<typename std::remove_reference_t<typename U::value_type>> create_mesh(
     MPI_Comm comm, MPI_Comm commt, std::span<const std::int64_t> cells,
-    std::span<std::int32_t> cell_weights,
+    std::span<const std::int32_t> cell_weights,
     const fem::CoordinateElement<
         typename std::remove_reference_t<typename U::value_type>>& element,
     MPI_Comm commg, const U& x, std::array<std::size_t, 2> xshape,

--- a/cpp/dolfinx/refinement/refine.h
+++ b/cpp/dolfinx/refinement/refine.h
@@ -49,7 +49,9 @@ create_identity_partitioner(const mesh::Mesh<T>& parent_mesh,
   return [&parent_mesh,
           parent_cell](MPI_Comm comm, int /*nparts*/,
                        std::vector<mesh::CellType> cell_types,
-                       std::vector<std::span<const std::int64_t>> cells)
+                       std::vector<std::span<const std::int64_t>> cells,
+                       std::span<const std::int32_t> /* cell_weights */,
+                       std::span<const std::int32_t> /* edge_weights */)
              -> graph::AdjacencyList<std::int32_t>
   {
     auto parent_cell_im
@@ -151,7 +153,8 @@ refine(const mesh::Mesh<T>& mesh,
 
   mesh::Mesh<T> mesh1 = mesh::create_mesh(
       mesh.comm(), mesh.comm(), cell_adj.array(),
-      mesh.geometry().cmaps().front(), mesh.comm(), new_vertex_coords, xshape,
+      std::span<const std::int32_t>(), mesh.geometry().cmaps().front(),
+      mesh.comm(), new_vertex_coords, xshape,
       std::get<mesh::CellPartitionFunction>(partitioner), 2, 1);
 
   // Report the number of refined cells

--- a/cpp/dolfinx/refinement/uniform.cpp
+++ b/cpp/dolfinx/refinement/uniform.cpp
@@ -303,8 +303,9 @@ refinement::uniform_refine(const mesh::Mesh<T>& mesh,
   for (auto cm : mesh.geometry().cmaps())
     geometry_cmaps.push_back(cm);
   mesh::Mesh new_mesh = mesh::create_mesh(
-      mesh.comm(), mesh.comm(), topo_span, geometry_cmaps, mesh.comm(), new_x,
-      {new_x.size() / 3, 3}, partitioner, 2, 1);
+      mesh.comm(), mesh.comm(), topo_span, std::span<std::int32_t>(),
+      geometry_cmaps, mesh.comm(), new_x, {new_x.size() / 3, 3}, partitioner, 2,
+      1);
 
   return new_mesh;
 }

--- a/cpp/test/mesh/distributed_mesh.cpp
+++ b/cpp/test/mesh/distributed_mesh.cpp
@@ -138,10 +138,9 @@ void test_distributed_mesh(const mesh::CellPartitionFunction& partitioner)
   CHECK(xshape[1] == 2);
 
   // Build mesh
-  mesh::Mesh mesh
-      = mesh::create_mesh(comm, subset_comm, cells,
-                         std::span<const std::int32_t>(), cmap, comm, x,
-                         xshape, partitioner, 2, 1);
+  mesh::Mesh mesh = mesh::create_mesh(comm, subset_comm, cells,
+                                      std::span<const std::int32_t>(), cmap,
+                                      comm, x, xshape, partitioner, 2, 1);
   auto t = mesh.topology();
   int tdim = t->dim();
   CHECK(t->index_map(tdim)->size_global() == 2 * N * N);

--- a/cpp/test/mesh/distributed_mesh.cpp
+++ b/cpp/test/mesh/distributed_mesh.cpp
@@ -138,8 +138,10 @@ void test_distributed_mesh(const mesh::CellPartitionFunction& partitioner)
   CHECK(xshape[1] == 2);
 
   // Build mesh
-  mesh::Mesh mesh = mesh::create_mesh(comm, subset_comm, cells, cmap, comm, x,
-                                      xshape, partitioner, 2, 1);
+  mesh::Mesh mesh
+      = mesh::create_mesh(comm, subset_comm, cells,
+                         std::span<const std::int32_t>(), cmap, comm, x,
+                         xshape, partitioner, 2, 1);
   auto t = mesh.topology();
   int tdim = t->dim();
   CHECK(t->index_map(tdim)->size_global() == 2 * N * N);

--- a/cpp/test/mesh/generation.cpp
+++ b/cpp/test/mesh/generation.cpp
@@ -99,7 +99,9 @@ TEMPLATE_TEST_CASE("Interval mesh (parallel)", "[mesh][interval]", float,
   mesh::CellPartitionFunction part =
       [comm_size](MPI_Comm /* comm */, int /* nparts */,
                   const std::vector<mesh::CellType>& /* cell_types */,
-                  const std::vector<std::span<const std::int64_t>>& /* cells */)
+                  const std::vector<std::span<const std::int64_t>>& /* cells */,
+                  std::span<const std::int32_t> /* cell_weights */,
+                  std::span<const std::int32_t> /* edge_weights */)
   {
     std::vector<std::vector<std::int32_t>> data;
     if (comm_size == 1)

--- a/cpp/test/mesh/refinement/interval.cpp
+++ b/cpp/test/mesh/refinement/interval.cpp
@@ -154,8 +154,8 @@ TEMPLATE_TEST_CASE("Interval Refinement (parallel)",
 
     MPI_Comm commt = rank == 0 ? MPI_COMM_SELF : MPI_COMM_NULL;
     return mesh::create_mesh(MPI_COMM_WORLD, commt, cells,
-                             std::span<const std::int32_t>(), element, commt,
-                             x, {x.size() / 3, 3}, partitioner, 2, 1);
+                             std::span<const std::int32_t>(), element, commt, x,
+                             {x.size() / 3, 3}, partitioner, 2, 1);
   };
 
   mesh::Mesh<T> mesh = create_mesh();

--- a/cpp/test/mesh/refinement/interval.cpp
+++ b/cpp/test/mesh/refinement/interval.cpp
@@ -59,8 +59,8 @@ mesh::Mesh<T> create_3_vertex_interval_mesh()
                    v1[2], v2[0], v2[1], v2[2]};
   fem::CoordinateElement<T> element(mesh::CellType::interval, 1);
   return mesh::create_mesh(
-      MPI_COMM_SELF, MPI_COMM_SELF, cells, element, MPI_COMM_SELF, x,
-      {x.size() / 3, 3},
+      MPI_COMM_SELF, MPI_COMM_SELF, cells, std::span<const std::int32_t>(),
+      element, MPI_COMM_SELF, x, {x.size() / 3, 3},
       mesh::create_cell_partitioner(mesh::GhostMode::none, 2), 2, 1);
 }
 
@@ -143,7 +143,9 @@ TEMPLATE_TEST_CASE("Interval Refinement (parallel)",
     auto partitioner
         = [](MPI_Comm /* comm */, int /* nparts */,
              const std::vector<mesh::CellType>& /* cell_types */,
-             const std::vector<std::span<const std::int64_t>>& /* cells */)
+             const std::vector<std::span<const std::int64_t>>& /* cells */,
+             std::span<const std::int32_t> /* cell_weights */,
+             std::span<const std::int32_t> /* edge_weights */)
         -> graph::AdjacencyList<std::int32_t>
     {
       return graph::AdjacencyList<std::int32_t>(
@@ -151,8 +153,9 @@ TEMPLATE_TEST_CASE("Interval Refinement (parallel)",
     };
 
     MPI_Comm commt = rank == 0 ? MPI_COMM_SELF : MPI_COMM_NULL;
-    return mesh::create_mesh(MPI_COMM_WORLD, commt, cells, element, commt, x,
-                             {x.size() / 3, 3}, partitioner, 2, 1);
+    return mesh::create_mesh(MPI_COMM_WORLD, commt, cells,
+                             std::span<const std::int32_t>(), element, commt,
+                             x, {x.size() / 3, 3}, partitioner, 2, 1);
   };
 
   mesh::Mesh<T> mesh = create_mesh();

--- a/python/demo/demo_mixed-topology.py
+++ b/python/demo/demo_mixed-topology.py
@@ -126,6 +126,7 @@ mesh = create_mesh(
     part,
     2,
     1,
+    cell_weights=None,
 )
 # -
 

--- a/python/dolfinx/io/gmsh.py
+++ b/python/dolfinx/io/gmsh.py
@@ -454,6 +454,7 @@ def model_to_mesh(
             partitioner,
             max_facet_to_cell_links,
             1,
+            cell_weights=None,
         )
         mesh = Mesh(cpp_mesh, None)
 

--- a/python/dolfinx/io/gmsh.py
+++ b/python/dolfinx/io/gmsh.py
@@ -289,7 +289,15 @@ def model_to_mesh(
     rank: int,
     gdim: int = 3,
     partitioner: Callable[
-        [_MPI.Comm, int, Sequence[CellType], Sequence[npt.NDArray[np.int64]]], _AdjacencyList_int32
+        [
+            _MPI.Comm,
+            int,
+            Sequence[CellType],
+            Sequence[npt.NDArray[np.int64]],
+            npt.NDArray[np.int32],
+            npt.NDArray[np.int32],
+        ],
+        _AdjacencyList_int32,
     ]
     | None = None,
     dtype: npt.DTypeLike = default_real_type,
@@ -512,7 +520,15 @@ def read_from_msh(
     rank: int = 0,
     gdim: int = 3,
     partitioner: Callable[
-        [_MPI.Comm, int, Sequence[CellType], Sequence[npt.NDArray[np.int64]]], _AdjacencyList_int32
+        [
+            _MPI.Comm,
+            int,
+            Sequence[CellType],
+            Sequence[npt.NDArray[np.int64]],
+            npt.NDArray[np.int32],
+            npt.NDArray[np.int32],
+        ],
+        _AdjacencyList_int32,
     ]
     | None = None,
 ) -> MeshData:

--- a/python/dolfinx/io/utils.py
+++ b/python/dolfinx/io/utils.py
@@ -426,6 +426,7 @@ class XDMFFile:
             _cell_partitioner(ghost_mode, max_facet_to_cell_links),
             max_facet_to_cell_links,
             1,
+            cell_weights=None,
         )
         msh.name = name
         domain = ufl.Mesh(basix_el)

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -846,6 +846,7 @@ def create_mesh(
     partitioner: Callable | None = None,
     max_facet_to_cell_links: int = 2,
     num_threads: int = 1,
+    cell_weights: npt.NDArray[np.int32] | None = None,
 ) -> Mesh:
     """Create a mesh from topology and geometry arrays.
 
@@ -863,6 +864,9 @@ def create_mesh(
             be connected to.
         num_threads: Number of threads to use to build mesh. Must be
             greater than 0.
+        cell_weights: Weights associated with each cell in ``cells``,
+            e.g. for use by the graph partitioner. If not provided,
+            cells are treated as having equal weight.
 
     Note:
         If required, the coordinates ``x`` will be cast to the same
@@ -914,6 +918,8 @@ def create_mesh(
 
     x = np.asarray(x, dtype=dtype, order="C")
     cells = np.asarray(cells, dtype=np.int64, order="C")
+    if cell_weights is not None:
+        cell_weights = np.asarray(cell_weights, dtype=np.int32, order="C")
     msh: _cpp.mesh.Mesh_float32 | _cpp.mesh.Mesh_float64 = _cpp.mesh.create_mesh(
         comm,
         cells,
@@ -922,6 +928,7 @@ def create_mesh(
         partitioner,
         max_facet_to_cell_links,
         num_threads,
+        cell_weights,
     )
 
     return Mesh(msh, domain)

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -88,7 +88,14 @@ __all__ = [
 ]
 
 PartitioningFunc = typing.Callable[
-    [_MPI.Comm, int, _cpp.graph.AdjacencyList_int64, bool],
+    [
+        _MPI.Comm,
+        int,
+        _cpp.graph.AdjacencyList_int64,
+        npt.NDArray[np.int32],
+        npt.NDArray[np.int32],
+        bool,
+    ],
     _cpp.graph.AdjacencyList_int32,
 ]
 

--- a/python/dolfinx/wrappers/dolfinx_wrappers/graph.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/graph.h
@@ -35,11 +35,11 @@ auto create_partitioner_py(Functor&& p_cpp)
                  bool ghosting)
   {
     std::span<const std::int32_t> node_weights_span(node_weights.data(),
-                                                     node_weights.size());
+                                                    node_weights.size());
     std::span<const std::int32_t> edge_weights_span(edge_weights.data(),
-                                                     edge_weights.size());
+                                                    edge_weights.size());
     return p_cpp(comm.get(), nparts, local_graph, node_weights_span,
-                edge_weights_span, ghosting);
+                 edge_weights_span, ghosting);
   };
 }
 

--- a/python/dolfinx/wrappers/dolfinx_wrappers/graph.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/graph.h
@@ -20,14 +20,27 @@
 namespace dolfinx_wrappers
 {
 
+namespace nb = nanobind;
+
 /// Wrap a C++ graph partitioning function as a Python-ready function
 template <typename Functor>
 auto create_partitioner_py(Functor&& p_cpp)
 {
   return [p_cpp](dolfinx_wrappers::MPICommWrapper comm, int nparts,
                  const dolfinx::graph::AdjacencyList<std::int64_t>& local_graph,
+                 nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>
+                     node_weights,
+                 nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>
+                     edge_weights,
                  bool ghosting)
-  { return p_cpp(comm.get(), nparts, local_graph, ghosting); };
+  {
+    std::span<const std::int32_t> node_weights_span(node_weights.data(),
+                                                     node_weights.size());
+    std::span<const std::int32_t> edge_weights_span(edge_weights.data(),
+                                                     edge_weights.size());
+    return p_cpp(comm.get(), nparts, local_graph, node_weights_span,
+                edge_weights_span, ghosting);
+  };
 }
 
 /// Declare AdjacencyList class with __init__ methods for a given type

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -60,9 +60,9 @@ auto create_cell_partitioner_py(Functor&& p)
   {
     std::vector<std::span<const std::int64_t>> cells = vec_of_spans(cells_nb);
     std::span<const std::int32_t> cell_weights_span(cell_weights.data(),
-                                                     cell_weights.size());
+                                                    cell_weights.size());
     std::span<const std::int32_t> edge_weights_span(edge_weights.data(),
-                                                     edge_weights.size());
+                                                    edge_weights.size());
     return p(comm.get(), n, cell_types, cells, cell_weights_span,
              edge_weights_span);
   };
@@ -335,8 +335,8 @@ void declare_mesh(nb::module_& m, std::string type)
          nb::ndarray<const T, nb::c_contig> x,
          const part::impl::PythonCellPartitionFunction& p,
          std::optional<std::int32_t> max_facet_to_cell_links, int num_threads,
-         std::optional<nb::ndarray<const std::int32_t, nb::ndim<1>,
-                                   nb::c_contig>>
+         std::optional<
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>>
              cell_weights)
       {
         std::size_t shape1 = x.ndim() == 1 ? 1 : x.shape(1);
@@ -347,15 +347,15 @@ void declare_mesh(nb::module_& m, std::string type)
             { return std::span<const std::int64_t>(c.data(), c.size()); });
 
         std::span<const std::int32_t> cell_weights_span
-            = cell_weights ? std::span<const std::int32_t>(
-                  cell_weights->data(), cell_weights->size())
-                          : std::span<const std::int32_t>();
+            = cell_weights ? std::span<const std::int32_t>(cell_weights->data(),
+                                                           cell_weights->size())
+                           : std::span<const std::int32_t>();
 
         return dolfinx::mesh::create_mesh(
             comm.get(), comm.get(), cells, cell_weights_span, elements,
             comm.get(), std::span(x.data(), x.size()), {x.shape(0), shape1},
-            part::impl::create_cell_partitioner_cpp(p),
-            max_facet_to_cell_links, num_threads);
+            part::impl::create_cell_partitioner_cpp(p), max_facet_to_cell_links,
+            num_threads);
       },
       nb::arg("comm"), nb::arg("cells"), nb::arg("elements"),
       nb::arg("x").noconvert(), nb::arg("partitioner").none(),
@@ -371,15 +371,15 @@ void declare_mesh(nb::module_& m, std::string type)
          nb::ndarray<const T, nb::c_contig> x,
          const part::impl::PythonCellPartitionFunction& p,
          std::optional<std::int32_t> max_facet_to_cell_links, int num_threads,
-         std::optional<nb::ndarray<const std::int32_t, nb::ndim<1>,
-                                   nb::c_contig>>
+         std::optional<
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>>
              cell_weights)
       {
         std::size_t shape1 = x.ndim() == 1 ? 1 : x.shape(1);
         std::span<const std::int32_t> cell_weights_span
-            = cell_weights ? std::span<const std::int32_t>(
-                  cell_weights->data(), cell_weights->size())
-                          : std::span<const std::int32_t>();
+            = cell_weights ? std::span<const std::int32_t>(cell_weights->data(),
+                                                           cell_weights->size())
+                           : std::span<const std::int32_t>();
         return dolfinx::mesh::create_mesh(
             comm.get(), comm.get(), std::span(cells.data(), cells.size()),
             cell_weights_span, element, comm.get(),
@@ -390,8 +390,7 @@ void declare_mesh(nb::module_& m, std::string type)
       nb::arg("comm"), nb::arg("cells"), nb::arg("element"),
       nb::arg("x").noconvert(), nb::arg("partitioner").none(),
       nb::arg("max_facet_to_cell_links").none(), nb::arg("num_threads"),
-      nb::arg("cell_weights").none(),
-      "Helper function for creating meshes.");
+      nb::arg("cell_weights").none(), "Helper function for creating meshes.");
   m.def(
       "create_submesh",
       [](const dolfinx::mesh::Mesh<T>& mesh, int dim,

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -36,10 +36,15 @@ auto create_partitioner_cpp(Functor&& p)
 {
   return [p](MPI_Comm comm, int nparts,
              const dolfinx::graph::AdjacencyList<std::int64_t>& local_graph,
-             bool ghosting)
+             std::span<const std::int32_t> node_weights,
+             std::span<const std::int32_t> edge_weights, bool ghosting)
   {
+    nb::ndarray<const std::int32_t, nb::numpy> node_weights_nb(
+        node_weights.data(), {node_weights.size()});
+    nb::ndarray<const std::int32_t, nb::numpy> edge_weights_nb(
+        edge_weights.data(), {edge_weights.size()});
     return p(dolfinx_wrappers::MPICommWrapper(comm), nparts, local_graph,
-             ghosting);
+             node_weights_nb, edge_weights_nb, ghosting);
   };
 }
 
@@ -49,10 +54,17 @@ auto create_cell_partitioner_py(Functor&& p)
 {
   return [p](dolfinx_wrappers::MPICommWrapper comm, int n,
              const std::vector<dolfinx::mesh::CellType>& cell_types,
-             std::vector<nb::ndarray<const std::int64_t, nb::numpy>> cells_nb)
+             std::vector<nb::ndarray<const std::int64_t, nb::numpy>> cells_nb,
+             nb::ndarray<const std::int32_t, nb::numpy> cell_weights,
+             nb::ndarray<const std::int32_t, nb::numpy> edge_weights)
   {
     std::vector<std::span<const std::int64_t>> cells = vec_of_spans(cells_nb);
-    return p(comm.get(), n, cell_types, cells);
+    std::span<const std::int32_t> cell_weights_span(cell_weights.data(),
+                                                     cell_weights.size());
+    std::span<const std::int32_t> edge_weights_span(edge_weights.data(),
+                                                     edge_weights.size());
+    return p(comm.get(), n, cell_types, cells, cell_weights_span,
+             edge_weights_span);
   };
 }
 
@@ -60,12 +72,15 @@ using PythonCellPartitionFunction
     = std::function<dolfinx::graph::AdjacencyList<std::int32_t>(
         dolfinx_wrappers::MPICommWrapper, int,
         const std::vector<dolfinx::mesh::CellType>&,
-        std::vector<nb::ndarray<const std::int64_t, nb::numpy>>)>;
+        std::vector<nb::ndarray<const std::int64_t, nb::numpy>>,
+        nb::ndarray<const std::int32_t, nb::numpy>,
+        nb::ndarray<const std::int32_t, nb::numpy>)>;
 
 using CppCellPartitionFunction
     = std::function<dolfinx::graph::AdjacencyList<std::int32_t>(
         MPI_Comm, int, const std::vector<dolfinx::mesh::CellType>& q,
-        const std::vector<std::span<const std::int64_t>>&)>;
+        const std::vector<std::span<const std::int64_t>>&,
+        std::span<const std::int32_t>, std::span<const std::int32_t>)>;
 
 /// Wrap a Python cell graph partitioning function as a C++ function
 CppCellPartitionFunction
@@ -329,10 +344,10 @@ void declare_mesh(nb::module_& m, std::string type)
             { return std::span<const std::int64_t>(c.data(), c.size()); });
 
         return dolfinx::mesh::create_mesh(
-            comm.get(), comm.get(), cells, elements, comm.get(),
-            std::span(x.data(), x.size()), {x.shape(0), shape1},
-            part::impl::create_cell_partitioner_cpp(p), max_facet_to_cell_links,
-            num_threads);
+            comm.get(), comm.get(), cells, std::span<const std::int32_t>(),
+            elements, comm.get(), std::span(x.data(), x.size()),
+            {x.shape(0), shape1}, part::impl::create_cell_partitioner_cpp(p),
+            max_facet_to_cell_links, num_threads);
       },
       nb::arg("comm"), nb::arg("cells"), nb::arg("elements"),
       nb::arg("x").noconvert(), nb::arg("partitioner").none(),
@@ -351,9 +366,10 @@ void declare_mesh(nb::module_& m, std::string type)
         std::size_t shape1 = x.ndim() == 1 ? 1 : x.shape(1);
         return dolfinx::mesh::create_mesh(
             comm.get(), comm.get(), std::span(cells.data(), cells.size()),
-            element, comm.get(), std::span(x.data(), x.size()),
-            {x.shape(0), shape1}, part::impl::create_cell_partitioner_cpp(p),
-            max_facet_to_cell_links, num_threads);
+            std::span<const std::int32_t>(), element, comm.get(),
+            std::span(x.data(), x.size()), {x.shape(0), shape1},
+            part::impl::create_cell_partitioner_cpp(p), max_facet_to_cell_links,
+            num_threads);
       },
       nb::arg("comm"), nb::arg("cells"), nb::arg("element"),
       nb::arg("x").noconvert(), nb::arg("partitioner").none(),

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -60,9 +60,9 @@ auto create_cell_partitioner_py(Functor&& p)
   {
     std::vector<std::span<const std::int64_t>> cells = vec_of_spans(cells_nb);
     std::span<const std::int32_t> cell_weights_span(cell_weights.data(),
-                                                     cell_weights.size());
+                                                    cell_weights.size());
     std::span<const std::int32_t> edge_weights_span(edge_weights.data(),
-                                                     edge_weights.size());
+                                                    edge_weights.size());
     return p(comm.get(), n, cell_types, cells, cell_weights_span,
              edge_weights_span);
   };

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -60,9 +60,9 @@ auto create_cell_partitioner_py(Functor&& p)
   {
     std::vector<std::span<const std::int64_t>> cells = vec_of_spans(cells_nb);
     std::span<const std::int32_t> cell_weights_span(cell_weights.data(),
-                                                    cell_weights.size());
+                                                     cell_weights.size());
     std::span<const std::int32_t> edge_weights_span(edge_weights.data(),
-                                                    edge_weights.size());
+                                                     edge_weights.size());
     return p(comm.get(), n, cell_types, cells, cell_weights_span,
              edge_weights_span);
   };
@@ -334,7 +334,10 @@ void declare_mesh(nb::module_& m, std::string type)
          const std::vector<dolfinx::fem::CoordinateElement<T>>& elements,
          nb::ndarray<const T, nb::c_contig> x,
          const part::impl::PythonCellPartitionFunction& p,
-         std::optional<std::int32_t> max_facet_to_cell_links, int num_threads)
+         std::optional<std::int32_t> max_facet_to_cell_links, int num_threads,
+         std::optional<nb::ndarray<const std::int32_t, nb::ndim<1>,
+                                   nb::c_contig>>
+             cell_weights)
       {
         std::size_t shape1 = x.ndim() == 1 ? 1 : x.shape(1);
 
@@ -343,15 +346,21 @@ void declare_mesh(nb::module_& m, std::string type)
             cells_nb, std::back_inserter(cells), [](auto& c)
             { return std::span<const std::int64_t>(c.data(), c.size()); });
 
+        std::span<const std::int32_t> cell_weights_span
+            = cell_weights ? std::span<const std::int32_t>(
+                  cell_weights->data(), cell_weights->size())
+                          : std::span<const std::int32_t>();
+
         return dolfinx::mesh::create_mesh(
-            comm.get(), comm.get(), cells, std::span<const std::int32_t>(),
-            elements, comm.get(), std::span(x.data(), x.size()),
-            {x.shape(0), shape1}, part::impl::create_cell_partitioner_cpp(p),
+            comm.get(), comm.get(), cells, cell_weights_span, elements,
+            comm.get(), std::span(x.data(), x.size()), {x.shape(0), shape1},
+            part::impl::create_cell_partitioner_cpp(p),
             max_facet_to_cell_links, num_threads);
       },
       nb::arg("comm"), nb::arg("cells"), nb::arg("elements"),
       nb::arg("x").noconvert(), nb::arg("partitioner").none(),
       nb::arg("max_facet_to_cell_links").none(), nb::arg("num_threads"),
+      nb::arg("cell_weights").none(),
       "Helper function for creating a mixed topology mesh.");
 
   m.def(
@@ -361,12 +370,19 @@ void declare_mesh(nb::module_& m, std::string type)
          const dolfinx::fem::CoordinateElement<T>& element,
          nb::ndarray<const T, nb::c_contig> x,
          const part::impl::PythonCellPartitionFunction& p,
-         std::optional<std::int32_t> max_facet_to_cell_links, int num_threads)
+         std::optional<std::int32_t> max_facet_to_cell_links, int num_threads,
+         std::optional<nb::ndarray<const std::int32_t, nb::ndim<1>,
+                                   nb::c_contig>>
+             cell_weights)
       {
         std::size_t shape1 = x.ndim() == 1 ? 1 : x.shape(1);
+        std::span<const std::int32_t> cell_weights_span
+            = cell_weights ? std::span<const std::int32_t>(
+                  cell_weights->data(), cell_weights->size())
+                          : std::span<const std::int32_t>();
         return dolfinx::mesh::create_mesh(
             comm.get(), comm.get(), std::span(cells.data(), cells.size()),
-            std::span<const std::int32_t>(), element, comm.get(),
+            cell_weights_span, element, comm.get(),
             std::span(x.data(), x.size()), {x.shape(0), shape1},
             part::impl::create_cell_partitioner_cpp(p), max_facet_to_cell_links,
             num_threads);
@@ -374,6 +390,7 @@ void declare_mesh(nb::module_& m, std::string type)
       nb::arg("comm"), nb::arg("cells"), nb::arg("element"),
       nb::arg("x").noconvert(), nb::arg("partitioner").none(),
       nb::arg("max_facet_to_cell_links").none(), nb::arg("num_threads"),
+      nb::arg("cell_weights").none(),
       "Helper function for creating meshes.");
   m.def(
       "create_submesh",

--- a/python/dolfinx/wrappers/graph.cpp
+++ b/python/dolfinx/wrappers/graph.cpp
@@ -40,7 +40,9 @@ void graph(nb::module_& m)
   using partition_fn
       = std::function<dolfinx::graph::AdjacencyList<std::int32_t>(
           MPICommWrapper, int,
-          const dolfinx::graph::AdjacencyList<std::int64_t>&, bool)>;
+          const dolfinx::graph::AdjacencyList<std::int64_t>&,
+          nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>,
+          nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>, bool)>;
   m.def(
       "partitioner", []() -> partition_fn
       { return create_partitioner_py(dolfinx::graph::partition_graph); },

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -48,7 +48,9 @@ create_cell_partitioner_cpp(const PythonCellPartitionFunction& p)
   {
     return [p](MPI_Comm comm, int n,
                const std::vector<dolfinx::mesh::CellType>& cell_types,
-               const std::vector<std::span<const std::int64_t>>& cells)
+               const std::vector<std::span<const std::int64_t>>& cells,
+               std::span<const std::int32_t> cell_weights,
+               std::span<const std::int32_t> edge_weights)
     {
       std::vector<nb::ndarray<const std::int64_t, nb::numpy>> cells_nb;
       std::ranges::transform(
@@ -58,7 +60,12 @@ create_cell_partitioner_cpp(const PythonCellPartitionFunction& p)
             return nb::ndarray<const std::int64_t, nb::numpy>(c.data(),
                                                               {c.size()});
           });
-      return p(dolfinx_wrappers::MPICommWrapper(comm), n, cell_types, cells_nb);
+      nb::ndarray<const std::int32_t, nb::numpy> cell_weights_nb(
+          cell_weights.data(), {cell_weights.size()});
+      nb::ndarray<const std::int32_t, nb::numpy> edge_weights_nb(
+          edge_weights.data(), {edge_weights.size()});
+      return p(dolfinx_wrappers::MPICommWrapper(comm), n, cell_types, cells_nb,
+               cell_weights_nb, edge_weights_nb);
     };
   }
   else
@@ -374,6 +381,8 @@ void mesh(nb::module_& m)
       [](const std::function<dolfinx::graph::AdjacencyList<std::int32_t>(
              MPICommWrapper comm, int nparts,
              const dolfinx::graph::AdjacencyList<std::int64_t>& local_graph,
+             nb::ndarray<const std::int32_t, nb::numpy> node_weights,
+             nb::ndarray<const std::int32_t, nb::numpy> edge_weights,
              bool ghosting)>& part,
          dolfinx::mesh::GhostMode mode,
          std::optional<std::int32_t> max_facet_to_cell_links)

--- a/python/test/unit/conftest.py
+++ b/python/test/unit/conftest.py
@@ -120,4 +120,5 @@ def mixed_topology_mesh():
         part,
         max_cells_per_facet,
         num_threads=1,
+        cell_weights=None,
     )

--- a/python/test/unit/fem/test_assembler.py
+++ b/python/test/unit/fem/test_assembler.py
@@ -1344,7 +1344,7 @@ class TestPETScAssemblers:
             element("Lagrange", cell_type.name, 1, shape=(2,), dtype=default_real_type)
         )
 
-        def partitioner(comm, nparts, local_graph, num_ghost_nodes):
+        def partitioner(comm, nparts, cell_types, cell_topology, cell_weights, edge_weights):
             """Leave cells on the current rank."""
             dest = np.full(len(cells), comm.rank, dtype=np.int32)
             return graph.adjacencylist(dest)._cpp_object

--- a/python/test/unit/fem/test_dofmap.py
+++ b/python/test/unit/fem/test_dofmap.py
@@ -437,7 +437,7 @@ def test_empty_rank_collapse():
         cells = np.empty((0, 2), dtype=np.int64)
     c_el = element("Lagrange", "interval", 1, shape=(1,))
 
-    def self_partitioner(comm: MPI.Intracomm, n, m, topo):
+    def self_partitioner(comm: MPI.Intracomm, n, m, topo, cell_weights, edge_weights):
         dests = np.full(len(topo[0]) // 2, comm.rank, dtype=np.int32)
         offsets = np.arange(len(topo[0]) // 2 + 1, dtype=np.int32)
         # TODO: can we improve on this interface? I.e. warp to do cpp type conversion automatically

--- a/python/test/unit/io/test_adios2.py
+++ b/python/test/unit/io/test_adios2.py
@@ -188,7 +188,7 @@ class TestVTX:
             element("Lagrange", cell_type.name, 1, shape=(2,), dtype=default_real_type)
         )
 
-        def partitioner(comm, nparts, local_graph, num_ghost_nodes):
+        def partitioner(comm, nparts, cell_types, cell_topology, cell_weights, edge_weights):
             """Leave cells on the current rank."""
             dest = np.full(len(cells), comm.rank, dtype=np.int32)
             return adjacencylist(dest)._cpp_object

--- a/python/test/unit/io/test_vtkhdf.py
+++ b/python/test/unit/io/test_vtkhdf.py
@@ -92,6 +92,7 @@ def test_read_write_higher_order():
         part,
         max_cells_per_facet,
         num_threads=1,
+        cell_weights=None,
     )
     py_mesh = Mesh(mesh, None)
 

--- a/python/test/unit/mesh/test_create_mixed_mesh.py
+++ b/python/test/unit/mesh/test_create_mixed_mesh.py
@@ -92,6 +92,7 @@ def test_create_mixed_mesh(dtype):
         part,
         max_cells_per_facet,
         num_threads=1,
+        cell_weights=None,
     )
 
     entity_types = mesh.topology.entity_types[3]

--- a/python/test/unit/mesh/test_mesh.py
+++ b/python/test/unit/mesh/test_mesh.py
@@ -596,7 +596,7 @@ def test_empty_rank_mesh(dtype):
     tdim = 2
     domain = ufl.Mesh(element("Lagrange", cell_type.name, 1, shape=(2,), dtype=dtype))
 
-    def partitioner(comm, nparts, local_graph, num_ghost_nodes):
+    def partitioner(comm, nparts, cell_types, cell_topology, cell_weights, edge_weights):
         """Leave cells on the current rank,."""
         dest = np.full(len(cells), comm.rank, dtype=np.int32)
         return graph.adjacencylist(dest)._cpp_object

--- a/python/test/unit/mesh/test_mesh_partitioners.py
+++ b/python/test/unit/mesh/test_mesh_partitioners.py
@@ -151,7 +151,7 @@ def test_asymmetric_partitioner():
         x = np.zeros((0, 2), dtype=np.float64)
 
     # Send cells to self, and if on process 1, also send to process 0.
-    def partitioner(comm, n, cell_types, topo):
+    def partitioner(comm, n, cell_types, topo, cell_weights, edge_weights):
         r = comm.Get_rank()
         dests = []
         offsets = [0]
@@ -234,6 +234,8 @@ def test_mixed_topology_partitioning():
         nparts,
         [CellType.hexahedron, CellType.pyramid, CellType.tetrahedron],
         cells_np,
+        np.array([], dtype=np.int32),
+        np.array([], dtype=np.int32),
     )
 
     counts = np.array([sum(p.array == i) for i in range(nparts)])

--- a/python/test/unit/mesh/test_mesh_partitioners.py
+++ b/python/test/unit/mesh/test_mesh_partitioners.py
@@ -16,6 +16,7 @@ from basix.ufl import element
 from dolfinx import cpp as _cpp
 from dolfinx import default_real_type
 from dolfinx.cpp.mesh import cell_num_vertices
+from dolfinx.fem import coordinate_element
 from dolfinx.graph import partitioner
 from dolfinx.io import XDMFFile
 from dolfinx.mesh import (
@@ -51,6 +52,27 @@ try:
 except ImportError:
     partitioners.append(
         pytest.param(None, marks=pytest.mark.skip(reason="DOLFINx built without KaHiP"))
+    )
+
+# Graph partitioners that actually honour node/edge weights. KaHIP is
+# deliberately excluded: it does not support weights (they are ignored
+# with a warning), so it is not expected to balance by weight below.
+weighted_partitioners: list = []
+try:
+    from dolfinx.graph import partitioner_scotch
+
+    weighted_partitioners.append(partitioner_scotch())
+except ImportError:
+    weighted_partitioners.append(
+        pytest.param(None, marks=pytest.mark.skip(reason="DOLFINx build without SCOTCH"))
+    )
+try:
+    from dolfinx.graph import partitioner_parmetis
+
+    weighted_partitioners.append(partitioner_parmetis())
+except ImportError:
+    weighted_partitioners.append(
+        pytest.param(None, marks=pytest.mark.skip(reason="DOLFINx built without Parmetis"))
     )
 
 
@@ -242,3 +264,97 @@ def test_mixed_topology_partitioning():
     count_mpi = MPI.COMM_WORLD.allreduce(counts)
 
     assert count_mpi.sum() == 14080
+
+
+def _structured_triangle_grid(n):
+    """A unit square, `n` x `n` structured triangle grid, returned as
+    (cells, points), with global vertex numbering `i * (n + 1) + j`.
+    """
+    xs = np.linspace(0.0, 1.0, n + 1)
+    ys = np.linspace(0.0, 1.0, n + 1)
+    xv, yv = np.meshgrid(xs, ys, indexing="ij")
+    points = np.column_stack([xv.ravel(), yv.ravel()]).astype(np.float64)
+
+    def vidx(i, j):
+        return i * (n + 1) + j
+
+    cells = []
+    for i in range(n):
+        for j in range(n):
+            v0, v1 = vidx(i, j), vidx(i + 1, j)
+            v2, v3 = vidx(i, j + 1), vidx(i + 1, j + 1)
+            cells.append([v0, v1, v2])
+            cells.append([v1, v3, v2])
+
+    return np.array(cells, dtype=np.int64), points
+
+
+@pytest.mark.parametrize("gpart", weighted_partitioners)
+def test_partition_respects_cell_weights(gpart):
+    """Weight the cells in the left half of a structured triangle mesh
+    twice as heavily as those in the right half, and check that a
+    weight-aware graph partitioner balances the *sum of cell weights*
+    across ranks (rather than the plain cell count) to within a
+    tolerance.
+
+    Because the two weight classes occupy distinct halves of the
+    domain, a partitioner that ignored the weights would tend to give
+    one rank most of the (heavier) left half and another rank most of
+    the (lighter) right half, producing a badly unbalanced weight sum
+    -- so this is a reasonably sharp check that the weights are having
+    an effect, not just that the code runs.
+    """
+    comm = MPI.COMM_WORLD
+    if comm.size < 2:
+        pytest.skip("Only meaningful with more than one MPI rank")
+
+    n = 24
+    cells, points = _structured_triangle_grid(n)
+
+    # Cells with a midpoint in the left half of the domain are weighted
+    # twice as heavily as those in the right half.
+    cell_midpoints_x = points[cells].mean(axis=1)[:, 0]
+    weights = np.where(cell_midpoints_x < 0.5, 2, 1).astype(np.int32)
+
+    # Give each rank a contiguous slice of the cells (and matching
+    # weights), and a contiguous slice of the points. The two splits
+    # need not align: DOLFINx redistributes geometry data to wherever
+    # it is needed based on global vertex indices.
+    local_cells = np.array_split(cells, comm.size)[comm.rank]
+    local_weights = np.array_split(weights, comm.size)[comm.rank]
+    local_points = np.array_split(points, comm.size)[comm.rank]
+
+    elem = coordinate_element(CellType.triangle, 1)
+    part = create_cell_partitioner(gpart, GhostMode.none, 2)
+
+    new_mesh = create_mesh(
+        comm,
+        local_cells,
+        elem,
+        local_points,
+        partitioner=part,
+        cell_weights=local_weights,
+    )
+
+    tdim = new_mesh.topology.dim
+    new_mesh.topology.create_connectivity(tdim, tdim)
+    num_local = new_mesh.topology.index_map(tdim).size_local
+    if num_local > 0:
+        midpoints = compute_midpoints(new_mesh, tdim, np.arange(num_local))
+        local_weight = float(np.sum(np.where(midpoints[:, 0] < 0.5, 2, 1)))
+    else:
+        local_weight = 0.0
+
+    all_weights = np.array(comm.allgather(local_weight))
+    total_weight = all_weights.sum()
+    assert total_weight == 3 * n * n  # sanity check: no cells lost or duplicated
+
+    expected = total_weight / comm.size
+    # Graph partitioners only balance approximately, and there is a
+    # trade-off against minimizing edge cut, so allow a generous
+    # tolerance -- while still being tight enough that an unweighted
+    # (or incorrectly-weighted) partition of this checkerboard-style
+    # problem would fail it.
+    assert np.all(np.abs(all_weights - expected) <= 0.3 * expected), (
+        f"Per-rank weight sums {all_weights} are not balanced around {expected}"
+    )

--- a/python/test/unit/mesh/test_mixed_topology.py
+++ b/python/test/unit/mesh/test_mixed_topology.py
@@ -362,7 +362,14 @@ def test_locate_entities(dtype):
     comm = MPI.COMM_WORLD
     max_cells_per_facet = 2
     mesh = create_mesh(
-        comm, cells, [hexahedron._cpp_object, prism._cpp_object], geom, part, max_cells_per_facet, 1
+        comm,
+        cells,
+        [hexahedron._cpp_object, prism._cpp_object],
+        geom,
+        part,
+        max_cells_per_facet,
+        1,
+        cell_weights=None,
     )
 
     fdim = mesh.topology.dim - 1


### PR DESCRIPTION
Adds a `cell_weights` argument when creating meshes from scratch, which is passed through to the cell partitioner (ParMETIS, SCOTCH, KaHiP etc.)

Currently, there is no defined way to load cell weights from file. I temporarily added a way of doing this for [XDMFFile.cpp](https://github.com/FEniCS/dolfinx/pull/4439/changes#diff-6d996a20b980b667c6520ba09ac82e6e0e6a39dc5305011684a7eeb4742dd4ec), but we need some thought about how it should work in the future, especially for e.g. mixed topology.

Support for `edge_weights`, i.e. the strength of connection between cells, is partially completed, but not wired through yet to top-level. This will be a future PR.

Prepared with help from Claude Sonnet 5.