### PR TITLE
Simplify la::petsc/fem::petsc/la::slepc error handling and remove unused Operator base class

### DIFF
--- a/cpp/demo/biharmonic/main.cpp
+++ b/cpp/demo/biharmonic/main.cpp
@@ -228,15 +228,19 @@ int main(int argc, char* argv[])
     la::Vector<T> b(L.function_spaces()[0]->dofmap()->index_map,
                     L.function_spaces()[0]->dofmap()->index_map_bs());
 
-    MatZeroEntries(A.mat());
+    common::petsc::check(MatZeroEntries(A.mat()), "MatZeroEntries");
     fem::assemble_matrix(la::petsc::Matrix::set_block_fn(A.mat(), ADD_VALUES),
                          a, {bc});
-    MatAssemblyBegin(A.mat(), MAT_FLUSH_ASSEMBLY);
-    MatAssemblyEnd(A.mat(), MAT_FLUSH_ASSEMBLY);
+    common::petsc::check(MatAssemblyBegin(A.mat(), MAT_FLUSH_ASSEMBLY),
+                         "MatAssemblyBegin");
+    common::petsc::check(MatAssemblyEnd(A.mat(), MAT_FLUSH_ASSEMBLY),
+                         "MatAssemblyEnd");
     fem::set_diagonal<T>(la::petsc::Matrix::set_fn(A.mat(), INSERT_VALUES), *V,
                          {bc});
-    MatAssemblyBegin(A.mat(), MAT_FINAL_ASSEMBLY);
-    MatAssemblyEnd(A.mat(), MAT_FINAL_ASSEMBLY);
+    common::petsc::check(MatAssemblyBegin(A.mat(), MAT_FINAL_ASSEMBLY),
+                         "MatAssemblyBegin");
+    common::petsc::check(MatAssemblyEnd(A.mat(), MAT_FINAL_ASSEMBLY),
+                         "MatAssemblyEnd");
 
     std::ranges::fill(b.array(), 0);
     fem::assemble_vector(b.array(), L);

--- a/cpp/demo/biharmonic/main.cpp
+++ b/cpp/demo/biharmonic/main.cpp
@@ -245,8 +245,8 @@ int main(int argc, char* argv[])
     bc.set(b.array(), std::nullopt);
 
     la::petsc::KrylovSolver lu(MPI_COMM_WORLD);
-    la::petsc::options::set("ksp_type", "preonly");
-    la::petsc::options::set("pc_type", "lu");
+    common::petsc::set_option("ksp_type", "preonly");
+    common::petsc::set_option("pc_type", "lu");
     lu.set_from_options();
 
     lu.set_operator(A.mat());

--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -58,9 +58,11 @@ public:
 
     std::vector<PetscInt> ghosts(map->ghosts().begin(), map->ghosts().end());
     std::int64_t size_global = bs * map->size_global();
-    VecCreateGhostBlockWithArray(map->comm(), bs, size_local, size_global,
-                                 ghosts.size(), ghosts.data(),
-                                 _b_vec.array().data(), &_b);
+    common::petsc::check(
+        VecCreateGhostBlockWithArray(map->comm(), bs, size_local, size_global,
+                                     ghosts.size(), ghosts.data(),
+                                     _b_vec.array().data(), &_b),
+        "VecCreateGhostBlockWithArray");
 
     // Create linear solver. Default to LU.
     _solver.set_options_prefix("nls_solve_");
@@ -73,7 +75,9 @@ public:
   virtual ~HyperElasticProblem()
   {
     assert(_b);
-    VecDestroy(&_b);
+    // Destructor is implicitly noexcept, so a thrown error here calls
+    // std::terminate rather than propagating
+    common::petsc::check(VecDestroy(&_b), "VecDestroy");
   }
 
   /// @brief Newton Solver
@@ -88,7 +92,7 @@ public:
         = [&iteration, &residual0, this](const Vec r) -> std::pair<double, bool>
     {
       PetscReal residual = 0;
-      VecNorm(r, NORM_2, &residual);
+      common::petsc::check(VecNorm(r, NORM_2, &residual), "VecNorm");
 
       // Relative residual
       const double relative_residual = residual / residual0;
@@ -111,7 +115,8 @@ public:
     _solver.set_operators(_matJ.mat(), _matJ.mat());
 
     Vec dx;
-    MatCreateVecs(_matJ.mat(), &dx, nullptr);
+    common::petsc::check(MatCreateVecs(_matJ.mat(), &dx, nullptr),
+                         "MatCreateVecs");
 
     int max_it = 50;
     int krylov_iterations = 0;
@@ -128,7 +133,7 @@ public:
 
       // Update solution
       double relaxation_parameter = 1.0;
-      VecAXPY(x, -relaxation_parameter, dx);
+      common::petsc::check(VecAXPY(x, -relaxation_parameter, dx), "VecAXPY");
 
       // Increment iteration count
       ++iteration;
@@ -138,7 +143,7 @@ public:
 
       // Initialize residual0
       if (iteration == 1)
-        VecNorm(dx, NORM_2, &residual0);
+        common::petsc::check(VecNorm(dx, NORM_2, &residual0), "VecNorm");
 
       // Test for convergence
       std::tie(residual, newton_converged) = converged(_b);
@@ -151,7 +156,7 @@ public:
                  "solver iterations.",
                  iteration, krylov_iterations);
 
-    VecDestroy(&dx);
+    common::petsc::check(VecDestroy(&dx), "VecDestroy");
 
     return {iteration, newton_converged};
   }
@@ -159,15 +164,19 @@ public:
   /// Compute F at current point x
   void F(const Vec x)
   {
-    VecGhostUpdateBegin(x, INSERT_VALUES, SCATTER_FORWARD);
-    VecGhostUpdateEnd(x, INSERT_VALUES, SCATTER_FORWARD);
+    common::petsc::check(VecGhostUpdateBegin(x, INSERT_VALUES, SCATTER_FORWARD),
+                         "VecGhostUpdateBegin");
+    common::petsc::check(VecGhostUpdateEnd(x, INSERT_VALUES, SCATTER_FORWARD),
+                         "VecGhostUpdateEnd");
 
     // Assemble b and update ghosts
     std::span b(_b_vec.array());
     std::ranges::fill(b, 0);
     fem::assemble_vector(b, _l);
-    VecGhostUpdateBegin(_b, ADD_VALUES, SCATTER_REVERSE);
-    VecGhostUpdateEnd(_b, ADD_VALUES, SCATTER_REVERSE);
+    common::petsc::check(VecGhostUpdateBegin(_b, ADD_VALUES, SCATTER_REVERSE),
+                         "VecGhostUpdateBegin");
+    common::petsc::check(VecGhostUpdateEnd(_b, ADD_VALUES, SCATTER_REVERSE),
+                         "VecGhostUpdateEnd");
 
     // Set bcs
     fem::petsc::set_bc(_b, _bcs, x, -1);
@@ -176,15 +185,19 @@ public:
   /// Compute J = F' at current point x
   void J(const Vec, Mat A)
   {
-    MatZeroEntries(A);
+    common::petsc::check(MatZeroEntries(A), "MatZeroEntries");
     fem::assemble_matrix(la::petsc::Matrix::set_block_fn(A, ADD_VALUES), _j,
                          _bcs);
-    MatAssemblyBegin(A, MAT_FLUSH_ASSEMBLY);
-    MatAssemblyEnd(A, MAT_FLUSH_ASSEMBLY);
+    common::petsc::check(MatAssemblyBegin(A, MAT_FLUSH_ASSEMBLY),
+                         "MatAssemblyBegin");
+    common::petsc::check(MatAssemblyEnd(A, MAT_FLUSH_ASSEMBLY),
+                         "MatAssemblyEnd");
     fem::set_diagonal(la::petsc::Matrix::set_fn(A, INSERT_VALUES),
                       *_j.function_spaces()[0], _bcs);
-    MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
-    MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
+    common::petsc::check(MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY),
+                         "MatAssemblyBegin");
+    common::petsc::check(MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY),
+                         "MatAssemblyEnd");
   }
 
   /// @brief Relative convergence tolerance.

--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -64,8 +64,8 @@ public:
 
     // Create linear solver. Default to LU.
     _solver.set_options_prefix("nls_solve_");
-    la::petsc::options::set("nls_solve_ksp_type", "preonly");
-    la::petsc::options::set("nls_solve_pc_type", "lu");
+    common::petsc::set_option("nls_solve_ksp_type", "preonly");
+    common::petsc::set_option("nls_solve_pc_type", "lu");
     _solver.set_from_options();
   }
 

--- a/cpp/demo/mixed_poisson/main.cpp
+++ b/cpp/demo/mixed_poisson/main.cpp
@@ -340,12 +340,12 @@ int main(int argc, char* argv[])
 
     // Create PETSc linear solver
     la::petsc::KrylovSolver lu(MPI_COMM_WORLD);
-    la::petsc::options::set("ksp_type", "preonly");
-    la::petsc::options::set("pc_type", "lu");
+    common::petsc::set_option("ksp_type", "preonly");
+    common::petsc::set_option("pc_type", "lu");
     if (sizeof(PetscInt) == 4)
-      la::petsc::options::set("pc_factor_mat_solver_type", "mumps");
+      common::petsc::set_option("pc_factor_mat_solver_type", "mumps");
     else
-      la::petsc::options::set("pc_factor_mat_solver_type", "superlu_dist");
+      common::petsc::set_option("pc_factor_mat_solver_type", "superlu_dist");
     lu.set_from_options();
 
     // Solve linear system Ax = b

--- a/cpp/demo/mixed_poisson/main.cpp
+++ b/cpp/demo/mixed_poisson/main.cpp
@@ -314,17 +314,21 @@ int main(int argc, char* argv[])
 
     // Assemble the bilinear form into a matrix. The PETSc matrix is
     // 'flushed' so we can set values in it in the subsequent step.
-    MatZeroEntries(A.mat());
+    common::petsc::check(MatZeroEntries(A.mat()), "MatZeroEntries");
     fem::assemble_matrix(la::petsc::Matrix::set_fn(A.mat(), ADD_VALUES), a,
                          {bc});
-    MatAssemblyBegin(A.mat(), MAT_FLUSH_ASSEMBLY);
-    MatAssemblyEnd(A.mat(), MAT_FLUSH_ASSEMBLY);
+    common::petsc::check(MatAssemblyBegin(A.mat(), MAT_FLUSH_ASSEMBLY),
+                         "MatAssemblyBegin");
+    common::petsc::check(MatAssemblyEnd(A.mat(), MAT_FLUSH_ASSEMBLY),
+                         "MatAssemblyEnd");
 
     // Set '1' on diagonal for Dirichlet dofs
     fem::set_diagonal<T>(la::petsc::Matrix::set_fn(A.mat(), INSERT_VALUES), *V,
                          {bc});
-    MatAssemblyBegin(A.mat(), MAT_FINAL_ASSEMBLY);
-    MatAssemblyEnd(A.mat(), MAT_FINAL_ASSEMBLY);
+    common::petsc::check(MatAssemblyBegin(A.mat(), MAT_FINAL_ASSEMBLY),
+                         "MatAssemblyBegin");
+    common::petsc::check(MatAssemblyEnd(A.mat(), MAT_FINAL_ASSEMBLY),
+                         "MatAssemblyEnd");
 
     // Assemble the linear form `L` into RHS vector
     std::ranges::fill(b.array(), 0);

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -209,15 +209,19 @@ int main(int argc, char* argv[])
     la::Vector<T> b(L.function_spaces()[0]->dofmap()->index_map,
                     L.function_spaces()[0]->dofmap()->index_map_bs());
 
-    MatZeroEntries(A.mat());
+    common::petsc::check(MatZeroEntries(A.mat()), "MatZeroEntries");
     fem::assemble_matrix(la::petsc::Matrix::set_block_fn(A.mat(), ADD_VALUES),
                          a, {bc});
-    MatAssemblyBegin(A.mat(), MAT_FLUSH_ASSEMBLY);
-    MatAssemblyEnd(A.mat(), MAT_FLUSH_ASSEMBLY);
+    common::petsc::check(MatAssemblyBegin(A.mat(), MAT_FLUSH_ASSEMBLY),
+                         "MatAssemblyBegin");
+    common::petsc::check(MatAssemblyEnd(A.mat(), MAT_FLUSH_ASSEMBLY),
+                         "MatAssemblyEnd");
     fem::set_diagonal<T>(la::petsc::Matrix::set_fn(A.mat(), INSERT_VALUES), *V,
                          {bc});
-    MatAssemblyBegin(A.mat(), MAT_FINAL_ASSEMBLY);
-    MatAssemblyEnd(A.mat(), MAT_FINAL_ASSEMBLY);
+    common::petsc::check(MatAssemblyBegin(A.mat(), MAT_FINAL_ASSEMBLY),
+                         "MatAssemblyBegin");
+    common::petsc::check(MatAssemblyEnd(A.mat(), MAT_FINAL_ASSEMBLY),
+                         "MatAssemblyEnd");
 
     std::ranges::fill(b.array(), 0);
     fem::assemble_vector(b.array(), L);

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -226,8 +226,8 @@ int main(int argc, char* argv[])
     bc.set(b.array(), std::nullopt);
 
     la::petsc::KrylovSolver lu(MPI_COMM_WORLD);
-    la::petsc::options::set("ksp_type", "preonly");
-    la::petsc::options::set("pc_type", "lu");
+    common::petsc::set_option("ksp_type", "preonly");
+    common::petsc::set_option("pc_type", "lu");
     lu.set_from_options();
 
     lu.set_operator(A.mat());

--- a/cpp/dolfinx/common/CMakeLists.txt
+++ b/cpp/dolfinx/common/CMakeLists.txt
@@ -22,6 +22,12 @@ set(
 
 target_sources(
   dolfinx
-  PRIVATE IndexMap.cpp log.cpp MPI.cpp petsc.cpp Table.cpp TimeLogger.cpp
-          timing.cpp
+  PRIVATE
+    IndexMap.cpp
+    log.cpp
+    MPI.cpp
+    petsc.cpp
+    Table.cpp
+    TimeLogger.cpp
+    timing.cpp
 )

--- a/cpp/dolfinx/common/CMakeLists.txt
+++ b/cpp/dolfinx/common/CMakeLists.txt
@@ -10,6 +10,7 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/local_range.h
   ${CMAKE_CURRENT_SOURCE_DIR}/math.h
   ${CMAKE_CURRENT_SOURCE_DIR}/MPI.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/petsc.h
   ${CMAKE_CURRENT_SOURCE_DIR}/Scatterer.h
   ${CMAKE_CURRENT_SOURCE_DIR}/Table.h
   ${CMAKE_CURRENT_SOURCE_DIR}/Timer.h
@@ -21,5 +22,6 @@ set(
 
 target_sources(
   dolfinx
-  PRIVATE IndexMap.cpp log.cpp MPI.cpp Table.cpp TimeLogger.cpp timing.cpp
+  PRIVATE IndexMap.cpp log.cpp MPI.cpp petsc.cpp Table.cpp TimeLogger.cpp
+          timing.cpp
 )

--- a/cpp/dolfinx/common/petsc.cpp
+++ b/cpp/dolfinx/common/petsc.cpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2004-2018 Johan Hoffman, Johan Jansson, Anders Logg and
+// Garth N. Wells
+//
+// This file is part of DOLFINx (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+
+#ifdef HAS_PETSC
+
+#include "petsc.h"
+#include <dolfinx/common/log.h>
+#include <format>
+#include <stdexcept>
+
+using namespace dolfinx;
+
+//-----------------------------------------------------------------------------
+void common::petsc::error(PetscErrorCode error_code,
+                          std::string_view petsc_function,
+                          std::source_location loc)
+{
+  // Fetch PETSc error description
+  const char* desc;
+  PetscErrorMessage(error_code, &desc, nullptr);
+
+  // Log detailed error info
+  spdlog::error("PETSc error in '{}:{}', '{}'", loc.file_name(), loc.line(),
+                petsc_function);
+  spdlog::error("PETSc error code '{}' '{}'", static_cast<int>(error_code),
+                desc);
+  throw std::runtime_error(
+      std::format("Failed to successfully call PETSc function '{}'. PETSc "
+                  "error code is: {}, {}",
+                  petsc_function, static_cast<int>(error_code), desc));
+}
+//-----------------------------------------------------------------------------
+
+#endif

--- a/cpp/dolfinx/common/petsc.cpp
+++ b/cpp/dolfinx/common/petsc.cpp
@@ -8,6 +8,7 @@
 #ifdef HAS_PETSC
 
 #include "petsc.h"
+#include <cassert>
 #include <dolfinx/common/log.h>
 #include <format>
 #include <stdexcept>
@@ -19,6 +20,9 @@ void common::petsc::error(PetscErrorCode error_code,
                           std::string_view petsc_function,
                           std::source_location loc)
 {
+  // Only called from check() with a nonzero error code
+  assert(error_code);
+
   // Fetch PETSc error description
   const char* desc;
   PetscErrorMessage(error_code, &desc, nullptr);

--- a/cpp/dolfinx/common/petsc.cpp
+++ b/cpp/dolfinx/common/petsc.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2004-2018 Johan Hoffman, Johan Jansson, Anders Logg and
-// Garth N. Wells
+// Copyright (C) 2004-2026 Johan Hoffman, Johan Jansson, Anders Logg,
+// Garth N. Wells and Jack S. Hale
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //

--- a/cpp/dolfinx/common/petsc.cpp
+++ b/cpp/dolfinx/common/petsc.cpp
@@ -12,6 +12,7 @@
 #include <dolfinx/common/log.h>
 #include <format>
 #include <stdexcept>
+#include <utility>
 
 using namespace dolfinx;
 
@@ -36,6 +37,25 @@ void common::petsc::error(PetscErrorCode error_code,
       std::format("Failed to successfully call PETSc function '{}'. PETSc "
                   "error code is: {}, {}",
                   petsc_function, static_cast<int>(error_code), desc));
+}
+//-----------------------------------------------------------------------------
+void common::petsc::set_option(std::string option)
+{
+  common::petsc::set_option<std::string>(std::move(option), "");
+}
+//-----------------------------------------------------------------------------
+void common::petsc::clear_option(std::string option)
+{
+  if (option[0] != '-')
+    option = '-' + option;
+
+  check(PetscOptionsClearValue(nullptr, option.c_str()),
+        "PetscOptionsClearValue");
+}
+//-----------------------------------------------------------------------------
+void common::petsc::clear_options()
+{
+  check(PetscOptionsClear(nullptr), "PetscOptionsClear");
 }
 //-----------------------------------------------------------------------------
 

--- a/cpp/dolfinx/common/petsc.h
+++ b/cpp/dolfinx/common/petsc.h
@@ -9,8 +9,10 @@
 
 #ifdef HAS_PETSC
 
+#include <format>
 #include <petscsys.h>
 #include <source_location>
+#include <string>
 #include <string_view>
 
 namespace dolfinx::common
@@ -42,6 +44,36 @@ inline void check(PetscErrorCode ierr, std::string_view petsc_function,
   if (ierr != 0)
     error(ierr, petsc_function, loc);
 }
+
+/// @brief Set a PETSc option in the PETSc options/parameter database.
+/// The option must not be prefixed by '-', e.g.
+///
+///     common::petsc::set_option("mat_mumps_icntl_14", 40);
+void set_option(std::string option);
+
+/// @brief Set a PETSc option that takes a value in the PETSc
+/// options/parameter database. The option must not be prefixed by
+/// '-', e.g.
+///
+///     common::petsc::set_option("mat_mumps_icntl_14", 40);
+template <typename T>
+  requires requires(const T& value) { std::format("{}", value); }
+void set_option(std::string option, const T& value)
+{
+  if (option[0] != '-')
+    option = '-' + option;
+
+  check(PetscOptionsSetValue(nullptr, option.c_str(),
+                             std::format("{}", value).c_str()),
+        "PetscOptionsSetValue");
+}
+
+/// @brief Clear a PETSc option from the PETSc options/parameter
+/// database.
+void clear_option(std::string option);
+
+/// @brief Clear the PETSc global options/parameter database.
+void clear_options();
 } // namespace petsc
 } // namespace dolfinx::common
 

--- a/cpp/dolfinx/common/petsc.h
+++ b/cpp/dolfinx/common/petsc.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2004-2018 Johan Hoffman, Johan Jansson, Anders Logg and
-// Garth N. Wells
+// Copyright (C) 2004-2026 Johan Hoffman, Johan Jansson, Anders Logg,
+// Garth N. Wells and Jack S. Hale
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //

--- a/cpp/dolfinx/common/petsc.h
+++ b/cpp/dolfinx/common/petsc.h
@@ -1,0 +1,48 @@
+// Copyright (C) 2004-2018 Johan Hoffman, Johan Jansson, Anders Logg and
+// Garth N. Wells
+//
+// This file is part of DOLFINx (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+
+#pragma once
+
+#ifdef HAS_PETSC
+
+#include <petscsys.h>
+#include <source_location>
+#include <string_view>
+
+namespace dolfinx::common
+{
+/// @brief PETSc error handling helpers shared across DOLFINx's PETSc
+/// wrappers
+namespace petsc
+{
+/// @brief Print error message for a PETSc call that returned an error
+/// and throw a std::runtime_error.
+/// @param[in] error_code PETSc error code
+/// @param[in] petsc_function Name of the PETSc function that returned
+/// `error_code`
+/// @param[in] loc Call site of the failed PETSc call (captured
+/// automatically; do not pass explicitly)
+void error(PetscErrorCode error_code, std::string_view petsc_function,
+           std::source_location loc = std::source_location::current());
+
+/// @brief Throw a std::runtime_error via error() if `ierr` indicates a
+/// PETSc call failed.
+/// @param[in] ierr PETSc error code returned by `petsc_function`
+/// @param[in] petsc_function Name of the PETSc function that returned
+/// `ierr`
+/// @param[in] loc Call site of the failed PETSc call (captured
+/// automatically; do not pass explicitly)
+inline void check(PetscErrorCode ierr, std::string_view petsc_function,
+                  std::source_location loc = std::source_location::current())
+{
+  if (ierr != 0)
+    error(ierr, petsc_function, loc);
+}
+} // namespace petsc
+} // namespace dolfinx::common
+
+#endif

--- a/cpp/dolfinx/fem/petsc.cpp
+++ b/cpp/dolfinx/fem/petsc.cpp
@@ -57,7 +57,7 @@ Vec fem::petsc::create_vector_block(
   PetscErrorCode ierr
       = VecCreateGhost(maps[0].first.get().comm(), local_size, PETSC_DETERMINE,
                        _ghosts.size(), _ghosts.data(), &x);
-  la::petsc::check(ierr, "VecCreateGhost");
+  common::petsc::check(ierr, "VecCreateGhost");
 
   return x;
 }
@@ -84,7 +84,7 @@ Vec fem::petsc::create_vector_nest(
   Vec y;
   PetscErrorCode ierr = VecCreateNest(vecs.front()->comm(), petsc_vecs.size(),
                                       nullptr, petsc_vecs.data(), &y);
-  la::petsc::check(ierr, "VecCreateNest");
+  common::petsc::check(ierr, "VecCreateNest");
 
   return y;
 }

--- a/cpp/dolfinx/fem/petsc.cpp
+++ b/cpp/dolfinx/fem/petsc.cpp
@@ -54,10 +54,10 @@ Vec fem::petsc::create_vector_block(
   std::int32_t local_size = range[1] - range[0];
   std::vector<PetscInt> _ghosts(ghosts.begin(), ghosts.end());
   Vec x = nullptr;
-  PetscErrorCode ierr
-      = VecCreateGhost(maps[0].first.get().comm(), local_size, PETSC_DETERMINE,
-                       _ghosts.size(), _ghosts.data(), &x);
-  common::petsc::check(ierr, "VecCreateGhost");
+  common::petsc::check(VecCreateGhost(maps[0].first.get().comm(), local_size,
+                                      PETSC_DETERMINE, _ghosts.size(),
+                                      _ghosts.data(), &x),
+                       "VecCreateGhost");
 
   return x;
 }
@@ -82,9 +82,9 @@ Vec fem::petsc::create_vector_nest(
   // vecs (and the Vec objects they own) can be safely destroyed once
   // this function returns.
   Vec y;
-  PetscErrorCode ierr = VecCreateNest(vecs.front()->comm(), petsc_vecs.size(),
-                                      nullptr, petsc_vecs.data(), &y);
-  common::petsc::check(ierr, "VecCreateNest");
+  common::petsc::check(VecCreateNest(vecs.front()->comm(), petsc_vecs.size(),
+                                     nullptr, petsc_vecs.data(), &y),
+                       "VecCreateNest");
 
   return y;
 }

--- a/cpp/dolfinx/fem/petsc.cpp
+++ b/cpp/dolfinx/fem/petsc.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 Garth N. Wells
+// Copyright (C) 2018-2026 Garth N. Wells and Jack S. Hale
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //

--- a/cpp/dolfinx/fem/petsc.cpp
+++ b/cpp/dolfinx/fem/petsc.cpp
@@ -57,8 +57,7 @@ Vec fem::petsc::create_vector_block(
   PetscErrorCode ierr
       = VecCreateGhost(maps[0].first.get().comm(), local_size, PETSC_DETERMINE,
                        _ghosts.size(), _ghosts.data(), &x);
-  if (ierr != 0)
-    la::petsc::error(ierr, __FILE__, "VecCreateGhost");
+  la::petsc::check(ierr, "VecCreateGhost");
 
   return x;
 }
@@ -85,8 +84,7 @@ Vec fem::petsc::create_vector_nest(
   Vec y;
   PetscErrorCode ierr = VecCreateNest(vecs.front()->comm(), petsc_vecs.size(),
                                       nullptr, petsc_vecs.data(), &y);
-  if (ierr != 0)
-    la::petsc::error(ierr, __FILE__, "VecCreateNest");
+  la::petsc::check(ierr, "VecCreateNest");
 
   return y;
 }

--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -181,32 +181,32 @@ Mat create_matrix_block(
 
   // Create PETSc local-to-global map/index sets and attach to matrix
   ISLocalToGlobalMapping petsc_local_to_global0;
-  PetscErrorCode ierr = ISLocalToGlobalMappingCreate(
-      MPI_COMM_SELF, 1, _maps[0].size(), _maps[0].data(), PETSC_COPY_VALUES,
-      &petsc_local_to_global0);
-  common::petsc::check(ierr, "ISLocalToGlobalMappingCreate");
+  common::petsc::check(ISLocalToGlobalMappingCreate(
+                           MPI_COMM_SELF, 1, _maps[0].size(), _maps[0].data(),
+                           PETSC_COPY_VALUES, &petsc_local_to_global0),
+                       "ISLocalToGlobalMappingCreate");
   if (V[0] == V[1])
   {
-    ierr = MatSetLocalToGlobalMapping(A, petsc_local_to_global0,
-                                      petsc_local_to_global0);
-    common::petsc::check(ierr, "MatSetLocalToGlobalMapping");
-    ierr = ISLocalToGlobalMappingDestroy(&petsc_local_to_global0);
-    common::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
+    common::petsc::check(MatSetLocalToGlobalMapping(A, petsc_local_to_global0,
+                                                    petsc_local_to_global0),
+                         "MatSetLocalToGlobalMapping");
+    common::petsc::check(ISLocalToGlobalMappingDestroy(&petsc_local_to_global0),
+                         "ISLocalToGlobalMappingDestroy");
   }
   else
   {
     ISLocalToGlobalMapping petsc_local_to_global1;
-    ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, 1, _maps[1].size(),
-                                        _maps[1].data(), PETSC_COPY_VALUES,
-                                        &petsc_local_to_global1);
-    common::petsc::check(ierr, "ISLocalToGlobalMappingCreate");
-    ierr = MatSetLocalToGlobalMapping(A, petsc_local_to_global0,
-                                      petsc_local_to_global1);
-    common::petsc::check(ierr, "MatSetLocalToGlobalMapping");
-    ierr = ISLocalToGlobalMappingDestroy(&petsc_local_to_global0);
-    common::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
-    ierr = ISLocalToGlobalMappingDestroy(&petsc_local_to_global1);
-    common::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
+    common::petsc::check(ISLocalToGlobalMappingCreate(
+                             MPI_COMM_SELF, 1, _maps[1].size(), _maps[1].data(),
+                             PETSC_COPY_VALUES, &petsc_local_to_global1),
+                         "ISLocalToGlobalMappingCreate");
+    common::petsc::check(MatSetLocalToGlobalMapping(A, petsc_local_to_global0,
+                                                    petsc_local_to_global1),
+                         "MatSetLocalToGlobalMapping");
+    common::petsc::check(ISLocalToGlobalMappingDestroy(&petsc_local_to_global0),
+                         "ISLocalToGlobalMappingDestroy");
+    common::petsc::check(ISLocalToGlobalMappingDestroy(&petsc_local_to_global1),
+                         "ISLocalToGlobalMappingDestroy");
   }
 
   return A;
