### PR TITLE
Add one-shot common::scatter_fwd/scatter_rev helpers

### DIFF
--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2025 Igor Baratta and Garth N. Wells
+// Copyright (C) 2022-2026 Igor Baratta, Garth N. Wells and Jack S. Hale
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -15,6 +15,7 @@
 #include <memory>
 #include <mpi.h>
 #include <numeric>
+#include <ranges>
 #include <span>
 #include <type_traits>
 #include <vector>
@@ -536,4 +537,78 @@ private:
   // Displacements of local data for mpi scatter and gather
   std::vector<int> _displs_local;
 };
+
+/// @brief One-shot forward (owner -> ghost) scatter of contiguous host
+/// data.
+///
+/// Packs `local_data`, communicates, and unpacks into `remote_data`.
+/// The send and receive buffers are allocated for the duration of the
+/// call. For repeated scatters where the allocation matters, use
+/// Scatterer::scatter_fwd_begin and Scatterer::scatter_end directly, or
+/// la::Vector, which holds persistent buffers.
+///
+/// @note Collective MPI operation.
+/// @note Host data only. The pack/unpack loops dereference the
+/// Scatterer index containers on the host, hence the constraint on
+/// `Container`.
+///
+/// @param[in] sc Scatterer describing the communication pattern.
+/// @param[in] local_data Owned values, indexed by local index.
+/// @param[out] remote_data Ghost values, indexed from the first ghost.
+template <typename T, class Container>
+  requires std::ranges::contiguous_range<Container>
+void scatter_fwd(const Scatterer<Container>& sc, std::span<const T> local_data,
+                 std::span<T> remote_data)
+{
+  const Container& local_inds = sc.local_indices();
+  std::vector<T> send_buffer(local_inds.size());
+  std::ranges::transform(local_inds, send_buffer.begin(),
+                         [local_data](auto i) { return local_data[i]; });
+
+  const Container& remote_inds = sc.remote_indices();
+  std::vector<T> recv_buffer(remote_inds.size());
+  MPI_Request request = MPI_REQUEST_NULL;
+  sc.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), request);
+  sc.scatter_end(request);
+
+  for (std::size_t i = 0; i < remote_inds.size(); ++i)
+    remote_data[remote_inds[i]] = recv_buffer[i];
+}
+
+/// @brief One-shot reverse (ghost -> owner) scatter of contiguous host
+/// data.
+///
+/// Packs `remote_data`, communicates, and accumulates into `local_data`
+/// using `op`. The send and receive buffers are allocated for the
+/// duration of the call. For repeated scatters where the allocation
+/// matters, use Scatterer::scatter_rev_begin and Scatterer::scatter_end
+/// directly, or la::Vector, which holds persistent buffers.
+///
+/// @note Collective MPI operation.
+/// @note Host data only, see ::scatter_fwd.
+///
+/// @param[in] sc Scatterer describing the communication pattern.
+/// @param[in,out] local_data Owned values, indexed by local index.
+/// @param[in] remote_data Ghost values, indexed from the first ghost.
+/// @param[in] op Binary operation applied as `local_data[i] =
+/// op(received, local_data[i])`, e.g. `std::plus<T>()` to accumulate.
+template <typename T, class Container, typename BinaryOperation>
+  requires std::ranges::contiguous_range<Container>
+void scatter_rev(const Scatterer<Container>& sc, std::span<T> local_data,
+                 std::span<const T> remote_data, BinaryOperation op)
+{
+  const Container& remote_inds = sc.remote_indices();
+  std::vector<T> send_buffer(remote_inds.size());
+  std::ranges::transform(remote_inds, send_buffer.begin(),
+                         [remote_data](auto i) { return remote_data[i]; });
+
+  const Container& local_inds = sc.local_indices();
+  std::vector<T> recv_buffer(local_inds.size());
+  MPI_Request request = MPI_REQUEST_NULL;
+  sc.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), request);
+  sc.scatter_end(request);
+
+  for (std::size_t i = 0; i < local_inds.size(); ++i)
+    local_data[local_inds[i]] = op(recv_buffer[i], local_data[local_inds[i]]);
+}
 } // namespace dolfinx::common

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -15,7 +15,6 @@
 #include <memory>
 #include <mpi.h>
 #include <numeric>
