### PR TITLE
Reclassify fem exceptions to std::invalid_argument/std::out_of_range

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,9 +96,13 @@ disclosure process.
   the first comment draft, compress comments to their essence using
   concise technical language.
 - **Errors and invariants**: For user-facing/API-boundary errors, throw
-  `std::runtime_error` with a descriptive message — unconditionally when
-  the check is O(1), or guarded behind `#ifndef NDEBUG` when the check is
-  more expensive, so it's skipped in release builds. For internal
+  `std::invalid_argument` for a bad argument or violated parameter
+  precondition, `std::out_of_range` for an index/lookup-key failure, and
+  `std::runtime_error` for other runtime/state/IO/MPI failures. Do not
+  introduce a custom exception hierarchy. Use a descriptive message —
+  unconditionally when the check is O(1), or guarded behind
+  `#ifndef NDEBUG` when the check is more expensive, so it's skipped in
+  release builds. For internal
   invariants that indicate a library bug rather than bad user input, use
   `assert` when the check fits in a single expression, or a
   `#ifndef NDEBUG`-guarded block with an explicit throw/abort when it

--- a/cpp/dolfinx/fem/DirichletBC.cpp
+++ b/cpp/dolfinx/fem/DirichletBC.cpp
@@ -17,6 +17,7 @@
 #include <format>
 #include <map>
 #include <numeric>
+#include <stdexcept>
 #include <utility>
 
 using namespace dolfinx;
@@ -260,7 +261,7 @@ std::vector<std::int32_t> fem::locate_dofs_topological(
     }
   }
   else
-    throw std::runtime_error("Block size combination not supported");
+    throw std::invalid_argument("Block size combination not supported");
 
   // TODO: is removing duplicates at this point worth the effort?
   // Remove duplicates

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <optional>
 #include <span>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 #include <variant>
@@ -112,7 +113,7 @@ std::vector<std::int32_t> locate_dofs_geometrical(const FunctionSpace<T>& V,
     assert(V.elements(i));
     if (V.elements(i)->is_mixed())
     {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "Cannot locate dofs geometrically for mixed space. Use subspaces.");
     }
   }
@@ -169,13 +170,13 @@ std::array<std::vector<std::int32_t>, 2> locate_dofs_geometrical(
   assert(mesh);
   assert(V1.mesh());
   if (mesh != V1.mesh())
-    throw std::runtime_error("Meshes are not the same.");
+    throw std::invalid_argument("Meshes are not the same.");
   const int tdim = mesh->topology()->dim();
 
   assert(V0.element());
   assert(V1.element());
   if (*V0.element() != *V1.element())
-    throw std::runtime_error("Function spaces must have the same element.");
+    throw std::invalid_argument("Function spaces must have the same element.");
 
   // Compute dof coordinates
   const std::vector<T> dof_coordinates = V1.tabulate_dof_coordinates(true);
@@ -335,14 +336,14 @@ public:
     assert(V->elements(0));
     if (g->shape.size() != V->elements(0)->value_shape().size())
     {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "Rank mismatch between Constant and function space in DirichletBC");
     }
 
     if (g->value.size()
         != (std::size_t)_function_space->dofmaps().front()->bs())
     {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "Creating a DirichletBC using a Constant is not supported when the "
           "Constant size is not equal to the block size of the constrained "
           "(sub-)space. Use a fem::Function to create the fem::DirichletBC.");
@@ -350,7 +351,7 @@ public:
 
     if (!V->elements(0)->interpolation_ident())
     {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "Constant can be used only with point-evaluation elements");
     }
 

--- a/cpp/dolfinx/fem/DofMap.cpp
+++ b/cpp/dolfinx/fem/DofMap.cpp
@@ -15,6 +15,7 @@
 #include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/mesh/Topology.h>
 #include <memory>
+#include <stdexcept>
 #include <utility>
 
 using namespace dolfinx;
@@ -31,11 +32,11 @@ fem::DofMap build_collapsed_dofmap(const DofMap& dofmap_view)
 
   if (dofmap_view.element_dof_layout().block_size() > 1)
   {
-    throw std::runtime_error("Cannot collapse a dofmap view with "
-                             "block size greater "
-                             "than 1 when the parent has a block "
-                             "size of 1. Create new dofmap "
-                             "first.");
+    throw std::invalid_argument("Cannot collapse a dofmap view with "
+                                "block size greater "
+                                "than 1 when the parent has a block "
+                                "size of 1. Create new dofmap "
+                                "first.");
   }
 
   // Build set of dofs that are in the new dofmap (un-blocked)

