### PR TITLE
Rework marking interface to respect ghosts

### DIFF
--- a/cpp/dolfinx/refinement/mark.h
+++ b/cpp/dolfinx/refinement/mark.h
@@ -16,42 +16,48 @@
 #include <vector>
 
 #include "dolfinx/common/MPI.h"
+#include "dolfinx/la/Vector.h"
 
 namespace dolfinx::refinement
 {
 
 /// @brief Maximum marking of a marker.
 ///
-/// @param[in] marker Input marker (local) - usually an error indicator per
+/// @param[in] marker Input marker - usually an error indicator per
 /// entity
 /// @param[in] theta Cut off parameter, 0 < θ < 1
-/// @param[in] comm Communicator over which the maximum is computed.
-/// @return Indices (local) of marker elements, which satisfy: marker_i ≥ θ
-/// max(marker).
+/// @return Indices (local, including ghosts) of marker elements, which satisfy:
+/// marker_i ≥ θ max(marker).
 template <std::floating_point T>
-std::vector<std::int32_t> mark_maximum(std::span<const T> marker, T theta,
-                                       MPI_Comm comm)
+std::vector<std::int32_t> mark_maximum(const dolfinx::la::Vector<T>& marker,
+                                       T theta)
 {
   if ((theta <= 0) || (theta >= 1))
     throw std::invalid_argument("Theta needs to fulfill 0 < θ < 1.");
 
-  T max = marker.empty() ? std::numeric_limits<T>::lowest()
-                         : std::ranges::max(marker);
+  auto im = marker.index_map();
+  MPI_Comm comm = im->comm();
+
+  std::span local_part = std::span{marker.array()}.subspan(0, im->size_local());
+
+  T max = local_part.empty() ? std::numeric_limits<T>::lowest()
+                             : std::ranges::max(local_part);
   MPI_Allreduce(MPI_IN_PLACE, &max, 1, dolfinx::MPI::mpi_t<T>, MPI_MAX, comm);
 
   auto mark = [&theta, &max](T e) { return e > theta * max; };
 
   std::vector<std::int32_t> indices;
-  indices.reserve(std::ranges::count_if(marker, mark));
+  indices.reserve(std::ranges::count_if(marker.array(), mark));
 
-  for (std::int32_t i = 0; i < static_cast<std::int32_t>(marker.size()); ++i)
+  for (std::int32_t i = 0; i < static_cast<std::int32_t>(marker.array().size());
+       ++i)
   {
-    if (mark(marker[i]))
+    if (mark(marker.array()[i]))
       indices.push_back(i);
   }
 
   spdlog::info("Marking (max) {} / {} (local) entities.", indices.size(),
-               marker.size());
+               im->size_local() + im->num_ghosts());
 
   return indices;
 }

--- a/cpp/dolfinx/refinement/mark.h
+++ b/cpp/dolfinx/refinement/mark.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 Paul T. Kühner
+// Copyright (C) 2026 Paul T. Kühner and Jack S. Hale
 //
 // This file is part of DOLFINX (https://www.fenicsproject.org)
 //
@@ -7,59 +7,110 @@
 #pragma once
 
 #include <algorithm>
-#include <cassert>
 #include <concepts>
 #include <cstdint>
+#include <dolfinx/common/IndexMap.h>
+#include <dolfinx/common/MPI.h>
+#include <dolfinx/la/Vector.h>
+#include <format>
 #include <limits>
 #include <mpi.h>
+#include <span>
 #include <spdlog/spdlog.h>
+#include <stdexcept>
+#include <type_traits>
 #include <vector>