-#include <ranges>
 #include <span>
 #include <type_traits>
 #include <vector>
@@ -538,8 +537,7 @@ private:
   std::vector<int> _displs_local;
 };
 
-/// @brief One-shot forward (owner -> ghost) scatter of contiguous host
-/// data.
+/// @brief One-shot forward (owner -> ghost) scatter of host data.
 ///
 /// Packs `local_data`, communicates, and unpacks into `remote_data`.
 /// The send and receive buffers are allocated for the duration of the
@@ -548,15 +546,18 @@ private:
 /// la::Vector, which holds persistent buffers.
 ///
 /// @note Collective MPI operation.
-/// @note Host data only. The pack/unpack loops dereference the
-/// Scatterer index containers on the host, hence the constraint on
-/// `Container`.
+/// @note For host data. `Container` is constrained to containers with
+/// raw pointer storage, which excludes the device containers used in
+/// GPU builds, but host residency of `local_data` and `remote_data` is
+/// a caller precondition that is not checked.
 ///
 /// @param[in] sc Scatterer describing the communication pattern.
 /// @param[in] local_data Owned values, indexed by local index.
 /// @param[out] remote_data Ghost values, indexed from the first ghost.
 template <typename T, class Container>
-  requires std::ranges::contiguous_range<Container>
+  requires requires(Container c) {
+    { c.data() } -> std::same_as<typename Container::value_type*>;
+  }
 void scatter_fwd(const Scatterer<Container>& sc, std::span<const T> local_data,
                  std::span<T> remote_data)
 {
@@ -575,8 +576,7 @@ void scatter_fwd(const Scatterer<Container>& sc, std::span<const T> local_data,
     remote_data[remote_inds[i]] = recv_buffer[i];
 }
 
-/// @brief One-shot reverse (ghost -> owner) scatter of contiguous host
-/// data.
+/// @brief One-shot reverse (ghost -> owner) scatter of host data.
 ///
 /// Packs `remote_data`, communicates, and accumulates into `local_data`
 /// using `op`. The send and receive buffers are allocated for the
@@ -585,7 +585,7 @@ void scatter_fwd(const Scatterer<Container>& sc, std::span<const T> local_data,
 /// directly, or la::Vector, which holds persistent buffers.
 ///
 /// @note Collective MPI operation.
-/// @note Host data only, see ::scatter_fwd.
+/// @note For host data, see ::scatter_fwd.
 ///
 /// @param[in] sc Scatterer describing the communication pattern.
 /// @param[in,out] local_data Owned values, indexed by local index.
@@ -593,7 +593,9 @@ void scatter_fwd(const Scatterer<Container>& sc, std::span<const T> local_data,
 /// @param[in] op Binary operation applied as `local_data[i] =
 /// op(received, local_data[i])`, e.g. `std::plus<T>()` to accumulate.
 template <typename T, class Container, typename BinaryOperation>
-  requires std::ranges::contiguous_range<Container>
+  requires requires(Container c) {
+    { c.data() } -> std::same_as<typename Container::value_type*>;
+  }
 void scatter_rev(const Scatterer<Container>& sc, std::span<T> local_data,
                  std::span<const T> remote_data, BinaryOperation op)
 {

--- a/cpp/dolfinx/refinement/uniform.cpp
+++ b/cpp/dolfinx/refinement/uniform.cpp
@@ -153,23 +153,9 @@ mesh::Mesh<T> refinement::uniform_refine(const mesh::Mesh<T>& mesh,
               local_range[0] + entity_offsets[j]);
 
     common::Scatterer sc(*index_maps[j], 1);
-    std::vector<std::int64_t> send_buffer(sc.local_indices().size());
-    {
-      auto& idx = sc.local_indices();
-      for (std::size_t i = 0; i < idx.size(); ++i)
-        send_buffer[i] = new_v[j][idx[i]];
-    }
-    std::vector<std::int64_t> recv_buffer(sc.remote_indices().size());
-    MPI_Request request = MPI_REQUEST_NULL;
-    sc.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), request);
-    sc.scatter_end(request);
-    {
-      std::span ghosts(std::next(new_v[j].begin(), num_entities),
-                       new_v[j].end());
-      auto& idx = sc.remote_indices();
-      for (std::size_t i = 0; i < idx.size(); ++i)
-        ghosts[idx[i]] = recv_buffer[i];
-    }
+    std::span<std::int64_t> v(new_v[j]);
+    common::scatter_fwd<std::int64_t>(sc, v.first(num_entities),
+                                      v.subspan(num_entities));
   }
 
   // Create new topology

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -7,13 +7,16 @@
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <cstdint>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/Scatterer.h>
 #include <dolfinx/common/utils.h>
+#include <functional>
 #include <iostream>
 #include <numeric>
 #include <set>
+#include <span>
 #include <vector>
 
 using namespace dolfinx;
@@ -231,6 +234,47 @@ void test_rank_weights()
     REQUIRE(weight_dest.empty());
   }
 }