--- a/cpp/dolfinx/fem/ElementDofLayout.cpp
+++ b/cpp/dolfinx/fem/ElementDofLayout.cpp
@@ -85,7 +85,7 @@ const ElementDofLayout&
 ElementDofLayout::sub_layout(std::span<const int> component) const
 {
   if (component.empty())
-    throw std::runtime_error("No sub dofmap specified");
+    throw std::invalid_argument("No sub dofmap specified");
   std::reference_wrapper<const ElementDofLayout> current
       = _sub_dofmaps.at(component[0]);
   for (std::size_t i = 1; i < component.size(); ++i)
@@ -107,7 +107,7 @@ ElementDofLayout::sub_view(std::span<const int> component) const
     // Switch to sub-dofmap
     assert(element_dofmap_current);
     if (i >= (int)element_dofmap_current->_sub_dofmaps.size())
-      throw std::runtime_error("Invalid component");
+      throw std::out_of_range("Invalid component");
     element_dofmap_current = &_sub_dofmaps.at(i);
 
     std::vector<int> dof_list_new(element_dofmap_current->_num_dofs

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -14,6 +14,7 @@
 #include <format>
 #include <functional>
 #include <numeric>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -51,22 +52,23 @@ _extract_sub_element(const FiniteElement<T>& finite_element,
   // Check that a sub system has been specified
   if (component.empty())
   {
-    throw std::runtime_error("Cannot extract subsystem of finite element. No "
-                             "system was specified");
+    throw std::invalid_argument(
+        "Cannot extract subsystem of finite element. No "
+        "system was specified");
   }
 
   // Check if there are any sub systems
   if (finite_element.num_sub_elements() == 0)
   {
-    throw std::runtime_error("Cannot extract subsystem of finite element. "
-                             "There are no subsystems.");
+    throw std::invalid_argument("Cannot extract subsystem of finite element. "
+                                "There are no subsystems.");
   }
 
   // Check the number of available sub systems
   if (component[0] >= finite_element.num_sub_elements())
   {
-    throw std::runtime_error("Cannot extract subsystem of finite element. "
-                             "Requested subsystem out of range.");
+    throw std::invalid_argument("Cannot extract subsystem of finite element. "
+                                "Requested subsystem out of range.");
   }
 
   // Get sub system
@@ -91,7 +93,7 @@ int _compute_block_size(std::optional<std::vector<std::size_t>> value_shape,
     if (value_shape->size() != 2
         or (value_shape->front() != value_shape->back()))
     {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "Symmetric elements require square rank-2 value shape.");
     }
 
@@ -130,8 +132,9 @@ FiniteElement<T>::FiniteElement(
 {
   if (value_shape and !element.value_shape().empty())
   {
-    throw std::runtime_error("Blocked finite elements can be constructed only "
-                             "from scalar base elements.");
+    throw std::invalid_argument(
+        "Blocked finite elements can be constructed only "
+        "from scalar base elements.");
   }
 
   if (value_shape)
@@ -416,8 +419,8 @@ const basix::FiniteElement<T>& FiniteElement<T>::basix_element() const
     return *_element;
   else
   {
-    throw std::runtime_error("No Basix element available. "
-                             "Maybe this is a mixed element?");
+    throw std::invalid_argument("No Basix element available. "
+                                "Maybe this is a mixed element?");
   }
 }
 //-----------------------------------------------------------------------------
@@ -428,8 +431,8 @@ basix::maps::type FiniteElement<T>::map_type() const
     return _element->map_type();
   else
   {
-    throw std::runtime_error("Cannot element map type - no Basix element "
-                             "available. Maybe this is a mixed element?");
+    throw std::invalid_argument("Cannot element map type - no Basix element "
+                                "available. Maybe this is a mixed element?");
   }
 }
 //-----------------------------------------------------------------------------
@@ -469,9 +472,9 @@ FiniteElement<T>::interpolation_points() const
   {
     if (!_element)
     {
-      throw std::runtime_error(
-          "Cannot get interpolation points - no Basix element available. Maybe "
-          "this is a mixed element?");
+      throw std::invalid_argument(
+          "Cannot get interpolation points - no Basix element available. "
+          "Maybe this is a mixed element?");
     }
 
     return _element->points();
@@ -499,8 +502,8 @@ FiniteElement<T>::create_interpolation_operator(const FiniteElement& from) const
   assert(from._element);
   if (_element->map_type() != from._element->map_type())
   {
-    throw std::runtime_error("Interpolation between elements with different "
-                             "maps is not supported.");
+    throw std::invalid_argument("Interpolation between elements with different "
+                                "maps is not supported.");
   }
 
   if (_bs == 1 or from._bs == 1)
@@ -530,7 +533,7 @@ FiniteElement<T>::create_interpolation_operator(const FiniteElement& from) const
   }
   else
   {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "Interpolation for element combination is not supported.");
   }
 }

--- a/cpp/dolfinx/fem/FiniteElement.cpp
+++ b/cpp/dolfinx/fem/FiniteElement.cpp
@@ -67,8 +67,8 @@ _extract_sub_element(const FiniteElement<T>& finite_element,
   // Check the number of available sub systems
   if (component[0] >= finite_element.num_sub_elements())
   {
-    throw std::invalid_argument("Cannot extract subsystem of finite element. "
-                                "Requested subsystem out of range.");
+    throw std::out_of_range("Cannot extract subsystem of finite element. "
+                            "Requested subsystem out of range.");
   }
 
   // Get sub system

--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -16,6 +16,7 @@
 #include <memory>
 #include <optional>
 #include <span>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -507,7 +508,7 @@ public:
                     std::int32_t cell, int block_size)
       { T_apply(data, cell_info[cell], block_size); };
     default:
-      throw std::runtime_error("Unknown transformation type");
+      throw std::invalid_argument("Unknown transformation type");
     }
   }
 
@@ -622,7 +623,7 @@ public:
                     std::int32_t cell, int n)
       { T_apply_right(data, cell_info[cell], n); };
     default:
-      throw std::runtime_error("Unknown transformation type");
+      throw std::invalid_argument("Unknown transformation type");
     }
   }
 

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -169,7 +169,7 @@ public:
         _needs_facet_permutations(needs_facet_permutations)
   {
     if (!_mesh)
-      throw std::runtime_error("Form Mesh is null.");
+      throw std::invalid_argument("Form Mesh is null.");
 
     // `_mesh` is fixed for the remainder of construction, so its
     // topology and dimension are fetched once and reused below rather
@@ -193,7 +193,7 @@ public:
 
       if (it == entity_maps.end())
       {
-        throw std::runtime_error(
+        throw std::invalid_argument(
             "Incompatible mesh. argument entity_maps must be provided.");
       }
       return *it;
@@ -233,7 +233,7 @@ public:
         }
       }
       else
-        throw std::runtime_error("Codimension > 1 not supported.");
+        throw std::invalid_argument("Codimension > 1 not supported.");
 
       // Map from entity indices in `this->mesh()` to the corresponding
       // cell indices in the argument/coefficient mesh
@@ -292,7 +292,7 @@ public:
                                       inverse);
           }
           else
-            throw std::runtime_error("Integral type not supported.");
+            throw std::invalid_argument("Integral type not supported.");
 
           vdata.insert({key, std::move(e)});
         }
@@ -331,7 +331,7 @@ public:
                                       inverse);
           }
           else
-            throw std::runtime_error("Integral type not supported.");
+            throw std::invalid_argument("Integral type not supported.");
           _cdata.insert({{type, idx, c}, std::move(e)});
         }
       }
@@ -391,7 +391,7 @@ public:
   {
     auto it = _integrals.find({type, idx, kernel_idx});
     if (it == _integrals.end())
-      throw std::runtime_error("Requested integral kernel not found.");
+      throw std::out_of_range("Requested integral kernel not found.");
     return it->second.kernel;
   }
 
@@ -427,7 +427,7 @@ public:
                                      return t == type and idx_ == idx;
                                    });
     if (it == _integrals.end())