-
-#include "dolfinx/common/MPI.h"
-#include "dolfinx/la/Vector.h"
 
 namespace dolfinx::refinement
 {
 
-/// @brief Maximum marking of a marker.
+/// @brief Return local indices of a set of values whose entry exceeds a
+/// fraction of the global maximum value.
 ///
-/// @param[in] marker Input marker - usually an error indicator per
-/// entity
-/// @param[in] theta Cut off parameter, 0 < θ < 1
-/// @return Indices (local, including ghosts) of marker elements, which satisfy:
-/// marker_i ≥ θ max(marker).
+/// Computes the maximum `max` of @p values over the locally owned entries on
+/// every rank of `index_map.comm()`, and returns the local indices `i`,
+/// satisfying `values[i] > θ max`. This is commonly referred to as 'maximum
+/// marking' in the adaptive finite element literature.
+///
+/// @pre @p values has size `index_map.size_local() + index_map.num_ghosts()`.
+/// @pre Ghost entries of @p values are up to date, i.e. `scatter_forward` has
+/// been called since the owned entries were last modified.
+///
+/// @note θ = 1 marks nothing, since no entry can strictly exceed the true
+/// maximum. θ = 0 is rejected, since `threshold` would be 0 and the
+/// criterion would degenerate to marking every entry with a positive
+/// value.
+///
+///
+/// @param[in] values Values, often with each entry associated with a mesh
+///   entity, e.g. an error indicator.
+/// @param[in] index_map Index map describing the parallel layout of @p
+///   values.
+/// @param[in] theta Cut-off parameter, 0 < θ ≤ 1.
+/// @return Local indices, ascending and including ghosts, of `values`
+/// that satisfy `values[i] > θ max`.
 template <std::floating_point T>
-std::vector<std::int32_t> mark_maximum(const dolfinx::la::Vector<T>& marker,
-                                       T theta)
+std::vector<std::int32_t> mark_maximum(std::span<const T> values,
+                                       const common::IndexMap& index_map,
+                                       std::type_identity_t<T> theta)
 {
-  if ((theta <= 0) || (theta >= 1))
-    throw std::invalid_argument("Theta needs to fulfill 0 < θ < 1.");
+  if ((theta <= 0) or (theta > 1))
+  {
+    throw std::invalid_argument(
+        std::format("theta must satisfy 0 < theta <= 1, got {}.", theta));
+  }
 
-  auto im = marker.index_map();
-  MPI_Comm comm = im->comm();
+  std::int32_t n = values.size();
+  std::int32_t size = index_map.size_local() + index_map.num_ghosts();
+  if (n != size)
+  {
+    throw std::invalid_argument(
+        std::format("values must have size index_map.size_local() + "
+                    "index_map.num_ghosts() = {}, got {}.",
+                    size, n));
+  }
 
-  std::span local_part = std::span{marker.array()}.subspan(0, im->size_local());
+  T local_max = index_map.size_local() == 0
+                    ? std::numeric_limits<T>::lowest()
+                    : std::ranges::max(values.first(index_map.size_local()));
 
-  T max = local_part.empty() ? std::numeric_limits<T>::lowest()
-                             : std::ranges::max(local_part);
-  MPI_Allreduce(MPI_IN_PLACE, &max, 1, dolfinx::MPI::mpi_t<T>, MPI_MAX, comm);
+  T max = 0;
+  MPI_Allreduce(&local_max, &max, 1, dolfinx::MPI::mpi_t<T>, MPI_MAX,
+                index_map.comm());
 
-  auto mark = [&theta, &max](T e) { return e > theta * max; };
+  T threshold = theta * max;
+
+  auto mark = [threshold](T e) { return e > threshold; };
 
   std::vector<std::int32_t> indices;
-  indices.reserve(std::ranges::count_if(marker.array(), mark));
-
-  for (std::int32_t i = 0; i < static_cast<std::int32_t>(marker.array().size());
-       ++i)
+  indices.reserve(std::ranges::count_if(values, mark));
+  for (std::int32_t i = 0; i < n; ++i)
   {
-    if (mark(marker.array()[i]))
+    if (mark(values[i]))
       indices.push_back(i);
   }
 
-  spdlog::info("Marking (max) {} / {} (local) entities.", indices.size(),
-               im->size_local() + im->num_ghosts());
+  spdlog::info("Marking (maximum): marked {} of {} local entries (owned + "
+               "ghost).",
+               indices.size(), n);
 
   return indices;
+}
+
+/// @brief Wrapper for vector based maximum marking.
+///
+/// @note See documentation of index map based mark_maximum.
+///
+/// @param[in] values Values, often with each entry associated with a mesh
+///   entity, e.g. an error indicator.
+/// @param[in] theta Cut-off parameter, 0 < θ ≤ 1.
+/// @return Local indices, ascending and including ghosts, of `values`
+/// that satisfy `values[i] > θ max`.
+template <std::floating_point T>
+std::vector<std::int32_t> mark_maximum(const dolfinx::la::Vector<T>& values,
+                                       std::type_identity_t<T> theta)
+{
+  return mark_maximum<T>(values.array(), *values.index_map(), theta);
 }
 
 } // namespace dolfinx::refinement

--- a/cpp/dolfinx/refinement/mark.h
+++ b/cpp/dolfinx/refinement/mark.h
@@ -97,20 +97,4 @@ std::vector<std::int32_t> mark_maximum(std::span<const T> values,
   return indices;
 }
 