@@ -256,14 +256,12 @@ Mat create_matrix_nest(
   Mat A;
   try
   {
-    PetscErrorCode ierr = MatCreate(mesh->comm(), &A);
-    common::petsc::check(ierr, "MatCreate");
-    ierr = MatSetType(A, MATNEST);
-    common::petsc::check(ierr, "MatSetType");
-    ierr = MatNestSetSubMats(A, rows, nullptr, cols, nullptr, mats.data());
-    common::petsc::check(ierr, "MatNestSetSubMats");
-    ierr = MatSetUp(A);
-    common::petsc::check(ierr, "MatSetUp");
+    common::petsc::check(MatCreate(mesh->comm(), &A), "MatCreate");
+    common::petsc::check(MatSetType(A, MATNEST), "MatSetType");
+    common::petsc::check(
+        MatNestSetSubMats(A, rows, nullptr, cols, nullptr, mats.data()),
+        "MatNestSetSubMats");
+    common::petsc::check(MatSetUp(A), "MatSetUp");
   }
   catch (...)
   {
@@ -315,20 +313,17 @@ void assemble_vector(
                    std::pair<std::span<const PetscScalar>, int>>& coeffs)
 {
   Vec b_local;
-  PetscErrorCode ierr = VecGhostGetLocalForm(b, &b_local);
-  common::petsc::check(ierr, "VecGhostGetLocalForm");
+  common::petsc::check(VecGhostGetLocalForm(b, &b_local),
+                       "VecGhostGetLocalForm");
   PetscInt n = 0;
-  ierr = VecGetSize(b_local, &n);
-  common::petsc::check(ierr, "VecGetSize");
+  common::petsc::check(VecGetSize(b_local, &n), "VecGetSize");
   PetscScalar* array = nullptr;
-  ierr = VecGetArray(b_local, &array);
-  common::petsc::check(ierr, "VecGetArray");
+  common::petsc::check(VecGetArray(b_local, &array), "VecGetArray");
   std::span<PetscScalar> _b(array, n);
   fem::assemble_vector(_b, L, constants, coeffs);
-  ierr = VecRestoreArray(b_local, &array);
-  common::petsc::check(ierr, "VecRestoreArray");
-  ierr = VecGhostRestoreLocalForm(b, &b_local);
-  common::petsc::check(ierr, "VecGhostRestoreLocalForm");
+  common::petsc::check(VecRestoreArray(b_local, &array), "VecRestoreArray");
+  common::petsc::check(VecGhostRestoreLocalForm(b, &b_local),
+                       "VecGhostRestoreLocalForm");
 }
 
 /// @brief Assemble linear form into an already allocated PETSc vector.
@@ -345,20 +340,17 @@ template <std::floating_point T>
 void assemble_vector(Vec b, const Form<PetscScalar, T>& L)
 {
   Vec b_local;
-  PetscErrorCode ierr = VecGhostGetLocalForm(b, &b_local);
-  common::petsc::check(ierr, "VecGhostGetLocalForm");
+  common::petsc::check(VecGhostGetLocalForm(b, &b_local),
+                       "VecGhostGetLocalForm");
   PetscInt n = 0;
-  ierr = VecGetSize(b_local, &n);
-  common::petsc::check(ierr, "VecGetSize");
+  common::petsc::check(VecGetSize(b_local, &n), "VecGetSize");
   PetscScalar* array = nullptr;
-  ierr = VecGetArray(b_local, &array);
-  common::petsc::check(ierr, "VecGetArray");
+  common::petsc::check(VecGetArray(b_local, &array), "VecGetArray");
   std::span<PetscScalar> _b(array, n);
   fem::assemble_vector(_b, L);
-  ierr = VecRestoreArray(b_local, &array);
-  common::petsc::check(ierr, "VecRestoreArray");
-  ierr = VecGhostRestoreLocalForm(b, &b_local);
-  common::petsc::check(ierr, "VecGhostRestoreLocalForm");
+  common::petsc::check(VecRestoreArray(b_local, &array), "VecRestoreArray");
+  common::petsc::check(VecGhostRestoreLocalForm(b, &b_local),
+                       "VecGhostRestoreLocalForm");
 }
 
 // FIXME: clarify zeroing of vector
@@ -411,14 +403,12 @@ void apply_lifting(
     throw std::runtime_error("Mismatch between x0 and a in apply_lifting.");
 
   Vec b_local;
-  PetscErrorCode ierr = VecGhostGetLocalForm(b, &b_local);
-  common::petsc::check(ierr, "VecGhostGetLocalForm");
+  common::petsc::check(VecGhostGetLocalForm(b, &b_local),
+                       "VecGhostGetLocalForm");
   PetscInt n = 0;
-  ierr = VecGetSize(b_local, &n);
-  common::petsc::check(ierr, "VecGetSize");
+  common::petsc::check(VecGetSize(b_local, &n), "VecGetSize");
   PetscScalar* array = nullptr;
-  ierr = VecGetArray(b_local, &array);
-  common::petsc::check(ierr, "VecGetArray");
+  common::petsc::check(VecGetArray(b_local, &array), "VecGetArray");
   std::span<PetscScalar> _b(array, n);
 
   if (x0.empty())
@@ -431,13 +421,12 @@ void apply_lifting(
     for (std::size_t i = 0; i < a.size(); ++i)
     {
       assert(x0[i]);
-      ierr = VecGhostGetLocalForm(x0[i], &x0_local[i]);
-      common::petsc::check(ierr, "VecGhostGetLocalForm");
+      common::petsc::check(VecGhostGetLocalForm(x0[i], &x0_local[i]),
+                           "VecGhostGetLocalForm");
       PetscInt n0 = 0;
-      ierr = VecGetSize(x0_local[i], &n0);
-      common::petsc::check(ierr, "VecGetSize");
-      ierr = VecGetArrayRead(x0_local[i], &x0_array[i]);
-      common::petsc::check(ierr, "VecGetArrayRead");
+      common::petsc::check(VecGetSize(x0_local[i], &n0), "VecGetSize");
+      common::petsc::check(VecGetArrayRead(x0_local[i], &x0_array[i]),
+                           "VecGetArrayRead");
       x0_ref.emplace_back(x0_array[i], n0);
     }
 
@@ -445,17 +434,16 @@ void apply_lifting(
 
     for (std::size_t i = 0; i < x0_local.size(); ++i)
     {
-      ierr = VecRestoreArrayRead(x0_local[i], &x0_array[i]);
-      common::petsc::check(ierr, "VecRestoreArrayRead");
-      ierr = VecGhostRestoreLocalForm(x0[i], &x0_local[i]);
-      common::petsc::check(ierr, "VecGhostRestoreLocalForm");
+      common::petsc::check(VecRestoreArrayRead(x0_local[i], &x0_array[i]),
+                           "VecRestoreArrayRead");
+      common::petsc::check(VecGhostRestoreLocalForm(x0[i], &x0_local[i]),
+                           "VecGhostRestoreLocalForm");
     }
   }
 
-  ierr = VecRestoreArray(b_local, &array);
-  common::petsc::check(ierr, "VecRestoreArray");
-  ierr = VecGhostRestoreLocalForm(b, &b_local);
-  common::petsc::check(ierr, "VecGhostRestoreLocalForm");
+  common::petsc::check(VecRestoreArray(b_local, &array), "VecRestoreArray");
+  common::petsc::check(VecGhostRestoreLocalForm(b, &b_local),
+                       "VecGhostRestoreLocalForm");
 }
 
 // FIXME: clarify zeroing of vector
@@ -499,14 +487,12 @@ void apply_lifting(
     throw std::runtime_error("Mismatch between x0 and a in apply_lifting.");
 
   Vec b_local;
-  PetscErrorCode ierr = VecGhostGetLocalForm(b, &b_local);
-  common::petsc::check(ierr, "VecGhostGetLocalForm");
+  common::petsc::check(VecGhostGetLocalForm(b, &b_local),
+                       "VecGhostGetLocalForm");
   PetscInt n = 0;
-  ierr = VecGetSize(b_local, &n);
-  common::petsc::check(ierr, "VecGetSize");
+  common::petsc::check(VecGetSize(b_local, &n), "VecGetSize");
   PetscScalar* array = nullptr;
-  ierr = VecGetArray(b_local, &array);
-  common::petsc::check(ierr, "VecGetArray");
+  common::petsc::check(VecGetArray(b_local, &array), "VecGetArray");
   std::span<PetscScalar> _b(array, n);
 
   if (x0.empty())
@@ -519,13 +505,12 @@ void apply_lifting(
     for (std::size_t i = 0; i < a.size(); ++i)
     {
       assert(x0[i]);
-      ierr = VecGhostGetLocalForm(x0[i], &x0_local[i]);
-      common::petsc::check(ierr, "VecGhostGetLocalForm");
+      common::petsc::check(VecGhostGetLocalForm(x0[i], &x0_local[i]),
+                           "VecGhostGetLocalForm");
       PetscInt n0 = 0;
-      ierr = VecGetSize(x0_local[i], &n0);
-      common::petsc::check(ierr, "VecGetSize");
-      ierr = VecGetArrayRead(x0_local[i], &x0_array[i]);
-      common::petsc::check(ierr, "VecGetArrayRead");
+      common::petsc::check(VecGetSize(x0_local[i], &n0), "VecGetSize");
+      common::petsc::check(VecGetArrayRead(x0_local[i], &x0_array[i]),
+                           "VecGetArrayRead");
       x0_ref.emplace_back(x0_array[i], n0);
     }
 
@@ -533,17 +518,16 @@ void apply_lifting(
 
     for (std::size_t i = 0; i < x0_local.size(); ++i)
     {
-      ierr = VecRestoreArrayRead(x0_local[i], &x0_array[i]);
-      common::petsc::check(ierr, "VecRestoreArrayRead");
-      ierr = VecGhostRestoreLocalForm(x0[i], &x0_local[i]);
-      common::petsc::check(ierr, "VecGhostRestoreLocalForm");
+      common::petsc::check(VecRestoreArrayRead(x0_local[i], &x0_array[i]),
+                           "VecRestoreArrayRead");
+      common::petsc::check(VecGhostRestoreLocalForm(x0[i], &x0_local[i]),
+                           "VecGhostRestoreLocalForm");
     }
   }
 
-  ierr = VecRestoreArray(b_local, &array);
-  common::petsc::check(ierr, "VecRestoreArray");
-  ierr = VecGhostRestoreLocalForm(b, &b_local);
-  common::petsc::check(ierr, "VecGhostRestoreLocalForm");
+  common::petsc::check(VecRestoreArray(b_local, &array), "VecRestoreArray");
+  common::petsc::check(VecGhostRestoreLocalForm(b, &b_local),
+                       "VecGhostRestoreLocalForm");
 }
 
 // -- Setting bcs ------------------------------------------------------------
@@ -569,38 +553,34 @@ void set_bc(Vec b,
             std::optional<const Vec> x0, PetscScalar alpha = 1)
 {
   PetscInt n = 0;
-  PetscErrorCode ierr = VecGetLocalSize(b, &n);
-  common::petsc::check(ierr, "VecGetLocalSize");
+  common::petsc::check(VecGetLocalSize(b, &n), "VecGetLocalSize");
   PetscScalar* array = nullptr;
-  ierr = VecGetArray(b, &array);
-  common::petsc::check(ierr, "VecGetArray");
+  common::petsc::check(VecGetArray(b, &array), "VecGetArray");
   std::span<PetscScalar> _b(array, n);
   if (x0.has_value())
   {
     Vec x0_local;
-    ierr = VecGhostGetLocalForm(x0.value(), &x0_local);
-    common::petsc::check(ierr, "VecGhostGetLocalForm");
+    common::petsc::check(VecGhostGetLocalForm(x0.value(), &x0_local),
+                         "VecGhostGetLocalForm");
     PetscInt n0 = 0;
-    ierr = VecGetSize(x0_local, &n0);
-    common::petsc::check(ierr, "VecGetSize");
+    common::petsc::check(VecGetSize(x0_local, &n0), "VecGetSize");
     const PetscScalar* x0_array = nullptr;
-    ierr = VecGetArrayRead(x0_local, &x0_array);
-    common::petsc::check(ierr, "VecGetArrayRead");
+    common::petsc::check(VecGetArrayRead(x0_local, &x0_array),
+                         "VecGetArrayRead");
     std::span<const PetscScalar> _x0(x0_array, n0);
     for (auto& bc : bcs)
       bc.get().set(_b, _x0, alpha);
-    ierr = VecRestoreArrayRead(x0_local, &x0_array);
-    common::petsc::check(ierr, "VecRestoreArrayRead");
-    ierr = VecGhostRestoreLocalForm(x0.value(), &x0_local);
-    common::petsc::check(ierr, "VecGhostRestoreLocalForm");
+    common::petsc::check(VecRestoreArrayRead(x0_local, &x0_array),
+                         "VecRestoreArrayRead");
+    common::petsc::check(VecGhostRestoreLocalForm(x0.value(), &x0_local),
+                         "VecGhostRestoreLocalForm");
   }
   else
   {
     for (auto& bc : bcs)
       bc.get().set(_b, std::nullopt, alpha);
   }
-  ierr = VecRestoreArray(b, &array);
-  common::petsc::check(ierr, "VecRestoreArray");
+  common::petsc::check(VecRestoreArray(b, &array), "VecRestoreArray");
 }
 
 } // namespace petsc

--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -184,14 +184,14 @@ Mat create_matrix_block(
   PetscErrorCode ierr = ISLocalToGlobalMappingCreate(
       MPI_COMM_SELF, 1, _maps[0].size(), _maps[0].data(), PETSC_COPY_VALUES,
       &petsc_local_to_global0);
-  la::petsc::check(ierr, "ISLocalToGlobalMappingCreate");
+  common::petsc::check(ierr, "ISLocalToGlobalMappingCreate");
   if (V[0] == V[1])
   {
     ierr = MatSetLocalToGlobalMapping(A, petsc_local_to_global0,
                                       petsc_local_to_global0);
-    la::petsc::check(ierr, "MatSetLocalToGlobalMapping");
+    common::petsc::check(ierr, "MatSetLocalToGlobalMapping");
     ierr = ISLocalToGlobalMappingDestroy(&petsc_local_to_global0);
-    la::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
+    common::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
   }
   else
   {
@@ -199,14 +199,14 @@ Mat create_matrix_block(
     ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, 1, _maps[1].size(),
                                         _maps[1].data(), PETSC_COPY_VALUES,
                                         &petsc_local_to_global1);
-    la::petsc::check(ierr, "ISLocalToGlobalMappingCreate");
+    common::petsc::check(ierr, "ISLocalToGlobalMappingCreate");
     ierr = MatSetLocalToGlobalMapping(A, petsc_local_to_global0,
                                       petsc_local_to_global1);
-    la::petsc::check(ierr, "MatSetLocalToGlobalMapping");
+    common::petsc::check(ierr, "MatSetLocalToGlobalMapping");
     ierr = ISLocalToGlobalMappingDestroy(&petsc_local_to_global0);
-    la::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
+    common::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
     ierr = ISLocalToGlobalMappingDestroy(&petsc_local_to_global1);
-    la::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
+    common::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
   }
 
   return A;
@@ -257,13 +257,13 @@ Mat create_matrix_nest(
   try
   {
     PetscErrorCode ierr = MatCreate(mesh->comm(), &A);
-    la::petsc::check(ierr, "MatCreate");
+    common::petsc::check(ierr, "MatCreate");
     ierr = MatSetType(A, MATNEST);
-    la::petsc::check(ierr, "MatSetType");
+    common::petsc::check(ierr, "MatSetType");
     ierr = MatNestSetSubMats(A, rows, nullptr, cols, nullptr, mats.data());
-    la::petsc::check(ierr, "MatNestSetSubMats");
+    common::petsc::check(ierr, "MatNestSetSubMats");
     ierr = MatSetUp(A);
-    la::petsc::check(ierr, "MatSetUp");
+    common::petsc::check(ierr, "MatSetUp");
   }
   catch (...)
   {
@@ -316,19 +316,19 @@ void assemble_vector(
 {
   Vec b_local;
   PetscErrorCode ierr = VecGhostGetLocalForm(b, &b_local);
-  la::petsc::check(ierr, "VecGhostGetLocalForm");
+  common::petsc::check(ierr, "VecGhostGetLocalForm");
   PetscInt n = 0;
   ierr = VecGetSize(b_local, &n);
-  la::petsc::check(ierr, "VecGetSize");
+  common::petsc::check(ierr, "VecGetSize");
   PetscScalar* array = nullptr;
   ierr = VecGetArray(b_local, &array);
-  la::petsc::check(ierr, "VecGetArray");
+  common::petsc::check(ierr, "VecGetArray");
   std::span<PetscScalar> _b(array, n);
   fem::assemble_vector(_b, L, constants, coeffs);
   ierr = VecRestoreArray(b_local, &array);
-  la::petsc::check(ierr, "VecRestoreArray");
+  common::petsc::check(ierr, "VecRestoreArray");
   ierr = VecGhostRestoreLocalForm(b, &b_local);
-  la::petsc::check(ierr, "VecGhostRestoreLocalForm");
+  common::petsc::check(ierr, "VecGhostRestoreLocalForm");
 }
 
 /// @brief Assemble linear form into an already allocated PETSc vector.
@@ -346,19 +346,19 @@ void assemble_vector(Vec b, const Form<PetscScalar, T>& L)
 {
   Vec b_local;
   PetscErrorCode ierr = VecGhostGetLocalForm(b, &b_local);
-  la::petsc::check(ierr, "VecGhostGetLocalForm");
+  common::petsc::check(ierr, "VecGhostGetLocalForm");
   PetscInt n = 0;
   ierr = VecGetSize(b_local, &n);
-  la::petsc::check(ierr, "VecGetSize");
+  common::petsc::check(ierr, "VecGetSize");
   PetscScalar* array = nullptr;
   ierr = VecGetArray(b_local, &array);
-  la::petsc::check(ierr, "VecGetArray");
+  common::petsc::check(ierr, "VecGetArray");
   std::span<PetscScalar> _b(array, n);
   fem::assemble_vector(_b, L);
   ierr = VecRestoreArray(b_local, &array);
-  la::petsc::check(ierr, "VecRestoreArray");
+  common::petsc::check(ierr, "VecRestoreArray");
   ierr = VecGhostRestoreLocalForm(b, &b_local);
-  la::petsc::check(ierr, "VecGhostRestoreLocalForm");
+  common::petsc::check(ierr, "VecGhostRestoreLocalForm");
 }
 
 // FIXME: clarify zeroing of vector
@@ -412,13 +412,13 @@ void apply_lifting(
 
   Vec b_local;
   PetscErrorCode ierr = VecGhostGetLocalForm(b, &b_local);
-  la::petsc::check(ierr, "VecGhostGetLocalForm");
+  common::petsc::check(ierr, "VecGhostGetLocalForm");
   PetscInt n = 0;
   ierr = VecGetSize(b_local, &n);
-  la::petsc::check(ierr, "VecGetSize");
+  common::petsc::check(ierr, "VecGetSize");
   PetscScalar* array = nullptr;
   ierr = VecGetArray(b_local, &array);
-  la::petsc::check(ierr, "VecGetArray");
+  common::petsc::check(ierr, "VecGetArray");
   std::span<PetscScalar> _b(array, n);
 
   if (x0.empty())
@@ -432,12 +432,12 @@ void apply_lifting(
     {
       assert(x0[i]);
       ierr = VecGhostGetLocalForm(x0[i], &x0_local[i]);
-      la::petsc::check(ierr, "VecGhostGetLocalForm");
+      common::petsc::check(ierr, "VecGhostGetLocalForm");
       PetscInt n0 = 0;
       ierr = VecGetSize(x0_local[i], &n0);
-      la::petsc::check(ierr, "VecGetSize");
+      common::petsc::check(ierr, "VecGetSize");
       ierr = VecGetArrayRead(x0_local[i], &x0_array[i]);
-      la::petsc::check(ierr, "VecGetArrayRead");
+      common::petsc::check(ierr, "VecGetArrayRead");
       x0_ref.emplace_back(x0_array[i], n0);
     }
 
@@ -446,16 +446,16 @@ void apply_lifting(
     for (std::size_t i = 0; i < x0_local.size(); ++i)
     {
       ierr = VecRestoreArrayRead(x0_local[i], &x0_array[i]);
-      la::petsc::check(ierr, "VecRestoreArrayRead");
+      common::petsc::check(ierr, "VecRestoreArrayRead");
       ierr = VecGhostRestoreLocalForm(x0[i], &x0_local[i]);
-      la::petsc::check(ierr, "VecGhostRestoreLocalForm");
+      common::petsc::check(ierr, "VecGhostRestoreLocalForm");
     }
   }
 
   ierr = VecRestoreArray(b_local, &array);
-  la::petsc::check(ierr, "VecRestoreArray");
+  common::petsc::check(ierr, "VecRestoreArray");
   ierr = VecGhostRestoreLocalForm(b, &b_local);
-  la::petsc::check(ierr, "VecGhostRestoreLocalForm");
+  common::petsc::check(ierr, "VecGhostRestoreLocalForm");
 }
 
 // FIXME: clarify zeroing of vector
@@ -500,13 +500,13 @@ void apply_lifting(
 
   Vec b_local;
   PetscErrorCode ierr = VecGhostGetLocalForm(b, &b_local);
-  la::petsc::check(ierr, "VecGhostGetLocalForm");
+  common::petsc::check(ierr, "VecGhostGetLocalForm");
   PetscInt n = 0;
   ierr = VecGetSize(b_local, &n);
-  la::petsc::check(ierr, "VecGetSize");
+  common::petsc::check(ierr, "VecGetSize");
   PetscScalar* array = nullptr;
   ierr = VecGetArray(b_local, &array);
-  la::petsc::check(ierr, "VecGetArray");
+  common::petsc::check(ierr, "VecGetArray");
   std::span<PetscScalar> _b(array, n);
 
   if (x0.empty())
@@ -520,12 +520,12 @@ void apply_lifting(
     {
       assert(x0[i]);
       ierr = VecGhostGetLocalForm(x0[i], &x0_local[i]);
-      la::petsc::check(ierr, "VecGhostGetLocalForm");
+      common::petsc::check(ierr, "VecGhostGetLocalForm");
       PetscInt n0 = 0;
       ierr = VecGetSize(x0_local[i], &n0);
-      la::petsc::check(ierr, "VecGetSize");
+      common::petsc::check(ierr, "VecGetSize");
       ierr = VecGetArrayRead(x0_local[i], &x0_array[i]);
-      la::petsc::check(ierr, "VecGetArrayRead");
+      common::petsc::check(ierr, "VecGetArrayRead");
       x0_ref.emplace_back(x0_array[i], n0);
     }
 
@@ -534,16 +534,16 @@ void apply_lifting(
     for (std::size_t i = 0; i < x0_local.size(); ++i)
     {
       ierr = VecRestoreArrayRead(x0_local[i], &x0_array[i]);
-      la::petsc::check(ierr, "VecRestoreArrayRead");
+      common::petsc::check(ierr, "VecRestoreArrayRead");
       ierr = VecGhostRestoreLocalForm(x0[i], &x0_local[i]);
-      la::petsc::check(ierr, "VecGhostRestoreLocalForm");
+      common::petsc::check(ierr, "VecGhostRestoreLocalForm");
     }
   }
 
   ierr = VecRestoreArray(b_local, &array);
-  la::petsc::check(ierr, "VecRestoreArray");
+  common::petsc::check(ierr, "VecRestoreArray");
   ierr = VecGhostRestoreLocalForm(b, &b_local);
-  la::petsc::check(ierr, "VecGhostRestoreLocalForm");
+  common::petsc::check(ierr, "VecGhostRestoreLocalForm");
 }
 
 // -- Setting bcs ------------------------------------------------------------
@@ -570,29 +570,29 @@ void set_bc(Vec b,
 {
   PetscInt n = 0;
   PetscErrorCode ierr = VecGetLocalSize(b, &n);
-  la::petsc::check(ierr, "VecGetLocalSize");
+  common::petsc::check(ierr, "VecGetLocalSize");
   PetscScalar* array = nullptr;
   ierr = VecGetArray(b, &array);
-  la::petsc::check(ierr, "VecGetArray");
+  common::petsc::check(ierr, "VecGetArray");
   std::span<PetscScalar> _b(array, n);
   if (x0.has_value())
   {
     Vec x0_local;
     ierr = VecGhostGetLocalForm(x0.value(), &x0_local);
-    la::petsc::check(ierr, "VecGhostGetLocalForm");
+    common::petsc::check(ierr, "VecGhostGetLocalForm");
     PetscInt n0 = 0;
     ierr = VecGetSize(x0_local, &n0);
-    la::petsc::check(ierr, "VecGetSize");
+    common::petsc::check(ierr, "VecGetSize");
     const PetscScalar* x0_array = nullptr;
     ierr = VecGetArrayRead(x0_local, &x0_array);
-    la::petsc::check(ierr, "VecGetArrayRead");
+    common::petsc::check(ierr, "VecGetArrayRead");
     std::span<const PetscScalar> _x0(x0_array, n0);
     for (auto& bc : bcs)
       bc.get().set(_b, _x0, alpha);
     ierr = VecRestoreArrayRead(x0_local, &x0_array);
-    la::petsc::check(ierr, "VecRestoreArrayRead");
+    common::petsc::check(ierr, "VecRestoreArrayRead");
     ierr = VecGhostRestoreLocalForm(x0.value(), &x0_local);
-    la::petsc::check(ierr, "VecGhostRestoreLocalForm");
+    common::petsc::check(ierr, "VecGhostRestoreLocalForm");
   }
   else
   {
@@ -600,7 +600,7 @@ void set_bc(Vec b,
       bc.get().set(_b, std::nullopt, alpha);
   }
   ierr = VecRestoreArray(b, &array);
-  la::petsc::check(ierr, "VecRestoreArray");
+  common::petsc::check(ierr, "VecRestoreArray");
 }
 
 } // namespace petsc

--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -41,15 +41,6 @@ class DirichletBC;
 /// @brief Helper functions for assembly into PETSc data structures
 namespace petsc
 {
-// Check a PETSc error code and throw a descriptive exception if it is
-// non-zero. Expects a local `PetscErrorCode ierr` in scope.
-#define CHECK_ERROR(NAME)                                                      \
-  do                                                                           \
-  {                                                                            \
-    if (ierr != 0)                                                             \
-      la::petsc::error(ierr, __FILE__, NAME);                                  \
-  } while (0)
-
 /// @brief Create a matrix
 /// @param[in] a A bilinear form
 /// @param[in] type The PETSc matrix type to create
@@ -193,14 +184,14 @@ Mat create_matrix_block(
   PetscErrorCode ierr = ISLocalToGlobalMappingCreate(
       MPI_COMM_SELF, 1, _maps[0].size(), _maps[0].data(), PETSC_COPY_VALUES,
       &petsc_local_to_global0);
-  CHECK_ERROR("ISLocalToGlobalMappingCreate");
+  la::petsc::check(ierr, "ISLocalToGlobalMappingCreate");
   if (V[0] == V[1])
   {
     ierr = MatSetLocalToGlobalMapping(A, petsc_local_to_global0,
                                       petsc_local_to_global0);
-    CHECK_ERROR("MatSetLocalToGlobalMapping");
+    la::petsc::check(ierr, "MatSetLocalToGlobalMapping");
     ierr = ISLocalToGlobalMappingDestroy(&petsc_local_to_global0);
-    CHECK_ERROR("ISLocalToGlobalMappingDestroy");
+    la::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
   }
   else
   {
@@ -208,14 +199,14 @@ Mat create_matrix_block(
     ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, 1, _maps[1].size(),
                                         _maps[1].data(), PETSC_COPY_VALUES,
                                         &petsc_local_to_global1);
-    CHECK_ERROR("ISLocalToGlobalMappingCreate");
+    la::petsc::check(ierr, "ISLocalToGlobalMappingCreate");
     ierr = MatSetLocalToGlobalMapping(A, petsc_local_to_global0,
                                       petsc_local_to_global1);
-    CHECK_ERROR("MatSetLocalToGlobalMapping");
+    la::petsc::check(ierr, "MatSetLocalToGlobalMapping");
     ierr = ISLocalToGlobalMappingDestroy(&petsc_local_to_global0);
-    CHECK_ERROR("ISLocalToGlobalMappingDestroy");
+    la::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
     ierr = ISLocalToGlobalMappingDestroy(&petsc_local_to_global1);
-    CHECK_ERROR("ISLocalToGlobalMappingDestroy");
+    la::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
   }
 
   return A;
@@ -266,13 +257,13 @@ Mat create_matrix_nest(
   try
   {
     PetscErrorCode ierr = MatCreate(mesh->comm(), &A);
-    CHECK_ERROR("MatCreate");
+    la::petsc::check(ierr, "MatCreate");
     ierr = MatSetType(A, MATNEST);
-    CHECK_ERROR("MatSetType");
+    la::petsc::check(ierr, "MatSetType");
     ierr = MatNestSetSubMats(A, rows, nullptr, cols, nullptr, mats.data());
-    CHECK_ERROR("MatNestSetSubMats");
+    la::petsc::check(ierr, "MatNestSetSubMats");
     ierr = MatSetUp(A);
-    CHECK_ERROR("MatSetUp");
+    la::petsc::check(ierr, "MatSetUp");
   }
   catch (...)
   {
@@ -325,19 +316,19 @@ void assemble_vector(
 {
   Vec b_local;
   PetscErrorCode ierr = VecGhostGetLocalForm(b, &b_local);
-  CHECK_ERROR("VecGhostGetLocalForm");
+  la::petsc::check(ierr, "VecGhostGetLocalForm");
   PetscInt n = 0;
   ierr = VecGetSize(b_local, &n);
-  CHECK_ERROR("VecGetSize");
+  la::petsc::check(ierr, "VecGetSize");
   PetscScalar* array = nullptr;
   ierr = VecGetArray(b_local, &array);
-  CHECK_ERROR("VecGetArray");
+  la::petsc::check(ierr, "VecGetArray");
   std::span<PetscScalar> _b(array, n);
   fem::assemble_vector(_b, L, constants, coeffs);
   ierr = VecRestoreArray(b_local, &array);
-  CHECK_ERROR("VecRestoreArray");
+  la::petsc::check(ierr, "VecRestoreArray");
   ierr = VecGhostRestoreLocalForm(b, &b_local);
-  CHECK_ERROR("VecGhostRestoreLocalForm");
+  la::petsc::check(ierr, "VecGhostRestoreLocalForm");
 }
 
 /// @brief Assemble linear form into an already allocated PETSc vector.
@@ -355,19 +346,19 @@ void assemble_vector(Vec b, const Form<PetscScalar, T>& L)
 {
   Vec b_local;
   PetscErrorCode ierr = VecGhostGetLocalForm(b, &b_local);
-  CHECK_ERROR("VecGhostGetLocalForm");
+  la::petsc::check(ierr, "VecGhostGetLocalForm");
   PetscInt n = 0;
   ierr = VecGetSize(b_local, &n);
-  CHECK_ERROR("VecGetSize");
+  la::petsc::check(ierr, "VecGetSize");
   PetscScalar* array = nullptr;
   ierr = VecGetArray(b_local, &array);
-  CHECK_ERROR("VecGetArray");
+  la::petsc::check(ierr, "VecGetArray");
   std::span<PetscScalar> _b(array, n);
   fem::assemble_vector(_b, L);
   ierr = VecRestoreArray(b_local, &array);
-  CHECK_ERROR("VecRestoreArray");
+  la::petsc::check(ierr, "VecRestoreArray");
   ierr = VecGhostRestoreLocalForm(b, &b_local);
-  CHECK_ERROR("VecGhostRestoreLocalForm");
+  la::petsc::check(ierr, "VecGhostRestoreLocalForm");
 }
 
 // FIXME: clarify zeroing of vector
@@ -421,13 +412,13 @@ void apply_lifting(
 
   Vec b_local;
   PetscErrorCode ierr = VecGhostGetLocalForm(b, &b_local);
-  CHECK_ERROR("VecGhostGetLocalForm");
+  la::petsc::check(ierr, "VecGhostGetLocalForm");
   PetscInt n = 0;
   ierr = VecGetSize(b_local, &n);
-  CHECK_ERROR("VecGetSize");
+  la::petsc::check(ierr, "VecGetSize");
   PetscScalar* array = nullptr;
   ierr = VecGetArray(b_local, &array);
-  CHECK_ERROR("VecGetArray");
+  la::petsc::check(ierr, "VecGetArray");
   std::span<PetscScalar> _b(array, n);
 
   if (x0.empty())
@@ -441,12 +432,12 @@ void apply_lifting(
     {
       assert(x0[i]);
       ierr = VecGhostGetLocalForm(x0[i], &x0_local[i]);
-      CHECK_ERROR("VecGhostGetLocalForm");
+      la::petsc::check(ierr, "VecGhostGetLocalForm");
       PetscInt n0 = 0;
       ierr = VecGetSize(x0_local[i], &n0);
-      CHECK_ERROR("VecGetSize");
+      la::petsc::check(ierr, "VecGetSize");
       ierr = VecGetArrayRead(x0_local[i], &x0_array[i]);
-      CHECK_ERROR("VecGetArrayRead");
+      la::petsc::check(ierr, "VecGetArrayRead");
       x0_ref.emplace_back(x0_array[i], n0);
     }
 
@@ -455,16 +446,16 @@ void apply_lifting(
     for (std::size_t i = 0; i < x0_local.size(); ++i)
     {
       ierr = VecRestoreArrayRead(x0_local[i], &x0_array[i]);
-      CHECK_ERROR("VecRestoreArrayRead");
+      la::petsc::check(ierr, "VecRestoreArrayRead");
       ierr = VecGhostRestoreLocalForm(x0[i], &x0_local[i]);
-      CHECK_ERROR("VecGhostRestoreLocalForm");
+      la::petsc::check(ierr, "VecGhostRestoreLocalForm");
     }
   }
 
   ierr = VecRestoreArray(b_local, &array);
-  CHECK_ERROR("VecRestoreArray");
+  la::petsc::check(ierr, "VecRestoreArray");
   ierr = VecGhostRestoreLocalForm(b, &b_local);
-  CHECK_ERROR("VecGhostRestoreLocalForm");
+  la::petsc::check(ierr, "VecGhostRestoreLocalForm");
 }
 
 // FIXME: clarify zeroing of vector
@@ -509,13 +500,13 @@ void apply_lifting(
 
   Vec b_local;
   PetscErrorCode ierr = VecGhostGetLocalForm(b, &b_local);
-  CHECK_ERROR("VecGhostGetLocalForm");
+  la::petsc::check(ierr, "VecGhostGetLocalForm");
   PetscInt n = 0;
   ierr = VecGetSize(b_local, &n);
-  CHECK_ERROR("VecGetSize");
+  la::petsc::check(ierr, "VecGetSize");
   PetscScalar* array = nullptr;
   ierr = VecGetArray(b_local, &array);
-  CHECK_ERROR("VecGetArray");
+  la::petsc::check(ierr, "VecGetArray");
   std::span<PetscScalar> _b(array, n);
 
   if (x0.empty())
@@ -529,12 +520,12 @@ void apply_lifting(
     {
       assert(x0[i]);
       ierr = VecGhostGetLocalForm(x0[i], &x0_local[i]);
-      CHECK_ERROR("VecGhostGetLocalForm");
+      la::petsc::check(ierr, "VecGhostGetLocalForm");
       PetscInt n0 = 0;
       ierr = VecGetSize(x0_local[i], &n0);
-      CHECK_ERROR("VecGetSize");
+      la::petsc::check(ierr, "VecGetSize");
       ierr = VecGetArrayRead(x0_local[i], &x0_array[i]);
-      CHECK_ERROR("VecGetArrayRead");
+      la::petsc::check(ierr, "VecGetArrayRead");
       x0_ref.emplace_back(x0_array[i], n0);
     }
 
@@ -543,16 +534,16 @@ void apply_lifting(
     for (std::size_t i = 0; i < x0_local.size(); ++i)
     {
       ierr = VecRestoreArrayRead(x0_local[i], &x0_array[i]);
-      CHECK_ERROR("VecRestoreArrayRead");
+      la::petsc::check(ierr, "VecRestoreArrayRead");
       ierr = VecGhostRestoreLocalForm(x0[i], &x0_local[i]);
-      CHECK_ERROR("VecGhostRestoreLocalForm");
+      la::petsc::check(ierr, "VecGhostRestoreLocalForm");
     }
   }
 
   ierr = VecRestoreArray(b_local, &array);
-  CHECK_ERROR("VecRestoreArray");
+  la::petsc::check(ierr, "VecRestoreArray");
   ierr = VecGhostRestoreLocalForm(b, &b_local);
-  CHECK_ERROR("VecGhostRestoreLocalForm");
+  la::petsc::check(ierr, "VecGhostRestoreLocalForm");
 }
 
 // -- Setting bcs ------------------------------------------------------------
@@ -579,29 +570,29 @@ void set_bc(Vec b,
 {
   PetscInt n = 0;
   PetscErrorCode ierr = VecGetLocalSize(b, &n);
-  CHECK_ERROR("VecGetLocalSize");
+  la::petsc::check(ierr, "VecGetLocalSize");
   PetscScalar* array = nullptr;
   ierr = VecGetArray(b, &array);
-  CHECK_ERROR("VecGetArray");
+  la::petsc::check(ierr, "VecGetArray");
   std::span<PetscScalar> _b(array, n);
   if (x0.has_value())
   {
     Vec x0_local;
     ierr = VecGhostGetLocalForm(x0.value(), &x0_local);
-    CHECK_ERROR("VecGhostGetLocalForm");
+    la::petsc::check(ierr, "VecGhostGetLocalForm");
     PetscInt n0 = 0;
     ierr = VecGetSize(x0_local, &n0);
-    CHECK_ERROR("VecGetSize");
+    la::petsc::check(ierr, "VecGetSize");
     const PetscScalar* x0_array = nullptr;
     ierr = VecGetArrayRead(x0_local, &x0_array);
-    CHECK_ERROR("VecGetArrayRead");
+    la::petsc::check(ierr, "VecGetArrayRead");
     std::span<const PetscScalar> _x0(x0_array, n0);
     for (auto& bc : bcs)
       bc.get().set(_b, _x0, alpha);
     ierr = VecRestoreArrayRead(x0_local, &x0_array);
-    CHECK_ERROR("VecRestoreArrayRead");
+    la::petsc::check(ierr, "VecRestoreArrayRead");
     ierr = VecGhostRestoreLocalForm(x0.value(), &x0_local);
-    CHECK_ERROR("VecGhostRestoreLocalForm");
+    la::petsc::check(ierr, "VecGhostRestoreLocalForm");
   }
   else
   {
@@ -609,10 +600,8 @@ void set_bc(Vec b,
       bc.get().set(_b, std::nullopt, alpha);
   }
   ierr = VecRestoreArray(b, &array);
-  CHECK_ERROR("VecRestoreArray");
+  la::petsc::check(ierr, "VecRestoreArray");
 }
-
-#undef CHECK_ERROR
 
 } // namespace petsc
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 Garth N. Wells
+// Copyright (C) 2018-2026 Garth N. Wells and Jack S. Hale
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //

--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -550,7 +550,7 @@ void apply_lifting(
 
 // FIXME: Move these function elsewhere?
 
-/// Entries in `b` that are constrained by a Dirichlet boundary
+/// @brief Entries in `b` that are constrained by a Dirichlet boundary
 /// conditions are set to `alpha * (x_bc - x0)`, where `x_bc` is the
 /// (interpolated) boundary condition value.
 ///

--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -33,15 +33,13 @@ la::petsc::create_vectors(MPI_Comm comm,
   std::vector<Vec> v(x.size());
   for (std::size_t i = 0; i < v.size(); ++i)
   {
-    PetscErrorCode ierr;
-    ierr = VecCreateMPI(comm, x[i].size(), PETSC_DETERMINE, &v[i]);
-    common::petsc::check(ierr, "VecCreateMPI");
+    common::petsc::check(
+        VecCreateMPI(comm, x[i].size(), PETSC_DETERMINE, &v[i]),
+        "VecCreateMPI");
     PetscScalar* data;
-    ierr = VecGetArray(v[i], &data);
-    common::petsc::check(ierr, "VecGetArray");
+    common::petsc::check(VecGetArray(v[i], &data), "VecGetArray");
     std::ranges::copy(x[i], data);
-    ierr = VecRestoreArray(v[i], &data);
-    common::petsc::check(ierr, "VecRestoreArray");
+    common::petsc::check(VecRestoreArray(v[i], &data), "VecRestoreArray");
   }
 
   return v;
@@ -56,8 +54,6 @@ Vec la::petsc::create_vector(const common::IndexMap& map, int bs)
 Vec la::petsc::create_vector(MPI_Comm comm, std::array<std::int64_t, 2> range,
                              std::span<const std::int64_t> ghosts, int bs)
 {
-  PetscErrorCode ierr;
-
   // Get local size
   assert(range[1] >= range[0]);
   std::int32_t local_size = range[1] - range[0];
@@ -66,15 +62,16 @@ Vec la::petsc::create_vector(MPI_Comm comm, std::array<std::int64_t, 2> range,
   std::vector<PetscInt> _ghosts(ghosts.begin(), ghosts.end());
   if (bs == 1)
   {
-    ierr = VecCreateGhost(comm, local_size, PETSC_DETERMINE, _ghosts.size(),
-                          _ghosts.data(), &x);
-    common::petsc::check(ierr, "VecCreateGhost");
+    common::petsc::check(VecCreateGhost(comm, local_size, PETSC_DETERMINE,
+                                        _ghosts.size(), _ghosts.data(), &x),
+                         "VecCreateGhost");
   }
   else
   {
-    ierr = VecCreateGhostBlock(comm, bs, bs * local_size, PETSC_DETERMINE,
-                               _ghosts.size(), _ghosts.data(), &x);
-    common::petsc::check(ierr, "VecCreateGhostBlock");
+    common::petsc::check(VecCreateGhostBlock(comm, bs, bs * local_size,
+                                             PETSC_DETERMINE, _ghosts.size(),
+                                             _ghosts.data(), &x),
+                         "VecCreateGhostBlock");
   }
 
   assert(x);
@@ -94,20 +91,19 @@ Vec la::petsc::create_vector_wrap(const common::IndexMap& map, int bs,
   }
 
   Vec vec;
-  PetscErrorCode ierr;
   if (bs == 1)
   {
-    ierr
-        = VecCreateGhostWithArray(map.comm(), size_local, size_global,
-                                  ghosts.size(), ghosts.data(), x.data(), &vec);
-    common::petsc::check(ierr, "VecCreateGhostWithArray");
+    common::petsc::check(VecCreateGhostWithArray(map.comm(), size_local,
+                                                 size_global, ghosts.size(),
+                                                 ghosts.data(), x.data(), &vec),
+                         "VecCreateGhostWithArray");
   }
   else
   {
-    ierr = VecCreateGhostBlockWithArray(map.comm(), bs, size_local, size_global,
-                                        ghosts.size(), ghosts.data(), x.data(),
-                                        &vec);
-    common::petsc::check(ierr, "VecCreateGhostBlockWithArray");
+    common::petsc::check(VecCreateGhostBlockWithArray(
+                             map.comm(), bs, size_local, size_global,
+                             ghosts.size(), ghosts.data(), x.data(), &vec),
+                         "VecCreateGhostBlockWithArray");
   }
 
   assert(vec);
@@ -124,9 +120,9 @@ std::vector<IS> la::petsc::create_index_sets(
   {
     std::int32_t size = map.get().size_local() + map.get().num_ghosts();
     IS _is;
-    PetscErrorCode ierr
-        = ISCreateStride(PETSC_COMM_SELF, bs * size, offset, 1, &_is);
-    common::petsc::check(ierr, "ISCreateStride");
+    common::petsc::check(
+        ISCreateStride(PETSC_COMM_SELF, bs * size, offset, 1, &_is),
+        "ISCreateStride");
     is.push_back(_is);
     offset += bs * size;
   }
@@ -145,16 +141,13 @@ std::vector<std::vector<PetscScalar>> la::petsc::get_local_vectors(
     offset_owned += map.get().size_local() * bs;
 
   // Unwrap PETSc vector
-  PetscErrorCode ierr;
   Vec x_local;
-  ierr = VecGhostGetLocalForm(x, &x_local);
-  common::petsc::check(ierr, "VecGhostGetLocalForm");
+  common::petsc::check(VecGhostGetLocalForm(x, &x_local),
+                       "VecGhostGetLocalForm");
   PetscInt n = 0;
-  ierr = VecGetSize(x_local, &n);
-  common::petsc::check(ierr, "VecGetSize");
+  common::petsc::check(VecGetSize(x_local, &n), "VecGetSize");
   const PetscScalar* array = nullptr;
-  ierr = VecGetArrayRead(x_local, &array);
-  common::petsc::check(ierr, "VecGetArrayRead");
+  common::petsc::check(VecGetArrayRead(x_local, &array), "VecGetArrayRead");
   std::span _x(array, n);
 
   // Copy PETSc Vec data in to local vectors
@@ -175,10 +168,10 @@ std::vector<std::vector<PetscScalar>> la::petsc::get_local_vectors(
     offset_ghost += size_ghost;
   }
 
-  ierr = VecRestoreArrayRead(x_local, &array);
-  common::petsc::check(ierr, "VecRestoreArrayRead");
-  ierr = VecGhostRestoreLocalForm(x, &x_local);
-  common::petsc::check(ierr, "VecGhostRestoreLocalForm");
+  common::petsc::check(VecRestoreArrayRead(x_local, &array),
+                       "VecRestoreArrayRead");
+  common::petsc::check(VecGhostRestoreLocalForm(x, &x_local),
+                       "VecGhostRestoreLocalForm");
 
   return x_b;
 }
@@ -196,16 +189,13 @@ void la::petsc::scatter_local_vectors(
   for (auto& [map, bs] : maps)
     offset_owned += map.get().size_local() * bs;
 
-  PetscErrorCode ierr;
   Vec x_local;
-  ierr = VecGhostGetLocalForm(x, &x_local);
-  common::petsc::check(ierr, "VecGhostGetLocalForm");
+  common::petsc::check(VecGhostGetLocalForm(x, &x_local),
+                       "VecGhostGetLocalForm");
   PetscInt n = 0;
-  ierr = VecGetSize(x_local, &n);
-  common::petsc::check(ierr, "VecGetSize");
+  common::petsc::check(VecGetSize(x_local, &n), "VecGetSize");
   PetscScalar* array = nullptr;
-  ierr = VecGetArray(x_local, &array);
-  common::petsc::check(ierr, "VecGetArray");
+  common::petsc::check(VecGetArray(x_local, &array), "VecGetArray");
   std::span _x(array, n);
 
   // Copy local vectors into PETSc Vec
@@ -225,29 +215,24 @@ void la::petsc::scatter_local_vectors(
     offset_ghost += size_ghost;
   }
 
-  ierr = VecRestoreArray(x_local, &array);
-  common::petsc::check(ierr, "VecRestoreArray");
-  ierr = VecGhostRestoreLocalForm(x, &x_local);
-  common::petsc::check(ierr, "VecGhostRestoreLocalForm");
+  common::petsc::check(VecRestoreArray(x_local, &array), "VecRestoreArray");
+  common::petsc::check(VecGhostRestoreLocalForm(x, &x_local),
+                       "VecGhostRestoreLocalForm");
 }
 //-----------------------------------------------------------------------------
 Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
                              std::optional<std::string_view> type)
 {
-  PetscErrorCode ierr;
   Mat A;
-  ierr = MatCreate(comm, &A);
-  common::petsc::check(ierr, "MatCreate");
+  common::petsc::check(MatCreate(comm, &A), "MatCreate");
 
   // Get IndexMaps from sparsity pattern, and block size
   std::array maps = {sp.index_map(0), sp.index_map(1)};
   const std::array bs = {sp.block_size(0), sp.block_size(1)};
 
   if (type and !type->empty())
-  {
-    ierr = MatSetType(A, std::string(*type).c_str());
-    common::petsc::check(ierr, "MatSetType");
-  }
+    common::petsc::check(MatSetType(A, std::string(*type).c_str()),
+                         "MatSetType");
 
   // Get global and local dimensions
   const std::int64_t M = bs[0] * maps[0]->size_global();
@@ -256,13 +241,11 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   const std::int32_t n = bs[1] * maps[1]->size_local();
 
   // Set matrix size
-  ierr = MatSetSizes(A, m, n, M, N);
-  common::petsc::check(ierr, "MatSetSizes");
+  common::petsc::check(MatSetSizes(A, m, n, M, N), "MatSetSizes");
 
   // Apply PETSc options from the options database to the matrix (this
   // includes changing the matrix type to one specified by the user)
-  ierr = MatSetFromOptions(A);
-  common::petsc::check(ierr, "MatSetFromOptions");
+  common::petsc::check(MatSetFromOptions(A), "MatSetFromOptions");
 
   // Find a common block size across rows/columns
   const int _bs = (bs[0] == bs[1] ? bs[0] : 1);
@@ -295,13 +278,13 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   }
 
   // Allocate space for matrix
-  ierr = MatXAIJSetPreallocation(A, _bs, _nnz_diag.data(), _nnz_offdiag.data(),
-                                 nullptr, nullptr);
-  common::petsc::check(ierr, "MatXAIJSetPreallocation");
+  common::petsc::check(MatXAIJSetPreallocation(A, _bs, _nnz_diag.data(),
+                                               _nnz_offdiag.data(), nullptr,
+                                               nullptr),
+                       "MatXAIJSetPreallocation");
 
   // Set block sizes
-  ierr = MatSetBlockSizes(A, bs[0], bs[1]);
-  common::petsc::check(ierr, "MatSetBlockSizes");
+  common::petsc::check(MatSetBlockSizes(A, bs[0], bs[1]), "MatSetBlockSizes");
 
   // Build a PETSc (PetscInt) local-to-global map directly from an
   // IndexMap's local range and ghosts, rather than going via
@@ -322,34 +305,36 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   // Create PETSc local-to-global map/index sets
   ISLocalToGlobalMapping local_to_global0;
   std::vector<PetscInt> _map0 = build_l2g(*maps[0]);
-  ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs[0], _map0.size(),
-                                      _map0.data(), PETSC_COPY_VALUES,
-                                      &local_to_global0);
-  common::petsc::check(ierr, "ISLocalToGlobalMappingCreate");
+  common::petsc::check(ISLocalToGlobalMappingCreate(
+                           MPI_COMM_SELF, bs[0], _map0.size(), _map0.data(),
+                           PETSC_COPY_VALUES, &local_to_global0),
+                       "ISLocalToGlobalMappingCreate");
 
   // Check for common index maps
   if (maps[0] == maps[1] and bs[0] == bs[1])
   {
-    ierr = MatSetLocalToGlobalMapping(A, local_to_global0, local_to_global0);
-    common::petsc::check(ierr, "MatSetLocalToGlobalMapping");
+    common::petsc::check(
+        MatSetLocalToGlobalMapping(A, local_to_global0, local_to_global0),
+        "MatSetLocalToGlobalMapping");
   }
   else
   {
     ISLocalToGlobalMapping local_to_global1;
     std::vector<PetscInt> _map1 = build_l2g(*maps[1]);
-    ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs[1], _map1.size(),
-                                        _map1.data(), PETSC_COPY_VALUES,
-                                        &local_to_global1);
-    common::petsc::check(ierr, "ISLocalToGlobalMappingCreate");
-    ierr = MatSetLocalToGlobalMapping(A, local_to_global0, local_to_global1);
-    common::petsc::check(ierr, "MatSetLocalToGlobalMapping");
-    ierr = ISLocalToGlobalMappingDestroy(&local_to_global1);
-    common::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
+    common::petsc::check(ISLocalToGlobalMappingCreate(
+                             MPI_COMM_SELF, bs[1], _map1.size(), _map1.data(),
+                             PETSC_COPY_VALUES, &local_to_global1),
+                         "ISLocalToGlobalMappingCreate");
+    common::petsc::check(
+        MatSetLocalToGlobalMapping(A, local_to_global0, local_to_global1),
+        "MatSetLocalToGlobalMapping");
+    common::petsc::check(ISLocalToGlobalMappingDestroy(&local_to_global1),
+                         "ISLocalToGlobalMappingDestroy");
   }
 
   // Clean up local-to-global 0
-  ierr = ISLocalToGlobalMappingDestroy(&local_to_global0);
-  common::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
+  common::petsc::check(ISLocalToGlobalMappingDestroy(&local_to_global0),
+                       "ISLocalToGlobalMappingDestroy");
 
   // Note: This should be called after having set the local-to-global
   // map for MATIS (this is a dummy call if A is not of type MATIS)
@@ -358,10 +343,11 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   //   error(ierr, __FILE__, "MatISSetPreallocation");
 
   // Set some options on Mat object
-  ierr = MatSetOption(A, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
-  common::petsc::check(ierr, "MatSetOption");
-  ierr = MatSetOption(A, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
-  common::petsc::check(ierr, "MatSetOption");
+  common::petsc::check(
+      MatSetOption(A, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE),
+      "MatSetOption");
+  common::petsc::check(MatSetOption(A, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE),
+                       "MatSetOption");
 
   return A;
 }
@@ -370,9 +356,9 @@ MatNullSpace la::petsc::create_nullspace(MPI_Comm comm,
                                          std::span<const Vec> basis)
 {
   MatNullSpace ns = nullptr;
-  PetscErrorCode ierr
-      = MatNullSpaceCreate(comm, PETSC_FALSE, basis.size(), basis.data(), &ns);
-  common::petsc::check(ierr, "MatNullSpaceCreate");
+  common::petsc::check(
+      MatNullSpaceCreate(comm, PETSC_FALSE, basis.size(), basis.data(), &ns),
+      "MatNullSpaceCreate");
   return ns;
 }
 //-----------------------------------------------------------------------------
@@ -387,15 +373,13 @@ void petsc::options::clear(std::string option)
   if (option[0] != '-')
     option = '-' + option;
 
-  PetscErrorCode ierr;
-  ierr = PetscOptionsClearValue(nullptr, option.c_str());
-  common::petsc::check(ierr, "PetscOptionsClearValue");
+  common::petsc::check(PetscOptionsClearValue(nullptr, option.c_str()),
+                       "PetscOptionsClearValue");
 }
 //-----------------------------------------------------------------------------
 void petsc::options::clear()
 {
-  PetscErrorCode ierr = PetscOptionsClear(nullptr);
-  common::petsc::check(ierr, "PetscOptionsClear");
+  common::petsc::check(PetscOptionsClear(nullptr), "PetscOptionsClear");
 }
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
@@ -412,8 +396,8 @@ petsc::Vector::Vector(Vec x, bool inc_ref_count) : _x(x)
 
   if (inc_ref_count)
   {
-    PetscErrorCode ierr = PetscObjectReference((PetscObject)_x);
-    common::petsc::check(ierr, "PetscObjectReference");
+    common::petsc::check(PetscObjectReference((PetscObject)_x),
+                         "PetscObjectReference");
   }
 }
 //-----------------------------------------------------------------------------
@@ -434,10 +418,8 @@ petsc::Vector& petsc::Vector::operator=(Vector&& v) noexcept
 petsc::Vector petsc::Vector::copy() const
 {
   Vec _y;
-  PetscErrorCode ierr = VecDuplicate(_x, &_y);
-  common::petsc::check(ierr, "VecDuplicate");
-  ierr = VecCopy(_x, _y);
-  common::petsc::check(ierr, "VecCopy");
+  common::petsc::check(VecDuplicate(_x, &_y), "VecDuplicate");
+  common::petsc::check(VecCopy(_x, _y), "VecCopy");
   return Vector(_y, false);
 }
 //-----------------------------------------------------------------------------
@@ -445,8 +427,7 @@ std::int64_t petsc::Vector::size() const
 {
   assert(_x);
   PetscInt n = 0;
-  PetscErrorCode ierr = VecGetSize(_x, &n);
-  common::petsc::check(ierr, "VecGetSize");
+  common::petsc::check(VecGetSize(_x, &n), "VecGetSize");
   return n;
 }
 //-----------------------------------------------------------------------------
@@ -454,8 +435,7 @@ std::int32_t petsc::Vector::local_size() const
 {
   assert(_x);
   PetscInt n = 0;
-  PetscErrorCode ierr = VecGetLocalSize(_x, &n);
-  common::petsc::check(ierr, "VecGetLocalSize");
+  common::petsc::check(VecGetLocalSize(_x, &n), "VecGetLocalSize");
   return n;
 }
 //-----------------------------------------------------------------------------
@@ -463,8 +443,8 @@ std::array<std::int64_t, 2> petsc::Vector::local_range() const
 {
   assert(_x);
   PetscInt n0, n1;
-  PetscErrorCode ierr = VecGetOwnershipRange(_x, &n0, &n1);
-  common::petsc::check(ierr, "VecGetOwnershipRange");
+  common::petsc::check(VecGetOwnershipRange(_x, &n0, &n1),
+                       "VecGetOwnershipRange");
   assert(n0 <= n1);
   return {n0, n1};
 }
@@ -473,33 +453,31 @@ MPI_Comm petsc::Vector::comm() const
 {
   assert(_x);
   MPI_Comm mpi_comm = MPI_COMM_NULL;
-  PetscErrorCode ierr = PetscObjectGetComm((PetscObject)(_x), &mpi_comm);
-  common::petsc::check(ierr, "PetscObjectGetComm");
+  common::petsc::check(PetscObjectGetComm((PetscObject)(_x), &mpi_comm),
+                       "PetscObjectGetComm");
   return mpi_comm;
 }
 //-----------------------------------------------------------------------------
 void petsc::Vector::set_options_prefix(std::string_view options_prefix)
 {
   assert(_x);
-  PetscErrorCode ierr
-      = VecSetOptionsPrefix(_x, std::string(options_prefix).c_str());
-  common::petsc::check(ierr, "VecSetOptionsPrefix");
+  common::petsc::check(
+      VecSetOptionsPrefix(_x, std::string(options_prefix).c_str()),
+      "VecSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string petsc::Vector::get_options_prefix() const
 {
   assert(_x);
   const char* prefix = nullptr;
-  PetscErrorCode ierr = VecGetOptionsPrefix(_x, &prefix);
-  common::petsc::check(ierr, "VecGetOptionsPrefix");
+  common::petsc::check(VecGetOptionsPrefix(_x, &prefix), "VecGetOptionsPrefix");
   return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
 void petsc::Vector::set_from_options()
 {
   assert(_x);
-  PetscErrorCode ierr = VecSetFromOptions(_x);
-  common::petsc::check(ierr, "VecSetFromOptions");
+  common::petsc::check(VecSetFromOptions(_x), "VecSetFromOptions");
 }
 //-----------------------------------------------------------------------------
 Vec petsc::Vector::vec() const { return _x; }
@@ -519,8 +497,8 @@ petsc::Matrix::Matrix(Mat A, bool inc_ref_count) : _matA(A)
 
   if (inc_ref_count)
   {
-    PetscErrorCode ierr = PetscObjectReference((PetscObject)_matA);
-    common::petsc::check(ierr, "PetscObjectReference");
+    common::petsc::check(PetscObjectReference((PetscObject)_matA),
+                         "PetscObjectReference");
   }
 }
 //-----------------------------------------------------------------------------
@@ -547,27 +525,19 @@ std::array<std::int64_t, 2> petsc::Matrix::size() const
 {
   assert(_matA);
   PetscInt m(0), n(0);
-  PetscErrorCode ierr = MatGetSize(_matA, &m, &n);
-  common::petsc::check(ierr, "MatGetSize");
+  common::petsc::check(MatGetSize(_matA, &m, &n), "MatGetSize");
   return {{m, n}};
 }
 //-----------------------------------------------------------------------------
 Vec petsc::Matrix::create_vector(std::size_t dim) const
 {
   assert(_matA);
-  PetscErrorCode ierr;
 
   Vec x = nullptr;
   if (dim == 0)
-  {
-    ierr = MatCreateVecs(_matA, nullptr, &x);
-    common::petsc::check(ierr, "MatCreateVecs");
-  }
+    common::petsc::check(MatCreateVecs(_matA, nullptr, &x), "MatCreateVecs");
   else if (dim == 1)
-  {
-    ierr = MatCreateVecs(_matA, &x, nullptr);
-    common::petsc::check(ierr, "MatCreateVecs");
-  }
+    common::petsc::check(MatCreateVecs(_matA, &x, nullptr), "MatCreateVecs");
   else
   {
     spdlog::error("Cannot initialize PETSc vector to match PETSc matrix. "
@@ -584,33 +554,31 @@ Mat petsc::Matrix::mat() const { return _matA; }
 void petsc::Matrix::set_options_prefix(std::string_view options_prefix)
 {
   assert(_matA);
-  PetscErrorCode ierr
-      = MatSetOptionsPrefix(_matA, std::string(options_prefix).c_str());
-  common::petsc::check(ierr, "MatSetOptionsPrefix");
+  common::petsc::check(
+      MatSetOptionsPrefix(_matA, std::string(options_prefix).c_str()),
+      "MatSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string petsc::Matrix::get_options_prefix() const
 {
   assert(_matA);
   const char* prefix = nullptr;
-  PetscErrorCode ierr = MatGetOptionsPrefix(_matA, &prefix);
-  common::petsc::check(ierr, "MatGetOptionsPrefix");
+  common::petsc::check(MatGetOptionsPrefix(_matA, &prefix),
+                       "MatGetOptionsPrefix");
   return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
 void petsc::Matrix::set_from_options()
 {
   assert(_matA);
-  PetscErrorCode ierr = MatSetFromOptions(_matA);
-  common::petsc::check(ierr, "MatSetFromOptions");
+  common::petsc::check(MatSetFromOptions(_matA), "MatSetFromOptions");
 }
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 petsc::KrylovSolver::KrylovSolver(MPI_Comm comm) : _ksp(nullptr)
 {
   // Create PETSc KSP object
-  PetscErrorCode ierr = KSPCreate(comm, &_ksp);
-  common::petsc::check(ierr, "KSPCreate");
+  common::petsc::check(KSPCreate(comm, &_ksp), "KSPCreate");
 }
 //-----------------------------------------------------------------------------
 petsc::KrylovSolver::KrylovSolver(KSP ksp, bool inc_ref_count) : _ksp(ksp)
@@ -620,8 +588,8 @@ petsc::KrylovSolver::KrylovSolver(KSP ksp, bool inc_ref_count) : _ksp(ksp)
 
   if (inc_ref_count)
   {
-    PetscErrorCode ierr = PetscObjectReference((PetscObject)_ksp);
-    common::petsc::check(ierr, "PetscObjectReference");
+    common::petsc::check(PetscObjectReference((PetscObject)_ksp),
+                         "PetscObjectReference");
   }
 }
 //-----------------------------------------------------------------------------
@@ -650,8 +618,7 @@ void petsc::KrylovSolver::set_operators(const Mat A, const Mat P)
 {
   assert(A);
   assert(_ksp);
-  PetscErrorCode ierr = KSPSetOperators(_ksp, A, P);
-  common::petsc::check(ierr, "KSPSetOperators");
+  common::petsc::check(KSPSetOperators(_ksp, A, P), "KSPSetOperators");
 }
 //-----------------------------------------------------------------------------
 PetscInt petsc::KrylovSolver::solve(Vec x, const Vec b, bool transpose) const
@@ -661,40 +628,32 @@ PetscInt petsc::KrylovSolver::solve(Vec x, const Vec b, bool transpose) const
   assert(x);
   assert(b);
 
-  PetscErrorCode ierr;
-
   // Solve linear system. With no operator set, PCGetOperators creates an
   // untyped Mat and setup fails on it, so KSPSolve errors rather than
   // silently solving
   spdlog::info("PETSc Krylov solver starting to solve system.");
   if (!transpose)
-  {
-    ierr = KSPSolve(_ksp, b, x);
-    common::petsc::check(ierr, "KSPSolve");
-  }
+    common::petsc::check(KSPSolve(_ksp, b, x), "KSPSolve");
   else
-  {
-    ierr = KSPSolveTranspose(_ksp, b, x);
-    common::petsc::check(ierr, "KSPSolveTranspose");
-  }
+    common::petsc::check(KSPSolveTranspose(_ksp, b, x), "KSPSolveTranspose");
 
   // Get the number of iterations
   PetscInt num_iterations = 0;
-  ierr = KSPGetIterationNumber(_ksp, &num_iterations);
-  common::petsc::check(ierr, "KSPGetIterationNumber");
+  common::petsc::check(KSPGetIterationNumber(_ksp, &num_iterations),
+                       "KSPGetIterationNumber");
 
   // Check if the solution converged and warn if not. Note: this does
   // not throw on non-convergence -- the caller is responsible for
   // checking the convergence reason (via ksp()) if this matters for
   // its use case.
   KSPConvergedReason reason;
-  ierr = KSPGetConvergedReason(_ksp, &reason);
-  common::petsc::check(ierr, "KSPGetConvergedReason");
+  common::petsc::check(KSPGetConvergedReason(_ksp, &reason),
+                       "KSPGetConvergedReason");
   if (reason < 0)
   {
     const char* reason_str;
-    ierr = KSPGetConvergedReasonString(_ksp, &reason_str);
-    common::petsc::check(ierr, "KSPGetConvergedReasonString");
+    common::petsc::check(KSPGetConvergedReasonString(_ksp, &reason_str),
+                         "KSPGetConvergedReasonString");
     spdlog::warn("PETSc Krylov solver did not converge in {} iterations "
                  "(PETSc reason: {}).",
                  num_iterations, reason_str);
@@ -707,25 +666,24 @@ void petsc::KrylovSolver::set_options_prefix(std::string_view options_prefix)
 {
   // Set options prefix
   assert(_ksp);
-  PetscErrorCode ierr
-      = KSPSetOptionsPrefix(_ksp, std::string(options_prefix).c_str());
-  common::petsc::check(ierr, "KSPSetOptionsPrefix");
+  common::petsc::check(
+      KSPSetOptionsPrefix(_ksp, std::string(options_prefix).c_str()),
+      "KSPSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string petsc::KrylovSolver::get_options_prefix() const
 {
   assert(_ksp);
   const char* prefix = nullptr;
-  PetscErrorCode ierr = KSPGetOptionsPrefix(_ksp, &prefix);
-  common::petsc::check(ierr, "KSPGetOptionsPrefix");
+  common::petsc::check(KSPGetOptionsPrefix(_ksp, &prefix),
+                       "KSPGetOptionsPrefix");
   return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
 void petsc::KrylovSolver::set_from_options() const
 {
   assert(_ksp);
-  PetscErrorCode ierr = KSPSetFromOptions(_ksp);
-  common::petsc::check(ierr, "KSPSetFromOptions");
+  common::petsc::check(KSPSetFromOptions(_ksp), "KSPSetFromOptions");
 }
 //-----------------------------------------------------------------------------
 KSP petsc::KrylovSolver::ksp() const { return _ksp; }

--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -26,23 +26,16 @@ using namespace dolfinx;
 using namespace dolfinx::la;
 
 //-----------------------------------------------------------------------------
-#define CHECK_ERROR(NAME)                                                      \
-  do                                                                           \
-  {                                                                            \
-    if (ierr != 0)                                                             \
-      petsc::error(ierr, __FILE__, NAME);                                      \
-  } while (0)
-
-//-----------------------------------------------------------------------------
-void la::petsc::error(PetscErrorCode error_code, std::string_view filename,
-                      std::string_view petsc_function)
+void la::petsc::error(PetscErrorCode error_code,
+                      std::string_view petsc_function, std::source_location loc)
 {
   // Fetch PETSc error description
   const char* desc;
   PetscErrorMessage(error_code, &desc, nullptr);
 
   // Log detailed error info
-  spdlog::error("PETSc error in '{}', '{}'", filename, petsc_function);
+  spdlog::error("PETSc error in '{}:{}', '{}'", loc.file_name(), loc.line(),
+                petsc_function);
   spdlog::error("PETSc error code '{}' '{}'", static_cast<int>(error_code),
                 desc);
   throw std::runtime_error(
@@ -60,13 +53,13 @@ la::petsc::create_vectors(MPI_Comm comm,
   {
     PetscErrorCode ierr;
     ierr = VecCreateMPI(comm, x[i].size(), PETSC_DETERMINE, &v[i]);
-    CHECK_ERROR("VecCreateMPI");
+    petsc::check(ierr, "VecCreateMPI");
     PetscScalar* data;
     ierr = VecGetArray(v[i], &data);
-    CHECK_ERROR("VecGetArray");
+    petsc::check(ierr, "VecGetArray");
     std::ranges::copy(x[i], data);
     ierr = VecRestoreArray(v[i], &data);
-    CHECK_ERROR("VecRestoreArray");
+    petsc::check(ierr, "VecRestoreArray");
   }
 
   return v;
@@ -93,13 +86,13 @@ Vec la::petsc::create_vector(MPI_Comm comm, std::array<std::int64_t, 2> range,
   {
     ierr = VecCreateGhost(comm, local_size, PETSC_DETERMINE, _ghosts.size(),
                           _ghosts.data(), &x);
-    CHECK_ERROR("VecCreateGhost");
+    petsc::check(ierr, "VecCreateGhost");
   }
   else
   {
     ierr = VecCreateGhostBlock(comm, bs, bs * local_size, PETSC_DETERMINE,
                                _ghosts.size(), _ghosts.data(), &x);
-    CHECK_ERROR("VecCreateGhostBlock");
+    petsc::check(ierr, "VecCreateGhostBlock");
   }
 
   assert(x);
@@ -125,14 +118,14 @@ Vec la::petsc::create_vector_wrap(const common::IndexMap& map, int bs,
     ierr
         = VecCreateGhostWithArray(map.comm(), size_local, size_global,
                                   ghosts.size(), ghosts.data(), x.data(), &vec);
-    CHECK_ERROR("VecCreateGhostWithArray");
+    petsc::check(ierr, "VecCreateGhostWithArray");
   }
   else
   {
     ierr = VecCreateGhostBlockWithArray(map.comm(), bs, size_local, size_global,
                                         ghosts.size(), ghosts.data(), x.data(),
                                         &vec);
-    CHECK_ERROR("VecCreateGhostBlockWithArray");
+    petsc::check(ierr, "VecCreateGhostBlockWithArray");
   }
 
   assert(vec);
@@ -151,7 +144,7 @@ std::vector<IS> la::petsc::create_index_sets(
     IS _is;
     PetscErrorCode ierr
         = ISCreateStride(PETSC_COMM_SELF, bs * size, offset, 1, &_is);
-    CHECK_ERROR("ISCreateStride");
+    petsc::check(ierr, "ISCreateStride");
     is.push_back(_is);
     offset += bs * size;
   }
@@ -173,13 +166,13 @@ std::vector<std::vector<PetscScalar>> la::petsc::get_local_vectors(
   PetscErrorCode ierr;
   Vec x_local;
   ierr = VecGhostGetLocalForm(x, &x_local);
-  CHECK_ERROR("VecGhostGetLocalForm");
+  petsc::check(ierr, "VecGhostGetLocalForm");
   PetscInt n = 0;
   ierr = VecGetSize(x_local, &n);
-  CHECK_ERROR("VecGetSize");
+  petsc::check(ierr, "VecGetSize");
   const PetscScalar* array = nullptr;
   ierr = VecGetArrayRead(x_local, &array);
-  CHECK_ERROR("VecGetArrayRead");
+  petsc::check(ierr, "VecGetArrayRead");
   std::span _x(array, n);
 
   // Copy PETSc Vec data in to local vectors
@@ -201,9 +194,9 @@ std::vector<std::vector<PetscScalar>> la::petsc::get_local_vectors(
   }
 
   ierr = VecRestoreArrayRead(x_local, &array);
-  CHECK_ERROR("VecRestoreArrayRead");
+  petsc::check(ierr, "VecRestoreArrayRead");
   ierr = VecGhostRestoreLocalForm(x, &x_local);
-  CHECK_ERROR("VecGhostRestoreLocalForm");
+  petsc::check(ierr, "VecGhostRestoreLocalForm");
 
   return x_b;
 }
@@ -224,13 +217,13 @@ void la::petsc::scatter_local_vectors(
   PetscErrorCode ierr;
   Vec x_local;
   ierr = VecGhostGetLocalForm(x, &x_local);
-  CHECK_ERROR("VecGhostGetLocalForm");
+  petsc::check(ierr, "VecGhostGetLocalForm");
   PetscInt n = 0;
   ierr = VecGetSize(x_local, &n);
-  CHECK_ERROR("VecGetSize");
+  petsc::check(ierr, "VecGetSize");
   PetscScalar* array = nullptr;
   ierr = VecGetArray(x_local, &array);
-  CHECK_ERROR("VecGetArray");
+  petsc::check(ierr, "VecGetArray");
   std::span _x(array, n);
 
   // Copy local vectors into PETSc Vec
@@ -251,9 +244,9 @@ void la::petsc::scatter_local_vectors(
   }
 
   ierr = VecRestoreArray(x_local, &array);
-  CHECK_ERROR("VecRestoreArray");
+  petsc::check(ierr, "VecRestoreArray");
   ierr = VecGhostRestoreLocalForm(x, &x_local);
-  CHECK_ERROR("VecGhostRestoreLocalForm");
+  petsc::check(ierr, "VecGhostRestoreLocalForm");
 }
 //-----------------------------------------------------------------------------
 Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
@@ -262,7 +255,7 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   PetscErrorCode ierr;
   Mat A;
   ierr = MatCreate(comm, &A);
-  CHECK_ERROR("MatCreate");
+  petsc::check(ierr, "MatCreate");
 
   // Get IndexMaps from sparsity pattern, and block size
   std::array maps = {sp.index_map(0), sp.index_map(1)};
@@ -271,7 +264,7 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   if (type and !type->empty())
   {
     ierr = MatSetType(A, std::string(*type).c_str());
-    CHECK_ERROR("MatSetType");
+    petsc::check(ierr, "MatSetType");
   }
 
   // Get global and local dimensions
@@ -282,12 +275,12 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
 
   // Set matrix size
   ierr = MatSetSizes(A, m, n, M, N);
-  CHECK_ERROR("MatSetSizes");
+  petsc::check(ierr, "MatSetSizes");
 
   // Apply PETSc options from the options database to the matrix (this
   // includes changing the matrix type to one specified by the user)
   ierr = MatSetFromOptions(A);
-  CHECK_ERROR("MatSetFromOptions");
+  petsc::check(ierr, "MatSetFromOptions");
 
   // Find a common block size across rows/columns
   const int _bs = (bs[0] == bs[1] ? bs[0] : 1);
@@ -322,11 +315,11 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   // Allocate space for matrix
   ierr = MatXAIJSetPreallocation(A, _bs, _nnz_diag.data(), _nnz_offdiag.data(),
                                  nullptr, nullptr);
-  CHECK_ERROR("MatXAIJSetPreallocation");
+  petsc::check(ierr, "MatXAIJSetPreallocation");
 
   // Set block sizes
   ierr = MatSetBlockSizes(A, bs[0], bs[1]);
-  CHECK_ERROR("MatSetBlockSizes");
+  petsc::check(ierr, "MatSetBlockSizes");
 
   // Build a PETSc (PetscInt) local-to-global map directly from an
   // IndexMap's local range and ghosts, rather than going via
@@ -350,13 +343,13 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs[0], _map0.size(),
                                       _map0.data(), PETSC_COPY_VALUES,
                                       &local_to_global0);
-  CHECK_ERROR("ISLocalToGlobalMappingCreate");
+  petsc::check(ierr, "ISLocalToGlobalMappingCreate");
 
   // Check for common index maps
   if (maps[0] == maps[1] and bs[0] == bs[1])
   {
     ierr = MatSetLocalToGlobalMapping(A, local_to_global0, local_to_global0);
-    CHECK_ERROR("MatSetLocalToGlobalMapping");
+    petsc::check(ierr, "MatSetLocalToGlobalMapping");
   }
   else
   {
@@ -365,16 +358,16 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
     ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs[1], _map1.size(),
                                         _map1.data(), PETSC_COPY_VALUES,
                                         &local_to_global1);
-    CHECK_ERROR("ISLocalToGlobalMappingCreate");
+    petsc::check(ierr, "ISLocalToGlobalMappingCreate");
     ierr = MatSetLocalToGlobalMapping(A, local_to_global0, local_to_global1);
-    CHECK_ERROR("MatSetLocalToGlobalMapping");
+    petsc::check(ierr, "MatSetLocalToGlobalMapping");
     ierr = ISLocalToGlobalMappingDestroy(&local_to_global1);
-    CHECK_ERROR("ISLocalToGlobalMappingDestroy");
+    petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
   }
 
   // Clean up local-to-global 0
   ierr = ISLocalToGlobalMappingDestroy(&local_to_global0);
-  CHECK_ERROR("ISLocalToGlobalMappingDestroy");
+  petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
 
   // Note: This should be called after having set the local-to-global
   // map for MATIS (this is a dummy call if A is not of type MATIS)
@@ -384,9 +377,9 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
 
   // Set some options on Mat object
   ierr = MatSetOption(A, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
-  CHECK_ERROR("MatSetOption");
+  petsc::check(ierr, "MatSetOption");
   ierr = MatSetOption(A, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
-  CHECK_ERROR("MatSetOption");
+  petsc::check(ierr, "MatSetOption");
 
   return A;
 }
@@ -397,7 +390,7 @@ MatNullSpace la::petsc::create_nullspace(MPI_Comm comm,
   MatNullSpace ns = nullptr;
   PetscErrorCode ierr
       = MatNullSpaceCreate(comm, PETSC_FALSE, basis.size(), basis.data(), &ns);
-  CHECK_ERROR("MatNullSpaceCreate");
+  petsc::check(ierr, "MatNullSpaceCreate");
   return ns;
 }
 //-----------------------------------------------------------------------------
@@ -414,13 +407,13 @@ void petsc::options::clear(std::string option)
 
   PetscErrorCode ierr;
   ierr = PetscOptionsClearValue(nullptr, option.c_str());
-  CHECK_ERROR("PetscOptionsClearValue");
+  petsc::check(ierr, "PetscOptionsClearValue");
 }
 //-----------------------------------------------------------------------------
 void petsc::options::clear()
 {
   PetscErrorCode ierr = PetscOptionsClear(nullptr);
-  CHECK_ERROR("PetscOptionsClear");
+  petsc::check(ierr, "PetscOptionsClear");
 }
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
@@ -438,7 +431,7 @@ petsc::Vector::Vector(Vec x, bool inc_ref_count) : _x(x)
   if (inc_ref_count)
   {
     PetscErrorCode ierr = PetscObjectReference((PetscObject)_x);
-    CHECK_ERROR("PetscObjectReference");
+    petsc::check(ierr, "PetscObjectReference");
   }
 }
 //-----------------------------------------------------------------------------
@@ -460,9 +453,9 @@ petsc::Vector petsc::Vector::copy() const
 {
   Vec _y;
   PetscErrorCode ierr = VecDuplicate(_x, &_y);
-  CHECK_ERROR("VecDuplicate");
+  petsc::check(ierr, "VecDuplicate");
   ierr = VecCopy(_x, _y);
-  CHECK_ERROR("VecCopy");
+  petsc::check(ierr, "VecCopy");
   return Vector(_y, false);
 }
 //-----------------------------------------------------------------------------
@@ -471,7 +464,7 @@ std::int64_t petsc::Vector::size() const
   assert(_x);
   PetscInt n = 0;
   PetscErrorCode ierr = VecGetSize(_x, &n);
-  CHECK_ERROR("VecGetSize");
+  petsc::check(ierr, "VecGetSize");
   return n;
 }
 //-----------------------------------------------------------------------------
@@ -480,7 +473,7 @@ std::int32_t petsc::Vector::local_size() const
   assert(_x);
   PetscInt n = 0;
   PetscErrorCode ierr = VecGetLocalSize(_x, &n);
-  CHECK_ERROR("VecGetLocalSize");
+  petsc::check(ierr, "VecGetLocalSize");
   return n;
 }
 //-----------------------------------------------------------------------------
@@ -489,7 +482,7 @@ std::array<std::int64_t, 2> petsc::Vector::local_range() const
   assert(_x);
   PetscInt n0, n1;
   PetscErrorCode ierr = VecGetOwnershipRange(_x, &n0, &n1);
-  CHECK_ERROR("VecGetOwnershipRange");
+  petsc::check(ierr, "VecGetOwnershipRange");
   assert(n0 <= n1);
   return {n0, n1};
 }
@@ -499,7 +492,7 @@ MPI_Comm petsc::Vector::comm() const
   assert(_x);
   MPI_Comm mpi_comm = MPI_COMM_NULL;
   PetscErrorCode ierr = PetscObjectGetComm((PetscObject)(_x), &mpi_comm);
-  CHECK_ERROR("PetscObjectGetComm");
+  petsc::check(ierr, "PetscObjectGetComm");
   return mpi_comm;
 }
 //-----------------------------------------------------------------------------
@@ -508,7 +501,7 @@ void petsc::Vector::set_options_prefix(std::string_view options_prefix)
   assert(_x);
   PetscErrorCode ierr
       = VecSetOptionsPrefix(_x, std::string(options_prefix).c_str());
-  CHECK_ERROR("VecSetOptionsPrefix");
+  petsc::check(ierr, "VecSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string petsc::Vector::get_options_prefix() const
@@ -516,7 +509,7 @@ std::string petsc::Vector::get_options_prefix() const
   assert(_x);
   const char* prefix = nullptr;
   PetscErrorCode ierr = VecGetOptionsPrefix(_x, &prefix);
-  CHECK_ERROR("VecGetOptionsPrefix");
+  petsc::check(ierr, "VecGetOptionsPrefix");
   return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
@@ -524,7 +517,7 @@ void petsc::Vector::set_from_options()
 {
   assert(_x);
   PetscErrorCode ierr = VecSetFromOptions(_x);
-  CHECK_ERROR("VecSetFromOptions");
+  petsc::check(ierr, "VecSetFromOptions");
 }
 //-----------------------------------------------------------------------------
 Vec petsc::Vector::vec() const { return _x; }
@@ -545,7 +538,7 @@ petsc::Matrix::Matrix(Mat A, bool inc_ref_count) : _matA(A)
   if (inc_ref_count)
   {
     PetscErrorCode ierr = PetscObjectReference((PetscObject)_matA);
-    CHECK_ERROR("PetscObjectReference");
+    petsc::check(ierr, "PetscObjectReference");
   }
 }
 //-----------------------------------------------------------------------------
@@ -573,7 +566,7 @@ std::array<std::int64_t, 2> petsc::Matrix::size() const
   assert(_matA);
   PetscInt m(0), n(0);
   PetscErrorCode ierr = MatGetSize(_matA, &m, &n);
-  CHECK_ERROR("MatGetSize");
+  petsc::check(ierr, "MatGetSize");
   return {{m, n}};
 }
 //-----------------------------------------------------------------------------
@@ -586,12 +579,12 @@ Vec petsc::Matrix::create_vector(std::size_t dim) const
   if (dim == 0)
   {
     ierr = MatCreateVecs(_matA, nullptr, &x);
-    CHECK_ERROR("MatCreateVecs");
+    petsc::check(ierr, "MatCreateVecs");
   }
   else if (dim == 1)
   {
     ierr = MatCreateVecs(_matA, &x, nullptr);
-    CHECK_ERROR("MatCreateVecs");
+    petsc::check(ierr, "MatCreateVecs");
   }
   else
   {
@@ -611,7 +604,7 @@ void petsc::Matrix::set_options_prefix(std::string_view options_prefix)
   assert(_matA);
   PetscErrorCode ierr
       = MatSetOptionsPrefix(_matA, std::string(options_prefix).c_str());
-  CHECK_ERROR("MatSetOptionsPrefix");
+  petsc::check(ierr, "MatSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string petsc::Matrix::get_options_prefix() const
@@ -619,7 +612,7 @@ std::string petsc::Matrix::get_options_prefix() const
   assert(_matA);
   const char* prefix = nullptr;
   PetscErrorCode ierr = MatGetOptionsPrefix(_matA, &prefix);
-  CHECK_ERROR("MatGetOptionsPrefix");
+  petsc::check(ierr, "MatGetOptionsPrefix");
   return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
@@ -627,7 +620,7 @@ void petsc::Matrix::set_from_options()
 {
   assert(_matA);
   PetscErrorCode ierr = MatSetFromOptions(_matA);
-  CHECK_ERROR("MatSetFromOptions");
+  petsc::check(ierr, "MatSetFromOptions");
 }
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
@@ -635,7 +628,7 @@ petsc::KrylovSolver::KrylovSolver(MPI_Comm comm) : _ksp(nullptr)
 {
   // Create PETSc KSP object
   PetscErrorCode ierr = KSPCreate(comm, &_ksp);
-  CHECK_ERROR("KSPCreate");
+  petsc::check(ierr, "KSPCreate");
 }
 //-----------------------------------------------------------------------------
 petsc::KrylovSolver::KrylovSolver(KSP ksp, bool inc_ref_count) : _ksp(ksp)
@@ -646,7 +639,7 @@ petsc::KrylovSolver::KrylovSolver(KSP ksp, bool inc_ref_count) : _ksp(ksp)
   if (inc_ref_count)
   {
     PetscErrorCode ierr = PetscObjectReference((PetscObject)_ksp);
-    CHECK_ERROR("PetscObjectReference");
+    petsc::check(ierr, "PetscObjectReference");
   }
 }
 //-----------------------------------------------------------------------------
@@ -676,7 +669,7 @@ void petsc::KrylovSolver::set_operators(const Mat A, const Mat P)
   assert(A);
   assert(_ksp);
   PetscErrorCode ierr = KSPSetOperators(_ksp, A, P);
-  CHECK_ERROR("KSPSetOperators");
+  petsc::check(ierr, "KSPSetOperators");
 }
 //-----------------------------------------------------------------------------
 PetscInt petsc::KrylovSolver::solve(Vec x, const Vec b, bool transpose) const
@@ -695,18 +688,18 @@ PetscInt petsc::KrylovSolver::solve(Vec x, const Vec b, bool transpose) const
   if (!transpose)
   {
     ierr = KSPSolve(_ksp, b, x);
-    CHECK_ERROR("KSPSolve");
+    petsc::check(ierr, "KSPSolve");
   }
   else
   {
     ierr = KSPSolveTranspose(_ksp, b, x);
-    CHECK_ERROR("KSPSolveTranspose");
+    petsc::check(ierr, "KSPSolveTranspose");
   }
 
   // Get the number of iterations
   PetscInt num_iterations = 0;
   ierr = KSPGetIterationNumber(_ksp, &num_iterations);
-  CHECK_ERROR("KSPGetIterationNumber");
+  petsc::check(ierr, "KSPGetIterationNumber");
 
   // Check if the solution converged and warn if not. Note: this does
   // not throw on non-convergence -- the caller is responsible for
@@ -714,12 +707,12 @@ PetscInt petsc::KrylovSolver::solve(Vec x, const Vec b, bool transpose) const
   // its use case.
   KSPConvergedReason reason;
   ierr = KSPGetConvergedReason(_ksp, &reason);
-  CHECK_ERROR("KSPGetConvergedReason");
+  petsc::check(ierr, "KSPGetConvergedReason");
   if (reason < 0)
   {
     const char* reason_str;
     ierr = KSPGetConvergedReasonString(_ksp, &reason_str);
-    CHECK_ERROR("KSPGetConvergedReasonString");
+    petsc::check(ierr, "KSPGetConvergedReasonString");
     spdlog::warn("PETSc Krylov solver did not converge in {} iterations "
                  "(PETSc reason: {}).",
                  num_iterations, reason_str);
@@ -734,7 +727,7 @@ void petsc::KrylovSolver::set_options_prefix(std::string_view options_prefix)
   assert(_ksp);
   PetscErrorCode ierr
       = KSPSetOptionsPrefix(_ksp, std::string(options_prefix).c_str());
-  CHECK_ERROR("KSPSetOptionsPrefix");
+  petsc::check(ierr, "KSPSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string petsc::KrylovSolver::get_options_prefix() const
@@ -742,7 +735,7 @@ std::string petsc::KrylovSolver::get_options_prefix() const
   assert(_ksp);
   const char* prefix = nullptr;
   PetscErrorCode ierr = KSPGetOptionsPrefix(_ksp, &prefix);
-  CHECK_ERROR("KSPGetOptionsPrefix");
+  petsc::check(ierr, "KSPGetOptionsPrefix");
   return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
@@ -750,7 +743,7 @@ void petsc::KrylovSolver::set_from_options() const
 {
   assert(_ksp);
   PetscErrorCode ierr = KSPSetFromOptions(_ksp);
-  CHECK_ERROR("KSPSetFromOptions");
+  petsc::check(ierr, "KSPSetFromOptions");
 }
 //-----------------------------------------------------------------------------
 KSP petsc::KrylovSolver::ksp() const { return _ksp; }

--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -263,8 +263,7 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   PetscErrorCode ierr;
   Mat A;
   ierr = MatCreate(comm, &A);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "MatCreate");
+  CHECK_ERROR("MatCreate");
 
   // Get IndexMaps from sparsity pattern, and block size
   std::array maps = {sp.index_map(0), sp.index_map(1)};
@@ -273,8 +272,7 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   if (type and !type->empty())
   {
     ierr = MatSetType(A, std::string(*type).c_str());
-    if (ierr != 0)
-      petsc::error(ierr, __FILE__, "MatSetType");
+    CHECK_ERROR("MatSetType");
   }
 
   // Get global and local dimensions
@@ -285,14 +283,12 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
 
   // Set matrix size
   ierr = MatSetSizes(A, m, n, M, N);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "MatSetSizes");
+  CHECK_ERROR("MatSetSizes");
 
   // Apply PETSc options from the options database to the matrix (this
   // includes changing the matrix type to one specified by the user)
   ierr = MatSetFromOptions(A);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "MatSetFromOptions");
+  CHECK_ERROR("MatSetFromOptions");
 
   // Find a common block size across rows/columns
   const int _bs = (bs[0] == bs[1] ? bs[0] : 1);
@@ -327,13 +323,11 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   // Allocate space for matrix
   ierr = MatXAIJSetPreallocation(A, _bs, _nnz_diag.data(), _nnz_offdiag.data(),
                                  nullptr, nullptr);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "MatXAIJSetPreallocation");
+  CHECK_ERROR("MatXAIJSetPreallocation");
 
   // Set block sizes
   ierr = MatSetBlockSizes(A, bs[0], bs[1]);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "MatSetBlockSizes");
+  CHECK_ERROR("MatSetBlockSizes");
 
   // Build a PETSc (PetscInt) local-to-global map directly from an
   // IndexMap's local range and ghosts, rather than going via
@@ -357,16 +351,13 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs[0], _map0.size(),
                                       _map0.data(), PETSC_COPY_VALUES,
                                       &local_to_global0);
-
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "ISLocalToGlobalMappingCreate");
+  CHECK_ERROR("ISLocalToGlobalMappingCreate");
 
   // Check for common index maps
   if (maps[0] == maps[1] and bs[0] == bs[1])
   {
     ierr = MatSetLocalToGlobalMapping(A, local_to_global0, local_to_global0);
-    if (ierr != 0)
-      petsc::error(ierr, __FILE__, "MatSetLocalToGlobalMapping");
+    CHECK_ERROR("MatSetLocalToGlobalMapping");
   }
   else
   {
@@ -375,20 +366,16 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
     ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs[1], _map1.size(),
                                         _map1.data(), PETSC_COPY_VALUES,
                                         &local_to_global1);
-    if (ierr != 0)
-      petsc::error(ierr, __FILE__, "ISLocalToGlobalMappingCreate");
+    CHECK_ERROR("ISLocalToGlobalMappingCreate");
     ierr = MatSetLocalToGlobalMapping(A, local_to_global0, local_to_global1);
-    if (ierr != 0)
-      petsc::error(ierr, __FILE__, "MatSetLocalToGlobalMapping");
+    CHECK_ERROR("MatSetLocalToGlobalMapping");
     ierr = ISLocalToGlobalMappingDestroy(&local_to_global1);
-    if (ierr != 0)
-      petsc::error(ierr, __FILE__, "ISLocalToGlobalMappingDestroy");
+    CHECK_ERROR("ISLocalToGlobalMappingDestroy");
   }
 
   // Clean up local-to-global 0
   ierr = ISLocalToGlobalMappingDestroy(&local_to_global0);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "ISLocalToGlobalMappingDestroy");
+  CHECK_ERROR("ISLocalToGlobalMappingDestroy");
 
   // Note: This should be called after having set the local-to-global
   // map for MATIS (this is a dummy call if A is not of type MATIS)
@@ -398,11 +385,9 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
 
   // Set some options on Mat object
   ierr = MatSetOption(A, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "MatSetOption");
+  CHECK_ERROR("MatSetOption");
   ierr = MatSetOption(A, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "MatSetOption");
+  CHECK_ERROR("MatSetOption");
 
   return A;
 }
@@ -413,8 +398,7 @@ MatNullSpace la::petsc::create_nullspace(MPI_Comm comm,
   MatNullSpace ns = nullptr;
   PetscErrorCode ierr
       = MatNullSpaceCreate(comm, PETSC_FALSE, basis.size(), basis.data(), &ns);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "MatNullSpaceCreate");
+  CHECK_ERROR("MatNullSpaceCreate");
   return ns;
 }
 //-----------------------------------------------------------------------------
@@ -431,15 +415,13 @@ void petsc::options::clear(std::string option)
 
   PetscErrorCode ierr;
   ierr = PetscOptionsClearValue(nullptr, option.c_str());
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "PetscOptionsClearValue");
+  CHECK_ERROR("PetscOptionsClearValue");
 }
 //-----------------------------------------------------------------------------
 void petsc::options::clear()
 {
   PetscErrorCode ierr = PetscOptionsClear(nullptr);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "PetscOptionsClear");
+  CHECK_ERROR("PetscOptionsClear");
 }
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
@@ -585,8 +567,7 @@ std::array<std::int64_t, 2> petsc::Operator::size() const
   assert(_matA);
   PetscInt m(0), n(0);
   PetscErrorCode ierr = MatGetSize(_matA, &m, &n);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "MatGetSize");
+  CHECK_ERROR("MatGetSize");
   return {{m, n}};
 }
 //-----------------------------------------------------------------------------
@@ -599,14 +580,12 @@ Vec petsc::Operator::create_vector(std::size_t dim) const
   if (dim == 0)
   {
     ierr = MatCreateVecs(_matA, nullptr, &x);
-    if (ierr != 0)
-      petsc::error(ierr, __FILE__, "MatCreateVecs");
+    CHECK_ERROR("MatCreateVecs");
   }
   else if (dim == 1)
   {
     ierr = MatCreateVecs(_matA, &x, nullptr);
-    if (ierr != 0)
-      petsc::error(ierr, __FILE__, "MatCreateVecs");
+    CHECK_ERROR("MatCreateVecs");
   }
   else
   {
@@ -654,8 +633,7 @@ double petsc::Matrix::norm(Norm norm_type) const
     throw std::runtime_error("Unknown PETSc Mat norm type");
   }
 
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "MatNorm");
+  CHECK_ERROR("MatNorm");
   return value;
 }
 //-----------------------------------------------------------------------------
@@ -669,31 +647,33 @@ void petsc::Matrix::apply(AssemblyType type)
   if (type == AssemblyType::FLUSH)
     petsc_type = MAT_FLUSH_ASSEMBLY;
   ierr = MatAssemblyBegin(_matA, petsc_type);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "MatAssemblyBegin");
+  CHECK_ERROR("MatAssemblyBegin");
   ierr = MatAssemblyEnd(_matA, petsc_type);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "MatAssemblyEnd");
+  CHECK_ERROR("MatAssemblyEnd");
 }
 //-----------------------------------------------------------------------------
 void petsc::Matrix::set_options_prefix(std::string_view options_prefix)
 {
   assert(_matA);
-  MatSetOptionsPrefix(_matA, std::string(options_prefix).c_str());
+  PetscErrorCode ierr
+      = MatSetOptionsPrefix(_matA, std::string(options_prefix).c_str());
+  CHECK_ERROR("MatSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string petsc::Matrix::get_options_prefix() const
 {
   assert(_matA);
   const char* prefix = nullptr;
-  MatGetOptionsPrefix(_matA, &prefix);
+  PetscErrorCode ierr = MatGetOptionsPrefix(_matA, &prefix);
+  CHECK_ERROR("MatGetOptionsPrefix");
   return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
 void petsc::Matrix::set_from_options()
 {
   assert(_matA);
-  MatSetFromOptions(_matA);
+  PetscErrorCode ierr = MatSetFromOptions(_matA);
+  CHECK_ERROR("MatSetFromOptions");
 }
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
@@ -701,8 +681,7 @@ petsc::KrylovSolver::KrylovSolver(MPI_Comm comm) : _ksp(nullptr)
 {
   // Create PETSc KSP object
   PetscErrorCode ierr = KSPCreate(comm, &_ksp);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "KSPCreate");
+  CHECK_ERROR("KSPCreate");
 }
 //-----------------------------------------------------------------------------
 petsc::KrylovSolver::KrylovSolver(KSP ksp, bool inc_ref_count) : _ksp(ksp)
@@ -743,8 +722,7 @@ void petsc::KrylovSolver::set_operators(const Mat A, const Mat P)
   assert(A);
   assert(_ksp);
   PetscErrorCode ierr = KSPSetOperators(_ksp, A, P);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "KSPSetOperators");
+  CHECK_ERROR("KSPSetOperators");
 }
 //-----------------------------------------------------------------------------
 PetscInt petsc::KrylovSolver::solve(Vec x, const Vec b, bool transpose) const
@@ -782,14 +760,12 @@ PetscInt petsc::KrylovSolver::solve(Vec x, const Vec b, bool transpose) const
   // its use case.
   KSPConvergedReason reason;
   ierr = KSPGetConvergedReason(_ksp, &reason);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "KSPGetConvergedReason");
+  CHECK_ERROR("KSPGetConvergedReason");
   if (reason < 0)
   {
     const char* reason_str;
     ierr = KSPGetConvergedReasonString(_ksp, &reason_str);
-    if (ierr != 0)
-      petsc::error(ierr, __FILE__, "KSPGetConvergedReasonString");
+    CHECK_ERROR("KSPGetConvergedReasonString");
     spdlog::warn("PETSc Krylov solver did not converge in {} iterations "
                  "(PETSc reason: {}).",
                  num_iterations, reason_str);
@@ -804,8 +780,7 @@ void petsc::KrylovSolver::set_options_prefix(std::string_view options_prefix)
   assert(_ksp);
   PetscErrorCode ierr
       = KSPSetOptionsPrefix(_ksp, std::string(options_prefix).c_str());
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "KSPSetOptionsPrefix");
+  CHECK_ERROR("KSPSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string petsc::KrylovSolver::get_options_prefix() const
@@ -813,8 +788,7 @@ std::string petsc::KrylovSolver::get_options_prefix() const
   assert(_ksp);
   const char* prefix = nullptr;
   PetscErrorCode ierr = KSPGetOptionsPrefix(_ksp, &prefix);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "KSPGetOptionsPrefix");
+  CHECK_ERROR("KSPGetOptionsPrefix");
   return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
@@ -822,8 +796,7 @@ void petsc::KrylovSolver::set_from_options() const
 {
   assert(_ksp);
   PetscErrorCode ierr = KSPSetFromOptions(_ksp);
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "KSPSetFromOptions");
+  CHECK_ERROR("KSPSetFromOptions");
 }
 //-----------------------------------------------------------------------------
 KSP petsc::KrylovSolver::ksp() const { return _ksp; }

--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2004-2018 Johan Hoffman, Johan Jansson, Anders Logg and
-// Garth N. Wells
+// Copyright (C) 2004-2026 Johan Hoffman, Johan Jansson, Anders Logg,
+// Garth N. Wells and Jack S. Hale
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //

--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -26,24 +26,6 @@ using namespace dolfinx;
 using namespace dolfinx::la;
 
 //-----------------------------------------------------------------------------
-void la::petsc::error(PetscErrorCode error_code,
-                      std::string_view petsc_function, std::source_location loc)
-{
-  // Fetch PETSc error description
-  const char* desc;
-  PetscErrorMessage(error_code, &desc, nullptr);
-
-  // Log detailed error info
-  spdlog::error("PETSc error in '{}:{}', '{}'", loc.file_name(), loc.line(),
-                petsc_function);
-  spdlog::error("PETSc error code '{}' '{}'", static_cast<int>(error_code),
-                desc);
-  throw std::runtime_error(
-      std::format("Failed to successfully call PETSc function '{}'. PETSc "
-                  "error code is: {}, {}",
-                  petsc_function, static_cast<int>(error_code), desc));
-}
-//-----------------------------------------------------------------------------
 std::vector<Vec>
 la::petsc::create_vectors(MPI_Comm comm,
                           const std::vector<std::span<const PetscScalar>>& x)
@@ -53,13 +35,13 @@ la::petsc::create_vectors(MPI_Comm comm,
   {
     PetscErrorCode ierr;
     ierr = VecCreateMPI(comm, x[i].size(), PETSC_DETERMINE, &v[i]);
-    petsc::check(ierr, "VecCreateMPI");
+    common::petsc::check(ierr, "VecCreateMPI");
     PetscScalar* data;
     ierr = VecGetArray(v[i], &data);
-    petsc::check(ierr, "VecGetArray");
+    common::petsc::check(ierr, "VecGetArray");
     std::ranges::copy(x[i], data);
     ierr = VecRestoreArray(v[i], &data);
-    petsc::check(ierr, "VecRestoreArray");
+    common::petsc::check(ierr, "VecRestoreArray");
   }
 
   return v;
@@ -86,13 +68,13 @@ Vec la::petsc::create_vector(MPI_Comm comm, std::array<std::int64_t, 2> range,
   {
     ierr = VecCreateGhost(comm, local_size, PETSC_DETERMINE, _ghosts.size(),
                           _ghosts.data(), &x);
-    petsc::check(ierr, "VecCreateGhost");
+    common::petsc::check(ierr, "VecCreateGhost");
   }
   else
   {
     ierr = VecCreateGhostBlock(comm, bs, bs * local_size, PETSC_DETERMINE,
                                _ghosts.size(), _ghosts.data(), &x);
-    petsc::check(ierr, "VecCreateGhostBlock");
+    common::petsc::check(ierr, "VecCreateGhostBlock");
   }
 
   assert(x);
@@ -118,14 +100,14 @@ Vec la::petsc::create_vector_wrap(const common::IndexMap& map, int bs,
     ierr
         = VecCreateGhostWithArray(map.comm(), size_local, size_global,
                                   ghosts.size(), ghosts.data(), x.data(), &vec);
-    petsc::check(ierr, "VecCreateGhostWithArray");
+    common::petsc::check(ierr, "VecCreateGhostWithArray");
   }
   else
   {
     ierr = VecCreateGhostBlockWithArray(map.comm(), bs, size_local, size_global,
                                         ghosts.size(), ghosts.data(), x.data(),
                                         &vec);
-    petsc::check(ierr, "VecCreateGhostBlockWithArray");
+    common::petsc::check(ierr, "VecCreateGhostBlockWithArray");
   }
 
   assert(vec);
@@ -144,7 +126,7 @@ std::vector<IS> la::petsc::create_index_sets(
     IS _is;
     PetscErrorCode ierr
         = ISCreateStride(PETSC_COMM_SELF, bs * size, offset, 1, &_is);
-    petsc::check(ierr, "ISCreateStride");
+    common::petsc::check(ierr, "ISCreateStride");
     is.push_back(_is);
     offset += bs * size;
   }
@@ -166,13 +148,13 @@ std::vector<std::vector<PetscScalar>> la::petsc::get_local_vectors(
   PetscErrorCode ierr;
   Vec x_local;
   ierr = VecGhostGetLocalForm(x, &x_local);
-  petsc::check(ierr, "VecGhostGetLocalForm");
+  common::petsc::check(ierr, "VecGhostGetLocalForm");
   PetscInt n = 0;
   ierr = VecGetSize(x_local, &n);
-  petsc::check(ierr, "VecGetSize");
+  common::petsc::check(ierr, "VecGetSize");
   const PetscScalar* array = nullptr;
   ierr = VecGetArrayRead(x_local, &array);
-  petsc::check(ierr, "VecGetArrayRead");
+  common::petsc::check(ierr, "VecGetArrayRead");
   std::span _x(array, n);
 
   // Copy PETSc Vec data in to local vectors
@@ -194,9 +176,9 @@ std::vector<std::vector<PetscScalar>> la::petsc::get_local_vectors(
   }
 
   ierr = VecRestoreArrayRead(x_local, &array);
-  petsc::check(ierr, "VecRestoreArrayRead");
+  common::petsc::check(ierr, "VecRestoreArrayRead");
   ierr = VecGhostRestoreLocalForm(x, &x_local);
-  petsc::check(ierr, "VecGhostRestoreLocalForm");
+  common::petsc::check(ierr, "VecGhostRestoreLocalForm");
 
   return x_b;
 }
@@ -217,13 +199,13 @@ void la::petsc::scatter_local_vectors(
   PetscErrorCode ierr;
   Vec x_local;
   ierr = VecGhostGetLocalForm(x, &x_local);
-  petsc::check(ierr, "VecGhostGetLocalForm");
+  common::petsc::check(ierr, "VecGhostGetLocalForm");
   PetscInt n = 0;
   ierr = VecGetSize(x_local, &n);
-  petsc::check(ierr, "VecGetSize");
+  common::petsc::check(ierr, "VecGetSize");
   PetscScalar* array = nullptr;
   ierr = VecGetArray(x_local, &array);
-  petsc::check(ierr, "VecGetArray");
+  common::petsc::check(ierr, "VecGetArray");
   std::span _x(array, n);
 
   // Copy local vectors into PETSc Vec
@@ -244,9 +226,9 @@ void la::petsc::scatter_local_vectors(
   }
 
   ierr = VecRestoreArray(x_local, &array);
-  petsc::check(ierr, "VecRestoreArray");
+  common::petsc::check(ierr, "VecRestoreArray");
   ierr = VecGhostRestoreLocalForm(x, &x_local);
-  petsc::check(ierr, "VecGhostRestoreLocalForm");
+  common::petsc::check(ierr, "VecGhostRestoreLocalForm");
 }
 //-----------------------------------------------------------------------------
 Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
@@ -255,7 +237,7 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   PetscErrorCode ierr;
   Mat A;
   ierr = MatCreate(comm, &A);
-  petsc::check(ierr, "MatCreate");
+  common::petsc::check(ierr, "MatCreate");
 
   // Get IndexMaps from sparsity pattern, and block size
   std::array maps = {sp.index_map(0), sp.index_map(1)};
@@ -264,7 +246,7 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   if (type and !type->empty())
   {
     ierr = MatSetType(A, std::string(*type).c_str());
-    petsc::check(ierr, "MatSetType");
+    common::petsc::check(ierr, "MatSetType");
   }
 
   // Get global and local dimensions
@@ -275,12 +257,12 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
 
   // Set matrix size
   ierr = MatSetSizes(A, m, n, M, N);
-  petsc::check(ierr, "MatSetSizes");
+  common::petsc::check(ierr, "MatSetSizes");
 
   // Apply PETSc options from the options database to the matrix (this
   // includes changing the matrix type to one specified by the user)
   ierr = MatSetFromOptions(A);
-  petsc::check(ierr, "MatSetFromOptions");
+  common::petsc::check(ierr, "MatSetFromOptions");
 
   // Find a common block size across rows/columns
   const int _bs = (bs[0] == bs[1] ? bs[0] : 1);
@@ -315,11 +297,11 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   // Allocate space for matrix
   ierr = MatXAIJSetPreallocation(A, _bs, _nnz_diag.data(), _nnz_offdiag.data(),
                                  nullptr, nullptr);
-  petsc::check(ierr, "MatXAIJSetPreallocation");
+  common::petsc::check(ierr, "MatXAIJSetPreallocation");
 
   // Set block sizes
   ierr = MatSetBlockSizes(A, bs[0], bs[1]);
-  petsc::check(ierr, "MatSetBlockSizes");
+  common::petsc::check(ierr, "MatSetBlockSizes");
 
   // Build a PETSc (PetscInt) local-to-global map directly from an
   // IndexMap's local range and ghosts, rather than going via
@@ -343,13 +325,13 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
   ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs[0], _map0.size(),
                                       _map0.data(), PETSC_COPY_VALUES,
                                       &local_to_global0);
-  petsc::check(ierr, "ISLocalToGlobalMappingCreate");
+  common::petsc::check(ierr, "ISLocalToGlobalMappingCreate");
 
   // Check for common index maps
   if (maps[0] == maps[1] and bs[0] == bs[1])
   {
     ierr = MatSetLocalToGlobalMapping(A, local_to_global0, local_to_global0);
-    petsc::check(ierr, "MatSetLocalToGlobalMapping");
+    common::petsc::check(ierr, "MatSetLocalToGlobalMapping");
   }
   else
   {
@@ -358,16 +340,16 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
     ierr = ISLocalToGlobalMappingCreate(MPI_COMM_SELF, bs[1], _map1.size(),
                                         _map1.data(), PETSC_COPY_VALUES,
                                         &local_to_global1);
-    petsc::check(ierr, "ISLocalToGlobalMappingCreate");
+    common::petsc::check(ierr, "ISLocalToGlobalMappingCreate");
     ierr = MatSetLocalToGlobalMapping(A, local_to_global0, local_to_global1);
-    petsc::check(ierr, "MatSetLocalToGlobalMapping");
+    common::petsc::check(ierr, "MatSetLocalToGlobalMapping");
     ierr = ISLocalToGlobalMappingDestroy(&local_to_global1);
-    petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
+    common::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
   }
 
   // Clean up local-to-global 0
   ierr = ISLocalToGlobalMappingDestroy(&local_to_global0);
-  petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
+  common::petsc::check(ierr, "ISLocalToGlobalMappingDestroy");
 
   // Note: This should be called after having set the local-to-global
   // map for MATIS (this is a dummy call if A is not of type MATIS)
@@ -377,9 +359,9 @@ Mat la::petsc::create_matrix(MPI_Comm comm, const SparsityPattern& sp,
 
   // Set some options on Mat object
   ierr = MatSetOption(A, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
-  petsc::check(ierr, "MatSetOption");
+  common::petsc::check(ierr, "MatSetOption");
   ierr = MatSetOption(A, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
-  petsc::check(ierr, "MatSetOption");
+  common::petsc::check(ierr, "MatSetOption");
 
   return A;
 }
@@ -390,7 +372,7 @@ MatNullSpace la::petsc::create_nullspace(MPI_Comm comm,
   MatNullSpace ns = nullptr;
   PetscErrorCode ierr
       = MatNullSpaceCreate(comm, PETSC_FALSE, basis.size(), basis.data(), &ns);
-  petsc::check(ierr, "MatNullSpaceCreate");
+  common::petsc::check(ierr, "MatNullSpaceCreate");
   return ns;
 }
 //-----------------------------------------------------------------------------
@@ -407,13 +389,13 @@ void petsc::options::clear(std::string option)
 
   PetscErrorCode ierr;
   ierr = PetscOptionsClearValue(nullptr, option.c_str());
-  petsc::check(ierr, "PetscOptionsClearValue");
+  common::petsc::check(ierr, "PetscOptionsClearValue");
 }
 //-----------------------------------------------------------------------------
 void petsc::options::clear()
 {
   PetscErrorCode ierr = PetscOptionsClear(nullptr);
-  petsc::check(ierr, "PetscOptionsClear");
+  common::petsc::check(ierr, "PetscOptionsClear");
 }
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
@@ -431,7 +413,7 @@ petsc::Vector::Vector(Vec x, bool inc_ref_count) : _x(x)
   if (inc_ref_count)
   {
     PetscErrorCode ierr = PetscObjectReference((PetscObject)_x);
-    petsc::check(ierr, "PetscObjectReference");
+    common::petsc::check(ierr, "PetscObjectReference");
   }
 }
 //-----------------------------------------------------------------------------
@@ -453,9 +435,9 @@ petsc::Vector petsc::Vector::copy() const
 {
   Vec _y;
   PetscErrorCode ierr = VecDuplicate(_x, &_y);
-  petsc::check(ierr, "VecDuplicate");
+  common::petsc::check(ierr, "VecDuplicate");
   ierr = VecCopy(_x, _y);
-  petsc::check(ierr, "VecCopy");
+  common::petsc::check(ierr, "VecCopy");
   return Vector(_y, false);
 }
 //-----------------------------------------------------------------------------
@@ -464,7 +446,7 @@ std::int64_t petsc::Vector::size() const
   assert(_x);
   PetscInt n = 0;
   PetscErrorCode ierr = VecGetSize(_x, &n);
-  petsc::check(ierr, "VecGetSize");
+  common::petsc::check(ierr, "VecGetSize");
   return n;
 }
 //-----------------------------------------------------------------------------
@@ -473,7 +455,7 @@ std::int32_t petsc::Vector::local_size() const
   assert(_x);
   PetscInt n = 0;
   PetscErrorCode ierr = VecGetLocalSize(_x, &n);
-  petsc::check(ierr, "VecGetLocalSize");
+  common::petsc::check(ierr, "VecGetLocalSize");
   return n;
 }
 //-----------------------------------------------------------------------------
@@ -482,7 +464,7 @@ std::array<std::int64_t, 2> petsc::Vector::local_range() const
   assert(_x);
   PetscInt n0, n1;
   PetscErrorCode ierr = VecGetOwnershipRange(_x, &n0, &n1);
-  petsc::check(ierr, "VecGetOwnershipRange");
+  common::petsc::check(ierr, "VecGetOwnershipRange");
   assert(n0 <= n1);
   return {n0, n1};
 }
@@ -492,7 +474,7 @@ MPI_Comm petsc::Vector::comm() const
   assert(_x);
   MPI_Comm mpi_comm = MPI_COMM_NULL;
   PetscErrorCode ierr = PetscObjectGetComm((PetscObject)(_x), &mpi_comm);
-  petsc::check(ierr, "PetscObjectGetComm");
+  common::petsc::check(ierr, "PetscObjectGetComm");
   return mpi_comm;
 }
 //-----------------------------------------------------------------------------
@@ -501,7 +483,7 @@ void petsc::Vector::set_options_prefix(std::string_view options_prefix)
   assert(_x);
   PetscErrorCode ierr
       = VecSetOptionsPrefix(_x, std::string(options_prefix).c_str());
-  petsc::check(ierr, "VecSetOptionsPrefix");
+  common::petsc::check(ierr, "VecSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string petsc::Vector::get_options_prefix() const
@@ -509,7 +491,7 @@ std::string petsc::Vector::get_options_prefix() const
   assert(_x);
   const char* prefix = nullptr;
   PetscErrorCode ierr = VecGetOptionsPrefix(_x, &prefix);
-  petsc::check(ierr, "VecGetOptionsPrefix");
+  common::petsc::check(ierr, "VecGetOptionsPrefix");
   return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
@@ -517,7 +499,7 @@ void petsc::Vector::set_from_options()
 {
   assert(_x);
   PetscErrorCode ierr = VecSetFromOptions(_x);
-  petsc::check(ierr, "VecSetFromOptions");
+  common::petsc::check(ierr, "VecSetFromOptions");
 }
 //-----------------------------------------------------------------------------
 Vec petsc::Vector::vec() const { return _x; }
@@ -538,7 +520,7 @@ petsc::Matrix::Matrix(Mat A, bool inc_ref_count) : _matA(A)
   if (inc_ref_count)
   {
     PetscErrorCode ierr = PetscObjectReference((PetscObject)_matA);
-    petsc::check(ierr, "PetscObjectReference");
+    common::petsc::check(ierr, "PetscObjectReference");
   }
 }
 //-----------------------------------------------------------------------------
@@ -566,7 +548,7 @@ std::array<std::int64_t, 2> petsc::Matrix::size() const
   assert(_matA);
   PetscInt m(0), n(0);
   PetscErrorCode ierr = MatGetSize(_matA, &m, &n);
-  petsc::check(ierr, "MatGetSize");
+  common::petsc::check(ierr, "MatGetSize");
   return {{m, n}};
 }
 //-----------------------------------------------------------------------------
@@ -579,12 +561,12 @@ Vec petsc::Matrix::create_vector(std::size_t dim) const
   if (dim == 0)
   {
     ierr = MatCreateVecs(_matA, nullptr, &x);
-    petsc::check(ierr, "MatCreateVecs");
+    common::petsc::check(ierr, "MatCreateVecs");
   }
   else if (dim == 1)
   {
     ierr = MatCreateVecs(_matA, &x, nullptr);
-    petsc::check(ierr, "MatCreateVecs");
+    common::petsc::check(ierr, "MatCreateVecs");
   }
   else
   {
@@ -604,7 +586,7 @@ void petsc::Matrix::set_options_prefix(std::string_view options_prefix)
   assert(_matA);
   PetscErrorCode ierr
       = MatSetOptionsPrefix(_matA, std::string(options_prefix).c_str());
-  petsc::check(ierr, "MatSetOptionsPrefix");
+  common::petsc::check(ierr, "MatSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string petsc::Matrix::get_options_prefix() const
@@ -612,7 +594,7 @@ std::string petsc::Matrix::get_options_prefix() const
   assert(_matA);
   const char* prefix = nullptr;
   PetscErrorCode ierr = MatGetOptionsPrefix(_matA, &prefix);
-  petsc::check(ierr, "MatGetOptionsPrefix");
+  common::petsc::check(ierr, "MatGetOptionsPrefix");
   return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
@@ -620,7 +602,7 @@ void petsc::Matrix::set_from_options()
 {
   assert(_matA);
   PetscErrorCode ierr = MatSetFromOptions(_matA);
-  petsc::check(ierr, "MatSetFromOptions");
+  common::petsc::check(ierr, "MatSetFromOptions");
 }
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
@@ -628,7 +610,7 @@ petsc::KrylovSolver::KrylovSolver(MPI_Comm comm) : _ksp(nullptr)
 {
   // Create PETSc KSP object
   PetscErrorCode ierr = KSPCreate(comm, &_ksp);
-  petsc::check(ierr, "KSPCreate");
+  common::petsc::check(ierr, "KSPCreate");
 }
 //-----------------------------------------------------------------------------
 petsc::KrylovSolver::KrylovSolver(KSP ksp, bool inc_ref_count) : _ksp(ksp)
@@ -639,7 +621,7 @@ petsc::KrylovSolver::KrylovSolver(KSP ksp, bool inc_ref_count) : _ksp(ksp)
   if (inc_ref_count)
   {
     PetscErrorCode ierr = PetscObjectReference((PetscObject)_ksp);
-    petsc::check(ierr, "PetscObjectReference");
+    common::petsc::check(ierr, "PetscObjectReference");
   }
 }
 //-----------------------------------------------------------------------------
@@ -669,7 +651,7 @@ void petsc::KrylovSolver::set_operators(const Mat A, const Mat P)
   assert(A);
   assert(_ksp);
   PetscErrorCode ierr = KSPSetOperators(_ksp, A, P);
-  petsc::check(ierr, "KSPSetOperators");
+  common::petsc::check(ierr, "KSPSetOperators");
 }
 //-----------------------------------------------------------------------------
 PetscInt petsc::KrylovSolver::solve(Vec x, const Vec b, bool transpose) const
@@ -688,18 +670,18 @@ PetscInt petsc::KrylovSolver::solve(Vec x, const Vec b, bool transpose) const
   if (!transpose)
   {
     ierr = KSPSolve(_ksp, b, x);
-    petsc::check(ierr, "KSPSolve");
+    common::petsc::check(ierr, "KSPSolve");
   }
   else
   {
     ierr = KSPSolveTranspose(_ksp, b, x);
-    petsc::check(ierr, "KSPSolveTranspose");
+    common::petsc::check(ierr, "KSPSolveTranspose");
   }
 
   // Get the number of iterations
   PetscInt num_iterations = 0;
   ierr = KSPGetIterationNumber(_ksp, &num_iterations);
-  petsc::check(ierr, "KSPGetIterationNumber");
+  common::petsc::check(ierr, "KSPGetIterationNumber");
 
   // Check if the solution converged and warn if not. Note: this does
   // not throw on non-convergence -- the caller is responsible for
@@ -707,12 +689,12 @@ PetscInt petsc::KrylovSolver::solve(Vec x, const Vec b, bool transpose) const
   // its use case.
   KSPConvergedReason reason;
   ierr = KSPGetConvergedReason(_ksp, &reason);
-  petsc::check(ierr, "KSPGetConvergedReason");
+  common::petsc::check(ierr, "KSPGetConvergedReason");
   if (reason < 0)
   {
     const char* reason_str;
     ierr = KSPGetConvergedReasonString(_ksp, &reason_str);
-    petsc::check(ierr, "KSPGetConvergedReasonString");
+    common::petsc::check(ierr, "KSPGetConvergedReasonString");
     spdlog::warn("PETSc Krylov solver did not converge in {} iterations "
                  "(PETSc reason: {}).",
                  num_iterations, reason_str);
@@ -727,7 +709,7 @@ void petsc::KrylovSolver::set_options_prefix(std::string_view options_prefix)
   assert(_ksp);
   PetscErrorCode ierr
       = KSPSetOptionsPrefix(_ksp, std::string(options_prefix).c_str());
-  petsc::check(ierr, "KSPSetOptionsPrefix");
+  common::petsc::check(ierr, "KSPSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string petsc::KrylovSolver::get_options_prefix() const
@@ -735,7 +717,7 @@ std::string petsc::KrylovSolver::get_options_prefix() const
   assert(_ksp);
   const char* prefix = nullptr;
   PetscErrorCode ierr = KSPGetOptionsPrefix(_ksp, &prefix);
-  petsc::check(ierr, "KSPGetOptionsPrefix");
+  common::petsc::check(ierr, "KSPGetOptionsPrefix");
   return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
@@ -743,7 +725,7 @@ void petsc::KrylovSolver::set_from_options() const
 {
   assert(_ksp);
   PetscErrorCode ierr = KSPSetFromOptions(_ksp);
-  petsc::check(ierr, "KSPSetFromOptions");
+  common::petsc::check(ierr, "KSPSetFromOptions");
 }
 //-----------------------------------------------------------------------------
 KSP petsc::KrylovSolver::ksp() const { return _ksp; }

--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -16,7 +16,6 @@
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/common/log.h>
-#include <format>
 #include <numeric>
 #include <ranges>
 #include <stdexcept>
@@ -360,26 +359,6 @@ MatNullSpace la::petsc::create_nullspace(MPI_Comm comm,
       MatNullSpaceCreate(comm, PETSC_FALSE, basis.size(), basis.data(), &ns),
       "MatNullSpaceCreate");
   return ns;
-}
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
-void petsc::options::set(std::string option)
-{
-  petsc::options::set<std::string>(std::move(option), "");
-}
-//-----------------------------------------------------------------------------
-void petsc::options::clear(std::string option)
-{
-  if (option[0] != '-')
-    option = '-' + option;
-
-  common::petsc::check(PetscOptionsClearValue(nullptr, option.c_str()),
-                       "PetscOptionsClearValue");
-}
-//-----------------------------------------------------------------------------
-void petsc::options::clear()
-{
-  common::petsc::check(PetscOptionsClear(nullptr), "PetscOptionsClear");
 }
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -10,7 +10,6 @@
 #include "petsc.h"
 #include "SparsityPattern.h"
 #include "Vector.h"
-#include "utils.h"
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
@@ -531,7 +530,14 @@ void petsc::Vector::set_from_options()
 Vec petsc::Vector::vec() const { return _x; }
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-petsc::Operator::Operator(Mat A, bool inc_ref_count) : _matA(A)
+petsc::Matrix::Matrix(MPI_Comm comm, const SparsityPattern& sp,
+                      std::optional<std::string_view> type)
+    : _matA(petsc::create_matrix(comm, sp, type))
+{
+  // Do nothing
+}
+//-----------------------------------------------------------------------------
+petsc::Matrix::Matrix(Mat A, bool inc_ref_count) : _matA(A)
 {
   if (!_matA)
     throw std::runtime_error("PETSc Mat must be initialised before wrapping");
@@ -543,12 +549,12 @@ petsc::Operator::Operator(Mat A, bool inc_ref_count) : _matA(A)
   }
 }
 //-----------------------------------------------------------------------------
-petsc::Operator::Operator(Operator&& A) noexcept
+petsc::Matrix::Matrix(Matrix&& A) noexcept
     : _matA(std::exchange(A._matA, nullptr))
 {
 }
 //-----------------------------------------------------------------------------
-petsc::Operator::~Operator()
+petsc::Matrix::~Matrix()
 {
   // Decrease reference count (PETSc will destroy object once reference
   // counts reached zero)
@@ -556,13 +562,13 @@ petsc::Operator::~Operator()
     MatDestroy(&_matA);
 }
 //-----------------------------------------------------------------------------
-petsc::Operator& petsc::Operator::operator=(Operator&& A) noexcept
+petsc::Matrix& petsc::Matrix::operator=(Matrix&& A) noexcept
 {
   std::swap(_matA, A._matA);
   return *this;
 }
 //-----------------------------------------------------------------------------
-std::array<std::int64_t, 2> petsc::Operator::size() const
+std::array<std::int64_t, 2> petsc::Matrix::size() const
 {
   assert(_matA);
   PetscInt m(0), n(0);
@@ -571,7 +577,7 @@ std::array<std::int64_t, 2> petsc::Operator::size() const
   return {{m, n}};
 }
 //-----------------------------------------------------------------------------
-Vec petsc::Operator::create_vector(std::size_t dim) const
+Vec petsc::Matrix::create_vector(std::size_t dim) const
 {
   assert(_matA);
   PetscErrorCode ierr;
@@ -598,59 +604,7 @@ Vec petsc::Operator::create_vector(std::size_t dim) const
   return x;
 }
 //-----------------------------------------------------------------------------
-Mat petsc::Operator::mat() const { return _matA; }
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
-petsc::Matrix::Matrix(MPI_Comm comm, const SparsityPattern& sp,
-                      std::optional<std::string_view> type)
-    : Operator(petsc::create_matrix(comm, sp, type), false)
-{
-  // Do nothing
-}
-//-----------------------------------------------------------------------------
-petsc::Matrix::Matrix(Mat A, bool inc_ref_count) : Operator(A, inc_ref_count)
-{
-  // Reference count to A is incremented in base class
-}
-//-----------------------------------------------------------------------------
-double petsc::Matrix::norm(Norm norm_type) const
-{
-  assert(_matA);
-  PetscErrorCode ierr;
-  PetscReal value = 0;
-  switch (norm_type)
-  {
-  case Norm::l1:
-    ierr = MatNorm(_matA, NORM_1, &value);
-    break;
-  case Norm::linf:
-    ierr = MatNorm(_matA, NORM_INFINITY, &value);
-    break;
-  case Norm::frobenius:
-    ierr = MatNorm(_matA, NORM_FROBENIUS, &value);
-    break;
-  default:
-    throw std::runtime_error("Unknown PETSc Mat norm type");
-  }
-
-  CHECK_ERROR("MatNorm");
-  return value;
-}
-//-----------------------------------------------------------------------------
-void petsc::Matrix::apply(AssemblyType type)
-{
-  common::Timer timer("Apply (PETScMatrix)");
-
-  assert(_matA);
-  PetscErrorCode ierr;
-  MatAssemblyType petsc_type = MAT_FINAL_ASSEMBLY;
-  if (type == AssemblyType::FLUSH)
-    petsc_type = MAT_FLUSH_ASSEMBLY;
-  ierr = MatAssemblyBegin(_matA, petsc_type);
-  CHECK_ERROR("MatAssemblyBegin");
-  ierr = MatAssemblyEnd(_matA, petsc_type);
-  CHECK_ERROR("MatAssemblyEnd");
-}
+Mat petsc::Matrix::mat() const { return _matA; }
 //-----------------------------------------------------------------------------
 void petsc::Matrix::set_options_prefix(std::string_view options_prefix)
 {

--- a/cpp/dolfinx/la/petsc.cpp
+++ b/cpp/dolfinx/la/petsc.cpp
@@ -384,8 +384,10 @@ petsc::Vector::Vector(Vector&& v) noexcept : _x(std::exchange(v._x, nullptr)) {}
 //-----------------------------------------------------------------------------
 petsc::Vector::~Vector()
 {
+  // Destructor is implicitly noexcept, so a thrown error here calls
+  // std::terminate rather than propagating
   if (_x)
-    VecDestroy(&_x);
+    common::petsc::check(VecDestroy(&_x), "VecDestroy");
 }
 //-----------------------------------------------------------------------------
 petsc::Vector& petsc::Vector::operator=(Vector&& v) noexcept
@@ -489,9 +491,10 @@ petsc::Matrix::Matrix(Matrix&& A) noexcept
 petsc::Matrix::~Matrix()
 {
   // Decrease reference count (PETSc will destroy object once reference
-  // counts reached zero)
+  // counts reached zero). Destructor is implicitly noexcept, so a
+  // thrown error here calls std::terminate rather than propagating.
   if (_matA)
-    MatDestroy(&_matA);
+    common::petsc::check(MatDestroy(&_matA), "MatDestroy");
 }
 //-----------------------------------------------------------------------------
 petsc::Matrix& petsc::Matrix::operator=(Matrix&& A) noexcept
@@ -580,8 +583,10 @@ petsc::KrylovSolver::KrylovSolver(KrylovSolver&& solver) noexcept
 //-----------------------------------------------------------------------------
 petsc::KrylovSolver::~KrylovSolver()
 {
+  // Destructor is implicitly noexcept, so a thrown error here calls
+  // std::terminate rather than propagating
   if (_ksp)
-    KSPDestroy(&_ksp);
+    common::petsc::check(KSPDestroy(&_ksp), "KSPDestroy");
 }
 //-----------------------------------------------------------------------------
 petsc::KrylovSolver&

--- a/cpp/dolfinx/la/petsc.h
+++ b/cpp/dolfinx/la/petsc.h
@@ -61,10 +61,10 @@ inline void check(PetscErrorCode ierr, std::string_view petsc_function,
     error(ierr, petsc_function, loc);
 }
 
-/// Create PETSc vectors from the local data. The data is copied into
-/// the PETSc vectors and is not shared. Each vector's global size is
-/// determined by summing the corresponding local size across all
-/// ranks in `comm`.
+/// @brief Create PETSc vectors from the local data. The data is
+/// copied into the PETSc vectors and is not shared. Each vector's
+/// global size is determined by summing the corresponding local size
+/// across all ranks in `comm`.
 /// @note Caller is responsible for destroying the returned object
 /// @param[in] comm The MPI communicator
 /// @param[in] x The vector data owned by the calling rank
@@ -73,14 +73,15 @@ std::vector<Vec>
 create_vectors(MPI_Comm comm,
                const std::vector<std::span<const PetscScalar>>& x);
 
-/// Create a ghosted PETSc Vec
+/// @brief Create a ghosted PETSc Vec.
 /// @note Caller is responsible for destroying the returned object
 /// @param[in] map The index map describing the parallel layout (by block)
 /// @param[in] bs The block size
 /// @returns A PETSc Vec
 Vec create_vector(const common::IndexMap& map, int bs);
 
-/// Create a ghosted PETSc Vec from a local range and ghost indices
+/// @brief Create a ghosted PETSc Vec from a local range and ghost
+/// indices.
 /// @note Caller is responsible for freeing the returned object
 /// @param[in] comm The MPI communicator
 /// @param[in] range The local ownership range (by blocks)
@@ -91,7 +92,7 @@ Vec create_vector(const common::IndexMap& map, int bs);
 Vec create_vector(MPI_Comm comm, std::array<std::int64_t, 2> range,
                   std::span<const std::int64_t> ghosts, int bs);
 
-/// Create a PETSc Vec that wraps the data in an array
+/// @brief Create a PETSc Vec that wraps the data in an array.
 /// @param[in] map The index map that describes the parallel layout of
 /// the distributed vector (by block)
 /// @param[in] bs Block size
@@ -104,7 +105,7 @@ Vec create_vector(MPI_Comm comm, std::array<std::int64_t, 2> range,
 Vec create_vector_wrap(const common::IndexMap& map, int bs,
                        std::span<const PetscScalar> x);
 
-/// Create a PETSc Vec that wraps the data in an array
+/// @brief Create a PETSc Vec that wraps the data in an array.
 /// @param[in] x The vector to be wrapped
 /// @return A PETSc Vec object that shares the data in @p x
 template <class V>
@@ -142,7 +143,7 @@ void scatter_local_vectors(
     const std::vector<
         std::pair<std::reference_wrapper<const common::IndexMap>, int>>& maps);
 
-/// Create a PETSc Mat. Caller is responsible for destroying the
+/// @brief Create a PETSc Mat. Caller is responsible for destroying the
 /// returned object.
 /// @param[in] comm The MPI communicator
 /// @param[in] sp The sparsity pattern that determines the layout and
@@ -152,9 +153,9 @@ void scatter_local_vectors(
 Mat create_matrix(MPI_Comm comm, const SparsityPattern& sp,
                   std::optional<std::string_view> type = std::nullopt);
 
-/// Create PETSc MatNullSpace. Caller is responsible for destruction
-/// returned object.
-/// @param [in] comm The MPI communicator
+/// @brief Create PETSc MatNullSpace. Caller is responsible for
+/// destruction returned object.
+/// @param[in] comm The MPI communicator
 /// @param[in] basis The nullspace basis vectors
 /// @return A PETSc nullspace object
 MatNullSpace create_nullspace(MPI_Comm comm, std::span<const Vec> basis);
@@ -198,7 +199,7 @@ void clear();
 class Vector
 {
 public:
-  /// Create a vector
+  /// @brief Create a vector.
   /// @note Collective
   /// @param[in] map Index map describing the parallel layout
   /// @param[in] bs the block size
@@ -210,10 +211,10 @@ public:
   /// Move constructor
   Vector(Vector&& x) noexcept;
 
-  /// Create holder of a PETSc Vec object/pointer. The Vec x object
-  /// should already be created. If inc_ref_count is true, the reference
-  /// counter of the Vec object will be increased. The Vec reference
-  /// count will always be decreased upon destruction of the
+  /// @brief Create holder of a PETSc Vec object/pointer. The Vec x
+  /// object should already be created. If inc_ref_count is true, the
+  /// reference counter of the Vec object will be increased. The Vec
+  /// reference count will always be decreased upon destruction of the
   /// PETScVector.
   ///
   /// @note Collective
@@ -232,7 +233,7 @@ public:
   /// Move Assignment operator
   Vector& operator=(Vector&& x) noexcept;
 
-  /// Create a copy of the vector
+  /// @brief Create a copy of the vector.
   /// @note Collective
   Vector copy() const;
 
@@ -307,9 +308,9 @@ public:
     };
   }
 
-  /// Return a function with an interface for adding or inserting values
-  /// into the matrix A using blocked indices
-  /// (calls MatSetValuesBlockedLocal)
+  /// @brief Return a function with an interface for adding or
+  /// inserting values into the matrix A using blocked indices (calls
+  /// MatSetValuesBlockedLocal).
   /// @param[in] A The matrix to set values in
   /// @param[in] mode The PETSc insert mode (ADD_VALUES, INSERT_VALUES, ...)
   static auto set_block_fn(Mat A, InsertMode mode)
@@ -400,7 +401,7 @@ public:
   /// Destructor
   ~Matrix();
 
-  /// Assignment operator (deleted)
+  // Assignment operator (deleted)
   Matrix& operator=(const Matrix& A) = delete;
 
   /// Move assignment operator
@@ -410,8 +411,9 @@ public:
   /// returns -1 if size has not been set.
   std::array<std::int64_t, 2> size() const;
 
-  /// Initialize vector to be compatible with the matrix-vector product
-  /// y = Ax. In the parallel case, size and layout are both important.
+  /// @brief Initialize vector to be compatible with the matrix-vector
+  /// product y = Ax. In the parallel case, size and layout are both
+  /// important.
   ///
   /// @param[in] dim The dimension (axis): dim = 0 --> z = y, dim = 1
   /// --> z = x

--- a/cpp/dolfinx/la/petsc.h
+++ b/cpp/dolfinx/la/petsc.h
@@ -154,10 +154,9 @@ void set(std::string option, const T& value)
   if (option[0] != '-')
     option = '-' + option;
 
-  PetscErrorCode ierr;
-  ierr = PetscOptionsSetValue(nullptr, option.c_str(),
-                              std::format("{}", value).c_str());
-  common::petsc::check(ierr, "PetscOptionsSetValue");
+  common::petsc::check(PetscOptionsSetValue(nullptr, option.c_str(),
+                                            std::format("{}", value).c_str()),
+                       "PetscOptionsSetValue");
 }
 
 /// Clear a PETSc option

--- a/cpp/dolfinx/la/petsc.h
+++ b/cpp/dolfinx/la/petsc.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2004-2018 Johan Hoffman, Johan Jansson, Anders Logg and
-// Garth N. Wells
+// Copyright (C) 2004-2026 Johan Hoffman, Johan Jansson, Anders Logg,
+// Garth N. Wells and Jack S. Hale
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //

--- a/cpp/dolfinx/la/petsc.h
+++ b/cpp/dolfinx/la/petsc.h
@@ -32,7 +32,6 @@ class IndexMap;
 namespace dolfinx::la
 {
 class SparsityPattern;
-enum class Norm : std::int8_t;
 
 /// @brief PETSc linear algebra functions
 namespace petsc
@@ -247,59 +246,12 @@ private:
   Vec _x;
 };
 
-/// This class is a base class for matrices that can be used in
-/// petsc::KrylovSolver.
-class Operator
-{
-public:
-  /// @brief Create operator wrapper of a PETSc Mat object.
-  /// @param[in] A PETSc Mat object, which must already have been
-  /// created. The reference count of `A` is always decreased when this
-  /// Operator is destroyed.
-  /// @param[in] inc_ref_count True if the reference count of `A` should
-  /// be incremented.
-  Operator(Mat A, bool inc_ref_count);
-
-  // Copy constructor (deleted)
-  Operator(const Operator& A) = delete;
-
-  /// Move constructor
-  Operator(Operator&& A) noexcept;
-
-  /// Destructor
-  virtual ~Operator();
-
-  /// Assignment operator (deleted)
-  Operator& operator=(const Operator& A) = delete;
-
-  /// Move assignment operator
-  Operator& operator=(Operator&& A) noexcept;
-
-  /// Return number of rows and columns (num_rows, num_cols). PETSc
-  /// returns -1 if size has not been set.
-  std::array<std::int64_t, 2> size() const;
-
-  /// Initialize vector to be compatible with the matrix-vector product
-  /// y = Ax. In the parallel case, size and layout are both important.
-  ///
-  /// @param[in] dim The dimension (axis): dim = 0 --> z = y, dim = 1
-  /// --> z = x
-  Vec create_vector(std::size_t dim) const;
-
-  /// Return PETSc Mat pointer
-  Mat mat() const;
-
-protected:
-  // PETSc Mat pointer
-  Mat _matA;
-};
-
 /// It is a simple wrapper for a PETSc matrix pointer (Mat). Its main
 /// purpose is to assist memory management of PETSc Mat objects.
 ///
 /// For advanced usage, access the PETSc Mat pointer using the function
 /// mat() and use the standard PETSc interface.
-class Matrix : public Operator
+class Matrix
 {
 public:
   /// @brief Return a function with an interface for adding or inserting
@@ -413,45 +365,43 @@ public:
   Matrix(MPI_Comm comm, const SparsityPattern& sp,
          std::optional<std::string_view> type = std::nullopt);
 
-  /// Create holder of a PETSc Mat object/pointer. The Mat A object
-  /// should already be created. If inc_ref_count is true, the reference
-  /// counter of the Mat will be increased. The Mat reference count will
-  /// always be decreased upon destruction of the petsc::Matrix.
+  /// @brief Create holder of a PETSc Mat object/pointer. The Mat A object
+  /// should already be created.
+  /// @param[in] A PETSc Mat object, which must already have been
+  /// created. The reference count of `A` is always decreased when this
+  /// Matrix is destroyed.
+  /// @param[in] inc_ref_count True if the reference count of `A` should
+  /// be incremented.
   Matrix(Mat A, bool inc_ref_count);
 
   // Copy constructor (deleted)
   Matrix(const Matrix& A) = delete;
 
-  /// Move constructor (falls through to base class move constructor)
-  Matrix(Matrix&& A) = default;
+  /// Move constructor
+  Matrix(Matrix&& A) noexcept;
 
   /// Destructor
-  ~Matrix() = default;
+  ~Matrix();
 
   /// Assignment operator (deleted)
   Matrix& operator=(const Matrix& A) = delete;
 
   /// Move assignment operator
-  Matrix& operator=(Matrix&& A) = default;
+  Matrix& operator=(Matrix&& A) noexcept;
 
-  /// Assembly type
-  ///   FINAL - corresponds to PETSc MAT_FINAL_ASSEMBLY
-  ///   FLUSH - corresponds to PETSc MAT_FLUSH_ASSEMBLY
-  enum class AssemblyType : std::int8_t
-  {
-    FINAL,
-    FLUSH
-  };
+  /// Return number of rows and columns (num_rows, num_cols). PETSc
+  /// returns -1 if size has not been set.
+  std::array<std::int64_t, 2> size() const;
 
-  /// Finalize assembly of tensor. The following values are recognized
-  /// for the mode parameter:
-  /// @param type
-  ///   FINAL    - corresponds to PETSc MatAssemblyBegin+End(MAT_FINAL_ASSEMBLY)
-  ///   FLUSH  - corresponds to PETSc MatAssemblyBegin+End(MAT_FLUSH_ASSEMBLY)
-  void apply(AssemblyType type);
+  /// Initialize vector to be compatible with the matrix-vector product
+  /// y = Ax. In the parallel case, size and layout are both important.
+  ///
+  /// @param[in] dim The dimension (axis): dim = 0 --> z = y, dim = 1
+  /// --> z = x
+  Vec create_vector(std::size_t dim) const;
 
-  /// Return norm of matrix
-  double norm(Norm norm_type) const;
+  /// Return PETSc Mat pointer
+  Mat mat() const;
 
   //--- Special PETSc Functions ---
 
@@ -465,6 +415,10 @@ public:
 
   /// Call PETSc function MatSetFromOptions on the PETSc Mat object
   void set_from_options();
+
+private:
+  // PETSc Mat pointer
+  Mat _matA;
 };
 
 /// This class implements Krylov methods for linear systems of the form

--- a/cpp/dolfinx/la/petsc.h
+++ b/cpp/dolfinx/la/petsc.h
@@ -12,6 +12,7 @@
 #include "Vector.h"
 #include <cassert>
 #include <cstdint>
+#include <dolfinx/common/petsc.h>
 #include <format>
 #include <functional>
 #include <optional>
@@ -19,7 +20,6 @@
 #include <petscmat.h>
 #include <petscoptions.h>
 #include <petscvec.h>
-#include <source_location>
 #include <span>
 #include <string>
 #include <string_view>
@@ -37,30 +37,6 @@ class SparsityPattern;
 /// @brief PETSc linear algebra functions
 namespace petsc
 {
-/// @brief Print error message for a PETSc call that returned an error
-/// and throw a std::runtime_error.
-/// @param[in] error_code PETSc error code
-/// @param[in] petsc_function Name of the PETSc function that returned
-/// `error_code`
-/// @param[in] loc Call site of the failed PETSc call (captured
-/// automatically; do not pass explicitly)
-void error(PetscErrorCode error_code, std::string_view petsc_function,
-           std::source_location loc = std::source_location::current());
-
-/// @brief Throw a std::runtime_error via error() if `ierr` indicates a
-/// PETSc call failed.
-/// @param[in] ierr PETSc error code returned by `petsc_function`
-/// @param[in] petsc_function Name of the PETSc function that returned
-/// `ierr`
-/// @param[in] loc Call site of the failed PETSc call (captured
-/// automatically; do not pass explicitly)
-inline void check(PetscErrorCode ierr, std::string_view petsc_function,
-                  std::source_location loc = std::source_location::current())
-{
-  if (ierr != 0)
-    error(ierr, petsc_function, loc);
-}
-
 /// @brief Create PETSc vectors from the local data. The data is
 /// copied into the PETSc vectors and is not shared. Each vector's
 /// global size is determined by summing the corresponding local size
@@ -181,7 +157,7 @@ void set(std::string option, const T& value)
   PetscErrorCode ierr;
   ierr = PetscOptionsSetValue(nullptr, option.c_str(),
                               std::format("{}", value).c_str());
-  petsc::check(ierr, "PetscOptionsSetValue");
+  common::petsc::check(ierr, "PetscOptionsSetValue");
 }
 
 /// Clear a PETSc option
@@ -302,7 +278,7 @@ public:
 #endif
 
 #ifndef NDEBUG
-      petsc::check(ierr, "MatSetValuesLocal");
+      common::petsc::check(ierr, "MatSetValuesLocal");
 #endif
       return ierr;
     };
@@ -335,7 +311,7 @@ public:
 #endif
 
 #ifndef NDEBUG
-      petsc::check(ierr, "MatSetValuesBlockedLocal");
+      common::petsc::check(ierr, "MatSetValuesBlockedLocal");
 #endif
       return ierr;
     };