-      throw std::runtime_error("Could not find active coefficient list.");
+      throw std::out_of_range("Could not find active coefficient list.");
     return it->second.coeffs;
   }
 
@@ -496,7 +496,7 @@ public:
   {
     auto it = _integrals.find({type, idx, kernel_idx});
     if (it == _integrals.end())
-      throw std::runtime_error("Requested domain not found.");
+      throw std::out_of_range("Requested domain not found.");
     return it->second.entities;
   }
 
@@ -540,7 +540,7 @@ public:
   {
     auto it = _edata.at(rank).find({type, idx, kernel_idx});
     if (it == _edata.at(rank).end())
-      throw std::runtime_error("Requested domain for argument not found.");
+      throw std::out_of_range("Requested domain for argument not found.");
 
     return std::visit([](const auto& v) -> std::span<const std::int32_t>
                       { return v; }, it->second);
@@ -565,7 +565,7 @@ public:
   {
     auto it = _cdata.find({type, idx, c});
     if (it == _cdata.end())
-      throw std::runtime_error("No domain for requested integral.");
+      throw std::out_of_range("No domain for requested integral.");
     return std::visit([](const auto& v) -> std::span<const std::int32_t>
                       { return v; }, it->second);
   }

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <numeric>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -61,8 +62,9 @@ public:
   {
     if (!V->component().empty())
     {
-      throw std::runtime_error("Cannot create Function from subspace. Consider "
-                               "collapsing the function space");
+      throw std::invalid_argument(
+          "Cannot create Function from subspace. Consider "
+          "collapsing the function space");
     }
   }
 
@@ -184,23 +186,24 @@ public:
     {
       // Check for scalar-valued functions
       if (fshape.front() != x.size() / 3)
-        throw std::runtime_error("Data returned by callable has wrong length");
+        throw std::invalid_argument(
+            "Data returned by callable has wrong length");
     }
     else
     {
       // Check for vector/tensor value
       if (fshape.size() != 2)
-        throw std::runtime_error("Expected 2D array of data");
+        throw std::invalid_argument("Expected 2D array of data");
 
       if (fshape[0] != vs)
       {
-        throw std::runtime_error(
+        throw std::invalid_argument(
             "Data returned by callable has wrong shape(0) size");
       }
 
       if (fshape[1] != x.size() / 3)
       {
-        throw std::runtime_error(
+        throw std::invalid_argument(
             "Data returned by callable has wrong shape(1) size");
       }
     }
@@ -310,7 +313,7 @@ public:
         mesh0 = mesh;
       else if (mesh != mesh0)
       {
-        throw std::runtime_error(
+        throw std::invalid_argument(
             "Expression coefficient Functions have different meshes.");
       }
     }
@@ -322,17 +325,18 @@ public:
       mesh0 = _function_space->mesh().get();
 
     if (cells0.size() != cells1.size())
-      throw std::runtime_error("Cell lists have different lengths.");
+      throw std::invalid_argument("Cell lists have different lengths.");
 
     // Check that Function and Expression spaces are compatible
     assert(_function_space->element());
     std::size_t value_size = e0.value_size();
     if (e0.argument_space())
-      throw std::runtime_error("Cannot interpolate Expression with Argument.");
+      throw std::invalid_argument(
+          "Cannot interpolate Expression with Argument.");
 
     if (value_size != (std::size_t)_function_space->element()->value_size())
     {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "Function value size not equal to Expression value size.");
     }
 
@@ -342,7 +346,7 @@ public:
       auto [X1, shape1] = _function_space->element()->interpolation_points();
       if (shape0 != shape1)
       {
-        throw std::runtime_error(
+        throw std::invalid_argument(
             "Function element interpolation points has different shape to "
             "Expression interpolation points");
       }
@@ -351,8 +355,9 @@ public:
       {
         if (std::abs(X0[i] - X1[i]) > 1.0e-10)
         {
-          throw std::runtime_error("Function element interpolation points not "
-                                   "equal to Expression interpolation points");
+          throw std::invalid_argument(
+              "Function element interpolation points not "
+              "equal to Expression interpolation points");
         }
       }
     }
@@ -469,13 +474,13 @@ public:
 
     if (xshape[0] != cells.size())
     {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "Number of points and number of cells must be equal.");
     }
 
     if (xshape[0] != ushape[0])
     {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "Length of array for Function values must be the "
           "same as the number of points.");
     }
@@ -511,8 +516,8 @@ public:
     const int num_sub_elements = element->num_sub_elements();
     if (num_sub_elements > 1 and num_sub_elements != bs_element)
     {
-      throw std::runtime_error("Function::eval is not supported for mixed "
-                               "elements. Extract subspaces.");
+      throw std::invalid_argument("Function::eval is not supported for mixed "
+                                  "elements. Extract subspaces.");
     }
 
     // Create work vector for expansion coefficients

--- a/cpp/dolfinx/fem/FunctionSpace.h
+++ b/cpp/dolfinx/fem/FunctionSpace.h
@@ -20,6 +20,7 @@
 #include <dolfinx/mesh/Topology.h>
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <vector>
 
 namespace dolfinx::fem
@@ -69,18 +70,18 @@ public:
     std::size_t num_cell_types = cell_types.size();
     if (elements.size() != num_cell_types)
     {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "Number of elements must match number of cell types");
     }
     if (_dofmaps.size() != num_cell_types)
     {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "Number of dofmaps must match number of cell types");
     }
     for (std::size_t i = 0; i < num_cell_types; ++i)
     {
       if (elements.at(i)->cell_type() != cell_types.at(i))
-        throw std::runtime_error(
+        throw std::invalid_argument(
             "Element cell types must match mesh cell types");
     }
   }
@@ -116,7 +117,7 @@ public:
 
     // Check that component is valid
     if (component.empty())
-      throw std::runtime_error("Component must be non-empty");
+      throw std::invalid_argument("Component must be non-empty");
 
     // Extract sub-element
     std::vector<std::shared_ptr<const FiniteElement<geometry_type>>>