-/// @brief Wrapper for vector based maximum marking.
-///
-/// @note See documentation of index map based mark_maximum.
-///
-/// @param[in] values Values, often with each entry associated with a mesh
-///   entity, e.g. an error indicator.
-/// @param[in] theta Cut-off parameter, 0 < θ ≤ 1.
-/// @return Local indices, ascending and including ghosts, of `values`
-/// that satisfy `values[i] > θ max`.
-template <std::floating_point T>
-std::vector<std::int32_t> mark_maximum(const dolfinx::la::Vector<T>& values,
-                                       std::type_identity_t<T> theta)
-{
-  return mark_maximum<T>(values.array(), *values.index_map(), theta);
-}
-
 } // namespace dolfinx::refinement

--- a/cpp/test/mesh/refinement/mark.cpp
+++ b/cpp/test/mesh/refinement/mark.cpp
@@ -6,8 +6,11 @@
 
 #include <algorithm>
 #include <catch2/catch_template_test_macros.hpp>
+#include <cstddef>
+#include <cstdint>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/refinement/mark.h>
+#include <memory>
 #include <mpi.h>
 #include <vector>
 
@@ -17,36 +20,59 @@ using namespace dolfinx::refinement;
 TEMPLATE_TEST_CASE("Mark maximum empty", "[refinement][mark][maximum]", double,
                    float)
 {
-  std::vector<TestType> marker;
-  auto indices = mark_maximum<TestType>(marker, .5, MPI_COMM_WORLD);
+  dolfinx::la::Vector<TestType> marker(
+      std::make_shared<common::IndexMap>(MPI_COMM_WORLD, 0), 1);
+  auto indices = mark_maximum<TestType>(marker, .5);
   CHECK(indices.size() == 0);
 }
 
 TEMPLATE_TEST_CASE("Mark maximum", "[refinement][mark][maximum]", double, float)
 {
   MPI_Comm comm = MPI_COMM_WORLD;
+  int rank = dolfinx::MPI::rank(comm);
+  int size = dolfinx::MPI::size(comm);
 
-  std::vector<TestType> marker;
-  marker.reserve(10);
-  for (std::size_t i = 0; i < 10; i++)
-    marker.push_back(10 * dolfinx::MPI::rank(comm) + i);
+  // vec: comm size entries owned by rank 0; each other process (rank>0) gets
+  // one as ghost
+  std::int32_t local_size = (rank == 0) ? size : 0;
+  std::vector<std::int64_t> ghosts = (rank == 0)
+                                         ? std::vector<std::int64_t>{}
+                                         : std::vector<std::int64_t>{rank};
+  std::vector<int> owners
+      = (rank == 0) ? std::vector<int>{} : std::vector<int>{0};
+  dolfinx::la::Vector<TestType> marker(
+      std::make_shared<common::IndexMap>(comm, local_size, ghosts, owners), 1);
+
+  if (rank == 0)
+  {
+    CHECK(marker.array().size() == static_cast<std::size_t>(size));
+    for (int i = 0; i < size; i++)
+      marker.array()[i] = i;
+  }
+  else
+    CHECK(marker.array().size() == 1);
 
   TestType theta = 0.5;
-  auto indices = mark_maximum<TestType>(marker, theta, comm);
+  auto indices = mark_maximum<TestType>(marker, theta);
 
-  CHECK(std::ranges::all_of(
-      indices, [&marker](auto e)
-      { return (0 <= e) && (e <= static_cast<std::int32_t>(marker.size())); }));
+  CHECK(std::ranges::all_of(indices,
+                            [&marker](auto e)
+                            {
+                              return (0 <= e)
+                                     && (e <= static_cast<std::int32_t>(
+                                             marker.array().size()));
+                            }));
 
-  TestType max = dolfinx::MPI::size(comm) * 10 - 1;
+  TestType max = size - 1;
   auto mark = [&theta, &max](auto e) { return e > theta * max; };
 
-  CHECK(std::ranges::count_if(marker, mark)
+  CHECK(std::ranges::count_if(marker.array(), mark)
         == static_cast<std::int32_t>(indices.size()));
 
-  for (std::int32_t i = 0; i < static_cast<std::int32_t>(marker.size()); ++i)
+  for (std::int32_t i = 0; i < static_cast<std::int32_t>(marker.array().size());
+       ++i)
   {
-    bool expect_marked = mark(marker[i]);
+    bool expect_marked = mark(marker.array()[i]);
     bool marked = std::ranges::find(indices, i) != indices.end();
     CHECK(expect_marked == marked);
   }

--- a/cpp/test/mesh/refinement/mark.cpp
+++ b/cpp/test/mesh/refinement/mark.cpp
@@ -52,10 +52,8 @@ TEMPLATE_TEST_CASE("Mark maximum", "[refinement][mark][maximum]", double, float)
   else
   {
     CHECK(v.size() == 1);
-    // Poison the ghost slot: if the local max were wrongly computed over
-    // ghosts too, this would inflate the (globally reduced) threshold and
-    // the checks below would fail.
-    v[0] = static_cast<TestType>(1000);
+    // Check max reduction ignores ghosts.
+    v[0] = static_cast<TestType>(size + 1);
   }
 
   TestType theta = 0.5;

--- a/cpp/test/mesh/refinement/mark.cpp
+++ b/cpp/test/mesh/refinement/mark.cpp
@@ -20,9 +20,9 @@ using namespace dolfinx::refinement;
 TEMPLATE_TEST_CASE("Mark maximum empty", "[refinement][mark][maximum]", double,
                    float)
 {
-  dolfinx::la::Vector<TestType> marker(
-      std::make_shared<common::IndexMap>(MPI_COMM_WORLD, 0), 1);
-  auto indices = mark_maximum<TestType>(marker, .5);
+  common::IndexMap im(MPI_COMM_WORLD, 0);
+  std::vector<TestType> values;
+  auto indices = mark_maximum<TestType>(values, im, .5);
   CHECK(indices.size() == 0);
 }
 

--- a/cpp/test/mesh/refinement/mark.cpp
+++ b/cpp/test/mesh/refinement/mark.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 Paul T. Kühner
+// Copyright (C) 2026 Paul T. Kühner and Jack S. Hale
 //
 // This file is part of DOLFINX (https://www.fenicsproject.org)
 //
@@ -10,8 +10,8 @@
 #include <cstdint>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/refinement/mark.h>
-#include <memory>
 #include <mpi.h>
+#include <span>
 #include <vector>
 
 using namespace dolfinx;
@@ -40,39 +40,40 @@ TEMPLATE_TEST_CASE("Mark maximum", "[refinement][mark][maximum]", double, float)
                                          : std::vector<std::int64_t>{rank};
   std::vector<int> owners
       = (rank == 0) ? std::vector<int>{} : std::vector<int>{0};
-  dolfinx::la::Vector<TestType> marker(
-      std::make_shared<common::IndexMap>(comm, local_size, ghosts, owners), 1);
+  common::IndexMap im(comm, local_size, ghosts, owners);
 
+  std::vector<TestType> v(im.size_local() + im.num_ghosts());
   if (rank == 0)
   {
-    CHECK(marker.array().size() == static_cast<std::size_t>(size));
+    CHECK(v.size() == static_cast<std::size_t>(size));
     for (int i = 0; i < size; i++)
-      marker.array()[i] = i;
+      v[i] = i;
   }
   else
-    CHECK(marker.array().size() == 1);
+  {
+    CHECK(v.size() == 1);
+    // Poison the ghost slot: if the local max were wrongly computed over
+    // ghosts too, this would inflate the (globally reduced) threshold and
+    // the checks below would fail.
+    v[0] = static_cast<TestType>(1000);
+  }
 
   TestType theta = 0.5;
-  auto indices = mark_maximum<TestType>(marker, theta);
+  auto indices = mark_maximum(std::span<const TestType>(v), im, theta);
 
-  CHECK(std::ranges::all_of(indices,
-                            [&marker](auto e)
-                            {
-                              return (0 <= e)
-                                     && (e <= static_cast<std::int32_t>(
-                                             marker.array().size()));
-                            }));
+  CHECK(std::ranges::all_of(
+      indices, [&v](auto e)
+      { return (0 <= e) && (e <= static_cast<std::int32_t>(v.size())); }));
 
   TestType max = size - 1;
   auto mark = [&theta, &max](auto e) { return e > theta * max; };
 
-  CHECK(std::ranges::count_if(marker.array(), mark)
+  CHECK(std::ranges::count_if(v, mark)
         == static_cast<std::int32_t>(indices.size()));
 
-  for (std::int32_t i = 0; i < static_cast<std::int32_t>(marker.array().size());
-       ++i)
+  for (std::int32_t i = 0; i < static_cast<std::int32_t>(v.size()); ++i)
   {
-    bool expect_marked = mark(marker.array()[i]);
+    bool expect_marked = mark(v[i]);
     bool marked = std::ranges::find(indices, i) != indices.end();
     CHECK(expect_marked == marked);
   }

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -1,5 +1,5 @@
-# Copyright (C) 2017-2024 Chris N. Richardson, Garth N. Wells and
-# Jørgen S. Dokken
+# Copyright (C) 2017-2024 Chris N. Richardson, Garth N. Wells, Jørgen S.
+# Dokken, Paul T. Kühner and Jack S. Hale
 #
 # This file is part of DOLFINx (https://www.fenicsproject.org)
 #
@@ -35,14 +35,13 @@ from dolfinx.cpp.mesh import (
 from dolfinx.cpp.refinement import (
     IdentityPartitionerPlaceholder,
     RefinementOption,
-    mark_maximum,
 )
-from dolfinx.cpp.refinement import (
-    uniform_refine as _uniform_refine,
-)
+from dolfinx.cpp.refinement import mark_maximum as _mark_maximum
+from dolfinx.cpp.refinement import uniform_refine as _uniform_refine
 from dolfinx.fem import CoordinateElement as _CoordinateElement
 from dolfinx.fem.element import _coordinate_element_from_basix
 from dolfinx.graph import AdjacencyList
+from dolfinx.la import Vector
 from dolfinx.typing import Real
 
 __all__ = [
@@ -939,6 +938,27 @@ def _get_mesh_partitioner(
             raise TypeError("The partitioner in the tuple must not be None.")
         return partitioner_fn, cell_weights
     return partitioner, None
+
+
+def mark_maximum(
+    indicators: Vector[Real],
+    theta: float,
+) -> npt.NDArray[np.int32]:
+    r"""Compute maximum-based marking of indicators.
+
+    Returns the indices :math:`i` of the indicators :math:`\eta_i` that
+    satisfy the maximum threshold:
+    :math:`\eta_i > \theta \max_j \eta_j`.
+
+    Args:
+        indicators: Indicators (local) :math:`\eta_i` - usually an error
+            indicator associated with mesh entity :math:`i`.
+        theta: Parameter, :math:`0 < \theta < 1`.
+
+    Returns:
+        Local indices of marked entities (including ghosts).
+    """
+    return _mark_maximum(indicators._cpp_object, theta)  # type: ignore
 
 
 def _create_mesh_coordinate_element(

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -972,7 +972,7 @@ def mark_maximum(
         Local indices, ascending and including ghosts, of the entries
         satisfying :math:`v_i > \theta \max_j v_j`.
     """
-    return _mark_maximum(values, index_map, theta)  # type: ignore
+    return _mark_maximum(values, index_map, theta)
 
 
 def _create_mesh_coordinate_element(

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -941,9 +941,8 @@ def _get_mesh_partitioner(
     return partitioner, None
 
 
-@functools.singledispatch
 def mark_maximum(
-    values: npt.NDArray[Real] | Vector[Real],
+    values: npt.NDArray[Real],
     index_map: _IndexMap,
     theta: float,
 ) -> npt.NDArray[np.int32]:
@@ -976,28 +975,6 @@ def mark_maximum(
         satisfying :math:`v_i > \theta \max_j v_j`.
     """
     return _mark_maximum(values, index_map, theta)  # type: ignore
-
-
-@mark_maximum.register(Vector)
-def _mark_maximum_vector(
-    values: Vector[Real],
-    theta: float,
-) -> npt.NDArray[np.int32]:
-    r"""Return local indices of values exceeding a fraction of the max.
-
-    Note:
-        Wrapper, see index map based callback for further details.
-
-    Args:
-        values: Values, often with each entry associated with a mesh
-            entity, e.g. an error indicator.
-        theta: Cut-off parameter, :math:`0 < \theta \le 1`.
-
-    Returns:
-        Local indices, ascending and including ghosts, of the entries
-        satisfying :math:`v_i > \theta \max_j v_j`.
-    """
-    return _mark_maximum(values.array, values.index_map, theta)
 
 
 def _create_mesh_coordinate_element(

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import functools
 import typing
 import warnings
 from collections.abc import Callable, Sequence
@@ -940,25 +941,63 @@ def _get_mesh_partitioner(
     return partitioner, None
 
 
+@functools.singledispatch
 def mark_maximum(
-    indicators: Vector[Real],
+    values: npt.NDArray[Real],
+    index_map: _IndexMap,
     theta: float,
 ) -> npt.NDArray[np.int32]:
-    r"""Compute maximum-based marking of indicators.
+    r"""Return local indices of values exceeding a fraction of the max.
 
-    Returns the indices :math:`i` of the indicators :math:`\eta_i` that
-    satisfy the maximum threshold:
-    :math:`\eta_i > \theta \max_j \eta_j`.
+    Computes the maximum :math:`\max_j v_j` of ``values`` over the locally
+    owned entries on every rank of ``index_map``'s communicator, and
+    returns the local indices :math:`i` satisfying
+    :math:`v_i > \theta \max_j v_j`. This is commonly referred to as
+    'maximum marking' in the adaptive finite element literature.
+
+    Note:
+        Ghost entries of ``values`` must be up to date, i.e.
+        ``scatter_forward`` must have been called since the owned entries
+        were last modified.
+
+        :math:`\theta = 1` marks nothing, since no entry can strictly
+        exceed the true maximum. :math:`\theta = 0` is rejected, since the
+        threshold would be 0 and the criterion would degenerate to marking
+        every entry with a positive value.
 
     Args:
-        indicators: Indicators (local) :math:`\eta_i` - usually an error
-            indicator associated with mesh entity :math:`i`.
-        theta: Parameter, :math:`0 < \theta < 1`.
+        values: Values, often with each entry associated with a mesh
+            entity, e.g. an error indicator.
+        index_map: Index map describing the parallel layout of ``values``.
+        theta: Cut-off parameter, :math:`0 < \theta \le 1`.
 
     Returns:
-        Local indices of marked entities (including ghosts).
+        Local indices, ascending and including ghosts, of the entries
+        satisfying :math:`v_i > \theta \max_j v_j`.
     """
-    return _mark_maximum(indicators._cpp_object, theta)  # type: ignore
+    return _mark_maximum(values, index_map, theta)  # type: ignore
+
+
+@mark_maximum.register(Vector)
+def _mark_maximum_vector(
+    values: Vector[Real],
+    theta: float,
+) -> npt.NDArray[np.int32]:
+    r"""Return local indices of values exceeding a fraction of the max.
+
+    Note:
+        Wrapper, see index map based callback for further details.
+
+    Args:
+        values: Values, often with each entry associated with a mesh
+            entity, e.g. an error indicator.
+        theta: Cut-off parameter, :math:`0 < \theta \le 1`.
+
+    Returns:
+        Local indices, ascending and including ghosts, of the entries
+        satisfying :math:`v_i > \theta \max_j v_j`.
+    """
+    return _mark_maximum(values.array, values.index_map, theta)
 
 
 def _create_mesh_coordinate_element(

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -8,7 +8,6 @@
 
 from __future__ import annotations
 
-import functools
 import typing
 import warnings
 from collections.abc import Callable, Sequence
@@ -42,7 +41,6 @@ from dolfinx.cpp.refinement import uniform_refine as _uniform_refine
 from dolfinx.fem import CoordinateElement as _CoordinateElement
 from dolfinx.fem.element import _coordinate_element_from_basix
 from dolfinx.graph import AdjacencyList
-from dolfinx.la import Vector
 from dolfinx.typing import Real
 
 __all__ = [

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -943,7 +943,7 @@ def _get_mesh_partitioner(
 
 @functools.singledispatch
 def mark_maximum(
-    values: npt.NDArray[Real],
+    values: npt.NDArray[Real] | Vector[Real],
     index_map: _IndexMap,
     theta: float,
 ) -> npt.NDArray[np.int32]:
@@ -975,7 +975,7 @@ def mark_maximum(
         Local indices, ascending and including ghosts, of the entries
         satisfying :math:`v_i > \theta \max_j v_j`.
     """
-    return _mark_maximum(values, index_map, theta)  # type: ignore
+    return _mark_maximum(values, index_map, theta)
 
 
 @mark_maximum.register(Vector)

--- a/python/dolfinx/mesh.py
+++ b/python/dolfinx/mesh.py
@@ -975,7 +975,7 @@ def mark_maximum(
         Local indices, ascending and including ghosts, of the entries
         satisfying :math:`v_i > \theta \max_j v_j`.
     """
-    return _mark_maximum(values, index_map, theta)
+    return _mark_maximum(values, index_map, theta)  # type: ignore
 
 
 @mark_maximum.register(Vector)

--- a/python/dolfinx/wrappers/dolfinx_wrappers/refinement.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/refinement.h
@@ -135,13 +135,12 @@ void declare_refinement(nanobind::module_& m)
 
   m.def(
       "mark_maximum",
-      [](nb::ndarray<const T, nb::ndim<1>, nb::c_contig> marker, T theta,
-         MPICommWrapper comm)
+      [](const dolfinx::la::Vector<T>& marker, T theta)
       {
-        return dolfinx_wrappers::as_nbarray(dolfinx::refinement::mark_maximum(
-            std::span(marker.data(), marker.size()), theta, comm.get()));
+        return dolfinx_wrappers::as_nbarray(
+            dolfinx::refinement::mark_maximum(marker, theta));
       },
-      nb::arg("marker"), nb::arg("theta"), nb::arg("comm"));
+      nb::arg("marker"), nb::arg("theta"));
 }
 
 } // namespace dolfinx_wrappers

--- a/python/dolfinx/wrappers/dolfinx_wrappers/refinement.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/refinement.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2018-2024 Chris N. Richardson, Garth N. Wells and Paul T.
-// Kühner
+// Copyright (C) 2018-2026 Chris N. Richardson, Garth N. Wells, Paul T.
+// Kühner and Jack S. Hale
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -13,6 +13,7 @@
 #include "graph.h"
 #include "mesh.h"
 #include <concepts>
+#include <dolfinx/common/IndexMap.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/refinement/mark.h>
 #include <dolfinx/refinement/option.h>
@@ -135,12 +136,14 @@ void declare_refinement(nanobind::module_& m)
 
   m.def(
       "mark_maximum",
-      [](const dolfinx::la::Vector<T>& marker, T theta)
+      [](nb::ndarray<const T, nb::ndim<1>, nb::c_contig> values,
+         const dolfinx::common::IndexMap& index_map, T theta)
       {
-        return dolfinx_wrappers::as_nbarray(
-            dolfinx::refinement::mark_maximum(marker, theta));
+        return dolfinx_wrappers::as_nbarray(dolfinx::refinement::mark_maximum(
+            std::span<const T>(values.data(), values.size()), index_map,
+            theta));
       },
-      nb::arg("marker"), nb::arg("theta"));
+      nb::arg("values"), nb::arg("index_map"), nb::arg("theta"));
 }
 
 } // namespace dolfinx_wrappers

--- a/python/test/unit/refinement/test_mark.py
+++ b/python/test/unit/refinement/test_mark.py
@@ -31,7 +31,7 @@ def test_mark_maximum(theta: float, dtype: np.dtype, ghost_mode: dolfinx.mesh.Gh
     )
     marker.scatter_forward()
 
-    marked_cells = mesh.mark_maximum(marker._cpp_object, theta)
+    marked_cells = mesh.mark_maximum(marker, theta)
 
     threshold = theta * comm.allreduce(np.max(marker.array), MPI.MAX)
     assert np.allclose(

--- a/python/test/unit/refinement/test_mark.py
+++ b/python/test/unit/refinement/test_mark.py
@@ -9,23 +9,34 @@ from mpi4py import MPI
 import numpy as np
 import pytest
 
-from dolfinx import mesh
+import dolfinx
+from dolfinx import la, mesh
 
 
 @pytest.mark.parametrize("theta", [0.2, 0.4, 0.6, 0.8])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_mark_maximum(theta: float, dtype: np.dtype) -> None:
-    msh = mesh.create_unit_square(comm := MPI.COMM_WORLD, n := 10, n, dtype=dtype)
-
+@pytest.mark.parametrize(
+    "ghost_mode", [dolfinx.mesh.GhostMode.none, dolfinx.mesh.GhostMode.shared_facet]
+)
+def test_mark_maximum(theta: float, dtype: np.dtype, ghost_mode: dolfinx.mesh.GhostMode) -> None:
+    msh = mesh.create_unit_square(
+        comm := MPI.COMM_WORLD, n := 10, n, dtype=dtype, ghost_mode=ghost_mode
+    )
     tdim = msh.topology.dim
-    cell_count = (cell_im := msh.topology.index_map(tdim)).size_local + cell_im.num_ghosts
-    marker = np.random.default_rng(0).random(cell_count)
 
-    marked_cells = mesh.mark_maximum(marker, theta, comm)
+    im_c = msh.topology.index_map(tdim)
+    marker = la.vector(im_c, dtype=dtype)
+    marker.array[: marker.index_map.size_local] = np.random.default_rng(0).random(
+        marker.index_map.size_local
+    )
+    marker.scatter_forward()
 
+    marked_cells = mesh.mark_maximum(marker._cpp_object, theta)
+
+    threshold = theta * comm.allreduce(np.max(marker.array), MPI.MAX)
     assert np.allclose(
         marked_cells,
-        np.argwhere(marker > theta * comm.allreduce(np.max(marker), MPI.MAX)).flatten(),
+        np.argwhere(marker.array > threshold).flatten(),
     )
 
     msh.topology.create_entities(1)

--- a/python/test/unit/refinement/test_mark.py
+++ b/python/test/unit/refinement/test_mark.py
@@ -25,18 +25,14 @@ def test_mark_maximum(theta: float, dtype: np.dtype, ghost_mode: dolfinx.mesh.Gh
     tdim = msh.topology.dim
 
     im_c = msh.topology.index_map(tdim)
-    marker = la.vector(im_c, dtype=dtype)
-    marker.array[: marker.index_map.size_local] = np.random.default_rng(0).random(
-        marker.index_map.size_local
-    )
-    marker.scatter_forward()
+    marker = np.random.default_rng(0).random(im_c.size_local + im_c.num_ghosts)
 
-    marked_cells = mesh.mark_maximum(marker, theta)
+    marked_cells = mesh.mark_maximum(marker, im_c, theta)
 
-    threshold = theta * comm.allreduce(np.max(marker.array), MPI.MAX)
+    threshold = theta * comm.allreduce(np.max(marker), MPI.MAX)
     assert np.allclose(
         marked_cells,
-        np.argwhere(marker.array > threshold).flatten(),
+        np.argwhere(marker > threshold).flatten(),
     )
 
     msh.topology.create_entities(1)

--- a/python/test/unit/refinement/test_mark.py
+++ b/python/test/unit/refinement/test_mark.py
@@ -9,16 +9,13 @@ from mpi4py import MPI
 import numpy as np
 import pytest
 
-import dolfinx
-from dolfinx import la, mesh
+from dolfinx import mesh
 
 
 @pytest.mark.parametrize("theta", [0.2, 0.4, 0.6, 0.8])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-@pytest.mark.parametrize(
-    "ghost_mode", [dolfinx.mesh.GhostMode.none, dolfinx.mesh.GhostMode.shared_facet]
-)
-def test_mark_maximum(theta: float, dtype: np.dtype, ghost_mode: dolfinx.mesh.GhostMode) -> None:
+@pytest.mark.parametrize("ghost_mode", [mesh.GhostMode.none, mesh.GhostMode.shared_facet])
+def test_mark_maximum(theta: float, dtype: np.dtype, ghost_mode: mesh.GhostMode) -> None:
     msh = mesh.create_unit_square(
         comm := MPI.COMM_WORLD, n := 10, n, dtype=dtype, ghost_mode=ghost_mode
     )
@@ -30,10 +27,7 @@ def test_mark_maximum(theta: float, dtype: np.dtype, ghost_mode: dolfinx.mesh.Gh
     marked_cells = mesh.mark_maximum(marker, im_c, theta)
 
     threshold = theta * comm.allreduce(np.max(marker), MPI.MAX)
-    assert np.allclose(
-        marked_cells,
-        np.argwhere(marker > threshold).flatten(),
-    )
+    assert np.allclose(marked_cells, np.argwhere(marker > threshold).flatten())
 
     msh.topology.create_entities(1)
     marked_edges = mesh.compute_incident_entities(msh.topology, marked_cells, tdim, 1)


### PR DESCRIPTION
https://github.com/FEniCS/dolfinx/pull/4156 missed the handling of ghost entries; caught by @jhale in extending upon PR https://github.com/FEniCS/dolfinx/pull/4187.

The underlying issue is that marker computation needs to happen on locally owned entities; while the marked entities (output) need to include ghost members. The dolfinx native way to achieve this is to just rely on a vector which carries exactly the infrastructure to differentiate between ghosted and non-ghosted contributions. Also this makes the caller interface simpler; as usually markers are $\mathcal{DG}_0$ functions anyhow.

- `mark_maximum` now computes the max over the locally owned entries (no change here, max. is insensitive to duplicates - but delicate for other markers)
- and returns the marked ghost entities as well
- tests extended to include non-trivial ghost setups
- Python wrapper pulled in from https://github.com/FEniCS/dolfinx/pull/4187
- supports both vector and array based interfaces.

Part of https://github.com/FEniCS/dolfinx/issues/4141.