@@ -373,7 +349,7 @@ public:
       ierr = MatSetValuesLocal(A, cache0.size(), cache0.data(), cache1.size(),
                                cache1.data(), vals.data(), mode);
 #ifndef NDEBUG
-      petsc::check(ierr, "MatSetValuesLocal");
+      common::petsc::check(ierr, "MatSetValuesLocal");
 #endif
       return ierr;
     };

--- a/cpp/dolfinx/la/petsc.h
+++ b/cpp/dolfinx/la/petsc.h
@@ -13,12 +13,10 @@
 #include <cassert>
 #include <cstdint>
 #include <dolfinx/common/petsc.h>
-#include <format>
 #include <functional>
 #include <optional>
 #include <petscksp.h>
 #include <petscmat.h>
-#include <petscoptions.h>
 #include <petscvec.h>
 #include <span>
 #include <string>
@@ -135,36 +133,6 @@ Mat create_matrix(MPI_Comm comm, const SparsityPattern& sp,
 /// @param[in] basis The nullspace basis vectors
 /// @return A PETSc nullspace object
 MatNullSpace create_nullspace(MPI_Comm comm, std::span<const Vec> basis);
-
-/// These class provides static functions that permit users to set and
-/// retrieve PETSc options via the PETSc option/parameter system. The
-/// option must not be prefixed by '-', e.g.
-///
-///     la::petsc::options::set("mat_mumps_icntl_14", 40);
-namespace options
-{
-/// Set PETSc option that takes no value
-void set(std::string option);
-
-/// Generic function for setting PETSc option
-template <typename T>
-  requires requires(const T& value) { std::format("{}", value); }
-void set(std::string option, const T& value)
-{
-  if (option[0] != '-')
-    option = '-' + option;
-
-  common::petsc::check(PetscOptionsSetValue(nullptr, option.c_str(),
-                                            std::format("{}", value).c_str()),
-                       "PetscOptionsSetValue");
-}
-
-/// Clear a PETSc option
-void clear(std::string option);
-
-/// Clear PETSc global options database
-void clear();
-} // namespace options
 
 /// A simple wrapper for a PETSc vector pointer (Vec). Its main purpose
 /// is to assist with memory/lifetime management of PETSc Vec objects.

--- a/cpp/dolfinx/la/petsc.h
+++ b/cpp/dolfinx/la/petsc.h
@@ -19,6 +19,7 @@
 #include <petscmat.h>
 #include <petscoptions.h>
 #include <petscvec.h>
+#include <source_location>
 #include <span>
 #include <string>
 #include <string_view>
@@ -36,9 +37,29 @@ class SparsityPattern;
 /// @brief PETSc linear algebra functions
 namespace petsc
 {
-/// Print error message for PETSc calls that return an error
-void error(PetscErrorCode error_code, std::string_view filename,
-           std::string_view petsc_function);
+/// @brief Print error message for a PETSc call that returned an error
+/// and throw a std::runtime_error.
+/// @param[in] error_code PETSc error code
+/// @param[in] petsc_function Name of the PETSc function that returned
+/// `error_code`
+/// @param[in] loc Call site of the failed PETSc call (captured
+/// automatically; do not pass explicitly)
+void error(PetscErrorCode error_code, std::string_view petsc_function,
+           std::source_location loc = std::source_location::current());
+
+/// @brief Throw a std::runtime_error via error() if `ierr` indicates a
+/// PETSc call failed.
+/// @param[in] ierr PETSc error code returned by `petsc_function`
+/// @param[in] petsc_function Name of the PETSc function that returned
+/// `ierr`
+/// @param[in] loc Call site of the failed PETSc call (captured
+/// automatically; do not pass explicitly)
+inline void check(PetscErrorCode ierr, std::string_view petsc_function,
+                  std::source_location loc = std::source_location::current())
+{
+  if (ierr != 0)
+    error(ierr, petsc_function, loc);
+}
 
 /// Create PETSc vectors from the local data. The data is copied into
 /// the PETSc vectors and is not shared. Each vector's global size is
@@ -159,8 +180,7 @@ void set(std::string option, const T& value)
   PetscErrorCode ierr;
   ierr = PetscOptionsSetValue(nullptr, option.c_str(),
                               std::format("{}", value).c_str());
-  if (ierr != 0)
-    petsc::error(ierr, __FILE__, "PetscOptionsSetValue");
+  petsc::check(ierr, "PetscOptionsSetValue");
 }
 
 /// Clear a PETSc option
@@ -281,8 +301,7 @@ public:
 #endif
 
 #ifndef NDEBUG
-      if (ierr != 0)
-        petsc::error(ierr, __FILE__, "MatSetValuesLocal");
+      petsc::check(ierr, "MatSetValuesLocal");
 #endif
       return ierr;
     };
