### PR TITLE
Move declaration of OpenMPI-related environment variables to `docker/Dockerfile.test-env`

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -184,9 +184,6 @@ jobs:
     container: "ghcr.io/fenics/test-env:current"
     env:
       PETSC_ARCH: ${{ matrix.petsc_arch }}
-      OMPI_ALLOW_RUN_AS_ROOT: 1
-      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-      PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
       PYTEST_ADDOPTS: "-W error"
 
     name: Build and test (${{ matrix.petsc_arch }})
@@ -295,9 +292,6 @@ jobs:
     container: "ghcr.io/fenics/test-env:current"
     env:
       PETSC_ARCH: linux-gnu-real64-32
-      OMPI_ALLOW_RUN_AS_ROOT: 1
-      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-      PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
     name: Build and publish docs
     steps:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -184,6 +184,7 @@ jobs:
     container: "ghcr.io/fenics/test-env:current"
     env:
       PETSC_ARCH: ${{ matrix.petsc_arch }}
+      PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
       PYTEST_ADDOPTS: "-W error"
 
     name: Build and test (${{ matrix.petsc_arch }})
@@ -292,6 +293,7 @@ jobs:
     container: "ghcr.io/fenics/test-env:current"
     env:
       PETSC_ARCH: linux-gnu-real64-32
+      PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
     name: Build and publish docs
     steps:

--- a/.github/workflows/docker-end-user.yml
+++ b/.github/workflows/docker-end-user.yml
@@ -182,6 +182,8 @@ jobs:
               python3 -c "import dolfinx; from dolfinx.fem import functionspace; from dolfinx.mesh import create_unit_square; from mpi4py import MPI; mesh = create_unit_square(MPI.COMM_WORLD, 10, 10); V = functionspace(mesh, ('Lagrange', 1));"
           docker run --rm docker.io/dolfinx/dolfinx:${{ env.TAG }} \
               /bin/bash -c "source /usr/local/bin/dolfinx-complex-mode && python3 -c $'import dolfinx; from dolfinx.fem import functionspace; from dolfinx.mesh import create_unit_square; from mpi4py import MPI; mesh = create_unit_square(MPI.COMM_WORLD, 10, 10); V = functionspace(mesh, (\"Lagrange\", 1));'"
+          docker run --rm docker.io/dolfinx/dolfinx:${{ env.TAG }} \
+              mpirun -n 2 python3 -c "import dolfinx; from dolfinx.fem import functionspace; from dolfinx.mesh import create_unit_square; from mpi4py import MPI; mesh = create_unit_square(MPI.COMM_WORLD, 10, 10); V = functionspace(mesh, ('Lagrange', 1));"
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4

--- a/.github/workflows/docker-end-user.yml
+++ b/.github/workflows/docker-end-user.yml
@@ -183,7 +183,7 @@ jobs:
           docker run --rm docker.io/dolfinx/dolfinx:${{ env.TAG }} \
               /bin/bash -c "source /usr/local/bin/dolfinx-complex-mode && python3 -c $'import dolfinx; from dolfinx.fem import functionspace; from dolfinx.mesh import create_unit_square; from mpi4py import MPI; mesh = create_unit_square(MPI.COMM_WORLD, 10, 10); V = functionspace(mesh, (\"Lagrange\", 1));'"
           docker run --rm docker.io/dolfinx/dolfinx:${{ env.TAG }} \
-              mpirun -n 2 python3 -c "import dolfinx; from dolfinx.fem import functionspace; from dolfinx.mesh import create_unit_square; from mpi4py import MPI; mesh = create_unit_square(MPI.COMM_WORLD, 10, 10); V = functionspace(mesh, ('Lagrange', 1));"
+              mpiexec -n 2 python3 -c "import dolfinx; from dolfinx.fem import functionspace; from dolfinx.mesh import create_unit_square; from mpi4py import MPI; mesh = create_unit_square(MPI.COMM_WORLD, 10, 10); V = functionspace(mesh, ('Lagrange', 1));"
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -50,7 +50,10 @@ WORKDIR /tmp
 
 # Environment variables
 ENV OPENBLAS_NUM_THREADS=1 \
-    OPENBLAS_VERBOSE=0
+    OPENBLAS_VERBOSE=0 \
+    OMPI_ALLOW_RUN_AS_ROOT=1 \
+    OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+    PRTE_MCA_rmaps_default_mapping_policy=":oversubscribe"
 
 # Install dependencies available via apt-get.
 # OCCT (gmsh's CAD kernel) is built from source below since Ubuntu's

--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -52,8 +52,7 @@ WORKDIR /tmp
 ENV OPENBLAS_NUM_THREADS=1 \
     OPENBLAS_VERBOSE=0 \
     OMPI_ALLOW_RUN_AS_ROOT=1 \
-    OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
-    PRTE_MCA_rmaps_default_mapping_policy=":oversubscribe"
+    OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
 # Install dependencies available via apt-get.
 # OCCT (gmsh's CAD kernel) is built from source below since Ubuntu's


### PR DESCRIPTION
Move setting the variables
```
OMPI_ALLOW_RUN_AS_ROOT=1
OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
PRTE_MCA_rmaps_default_mapping_policy=":oversubscribe"
```
to `docker/Dockerfile.test-env`, instead of setting them in CI workflow.

The nightly image has been broken in parallel for around a week, probably since #4427, with errors like
```
prterun has detected an attempt to run as root.

Running as root is *strongly* discouraged as any mistake (e.g., in
defining TMPDIR) or bug can result in catastrophic damage to the OS
file system, leaving your system in an unusable state.

We strongly suggest that you run prterun as a non-root user.

You can override this protection by adding the --allow-run-as-root
option to your command line.  However, we reiterate our strong advice
against doing so - please do so at your own risk.
```
when trying to run with `mpirun`. Since a end user is not expected to use a non-root user, it makes sense that this variables should be part of the docker image, not added later on by the CI workflow.



