### PR TITLE
common::Scatterer: use neighbourhood collectives only

### DIFF
--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2025 Igor Baratta and Garth N. Wells
+// Copyright (C) 2022-2026 Igor Baratta and Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -62,12 +62,11 @@ public:
   /// @param[in] bs Number of values associated with each `map` index
   /// (the block size).
   Scatterer(const IndexMap& map, int bs)
-      : _single_rank(dolfinx::MPI::size(map.comm()) == 1),
-        _sizes_remote(map.src().size(), 0),
+      : _sizes_remote(map.src().size(), 0),
         _displs_remote(map.src().size() + 1), _sizes_local(map.dest().size()),
         _displs_local(map.dest().size() + 1)
   {
-    if (_single_rank)
+    if (dolfinx::MPI::size(map.comm()) == 1)
       return;
 
     int ierr;
@@ -216,7 +215,7 @@ public:
   /// @param s Scatterer to copy
   template <class U>
   Scatterer(const Scatterer<U>& s)
-      : _single_rank(s._single_rank), _comm0(s._comm0), _comm1(s._comm1),
+      : _comm0(s._comm0), _comm1(s._comm1),
         _remote_inds(s._remote_inds.begin(), s._remote_inds.end()),
         _sizes_remote(s._sizes_remote), _displs_remote(s._displs_remote),
         _local_inds(s._local_inds.begin(), s._local_inds.end()),
@@ -227,7 +226,7 @@ public:
   /// @brief Start a non-blocking neighbourhood collective exchange of
   /// owned data with ranks that ghost it.
   ///
-  /// The communication is completed by calling Scatterer::scatter_end.
+  /// The communication is completed by calling Scatterer::scatter_fwd_end.
   /// See ::local_indices for instructions on packing `send_buffer` and
   /// ::remote_indices for instructions on unpacking `recv_buffer`.
   ///
@@ -235,7 +234,7 @@ public:
   /// must call this function, including ranks without neighbours.
   ///
   /// @note The send and receive buffers must **not** be changed or
-  /// accessed until after a call to Scatterer::scatter_end.
+  /// accessed until after a call to Scatterer::scatter_fwd_end.
   ///
   /// @note The pointers `send_buffer` and `recv_buffer` must be
   /// pointers to the data on the *target device*. E.g., if the send and
@@ -250,12 +249,12 @@ public:
   /// Scatterer::remote_indices for the order of the buffer and how to unpack.
   /// @param[in] request MPI request handle for tracking the status of
   /// the non-blocking communication. The same request handle should be
-  /// passed to Scatterer::scatter_end to complete the communication.
+  /// passed to Scatterer::scatter_fwd_end to complete the communication.
   template <typename T>
   void scatter_fwd_begin(const T* send_buffer, T* recv_buffer,
                          MPI_Request& request) const
   {
-    if (_single_rank)
+    if (_comm0.comm() == MPI_COMM_NULL)
       return;
 
     int ierr = MPI_Ineighbor_alltoallv(
@@ -268,7 +267,7 @@ public:
   /// @brief Start a non-blocking neighbourhood collective exchange of
   /// ghost data with owning ranks.
   ///
-  /// The communication is completed by calling Scatterer::scatter_end.
+  /// The communication is completed by calling Scatterer::scatter_rev_end.
   /// See ::remote_indices for instructions on packing `send_buffer` and
   /// ::local_indices  for instructions on unpacking `recv_buffer`.
   ///
@@ -276,7 +275,7 @@ public:
   /// must call this function, including ranks without neighbours.
   ///
   /// @note The send and receive buffers must **not** be changed or
-  /// accessed until after a call to Scatterer::scatter_end.
+  /// accessed until after a call to Scatterer::scatter_rev_end.
   ///
   /// @note The pointers `send_buffer` and `recv_buffer` must be
   /// pointers to the data on the *target device*. E.g., if the send and
@@ -292,12 +291,12 @@ public:
   /// unpack.
   /// @param[in] request MPI request handle for tracking the status of
   /// the non-blocking communication. The same request handle should be
-  /// passed to Scatterer::scatter_end to complete the communication.
+  /// passed to Scatterer::scatter_rev_end to complete the communication.
   template <typename T>
   void scatter_rev_begin(const T* send_buffer, T* recv_buffer,
                          MPI_Request& request) const
   {
-    if (_single_rank)
+    if (_comm1.comm() == MPI_COMM_NULL)
       return;
 
     int ierr = MPI_Ineighbor_alltoallv(
@@ -310,20 +309,43 @@ public:
   /// @brief Complete a non-blocking MPI neighbourhood collective send.
   ///
   /// This function completes the communication started by
-  /// ::scatter_fwd_begin or ::scatter_rev_begin.
+  /// ::scatter_fwd_begin.
   ///
-  /// @note Collective MPI operation. Every rank in the communicator
-  /// must call this function, including ranks without neighbours.
+  /// @note This is a local completion of the calling rank's own
+  /// request; it is not itself a collective MPI call. Every rank that
+  /// called ::scatter_fwd_begin must nonetheless call this function
+  /// before reusing the send/receive buffers passed to it.
   ///
   /// @param[in] request MPI request handle for tracking the status of
   /// communication.
-  void scatter_end(MPI_Request& request) const
+  void scatter_fwd_end(MPI_Request& request) const
   {
-    if (_single_rank)
+    if (_comm0.comm() == MPI_COMM_NULL)
       return;
 
     int ierr = MPI_Wait(&request, MPI_STATUS_IGNORE);
     dolfinx::MPI::check_error(_comm0.comm(), ierr);
+  }
+
+  /// @brief Complete a non-blocking MPI neighbourhood collective send.
+  ///
+  /// This function completes the communication started by
+  /// ::scatter_rev_begin.
+  ///
+  /// @note This is a local completion of the calling rank's own
+  /// request; it is not itself a collective MPI call. Every rank that
+  /// called ::scatter_rev_begin must nonetheless call this function
+  /// before reusing the send/receive buffers passed to it.
+  ///
+  /// @param[in] request MPI request handle for tracking the status of
+  /// communication.
+  void scatter_rev_end(MPI_Request& request) const
+  {
+    if (_comm1.comm() == MPI_COMM_NULL)
+      return;
+
+    int ierr = MPI_Wait(&request, MPI_STATUS_IGNORE);
+    dolfinx::MPI::check_error(_comm1.comm(), ierr);
   }
 
   /// @brief Array of indices for packing/unpacking owned data to/from a
@@ -386,9 +408,6 @@ public:
   const container_type& remote_indices() const noexcept { return _remote_inds; }
 
 private:
-  // True if the source communicator has only one rank
-  bool _single_rank;
-
   // Communicator where the source ranks own the indices in the callers
   // halo, and the destination ranks 'ghost' indices owned by the
   // caller. I.e.,

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -10,7 +10,9 @@
 #include "MPI.h"
 #include "sort.h"
 #include <algorithm>
+#include <array>
 #include <concepts>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mpi.h>
@@ -25,9 +27,7 @@ namespace dolfinx::common
 /// distributed data that is associated with a common::IndexMap, using
 /// MPI.
 ///
-/// Scatter and gather operations can use:
-/// 1. MPI neighbourhood collectives (recommended), or
-/// 2. Non-blocking point-to-point communication modes.
+/// Scatter and gather operations use MPI neighbourhood collectives.
 ///
 /// The implementation is designed for sparse communication
 /// patterns, as is typical of patterns based on an IndexMap.
@@ -35,7 +35,7 @@ namespace dolfinx::common
 /// A Scatterer is stateless, i.e. it provides the required information
 /// and static data for a given parallel communication pattern but does
 /// not provide any communication caches or track the status of MPI
-/// requests. Callers of the a Scatterer's members are responsible for
+/// requests. Callers of a Scatterer's members are responsible for
 /// managing buffer and MPI request handles.
 ///
 /// @tparam Container Container type for storing the 'local' and
@@ -63,12 +63,13 @@ public:
   /// @param[in] bs Number of values associated with each `map` index
   /// (the block size).
   Scatterer(const IndexMap& map, int bs)
-      : _src(map.src().begin(), map.src().end()),
+      : _single_rank(dolfinx::MPI::size(map.comm()) == 1),
+        _src(map.src().begin(), map.src().end()),
         _dest(map.dest().begin(), map.dest().end()),
         _sizes_remote(_src.size(), 0), _displs_remote(_src.size() + 1),
         _sizes_local(_dest.size()), _displs_local(_dest.size() + 1)
   {
-    if (dolfinx::MPI::size(map.comm()) == 1)
+    if (_single_rank)
       return;
 
     int ierr;
@@ -202,7 +203,7 @@ public:
 
   /// @brief Cast-copy constructor.
   ///
-  /// Create a copy of a Scatterer, were the copy uses a different
+  /// Create a copy of a Scatterer, where the copy uses a different
   /// storage container for indices that are used in MPI communication.
   /// Example usage includes creating from a CPU-suitable Scatterer a
   /// GPU-suitable Scatterer that can be used with GPU-aware MPI to move
@@ -215,7 +216,8 @@ public:
   /// @param s Scatterer to copy
   template <class U>
   Scatterer(const Scatterer<U>& s)
-      : _comm0(s._comm0), _comm1(s._comm1), _src(s._src), _dest(s._dest),
+      : _single_rank(s._single_rank), _comm0(s._comm0), _comm1(s._comm1),
+        _src(s._src), _dest(s._dest),
         _remote_inds(s._remote_inds.begin(), s._remote_inds.end()),
         _sizes_remote(s._sizes_remote), _displs_remote(s._displs_remote),
         _local_inds(s._local_inds.begin(), s._local_inds.end()),
@@ -231,7 +233,10 @@ public:
   /// See ::local_indices for instructions on packing `send_buffer` and
   /// ::remote_indices for instructions on unpacking `recv_buffer`.
   ///
-  /// @note The send and receive buffers must **not** to be changed or
+  /// @note Collective MPI operation. Every rank in the communicator
+  /// must call this function, including ranks without neighbours.
+  ///
+  /// @note The send and receive buffers must **not** be changed or
   /// accessed until after a call to Scatterer::scatter_end.
   ///
   /// @note The pointers `send_buffer` and `recv_buffer` must be
@@ -252,8 +257,7 @@ public:
   void scatter_fwd_begin(const T* send_buffer, T* recv_buffer,
                          MPI_Request& request) const
   {
-    // Return early if there are no incoming or outgoing edges
-    if (_sizes_local.empty() and _sizes_remote.empty())
+    if (_single_rank)
       return;
 
     int ierr = MPI_Ineighbor_alltoallv(
@@ -263,59 +267,17 @@ public:
     dolfinx::MPI::check_error(_comm0.comm(), ierr);
   }
 
-  /// @brief Start a non-blocking send of owned data to ranks that ghost
-  /// the data using *point-to-point MPI communication*.
-  ///
-  /// See ::scatter_fwd_begin for a detailed explanation of usage,
-  /// including on the send and receive buffer packing and unpacking
-  ///
-  /// @note Use of the neighbourhood version of ::scatter_fwd_begin is
-  /// recommended over this version.
-  ///
-  /// @param[in] send_buffer Send buffer.
-  /// @param[in,out] recv_buffer Receive buffer.
-  /// @param[in] requests List of MPI request handles. The length of the
-  /// list must be ::num_p2p_requests()
-  template <typename T>
-  void scatter_fwd_begin(const T* send_buffer, T* recv_buffer,
-                         std::span<MPI_Request> requests) const
-  {
-    if (requests.size() != _dest.size() + _src.size())
-    {
-      throw std::runtime_error(
-          "Point-to-point scatterer has wrong number of MPI_Requests.");
-    }
-
-    // Return early if there are no incoming or outgoing edges
-    if (_sizes_local.empty() and _sizes_remote.empty())
-      return;
-
-    for (std::size_t i = 0; i < _src.size(); ++i)
-    {
-      int ierr = MPI_Irecv(recv_buffer + _displs_remote[i], _sizes_remote[i],
-                           dolfinx::MPI::mpi_t<T>, _src[i], MPI_ANY_TAG,
-                           _comm0.comm(), &requests[i]);
-      dolfinx::MPI::check_error(_comm0.comm(), ierr);
-    }
-
-    for (std::size_t i = 0; i < _dest.size(); ++i)
-    {
-      int ierr = MPI_Isend(send_buffer + _displs_local[i], _sizes_local[i],
-                           dolfinx::MPI::mpi_t<T>, _dest[i], 0, _comm0.comm(),
-                           &requests[i + _src.size()]);
-      dolfinx::MPI::check_error(_comm0.comm(), ierr);
-    }
-  }
-
-  /// @brief Start a non-blocking send of ghost data to ranks that own
-  /// the data using *MPI neighbourhood collective communication*
-  /// (recommended).
+  /// @brief Start a non-blocking neighbourhood collective exchange of
+  /// ghost data with owning ranks.
   ///
   /// The communication is completed by calling Scatterer::scatter_end.
   /// See ::remote_indices for instructions on packing `send_buffer` and
   /// ::local_indices  for instructions on unpacking `recv_buffer`.
   ///
-  /// @note The send and receive buffers must **not** to be changed or
+  /// @note Collective MPI operation. Every rank in the communicator
+  /// must call this function, including ranks without neighbours.
+  ///
+  /// @note The send and receive buffers must **not** be changed or
   /// accessed until after a call to Scatterer::scatter_end.
   ///
   /// @note The pointers `send_buffer` and `recv_buffer` must be
@@ -337,8 +299,7 @@ public:
   void scatter_rev_begin(const T* send_buffer, T* recv_buffer,
                          MPI_Request& request) const
   {
-    // Return early if there are no incoming or outgoing edges
-    if (_sizes_local.empty() and _sizes_remote.empty())
+    if (_single_rank)
       return;
 
     int ierr = MPI_Ineighbor_alltoallv(
@@ -348,80 +309,23 @@ public:
     dolfinx::MPI::check_error(_comm1.comm(), ierr);
   }
 
-  /// @brief Start a non-blocking send of ghost data to ranks that own
-  /// the data using *point-to-point MPI communication*.
-  ///
-  /// See ::scatter_rev_begin for a detailed explanation of usage,
-  /// including on the send and receive buffer packing and unpacking
-  ///
-  /// @note Use of the neighbourhood version of ::scatter_rev_begin is
-  /// recommended over this version
-  ///
-  /// @param[in] send_buffer Send buffer.
-  /// @param[in,out] recv_buffer Receive buffer.
-  /// @param[in] requests List of MPI request handles. The length of the
-  /// list must be ::num_p2p_requests()
-  template <typename T>
-  void scatter_rev_begin(const T* send_buffer, T* recv_buffer,
-                         std::span<MPI_Request> requests) const
-  {
-    if (requests.size() != _dest.size() + _src.size())
-    {
-      throw std::runtime_error(
-          "Point-to-point scatterer has wrong number of MPI_Requests.");
-    }
-
-    // Return early if there are no incoming or outgoing edges
-    if (_sizes_local.empty() and _sizes_remote.empty())
-      return;
-
-    // Start non-blocking send from this process to ghost owners
-    for (std::size_t i = 0; i < _dest.size(); i++)
-    {
-      int ierr = MPI_Irecv(recv_buffer + _displs_local[i], _sizes_local[i],
-                           dolfinx::MPI::mpi_t<T>, _dest[i], MPI_ANY_TAG,
-                           _comm0.comm(), &requests[i]);
-      dolfinx::MPI::check_error(_comm0.comm(), ierr);
-    }
-
-    // Start non-blocking receive from neighbor process for which an
-    // owned index is a ghost
-    for (std::size_t i = 0; i < _src.size(); i++)
-    {
-      int ierr = MPI_Isend(send_buffer + _displs_remote[i], _sizes_remote[i],
-                           dolfinx::MPI::mpi_t<T>, _src[i], 0, _comm0.comm(),
-                           &requests[i + _dest.size()]);
-      dolfinx::MPI::check_error(_comm0.comm(), ierr);
-    }
-  }
-
-  /// @brief Complete non-blocking MPI point-to-point sends.
-  ///
-  /// This function completes the communication started by
-  /// ::scatter_fwd_begin or ::scatter_rev_begin.
-  ///
-  /// @param[in] requests MPI request handles for tracking the status of
-  /// sends.
-  void scatter_end(std::span<MPI_Request> requests) const
-  {
-    // Return early if there are no incoming or outgoing edges
-    if (_sizes_local.empty() and _sizes_remote.empty())
-      return;
-
-    // Wait for communication to complete
-    MPI_Waitall(requests.size(), requests.data(), MPI_STATUS_IGNORE);
-  }
-
   /// @brief Complete a non-blocking MPI neighbourhood collective send.
   ///
   /// This function completes the communication started by
   /// ::scatter_fwd_begin or ::scatter_rev_begin.
   ///
+  /// @note Collective MPI operation. Every rank in the communicator
+  /// must call this function, including ranks without neighbours.
+  ///
   /// @param[in] request MPI request handle for tracking the status of
-  /// the send.
+  /// communication.
   void scatter_end(MPI_Request& request) const
   {
-    scatter_end(std::span<MPI_Request>(&request, 1));
+    if (_single_rank)
+      return;
+
+    int ierr = MPI_Wait(&request, MPI_STATUS_IGNORE);
+    dolfinx::MPI::check_error(_comm0.comm(), ierr);
   }
 
   /// @brief Array of indices for packing/unpacking owned data to/from a
@@ -459,14 +363,13 @@ public:
   /// @brief Array of indices for packing/unpacking ghost data to/from a
   /// send/receive buffer.
   ///
-  /// For a forward scatter, the indices are to copy required entries in
-  /// the owned array into the appropriate position in a send buffer.
-  /// For a reverse scatter, indices are used for assigning
+  /// For a forward scatter, the indices are used to unpack received data
+  /// into ghost entries. For a reverse scatter, indices are used for assigning
   /// (accumulating) the receive buffer values to correct position in
   /// the owned array.
   ///
   /// For a forward scatter, if `xg` is the ghost part of the data array
-  /// and `recv_buffer` is the receive buffer, `xg` is updated that
+  /// and `recv_buffer` is the receive buffer, `xg` is updated as
   ///
   ///     auto& idx = scatterer.remote_indices()
   ///     std::vector<T> recv_buffer(idx.size())
@@ -484,16 +387,10 @@ public:
   /// @return Indices container.
   const container_type& remote_indices() const noexcept { return _remote_inds; }
 
-  /// @brief Number of required `MPI_Request`s for point-to-point
-  /// communication.
-  ///
-  /// @return Number of required MPI request handles.
-  std::size_t num_p2p_requests() const noexcept
-  {
-    return _dest.size() + _src.size();
-  }
-
 private:
+  // True if the source communicator has only one rank
+  bool _single_rank;
+
   // Communicator where the source ranks own the indices in the callers
   // halo, and the destination ranks 'ghost' indices owned by the
   // caller. I.e.,

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -254,7 +254,7 @@ public:
   void scatter_fwd_begin(const T* send_buffer, T* recv_buffer,
                          MPI_Request& request) const
   {
-    if (_comm0.comm() == MPI_COMM_NULL)
+    if (!has_neighbours())
       return;
 
     int ierr = MPI_Ineighbor_alltoallv(
@@ -296,7 +296,7 @@ public:
   void scatter_rev_begin(const T* send_buffer, T* recv_buffer,
                          MPI_Request& request) const
   {
-    if (_comm1.comm() == MPI_COMM_NULL)
+    if (!has_neighbours())
       return;
 
     int ierr = MPI_Ineighbor_alltoallv(
@@ -311,20 +311,18 @@ public:
   /// This function completes the communication started by
   /// ::scatter_fwd_begin.
   ///
-  /// @note This is a local completion of the calling rank's own
-  /// request; it is not itself a collective MPI call. Every rank that
-  /// called ::scatter_fwd_begin must nonetheless call this function
-  /// before reusing the send/receive buffers passed to it.
+  /// @note Local completion of the caller's own request, not itself
+  /// collective. Every rank that called ::scatter_fwd_begin must
+  /// still call this before reusing the buffers.
   ///
   /// @param[in] request MPI request handle for tracking the status of
   /// communication.
   void scatter_fwd_end(MPI_Request& request) const
   {
-    if (_comm0.comm() == MPI_COMM_NULL)
+    if (!has_neighbours())
       return;
 
-    int ierr = MPI_Wait(&request, MPI_STATUS_IGNORE);
-    dolfinx::MPI::check_error(_comm0.comm(), ierr);
+    wait(_comm0, request);
   }
 
   /// @brief Complete a non-blocking MPI neighbourhood collective send.
@@ -332,20 +330,18 @@ public:
   /// This function completes the communication started by
   /// ::scatter_rev_begin.
   ///
-  /// @note This is a local completion of the calling rank's own
-  /// request; it is not itself a collective MPI call. Every rank that
-  /// called ::scatter_rev_begin must nonetheless call this function
-  /// before reusing the send/receive buffers passed to it.
+  /// @note Local completion of the caller's own request, not itself
+  /// collective. Every rank that called ::scatter_rev_begin must
+  /// still call this before reusing the buffers.
   ///
   /// @param[in] request MPI request handle for tracking the status of
   /// communication.
   void scatter_rev_end(MPI_Request& request) const
   {
-    if (_comm1.comm() == MPI_COMM_NULL)
+    if (!has_neighbours())
       return;
 
-    int ierr = MPI_Wait(&request, MPI_STATUS_IGNORE);
-    dolfinx::MPI::check_error(_comm1.comm(), ierr);
+    wait(_comm1, request);
   }
 
   /// @brief Array of indices for packing/unpacking owned data to/from a
@@ -408,6 +404,19 @@ public:
   const container_type& remote_indices() const noexcept { return _remote_inds; }
 
 private:
+  // False only on a single rank, where _comm0/_comm1 stay MPI_COMM_NULL
+  bool has_neighbours() const noexcept
+  {
+    return _comm0.comm() != MPI_COMM_NULL;
+  }
+
+  // Complete a non-blocking request, checking errors against `comm`
+  static void wait(const dolfinx::MPI::Comm& comm, MPI_Request& request)
+  {
+    int ierr = MPI_Wait(&request, MPI_STATUS_IGNORE);
+    dolfinx::MPI::check_error(comm.comm(), ierr);
+  }
+
   // Communicator where the source ranks own the indices in the callers
   // halo, and the destination ranks 'ghost' indices owned by the
   // caller. I.e.,

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -14,7 +14,6 @@
 #include <concepts>
 #include <cstdint>
 #include <functional>
-#include <memory>
 #include <mpi.h>
 #include <numeric>
 #include <span>
@@ -64,34 +63,35 @@ public:
   /// (the block size).
   Scatterer(const IndexMap& map, int bs)
       : _single_rank(dolfinx::MPI::size(map.comm()) == 1),
-        _src(map.src().begin(), map.src().end()),
-        _dest(map.dest().begin(), map.dest().end()),
-        _sizes_remote(_src.size(), 0), _displs_remote(_src.size() + 1),
-        _sizes_local(_dest.size()), _displs_local(_dest.size() + 1)
+        _sizes_remote(map.src().size(), 0),
+        _displs_remote(map.src().size() + 1), _sizes_local(map.dest().size()),
+        _displs_local(map.dest().size() + 1)
   {
     if (_single_rank)
       return;
 
     int ierr;
+    const std::span<const int> src = map.src();
+    const std::span<const int> dest = map.dest();
 
     // Check that src and dest ranks are unique and sorted
-    assert(std::ranges::is_sorted(_src));
-    assert(std::ranges::is_sorted(_dest));
+    assert(std::ranges::is_sorted(src));
+    assert(std::ranges::is_sorted(dest));
 
     // Create communicators with directed edges:
     // (0) owner -> ghost,
     // (1) ghost -> owner
     MPI_Comm comm0;
     ierr = MPI_Dist_graph_create_adjacent(
-        map.comm(), _src.size(), _src.data(), MPI_UNWEIGHTED, _dest.size(),
-        _dest.data(), MPI_UNWEIGHTED, MPI_INFO_NULL, false, &comm0);
+        map.comm(), src.size(), src.data(), MPI_UNWEIGHTED, dest.size(),
+        dest.data(), MPI_UNWEIGHTED, MPI_INFO_NULL, false, &comm0);
     _comm0 = dolfinx::MPI::Comm(comm0, false);
     dolfinx::MPI::check_error(map.comm(), ierr);
 
     MPI_Comm comm1;
     ierr = MPI_Dist_graph_create_adjacent(
-        map.comm(), _dest.size(), _dest.data(), MPI_UNWEIGHTED, _src.size(),
-        _src.data(), MPI_UNWEIGHTED, MPI_INFO_NULL, false, &comm1);
+        map.comm(), dest.size(), dest.data(), MPI_UNWEIGHTED, src.size(),
+        src.data(), MPI_UNWEIGHTED, MPI_INFO_NULL, false, &comm1);
     _comm1 = dolfinx::MPI::Comm(comm1, false);
     dolfinx::MPI::check_error(map.comm(), ierr);
 
@@ -117,12 +117,12 @@ public:
     // disp[i] is the first entry in the buffer sent to neighbourhood
     // rank i, and disp[i + 1] - disp[i] is the number of values sent to
     // rank i.
-    assert(_sizes_remote.size() == _src.size());
-    assert(_displs_remote.size() == _src.size() + 1);
+    assert(_sizes_remote.size() == src.size());
+    assert(_displs_remote.size() == src.size() + 1);
     auto begin = owners_sorted.begin();
-    for (std::size_t i = 0; i < _src.size(); i++)
+    for (std::size_t i = 0; i < src.size(); i++)
     {
-      auto upper = std::upper_bound(begin, owners_sorted.end(), _src[i]);
+      auto upper = std::upper_bound(begin, owners_sorted.end(), src[i]);
       std::size_t num_ind = std::ranges::distance(begin, upper);
       _displs_remote[i + 1] = _displs_remote[i] + num_ind;
       _sizes_remote[i] = num_ind;
@@ -136,8 +136,8 @@ public:
 
     // Compute sizes and displacements of local data (how many local
     // elements to be sent/received grouped by neighbors)
-    assert(_sizes_local.size() == _dest.size());
-    assert(_displs_local.size() == _dest.size() + 1);
+    assert(_sizes_local.size() == dest.size());
+    assert(_displs_local.size() == dest.size() + 1);
     _sizes_remote.reserve(1);
     _sizes_local.reserve(1);
     ierr = MPI_Neighbor_alltoall(_sizes_remote.data(), 1, MPI_INT32_T,
@@ -161,7 +161,7 @@ public:
 
     const std::array<std::int64_t, 2> range = map.local_range();
 #ifndef NDEBUG
-    // Check that all received indice are within the owned range
+    // Check that all received indices are within the owned range
     std::ranges::for_each(recv_buffer, [range](auto idx)
                           { assert(idx >= range[0] and idx < range[1]); });
 #endif
@@ -217,7 +217,6 @@ public:
   template <class U>
   Scatterer(const Scatterer<U>& s)
       : _single_rank(s._single_rank), _comm0(s._comm0), _comm1(s._comm1),
-        _src(s._src), _dest(s._dest),
         _remote_inds(s._remote_inds.begin(), s._remote_inds.end()),
         _sizes_remote(s._sizes_remote), _displs_remote(s._displs_remote),
         _local_inds(s._local_inds.begin(), s._local_inds.end()),
@@ -225,9 +224,8 @@ public:
   {
   }
 
-  /// @brief Start a non-blocking send of owned data to ranks that ghost
-  /// the data using *MPI neighbourhood collective communication*
-  /// (recommended).
+  /// @brief Start a non-blocking neighbourhood collective exchange of
+  /// owned data with ranks that ghost it.
   ///
   /// The communication is completed by calling Scatterer::scatter_end.
   /// See ::local_indices for instructions on packing `send_buffer` and
@@ -286,7 +284,7 @@ public:
   /// `recv_buffer` should be device pointers.
   ///
   /// @param[in] send_buffer Data associated with each ghost index. This
-  /// data is sent to process that owns the index. See
+  /// data is sent to the process that owns the index. See
   /// Scatterer::remote_indices for the order of the buffer and how to
   /// pack.
   /// @param[in,out] recv_buffer Buffer for storing received data. See
@@ -335,7 +333,7 @@ public:
   /// entries in the owned part of the data array into the appropriate
   /// position in a send buffer. For a reverse scatter, indices are used
   /// for assigning (accumulating) the receive buffer values into
-  /// correct position in the owned part of the data array.
+  /// the correct position in the owned part of the data array.
   ///
   /// For a forward scatter, if `x` is the owned part of an array and
   /// `send_buffer` is the send buffer, `send_buffer` is packed such
@@ -365,7 +363,7 @@ public:
   ///
   /// For a forward scatter, the indices are used to unpack received data
   /// into ghost entries. For a reverse scatter, indices are used for assigning
-  /// (accumulating) the receive buffer values to correct position in
+  /// (accumulating) the receive buffer values to the correct position in
   /// the owned array.
   ///
   /// For a forward scatter, if `xg` is the ghost part of the data array
@@ -377,7 +375,7 @@ public:
   ///         xg[idx[i]] = recv_buffer[i];
   ///
   /// For a reverse scatter, if `send_buffer` is the send buffer, then
-  /// `send_buffer` is packaged such that:
+  /// `send_buffer` is packed such that:
   ///
   ///     auto& idx = scatterer.remote_indices()
   ///     std::vector<T> send_buffer(idx.size())
@@ -404,14 +402,6 @@ private:
   // - in-edges (src) are from ranks that 'ghost' my owned indices
   // - out-edges (dest) are to the owning ranks of my ghost indices
   dolfinx::MPI::Comm _comm1{MPI_COMM_NULL};
-
-  // Set of ranks that own ghosts
-  // FIXME: Should we store the index map instead?
-  std::vector<int> _src;
-
-  // Set of ranks ghost owned indices
-  // FIXME: Should we store the index map instead?
-  std::vector<int> _dest;
 
   // Permutation indices used to pack and unpack ghost data (remote)
   container_type _remote_inds;

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2025 Garth N. Wells
+// Copyright (C) 2020-2026 Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -252,8 +252,10 @@ public:
   /// Typical use is a specialised function to unpack data
   /// that resides on a GPU.
   ///
-  /// @note Collective MPI operation. Every rank in the communicator
-  /// must call this function, including ranks without neighbours.
+  /// @note This is a local completion of the calling rank's own
+  /// request; it is not itself a collective MPI call. Every rank that
+  /// called ::scatter_fwd_begin must nonetheless call this function
+  /// before reusing the send/receive buffers.
   ///
   /// @tparam U Unpack function type.
   /// @param unpack Function to unpack the receive buffer into the ghost
@@ -262,7 +264,7 @@ public:
     requires VectorPackKernel<U, container_type, ScatterContainer>
   void scatter_fwd_end(U unpack)
   {
-    _scatterer->scatter_end(_request);
+    _scatterer->scatter_fwd_end(_request);
     unpack(_scatterer->remote_indices().begin(),
            _scatterer->remote_indices().end(), _buffer_remote.begin(),
            std::next(_x.begin(), _bs * _map->size_local()));
@@ -275,8 +277,10 @@ public:
   /// storage. The receive buffer is unpacked internally by a function
   /// that is suitable for use on a CPU.
   ///
-  /// @note Collective MPI operation. Every rank in the communicator
-  /// must call this function, including ranks without neighbours.
+  /// @note This is a local completion of the calling rank's own
+  /// request; it is not itself a collective MPI call. Every rank that
+  /// called ::scatter_fwd_begin must nonetheless call this function
+  /// before reusing the send/receive buffers.
   void scatter_fwd_end()
     requires requires(Container c) {
       { c.data() } -> std::same_as<T*>;
@@ -354,15 +358,17 @@ public:
   /// received. The received data can be summed or inserted into the
   /// owning entry by the `unpack` function.
   ///
-  /// @note Collective MPI operation. Every rank in the communicator
-  /// must call this function, including ranks without neighbours.
+  /// @note This is a local completion of the calling rank's own
+  /// request; it is not itself a collective MPI call. Every rank that
+  /// called ::scatter_rev_begin must nonetheless call this function
+  /// before reusing the send/receive buffers.
   ///
   /// @tparam U Unpack function type.
   template <typename U>
     requires VectorPackKernel<U, container_type, ScatterContainer>
   void scatter_rev_end(U unpack)
   {
-    _scatterer->scatter_end(_request);
+    _scatterer->scatter_rev_end(_request);
     unpack(_scatterer->local_indices().begin(),
            _scatterer->local_indices().end(), _buffer_local.begin(),
            _x.begin());

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -221,6 +221,9 @@ public:
              and GetPtrConcept<GetPtr, Container, T>
   void scatter_fwd_begin(U pack, GetPtr get_ptr)
   {
+    if (dolfinx::MPI::size(_map->comm()) == 1)
+      return;
+
     pack(_scatterer->local_indices().begin(), _scatterer->local_indices().end(),
          _x.begin(), _buffer_local.begin());
     _scatterer->scatter_fwd_begin(get_ptr(_buffer_local),
@@ -258,6 +261,9 @@ public:
     requires VectorPackKernel<U, container_type, ScatterContainer>
   void scatter_fwd_end(U unpack)
   {
+    if (dolfinx::MPI::size(_map->comm()) == 1)
+      return;
+
     _scatterer->scatter_end(_request);
     unpack(_scatterer->remote_indices().begin(),
            _scatterer->remote_indices().end(), _buffer_remote.begin(),
@@ -316,6 +322,9 @@ public:
              and GetPtrConcept<GetPtr, Container, T>
   void scatter_rev_begin(U pack, GetPtr get_ptr)
   {
+    if (dolfinx::MPI::size(_map->comm()) == 1)
+      return;
+
     std::int32_t local_size = _bs * _map->size_local();
     pack(_scatterer->remote_indices().begin(),
          _scatterer->remote_indices().end(), std::next(_x.begin(), local_size),
@@ -351,6 +360,9 @@ public:
     requires VectorPackKernel<U, container_type, ScatterContainer>
   void scatter_rev_end(U unpack)
   {
+    if (dolfinx::MPI::size(_map->comm()) == 1)
+      return;
+
     _scatterer->scatter_end(_request);
     unpack(_scatterer->local_indices().begin(),
            _scatterer->local_indices().end(), _buffer_local.begin(),

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -81,11 +81,11 @@ private:
               const auto in_first, auto out_first)
     {
       // out[idx[i]] = in[i]
+      auto in = in_first;
       for (typename ScatterContainer::const_iterator idx = idx_first;
-           idx != idx_last; ++idx)
+           idx != idx_last; ++idx, ++in)
       {
-        std::size_t d = std::ranges::distance(idx_first, idx);
-        *std::next(out_first, *idx) = *std::next(in_first, d);
+        *std::next(out_first, *idx) = *in;
       }
     };
   }
@@ -103,12 +103,12 @@ private:
                 const auto in_first, auto out_first)
     {
       // out[idx[i]] = op(out[idx[i]], in[i])
+      auto in = in_first;
       for (typename ScatterContainer::const_iterator idx = idx_first;
-           idx != idx_last; ++idx)
+           idx != idx_last; ++idx, ++in)
       {
-        std::size_t d = std::ranges::distance(idx_first, idx);
         auto& out = *std::next(out_first, *idx);
-        out = op(out, *std::next(in_first, d));
+        out = op(out, *in);
       }
     };
   }
@@ -209,7 +209,8 @@ public:
   /// Typical use is a specialised function to pack data that
   /// resides on a GPU.
   ///
-  /// @note Collective MPI operation
+  /// @note Collective MPI operation. Every rank in the communicator
+  /// must call this function, including ranks without neighbours.
   ///
   /// @tparam U Pack function type.
   /// @tparam GetPtr Function type that accesses a container's data pointer.
@@ -234,7 +235,8 @@ public:
   /// storage. The send buffer is packed internally by a function that
   /// is suitable for use on a CPU.
   ///
-  /// @note Collective MPI operation.
+  /// @note Collective MPI operation. Every rank in the communicator
+  /// must call this function, including ranks without neighbours.
   void scatter_fwd_begin()
     requires requires(Container c) {
       { c.data() } -> std::same_as<T*>;
@@ -247,11 +249,13 @@ public:
   /// other processes.
   ///
   /// The user provides the function to unpack the receive buffer.
-  /// Typically usage would be a specialised function to unpack data
+  /// Typical use is a specialised function to unpack data
   /// that resides on a GPU.
   ///
-  /// @note Collective MPI operation.
+  /// @note Collective MPI operation. Every rank in the communicator
+  /// must call this function, including ranks without neighbours.
   ///
+  /// @tparam U Unpack function type.
   /// @param unpack Function to unpack the receive buffer into the ghost
   /// entries.
   template <typename U>
@@ -271,7 +275,8 @@ public:
   /// storage. The receive buffer is unpacked internally by a function
   /// that is suitable for use on a CPU.
   ///
-  /// @note Collective MPI operation.
+  /// @note Collective MPI operation. Every rank in the communicator
+  /// must call this function, including ranks without neighbours.
   void scatter_fwd_end()
     requires requires(Container c) {
       { c.data() } -> std::same_as<T*>;
@@ -288,7 +293,8 @@ public:
   /// storage. The send buffer is packed and the receive buffer unpacked
   /// by a function that is suitable for use on a CPU.
   ///
-  /// @note Collective MPI operation
+  /// @note Collective MPI operation. Every rank in the communicator
+  /// must call this function, including ranks without neighbours.
   void scatter_fwd()
     requires requires(Container c) {
       { c.data() } -> std::same_as<T*>;
@@ -305,7 +311,8 @@ public:
   /// Typical use is a specialised function to pack data that
   /// resides on a GPU.
   ///
-  /// @note Collective MPI operation
+  /// @note Collective MPI operation. Every rank in the communicator
+  /// must call this function, including ranks without neighbours.
   /// @tparam U Pack function type.
   /// @tparam GetPtr Function type that accesses a container's data pointer.
   /// @param pack Function that packs ghost data into a send buffer.
@@ -331,7 +338,8 @@ public:
   /// storage. The send buffer is packed internally by a function that
   /// is suitable for use on a CPU.
   ///
-  /// @note Collective MPI operation
+  /// @note Collective MPI operation. Every rank in the communicator
+  /// must call this function, including ranks without neighbours.
   void scatter_rev_begin()
     requires requires(Container c) {
       { c.data() } -> std::same_as<T*>;
@@ -346,7 +354,10 @@ public:
   /// received. The received data can be summed or inserted into the
   /// owning entry by the `unpack` function.
   ///
-  /// @note Collective MPI operation
+  /// @note Collective MPI operation. Every rank in the communicator
+  /// must call this function, including ranks without neighbours.
+  ///
+  /// @tparam U Unpack function type.
   template <typename U>
     requires VectorPackKernel<U, container_type, ScatterContainer>
   void scatter_rev_end(U unpack)
@@ -365,7 +376,8 @@ public:
   /// received. The received data can be summed or inserted into the
   /// owning entry. This is controlled by the `op` function.
   ///
-  /// @note Collective MPI operation
+  /// @note Collective MPI operation. Every rank in the communicator
+  /// must call this function, including ranks without neighbours.
   ///
   /// @param op IndexMap operation (add or insert).
   template <class BinaryOperation>

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -252,10 +252,9 @@ public:
   /// Typical use is a specialised function to unpack data
   /// that resides on a GPU.
   ///
-  /// @note This is a local completion of the calling rank's own
-  /// request; it is not itself a collective MPI call. Every rank that
-  /// called ::scatter_fwd_begin must nonetheless call this function
-  /// before reusing the send/receive buffers.
+  /// @note Local completion of the caller's own request, not itself
+  /// collective. Every rank that called ::scatter_fwd_begin must
+  /// still call this before reusing the buffers.
   ///
   /// @tparam U Unpack function type.
   /// @param unpack Function to unpack the receive buffer into the ghost
@@ -277,10 +276,9 @@ public:
   /// storage. The receive buffer is unpacked internally by a function
   /// that is suitable for use on a CPU.
   ///
-  /// @note This is a local completion of the calling rank's own
-  /// request; it is not itself a collective MPI call. Every rank that
-  /// called ::scatter_fwd_begin must nonetheless call this function
-  /// before reusing the send/receive buffers.
+  /// @note Local completion of the caller's own request, not itself
+  /// collective. Every rank that called ::scatter_fwd_begin must
+  /// still call this before reusing the buffers.
   void scatter_fwd_end()
     requires requires(Container c) {
       { c.data() } -> std::same_as<T*>;
@@ -358,10 +356,9 @@ public:
   /// received. The received data can be summed or inserted into the
   /// owning entry by the `unpack` function.
   ///
-  /// @note This is a local completion of the calling rank's own
-  /// request; it is not itself a collective MPI call. Every rank that
-  /// called ::scatter_rev_begin must nonetheless call this function
-  /// before reusing the send/receive buffers.
+  /// @note Local completion of the caller's own request, not itself
+  /// collective. Every rank that called ::scatter_rev_begin must
+  /// still call this before reusing the buffers.
   ///
   /// @tparam U Unpack function type.
   template <typename U>

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -91,7 +91,7 @@ private:
   }
 
   /// @brief Return an 'unpack' function for unpacking a receive buffer.
-  /// Applied a binary operation an then assigns to entries.
+  /// Applies a binary operation and assigns to entries.
   ///
   /// Typically used to unpack into owned entries on a CPU. Commonly
   /// more than one value per entry is received.
@@ -165,7 +165,7 @@ private:
   }
 
 public:
-  /// @brief Copy-convert vector, possibly using to different container
+  /// @brief Copy-convert vector, possibly using different container
   /// types.
   ///
   /// Examples of use include copying a Vector to a different value
@@ -206,13 +206,13 @@ public:
   /// processes.
   ///
   /// The user provides the function to pack to the send buffer.
-  /// Typically usage would be a specialised function to pack data that
+  /// Typical use is a specialised function to pack data that
   /// resides on a GPU.
   ///
   /// @note Collective MPI operation
   ///
   /// @tparam U Pack function type.
-  /// @tparam GetPtr
+  /// @tparam GetPtr Function type that accesses a container's data pointer.
   /// @param pack Function that packs owned data into a send buffer.
   /// @param get_ptr Function that for a `Container` type returns the
   /// pointer to the underlying data.
@@ -221,9 +221,6 @@ public:
              and GetPtrConcept<GetPtr, Container, T>
   void scatter_fwd_begin(U pack, GetPtr get_ptr)
   {
-    if (_buffer_local.empty() and _buffer_remote.empty())
-      return;
-
     pack(_scatterer->local_indices().begin(), _scatterer->local_indices().end(),
          _x.begin(), _buffer_local.begin());
     _scatterer->scatter_fwd_begin(get_ptr(_buffer_local),
@@ -261,9 +258,6 @@ public:
     requires VectorPackKernel<U, container_type, ScatterContainer>
   void scatter_fwd_end(U unpack)
   {
-    if (_buffer_local.empty() and _buffer_remote.empty())
-      return;
-
     _scatterer->scatter_end(_request);
     unpack(_scatterer->remote_indices().begin(),
            _scatterer->remote_indices().end(), _buffer_remote.begin(),
@@ -308,12 +302,12 @@ public:
   /// process of an index.
   ///
   /// The user provides the function to pack to the send buffer.
-  /// Typically usage would be a specialised function to pack data that
+  /// Typical use is a specialised function to pack data that
   /// resides on a GPU.
   ///
   /// @note Collective MPI operation
   /// @tparam U Pack function type.
-  /// @tparam GetPtr
+  /// @tparam GetPtr Function type that accesses a container's data pointer.
   /// @param pack Function that packs ghost data into a send buffer.
   /// @param get_ptr Function that for a `Container` type returns the
   /// pointer to the underlying data.
@@ -322,9 +316,6 @@ public:
              and GetPtrConcept<GetPtr, Container, T>
   void scatter_rev_begin(U pack, GetPtr get_ptr)
   {
-    if (_buffer_local.empty() and _buffer_remote.empty())
-      return;
-
     std::int32_t local_size = _bs * _map->size_local();
     pack(_scatterer->remote_indices().begin(),
          _scatterer->remote_indices().end(), std::next(_x.begin(), local_size),
@@ -360,9 +351,6 @@ public:
     requires VectorPackKernel<U, container_type, ScatterContainer>
   void scatter_rev_end(U unpack)
   {
-    if (_buffer_local.empty() and _buffer_remote.empty())
-      return;
-
     _scatterer->scatter_end(_request);
     unpack(_scatterer->local_indices().begin(),
            _scatterer->local_indices().end(), _buffer_local.begin(),
@@ -375,7 +363,7 @@ public:
   ///
   /// For an owned entry, data from more than one process may be
   /// received. The received data can be summed or inserted into the
-  /// owning entry. The this is controlled by the `op` function.
+  /// owning entry. This is controlled by the `op` function.
   ///
   /// @note Collective MPI operation
   ///

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -221,7 +221,7 @@ public:
              and GetPtrConcept<GetPtr, Container, T>
   void scatter_fwd_begin(U pack, GetPtr get_ptr)
   {
-    if (dolfinx::MPI::size(_map->comm()) == 1)
+    if (_buffer_local.empty() and _buffer_remote.empty())
       return;
 
     pack(_scatterer->local_indices().begin(), _scatterer->local_indices().end(),
@@ -261,7 +261,7 @@ public:
     requires VectorPackKernel<U, container_type, ScatterContainer>
   void scatter_fwd_end(U unpack)
   {
-    if (dolfinx::MPI::size(_map->comm()) == 1)
+    if (_buffer_local.empty() and _buffer_remote.empty())
       return;
 
     _scatterer->scatter_end(_request);
@@ -322,7 +322,7 @@ public:
              and GetPtrConcept<GetPtr, Container, T>
   void scatter_rev_begin(U pack, GetPtr get_ptr)
   {
-    if (dolfinx::MPI::size(_map->comm()) == 1)
+    if (_buffer_local.empty() and _buffer_remote.empty())
       return;
 
     std::int32_t local_size = _bs * _map->size_local();
@@ -360,7 +360,7 @@ public:
     requires VectorPackKernel<U, container_type, ScatterContainer>
   void scatter_rev_end(U unpack)
   {
-    if (dolfinx::MPI::size(_map->comm()) == 1)
+    if (_buffer_local.empty() and _buffer_remote.empty())
       return;
 
     _scatterer->scatter_end(_request);

--- a/cpp/dolfinx/refinement/uniform.cpp
+++ b/cpp/dolfinx/refinement/uniform.cpp
@@ -162,7 +162,7 @@ mesh::Mesh<T> refinement::uniform_refine(const mesh::Mesh<T>& mesh,
     std::vector<std::int64_t> recv_buffer(sc.remote_indices().size());
     MPI_Request request = MPI_REQUEST_NULL;
     sc.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), request);
-    sc.scatter_end(request);
+    sc.scatter_fwd_end(request);
     {
       std::span ghosts(std::next(new_v[j].begin(), num_entities),
                        new_v[j].end());

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -128,9 +128,8 @@ void test_scatter_rev()
     CHECK(sum == n * value * num_ghosts);
   }
 
-  // Repeat the scatter and accumulate again into the already-populated
-  // data_local, to check that unpacking with std::plus<> correctly
-  // accumulates onto a non-zero owned value rather than overwriting it
+  // Repeat, to check accumulation onto the already-populated
+  // data_local rather than overwriting it
   {
     MPI_Request request = MPI_REQUEST_NULL;
     std::vector<std::int64_t> send_buffer(sct.remote_indices().size(), 0);

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -5,8 +5,10 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include <algorithm>
+#include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <cstdint>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/Scatterer.h>
@@ -76,28 +78,6 @@ void test_scatter_fwd(int n)
         data_ghost, [&val, &mpi_rank, &mpi_size](auto i)
         { return i == val * ((mpi_rank + 1) % mpi_size); }));
   }
-
-  {
-    std::vector<MPI_Request> requests(sct.num_p2p_requests(), MPI_REQUEST_NULL);
-    std::ranges::fill(data_ghost, 0);
-    std::vector<std::int64_t> send_buffer(sct.local_indices().size());
-    {
-      auto& idx = sct.local_indices();
-      for (std::size_t i = 0; i < idx.size(); ++i)
-        send_buffer[i] = data_local[idx[i]];
-    }
-    std::vector<std::int64_t> recv_buffer(sct.remote_indices().size());
-    sct.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), requests);
-    sct.scatter_end(requests);
-    {
-      auto& idx = sct.remote_indices();
-      for (std::size_t i = 0; i < idx.size(); ++i)
-        data_ghost[idx[i]] = recv_buffer[i];
-    }
-    CHECK(std::ranges::all_of(
-        data_ghost, [val, mpi_rank, mpi_size](auto i)
-        { return i == val * ((mpi_rank + 1) % mpi_size); }));
-  }
 }
 
 void test_scatter_rev()
@@ -135,7 +115,6 @@ void test_scatter_rev()
   std::vector<std::int64_t> data_ghost(n * num_ghosts, value);
   {
     MPI_Request request = MPI_REQUEST_NULL;
-    std::vector<std::int64_t> remote_buffer(sct.remote_indices().size(), 0);
     std::vector<std::int64_t> send_buffer(sct.local_indices().size(), 0);
     pack_fn(data_ghost, sct.remote_indices(), send_buffer);
     std::vector<std::int64_t> recv_buffer(sct.remote_indices().size(), 0);
@@ -148,21 +127,53 @@ void test_scatter_rev()
     sum = std::reduce(data_local.begin(), data_local.end(), 0);
     CHECK(sum == n * value * num_ghosts);
   }
+}
+
+void test_scatter_with_isolated_rank()
+{
+  const int mpi_size = dolfinx::MPI::size(MPI_COMM_WORLD);
+  const int mpi_rank = dolfinx::MPI::rank(MPI_COMM_WORLD);
+  if (mpi_size < 3)
+    return;
+
+  std::array<std::vector<int>, 2> src_dest;
+  std::vector<std::int64_t> ghosts;
+  std::vector<int> owners;
+  if (mpi_rank == 0)
+    src_dest[1] = {1};
+  else if (mpi_rank == 1)
+  {
+    src_dest[0] = {0};
+    ghosts = {0};
+    owners = {0};
+  }
+
+  const common::IndexMap map(MPI_COMM_WORLD, 1, src_dest, ghosts, owners);
+  const common::Scatterer scatterer(map, 1);
 
   {
-    int num_requests = idx_map.dest().size() + idx_map.src().size();
-    std::vector<MPI_Request> requests(num_requests, MPI_REQUEST_NULL);
-    std::vector<std::int64_t> remote_buffer(sct.remote_indices().size(), 0);
+    std::vector<std::int64_t> send_buffer(scatterer.local_indices().size(), 17);
+    std::vector<std::int64_t> recv_buffer(scatterer.remote_indices().size());
+    MPI_Request request = MPI_REQUEST_NULL;
+    scatterer.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(),
+                                request);
+    CHECK(request != MPI_REQUEST_NULL);
+    scatterer.scatter_end(request);
+    if (mpi_rank == 1)
+      CHECK(recv_buffer == std::vector<std::int64_t>{17});
+  }
 
-    std::vector<std::int64_t> send_buffer(sct.local_indices().size(), 0);
-    pack_fn(data_ghost, sct.remote_indices(), send_buffer);
-    std::vector<std::int64_t> recv_buffer(sct.remote_indices().size(), 0);
-    sct.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), requests);
-    sct.scatter_end(requests);
-    unpack_fn(recv_buffer, sct.local_indices(), data_local, std::plus<>{});
-
-    std::int64_t sum = std::reduce(data_local.begin(), data_local.end(), 0);
-    CHECK(sum == 2 * n * value * num_ghosts);
+  {
+    std::vector<std::int64_t> send_buffer(scatterer.remote_indices().size(),
+                                          29);
+    std::vector<std::int64_t> recv_buffer(scatterer.local_indices().size());
+    MPI_Request request = MPI_REQUEST_NULL;
+    scatterer.scatter_rev_begin(send_buffer.data(), recv_buffer.data(),
+                                request);
+    CHECK(request != MPI_REQUEST_NULL);
+    scatterer.scatter_end(request);
+    if (mpi_rank == 0)
+      CHECK(recv_buffer == std::vector<std::int64_t>{29});
   }
 }
 
@@ -242,6 +253,11 @@ TEST_CASE("Scatter forward using IndexMap", "[index_map_scatter_fwd]")
 TEST_CASE("Scatter reverse using IndexMap", "[index_map_scatter_rev]")
 {
   CHECK_NOTHROW(test_scatter_rev());
+}
+
+TEST_CASE("Scatter with an isolated rank", "[index_map_scatter]")
+{
+  CHECK_NOTHROW(test_scatter_with_isolated_rank());
 }
 
 TEST_CASE("Communication graph edges via consensus "

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Chris Richardson
+// Copyright (C) 2018-2026 Chris Richardson and Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -67,7 +67,7 @@ void test_scatter_fwd(int n)
     std::vector<std::int64_t> recv_buffer(sct.remote_indices().size());
     MPI_Request request = MPI_REQUEST_NULL;
     sct.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), request);
-    sct.scatter_end(request);
+    sct.scatter_fwd_end(request);
     {
       auto& idx = sct.remote_indices();
       for (std::size_t i = 0; i < idx.size(); ++i)
@@ -115,17 +115,33 @@ void test_scatter_rev()
   std::vector<std::int64_t> data_ghost(n * num_ghosts, value);
   {
     MPI_Request request = MPI_REQUEST_NULL;
-    std::vector<std::int64_t> send_buffer(sct.local_indices().size(), 0);
+    std::vector<std::int64_t> send_buffer(sct.remote_indices().size(), 0);
     pack_fn(data_ghost, sct.remote_indices(), send_buffer);
-    std::vector<std::int64_t> recv_buffer(sct.remote_indices().size(), 0);
+    std::vector<std::int64_t> recv_buffer(sct.local_indices().size(), 0);
     sct.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), request);
-    sct.scatter_end(request);
+    sct.scatter_rev_end(request);
     unpack_fn(recv_buffer, sct.local_indices(), data_local, std::plus<>{});
 
     std::int64_t sum;
     CHECK((int)data_local.size() == n * size_local);
     sum = std::reduce(data_local.begin(), data_local.end(), 0);
     CHECK(sum == n * value * num_ghosts);
+  }
+
+  // Repeat the scatter and accumulate again into the already-populated
+  // data_local, to check that unpacking with std::plus<> correctly
+  // accumulates onto a non-zero owned value rather than overwriting it
+  {
+    MPI_Request request = MPI_REQUEST_NULL;
+    std::vector<std::int64_t> send_buffer(sct.remote_indices().size(), 0);
+    pack_fn(data_ghost, sct.remote_indices(), send_buffer);
+    std::vector<std::int64_t> recv_buffer(sct.local_indices().size(), 0);
+    sct.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), request);
+    sct.scatter_rev_end(request);
+    unpack_fn(recv_buffer, sct.local_indices(), data_local, std::plus<>{});
+
+    std::int64_t sum = std::reduce(data_local.begin(), data_local.end(), 0);
+    CHECK(sum == 2 * n * value * num_ghosts);
   }
 }
 
@@ -158,7 +174,7 @@ void test_scatter_with_isolated_rank()
     scatterer.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(),
                                 request);
     CHECK(request != MPI_REQUEST_NULL);
-    scatterer.scatter_end(request);
+    scatterer.scatter_fwd_end(request);
     if (mpi_rank == 1)
       CHECK(recv_buffer == std::vector<std::int64_t>{17});
   }
@@ -171,7 +187,7 @@ void test_scatter_with_isolated_rank()
     scatterer.scatter_rev_begin(send_buffer.data(), recv_buffer.data(),
                                 request);
     CHECK(request != MPI_REQUEST_NULL);
-    scatterer.scatter_end(request);
+    scatterer.scatter_rev_end(request);
     if (mpi_rank == 0)
       CHECK(recv_buffer == std::vector<std::int64_t>{29});
   }

--- a/cpp/test/vector.cpp
+++ b/cpp/test/vector.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Chris Richardson
+// Copyright (C) 2021-2026 Chris Richardson and Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -124,9 +124,8 @@ void test_vector_scatter_rev()
                                   std::next(v.array().begin(), size_local));
   CHECK(sum0 == 2.0 * num_ghosts);
 
-  // Repeat, to check that std::plus<> accumulates onto the
-  // already-nonzero owned values from the first scatter, rather than
-  // overwriting them
+  // Repeat, to check accumulation onto the non-zero values from the
+  // first scatter, rather than overwriting them
   v.scatter_rev(std::plus<>{});
   const double sum1 = std::reduce(v.array().begin(),
                                   std::next(v.array().begin(), size_local));

--- a/cpp/test/vector.cpp
+++ b/cpp/test/vector.cpp
@@ -13,6 +13,8 @@
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/la/Vector.h>
+#include <functional>
+#include <numeric>
 
 using namespace dolfinx;
 
@@ -91,6 +93,45 @@ void test_vector_cast()
   CHECK(la::inner_product(v1, v1) == sumn2);
   CHECK(la::norm(v1, la::Norm::linf) == static_cast<U>(mpi_size - 1));
 }
+
+void test_vector_scatter_rev()
+{
+  const int mpi_size = dolfinx::MPI::size(MPI_COMM_WORLD);
+  const int mpi_rank = dolfinx::MPI::rank(MPI_COMM_WORLD);
+  constexpr int size_local = 100;
+
+  // Create some ghost entries on next process
+  int num_ghosts = (mpi_size - 1) * 3;
+  std::vector<std::int64_t> ghosts(num_ghosts);
+  for (int i = 0; i < num_ghosts; ++i)
+    ghosts[i] = (mpi_rank + 1) % mpi_size * size_local + i;
+
+  const std::vector<int> global_ghost_owner(ghosts.size(),
+                                            (mpi_rank + 1) % mpi_size);
+
+  // Create an IndexMap
+  auto index_map = std::make_shared<common::IndexMap>(
+      MPI_COMM_WORLD, size_local, ghosts, global_ghost_owner);
+
+  la::Vector<double> v(index_map, 1);
+  std::ranges::fill(v.array(), 0.0);
+  std::fill(std::next(v.array().begin(), size_local), v.array().end(), 2.0);
+
+  // Scatter ghost values to owning ranks and accumulate into owned
+  // entries via Vector::get_unpack_op
+  v.scatter_rev(std::plus<>{});
+  const double sum0 = std::reduce(v.array().begin(),
+                                  std::next(v.array().begin(), size_local));
+  CHECK(sum0 == 2.0 * num_ghosts);
+
+  // Repeat, to check that std::plus<> accumulates onto the
+  // already-nonzero owned values from the first scatter, rather than
+  // overwriting them
+  v.scatter_rev(std::plus<>{});
+  const double sum1 = std::reduce(v.array().begin(),
+                                  std::next(v.array().begin(), size_local));
+  CHECK(sum1 == 2 * sum0);
+}
 } // namespace
 
 TEMPLATE_TEST_CASE("Linear Algebra Vector", "[la_vector]", double,
@@ -102,4 +143,9 @@ TEMPLATE_TEST_CASE("Linear Algebra Vector", "[la_vector]", double,
 TEST_CASE("Linear Algebra Vector", "[la_vector]")
 {
   CHECK_NOTHROW(test_vector_cast());
+}
+
+TEST_CASE("Linear Algebra Vector scatter reverse", "[la_vector]")
+{
+  CHECK_NOTHROW(test_vector_scatter_rev());
 }

--- a/python/dolfinx/wrappers/dolfinx_wrappers/common.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/common.h
@@ -49,7 +49,7 @@ void declare_scatter_functions(
         std::vector<T> recv_buffer(self.remote_indices().size());
         MPI_Request request = MPI_REQUEST_NULL;
         self.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), request);
-        self.scatter_end(request);
+        self.scatter_fwd_end(request);
         {
           auto _remote_data = remote_data.view();
           auto& idx = self.remote_indices();
@@ -87,7 +87,7 @@ void declare_scatter_functions(
         MPI_Request request = MPI_REQUEST_NULL;
         self.scatter_rev_begin<T>(send_buffer.data(), recv_buffer.data(),
                                   request);
-        self.scatter_end(request);
+        self.scatter_rev_end(request);
         {
           auto _local_data = local_data.view();
           auto& idx = self.local_indices();


### PR DESCRIPTION
## Summary
- Move the single-rank communication fast path from `la::Vector` to `common::Scatterer`, so all ranks in a multi-rank communicator enter the neighbourhood collective, including ranks without neighbours.
- Remove the point-to-point Scatterer interface; scatter and gather now use non-blocking MPI neighbourhood collectives only.
- Replace `Scatterer::scatter_end` with direction-specific `scatter_fwd_end` and `scatter_rev_end` methods, so completion and MPI error handling use the request's communicator. This is a C++ API change.
- Add a three-rank C++ regression test with an isolated rank, which would fail with the implementation on `main`, and a Vector reverse-scatter accumulation test.
- Simplify Scatterer metadata and Vector unpack loops, and clarify collective initiation versus local completion in the documentation.

## Test plan
- [x] `clang-format --dry-run --Werror` on all changed C++ sources and headers
- [x] `ninja -C build-cpp -j2`
- [x] `ctest --test-dir build-cpp --output-on-failure` (1, 2, and 3 MPI ranks)