### PR TITLE
Pin cython<3.3 in the macOS workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -54,7 +54,10 @@ jobs:
 
       - name: Install Python dependencies (petsc4py)
         run: |
-          pip install cython setuptools wheel
+          # Cython 3.3 tightened pointer-indexing checks that break
+          # petsc4py 3.25.4's generated PC.pyx; pin below that for now.
+          # Mirrors the pin in docker/Dockerfile.test-env.
+          pip install "cython<3.3" setuptools wheel
           pip install mpi4py numpy
 
       - name: Restore cache PETSc and petsc4py


### PR DESCRIPTION
## Summary

The macOS job has started failing on every open pull request. It is not caused by any of them.

The job builds petsc4py from a PETSc v3.25.4 clone with an unpinned Cython. Cython 3.3 tightened pointer-indexing checks, and petsc4py 3.25.4 indexes a C array with a Python `int`:

```
petsc4py/PETSc/PC.pyx:1256:25: Invalid index type 'int'
```

`docker/Dockerfile.test-env` already pins `cython<3.3` for exactly this reason, at [line 128](https://github.com/FEniCS/dolfinx/blob/a0589c4da331cdf310153b22c7c9cb64a873b07f/docker/Dockerfile.test-env#L128). The macOS job was never pinned, but it was not building petsc4py either: the PETSc build is cached under a key containing the Python patch version. The runner image moved to Python 3.14.6, so the key changed and petsc4py was built from source for the first time since Cython 3.3 was released.

```
Cache not found for input keys: macOS-petsc-3.25.4-3.14.6
Successfully installed cython-3.3.0 ...
```

This applies the same pin, so both places that build petsc4py from source agree.

AI assistance: This PR was reviewed and tested with Claude Code (Opus 5).
