### PR TITLE
Additional tests for codim-1 manifolds

### DIFF
--- a/.github/workflows/fenicsx-refs.env
+++ b/.github/workflows/fenicsx-refs.env
@@ -1,6 +1,6 @@
 basix_repository=FEniCS/basix
 basix_ref=main
 ufl_repository=FEniCS/ufl
-ufl_ref=dokken/manifold-fixes
+ufl_ref=main
 ffcx_repository=FEniCS/ffcx
-ffcx_ref=main
+ffcx_ref=dokken/manifold-fixes

--- a/.github/workflows/fenicsx-refs.env
+++ b/.github/workflows/fenicsx-refs.env
@@ -1,6 +1,6 @@
 basix_repository=FEniCS/basix
 basix_ref=main
 ufl_repository=FEniCS/ufl
-ufl_ref=main
+ufl_ref=dokken/manifold-fixes
 ffcx_repository=FEniCS/ffcx
 ffcx_ref=main

--- a/python/test/unit/fem/test_assemble_submesh.py
+++ b/python/test/unit/fem/test_assemble_submesh.py
@@ -422,6 +422,46 @@ def test_mixed_dom_codim_1_gradient(n, k):
     assert np.isclose(c_parent, c_submesh)
 
 
+@pytest.mark.parametrize("cell_type", [CellType.tetrahedron, CellType.hexahedron])
+def test_mixed_dom_codim_1_gradient_3d(cell_type):
+    """3D analogue of test_mixed_dom_codim_1_gradient.
+
+    Grad of a coefficient defined on a codimension-1 (2D facet) submesh
+    of a 3D mesh must agree whether integrated via an exterior facet
+    measure on the parent mesh or directly on the submesh's own cell
+    measure, for both a simplex parent (tetrahedron -> triangle facets)
+    and a tensor-product parent (hexahedron -> quadrilateral facets).
+    """
+    msh = create_box(
+        MPI.COMM_WORLD, [[0.0, 0.0, 0.0], [3.0, 1.0, 2.0]], (6, 2, 4), cell_type=cell_type
+    )
+
+    tdim = msh.topology.dim
+    msh.topology.create_connectivity(tdim - 1, tdim)
+    boundary_facets = exterior_facet_indices(msh.topology)
+    smsh, entity_map = create_submesh(msh, tdim - 1, boundary_facets)[:2]
+
+    Vbar = fem.functionspace(smsh, ("Lagrange", 1))
+    g = fem.Function(Vbar)
+    g.interpolate(lambda x: x[0] + 2.0 * x[1] + 3.0 * x[2])
+
+    ds = ufl.Measure("ds", domain=msh)
+    dx_smsh = ufl.Measure("dx", domain=smsh)
+
+    entity_maps = [entity_map]
+    M_parent = fem.form(g.dx(0) * ds, entity_maps=entity_maps)
+    M_submesh = fem.form(g.dx(0) * dx_smsh)
+
+    c_parent = msh.comm.allreduce(fem.assemble_scalar(M_parent), op=MPI.SUM)
+    c_submesh = msh.comm.allreduce(fem.assemble_scalar(M_submesh), op=MPI.SUM)
+
+    # Guard against a vacuous test (a too-symmetric domain/coefficient can
+    # let this bug's error cancel to ~0 across the boundary, as happened
+    # with an earlier version of test_mixed_dom_codim_1_gradient).
+    assert not np.isclose(c_submesh, 0.0)
+    assert np.isclose(c_parent, c_submesh)
+
+
 def test_disjoint_submeshes():
     # FIXME Simplify this test
     """Test assembly with multiple disjoint submeshes in same variational form."""

--- a/python/test/unit/fem/test_assemble_submesh.py
+++ b/python/test/unit/fem/test_assemble_submesh.py
@@ -455,10 +455,14 @@ def test_mixed_dom_codim_1_gradient_3d(cell_type):
     c_parent = msh.comm.allreduce(fem.assemble_scalar(M_parent), op=MPI.SUM)
     c_submesh = msh.comm.allreduce(fem.assemble_scalar(M_submesh), op=MPI.SUM)
 
-    # Guard against a vacuous test (a too-symmetric domain/coefficient can
-    # let this bug's error cancel to ~0 across the boundary, as happened
-    # with an earlier version of test_mixed_dom_codim_1_gradient).
-    assert not np.isclose(c_submesh, 0.0)
+    # g.dx(0) is the x-component of the *manifold* (tangential) gradient
+    # of g, i.e. of (1, 2, 3) projected onto each face's own tangent
+    # plane. On the x=const faces (normal (1, 0, 0)) that projection
+    # removes the x-component entirely, giving 0; on the y=const and
+    # z=const faces it is 1. Weighted by each pair of faces' area:
+    # 2 * (0 * 1 * 2) [x=0, x=3; area 1*2] + 2 * (1 * 3 * 2) [y=0, y=1;
+    # area 3*2] + 2 * (1 * 3 * 1) [z=0, z=2; area 3*1] = 0 + 12 + 6 = 18.
+    assert np.isclose(c_submesh, 18.0)
     assert np.isclose(c_parent, c_submesh)
 
 

--- a/python/test/unit/fem/test_assemble_submesh.py
+++ b/python/test/unit/fem/test_assemble_submesh.py
@@ -377,6 +377,51 @@ def test_mixed_dom_codim_1(n, k):
     assert np.isclose(c, c1)
 
 
