### PR TITLE
Drop cython pin

### DIFF
--- a/docker/Dockerfile.test-env
+++ b/docker/Dockerfile.test-env
@@ -122,10 +122,7 @@ RUN python3 -m venv --system-site-packages ${VIRTUAL_ENV}
 # matplotlib is pip-only because Ubuntu's python3-fonttools pulls sympy
 # and unicode-data (~70 MiB); networkx, numba and pyamg follow it to keep
 # the demo and optional sets on one installer.
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    # Cython 3.3 tightened pointer-indexing checks that break
-    # petsc4py 3.25.4's generated PC.pyx; pin below that for now.
-    pip install --no-cache-dir "cython<3.3" && \
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel cython && \
     pip install --no-cache-dir matplotlib networkx numba pyamg
 
 # Install KaHIP


### PR DESCRIPTION
Image rebuild running at https://github.com/FEniCS/dolfinx/actions/runs/33727824797.

Fixes https://github.com/FEniCS/dolfinx/issues/4459