### PR TITLE
Fix right DOF transformation for mixed elements with block size > 1

### DIFF
--- a/cpp/dolfinx/fem/FiniteElement.h
+++ b/cpp/dolfinx/fem/FiniteElement.h
@@ -569,13 +569,20 @@ public:
                    std::span<U> data, std::span<const std::uint32_t> cell_info,
                    std::int32_t cell, int block_size)
         {
+          // `data` is (block_size, ndofs), row-major. Sub-element `e`
+          // owns columns [offset, offset + dims[e]) of every row, so the
+          // rows are transformed one at a time.
+          const std::size_t ndofs = data.size() / block_size;
           std::size_t offset = 0;
           for (std::size_t e = 0; e < sub_element_fns.size(); ++e)
           {
             if (sub_element_fns[e])
             {
-              sub_element_fns[e](data.subspan(offset, data.size() - offset),
-                                 cell_info, cell, block_size);
+              for (int i = 0; i < block_size; ++i)
+              {
+                sub_element_fns[e](data.subspan(i * ndofs + offset, dims[e]),
+                                   cell_info, cell, 1);
+              }
             }
             offset += dims[e];
           }

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(
   common/sub_systems_manager.cpp
   common/index_map.cpp
   common/sort.cpp
+  fem/finite_element.cpp
   fem/form.cpp
   fem/functionspace.cpp
   mesh/branching_manifold.cpp

--- a/cpp/test/fem/finite_element.cpp
+++ b/cpp/test/fem/finite_element.cpp
@@ -1,0 +1,171 @@
+// Copyright (C) 2026 Paul T. Kuehner
+//
+// This file is part of DOLFINX (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <basix/finite-element.h>
+
+#include <dolfinx/fem/FiniteElement.h>
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <numeric>
+#include <span>
+#include <vector>
+
+using namespace dolfinx;
+
+namespace
+{
+using Func = std::function<void(
+    std::span<double>, std::span<const std::uint32_t>, std::int32_t, int)>;
+
+/// Nedelec (first kind), degree 2, on a triangle. Two DOFs per edge, so
+/// the DOF transformations are non-trivial (and not permutations).
+basix::FiniteElement<double> nedelec()
+{
+  return basix::create_element<double>(
+      basix::element::family::N1E, basix::cell::type::triangle, 2,
+      basix::element::lagrange_variant::legendre,
+      basix::element::dpc_variant::unset, false);
+}
+
+/// P1 Lagrange on a triangle. DOF transformations are the identity, so
+/// the only role of this sub-element is to shift the offset of the
+/// element it is mixed with.
+basix::FiniteElement<double> lagrange()
+{
+  return basix::create_element<double>(
+      basix::element::family::P, basix::cell::type::triangle, 1,
+      basix::element::lagrange_variant::gll_isaac,
+      basix::element::dpc_variant::unset, false);
+}
+
+/// Apply `fn` to `A` (shape `(nrows, ncols)`, row-major) one row at a
+/// time, i.e. exclusively through the `block_size == 1` code path.
+std::vector<double> apply_row_by_row(const Func& fn, std::span<const double> A,
+                                     int nrows, int ncols,
+                                     std::span<const std::uint32_t> cell_info)
+{
+  std::vector<double> out(A.begin(), A.end());
+  for (int i = 0; i < nrows; ++i)
+  {
+    const std::uint32_t cell = 0;
+    const int block_size = 1;
+    fn(std::span(out).subspan(i * ncols, ncols), cell_info, cell, block_size);
+  }
+  return out;
+}
+
+/// Row-major matrix of distinct, well-separated entries.
+std::vector<double> test_data(int nrows, int ncols)
+{
+  std::vector<double> A(nrows * ncols);
+  std::iota(A.begin(), A.end(), 1.0);
+  return A;
+}
+} // namespace
+
+TEST_CASE("Mixed element DOF transformation from the right, block size > 1",
+          "[fem][finite_element]")
+{
+  // Cell permutation with edges 0 and 1 reflected.
+  const std::array<std::uint32_t, 1> cell_info{0b011};
+
+  const auto sub_nedelec
+      = std::make_shared<const fem::FiniteElement<double>>(nedelec());
+  const auto sub_lagrange
+      = std::make_shared<const fem::FiniteElement<double>>(lagrange());
+
+  // The transforming sub-element is placed second, so it sits at a
+  // non-zero DOF offset within the mixed element.
+  const fem::FiniteElement<double> e({sub_lagrange, sub_nedelec});
+  REQUIRE(e.needs_dof_transformations());
+
+  const int ncols = e.space_dimension();
+  const Func Pt
+      = e.dof_transformation_right_fn<double>(fem::doftransform::transpose);
+  REQUIRE(Pt);
+
+  SECTION("Single row is unaffected")
+  {
+    // The block_size == 1 path has no rows to stride over, so it is
+    // taken as the reference below.
+    const std::vector<double> A = test_data(1, ncols);
+    std::vector<double> B = A;
+    Pt(B, cell_info, /*cell=*/0, /*block_size=*/1);
+    CHECK(A != B); // Transformation is not a no-op for this cell
+  }
+
+  SECTION("Multiple rows match a row-by-row application")
+  {
+    const int nrows = 3;
+    const std::vector<double> A = test_data(nrows, ncols);
+    const std::vector<double> expected
+        = apply_row_by_row(Pt, A, nrows, ncols, cell_info);
+
+    std::vector<double> B = A;
+    Pt(B, cell_info, /*cell=*/0, nrows);
+    CHECK(B == expected);
+  }
+}
+
+TEST_CASE("Mixed element DOF transformation from the right, zero offset",
+          "[fem][finite_element]")
+{
+  // Same as above, but with the transforming sub-element first, i.e. at
+  // offset 0. This is the case that the sub-span slicing gets right.
+  const std::array<std::uint32_t, 1> cell_info{0b011};
+
+  const auto sub_nedelec
+      = std::make_shared<const fem::FiniteElement<double>>(nedelec());
+  const auto sub_lagrange
+      = std::make_shared<const fem::FiniteElement<double>>(lagrange());
+
+  const fem::FiniteElement<double> e({sub_nedelec, sub_lagrange});
+  REQUIRE(e.needs_dof_transformations());
+
+  const int ncols = e.space_dimension();
+  const Func Pt
+      = e.dof_transformation_right_fn<double>(fem::doftransform::transpose);
+  REQUIRE(Pt);
+
+  const int nrows = 3;
+  const std::vector<double> A = test_data(nrows, ncols);
+  const std::vector<double> expected
+      = apply_row_by_row(Pt, A, nrows, ncols, cell_info);
+
+  std::vector<double> B = A;
+  Pt(B, cell_info, /*cell=*/0, nrows);
+  CHECK(B == expected);
+}
+
+TEST_CASE("Non-mixed element DOF transformation from the right, block size > 1",
+          "[fem][finite_element]")
+{
+  // The leaf (non-mixed) code path with several rows, for contrast with
+  // the mixed cases above.
+  const std::array<std::uint32_t, 1> cell_info{0b011};
+
+  const fem::FiniteElement<double> e(nedelec());
+  REQUIRE(e.needs_dof_transformations());
+
+  const int ncols = e.space_dimension();
+  const Func Pt
+      = e.dof_transformation_right_fn<double>(fem::doftransform::transpose);
+  REQUIRE(Pt);
+
+  const int nrows = 3;
+  const std::vector<double> A = test_data(nrows, ncols);
+  const std::vector<double> expected
+      = apply_row_by_row(Pt, A, nrows, ncols, cell_info);
+
+  std::vector<double> B = A;
+  Pt(B, cell_info, /*cell=*/0, nrows);
+  CHECK(B == expected);
+}

--- a/cpp/test/fem/finite_element.cpp
+++ b/cpp/test/fem/finite_element.cpp
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
 
 #include <basix/finite-element.h>
 
@@ -16,6 +18,7 @@
 #include <memory>
 #include <numeric>
 #include <span>
+#include <string_view>
 #include <vector>
 
 using namespace dolfinx;
@@ -24,6 +27,30 @@ namespace
 {
 using Func = std::function<void(
     std::span<double>, std::span<const std::uint32_t>, std::int32_t, int)>;
+
+/// The sub-span slicing under test is shared by every transformation
+/// type, so all four are exercised.
+constexpr std::array ttypes{
+    fem::doftransform::standard, fem::doftransform::transpose,
+    fem::doftransform::inverse, fem::doftransform::inverse_transpose};
+
+/// Transformation type name, for test failure output.
+std::string_view name(fem::doftransform ttype)
+{
+  switch (ttype)
+  {
+  case fem::doftransform::standard:
+    return "standard";
+  case fem::doftransform::transpose:
+    return "transpose";
+  case fem::doftransform::inverse:
+    return "inverse";
+  case fem::doftransform::inverse_transpose:
+    return "inverse_transpose";
+  default:
+    return "unknown";
+  }
+}
 
 /// Nedelec (first kind), degree 2, on a triangle. Two DOFs per edge, so
 /// the DOF transformations are non-trivial (and not permutations).
@@ -87,9 +114,11 @@ TEST_CASE("Mixed element DOF transformation from the right, block size > 1",
   const fem::FiniteElement<double> e({sub_lagrange, sub_nedelec});
   REQUIRE(e.needs_dof_transformations());
 
+  const fem::doftransform ttype = GENERATE(from_range(ttypes));
+  CAPTURE(name(ttype));
+
   const int ncols = e.space_dimension();
-  const Func Pt
-      = e.dof_transformation_right_fn<double>(fem::doftransform::transpose);
+  const Func Pt = e.dof_transformation_right_fn<double>(ttype);
   REQUIRE(Pt);
 
   SECTION("Single row is unaffected")
@@ -130,9 +159,11 @@ TEST_CASE("Mixed element DOF transformation from the right, zero offset",
   const fem::FiniteElement<double> e({sub_nedelec, sub_lagrange});
   REQUIRE(e.needs_dof_transformations());
 
+  const fem::doftransform ttype = GENERATE(from_range(ttypes));
+  CAPTURE(name(ttype));
+
   const int ncols = e.space_dimension();
-  const Func Pt
-      = e.dof_transformation_right_fn<double>(fem::doftransform::transpose);
+  const Func Pt = e.dof_transformation_right_fn<double>(ttype);
   REQUIRE(Pt);
 
   const int nrows = 3;
@@ -155,9 +186,11 @@ TEST_CASE("Non-mixed element DOF transformation from the right, block size > 1",
   const fem::FiniteElement<double> e(nedelec());
   REQUIRE(e.needs_dof_transformations());
 
+  const fem::doftransform ttype = GENERATE(from_range(ttypes));
+  CAPTURE(name(ttype));
+
   const int ncols = e.space_dimension();
-  const Func Pt
-      = e.dof_transformation_right_fn<double>(fem::doftransform::transpose);
+  const Func Pt = e.dof_transformation_right_fn<double>(ttype);
   REQUIRE(Pt);
 
   const int nrows = 3;

--- a/cpp/test/fem/finite_element.cpp
+++ b/cpp/test/fem/finite_element.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 Paul T. Kuehner
+// Copyright (C) 2026 Paul Xi Cao
 //
 // This file is part of DOLFINX (https://www.fenicsproject.org)
 //


### PR DESCRIPTION
Fixes #4294.

In the mixed-element branch of `FiniteElement::dof_transformation_right_fn`,
the data passed to each sub-element was sliced as

```cpp
data.subspan(offset, data.size() - offset)
```

which treats the buffer as a single contiguous run. For a right-applied transformation the layout is `(block_size rows) x (ndofs columns)`, so sub-element `e` owns columns `[offset, offset + dims[e])` of *every* row. Basix derives the row stride as `data.size() / n`, so trimming the front of the span shortened the stride by `offset / n` and misaligned every row after the first. Only `block_size == 1`, where the trimmed prefix is absorbed exactly, was correct.

Each row is now transformed separately over the sub-element's own column range. This affects bilinear-form matrix assembly for mixed elements needing DOF transformations, where the transposed transformation is applied with one row per test-function DOF.

## Tests

`cpp/test/fem/finite_element.cpp` compares a multi-row application against a row-by-row application through the `block_size == 1` path, for a mixed element with the transforming sub-element at a non-zero DOF offset (mixed(P1 Lagrange, N1curl degree 2) on a triangle). Two control cases cover the same element at offset 0 and the non-mixed leaf path, both of which were already correct. All cases are parametrised over the four `doftransform` values, each of which failed independently before the fix.

## Note on performance

The sub-element transformation is now invoked once per row rather than once per sub-element, which loses the batching Basix does internally over `n`. Basix's right-apply already supports a column offset internally (`apply_tranpose_matrix_right` indexes `data[data_size * b + offset + i]`), so exposing that in the public `*_apply_right` signature would let this be a single call per sub-element again. Happy to follow up upstream if wanted.

---

AI assistance: I used Claude Code (Opus 5) to draft parts of this PR. I reviewed, edited, tested, and take responsibility for the final contribution.