@@ -315,8 +334,7 @@ public:
 #endif
 
 #ifndef NDEBUG
-      if (ierr != 0)
-        petsc::error(ierr, __FILE__, "MatSetValuesBlockedLocal");
+      petsc::check(ierr, "MatSetValuesBlockedLocal");
 #endif
       return ierr;
     };
@@ -354,8 +372,7 @@ public:
       ierr = MatSetValuesLocal(A, cache0.size(), cache0.data(), cache1.size(),
                                cache1.data(), vals.data(), mode);
 #ifndef NDEBUG
-      if (ierr != 0)
-        petsc::error(ierr, __FILE__, "MatSetValuesLocal");
+      petsc::check(ierr, "MatSetValuesLocal");
 #endif
       return ierr;
     };

--- a/cpp/dolfinx/la/slepc.cpp
+++ b/cpp/dolfinx/la/slepc.cpp
@@ -42,8 +42,10 @@ SLEPcEigenSolver::SLEPcEigenSolver(SLEPcEigenSolver&& solver) noexcept
 //-----------------------------------------------------------------------------
 SLEPcEigenSolver::~SLEPcEigenSolver()
 {
+  // Destructor is implicitly noexcept, so a thrown error here calls
+  // std::terminate rather than propagating
   if (_eps)
-    EPSDestroy(&_eps);
+    common::petsc::check(EPSDestroy(&_eps), "EPSDestroy");
 }
 //-----------------------------------------------------------------------------
 SLEPcEigenSolver&