+@pytest.mark.parametrize("n", [(6, 2), (9, 3)])
+@pytest.mark.parametrize("k", [1, 3])
+def test_mixed_dom_codim_1_gradient(n, k):
+    """Test that Grad of a coefficient defined on a codimension-1 submesh
+    (the boundary of a mesh) gives the same result whether integrated via
+    an exterior facet measure on the parent mesh, or directly via a cell
+    measure on the submesh itself.
+
+    Regression test: the parent-mesh facet integral used to silently use
+    the submesh coefficient's own (unavailable) Jacobian instead of the
+    parent's FacetJacobian, giving a facet-independent, wrong result. A
+    non-square rectangle and a coefficient linear in x (whose derivative
+    is a nonzero constant, exactly reproducible at every degree k) are
+    used deliberately: on a symmetric domain with a smooth/periodic
+    coefficient this bug's error can cancel to ~0 across the boundary,
+    masking the regression.
+    """
+    msh = create_rectangle(MPI.COMM_WORLD, ((0.0, 0.0), (3.0, 1.0)), n)
+
+    tdim = msh.topology.dim
+    msh.topology.create_connectivity(tdim - 1, tdim)
+    boundary_facets = exterior_facet_indices(msh.topology)
+    smsh, entity_map = create_submesh(msh, tdim - 1, boundary_facets)[:2]
+
+    Vbar = fem.functionspace(smsh, ("Lagrange", k))
+    g = fem.Function(Vbar)
+    g.interpolate(lambda x: x[0] + 2.0 * x[1])
+
+    ds = ufl.Measure("ds", domain=msh)
+    dx_smsh = ufl.Measure("dx", domain=smsh)
+
+    entity_maps = [entity_map]
+    M_parent = fem.form(g.dx(0) * ds, entity_maps=entity_maps)
+    M_submesh = fem.form(g.dx(0) * dx_smsh)
+
+    c_parent = msh.comm.allreduce(fem.assemble_scalar(M_parent), op=MPI.SUM)
+    c_submesh = msh.comm.allreduce(fem.assemble_scalar(M_submesh), op=MPI.SUM)
+
+    # g.dx(0) is the *manifold* (tangential) gradient's x-component: 1 on
+    # the horizontal edges (tangent (1, 0), total length 6), 0 on the
+    # vertical edges (tangent (0, 1), orthogonal to x).
+    assert np.isclose(c_submesh, 6.0)
+    assert np.isclose(c_parent, c_submesh)
+
+
 def test_disjoint_submeshes():
     # FIXME Simplify this test
     """Test assembly with multiple disjoint submeshes in same variational form."""


### PR DESCRIPTION
Companion tests for: https://github.com/FEniCS/ffcx/pull/879

Let $\Omega$ be the parent mesh and $\Lambda$ a codim-1 submesh of it, $g \in G(\Lambda)$ a
degree- $k$ Lagrange function on $\Lambda$, and $\bar x$ the spatial coordinate of $\Lambda$.
Write

- `dxL = ufl.dx(domain=Lambda)` — $\Lambda$ integrated as a mesh in its own right;
- `dsO = ufl.ds(domain=Omega)`, `dSO = ufl.dS(domain=Omega)` — the same entities
  integrated as facets of $\Omega$, assembled with `entity_maps=[entity_map]`.

Each test asserts that a quantity belonging to $\Lambda$ is unchanged by which of the two
measures carries it:

- **Manifold gradient**, $\Lambda = \partial\Omega$:
  `g.dx(0)*dxL == g.dx(0)*dsO`, on affine and on higher-order (curved) $\Omega$.
- **Spatial coordinate**, $\Lambda = \partial\Omega$:
  `h(x_bar)*dxL == h(x_bar)*dsO`. Here $\Lambda$ carries no coefficient or argument, so it
  enters only through geometry — this covers the coordinate-dof gather alone, and checks
  that a form which is mixed-dimensional only through a geometric terminal still gets its
  facet permutations computed. $h$ is nonlinear ($h(\bar x) = \bar x_0^2$); a linear one is
  orientation-invariant and is reproduced even by a wrong gather.
- **Restrictions**, $\Lambda =$ the interior facets:
  `g.dx(0)*dxL == g('+').dx(0)*dSO == g('-').dx(0)*dSO`. The `"-"` side's coordinate dofs
  start one *parent* cell into `coordinate_dofs`; the submesh's smaller stride gave 0.
  `test_interior_facet_codim_1` checks values only, and those are right on both
  restrictions even when the gradient is not.

$g$ interpolates $x_0 + 2x_1 + 3x_2$, which is linear (hence exact at every $k$) with a
distinct coefficient per axis (so a wrong tangential gradient does not cancel around the
boundary). $\Omega$ is a deliberately non-cubic box for the same reason. Each case is
parametrised over `triangle`, `quadrilateral`, `tetrahedron` and `hexahedron`; the gradient
test additionally over $k \in \{1, 3\}$, and the higher-order case over geometry degree
$\in \{2, 3\}$ — a unit square/cube mapped onto an ellipse/ellipsoid via
`interpolate_geometry`. The affine cases assert exact values (6/18 for the gradient,
27/72 for the coordinate); the curved ones have no closed form, so only the two paths are
compared.

Verified against FFCx `main` and against FFCx before #879, with a fresh JIT cache each time:
all 24 cases pass with #879 and all 24 fail without it, serially and under `mpirun -n 3`.