### PR TITLE
Relax mixed Poisson tolerance for single precision

### DIFF
--- a/python/demo/demo_mixed-poisson.py
+++ b/python/demo/demo_mixed-poisson.py
@@ -249,7 +249,7 @@ problem = fem.petsc.LinearProblem(
         "ksp_type": "gmres",
         "pc_type": "fieldsplit",
         "pc_fieldsplit_type": "additive",
-        "ksp_rtol": 1e-8,
+        "ksp_rtol": 1e-6 if np.finfo(dtype).bits == 32 else 1e-8,
         "ksp_gmres_restart": 100,
         "ksp_view": "",
     },


### PR DESCRIPTION
## Summary

- use a relative tolerance of 1e-6 for 32-bit scalar types in the mixed-Poisson demo
- retain the 1e-8 tolerance for 64-bit scalar types

The previous 1e-8 tolerance is not robust for the fp32 FFCx integration jobs: small, valid code-generation round-off differences can cause GMRES to break down before reaching it.

## Testing

- ruff check python/demo/demo_mixed-poisson.py
- ruff format --check python/demo/demo_mixed-poisson.py
- serial mixed-Poisson demo with the local PETSc build
- verified tolerance selection for float32, complex64, float64, and complex128

The local PETSc installation is fp64, so the fp32 demo execution is covered by CI.

AI assistance: I used Codex to draft parts of this PR. I reviewed, edited, tested, and take responsibility for the final contribution.