### PR TITLE
Build gmsh headless, OpenCASCADE from source, and trim dev-env bloat

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -181,7 +181,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        petsc_arch: [linux-gnu-real64-32, linux-gnu-complex128-32, linux-gnu-real64-64]
+        petsc_arch: [linux-gnu-real64-32, linux-gnu-complex128-32]
     container: "ghcr.io/fenics/test-env:current"
     env:
       PETSC_ARCH: ${{ matrix.petsc_arch }}

--- a/.github/workflows/docker-end-user.yml
+++ b/.github/workflows/docker-end-user.yml
@@ -155,6 +155,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           build-args: |
+            DOLFINX_CMAKE_BUILD_TYPE=RelWithDebInfo
             BASEIMAGE=${{ env.BASEIMAGE }}
           context: .
           file: dolfinx/${{ env.DOCKERFILE }}
@@ -166,6 +167,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           build-args: |
+            DOLFINX_CMAKE_BUILD_TYPE=RelWithDebInfo
             BASEIMAGE=${{ env.BASEIMAGE }}
           context: .
           file: dolfinx/${{ env.DOCKERFILE }}

--- a/docker/Dockerfile.end-user
+++ b/docker/Dockerfile.end-user
@@ -149,9 +149,12 @@ WORKDIR /root
 
 RUN pip install --no-cache-dir jupyter jupyterlab
 
-# pyvista dependencies from apt
+# pyvista dependencies from apt. libgl1 alone is only the GL loader,
+# with no rendering backend behind it: there is no X server/EGL in
+# this container, so VTK's off-screen render window needs
+# libosmesa6 (Mesa's software-only OSMesa backend) or it segfaults.
 RUN apt-get -qq update && \
-    apt-get -y install --no-install-recommends libgl1 && \
+    apt-get -y install --no-install-recommends libgl1 libosmesa6 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/docker/Dockerfile.end-user
+++ b/docker/Dockerfile.end-user
@@ -149,10 +149,9 @@ WORKDIR /root
 
 RUN pip install --no-cache-dir jupyter jupyterlab
 
-# pyvista dependencies from apt. libgl1 alone is only the GL loader,
-# with no rendering backend behind it: there is no X server/EGL in
-# this container, so VTK's off-screen render window needs
-# libosmesa6 (Mesa's software-only OSMesa backend) or it segfaults.
+# libgl1 is only the GL dispatch loader, not a rendering backend; with
+# no X server/EGL here, VTK's off-screen window needs libosmesa6's
+# software backend or it segfaults.
 RUN apt-get -qq update && \
     apt-get -y install --no-install-recommends libgl1 libosmesa6 && \
     apt-get clean && \

--- a/docker/Dockerfile.end-user
+++ b/docker/Dockerfile.end-user
@@ -151,22 +151,20 @@ RUN pip install --no-cache-dir jupyter jupyterlab
 
 # pyvista dependencies from apt
 RUN apt-get -qq update && \
-    apt-get -y install libgl1-mesa-dev mesa-utils  && \
+    apt-get -y install --no-install-recommends libgl1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install pyvista.
-# vtk>=9.5.0 required as minimal version for aarch64 wheels support.
 # jupytext ensures DOLFINx `.py` demos can be opened in a JupyterLab
 # notebook environment.
 RUN pip install --no-cache-dir matplotlib && \
-    pip install --no-cache-dir vtk>=9.5.0 pyvista[jupyter] jupytext && \
-    pip cache purge
+    pip install --no-cache-dir pyvista[jupyter] jupytext
 
 # Jupyter Notebook kernel specification for complex build DOLFINx
 COPY dolfinx/docker/complex-kernel.json /usr/local/share/jupyter/kernels/python3-complex/kernel.json
 
 EXPOSE 8888/tcp
