### PR TITLE
Avoid undefined behaviour in kernel-invocation coefficient pointer for empty coefficient arrays

### DIFF
--- a/cpp/dolfinx/fem/assemble_expression_impl.h
+++ b/cpp/dolfinx/fem/assemble_expression_impl.h
@@ -82,9 +82,6 @@ void tabulate_expression(
   std::vector<T> values_local(size0 * num_argument_dofs, 0);
   std::size_t offset = values_local.size();
 
-  // Base pointer and per-entity stride into coeffs, computed once rather
-  // than per entity; coeffs_data + e * cstride is well-defined even when
-  // coeffs is empty (cstride == 0), unlike &coeffs(e, 0).
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = coeffs.extent(1);
 

--- a/cpp/dolfinx/fem/assemble_expression_impl.h
+++ b/cpp/dolfinx/fem/assemble_expression_impl.h
@@ -83,10 +83,8 @@ void tabulate_expression(
   std::size_t offset = values_local.size();
 
   // Base pointer and per-entity stride into coeffs, computed once rather
-  // than per entity. coeffs_data is nullptr when coeffs is empty (a form
-  // with no Function coefficients); coeffs_data + e * cstride is
-  // well-defined even then, as cstride is 0 and every offset collapses to
-  // nullptr + 0.
+  // than per entity; coeffs_data + e * cstride is well-defined even when
+  // coeffs is empty (cstride == 0), unlike &coeffs(e, 0).
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = coeffs.extent(1);
 

--- a/cpp/dolfinx/fem/assemble_expression_impl.h
+++ b/cpp/dolfinx/fem/assemble_expression_impl.h
@@ -81,6 +81,15 @@ void tabulate_expression(
   int size0 = Xshape[0] * value_size;
   std::vector<T> values_local(size0 * num_argument_dofs, 0);
   std::size_t offset = values_local.size();
+
+  // Base pointer and per-entity stride into coeffs, computed once rather
+  // than per entity. coeffs_data is nullptr when coeffs is empty (a form
+  // with no Function coefficients); coeffs_data + e * cstride is
+  // well-defined even then, as cstride is 0 and every offset collapses to
+  // nullptr + 0.
+  const T* coeffs_data = coeffs.data_handle();
+  const std::size_t cstride = coeffs.extent(1);
+
   for (std::size_t e = 0; e < entities.extent(0); ++e)
   {
     std::ranges::fill(values_local, 0);
@@ -93,13 +102,8 @@ void tabulate_expression(
         std::copy_n(std::next(x.begin(), 3 * x_dofs[i]), 3,
                     std::next(coord_dofs.begin(), 3 * i));
       }
-      // submdspan(...).data_handle() is used rather than &coeffs(e, 0): the
-      // latter dereferences to form a reference before taking its address,
-      // which is UB when coeffs is empty (a form with no Function
-      // coefficients), whereas submdspan only computes an offset.
-      fn(values_local.data(),
-         md::submdspan(coeffs, e, md::full_extent).data_handle(),
-         constants.data(), coord_dofs.data(), nullptr, nullptr, nullptr);
+      fn(values_local.data(), coeffs_data + e * cstride, constants.data(),
+         coord_dofs.data(), nullptr, nullptr, nullptr);
 
       P0(values_local, cell_info, entity, size0);
     }
@@ -114,11 +118,8 @@ void tabulate_expression(
         std::copy_n(std::next(x.begin(), 3 * x_dofs[i]), 3,
                     std::next(coord_dofs.begin(), 3 * i));
       }
-      // See note above on avoiding &coeffs(e, 0), which is UB when coeffs is
-      // empty.
-      fn(values_local.data(),
-         md::submdspan(coeffs, e, md::full_extent).data_handle(),
-         constants.data(), coord_dofs.data(), &local_entity, &perm, nullptr);
+      fn(values_local.data(), coeffs_data + e * cstride, constants.data(),
+         coord_dofs.data(), &local_entity, &perm, nullptr);
       P0(values_local, cell_info, entity, size0);
     }
 

--- a/cpp/dolfinx/fem/assemble_expression_impl.h
+++ b/cpp/dolfinx/fem/assemble_expression_impl.h
@@ -93,8 +93,13 @@ void tabulate_expression(
         std::copy_n(std::next(x.begin(), 3 * x_dofs[i]), 3,
                     std::next(coord_dofs.begin(), 3 * i));
       }
-      fn(values_local.data(), &coeffs(e, 0), constants.data(),
-         coord_dofs.data(), nullptr, nullptr, nullptr);
+      // submdspan(...).data_handle() is used rather than &coeffs(e, 0): the
+      // latter dereferences to form a reference before taking its address,
+      // which is UB when coeffs is empty (a form with no Function
+      // coefficients), whereas submdspan only computes an offset.
+      fn(values_local.data(),
+         md::submdspan(coeffs, e, md::full_extent).data_handle(),
+         constants.data(), coord_dofs.data(), nullptr, nullptr, nullptr);
 
       P0(values_local, cell_info, entity, size0);
     }
@@ -109,8 +114,11 @@ void tabulate_expression(
         std::copy_n(std::next(x.begin(), 3 * x_dofs[i]), 3,
                     std::next(coord_dofs.begin(), 3 * i));
       }
-      fn(values_local.data(), &coeffs(e, 0), constants.data(),
-         coord_dofs.data(), &local_entity, &perm, nullptr);
+      // See note above on avoiding &coeffs(e, 0), which is UB when coeffs is
+      // empty.
+      fn(values_local.data(),
+         md::submdspan(coeffs, e, md::full_extent).data_handle(),
+         constants.data(), coord_dofs.data(), &local_entity, &perm, nullptr);
       P0(values_local, cell_info, entity, size0);
     }
 

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -147,10 +147,13 @@ void assemble_cells_matrix(
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
       std::copy_n(&x(x_dofs[i], 0), 3, std::next(cdofs_b.begin(), 3 * i));
 
-    // Tabulate tensor
+    // Tabulate tensor. submdspan(...).data_handle() is used rather than
+    // &coeffs(c, 0): the latter dereferences to form a reference before
+    // taking its address, which is UB when coeffs is empty (a form with no
+    // Function coefficients), whereas submdspan only computes an offset.
     std::ranges::fill(Ae, 0);
-    kernel(Ae.data(), &coeffs(c, 0), constants.data(), cdofs_b.data(), nullptr,
-           nullptr, nullptr);
+    kernel(Ae.data(), md::submdspan(coeffs, c, md::full_extent).data_handle(),
+           constants.data(), cdofs_b.data(), nullptr, nullptr, nullptr);
 
     // Compute A = P_0 \tilde{A} P_1^T (dof transformation)
     P0(Ae, cell_info0, cell0, ndim1);  // B = P0 \tilde{A}
@@ -329,10 +332,11 @@ void assemble_entities(
     // Permutations
     std::uint8_t perm = perms.empty() ? 0 : perms(cell, local_entity);
 
-    // Tabulate tensor
+    // Tabulate tensor. See note above on avoiding &coeffs(f, 0), which is UB
+    // when coeffs is empty.
     std::ranges::fill(Ae, 0);
-    kernel(Ae.data(), &coeffs(f, 0), constants.data(), cdofs_b.data(),
-           &local_entity, &perm, nullptr);
+    kernel(Ae.data(), md::submdspan(coeffs, f, md::full_extent).data_handle(),
+           constants.data(), cdofs_b.data(), &local_entity, &perm, nullptr);
     P0(Ae, cell_info0, cell0, ndim1);
     P1T(Ae, cell_info1, cell1, ndim0);
 
@@ -569,14 +573,17 @@ void assemble_interior_facets(
         continue;
     }
 
-    // Tabulate tensor
+    // Tabulate tensor. See note above on avoiding &coeffs(f, 0), which is UB
+    // when coeffs is empty.
     std::ranges::fill(Ae, 0);
     std::array perm = perms.empty()
                           ? std::array<std::uint8_t, 2>{0, 0}
                           : std::array{perms(cells[0], local_facet[0]),
                                        perms(cells[1], local_facet[1])};
-    kernel(Ae.data(), &coeffs(f, 0, 0), constants.data(), cdofs_b.data(),
-           local_facet.data(), perm.data(), nullptr);
+    kernel(Ae.data(),
+           md::submdspan(coeffs, f, 0, md::full_extent).data_handle(),
+           constants.data(), cdofs_b.data(), local_facet.data(), perm.data(),
+           nullptr);
 
     // Local element layout is a 2x2 block matrix with structure
     //

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -121,6 +121,13 @@ void assemble_cells_matrix(
   assert(cdofs_b.size() >= 3 * x_dofmap.extent(1));
   auto Ae = Ab.first(ndim0 * ndim1);
 
+  // Base pointer and per-cell stride into coeffs, computed once rather than
+  // per cell. coeffs_data is nullptr when coeffs is empty (a form with no
+  // Function coefficients); coeffs_data + c * cstride is well-defined even
+  // then, as cstride is 0 and every offset collapses to nullptr + 0.
+  const T* coeffs_data = coeffs.data_handle();
+  const std::size_t cstride = coeffs.extent(1);
+
   // Iterate over active cells
   assert(cells0.size() == cells.size());
   assert(cells1.size() == cells.size());
@@ -147,13 +154,10 @@ void assemble_cells_matrix(
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
       std::copy_n(&x(x_dofs[i], 0), 3, std::next(cdofs_b.begin(), 3 * i));
 
-    // Tabulate tensor. submdspan(...).data_handle() is used rather than
-    // &coeffs(c, 0): the latter dereferences to form a reference before
-    // taking its address, which is UB when coeffs is empty (a form with no
-    // Function coefficients), whereas submdspan only computes an offset.
+    // Tabulate tensor
     std::ranges::fill(Ae, 0);
-    kernel(Ae.data(), md::submdspan(coeffs, c, md::full_extent).data_handle(),
-           constants.data(), cdofs_b.data(), nullptr, nullptr, nullptr);
+    kernel(Ae.data(), coeffs_data + c * cstride, constants.data(),
+           cdofs_b.data(), nullptr, nullptr, nullptr);
 
     // Compute A = P_0 \tilde{A} P_1^T (dof transformation)
     P0(Ae, cell_info0, cell0, ndim1);  // B = P0 \tilde{A}
@@ -304,6 +308,11 @@ void assemble_entities(
   assert(Ab.size() >= ndim0 * ndim1);
   assert(cdofs_b.size() >= 3 * x_dofmap.extent(1));
   auto Ae = Ab.first(ndim0 * ndim1);
+
+  // See the note in assemble_cells_matrix on coeffs_data/cstride.
+  const T* coeffs_data = coeffs.data_handle();
+  const std::size_t cstride = coeffs.extent(1);
+
   for (std::size_t f = 0; f < entities.extent(0); ++f)
   {
     // Cell in the integration domain, local entity index relative to the
@@ -332,11 +341,10 @@ void assemble_entities(
     // Permutations
     std::uint8_t perm = perms.empty() ? 0 : perms(cell, local_entity);
 
-    // Tabulate tensor. See note above on avoiding &coeffs(f, 0), which is UB
-    // when coeffs is empty.
+    // Tabulate tensor
     std::ranges::fill(Ae, 0);
-    kernel(Ae.data(), md::submdspan(coeffs, f, md::full_extent).data_handle(),
-           constants.data(), cdofs_b.data(), &local_entity, &perm, nullptr);
+    kernel(Ae.data(), coeffs_data + f * cstride, constants.data(),
+           cdofs_b.data(), &local_entity, &perm, nullptr);
     P0(Ae, cell_info0, cell0, ndim1);
     P1T(Ae, cell_info1, cell1, ndim0);
 
@@ -504,6 +512,12 @@ void assemble_interior_facets(
   // where both cells exist, so such blocks must be inserted
   // individually rather than as part of the full joint block.
   assert(Ae_block_b.size() >= dmap0_size * bs0 * dmap1_size * bs1);
+
+  // See the note in assemble_cells_matrix on coeffs_data/cstride. coeffs is
+  // indexed (f, side, cstride), so the per-facet stride covers both sides.
+  const T* coeffs_data = coeffs.data_handle();
+  const std::size_t cstride = 2 * coeffs.extent(2);
+
   auto insert_block = [&Ae_block_b, &Ae, &bs0, &bs1, &num_cols,
                        &mat_set](std::span<const std::int32_t> rdofs,
                                  std::span<const std::int32_t> cdofs,
@@ -573,17 +587,14 @@ void assemble_interior_facets(
         continue;
     }
 
-    // Tabulate tensor. See note above on avoiding &coeffs(f, 0), which is UB
-    // when coeffs is empty.
+    // Tabulate tensor
     std::ranges::fill(Ae, 0);
     std::array perm = perms.empty()
                           ? std::array<std::uint8_t, 2>{0, 0}
                           : std::array{perms(cells[0], local_facet[0]),
                                        perms(cells[1], local_facet[1])};
-    kernel(Ae.data(),
-           md::submdspan(coeffs, f, 0, md::full_extent).data_handle(),
-           constants.data(), cdofs_b.data(), local_facet.data(), perm.data(),
-           nullptr);
+    kernel(Ae.data(), coeffs_data + f * cstride, constants.data(),
+           cdofs_b.data(), local_facet.data(), perm.data(), nullptr);
 
     // Local element layout is a 2x2 block matrix with structure
     //

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -122,9 +122,8 @@ void assemble_cells_matrix(
   auto Ae = Ab.first(ndim0 * ndim1);
 
   // Base pointer and per-cell stride into coeffs, computed once rather than
-  // per cell. coeffs_data is nullptr when coeffs is empty (a form with no
-  // Function coefficients); coeffs_data + c * cstride is well-defined even
-  // then, as cstride is 0 and every offset collapses to nullptr + 0.
+  // per cell; coeffs_data + c * cstride is well-defined even when coeffs is
+  // empty (cstride == 0), unlike &coeffs(c, 0).
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = coeffs.extent(1);
 
@@ -309,7 +308,6 @@ void assemble_entities(
   assert(cdofs_b.size() >= 3 * x_dofmap.extent(1));
   auto Ae = Ab.first(ndim0 * ndim1);
 
-  // See the note in assemble_cells_matrix on coeffs_data/cstride.
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = coeffs.extent(1);
 
@@ -513,8 +511,7 @@ void assemble_interior_facets(
   // individually rather than as part of the full joint block.
   assert(Ae_block_b.size() >= dmap0_size * bs0 * dmap1_size * bs1);
 
-  // See the note in assemble_cells_matrix on coeffs_data/cstride. coeffs is
-  // indexed (f, side, cstride), so the per-facet stride covers both sides.
+  // coeffs is indexed (f, side, cstride); cstride here covers both sides.
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = 2 * coeffs.extent(2);
 

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -121,9 +121,6 @@ void assemble_cells_matrix(
   assert(cdofs_b.size() >= 3 * x_dofmap.extent(1));
   auto Ae = Ab.first(ndim0 * ndim1);
 
-  // Base pointer and per-cell stride into coeffs, computed once rather than
-  // per cell; coeffs_data + c * cstride is well-defined even when coeffs is
-  // empty (cstride == 0), unlike &coeffs(c, 0).
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = coeffs.extent(1);
 
@@ -511,7 +508,6 @@ void assemble_interior_facets(
   // individually rather than as part of the full joint block.
   assert(Ae_block_b.size() >= dmap0_size * bs0 * dmap1_size * bs1);
 
-  // coeffs is indexed (f, side, cstride); cstride here covers both sides.
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = 2 * coeffs.extent(2);
 

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -43,9 +43,6 @@ T assemble_cells(
 
   assert(cdofs_b.size() >= 3 * x_dofmap.extent(1));
 
-  // Base pointer and per-cell stride into coeffs, computed once rather than
-  // per cell; coeffs_data + index * cstride is well-defined even when coeffs
-  // is empty (cstride == 0), unlike &coeffs(index, 0).
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = coeffs.extent(1);
 
@@ -151,7 +148,6 @@ T assemble_interior_facets(
   auto cdofs0 = cdofs_b.first(3 * x_dofmap.extent(1));
   auto cdofs1 = cdofs_b.last(3 * x_dofmap.extent(1));
 
-  // coeffs is indexed (f, side, cstride); cstride here covers both sides.
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = 2 * coeffs.extent(2);
 

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -44,9 +44,8 @@ T assemble_cells(
   assert(cdofs_b.size() >= 3 * x_dofmap.extent(1));
 
   // Base pointer and per-cell stride into coeffs, computed once rather than
-  // per cell. coeffs_data is nullptr when coeffs is empty (a form with no
-  // Function coefficients); coeffs_data + index * cstride is well-defined
-  // even then, as cstride is 0 and every offset collapses to nullptr + 0.
+  // per cell; coeffs_data + index * cstride is well-defined even when coeffs
+  // is empty (cstride == 0), unlike &coeffs(index, 0).
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = coeffs.extent(1);
 
@@ -100,7 +99,6 @@ T assemble_entities(
 
   assert(cdofs_b.size() >= 3 * x_dofmap.extent(1));
 
-  // See the note in assemble_cells on coeffs_data/cstride.
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = coeffs.extent(1);
 
@@ -153,8 +151,7 @@ T assemble_interior_facets(
   auto cdofs0 = cdofs_b.first(3 * x_dofmap.extent(1));
   auto cdofs1 = cdofs_b.last(3 * x_dofmap.extent(1));
 
-  // See the note in assemble_cells on coeffs_data/cstride. coeffs is
-  // indexed (f, side, cstride), so the per-facet stride covers both sides.
+  // coeffs is indexed (f, side, cstride); cstride here covers both sides.
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = 2 * coeffs.extent(2);
 

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -53,8 +53,12 @@ T assemble_cells(
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
       std::copy_n(&x(x_dofs[i], 0), 3, std::next(cdofs_b.begin(), 3 * i));
 
-    fn(&value, &coeffs(index, 0), constants.data(), cdofs_b.data(), nullptr,
-       nullptr, nullptr);
+    // submdspan(...).data_handle() is used rather than &coeffs(index, 0):
+    // the latter dereferences to form a reference before taking its
+    // address, which is UB when coeffs is empty (a form with no Function
+    // coefficients), whereas submdspan only computes an offset.
+    fn(&value, md::submdspan(coeffs, index, md::full_extent).data_handle(),
+       constants.data(), cdofs_b.data(), nullptr, nullptr, nullptr);
   }
 
   return value;
@@ -106,8 +110,10 @@ T assemble_entities(
 
     // Permutations
     std::uint8_t perm = perms.empty() ? 0 : perms(cell, local_entity);
-    fn(&value, &coeffs(f, 0), constants.data(), cdofs_b.data(), &local_entity,
-       &perm, nullptr);
+    // See note above on avoiding &coeffs(f, 0), which is UB when coeffs is
+    // empty.
+    fn(&value, md::submdspan(coeffs, f, md::full_extent).data_handle(),
+       constants.data(), cdofs_b.data(), &local_entity, &perm, nullptr);
   }
 
   return value;
@@ -160,8 +166,11 @@ T assemble_interior_facets(
                           ? std::array<std::uint8_t, 2>{0, 0}
                           : std::array{perms(cells[0], local_facet[0]),
                                        perms(cells[1], local_facet[1])};
-    fn(&value, &coeffs(f, 0, 0), constants.data(), cdofs_b.data(),
-       local_facet.data(), perm.data(), nullptr);
+    // See note above on avoiding &coeffs(f, 0), which is UB when coeffs is
+    // empty.
+    fn(&value, md::submdspan(coeffs, f, 0, md::full_extent).data_handle(),
+       constants.data(), cdofs_b.data(), local_facet.data(), perm.data(),
+       nullptr);
   }
 
   return value;

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -43,6 +43,13 @@ T assemble_cells(
 
   assert(cdofs_b.size() >= 3 * x_dofmap.extent(1));
 
+  // Base pointer and per-cell stride into coeffs, computed once rather than
+  // per cell. coeffs_data is nullptr when coeffs is empty (a form with no
+  // Function coefficients); coeffs_data + index * cstride is well-defined
+  // even then, as cstride is 0 and every offset collapses to nullptr + 0.
+  const T* coeffs_data = coeffs.data_handle();
+  const std::size_t cstride = coeffs.extent(1);
+
   // Iterate over all cells
   for (std::size_t index = 0; index < cells.size(); ++index)
   {
@@ -53,12 +60,8 @@ T assemble_cells(
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
       std::copy_n(&x(x_dofs[i], 0), 3, std::next(cdofs_b.begin(), 3 * i));
 
-    // submdspan(...).data_handle() is used rather than &coeffs(index, 0):
-    // the latter dereferences to form a reference before taking its
-    // address, which is UB when coeffs is empty (a form with no Function
-    // coefficients), whereas submdspan only computes an offset.
-    fn(&value, md::submdspan(coeffs, index, md::full_extent).data_handle(),
-       constants.data(), cdofs_b.data(), nullptr, nullptr, nullptr);
+    fn(&value, coeffs_data + index * cstride, constants.data(), cdofs_b.data(),
+       nullptr, nullptr, nullptr);
   }
 
   return value;
@@ -97,6 +100,10 @@ T assemble_entities(
 
   assert(cdofs_b.size() >= 3 * x_dofmap.extent(1));
 
+  // See the note in assemble_cells on coeffs_data/cstride.
+  const T* coeffs_data = coeffs.data_handle();
+  const std::size_t cstride = coeffs.extent(1);
+
   // Iterate over all facets
   for (std::size_t f = 0; f < entities.extent(0); ++f)
   {
@@ -110,10 +117,8 @@ T assemble_entities(
 
     // Permutations
     std::uint8_t perm = perms.empty() ? 0 : perms(cell, local_entity);
-    // See note above on avoiding &coeffs(f, 0), which is UB when coeffs is
-    // empty.
-    fn(&value, md::submdspan(coeffs, f, md::full_extent).data_handle(),
-       constants.data(), cdofs_b.data(), &local_entity, &perm, nullptr);
+    fn(&value, coeffs_data + f * cstride, constants.data(), cdofs_b.data(),
+       &local_entity, &perm, nullptr);
   }
 
   return value;
@@ -148,6 +153,11 @@ T assemble_interior_facets(
   auto cdofs0 = cdofs_b.first(3 * x_dofmap.extent(1));
   auto cdofs1 = cdofs_b.last(3 * x_dofmap.extent(1));
 
+  // See the note in assemble_cells on coeffs_data/cstride. coeffs is
+  // indexed (f, side, cstride), so the per-facet stride covers both sides.
+  const T* coeffs_data = coeffs.data_handle();
+  const std::size_t cstride = 2 * coeffs.extent(2);
+
   // Iterate over all facets
   for (std::size_t f = 0; f < facets.extent(0); ++f)
   {
@@ -166,11 +176,8 @@ T assemble_interior_facets(
                           ? std::array<std::uint8_t, 2>{0, 0}
                           : std::array{perms(cells[0], local_facet[0]),
                                        perms(cells[1], local_facet[1])};
-    // See note above on avoiding &coeffs(f, 0), which is UB when coeffs is
-    // empty.
-    fn(&value, md::submdspan(coeffs, f, 0, md::full_extent).data_handle(),
-       constants.data(), cdofs_b.data(), local_facet.data(), perm.data(),
-       nullptr);
+    fn(&value, coeffs_data + f * cstride, constants.data(), cdofs_b.data(),
+       local_facet.data(), perm.data(), nullptr);
   }
 
   return value;

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -90,9 +90,8 @@ void assemble_cells(
   auto be = be_b.first(bs * dmap.extent(1));
 
   // Base pointer and per-cell stride into coeffs, computed once rather than
-  // per cell. coeffs_data is nullptr when coeffs is empty (a form with no
-  // Function coefficients); coeffs_data + index * cstride is well-defined
-  // even then, as cstride is 0 and every offset collapses to nullptr + 0.
+  // per cell; coeffs_data + index * cstride is well-defined even when coeffs
+  // is empty (cstride == 0), unlike &coeffs(index, 0).
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = coeffs.extent(1);
 
@@ -188,7 +187,6 @@ void assemble_entities(
   auto be = be_b.first(bs * num_dofs);
   assert(entities0.size() == entities.size());
 
-  // See the note in assemble_cells on coeffs_data/cstride.
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = coeffs.extent(1);
 
@@ -289,8 +287,7 @@ void assemble_interior_facets(
   assert(be_b.size() >= static_cast<std::size_t>(bs) * 2 * dmap_size);
   auto be = be_b.first(bs * 2 * dmap_size);
 
-  // See the note in assemble_cells on coeffs_data/cstride. coeffs is
-  // indexed (f, side, cstride), so the per-facet stride covers both sides.
+  // coeffs is indexed (f, side, cstride); cstride here covers both sides.
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = 2 * coeffs.extent(2);
 

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -89,6 +89,13 @@ void assemble_cells(
   assert(be_b.size() >= bs * dmap.extent(1));
   auto be = be_b.first(bs * dmap.extent(1));
 
+  // Base pointer and per-cell stride into coeffs, computed once rather than
+  // per cell. coeffs_data is nullptr when coeffs is empty (a form with no
+  // Function coefficients); coeffs_data + index * cstride is well-defined
+  // even then, as cstride is 0 and every offset collapses to nullptr + 0.
+  const T* coeffs_data = coeffs.data_handle();
+  const std::size_t cstride = coeffs.extent(1);
+
   // Iterate over active cells
   for (std::size_t index = 0; index < cells.size(); ++index)
   {
@@ -101,15 +108,10 @@ void assemble_cells(
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
       std::copy_n(&x(x_dofs[i], 0), 3, std::next(cdofs_b.begin(), 3 * i));
 
-    // Tabulate vector for cell. submdspan(...).data_handle() is used rather
-    // than &coeffs(index, 0): the latter dereferences to form a reference
-    // before taking its address, which is UB when coeffs is empty (a form
-    // with no Function coefficients), whereas submdspan only computes an
-    // offset.
+    // Tabulate vector for cell
     std::ranges::fill(be, 0);
-    kernel(be.data(),
-           md::submdspan(coeffs, index, md::full_extent).data_handle(),
-           constants.data(), cdofs_b.data(), nullptr, nullptr, nullptr);
+    kernel(be.data(), coeffs_data + index * cstride, constants.data(),
+           cdofs_b.data(), nullptr, nullptr, nullptr);
     P0(be, cell_info0, c0, 1);
 
     // Scatter cell vector to 'global' vector array
@@ -185,6 +187,11 @@ void assemble_entities(
   assert(be_b.size() >= static_cast<std::size_t>(bs) * num_dofs);
   auto be = be_b.first(bs * num_dofs);
   assert(entities0.size() == entities.size());
+
+  // See the note in assemble_cells on coeffs_data/cstride.
+  const T* coeffs_data = coeffs.data_handle();
+  const std::size_t cstride = coeffs.extent(1);
+
   for (std::size_t f = 0; f < entities.extent(0); ++f)
   {
     // Cell in the integration domain, local facet index relative to the
@@ -201,11 +208,10 @@ void assemble_entities(
     // Permutations
     std::uint8_t perm = perms.empty() ? 0 : perms(cell, local_entity);
 
-    // Tabulate element vector. See note above on avoiding &coeffs(f, 0),
-    // which is UB when coeffs is empty.
+    // Tabulate element vector
     std::ranges::fill(be, 0);
-    kernel(be.data(), md::submdspan(coeffs, f, md::full_extent).data_handle(),
-           constants.data(), cdofs_b.data(), &local_entity, &perm, nullptr);
+    kernel(be.data(), coeffs_data + f * cstride, constants.data(),
+           cdofs_b.data(), &local_entity, &perm, nullptr);
     P0(be, cell_info0, cell0, 1);
 
     // Add to global vector
@@ -283,6 +289,11 @@ void assemble_interior_facets(
   assert(be_b.size() >= static_cast<std::size_t>(bs) * 2 * dmap_size);
   auto be = be_b.first(bs * 2 * dmap_size);
 
+  // See the note in assemble_cells on coeffs_data/cstride. coeffs is
+  // indexed (f, side, cstride), so the per-facet stride covers both sides.
+  const T* coeffs_data = coeffs.data_handle();
+  const std::size_t cstride = 2 * coeffs.extent(2);
+
   assert(facets0.size() == facets.size());
   for (std::size_t f = 0; f < facets.extent(0); ++f)
   {
@@ -309,17 +320,14 @@ void assemble_interior_facets(
     std::span dmap1 = cells0[1] >= 0 ? std::span(&dmap(cells0[1], 0), dmap_size)
                                      : std::span<const std::int32_t>();
 
-    // Tabulate element vector. See note above on avoiding &coeffs(f, 0),
-    // which is UB when coeffs is empty.
+    // Tabulate element vector
     std::ranges::fill(be, 0);
     std::array perm = perms.empty()
                           ? std::array<std::uint8_t, 2>{0, 0}
                           : std::array{perms(cells[0], local_facet[0]),
                                        perms(cells[1], local_facet[1])};
-    kernel(be.data(),
-           md::submdspan(coeffs, f, 0, md::full_extent).data_handle(),
-           constants.data(), cdofs_b.data(), local_facet.data(), perm.data(),
-           nullptr);
+    kernel(be.data(), coeffs_data + f * cstride, constants.data(),
+           cdofs_b.data(), local_facet.data(), perm.data(), nullptr);
 
     if (cells0[0] >= 0)
       P0(be, cell_info0, cells0[0], 1);

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -101,10 +101,15 @@ void assemble_cells(
     for (std::size_t i = 0; i < x_dofs.size(); ++i)
       std::copy_n(&x(x_dofs[i], 0), 3, std::next(cdofs_b.begin(), 3 * i));
 
-    // Tabulate vector for cell
+    // Tabulate vector for cell. submdspan(...).data_handle() is used rather
+    // than &coeffs(index, 0): the latter dereferences to form a reference
+    // before taking its address, which is UB when coeffs is empty (a form
+    // with no Function coefficients), whereas submdspan only computes an
+    // offset.
     std::ranges::fill(be, 0);
-    kernel(be.data(), &coeffs(index, 0), constants.data(), cdofs_b.data(),
-           nullptr, nullptr, nullptr);
+    kernel(be.data(),
+           md::submdspan(coeffs, index, md::full_extent).data_handle(),
+           constants.data(), cdofs_b.data(), nullptr, nullptr, nullptr);
     P0(be, cell_info0, c0, 1);
 
     // Scatter cell vector to 'global' vector array
@@ -196,10 +201,11 @@ void assemble_entities(
     // Permutations
     std::uint8_t perm = perms.empty() ? 0 : perms(cell, local_entity);
 
-    // Tabulate element vector
+    // Tabulate element vector. See note above on avoiding &coeffs(f, 0),
+    // which is UB when coeffs is empty.
     std::ranges::fill(be, 0);
-    kernel(be.data(), &coeffs(f, 0), constants.data(), cdofs_b.data(),
-           &local_entity, &perm, nullptr);
+    kernel(be.data(), md::submdspan(coeffs, f, md::full_extent).data_handle(),
+           constants.data(), cdofs_b.data(), &local_entity, &perm, nullptr);
     P0(be, cell_info0, cell0, 1);
 
     // Add to global vector
@@ -303,14 +309,17 @@ void assemble_interior_facets(
     std::span dmap1 = cells0[1] >= 0 ? std::span(&dmap(cells0[1], 0), dmap_size)
                                      : std::span<const std::int32_t>();
 
-    // Tabulate element vector
+    // Tabulate element vector. See note above on avoiding &coeffs(f, 0),
+    // which is UB when coeffs is empty.
     std::ranges::fill(be, 0);
     std::array perm = perms.empty()
                           ? std::array<std::uint8_t, 2>{0, 0}
                           : std::array{perms(cells[0], local_facet[0]),
                                        perms(cells[1], local_facet[1])};
-    kernel(be.data(), &coeffs(f, 0, 0), constants.data(), cdofs_b.data(),
-           local_facet.data(), perm.data(), nullptr);
+    kernel(be.data(),
+           md::submdspan(coeffs, f, 0, md::full_extent).data_handle(),
+           constants.data(), cdofs_b.data(), local_facet.data(), perm.data(),
+           nullptr);
 
     if (cells0[0] >= 0)
       P0(be, cell_info0, cells0[0], 1);

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -89,9 +89,6 @@ void assemble_cells(
   assert(be_b.size() >= bs * dmap.extent(1));
   auto be = be_b.first(bs * dmap.extent(1));
 
-  // Base pointer and per-cell stride into coeffs, computed once rather than
-  // per cell; coeffs_data + index * cstride is well-defined even when coeffs
-  // is empty (cstride == 0), unlike &coeffs(index, 0).
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = coeffs.extent(1);
 
@@ -287,7 +284,6 @@ void assemble_interior_facets(
   assert(be_b.size() >= static_cast<std::size_t>(bs) * 2 * dmap_size);
   auto be = be_b.first(bs * 2 * dmap_size);
 
-  // coeffs is indexed (f, side, cstride); cstride here covers both sides.
   const T* coeffs_data = coeffs.data_handle();
   const std::size_t cstride = 2 * coeffs.extent(2);
 


### PR DESCRIPTION
`&coeffs(idx, 0[, 0])` dereferences before taking the address, which is UB when `coeffs` is empty (a form with no `Function` coefficients, e.g. plain Poisson) — not an edge case, since it fires on ordinary `fem::assemble_matrix`. Caught by UBSan (`-fsanitize=undefined`).

This is a hot loop (once per cell/facet per assembly), so the fix was checked for overhead rather than assumed free. `submdspan(coeffs, idx, md::full_extent).data_handle()` is UB-free but not free: at `-O2` its generic offset computation adds a compare + conditional select per call versus the original. Instead, the base pointer and per-cell/per-facet stride are hoisted out of each loop once, and the pointer is computed with plain arithmetic: `coeffs.data_handle() + idx * coeffs.extent(1)` (and the two-term form for interior-facet integrals, where `coeffs` is indexed `(f, side, cstride)`). This is well-defined even when `coeffs` is empty — `cstride` is then `0`, so every offset collapses to `nullptr + 0`, which the standard explicitly permits (unlike a nonzero offset on a null pointer) — and compiles to *less* code than the original `&coeffs(idx, 0)`, since the per-iteration multiply is also eliminated.

Verified under `-fsanitize=address,undefined`: `cpp/test/` passes at np=1/2/3 (previously aborted on the first assembly test), and `python/test/unit` passes in full (3486 passed).

**Why this was never observed at runtime:** the loaded value from `&coeffs(idx, 0)` is discarded — only its address is used — so any optimizing compiler reduces it to plain pointer arithmetic with no actual memory access, identical to the fix in this PR. It's UBSan's job specifically to flag the abstract-machine violation regardless of generated-code behavior; no build type here previously enabled it.