--- a/cpp/dolfinx/la/slepc.cpp
+++ b/cpp/dolfinx/la/slepc.cpp
@@ -20,7 +20,7 @@ using namespace dolfinx::la;
 SLEPcEigenSolver::SLEPcEigenSolver(MPI_Comm comm) : _eps(nullptr)
 {
   PetscErrorCode ierr = EPSCreate(comm, &_eps);
-  petsc::check(ierr, "EPSCreate");
+  common::petsc::check(ierr, "EPSCreate");
 }
 //-----------------------------------------------------------------------------
 SLEPcEigenSolver::SLEPcEigenSolver(EPS eps, bool inc_ref_count) : _eps(eps)
@@ -31,7 +31,7 @@ SLEPcEigenSolver::SLEPcEigenSolver(EPS eps, bool inc_ref_count) : _eps(eps)
   if (inc_ref_count)
   {
     PetscErrorCode ierr = PetscObjectReference((PetscObject)_eps);
-    petsc::check(ierr, "PetscObjectReference");
+    common::petsc::check(ierr, "PetscObjectReference");
   }
 }
 //-----------------------------------------------------------------------------
@@ -59,7 +59,7 @@ void SLEPcEigenSolver::set_operators(const Mat A, const Mat B)
   assert(A);
   assert(_eps);
   PetscErrorCode ierr = EPSSetOperators(_eps, A, B);