@@ -180,7 +181,7 @@ public:
   {
     spdlog::debug("FunctionSpace::collapse");
     if (_component.empty())
-      throw std::runtime_error("Function space is not a subspace");
+      throw std::invalid_argument("Function space is not a subspace");
 
     // Create collapsed DofMap
     std::vector<std::shared_ptr<const DofMap>> collapsed_dofmaps;
@@ -230,14 +231,14 @@ public:
   {
     if (!_component.empty())
     {
-      throw std::runtime_error("Cannot tabulate coordinates for a "
-                               "FunctionSpace that is a subspace.");
+      throw std::invalid_argument("Cannot tabulate coordinates for a "
+                                  "FunctionSpace that is a subspace.");
     }
 
     assert(_elements.front());
     if (_elements.front()->is_mixed())
     {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "Cannot tabulate coordinates for a mixed FunctionSpace.");
     }
 
@@ -368,7 +369,7 @@ public:
   {
     if (_elements.size() > 1)
     {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "FunctionSpace has multiple elements, call `elements` instead.");
     }
 
@@ -387,7 +388,7 @@ public:
   {
     if (_dofmaps.size() > 1)
     {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "FunctionSpace has multiple dofmaps, call `dofmaps` instead.");
     }
 
@@ -455,7 +456,7 @@ common_function_spaces(
         else
         {
           if (spaces0[i] != V0)
-            throw std::runtime_error("Mismatched test space for row.");
+            throw std::invalid_argument("Mismatched test space for row.");
         }
 
         if (!spaces1[j])
@@ -463,7 +464,7 @@ common_function_spaces(
         else
         {
           if (spaces1[j] != V1)
-            throw std::runtime_error("Mismatched trial space for column.");
+            throw std::invalid_argument("Mismatched trial space for column.");
         }
       }
     }
@@ -471,9 +472,9 @@ common_function_spaces(
 
   // Check that there are no null entries
   if (std::find(spaces0.begin(), spaces0.end(), nullptr) != spaces0.end())
-    throw std::runtime_error("Could not deduce all block test spaces.");
+    throw std::invalid_argument("Could not deduce all block test spaces.");
   if (std::find(spaces1.begin(), spaces1.end(), nullptr) != spaces1.end())
-    throw std::runtime_error("Could not deduce all block trial spaces.");
+    throw std::invalid_argument("Could not deduce all block trial spaces.");
 
   return {spaces0, spaces1};
 }

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -19,6 +19,7 @@
 #include <functional>
 #include <iterator>
 #include <span>
+#include <stdexcept>
 #include <tuple>
 #include <vector>
 
@@ -807,8 +808,8 @@ void assemble_matrix(
     {
       if (num_cell_types > 1)
       {
-        throw std::runtime_error("Interior facet integrals with mixed "
-                                 "topology aren't supported yet");
+        throw std::invalid_argument("Interior facet integrals with mixed "
+                                    "topology aren't supported yet");
       }
 
       using mdspanx22_t
@@ -854,8 +855,8 @@ void assemble_matrix(
       {
         if (num_cell_types > 1)
         {
-          throw std::runtime_error("Exterior facet integrals with mixed "
-                                   "topology aren't supported yet");
+          throw std::invalid_argument("Exterior facet integrals with mixed "
+                                      "topology aren't supported yet");
         }
 
         using mdspanx2_t

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <optional>
 #include <span>
+#include <stdexcept>
 #include <vector>
 
 /// @file assembler.h
@@ -74,7 +75,7 @@ void tabulate_expression(
   // Check that domain is the same as mesh of the expression
   if (e.coordinate_element_hash() != mesh.geometry().cmaps().front().hash())
   {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "Expression was created on a different mesh. Cannot tabulate.");
   }
   auto [X, Xshape] = e.X();
@@ -105,7 +106,7 @@ void tabulate_expression(std::span<T> values, const fem::Expression<T, U>& e,
   // Check that domain is the same as mesh of the expression
   if (e.coordinate_element_hash() != mesh.geometry().cmaps().front().hash())
   {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "Expression was created on a different mesh. Cannot tabulate.");
   }
 
@@ -357,13 +358,13 @@ void apply_lifting(
 
   if (!x0.empty() and x0.size() != a.size())
   {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "Mismatch in size between x0 and bilinear form in assembler.");
   }
 
   if (a.size() != bcs1.size())
   {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "Mismatch in size between a and bcs in assembler.");
   }
 

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -18,6 +18,7 @@
 #include <dolfinx/mesh/Mesh.h>
 #include <memory>
 #include <span>
+#include <stdexcept>
 #include <vector>
 
 namespace dolfinx::fem
@@ -91,13 +92,13 @@ void discrete_curl(const FunctionSpace<T>& V0, const FunctionSpace<T>& V1,
   assert(mesh);
   assert(V1.mesh());
   if (mesh != V1.mesh())
-    throw std::runtime_error("Meshes must be the same.");
+    throw std::invalid_argument("Meshes must be the same.");
 
   if (mesh->geometry().dim() != 3)
-    throw std::runtime_error("Geometric must be equal to 3..");
+    throw std::invalid_argument("Geometric must be equal to 3..");
   if (mesh->geometry().dim() != mesh->topology()->dim())
   {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "Geometric and topological dimensions must be equal.");
   }
   constexpr int gdim = 3;
@@ -107,7 +108,7 @@ void discrete_curl(const FunctionSpace<T>& V0, const FunctionSpace<T>& V1,
   assert(e0);
   if (e0->map_type() != basix::maps::type::covariantPiola)
   {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "Finite element for parent space must be covariant Piola.");
   }
 
@@ -115,7 +116,7 @@ void discrete_curl(const FunctionSpace<T>& V0, const FunctionSpace<T>& V1,
   assert(e1);
   if (e1->map_type() != basix::maps::type::contravariantPiola)
   {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "Finite element for target space must be contracovariant Piola.");
   }
 
@@ -143,9 +144,9 @@ void discrete_curl(const FunctionSpace<T>& V0, const FunctionSpace<T>& V1,
   const std::size_t space_dim0 = e0->space_dimension();
   const std::size_t space_dim1 = e1->space_dimension();
   if (e0->reference_value_size() != 3)
-    throw std::runtime_error("Value size for parent space should be 3.");
+    throw std::invalid_argument("Value size for parent space should be 3.");
   if (e1->reference_value_size() != 3)
-    throw std::runtime_error("Value size for target space should be 3.");
+    throw std::invalid_argument("Value size for target space should be 3.");
 
   // Get the V1 reference interpolation points
   const auto [X, Xshape] = e1->interpolation_points();
@@ -289,16 +290,16 @@ void discrete_gradient(mesh::Topology& topology,
 
   // Check elements
   if (e0.map_type() != basix::maps::type::identity)
-    throw std::runtime_error("Wrong finite element space for V0.");
+    throw std::invalid_argument("Wrong finite element space for V0.");
   if (e0.block_size() != 1)
-    throw std::runtime_error("Block size is greater than 1 for V0.");
+    throw std::invalid_argument("Block size is greater than 1 for V0.");
   if (e0.reference_value_size() != 1)
-    throw std::runtime_error("Wrong value size for V0.");
+    throw std::invalid_argument("Wrong value size for V0.");
 
   if (e1.map_type() != basix::maps::type::covariantPiola)
-    throw std::runtime_error("Wrong finite element space for V1.");
+    throw std::invalid_argument("Wrong finite element space for V1.");
   if (e1.block_size() != 1)
-    throw std::runtime_error("Block size is greater than 1 for V1.");
+    throw std::invalid_argument("Block size is greater than 1 for V1.");
 
   // Get V1 (H(curl)) space interpolation points
   const auto [X, Xshape] = e1.interpolation_points();

--- a/cpp/dolfinx/fem/dofmapbuilder.cpp
+++ b/cpp/dolfinx/fem/dofmapbuilder.cpp
@@ -21,6 +21,7 @@
 #include <iterator>
 #include <memory>
 #include <numeric>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -226,7 +227,7 @@ build_basic_dofmaps(
             std::size_t k = std::ranges::distance(required_dim_et.begin(),
                                                   required_entity_it);
             if (num_entity_dofs_et[k] != (int)entity_dofs_d[e].size())
-              throw std::runtime_error("Incompatible elements detected.");
+              throw std::invalid_argument("Incompatible elements detected.");
           }
         }
       }

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -22,6 +22,7 @@
 #include <numeric>
 #include <ranges>
 #include <span>
+#include <stdexcept>
 #include <vector>
 
 namespace dolfinx::fem
@@ -418,7 +419,7 @@ void interpolate_same_map(Function<T, U>& u1, mesh::CellRange auto&& cells1,
   // Iterate over mesh and interpolate on each cell
   using X = U; // geometry (real) type, independent of the value scalar T
   if (cells0.size() != cells1.size())
-    throw std::runtime_error("Length of cells0 and cells1 must match.");
+    throw std::invalid_argument("Length of cells0 and cells1 must match.");
   for (auto cell0_it = cells0.begin(), cell1_it = cells1.begin();
        cell0_it != cells0.end() and cell1_it != cells1.end();
        ++cell0_it, ++cell1_it)
@@ -599,7 +600,7 @@ void interpolate_nonmatching_maps(Function<T, U>& u1,
   std::span<const T> array0 = u0.x()->array();
   std::span<T> array1 = u1.x()->array();
   if (cells0.size() != cells1.size())
-    throw std::runtime_error("Length of cells0 and cells1 must match.");
+    throw std::invalid_argument("Length of cells0 and cells1 must match.");
   for (auto cell0_it = cells0.begin(), cell1_it = cells1.begin();
        cell0_it != cells0.end() and cell1_it != cells1.end();
        ++cell0_it, ++cell1_it)
@@ -844,7 +845,8 @@ void identity_mapped_evaluation(const FiniteElement<U>& element, bool symmetric,
   // e.g. not Piola mapped
 
   if (symmetric)
-    throw std::runtime_error("Interpolation into this element not supported.");
+    throw std::invalid_argument(
+        "Interpolation into this element not supported.");
 
   const int element_bs = element.block_size();
   const int num_scalar_dofs = element.space_dimension() / element_bs;
@@ -927,7 +929,8 @@ void piola_mapped_evaluation(const FiniteElement<U>& element, bool symmetric,
                              const mesh::Mesh<U>& mesh, std::span<T> coeffs)
 {
   if (symmetric)
-    throw std::runtime_error("Interpolation into this element not supported.");
+    throw std::invalid_argument(
+        "Interpolation into this element not supported.");
 
   const int gdim = mesh.geometry().dim();
   assert(mesh.topology());
@@ -947,12 +950,12 @@ void piola_mapped_evaluation(const FiniteElement<U>& element, bool symmetric,
   const auto [X, Xshape] = element.interpolation_points();
   if (X.empty())
   {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "Interpolation into this space is not yet supported.");
   }
 
   if (_f.extent(1) != cells.size() * Xshape[0])
-    throw std::runtime_error("Interpolation data has the wrong shape.");
+    throw std::invalid_argument("Interpolation data has the wrong shape.");
 
   // Get coordinate map
   const CoordinateElement<U>& cmap = mesh.geometry().cmaps().front();
@@ -1141,8 +1144,8 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
   if (int num_sub = element->num_sub_elements();
       num_sub > 0 and num_sub != element_bs)
   {
-    throw std::runtime_error("Cannot directly interpolate a mixed space. "
-                             "Interpolate into subspaces.");
+    throw std::invalid_argument("Cannot directly interpolate a mixed space. "
+                                "Interpolate into subspaces.");
   }
 
   // Get mesh
@@ -1154,7 +1157,7 @@ void interpolate(Function<T, U>& u, std::span<const T> f,
           != (std::size_t)u.function_space()->elements(index)->value_size()
       or f.size() != fshape[0] * fshape[1])
   {
-    throw std::runtime_error("Interpolation data has the wrong shape/size.");
+    throw std::invalid_argument("Interpolation data has the wrong shape/size.");
   }
 
   spdlog::debug("Check for dof transformation");
@@ -1228,8 +1231,8 @@ void interpolate(Function<T, U>& u1, const Function<T, U>& u0,
     MPI_Comm_compare(comm, mesh0->comm(), &result);
     if (result == MPI_UNEQUAL)
     {
-      throw std::runtime_error("Interpolation on different meshes is only "
-                               "supported on the same communicator.");
+      throw std::invalid_argument("Interpolation on different meshes is only "
+                                  "supported on the same communicator.");
     }
   }
 
@@ -1295,7 +1298,7 @@ void interpolate(Function<T, U>& u1, mesh::CellRange auto&& cells1,
                  const Function<T, U>& u0, mesh::CellRange auto&& cells0)
 {
   if (cells0.size() != cells1.size())
-    throw std::runtime_error("Length of cell lists do not match.");
+    throw std::invalid_argument("Length of cell lists do not match.");
 
   auto V1 = u1.function_space();
   assert(V1);
@@ -1309,7 +1312,7 @@ void interpolate(Function<T, U>& u1, mesh::CellRange auto&& cells1,
   assert(e1);
   if (!std::ranges::equal(e0->value_shape(), e1->value_shape()))
   {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "Interpolation: elements have different value dimensions");
   }
 
@@ -1317,7 +1320,7 @@ void interpolate(Function<T, U>& u1, mesh::CellRange auto&& cells1,
   {
     // Same element and same mesh
     if (e1->block_size() != e0->block_size())
-      throw std::runtime_error("Mismatch in element block size.");
+      throw std::invalid_argument("Mismatch in element block size.");
 
     // Get dofmaps
     std::shared_ptr<const DofMap> dofmap0 = V0->dofmap();
@@ -1381,7 +1384,7 @@ void interpolate(Function<T, U>& u1, const Function<T, U>& u0,
   if (u1.function_space()->mesh() == u0.function_space()->mesh())
     interpolate<T, U>(u1, cells, u0, cells);
   else
-    throw std::runtime_error("Meshes do no match.");
+    throw std::invalid_argument("Meshes do no match.");
 }
 
 /// @brief Interpolate from one finite element Function to another

--- a/cpp/dolfinx/fem/pack.h
+++ b/cpp/dolfinx/fem/pack.h
@@ -299,8 +299,9 @@ void pack_coefficients(const Form<T, U>& form,
           // logic error, so fail loudly rather than pack it anyway.
           if (int codim = form_tdim - mesh->topology()->dim(); codim > 0)
           {
-            throw std::runtime_error("Should not be packing coefficients with "
-                                     "codim>0 in a cell integral");
+            throw std::invalid_argument(
+                "Should not be packing coefficients with "
+                "codim>0 in a cell integral");
           }
 
           std::span<const std::int32_t> cells_b
@@ -379,7 +380,7 @@ void pack_coefficients(const Form<T, U>& form,
         break;
       }
       default:
-        throw std::runtime_error(
+        throw std::invalid_argument(
             "Could not pack coefficient. Integral type not supported.");
       }
     }
@@ -460,7 +461,7 @@ std::vector<std::int32_t> extract_coefficient_cells_from_entities(
         // to cells of the submesh
         if (!inverse)
         {
-          throw std::runtime_error(
+          throw std::invalid_argument(
               "Unsupported mapping. Can only map from submesh to parent mesh.");
         }
         assert(codim > 0);
@@ -535,7 +536,7 @@ void pack_coefficients(
 
     if (it == entity_maps.end())
     {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "Incompatible mesh. argument entity_maps must be provided.");
     }
     return *it;

--- a/cpp/dolfinx/fem/petsc.h
+++ b/cpp/dolfinx/fem/petsc.h
@@ -111,7 +111,7 @@ Mat create_matrix_block(
   }
 
   if (!mesh)
-    throw std::runtime_error("Could not find a Mesh.");
+    throw std::invalid_argument("Could not find a Mesh.");
 
   // Compute offsets for the fields
   std::array<std::vector<std::pair<
@@ -230,7 +230,8 @@ Mat create_matrix_nest(
     std::optional<std::vector<std::vector<std::optional<std::string>>>> types)
 {
   if (a.empty())
-    throw std::runtime_error("Rectangular array of forms must be non-empty.");
+    throw std::invalid_argument(
+        "Rectangular array of forms must be non-empty.");
 
   // Extract and check row/column ranges
   auto V = fem::common_function_spaces(extract_function_spaces(a));
@@ -256,7 +257,7 @@ Mat create_matrix_nest(
   }
 
   if (!mesh)
-    throw std::runtime_error("Could not find a Mesh.");
+    throw std::invalid_argument("Could not find a Mesh.");
 
   // Initialise block (MatNest) matrix. On error, destroy the
   // already-created sub-matrices in `mats` before propagating, since
@@ -417,7 +418,7 @@ void apply_lifting(
     const std::vector<Vec>& x0, PetscScalar alpha)
 {
   if (!x0.empty() and x0.size() != a.size())
-    throw std::runtime_error("Mismatch between x0 and a in apply_lifting.");
+    throw std::invalid_argument("Mismatch between x0 and a in apply_lifting.");
 
   Vec b_local;
   PetscErrorCode ierr = VecGhostGetLocalForm(b, &b_local);
@@ -505,7 +506,7 @@ void apply_lifting(
     const std::vector<Vec>& x0, PetscScalar alpha)
 {
   if (!x0.empty() and x0.size() != a.size())
-    throw std::runtime_error("Mismatch between x0 and a in apply_lifting.");
+    throw std::invalid_argument("Mismatch between x0 and a in apply_lifting.");
 
   Vec b_local;
   PetscErrorCode ierr = VecGhostGetLocalForm(b, &b_local);

--- a/cpp/dolfinx/fem/utils.cpp
+++ b/cpp/dolfinx/fem/utils.cpp
@@ -113,7 +113,7 @@ std::vector<fem::DofMap> fem::create_dofmaps(
   {
     if (layouts.size() != 1)
     {
-      throw std::runtime_error(
+      throw std::invalid_argument(
           "DOF transformations not yet supported in mixed topology.");
     }
     std::int32_t num_cells = topology.connectivity(D, 0)->num_nodes();
@@ -176,7 +176,7 @@ fem::compute_integration_domains(fem::IntegralType integral_type,
     dim = tdim - 2;
     break;
   default:
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "Cannot compute integration domains. Integral type not supported.");
   }
 
@@ -246,7 +246,7 @@ fem::compute_integration_domains(fem::IntegralType integral_type,
       }
       else if (interprocess_marker[f])
       {
-        throw std::runtime_error(
+        throw std::invalid_argument(
             "Cannot compute interior facet integral over interprocess facet. "
             "Use \"shared facet\"  ghost mode when creating the mesh.");
       }
@@ -267,7 +267,7 @@ fem::compute_integration_domains(fem::IntegralType integral_type,
     break;
   }
   default:
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "Cannot compute integration domains. Integral type not supported.");
   }
 

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -227,7 +227,7 @@ void build_sparsity_pattern(la::SparsityPattern& pattern, const Form<T, U>& a)
 {
   if (a.rank() != 2)
   {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "Cannot create sparsity pattern. Form is not a bilinear.");
   }
 
@@ -305,7 +305,7 @@ void build_sparsity_pattern(la::SparsityPattern& pattern, const Form<T, U>& a)
         }
         break;
       default:
-        throw std::runtime_error("Unsupported integral type");
+        throw std::invalid_argument("Unsupported integral type");
       }
     }
   }
@@ -427,17 +427,17 @@ Form<T, U> create_form_factory(
   for (const ufcx_form& ufcx_form : ufcx_forms)
   {
     if (ufcx_form.rank != (int)spaces.size())
-      throw std::runtime_error("Wrong number of argument spaces for Form.");
+      throw std::invalid_argument("Wrong number of argument spaces for Form.");
     if (ufcx_form.num_coefficients != (int)coefficients.size())
     {
-      throw std::runtime_error("Mismatch between number of expected and "
-                               "provided Form coefficients.");
+      throw std::invalid_argument("Mismatch between number of expected and "
+                                  "provided Form coefficients.");
     }
 
     // Check Constants for rank and size consistency
     if (ufcx_form.num_constants != (int)constants.size())
     {
-      throw std::runtime_error(std::format(
+      throw std::invalid_argument(std::format(
           "Mismatch between number of expected and "
           "provided Form Constants. Expected {} constants, but got {}.",
           ufcx_form.num_constants, constants.size()));
@@ -446,7 +446,7 @@ Form<T, U> create_form_factory(
     {
       if (ufcx_form.constant_ranks[c] != (int)constants[c]->shape.size())
       {
-        throw std::runtime_error(std::format(
+        throw std::invalid_argument(std::format(
             "Mismatch between expected and actual rank of "
             "Form Constant. Rank of Constant {} should be {}, but got rank {}.",
             c, ufcx_form.constant_ranks[c], constants[c]->shape.size()));
@@ -454,7 +454,7 @@ Form<T, U> create_form_factory(
       if (!std::equal(constants[c]->shape.begin(), constants[c]->shape.end(),
                       ufcx_form.constant_shapes[c]))
       {
-        throw std::runtime_error(
+        throw std::invalid_argument(
             std::format("Mismatch between expected and actual shape of Form "
                         "Constant for Constant {}.",
                         c));
@@ -474,7 +474,7 @@ Form<T, U> create_form_factory(
           and element_hash
                   != spaces[i]->elements(form_idx)->basix_element().hash())
       {
-        throw std::runtime_error(
+        throw std::invalid_argument(
             "Cannot create form. Elements are different to "
             "those used to compile the form.");
       }
@@ -485,7 +485,7 @@ Form<T, U> create_form_factory(
   if (!mesh and !spaces.empty())
     mesh = spaces.front()->mesh();
   if (!mesh)
-    throw std::runtime_error("No mesh could be associated with the Form.");
+    throw std::invalid_argument("No mesh could be associated with the Form.");
 
   auto topology = mesh->topology();
   assert(topology);
@@ -571,7 +571,7 @@ Form<T, U> create_form_factory(
         impl::kernel_t<T, U> k = impl::extract_kernel<T, U>(integral);
         if (!k)
         {
-          throw std::runtime_error(
+          throw std::invalid_argument(
               "UFCx kernel function is NULL. Check requested types.");
         }
 
@@ -726,7 +726,7 @@ Form<T, U> create_form_factory(
         break;
       }
       default:
-        throw std::runtime_error("Unsupported integral type");
+        throw std::invalid_argument("Unsupported integral type");
       }
 
       const std::function<std::vector<std::int32_t>(const mesh::Topology&,
@@ -934,7 +934,7 @@ FunctionSpace<T> create_functionspace(
   assert(mesh);
   assert(mesh->topology());
   if (e->cell_type() != mesh->topology()->cell_type())
-    throw std::runtime_error("Cell type of element and mesh must match.");
+    throw std::invalid_argument("Cell type of element and mesh must match.");
 
   // Create element dof layout
   fem::ElementDofLayout layout = fem::create_element_dof_layout(*e);
@@ -961,8 +961,8 @@ Expression<T, U> create_expression(
 {
   if (e.rank > 0 and !argument_space)
   {
-    throw std::runtime_error("Expression has Argument but no Argument "
-                             "function space was provided.");
+    throw std::invalid_argument("Expression has Argument but no Argument "
+                                "function space was provided.");
   }
 
   std::vector<U> X(e.points, e.points + e.num_points * e.entity_dimension);
@@ -991,7 +991,7 @@ Expression<T, U> create_expression(
     tabulate_tensor = reinterpret_cast<kptr_t>(e.tabulate_tensor_complex128);
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
   else
-    throw std::runtime_error("Type not supported.");
+    throw std::invalid_argument("Type not supported.");
 
   assert(tabulate_tensor);
   std::uint64_t e_hash = e.coordinate_element_hash;
@@ -1076,7 +1076,7 @@ mesh::Mesh<T> interpolate_geometry(
   const CoordinateElement<T>& old_cmap = mesh->geometry().cmaps().front();
   if (new_cmap.cell_shape() != old_cmap.cell_shape())
   {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "Cell shape of new coordinate element must match input mesh.");
   }
 

--- a/python/test/unit/fem/test_bcs.py
+++ b/python/test/unit/fem/test_bcs.py
@@ -42,7 +42,7 @@ def test_locate_dofs_geometrical():
     W = functionspace(mesh, mixed_element([P0, P1]))
     V = W.sub(0).collapse()[0]
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         locate_dofs_geometrical(W, lambda x: np.isclose(x.T, [0, 0, 0]).all(axis=1))
 
     dofs = locate_dofs_geometrical((W.sub(0), V), lambda x: np.isclose(x.T, [0, 0, 0]).all(axis=1))
@@ -366,7 +366,7 @@ def test_mixed_blocked_constant():
 
     # Check that vector space throws error
     c1 = default_scalar_type((5, 7))
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         dofs1 = locate_dofs_topological(W.sub(1), tdim - 1, boundary_facets)
         dirichletbc(c1, dofs1, W.sub(1))
 

--- a/python/test/unit/fem/test_discrete_operators.py
+++ b/python/test/unit/fem/test_discrete_operators.py
@@ -55,7 +55,7 @@ def test_discrete_curl_gdim_raises(cell):
     E0 = element("N1curl", msh.basix_cell(), 2, dtype=np.float64)
     E1 = element("RT", msh.basix_cell(), 2, dtype=np.float64)
     V0, V1 = functionspace(msh, E0), functionspace(msh, E1)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         discrete_curl(V0, V1)
 
 
@@ -86,7 +86,7 @@ def test_discrete_curl_map_raises(elements):
         MPI.COMM_WORLD, 3, 3, 3, cell_type=CellType.tetrahedron, dtype=np.float64
     )
     V0, V1 = functionspace(msh, elements[0]), functionspace(msh, elements[1])
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         discrete_curl(V0, V1)
 
 

--- a/python/test/unit/fem/test_forms.py
+++ b/python/test/unit/fem/test_forms.py
@@ -111,7 +111,7 @@ def test_incorrect_element():
     )
     dolfinx.fem.Form(f, ufcx_form, code)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         f = ftype(
             [int(module.ffi.cast("uintptr_t", module.ffi.addressof(ufcx_form)))],
             [incorrect_space._cpp_object, incorrect_space._cpp_object],

--- a/python/test/unit/fem/test_function.py
+++ b/python/test/unit/fem/test_function.py
@@ -175,13 +175,13 @@ def test_eval_manifold(dtype):
 
 def test_interpolation_mismatch_rank0(W):
     u = Function(W)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         u.interpolate(lambda x: np.ones(x.shape[1]))
 
 
 def test_interpolation_mismatch_rank1(W):
     u = Function(W)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         u.interpolate(lambda x: np.ones((2, x.shape[1])))
 
 
@@ -214,7 +214,7 @@ def test_mixed_element_interpolation(dtype):
     el = element("Lagrange", mesh.basix_cell(), 1, dtype=xdtype)
     V = functionspace(mesh, mixed_element([el, el]))
     u = Function(V, dtype=dtype)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         u.interpolate(lambda x: np.ones(2, x.shape[1]))
 
 

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -168,7 +168,7 @@ def test_clone(W):
 
 
 def test_collapse(W, V):
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         Function(W.sub(1))
 
     Ws = [W.sub(i).collapse() for i in range(W.num_sub_spaces)]
@@ -261,7 +261,7 @@ def test_basix_element(V, W, Q, V2):
         )
 
     # Mixed spaces do not yet return a basix element
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         Q.element.basix_element
 
 

--- a/python/test/unit/fem/test_function_space.py
+++ b/python/test/unit/fem/test_function_space.py
@@ -99,6 +99,9 @@ def test_equality(V, V2, W, W2):
 def test_sub(Q, W):
     X = Q.sub(0)
 
+    with pytest.raises(IndexError):
+        Q._cpp_object.sub([Q.num_sub_spaces])
+
     assert W.dofmap.dof_layout.num_dofs == X.dofmap.dof_layout.num_dofs
     for dim, entity_count in enumerate([4, 6, 4, 1]):
         assert len(W.dofmap.dof_layout.entity_dofs(dim, 0)) == len(

--- a/python/test/unit/fem/test_interpolation.py
+++ b/python/test/unit/fem/test_interpolation.py
@@ -394,9 +394,9 @@ def test_mixed_sub_interpolation():
         V0 = functionspace(mesh, P.sub_elements[0])
         V1 = functionspace(mesh, P.sub_elements[1])
         v0, v1 = Function(V0), Function(V1)
-        with pytest.raises(RuntimeError):
+        with pytest.raises(ValueError):
             v0.interpolate(U.sub(1))
-        with pytest.raises(RuntimeError):
+        with pytest.raises(ValueError):
             v1.interpolate(U.sub(0))
 
 
@@ -409,7 +409,7 @@ def test_mixed_interpolation():
         "Lagrange", mesh.basix_cell(), 1, shape=(mesh.geometry.dim,), dtype=default_real_type
     )
     v = Function(functionspace(mesh, mixed_element([A, B])))
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         v.interpolate(lambda x: (x[1], 2 * x[0], 3 * x[1]))
 
 
@@ -882,7 +882,7 @@ def test_interpolate_callable():
     u0.interpolate(lambda x: x[0])
     u1.interpolate(f)
     assert np.allclose(u0.x.array, u1.x.array)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         u0.interpolate(lambda x: np.vstack([x[0], x[1]]))
 
 

--- a/python/test/unit/fem/test_mixed_element.py
+++ b/python/test/unit/fem/test_mixed_element.py
@@ -119,5 +119,5 @@ def test_single_element_in_mixed_element(rtype):
     w.interpolate(f)
     np.testing.assert_allclose(u.x.array, w.x.array)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         u.interpolate(f)


### PR DESCRIPTION
## Summary
- `cpp/dolfinx/fem` threw `std::runtime_error` almost universally, even
  for bad-argument and out-of-range-index failures.
- Reclassify 77 throw sites across 18 files: `std::invalid_argument`
  for bad/invalid function arguments (dimension/shape mismatch,
  unsupported enum/element combination, incompatible mesh/space),
  `std::out_of_range` for index/lookup-key failures. No new exception
  hierarchy; `std::runtime_error` remains for genuine runtime/state/IO
  failures.
- Note: this changes the exception type callers see at the C++ and
  Python (nanobind-translated) API boundary for these specific error
  messages (e.g. Python callers now see `ValueError`/`IndexError`
  instead of `RuntimeError`).
- Scoped to `fem` only, as a discussion piece — not rolling out to the
  other modules (`mesh`, `io`, `la`, etc.) until this approach is
  agreed on.
- Also documents the convention in `AGENTS.md`.

## Test plan
- [x] `clang-format --dry-run --Werror` on all touched files
- [x] C++ library builds and links (`ninja`)
- [x] Python bindings build and `import dolfinx` succeeds
- [x] Manually verified `std::invalid_argument` surfaces as Python
      `ValueError` (triggered via `Function()` on an uncollapsed
      subspace)