+
+/// Check the one-shot common::scatter_fwd/scatter_rev helpers. Only
+/// std::int8_t is exercised here: the other host types are covered
+/// through the Python bindings, which delegate to these helpers, but are
+/// instantiated only for int64/float/double.
+void test_scatter_helpers_int8()
+{
+  const int mpi_size = dolfinx::MPI::size(MPI_COMM_WORLD);
+  const int mpi_rank = dolfinx::MPI::rank(MPI_COMM_WORLD);
+  constexpr int size_local = 100;
+  constexpr int n = 2;
+
+  const common::IndexMap idx_map
+      = create_index_map(MPI_COMM_WORLD, size_local, (mpi_size - 1) * 3);
+  const std::int32_t num_ghosts = idx_map.num_ghosts();
+  common::Scatterer sct(idx_map, n);
+
+  // Forward scatter of the owning rank (+1, to keep zero distinguishable
+  // from an untouched buffer)
+  const std::vector<std::int8_t> data_local(
+      n * size_local, static_cast<std::int8_t>(1 + mpi_rank % 5));
+  std::vector<std::int8_t> data_ghost(n * num_ghosts, 0);
+  common::scatter_fwd<std::int8_t>(sct,
+                                   std::span<const std::int8_t>(data_local),
+                                   std::span<std::int8_t>(data_ghost));
+  const std::int8_t expected
+      = static_cast<std::int8_t>(1 + (mpi_rank + 1) % mpi_size % 5);
+  CHECK(std::ranges::all_of(data_ghost, [expected](std::int8_t v)
+                            { return v == expected; }));
+
+  // Reverse scatter, accumulating each ghost value onto its owner. Every
+  // ghost index is ghosted by exactly one rank, so each contribution
+  // arrives once.
+  std::ranges::fill(data_ghost, std::int8_t(2));
+  std::vector<std::int8_t> data_owned(n * size_local, 0);
+  common::scatter_rev<std::int8_t>(sct, std::span<std::int8_t>(data_owned),
+                                   std::span<const std::int8_t>(data_ghost),
+                                   std::plus<std::int8_t>());
+  CHECK(std::accumulate(data_owned.begin(), data_owned.end(), std::int64_t(0))
+        == 2 * n * num_ghosts);
+}
 } // namespace
 
 TEST_CASE("Scatter forward using IndexMap", "[index_map_scatter_fwd]")