-  petsc::check(ierr, "EPSSetOperators");
+  common::petsc::check(ierr, "EPSSetOperators");
 }
 //-----------------------------------------------------------------------------
 void SLEPcEigenSolver::solve()
@@ -69,23 +69,23 @@ void SLEPcEigenSolver::solve()
   // Solve eigenvalue problem. EPSSetUp errors if no operators have been
   // set
   PetscErrorCode ierr = EPSSolve(_eps);
-  petsc::check(ierr, "EPSSolve");
+  common::petsc::check(ierr, "EPSSolve");
 
   // Check for convergence
   EPSConvergedReason reason;
   ierr = EPSGetConvergedReason(_eps, &reason);
-  petsc::check(ierr, "EPSGetConvergedReason");
+  common::petsc::check(ierr, "EPSGetConvergedReason");
   if (reason < 0)
     spdlog::warn("Eigenvalue solver did not converge");
 
   // Report solver status
   PetscInt num_iterations = 0;
   ierr = EPSGetIterationNumber(_eps, &num_iterations);
-  petsc::check(ierr, "EPSGetIterationNumber");
+  common::petsc::check(ierr, "EPSGetIterationNumber");
 
   EPSType eps_type = nullptr;
   ierr = EPSGetType(_eps, &eps_type);
-  petsc::check(ierr, "EPSGetType");
+  common::petsc::check(ierr, "EPSGetType");
   spdlog::info("Eigenvalue solver ({}) converged in {} iterations.",
                eps_type ? eps_type : "unknown", num_iterations);
 }
