### PR TITLE
Trigger Spack-based CI in the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    branches:
+      - main
   workflow_dispatch:
 
 # Cancel superseded runs: a new commit on a pull request makes the


### PR DESCRIPTION
Nine of the eleven status checks required by the `main` ruleset come from
`ci.yml`, which had no `merge_group` trigger, so they were never reported
for a queue ref and every entry stalled until the ruleset's 60 minute
check response timeout ejected it. This adds the trigger, matching
`ccpp.yml`, `ci-spack.yml` and `macos.yml`.

AI assistance: I used Claude Code (Opus 5) to diagnose and draft this PR.
I reviewed, edited, tested, and take responsibility for the final
contribution.