-ENV SHELL /bin/bash
+ENV SHELL=/bin/bash
 ENV PYVISTA_JUPYTER_BACKEND=trame
 ENTRYPOINT ["jupyter", "lab", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -63,12 +63,9 @@ ENV OPENBLAS_NUM_THREADS=1 \
 # - First set of packages are required to build and run FEniCS.
 # - Second set of packages are recommended and/or required to build
 #   documentation or tests.
-# NOTE: OpenCASCADE (OCCT), the CAD kernel used by gmsh, is built from
-# source below rather than installed via apt: Ubuntu's
-# libocct-data-exchange-dev unconditionally pulls in the full
-# libvtk9-dev toolchain, which gmsh's headless build doesn't need.
-# libx11-dev below is OCCT's own dependency (Xlib.h headers only, no
-# runtime GUI), not related to gmsh's GUI, which stays disabled.
+# OCCT (gmsh's CAD kernel) is built from source below since Ubuntu's
+# libocct-data-exchange-dev drags in the full libvtk9-dev toolchain.
+# libx11-dev is OCCT's own header-only dependency, unrelated to gmsh's GUI.
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -qq update && \
     apt-get -yq --with-new-pkgs -o Dpkg::Options::="--force-confold" upgrade && \
@@ -128,9 +125,8 @@ RUN python3 -m venv ${VIRTUAL_ENV}
 
 # Install Python packages (via pip)
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    # Cython 3.3 tightened pointer-indexing type checks in a way that
-    # breaks petsc4py 3.25.4's generated Cython source (PC.pyx); pin
-    # below that until petsc4py catches up.
+    # Cython 3.3 tightened pointer-indexing checks that break
+    # petsc4py 3.25.4's generated PC.pyx; pin below that for now.
     pip install --no-cache-dir "cython<3.3" numpy==${NUMPY_VERSION} && \
     pip install --no-cache-dir mpi4py
 
@@ -142,17 +138,9 @@ RUN wget -nc --quiet https://github.com/kahip/kahip/archive/v${KAHIP_VERSION}.ta
     cmake --install build-dir && \
     rm -rf /tmp/*
 
-# Install OpenCASCADE (OCCT), the CAD kernel used by gmsh, from source,
-# headless: only the FoundationClasses/ModelingData/ModelingAlgorithms/
-# DataExchange modules gmsh needs for STEP/IGES/meshing are built;
-# Visualization, ApplicationFramework and Draw are disabled, and
-# FreeType is turned off explicitly (DataExchange still probes for it
-# otherwise). TKService, a DataExchange dependency, still needs
-# Xlib.h (libx11-dev) even with Visualization off, but nothing beyond
-# the header is used headless. Installs headers under
-# include/opencascade to match gmsh's find_path() search. ldconfig is
-# required since a manual cmake --install doesn't trigger the postinst
-# hook that updates the linker cache for an apt package.
+# Headless OCCT: only the modules gmsh's STEP/IGES/meshing needs are
+# built. FreeType is force-disabled since DataExchange still probes for
+# it with Visualization off. ldconfig covers what a manual install skips.
 RUN git clone -b V${OCCT_VERSION} --single-branch --depth 1 https://github.com/Open-Cascade-SAS/OCCT.git && \
     cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_LIBRARY_TYPE=Shared \

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -61,7 +61,9 @@ ENV OPENBLAS_NUM_THREADS=1 \
 #   documentation or tests.
 # OCCT (gmsh's CAD kernel) is built from source below since Ubuntu's
 # libocct-data-exchange-dev drags in the full libvtk9-dev toolchain.
-# libx11-dev is OCCT's own header-only dependency, unrelated to gmsh's GUI.
+# libx11-dev is OCCT's own header-only dependency.
+# libfltk1.3-dev pulls the whole GUI stack gmsh needs (FLTK, GL, Xft,
+# Xcursor, Xinerama, fonts); libGLU is the one piece outside its closure.
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -qq update && \
     apt-get -yq --with-new-pkgs -o Dpkg::Options::="--force-confold" upgrade && \
@@ -72,6 +74,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     gfortran \
     libadios2-mpi-c++-dev \
     libboost-dev \
+    libfltk1.3-dev \
+    libglu1-mesa-dev \
     libhdf5-mpi-dev \
     liblapack-dev \
     libopenblas-dev \
@@ -136,9 +140,10 @@ RUN git clone -b V${OCCT_VERSION} --single-branch --depth 1 https://github.com/O
     ldconfig && \
     rm -rf /tmp/*
 
-# Install GMSH, headless (no FLTK/OpenGL GUI, meshing/OCC/Python API only)
+# Install GMSH. The FLTK GUI costs ~70 MiB and is kept so gmsh.fltk.run()
+# works against a forwarded X11 display.
 RUN git clone -b gmsh_${GMSH_VERSION} --single-branch --depth 1 https://gitlab.onelab.info/gmsh/gmsh.git && \
-    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_BUILD_DYNAMIC=1 -DENABLE_OPENMP=1 -DENABLE_FLTK=0 -B build-dir -S gmsh && \
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_BUILD_DYNAMIC=1 -DENABLE_OPENMP=1 -DENABLE_FLTK=1 -B build-dir -S gmsh && \
     cmake --build build-dir && \
     cmake --install build-dir && \
     ldconfig && \

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -15,6 +15,7 @@
 ARG DOXYGEN_VERSION=1_17_0
 ARG GMSH_VERSION=4_15_2
 ARG KAHIP_VERSION=3.25
+ARG OCCT_VERSION=7_9_3
 # NOTE: The NumPy version (https://pypi.org/project/numpy/#history)
 # should be pinned to the most recent NumPy release that is supported by
 # the most recent Numba release, see
@@ -33,6 +34,7 @@ LABEL description="FEniCS testing and development environment with PETSc real, c
 ARG DOXYGEN_VERSION
 ARG GMSH_VERSION
 ARG KAHIP_VERSION
+ARG OCCT_VERSION
 ARG PETSC_VERSION
 ARG SLEPC_VERSION
 ARG SPDLOG_VERSION
@@ -61,8 +63,12 @@ ENV OPENBLAS_NUM_THREADS=1 \
 # - First set of packages are required to build and run FEniCS.
 # - Second set of packages are recommended and/or required to build
 #   documentation or tests.
-# - Third set of packages are required to build the OpenCASCADE CAD
-#   kernel used by gmsh (built headless, without its FLTK/OpenGL GUI).
+# NOTE: OpenCASCADE (OCCT), the CAD kernel used by gmsh, is built from
+# source below rather than installed via apt: Ubuntu's
+# libocct-data-exchange-dev unconditionally pulls in the full
+# libvtk9-dev toolchain, which gmsh's headless build doesn't need.
+# libx11-dev below is OCCT's own dependency (Xlib.h headers only, no
+# runtime GUI), not related to gmsh's GUI, which stays disabled.
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -qq update && \
     apt-get -yq --with-new-pkgs -o Dpkg::Options::="--force-confold" upgrade && \
@@ -88,12 +94,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     git \
     graphviz \
     libeigen3-dev \
+    libx11-dev \
     valgrind \
     wget && \
-    #
-    apt-get -y install --no-install-recommends \
-    libocct-foundation-dev \
-    libocct-data-exchange-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -137,11 +140,43 @@ RUN wget -nc --quiet https://github.com/kahip/kahip/archive/v${KAHIP_VERSION}.ta
     cmake --install build-dir && \
     rm -rf /tmp/*
 
+# Install OpenCASCADE (OCCT), the CAD kernel used by gmsh, from source,
+# headless: only the FoundationClasses/ModelingData/ModelingAlgorithms/
+# DataExchange modules gmsh needs for STEP/IGES/meshing are built;
+# Visualization, ApplicationFramework and Draw are disabled, and
+# FreeType is turned off explicitly (DataExchange still probes for it
+# otherwise). TKService, a DataExchange dependency, still needs
+# Xlib.h (libx11-dev) even with Visualization off, but nothing beyond
+# the header is used headless. Installs headers under
+# include/opencascade to match gmsh's find_path() search. ldconfig is
+# required since a manual cmake --install doesn't trigger the postinst
+# hook that updates the linker cache for an apt package.
+RUN git clone -b V${OCCT_VERSION} --single-branch --depth 1 https://github.com/Open-Cascade-SAS/OCCT.git && \
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_LIBRARY_TYPE=Shared \
+    -DBUILD_MODULE_ApplicationFramework=OFF \
+    -DBUILD_MODULE_DataExchange=ON \
+    -DBUILD_MODULE_Draw=OFF \
+    -DBUILD_MODULE_FoundationClasses=ON \
+    -DBUILD_MODULE_ModelingAlgorithms=ON \
+    -DBUILD_MODULE_ModelingData=ON \
+    -DBUILD_MODULE_Visualization=OFF \
+    -DINSTALL_DIR_INCLUDE=include/opencascade \
+    -DINSTALL_TEST_CASES=OFF \
+    -DUSE_FREETYPE=OFF \
+    -DUSE_TBB=OFF \
+    -B build-dir -S OCCT && \
+    cmake --build build-dir && \
+    cmake --install build-dir && \
+    ldconfig && \
+    rm -rf /tmp/*
+
 # Install GMSH, headless (no FLTK/OpenGL GUI, meshing/OCC/Python API only)
 RUN git clone -b gmsh_${GMSH_VERSION} --single-branch --depth 1 https://gitlab.onelab.info/gmsh/gmsh.git && \
     cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_BUILD_DYNAMIC=1 -DENABLE_OPENMP=1 -DENABLE_FLTK=0 -B build-dir -S gmsh && \
     cmake --build build-dir && \
     cmake --install build-dir && \
+    ldconfig && \
     rm -rf /tmp/*
 
 # GMSH installs python library in /usr/local/lib, see: https://gitlab.onelab.info/gmsh/gmsh/-/issues/1414

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -61,8 +61,8 @@ ENV OPENBLAS_NUM_THREADS=1 \
 # - First set of packages are required to build and run FEniCS.
 # - Second set of packages are recommended and/or required to build
 #   documentation or tests.
-# - Third set of packages are optional, but required to run gmsh
-#   pre-built binaries.
+# - Third set of packages are required to build the OpenCASCADE CAD
+#   kernel used by gmsh (built headless, without its FLTK/OpenGL GUI).
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -qq update && \
     apt-get -yq --with-new-pkgs -o Dpkg::Options::="--force-confold" upgrade && \
@@ -83,7 +83,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     python3-pip \
     python3-venv && \
     #
-    apt-get -y install \
+    apt-get -y install --no-install-recommends \
     catch2 \
     git \
     graphviz \
@@ -91,14 +91,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     valgrind \
     wget && \
     #
-    apt-get -y install \
-    libglu1 \
-    libxcursor-dev \
-    libxft2 \
-    libxinerama1 \
-    libfltk1.3-dev \
-    libfreetype6-dev  \
-    libgl1-mesa-dev \
+    apt-get -y install --no-install-recommends \
     libocct-foundation-dev \
     libocct-data-exchange-dev && \
     apt-get clean && \
@@ -144,9 +137,9 @@ RUN wget -nc --quiet https://github.com/kahip/kahip/archive/v${KAHIP_VERSION}.ta
     cmake --install build-dir && \
     rm -rf /tmp/*
 
-# Install GMSH
+# Install GMSH, headless (no FLTK/OpenGL GUI, meshing/OCC/Python API only)
 RUN git clone -b gmsh_${GMSH_VERSION} --single-branch --depth 1 https://gitlab.onelab.info/gmsh/gmsh.git && \
-    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_BUILD_DYNAMIC=1  -DENABLE_OPENMP=1 -B build-dir -S gmsh && \
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_BUILD_DYNAMIC=1 -DENABLE_OPENMP=1 -DENABLE_FLTK=0 -B build-dir -S gmsh && \
     cmake --build build-dir && \
     cmake --install build-dir && \
     rm -rf /tmp/*

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -12,7 +12,6 @@
 #    docker build --target dev-env --file dolfinx/docker/Dockerfile.test-env --build-arg PETSC_SLEPC_OPTFLAGS="-O2 -march=native" .
 #
 
-ARG DOXYGEN_VERSION=1_17_0
 ARG GMSH_VERSION=4_15_2
 ARG KAHIP_VERSION=3.25
 ARG OCCT_VERSION=7_9_3
@@ -23,7 +22,6 @@ ARG OCCT_VERSION=7_9_3
 ARG NUMPY_VERSION=2.4.6
 ARG PETSC_VERSION=3.25.4
 ARG SLEPC_VERSION=3.25.1
-ARG SPDLOG_VERSION=1.17.0
 
 ########################################
 
@@ -31,13 +29,11 @@ FROM ubuntu:26.04 AS dev-env
 LABEL maintainer="FEniCS Steering Council <fenics-steering-council@googlegroups.com>"
 LABEL description="FEniCS testing and development environment with PETSc real and complex, 32-bit modes"
 
-ARG DOXYGEN_VERSION
 ARG GMSH_VERSION
 ARG KAHIP_VERSION
 ARG OCCT_VERSION
 ARG PETSC_VERSION
 ARG SLEPC_VERSION
-ARG SPDLOG_VERSION
 ARG NUMPY_VERSION
 
 # The following ARGS are used in the dev-env layer.
@@ -71,6 +67,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -yq --with-new-pkgs -o Dpkg::Options::="--force-confold" upgrade && \
     apt-get -y install --no-install-recommends \
     cmake \
+    doxygen \
     g++ \
     gfortran \
     libadios2-mpi-c++-dev \
@@ -79,6 +76,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     liblapack-dev \
     libopenblas-dev \
     libpugixml-dev \
+    libspdlog-dev \
     make \
     mpi-default-dev \
     ninja-build \
@@ -95,29 +93,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Install spdlog from source - Ubuntu version is incompatible with CUDA 12.
-RUN wget -nc --quiet https://github.com/gabime/spdlog/archive/refs/tags/v${SPDLOG_VERSION}.tar.gz && \
-    tar xfz v${SPDLOG_VERSION}.tar.gz && \
-    cd spdlog-${SPDLOG_VERSION} && \
-    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DSPDLOG_BUILD_SHARED=ON -DSPDLOG_BUILD_PIC=ON -B build-dir . && \
-    cmake --build build-dir && \
-    cmake --install build-dir && \
-    rm -rf /tmp/*
-
-# Install Doxygen
-RUN apt-get -qq update && \
-    apt-get -y install bison flex && \
-    wget -nc --quiet https://github.com/doxygen/doxygen/archive/refs/tags/Release_${DOXYGEN_VERSION}.tar.gz && \
-    tar xfz Release_${DOXYGEN_VERSION}.tar.gz && \
-    cd doxygen-Release_${DOXYGEN_VERSION} && \
-    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -B build-dir . && \
-    cmake --build build-dir && \
-    cmake --install build-dir && \
-    apt-get -y purge bison flex && \
-    apt-get -y autoremove && \
-    apt-get clean && \
-    rm -rf /tmp/*
 
 ENV VIRTUAL_ENV=/dolfinx-env
 ENV PATH=/dolfinx-env/bin:$PATH

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -29,7 +29,7 @@ ARG SPDLOG_VERSION=1.17.0
 
 FROM ubuntu:26.04 AS dev-env
 LABEL maintainer="FEniCS Steering Council <fenics-steering-council@googlegroups.com>"
-LABEL description="FEniCS testing and development environment with PETSc real, complex, 32-bit and 64-bit modes"
+LABEL description="FEniCS testing and development environment with PETSc real and complex, 32-bit modes"
 
 ARG DOXYGEN_VERSION
 ARG GMSH_VERSION
@@ -51,7 +51,7 @@ ARG BUILD_NP=4
 
 # PETSc/SLEPc configurations to build, as PETSC_ARCH names understood by
 # petsc4py/slepc4py's colon-separated PETSC_ARCH install syntax.
-ARG PETSC_ARCHS="linux-gnu-real64-32:linux-gnu-complex128-32:linux-gnu-real64-64"
+ARG PETSC_ARCHS="linux-gnu-real64-32:linux-gnu-complex128-32"
 
 WORKDIR /tmp
 
@@ -82,6 +82,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     liblapack-dev \
     libopenblas-dev \
     libpugixml-dev \
+    make \
     mpi-default-dev \
     ninja-build \
     pkg-config \
@@ -93,9 +94,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     catch2 \
     git \
     graphviz \
-    libeigen3-dev \
     libx11-dev \
-    valgrind \
     wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -129,7 +128,10 @@ RUN python3 -m venv ${VIRTUAL_ENV}
 
 # Install Python packages (via pip)
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    pip install --no-cache-dir cython numpy==${NUMPY_VERSION} && \
+    # Cython 3.3 tightened pointer-indexing type checks in a way that
+    # breaks petsc4py 3.25.4's generated Cython source (PC.pyx); pin
+    # below that until petsc4py catches up.
+    pip install --no-cache-dir "cython<3.3" numpy==${NUMPY_VERSION} && \
     pip install --no-cache-dir mpi4py
 
 # Install KaHIP
@@ -238,26 +240,6 @@ RUN apt-get -qq update && \
     --with-scalar-type=complex \
     --with-precision=double && \
     make PETSC_ARCH=linux-gnu-complex128-32 -j${BUILD_NP} all && \
-    # Real64, 64-bit int
-    ./configure \
-    PETSC_ARCH=linux-gnu-real64-64 \
-    --COPTFLAGS="${PETSC_SLEPC_OPTFLAGS}" \
-    --CXXOPTFLAGS="${PETSC_SLEPC_OPTFLAGS}" \
-    --FOPTFLAGS="${PETSC_SLEPC_OPTFLAGS}" \
-    --with-64-bit-indices=yes \
-    --with-debugging=${PETSC_SLEPC_DEBUGGING} \
-    --with-fortran-bindings=no \
-    --with-shared-libraries \
-    --download-hypre \
-    --download-mumps-avoid-mpi-in-place \
-    --download-mumps \
-    --download-ptscotch \
-    --download-scalapack \
-    --download-suitesparse \
-    --download-superlu_dist \
-    --with-scalar-type=real \
-    --with-precision=double && \
-    make PETSC_ARCH=linux-gnu-real64-64 -j${BUILD_NP} all && \
     # Install petsc4py
     cd src/binding/petsc4py && \
     PETSC_ARCH=${PETSC_ARCHS} pip -v install --no-cache-dir --no-build-isolation . && \
@@ -285,9 +267,6 @@ RUN git clone --depth=1 -b v${SLEPC_VERSION} https://gitlab.com/slepc/slepc.git 
     ./configure && \
     make && \
     export PETSC_ARCH=linux-gnu-complex128-32 && \
-    ./configure && \
-    make && \
-    export PETSC_ARCH=linux-gnu-real64-64 && \
     ./configure && \
     make && \
     # Install slepc4py


### PR DESCRIPTION
## Summary

Bottom line: 4GB (!) to 2GB.

- Build gmsh with `-DENABLE_FLTK=0`, dropping its FLTK/OpenGL/X11 GUI
  dependencies (`libglu1`, `libxcursor-dev`, `libxft2`, `libxinerama1`,
  `libfltk1.3-dev`, `libfreetype6-dev`, `libgl1-mesa-dev`) since none of
  it is needed for headless meshing.
- Build OpenCASCADE (OCCT), gmsh's CAD kernel, from source instead of via
  apt: Ubuntu's `libocct-data-exchange-dev` unconditionally pulls in the
  full `libvtk9-dev` toolchain (GDAL, MySQL/Postgres client libs, ffmpeg,
  `default-jdk`, X11/GLU, Boost, ...), none of which the headless build
  uses. Only `FoundationClasses`/`ModelingData`/`ModelingAlgorithms`/
  `DataExchange` are enabled.
- Add `--no-install-recommends` to apt installs that were missing it
  (~128 fewer Recommends packages: fonts, gdb, openssh-client, etc.).
- Swap `libgl1-mesa-dev` + `mesa-utils` for runtime-only `libgl1` +
  `libosmesa6` in the `lab` image: nothing in that stage compiles
  against OpenGL (vtk/pyvista are pip wheels), but pyvista's headless
  render window needs OSMesa's software backend or it segfaults (there's
  no X server/EGL in the container).
- Drop the unused third PETSc/SLEPc build configuration
  (`linux-gnu-real64-64`, 64-bit indices) — DOLFINx's own build never
  targets it, and it was tripling the footprint of HYPRE, MUMPS,
  SuiteSparse, SuperLU, ScaLAPACK and (PT)SCOTCH for no benefit.
- Drop `libeigen3-dev` and `valgrind`: no C++ source in this repo uses
  Eigen (DOLFINx moved off it years ago), and valgrind isn't invoked by
  any test/CI script here.
- Fix two build regressions introduced by the `--no-install-recommends`
  tightening above: add back `make` (silently dropped, broke PETSc's
  configure step) and pin `cython<3.3` (3.3 tightened pointer-indexing
  type checks that break petsc4py 3.25.4's generated `PC.pyx`).
- Update the CI matrix (`ccpp.yml`) to match the dropped PETSc
  configuration.

Net effect: `dev-env` shrinks from ~4.0 GB to ~2.0 GB (arm64).

## Test plan

- [x] Built `dev-env` locally with `podman build --format docker`;
      verified both remaining PETSc/SLEPc configurations
      (`linux-gnu-real64-32`, `linux-gnu-complex128-32`) import and
      report the correct scalar type.
- [x] Verified gmsh imports, initializes, and meshes an OCC box via its
      Python API.
- [x] Built the full `dolfinx-onbuild` → `dolfinx` → `lab` chain against
      the trimmed `dev-env`.
- [x] Ran the full `python/demo` suite (25 demos) against the built
      `lab` image: 24/25 pass; the one failure (`demo_comm-pattern.py`,
      missing `networkx`) is a pre-existing gap unrelated to this PR.
- [x] Confirmed `demo_pyvista.py` renders successfully (only benign
      EGL/Xcursor warnings, handled by the OSMesa fallback).