@@ -259,4 +303,9 @@ TEST_CASE("Split IndexMap communicator by type", "[index_map_comm_split]")
 TEST_CASE("IndexMap stats", "[index_map_stats]")
 {
   CHECK_NOTHROW(test_rank_weights());
+}
+
+TEST_CASE("One-shot scatter helpers", "[index_map_scatter_helpers]")
+{
+  CHECK_NOTHROW(test_scatter_helpers_int8());
 }

--- a/python/dolfinx/wrappers/dolfinx_wrappers/common.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/common.h
@@ -7,11 +7,11 @@
 #pragma once
 
 #include <dolfinx/common/Scatterer.h>
-#include <mpi.h>
+#include <functional>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
+#include <span>
 #include <stdexcept>
-#include <vector>
 
 namespace dolfinx_wrappers
 {
@@ -39,23 +39,9 @@ void declare_scatter_functions(
               "Ghost data buffer too small in forward scatter.");
         }
 
-        std::vector<T> send_buffer(self.local_indices().size());
-        {
-          auto _local_data = local_data.view();
-          auto& idx = self.local_indices();
-          for (std::size_t i = 0; i < idx.size(); ++i)
-            send_buffer[i] = _local_data(idx[i]);
-        }
-        std::vector<T> recv_buffer(self.remote_indices().size());
-        MPI_Request request = MPI_REQUEST_NULL;
-        self.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), request);
-        self.scatter_end(request);
-        {
-          auto _remote_data = remote_data.view();
-          auto& idx = self.remote_indices();
-          for (std::size_t i = 0; i < idx.size(); ++i)
-            _remote_data(idx[i]) = recv_buffer[i];
-        }
+        dolfinx::common::scatter_fwd<T>(
+            self, std::span<const T>(local_data.data(), local_data.size()),
+            std::span<T>(remote_data.data(), remote_data.size()));
       },
       nb::arg("local_data"), nb::arg("remote_data"));
 
@@ -76,24 +62,10 @@ void declare_scatter_functions(
               "Ghost data buffer too small in reverse scatter.");
         }
 
-        std::vector<T> send_buffer(self.remote_indices().size());
-        {
-          auto _remote_data = remote_data.view();
-          auto& idx = self.remote_indices();
-          for (std::size_t i = 0; i < idx.size(); ++i)
-            send_buffer[i] = _remote_data(idx[i]);
-        }
-        std::vector<T> recv_buffer(self.local_indices().size());
-        MPI_Request request = MPI_REQUEST_NULL;
-        self.scatter_rev_begin<T>(send_buffer.data(), recv_buffer.data(),
-                                  request);
-        self.scatter_end(request);
-        {
-          auto _local_data = local_data.view();
-          auto& idx = self.local_indices();
-          for (std::size_t i = 0; i < idx.size(); ++i)
-            _local_data(idx[i]) += recv_buffer[i];
-        }
+        dolfinx::common::scatter_rev<T>(
+            self, std::span<T>(local_data.data(), local_data.size()),
+            std::span<const T>(remote_data.data(), remote_data.size()),
+            std::plus<T>());
       },
       nb::arg("local_data"), nb::arg("remote_data"));
 }


### PR DESCRIPTION
This duplication was found by Claude whilst implementing this pattern in another PR.

## Summary

The pack → `scatter_fwd_begin` → `scatter_end` → unpack sequence around
`common::Scatterer` is currently written out by hand at every call site. This
adds two free functions in `dolfinx::common` that do the whole thing in one
call for contiguous host data, and uses them at the sites where the
hand-rolled version bought nothing.

| # | Site | Direction | Action |
| - | ---- | --------- | ------ |
| 1 | `la/Vector.h` | fwd + rev | **Unchanged** — see below |
| 2 | `refinement/uniform.cpp` | fwd (`std::int64_t`) | 18 lines → 3 |
| 3 | `wrappers/dolfinx_wrappers/common.h` | fwd + rev (`int64`/`double`/`float`) | both lambda bodies now delegate |