@@ -100,12 +100,12 @@ std::complex<PetscReal> SLEPcEigenSolver::get_eigenvalue(PetscInt i) const
 #ifdef PETSC_USE_COMPLEX
   PetscScalar l;
   ierr = EPSGetEigenvalue(_eps, i, &l, nullptr);
-  petsc::check(ierr, "EPSGetEigenvalue");
+  common::petsc::check(ierr, "EPSGetEigenvalue");
   return l;
 #else
   PetscScalar lr, li;
   ierr = EPSGetEigenvalue(_eps, i, &lr, &li);
-  petsc::check(ierr, "EPSGetEigenvalue");
+  common::petsc::check(ierr, "EPSGetEigenvalue");
   return std::complex<PetscReal>(lr, li);
 #endif
 }
@@ -118,7 +118,7 @@ void SLEPcEigenSolver::get_eigenpair(PetscScalar& lr, PetscScalar& lc, Vec r,
   // EPSGetEigenpair checks that the problem has been solved and that i
   // is in range
   PetscErrorCode ierr = EPSGetEigenpair(_eps, i, &lr, &lc, r, c);
-  petsc::check(ierr, "EPSGetEigenpair");
+  common::petsc::check(ierr, "EPSGetEigenpair");
 }
 //-----------------------------------------------------------------------------
 void SLEPcEigenSolver::set_options_prefix(std::string_view options_prefix)
@@ -126,7 +126,7 @@ void SLEPcEigenSolver::set_options_prefix(std::string_view options_prefix)
   assert(_eps);
   PetscErrorCode ierr
       = EPSSetOptionsPrefix(_eps, std::string(options_prefix).c_str());
-  petsc::check(ierr, "EPSSetOptionsPrefix");
+  common::petsc::check(ierr, "EPSSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string SLEPcEigenSolver::get_options_prefix() const
@@ -134,7 +134,7 @@ std::string SLEPcEigenSolver::get_options_prefix() const
   assert(_eps);
   const char* prefix = nullptr;
   PetscErrorCode ierr = EPSGetOptionsPrefix(_eps, &prefix);
-  petsc::check(ierr, "EPSGetOptionsPrefix");
+  common::petsc::check(ierr, "EPSGetOptionsPrefix");
   return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
@@ -142,7 +142,7 @@ void SLEPcEigenSolver::set_from_options() const
 {
   assert(_eps);
   PetscErrorCode ierr = EPSSetFromOptions(_eps);
-  petsc::check(ierr, "EPSSetFromOptions");
+  common::petsc::check(ierr, "EPSSetFromOptions");
 }
 //-----------------------------------------------------------------------------
 EPS SLEPcEigenSolver::eps() const { return _eps; }
@@ -152,7 +152,7 @@ MPI_Comm SLEPcEigenSolver::comm() const
   assert(_eps);
   MPI_Comm mpi_comm = MPI_COMM_NULL;
   PetscErrorCode ierr = PetscObjectGetComm((PetscObject)_eps, &mpi_comm);
-  petsc::check(ierr, "PetscObjectGetComm");
+  common::petsc::check(ierr, "PetscObjectGetComm");
   return mpi_comm;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/la/slepc.cpp
+++ b/cpp/dolfinx/la/slepc.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005-2018 Garth N. Wells
+// Copyright (C) 2005-2026 Garth N. Wells and Jack S. Hale
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //

--- a/cpp/dolfinx/la/slepc.cpp
+++ b/cpp/dolfinx/la/slepc.cpp
@@ -17,18 +17,10 @@ using namespace dolfinx;
 using namespace dolfinx::la;
 
 //-----------------------------------------------------------------------------
-#define CHECK_ERROR(NAME)                                                      \
-  do                                                                           \
-  {                                                                            \
-    if (ierr != 0)                                                             \
-      petsc::error(ierr, __FILE__, NAME);                                      \
-  } while (0)
-
-//-----------------------------------------------------------------------------
 SLEPcEigenSolver::SLEPcEigenSolver(MPI_Comm comm) : _eps(nullptr)
 {
   PetscErrorCode ierr = EPSCreate(comm, &_eps);
-  CHECK_ERROR("EPSCreate");
+  petsc::check(ierr, "EPSCreate");
 }
 //-----------------------------------------------------------------------------
 SLEPcEigenSolver::SLEPcEigenSolver(EPS eps, bool inc_ref_count) : _eps(eps)
@@ -39,7 +31,7 @@ SLEPcEigenSolver::SLEPcEigenSolver(EPS eps, bool inc_ref_count) : _eps(eps)
   if (inc_ref_count)
   {
     PetscErrorCode ierr = PetscObjectReference((PetscObject)_eps);
-    CHECK_ERROR("PetscObjectReference");
+    petsc::check(ierr, "PetscObjectReference");
   }
 }
 //-----------------------------------------------------------------------------
@@ -67,7 +59,7 @@ void SLEPcEigenSolver::set_operators(const Mat A, const Mat B)
   assert(A);
   assert(_eps);
   PetscErrorCode ierr = EPSSetOperators(_eps, A, B);
-  CHECK_ERROR("EPSSetOperators");
+  petsc::check(ierr, "EPSSetOperators");
 }
 //-----------------------------------------------------------------------------
 void SLEPcEigenSolver::solve()
@@ -77,23 +69,23 @@ void SLEPcEigenSolver::solve()
   // Solve eigenvalue problem. EPSSetUp errors if no operators have been
   // set
   PetscErrorCode ierr = EPSSolve(_eps);
-  CHECK_ERROR("EPSSolve");
+  petsc::check(ierr, "EPSSolve");
 
   // Check for convergence
   EPSConvergedReason reason;
   ierr = EPSGetConvergedReason(_eps, &reason);
-  CHECK_ERROR("EPSGetConvergedReason");
+  petsc::check(ierr, "EPSGetConvergedReason");
   if (reason < 0)
     spdlog::warn("Eigenvalue solver did not converge");
 
   // Report solver status
   PetscInt num_iterations = 0;
   ierr = EPSGetIterationNumber(_eps, &num_iterations);
-  CHECK_ERROR("EPSGetIterationNumber");
+  petsc::check(ierr, "EPSGetIterationNumber");
 
   EPSType eps_type = nullptr;
   ierr = EPSGetType(_eps, &eps_type);
-  CHECK_ERROR("EPSGetType");
+  petsc::check(ierr, "EPSGetType");
   spdlog::info("Eigenvalue solver ({}) converged in {} iterations.",
                eps_type ? eps_type : "unknown", num_iterations);
 }
@@ -108,12 +100,12 @@ std::complex<PetscReal> SLEPcEigenSolver::get_eigenvalue(PetscInt i) const
 #ifdef PETSC_USE_COMPLEX
   PetscScalar l;
   ierr = EPSGetEigenvalue(_eps, i, &l, nullptr);
-  CHECK_ERROR("EPSGetEigenvalue");
+  petsc::check(ierr, "EPSGetEigenvalue");
   return l;
 #else
   PetscScalar lr, li;
   ierr = EPSGetEigenvalue(_eps, i, &lr, &li);
-  CHECK_ERROR("EPSGetEigenvalue");
+  petsc::check(ierr, "EPSGetEigenvalue");
   return std::complex<PetscReal>(lr, li);
 #endif
 }
@@ -126,7 +118,7 @@ void SLEPcEigenSolver::get_eigenpair(PetscScalar& lr, PetscScalar& lc, Vec r,
   // EPSGetEigenpair checks that the problem has been solved and that i
   // is in range
   PetscErrorCode ierr = EPSGetEigenpair(_eps, i, &lr, &lc, r, c);
-  CHECK_ERROR("EPSGetEigenpair");
+  petsc::check(ierr, "EPSGetEigenpair");
 }
 //-----------------------------------------------------------------------------
 void SLEPcEigenSolver::set_options_prefix(std::string_view options_prefix)
@@ -134,7 +126,7 @@ void SLEPcEigenSolver::set_options_prefix(std::string_view options_prefix)
   assert(_eps);
   PetscErrorCode ierr
       = EPSSetOptionsPrefix(_eps, std::string(options_prefix).c_str());
