### PR TITLE
Only guard the petsc4py import, not the whole block

### DIFF
--- a/python/dolfinx/__init__.py
+++ b/python/dolfinx/__init__.py
@@ -20,6 +20,11 @@ default_real_type: type[_np.floating]
 
 try:
     from petsc4py import PETSc as _PETSc
+except ImportError:
+    default_scalar_type = _np.float64
+    default_real_type = _np.float64
+else:
+    # Only the petsc4py import is guarded; a failure below is a broken install.
 
     # Additional sanity check that DOLFINx was built with petsc4py support.
     from dolfinx.common import has_petsc4py
@@ -33,9 +38,6 @@ try:
         "type[_np.floating | _np.complexfloating]", _PETSc.ScalarType
     )
     default_real_type = _typing.cast("type[_np.floating]", _PETSc.RealType)
-except ImportError:
-    default_scalar_type = _np.float64
-    default_real_type = _np.float64
 
 del _np
 


### PR DESCRIPTION
The `try` here wraps the petsc4py import *and* `from dolfinx.common import has_petsc4py`, which pulls in the compiled `dolfinx.cpp`. So if the extension fails to load missing `libpetsc`, ABI mismatch, mixed conda/pip env. The ImportError gets swallowed and we silently fall back to NumPy types, then hit the same failure four lines down at `from dolfinx import common` with the cause gone. That second traceback is the one people report, and it doesn't say what's missing which is useful for me as i try to build a wheel.