## Why a free function, not a member

`Scatterer`'s class documentation states:

> A Scatterer is stateless, i.e. it provides the required information and
> static data for a given parallel communication pattern but does not provide
> any communication caches or track the status of MPI requests. Callers of the
> a Scatterer's members are responsible for managing buffer and MPI request
> handles.

A one-shot *member* would contradict that contract, since it must allocate
buffers internally. A free function taking `const Scatterer&` and allocating
locally to the call leaves the class stateless and leaves the caller owning
the `Scatterer`, so its construction can still be amortised.

## API

```cpp
template <typename T, class Container>
  requires requires(Container c) {
    { c.data() } -> std::same_as<typename Container::value_type*>;
  }
void scatter_fwd(const Scatterer<Container>& sc, std::span<const T> local_data,
                 std::span<T> remote_data);

template <typename T, class Container, typename BinaryOperation>
  requires requires(Container c) {
    { c.data() } -> std::same_as<typename Container::value_type*>;
  }
void scatter_rev(const Scatterer<Container>& sc, std::span<T> local_data,
                 std::span<const T> remote_data, BinaryOperation op);
```

Two spans rather than one array plus a `bs * size_local()` offset: `Scatterer`
stores neither the block size nor the `IndexMap`, so an offset would have to be
recomputed by every caller. It also matches the existing Python binding's
signature exactly, so `test_scatterer.py` passes unchanged. A caller holding
one contiguous array splits it with `x.first(n)` / `x.subspan(n)`.

The constraint on `Container` is the same one `la::Vector` uses to select its
CPU overloads (`la/Vector.h:239`): raw-pointer storage, which the device
containers used in GPU builds do not have, so a `thrust::device_vector` is
rejected at the constraint rather than deep inside the body. It is a capability
check, not a memory-space check — host residency of the two spans remains a
caller precondition, and is documented as such.

## Why `la::Vector` is untouched

It cannot be expressed in terms of the helper:

1. `Vector` builds its `Scatterer` and its buffers once, in the constructor.
   Routing through a helper that allocates per call would turn an amortised
   setup into an allocation in a function called every solver iteration.
2. `Vector` exposes `scatter_fwd_begin`/`scatter_fwd_end` separately so callers
   can overlap communication with computation; that split cannot be rebuilt
   from a one-shot.
3. `std::span<T>` cannot express `Vector`'s generic `Container` (device storage
   on GPU); the generic path takes caller-supplied pack/unpack kernels for
   exactly that reason.
4. `Vector` packs with `_bs` and unpacks at `_bs * _map->size_local()`.

The layering stays: `Scatterer` is the primitive, `Vector` the stateful,
container-generic, block-aware wrapper, and these helpers a third peer for the
one-shot host case.

## Performance

No site regresses. Sites 2 and 3 already allocated exactly these two buffers on
every call — the allocation moved, it was not added. `la::Vector`, the only
place where the allocation is on a hot path, is unchanged.

## Tests

- `python/test/unit/common/test_scatterer.py` passes unchanged, as intended:
  its `scatter_fwd`/`scatter_rev` calls now go through the new helpers, so
  `int64`, `float32` and `float64`, both directions, are covered in serial and
  in parallel with no new test code.
- `cpp/test/common/index_map.cpp`: one new `[index_map_scatter_helpers]` case,
  for `std::int8_t` only — a narrow signed type, and the one host type the
  bindings do not instantiate, so it is the only gap the Python tests cannot
  reach.
- Sites 2 and 3 are also covered by the existing refinement suites.

Verified: full C++ suite on 1, 2 and 3 ranks; `pytest -k "scatterer or
refinement"` serially and on 3 ranks; `clang-format`, `ruff` and `gersemi`
clean (mypy output matches its pre-existing baseline — no Python source is
touched).

---

AI assistance: I used Claude Code to draft parts of this PR. I reviewed,
edited, tested, and take responsibility for the final contribution.