-  CHECK_ERROR("EPSSetOptionsPrefix");
+  petsc::check(ierr, "EPSSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string SLEPcEigenSolver::get_options_prefix() const
@@ -142,7 +134,7 @@ std::string SLEPcEigenSolver::get_options_prefix() const
   assert(_eps);
   const char* prefix = nullptr;
   PetscErrorCode ierr = EPSGetOptionsPrefix(_eps, &prefix);
-  CHECK_ERROR("EPSGetOptionsPrefix");
+  petsc::check(ierr, "EPSGetOptionsPrefix");
   return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
@@ -150,7 +142,7 @@ void SLEPcEigenSolver::set_from_options() const
 {
   assert(_eps);
   PetscErrorCode ierr = EPSSetFromOptions(_eps);
-  CHECK_ERROR("EPSSetFromOptions");
+  petsc::check(ierr, "EPSSetFromOptions");
 }
 //-----------------------------------------------------------------------------
 EPS SLEPcEigenSolver::eps() const { return _eps; }
@@ -160,7 +152,7 @@ MPI_Comm SLEPcEigenSolver::comm() const
   assert(_eps);
   MPI_Comm mpi_comm = MPI_COMM_NULL;
   PetscErrorCode ierr = PetscObjectGetComm((PetscObject)_eps, &mpi_comm);
-  CHECK_ERROR("PetscObjectGetComm");
+  petsc::check(ierr, "PetscObjectGetComm");
   return mpi_comm;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/la/slepc.cpp
+++ b/cpp/dolfinx/la/slepc.cpp
@@ -19,8 +19,7 @@ using namespace dolfinx::la;
 //-----------------------------------------------------------------------------
 SLEPcEigenSolver::SLEPcEigenSolver(MPI_Comm comm) : _eps(nullptr)
 {
-  PetscErrorCode ierr = EPSCreate(comm, &_eps);
-  common::petsc::check(ierr, "EPSCreate");
+  common::petsc::check(EPSCreate(comm, &_eps), "EPSCreate");
 }
 //-----------------------------------------------------------------------------
 SLEPcEigenSolver::SLEPcEigenSolver(EPS eps, bool inc_ref_count) : _eps(eps)
@@ -30,8 +29,8 @@ SLEPcEigenSolver::SLEPcEigenSolver(EPS eps, bool inc_ref_count) : _eps(eps)
 
   if (inc_ref_count)
   {
-    PetscErrorCode ierr = PetscObjectReference((PetscObject)_eps);
-    common::petsc::check(ierr, "PetscObjectReference");
+    common::petsc::check(PetscObjectReference((PetscObject)_eps),
+                         "PetscObjectReference");
   }
 }
 //-----------------------------------------------------------------------------
@@ -58,8 +57,7 @@ void SLEPcEigenSolver::set_operators(const Mat A, const Mat B)
 {
   assert(A);
   assert(_eps);
-  PetscErrorCode ierr = EPSSetOperators(_eps, A, B);
-  common::petsc::check(ierr, "EPSSetOperators");
+  common::petsc::check(EPSSetOperators(_eps, A, B), "EPSSetOperators");
 }
 //-----------------------------------------------------------------------------
 void SLEPcEigenSolver::solve()
@@ -68,24 +66,22 @@ void SLEPcEigenSolver::solve()
 
   // Solve eigenvalue problem. EPSSetUp errors if no operators have been
   // set
-  PetscErrorCode ierr = EPSSolve(_eps);
-  common::petsc::check(ierr, "EPSSolve");
+  common::petsc::check(EPSSolve(_eps), "EPSSolve");
 
   // Check for convergence
   EPSConvergedReason reason;
-  ierr = EPSGetConvergedReason(_eps, &reason);
-  common::petsc::check(ierr, "EPSGetConvergedReason");
+  common::petsc::check(EPSGetConvergedReason(_eps, &reason),
+                       "EPSGetConvergedReason");
   if (reason < 0)
     spdlog::warn("Eigenvalue solver did not converge");
 
   // Report solver status
   PetscInt num_iterations = 0;
-  ierr = EPSGetIterationNumber(_eps, &num_iterations);
-  common::petsc::check(ierr, "EPSGetIterationNumber");
+  common::petsc::check(EPSGetIterationNumber(_eps, &num_iterations),
+                       "EPSGetIterationNumber");
 
   EPSType eps_type = nullptr;
-  ierr = EPSGetType(_eps, &eps_type);
-  common::petsc::check(ierr, "EPSGetType");
+  common::petsc::check(EPSGetType(_eps, &eps_type), "EPSGetType");
   spdlog::info("Eigenvalue solver ({}) converged in {} iterations.",
                eps_type ? eps_type : "unknown", num_iterations);
 }
@@ -96,16 +92,14 @@ std::complex<PetscReal> SLEPcEigenSolver::get_eigenvalue(PetscInt i) const
 
   // EPSGetEigenvalue checks that the problem has been solved and that i
   // is in range
-  PetscErrorCode ierr;
 #ifdef PETSC_USE_COMPLEX
   PetscScalar l;
-  ierr = EPSGetEigenvalue(_eps, i, &l, nullptr);
-  common::petsc::check(ierr, "EPSGetEigenvalue");
+  common::petsc::check(EPSGetEigenvalue(_eps, i, &l, nullptr),
+                       "EPSGetEigenvalue");
   return l;
 #else
   PetscScalar lr, li;
-  ierr = EPSGetEigenvalue(_eps, i, &lr, &li);
-  common::petsc::check(ierr, "EPSGetEigenvalue");
+  common::petsc::check(EPSGetEigenvalue(_eps, i, &lr, &li), "EPSGetEigenvalue");
   return std::complex<PetscReal>(lr, li);
 #endif
 }
@@ -117,32 +111,31 @@ void SLEPcEigenSolver::get_eigenpair(PetscScalar& lr, PetscScalar& lc, Vec r,
 
   // EPSGetEigenpair checks that the problem has been solved and that i
   // is in range
-  PetscErrorCode ierr = EPSGetEigenpair(_eps, i, &lr, &lc, r, c);
-  common::petsc::check(ierr, "EPSGetEigenpair");
+  common::petsc::check(EPSGetEigenpair(_eps, i, &lr, &lc, r, c),
+                       "EPSGetEigenpair");
 }
 //-----------------------------------------------------------------------------
 void SLEPcEigenSolver::set_options_prefix(std::string_view options_prefix)
 {
   assert(_eps);
-  PetscErrorCode ierr
-      = EPSSetOptionsPrefix(_eps, std::string(options_prefix).c_str());
-  common::petsc::check(ierr, "EPSSetOptionsPrefix");
+  common::petsc::check(
+      EPSSetOptionsPrefix(_eps, std::string(options_prefix).c_str()),
+      "EPSSetOptionsPrefix");
 }
 //-----------------------------------------------------------------------------
 std::string SLEPcEigenSolver::get_options_prefix() const
 {
   assert(_eps);
   const char* prefix = nullptr;
-  PetscErrorCode ierr = EPSGetOptionsPrefix(_eps, &prefix);
-  common::petsc::check(ierr, "EPSGetOptionsPrefix");
+  common::petsc::check(EPSGetOptionsPrefix(_eps, &prefix),
+                       "EPSGetOptionsPrefix");
   return prefix ? std::string(prefix) : std::string();
 }
 //-----------------------------------------------------------------------------
 void SLEPcEigenSolver::set_from_options() const
 {
   assert(_eps);
-  PetscErrorCode ierr = EPSSetFromOptions(_eps);
-  common::petsc::check(ierr, "EPSSetFromOptions");
+  common::petsc::check(EPSSetFromOptions(_eps), "EPSSetFromOptions");
 }
 //-----------------------------------------------------------------------------
 EPS SLEPcEigenSolver::eps() const { return _eps; }
@@ -151,8 +144,8 @@ MPI_Comm SLEPcEigenSolver::comm() const
 {
   assert(_eps);
   MPI_Comm mpi_comm = MPI_COMM_NULL;
-  PetscErrorCode ierr = PetscObjectGetComm((PetscObject)_eps, &mpi_comm);
-  common::petsc::check(ierr, "PetscObjectGetComm");
+  common::petsc::check(PetscObjectGetComm((PetscObject)_eps, &mpi_comm),
+                       "PetscObjectGetComm");
   return mpi_comm;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/nls/NewtonSolver.cpp
+++ b/cpp/dolfinx/nls/NewtonSolver.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2005-2021 Garth N. Wells
+// Copyright (C) 2005-2026 Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //

--- a/cpp/dolfinx/nls/NewtonSolver.cpp
+++ b/cpp/dolfinx/nls/NewtonSolver.cpp
@@ -77,8 +77,8 @@ nls::petsc::NewtonSolver::NewtonSolver(MPI_Comm comm)
                "removed in a future release.\n";
   // Create linear solver if not already created. Default to LU.
   _solver.set_options_prefix("nls_solve_");
-  la::petsc::options::set("nls_solve_ksp_type", "preonly");
-  la::petsc::options::set("nls_solve_pc_type", "lu");
+  common::petsc::set_option("nls_solve_ksp_type", "preonly");
+  common::petsc::set_option("nls_solve_pc_type", "lu");
   _solver.set_from_options();
 }
 //-----------------------------------------------------------------------------

--- a/cpp/test/petsc.cpp
+++ b/cpp/test/petsc.cpp
@@ -39,8 +39,8 @@ TEST_CASE("PETSc wrappers reject null handles", "[petsc]")
   // is examined, so both values must be rejected.
   CHECK_THROWS_AS(la::petsc::Vector(nullptr, true), std::runtime_error);
   CHECK_THROWS_AS(la::petsc::Vector(nullptr, false), std::runtime_error);
-  CHECK_THROWS_AS(la::petsc::Operator(nullptr, true), std::runtime_error);
-  CHECK_THROWS_AS(la::petsc::Operator(nullptr, false), std::runtime_error);
+  CHECK_THROWS_AS(la::petsc::Matrix(nullptr, true), std::runtime_error);
+  CHECK_THROWS_AS(la::petsc::Matrix(nullptr, false), std::runtime_error);
   CHECK_THROWS_AS(la::petsc::KrylovSolver(nullptr, true), std::runtime_error);
   CHECK_THROWS_AS(la::petsc::KrylovSolver(nullptr, false), std::runtime_error);
 }
@@ -51,7 +51,7 @@ TEST_CASE("PETSc wrappers manage reference counts", "[petsc]")
 
   PetscInt refs = 0;
 
-  SECTION("Operator, inc_ref_count = true shares ownership")
+  SECTION("Matrix, inc_ref_count = true shares ownership")
   {
     Mat A = nullptr;
     CHECK(MatCreate(MPI_COMM_WORLD, &A) == 0);
@@ -62,7 +62,7 @@ TEST_CASE("PETSc wrappers manage reference counts", "[petsc]")
     CHECK(MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY) == 0);
 
     {
-      la::petsc::Operator op(A, true);
+      la::petsc::Matrix op(A, true);
       CHECK(PetscObjectGetReference((PetscObject)A, &refs) == 0);
       CHECK(refs == 2);
     }
@@ -73,7 +73,7 @@ TEST_CASE("PETSc wrappers manage reference counts", "[petsc]")
     CHECK(MatDestroy(&A) == 0);
   }
 
-  SECTION("Operator, inc_ref_count = false takes ownership")
+  SECTION("Matrix, inc_ref_count = false takes ownership")
   {
     Mat A = nullptr;
     CHECK(MatCreate(MPI_COMM_WORLD, &A) == 0);
@@ -86,7 +86,7 @@ TEST_CASE("PETSc wrappers manage reference counts", "[petsc]")
     // No caller-side reference remains once the wrapper is constructed;
     // destroying it must be the only thing that frees A (nothing left
     // here to double-destroy).
-    la::petsc::Operator op(A, false);
+    la::petsc::Matrix op(A, false);
     CHECK(PetscObjectGetReference((PetscObject)op.mat(), &refs) == 0);
     CHECK(refs == 1);
   }

--- a/cpp/test/slepc.cpp
+++ b/cpp/test/slepc.cpp
@@ -34,21 +34,21 @@ constexpr double eig_rtol
 Mat create_diagonal_matrix(PetscInt N)
 {
   Mat A = nullptr;
-  MatCreate(MPI_COMM_WORLD, &A);
-  MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, N, N);
-  MatSetType(A, MATAIJ);
-  MatSetUp(A);
+  CHECK(MatCreate(MPI_COMM_WORLD, &A) == 0);
+  CHECK(MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, N, N) == 0);
+  CHECK(MatSetType(A, MATAIJ) == 0);
+  CHECK(MatSetUp(A) == 0);
 
   PetscInt r0 = 0, r1 = 0;
-  MatGetOwnershipRange(A, &r0, &r1);
+  CHECK(MatGetOwnershipRange(A, &r0, &r1) == 0);
   for (PetscInt i = r0; i < r1; ++i)
   {
     PetscScalar v = static_cast<PetscReal>(i + 1);
-    MatSetValues(A, 1, &i, 1, &i, &v, INSERT_VALUES);
+    CHECK(MatSetValues(A, 1, &i, 1, &i, &v, INSERT_VALUES) == 0);
   }
 
-  MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
-  MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
+  CHECK(MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY) == 0);
+  CHECK(MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY) == 0);
   return A;
 }
 
@@ -60,14 +60,14 @@ Mat create_conjugate_pair_matrix(PetscInt num_blocks)
 {
   const PetscInt N = 2 * num_blocks;
   Mat A = nullptr;
-  MatCreate(MPI_COMM_WORLD, &A);
-  MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, N, N);
-  MatSetType(A, MATAIJ);
-  MatSeqAIJSetPreallocation(A, 2, nullptr);
-  MatMPIAIJSetPreallocation(A, 2, nullptr, 2, nullptr);
+  CHECK(MatCreate(MPI_COMM_WORLD, &A) == 0);
+  CHECK(MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, N, N) == 0);
+  CHECK(MatSetType(A, MATAIJ) == 0);
+  CHECK(MatSeqAIJSetPreallocation(A, 2, nullptr) == 0);
+  CHECK(MatMPIAIJSetPreallocation(A, 2, nullptr, 2, nullptr) == 0);
 
   PetscInt r0 = 0, r1 = 0;
-  MatGetOwnershipRange(A, &r0, &r1);
+  CHECK(MatGetOwnershipRange(A, &r0, &r1) == 0);
   for (PetscInt i = r0; i < r1; ++i)
   {
     const PetscInt block = i / 2;
@@ -76,18 +76,18 @@ Mat create_conjugate_pair_matrix(PetscInt num_blocks)
     {
       const PetscInt cols[2] = {i, i + 1};
       const PetscScalar vals[2] = {a, -a};
-      MatSetValues(A, 1, &i, 2, cols, vals, INSERT_VALUES);
+      CHECK(MatSetValues(A, 1, &i, 2, cols, vals, INSERT_VALUES) == 0);
     }
     else
     {
       const PetscInt cols[2] = {i - 1, i};
       const PetscScalar vals[2] = {a, a};
-      MatSetValues(A, 1, &i, 2, cols, vals, INSERT_VALUES);
+      CHECK(MatSetValues(A, 1, &i, 2, cols, vals, INSERT_VALUES) == 0);
     }
   }
 
-  MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY);
-  MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
+  CHECK(MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY) == 0);
+  CHECK(MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY) == 0);
   return A;
 }
 } // namespace
@@ -108,14 +108,15 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
 
     // Diagonal matrix is Hermitian; ask for the largest eigenvalues,
     // which Krylov methods recover first
-    EPSSetProblemType(solver.eps(), EPS_HEP);
-    EPSSetWhichEigenpairs(solver.eps(), EPS_LARGEST_MAGNITUDE);
-    EPSSetDimensions(solver.eps(), 3, PETSC_DETERMINE, PETSC_DETERMINE);
+    CHECK(EPSSetProblemType(solver.eps(), EPS_HEP) == 0);
+    CHECK(EPSSetWhichEigenpairs(solver.eps(), EPS_LARGEST_MAGNITUDE) == 0);
+    CHECK(EPSSetDimensions(solver.eps(), 3, PETSC_DETERMINE, PETSC_DETERMINE)
+          == 0);
 
     solver.solve();
 
     PetscInt nconv = 0;
-    EPSGetConverged(solver.eps(), &nconv);
+    CHECK(EPSGetConverged(solver.eps(), &nconv) == 0);
     REQUIRE(nconv >= 3);
 
     // Spectrum is {1, ..., N}, so the three largest are N, N-1, N-2
@@ -132,16 +133,16 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
     SECTION("Eigenpair matches eigenvalue")
     {
       Vec r = nullptr, c = nullptr;
-      MatCreateVecs(A, nullptr, &r);
-      MatCreateVecs(A, nullptr, &c);
+      CHECK(MatCreateVecs(A, nullptr, &r) == 0);
+      CHECK(MatCreateVecs(A, nullptr, &c) == 0);
 
       PetscScalar lr = 0, lc = 0;
       solver.get_eigenpair(lr, lc, r, c, 0);
       CHECK_THAT(static_cast<double>(PetscRealPart(lr)),
                  Catch::Matchers::WithinRel(static_cast<double>(N), eig_rtol));
 
-      VecDestroy(&r);
-      VecDestroy(&c);
+      CHECK(VecDestroy(&r) == 0);
+      CHECK(VecDestroy(&c) == 0);
     }
 
     // SLEPc rejects these itself; the point is that the return code is
@@ -157,7 +158,7 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
                       std::runtime_error);
     }
 
-    MatDestroy(&A);
+    CHECK(MatDestroy(&A) == 0);
   }
 
   SECTION("Complex conjugate eigenpair of a non-symmetric operator")
@@ -167,13 +168,14 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
     la::SLEPcEigenSolver solver(MPI_COMM_WORLD);
     solver.set_operators(A, nullptr);
 
-    EPSSetProblemType(solver.eps(), EPS_NHEP);
-    EPSSetWhichEigenpairs(solver.eps(), EPS_LARGEST_MAGNITUDE);
-    EPSSetDimensions(solver.eps(), 2, PETSC_DETERMINE, PETSC_DETERMINE);
+    CHECK(EPSSetProblemType(solver.eps(), EPS_NHEP) == 0);
+    CHECK(EPSSetWhichEigenpairs(solver.eps(), EPS_LARGEST_MAGNITUDE) == 0);
+    CHECK(EPSSetDimensions(solver.eps(), 2, PETSC_DETERMINE, PETSC_DETERMINE)
+          == 0);
 
     solver.solve();
     PetscInt nconv = 0;
-    EPSGetConverged(solver.eps(), &nconv);
+    CHECK(EPSGetConverged(solver.eps(), &nconv) == 0);
     REQUIRE(nconv >= 2);
 
     // get_eigenvalue is independent of the PETSc scalar type: the pair
@@ -214,7 +216,7 @@ TEST_CASE("SLEPc eigenvalue solver", "[slepc]")
 #endif
     }
 
-    MatDestroy(&A);
+    CHECK(MatDestroy(&A) == 0);
   }
 
   SECTION("Solving before setting operators throws")

--- a/python/dolfinx/wrappers/dolfinx_wrappers/petsc.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/petsc.h
@@ -14,6 +14,7 @@
 #include "pycoeff.h"
 #include <concepts>
 #include <dolfinx/common/IndexMap.h>
+#include <dolfinx/common/petsc.h>
 #include <dolfinx/fem/DirichletBC.h>
 #include <dolfinx/fem/DofMap.h>
 #include <dolfinx/fem/FiniteElement.h>
@@ -86,13 +87,17 @@ void declare_petsc_discrete_operators(nb::module_& m)
         Mat A = dolfinx::la::petsc::create_matrix(comm, sp);
         try
         {
-          MatSetOption(A, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE);
+          dolfinx::common::petsc::check(
+              MatSetOption(A, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE),
+              "MatSetOption");
           dolfinx::fem::discrete_curl<U, T>(
               V0, V1, dolfinx::la::petsc::Matrix::set_fn(A, INSERT_VALUES));
         }
         catch (...)
         {
-          MatDestroy(&A);
+          // Already unwinding, so a thrown error here calls
+          // std::terminate rather than propagating
+          dolfinx::common::petsc::check(MatDestroy(&A), "MatDestroy");
           throw;
         }
         return A;
@@ -134,7 +139,9 @@ void declare_petsc_discrete_operators(nb::module_& m)
         Mat A = dolfinx::la::petsc::create_matrix(comm, sp);
         try
         {
-          MatSetOption(A, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE);
+          dolfinx::common::petsc::check(
+              MatSetOption(A, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE),
+              "MatSetOption");
           dolfinx::fem::discrete_gradient<T, U>(
               *V0.mesh()->topology_mutable(), {*V0.element(), *V0.dofmap()},
               {*V1.element(), *V1.dofmap()},
@@ -142,7 +149,9 @@ void declare_petsc_discrete_operators(nb::module_& m)
         }
         catch (...)
         {
-          MatDestroy(&A);
+          // Already unwinding, so a thrown error here calls
+          // std::terminate rather than propagating
+          dolfinx::common::petsc::check(MatDestroy(&A), "MatDestroy");
           throw;
         }
         return A;
@@ -183,13 +192,17 @@ void declare_petsc_discrete_operators(nb::module_& m)
         Mat A = dolfinx::la::petsc::create_matrix(comm, sp);
         try
         {
-          MatSetOption(A, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE);
+          dolfinx::common::petsc::check(
+              MatSetOption(A, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE),
+              "MatSetOption");
           dolfinx::fem::interpolation_matrix<T, U>(
               V0, V1, dolfinx::la::petsc::Matrix::set_block_fn(A, ADD_VALUES));
         }
         catch (...)
         {
-          MatDestroy(&A);
+          // Already unwinding, so a thrown error here calls
+          // std::terminate rather than propagating
+          dolfinx::common::petsc::check(MatDestroy(&A), "MatDestroy");
           throw;
         }
         return A;

--- a/python/dolfinx/wrappers/petsc.cpp
+++ b/python/dolfinx/wrappers/petsc.cpp
@@ -60,8 +60,8 @@ to_index_map_refs(const std::vector<std::pair<U, int>>& maps)
 bool unit_block_size(Mat A)
 {
   PetscInt bs0 = -1, bs1 = -1;
-  if (PetscErrorCode ierr = MatGetBlockSizes(A, &bs0, &bs1); ierr != 0)
-    dolfinx::la::petsc::error(ierr, __FILE__, "MatGetBlockSizes");
+  PetscErrorCode ierr = MatGetBlockSizes(A, &bs0, &bs1);
+  dolfinx::la::petsc::check(ierr, "MatGetBlockSizes");
   return bs0 == 1 and bs1 == 1;
 }
 

--- a/python/dolfinx/wrappers/petsc.cpp
+++ b/python/dolfinx/wrappers/petsc.cpp
@@ -61,8 +61,8 @@ to_index_map_refs(const std::vector<std::pair<U, int>>& maps)
 bool unit_block_size(Mat A)
 {
   PetscInt bs0 = -1, bs1 = -1;
-  PetscErrorCode ierr = MatGetBlockSizes(A, &bs0, &bs1);
-  dolfinx::common::petsc::check(ierr, "MatGetBlockSizes");
+  dolfinx::common::petsc::check(MatGetBlockSizes(A, &bs0, &bs1),
+                                "MatGetBlockSizes");
   return bs0 == 1 and bs1 == 1;
 }
 

--- a/python/dolfinx/wrappers/petsc.cpp
+++ b/python/dolfinx/wrappers/petsc.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2025 Chris Richardson and Garth N. Wells
+// Copyright (C) 2017-2026 Chris Richardson and Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //

--- a/python/dolfinx/wrappers/petsc.cpp
+++ b/python/dolfinx/wrappers/petsc.cpp
@@ -10,6 +10,7 @@
 #include "dolfinx_wrappers/array.h"
 #include "dolfinx_wrappers/pycoeff.h"
 #include <dolfinx/common/IndexMap.h>
+#include <dolfinx/common/petsc.h>
 #include <dolfinx/fem/DirichletBC.h>
 #include <dolfinx/fem/DofMap.h>
 #include <dolfinx/fem/Form.h>
@@ -61,7 +62,7 @@ bool unit_block_size(Mat A)
 {
   PetscInt bs0 = -1, bs1 = -1;
   PetscErrorCode ierr = MatGetBlockSizes(A, &bs0, &bs1);
-  dolfinx::la::petsc::check(ierr, "MatGetBlockSizes");
+  dolfinx::common::petsc::check(ierr, "MatGetBlockSizes");
   return bs0 == 1 and bs1 == 1;
 }
 


### PR DESCRIPTION
## Summary

- Replace three independent copies of the `CHECK_ERROR` macro (in `la/petsc.{h,cpp}`, `fem/petsc.h`, `la/slepc.cpp`) with a single `check()`/`error()` function pair, usable from header-inline templates/lambdas where a macro couldn't be. `error()`/`check()` take a `std::source_location` defaulted to the call site instead of a caller-supplied `__FILE__`, so messages report the exact call-site line.
- Move `error()`/`check()` out of `la::petsc` into a new `dolfinx::common::petsc` namespace, since they are used well beyond `la` — by `la::slepc`, `fem::petsc`, `nls::NewtonSolver`, and the petsc4py wrapper — and don't depend on any `la`-specific type.
- Convert every `PetscErrorCode ierr = PetscCall(...); check(ierr, "PetscCall");` two-line pattern to a single inline `check(PetscCall(...), "PetscCall")` call, across `la::petsc`, `la::slepc`, `fem::petsc`, and the petsc4py wrapper, dropping the intermediate `ierr` variable wherever it wasn't needed afterward.
- Add `assert(error_code)` to `common::petsc::error()`, documenting that it is only ever reached from `check()` after a nonzero code.
- Move the PETSc options-database helpers (previously `la::petsc::options::set`/`clear`) into `common::petsc` for the same reason — already called from `nls::NewtonSolver` and several demos, not `la`-specific — flattening `options::set`/`options::clear` into plain `common::petsc::set_option`/`set_option<T>`/`clear_option`/`clear_options` functions rather than keeping a third-level namespace, matching the rest of the library's `dolfinx::<module>::<submodule>` convention.
- Fix three `Matrix` option-prefix methods (`set_options_prefix`, `get_options_prefix`, `set_from_options`) that were previously calling PETSc functions without checking the returned error code at all.
- Remove `la::petsc::Operator`, merging its members (`mat()`, `size()`, `create_vector(dim)`, `Mat` lifetime/ref-counting) directly into `la::petsc::Matrix`. `Matrix` was `Operator`'s only subclass and nothing in the codebase used `Operator` polymorphically, so the base class was pure indirection.
- Remove `Matrix::apply(AssemblyType)` and `Matrix::norm(Norm)`, confirmed unused everywhere in the codebase (demos and the Python layer call `MatAssemblyBegin`/`End` and `MatNorm` directly on the raw `Mat`).

## Why

`la::petsc` and its siblings had accumulated three independent, near-identical copies of the same error-checking macro; error-handling and options-database code that lived under `la::petsc` purely for historical reasons despite being used by `nls`, `fem`, `slepc`, and demos; an inconsistency in which methods actually checked PETSc return codes; and a base class with no remaining reason to exist. None of this changes observable behaviour except that a few previously-silent PETSc failures now correctly throw.

## Test plan

- [x] `cpp/test/petsc.cpp` and `cpp/test/slepc.cpp` pass (`Operator` reference-counting test sections renamed to exercise `Matrix` instead)
- [x] Full C++ library builds clean with `-Werror`; `ninja install` and the Python nanobind wrapper rebuild clean
- [x] All four affected demos (`poisson`, `biharmonic`, `hyperelasticity`, `mixed_poisson`) build and link clean
- [x] `clang-format --dry-run --Werror` clean on all touched files; `gersemi --check` clean on touched `CMakeLists.txt`

AI assistance: I used Claude to draft parts of this PR. I reviewed, edited, tested, and take responsibility for the final contribution.
