### PR TITLE
Remove stale xfail markers for higher-order VTK cell tests

### DIFF
--- a/python/test/unit/mesh/test_higher_order_mesh.py
+++ b/python/test/unit/mesh/test_higher_order_mesh.py
@@ -440,8 +440,6 @@ def test_triangle_mesh_vtk(order, dtype):
 @pytest.mark.parametrize("order", range(1, 5))
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_tetrahedron_mesh_vtk(order, dtype):
-    if order > 3:
-        pytest.xfail("VTK permutation for order > 3 tetrahedra not implemented in DOLFINx.")
     points = []
     points += [[i / order, j / order, 0] for j in range(order + 1) for i in range(order + 1 - j)]
     for k in range(1, order):
@@ -594,8 +592,6 @@ def test_quadrilateral_mesh_vtk(order, dtype):
 @pytest.mark.parametrize("order", [1, 2, 3, 4])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_hexahedron_mesh_vtk(order, dtype):
-    if order > 2:
-        pytest.xfail("VTK permutation for order > 2 hexahedra not implemented in DOLFINx.")
     random.seed(13)
 
     points = []


### PR DESCRIPTION
The `xfail` markers on `test_tetrahedron_mesh_vtk` (order > 3) and `test_hexahedron_mesh_vtk` (order > 2) claimed these VTK permutations weren't implemented. They are — `vtk_hexahedron`/`vtk_tetrahedron` in `cpp/dolfinx/io/cells.cpp` are degree-generic. Verified the previously-skipped cases now pass and removed the markers.

## Test plan
- [x] `pytest python/test/unit/mesh/test_higher_order_mesh.py` — 117 passed

---

AI assistance: I used Claude to draft parts of this PR. I reviewed, edited, tested, and take responsibility for the final contribution.