### PR TITLE
la::Vector: add a constructor taking a shared Scatterer

### DIFF
--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -62,7 +62,7 @@ public:
   /// @param[in] bs Number of values associated with each `map` index
   /// (the block size).
   Scatterer(const IndexMap& map, int bs)
-      : _sizes_remote(map.src().size(), 0),
+      : _bs(bs), _sizes_remote(map.src().size(), 0),
         _displs_remote(map.src().size() + 1), _sizes_local(map.dest().size()),
         _displs_local(map.dest().size() + 1)
   {
@@ -215,7 +215,7 @@ public:
   /// @param s Scatterer to copy
   template <class U>
   Scatterer(const Scatterer<U>& s)
-      : _comm0(s._comm0), _comm1(s._comm1),
+      : _comm0(s._comm0), _comm1(s._comm1), _bs(s._bs),
         _remote_inds(s._remote_inds.begin(), s._remote_inds.end()),
         _sizes_remote(s._sizes_remote), _displs_remote(s._displs_remote),
         _local_inds(s._local_inds.begin(), s._local_inds.end()),
@@ -403,6 +403,15 @@ public:
   /// @return Indices container.
   const container_type& remote_indices() const noexcept { return _remote_inds; }
 
+  /// @brief Number of values associated with each index map index that
+  /// this scatterer was built for (the block size).
+  ///
+  /// The scatter indices are expanded for this block size, so a
+  /// scatterer can only be used with data of this block size.
+  ///
+  /// @return Block size.
+  int bs() const noexcept { return _bs; }
+
 private:
   // False only on a single rank, where _comm0/_comm1 stay MPI_COMM_NULL
   bool has_neighbours() const noexcept
@@ -430,6 +439,9 @@ private:
   // - in-edges (src) are from ranks that 'ghost' my owned indices
   // - out-edges (dest) are to the owning ranks of my ghost indices
   dolfinx::MPI::Comm _comm1{MPI_COMM_NULL};
+
+  // Block size the scatter indices are expanded for
+  int _bs;
 
   // Permutation indices used to pack and unpack ghost data (remote)
   container_type _remote_inds;

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -123,17 +123,34 @@ public:
   static_assert(std::is_same_v<value_type, typename container_type::value_type>,
                 "Scalar type and container value type must be the same.");
 
+  /// @brief Create a distributed vector with a given communication
+  /// pattern.
+  ///
+  /// Sharing a scatterer avoids rebuilding a communication pattern, and
+  /// with it the two neighbourhood communicators that each Scatterer
+  /// creates.
+  ///
+  /// @param map Index map that describes the parallel layout of
+  /// the data.
+  /// @param bs Number of entries per index map 'index' (block size).
+  /// @param scatterer Scatterer for @p map and @p bs.
+  Vector(std::shared_ptr<const common::IndexMap> map, int bs,
+         std::shared_ptr<const common::Scatterer<ScatterContainer>> scatterer)
+      : _map(map), _bs(bs), _x(bs * (map->size_local() + map->num_ghosts())),
+        _scatterer(std::move(scatterer)),
+        _buffer_local(_scatterer->local_indices().size()),
+        _buffer_remote(_scatterer->remote_indices().size())
+  {
+  }
+
   /// @brief Create a distributed vector.
   ///
   /// @param map Index map that describes the parallel layout of
   /// the data.
   /// @param bs Number of entries per index map 'index' (block size).
   Vector(std::shared_ptr<const common::IndexMap> map, int bs)
-      : _map(map), _bs(bs), _x(bs * (map->size_local() + map->num_ghosts())),
-        _scatterer(
-            std::make_shared<common::Scatterer<ScatterContainer>>(*_map, bs)),
-        _buffer_local(_scatterer->local_indices().size()),
-        _buffer_remote(_scatterer->remote_indices().size())
+      : Vector(map, bs,
+               std::make_shared<common::Scatterer<ScatterContainer>>(*map, bs))
   {
   }
 
@@ -182,20 +199,6 @@ public:
       : _map(x.index_map()), _bs(x.bs()), _x(x._x.begin(), x._x.end()),
         _scatterer(scatter_ptr(x._scatterer)), _request(MPI_REQUEST_NULL),
         _buffer_local(_scatterer->local_indices().size()),
-        _buffer_remote(_scatterer->remote_indices().size())
-  {
-  }
-
-  /// @brief Create a vector with a given layout and an existing
-  /// communication pattern.
-  ///
-  /// @param map Index map that describes the parallel layout.
-  /// @param bs Number of entries per index map 'index' (block size).
-  /// @param sc Scatterer for @p map and @p bs. Shared, not rebuilt.
-  Vector(std::shared_ptr<const common::IndexMap> map, int bs,
-         std::shared_ptr<const common::Scatterer<ScatterContainer>> sc)
-      : _map(map), _bs(bs), _x(bs * (map->size_local() + map->num_ghosts())),
-        _scatterer(sc), _buffer_local(_scatterer->local_indices().size()),
         _buffer_remote(_scatterer->remote_indices().size())
   {
   }

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -400,10 +400,10 @@ public:
   ///
   /// The index map and scatterer are shared, so no communication pattern is
   /// rebuilt. Unlike the copy-converting constructor, no vector data is
-  /// copied, so `T1` can be different to `T`.
+  /// copied, so the Scalar type `T1` can be different to `T`.
   ///
   /// @note Both vectors scatter on the same communicators. Each owns its
-  /// buffers and request, so sequential scatters is safe, but concurrent
+  /// buffers and request, so sequential scatters are safe, but concurrent
   /// scatters must be issued in the same order on every rank.
   ///
   /// @tparam T1 Scalar type of the new vector.

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -131,13 +131,16 @@ public:
   /// scatter indices, and lets a caller give this vector a scatterer
   /// built on its own communication pattern.
   ///
+  /// The block size is taken from @p scatterer, whose scatter indices
+  /// are expanded for it, so the two cannot disagree.
+  ///
   /// @param map Index map that describes the parallel layout of
   /// the data.
-  /// @param bs Number of entries per index map 'index' (block size).
-  /// @param scatterer Scatterer for @p map and @p bs.
-  Vector(std::shared_ptr<const common::IndexMap> map, int bs,
+  /// @param scatterer Scatterer for @p map.
+  Vector(std::shared_ptr<const common::IndexMap> map,
          std::shared_ptr<const common::Scatterer<ScatterContainer>> scatterer)
-      : _map(map), _bs(bs), _x(bs * (map->size_local() + map->num_ghosts())),
+      : _map(map), _bs(scatterer->bs()),
+        _x(_bs * (map->size_local() + map->num_ghosts())),
         _scatterer(std::move(scatterer)),
         _buffer_local(_scatterer->local_indices().size()),
         _buffer_remote(_scatterer->remote_indices().size())
@@ -150,7 +153,7 @@ public:
   /// the data.
   /// @param bs Number of entries per index map 'index' (block size).
   Vector(std::shared_ptr<const common::IndexMap> map, int bs)
-      : Vector(map, bs,
+      : Vector(map,
                std::make_shared<common::Scatterer<ScatterContainer>>(*map, bs))
   {
   }

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -22,29 +22,6 @@
 
 namespace dolfinx::la
 {
-namespace impl
-{
-/// @brief Rebind a container template to a different value type, e.g.
-/// `std::vector<double>` to `std::vector<std::int8_t>`.
-///
-/// Allocator and other trailing arguments are dropped, so the rebound
-/// container uses its own defaults.
-template <class Container, class U>
-struct rebind_container;
-
-/// @cond
-template <template <class, class...> class Container, class T, class... Args,
-          class U>
-struct rebind_container<Container<T, Args...>, U>
-{
-  using type = Container<U>;
-};
-/// @endcond
-
-/// @brief Container type of ::rebind_container.
-template <class Container, class U>
-using rebind_container_t = typename rebind_container<Container, U>::type;
-} // namespace impl
 
 /// @brief la::Vector scatter pack/unpack function concept.
 template <class F, class Container, class ScatterContainer>
@@ -150,9 +127,9 @@ public:
   /// @brief Create a distributed vector with a given communication
   /// pattern.
   ///
-  /// Sharing a scatterer avoids rebuilding a communication pattern, and
-  /// with it the two neighbourhood communicators that each Scatterer
-  /// creates.
+  /// Sharing a scatterer avoids rebuilding the block size-expanded
+  /// scatter indices, and lets a caller give this vector a scatterer
+  /// built on its own communication pattern.
   ///
   /// @param map Index map that describes the parallel layout of
   /// the data.
@@ -436,29 +413,6 @@ public:
 
   /// Get IndexMap
   std::shared_ptr<const common::IndexMap> index_map() const { return _map; }
-
-  /// @brief Create a vector over the same layout, entries
-  /// value-initialised and not copied.
-  ///
-  /// The index map and scatterer are shared, so no communication pattern is
-  /// rebuilt. Unlike the copy-converting constructor, no vector data is
-  /// copied, so the Scalar type `T1` can be different to `T`.
-  ///
-  /// @note Both vectors scatter on the same communicators. Each owns its
-  /// buffers and request, so sequential scatters are safe, but concurrent
-  /// scatters must be issued in the same order on every rank.
-  ///
-  /// @tparam T1 Scalar type of the new vector.
-  /// @tparam Container1 Data container type of the new vector. Defaults
-  /// to this vector's container rebound to `T1`, so a device vector
-  /// clones to a device vector.
-  /// @return Vector over the same layout.
-  template <typename T1 = T,
-            typename Container1 = impl::rebind_container_t<Container, T1>>
-  Vector<T1, Container1, ScatterContainer> clone_layout() const
-  {
-    return Vector<T1, Container1, ScatterContainer>(_map, _bs, _scatterer);
-  }
 
   /// Get block size
   constexpr int bs() const { return _bs; }

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2025 Garth N. Wells
+// Copyright (C) 2020-2026 Garth N. Wells and Jack S. Hale
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -182,6 +182,20 @@ public:
       : _map(x.index_map()), _bs(x.bs()), _x(x._x.begin(), x._x.end()),
         _scatterer(scatter_ptr(x._scatterer)), _request(MPI_REQUEST_NULL),
         _buffer_local(_scatterer->local_indices().size()),
+        _buffer_remote(_scatterer->remote_indices().size())
+  {
+  }
+
+  /// @brief Create a vector with a given layout and an existing
+  /// communication pattern.
+  ///
+  /// @param map Index map that describes the parallel layout.
+  /// @param bs Number of entries per index map 'index' (block size).
+  /// @param sc Scatterer for @p map and @p bs. Shared, not rebuilt.
+  Vector(std::shared_ptr<const common::IndexMap> map, int bs,
+         std::shared_ptr<const common::Scatterer<ScatterContainer>> sc)
+      : _map(map), _bs(bs), _x(bs * (map->size_local() + map->num_ghosts())),
+        _scatterer(sc), _buffer_local(_scatterer->local_indices().size()),
         _buffer_remote(_scatterer->remote_indices().size())
   {
   }
@@ -380,6 +394,29 @@ public:
 
   /// Get IndexMap
   std::shared_ptr<const common::IndexMap> index_map() const { return _map; }
+
+  /// @brief Create a vector over the same layout, entries
+  /// value-initialised and not copied.
+  ///
+  /// The index map and scatterer are shared, so no communication
+  /// pattern is rebuilt. The block size is inherited, a scatterer being
+  /// built for one block size only. Unlike the copy-converting
+  /// constructor, no data is copied, so `T1` need not represent the
+  /// values of this vector, e.g. an `std::int8_t` marker array
+  /// alongside floating-point weights.
+  ///
+  /// @note Both vectors scatter on the same communicators. Each owns
+  /// its buffers and request, so sequential use is safe, but concurrent
+  /// scatters must be issued in the same order on every rank.
+  ///
+  /// @tparam T1 Scalar type of the new vector.
+  /// @tparam Container1 Data container type of the new vector.
+  /// @return Vector over the same layout.
+  template <typename T1 = T, typename Container1 = std::vector<T1>>
+  Vector<T1, Container1, ScatterContainer> clone_layout() const
+  {
+    return Vector<T1, Container1, ScatterContainer>(_map, _bs, _scatterer);
+  }
 
   /// Get block size
   constexpr int bs() const { return _bs; }

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -22,6 +22,30 @@
 
 namespace dolfinx::la
 {
+namespace impl
+{
+/// @brief Rebind a container template to a different value type, e.g.
+/// `std::vector<double>` to `std::vector<std::int8_t>`.
+///
+/// Allocator and other trailing arguments are dropped, so the rebound
+/// container uses its own defaults.
+template <class Container, class U>
+struct rebind_container;
+
+/// @cond
+template <template <class, class...> class Container, class T, class... Args,
+          class U>
+struct rebind_container<Container<T, Args...>, U>
+{
+  using type = Container<U>;
+};
+/// @endcond
+
+/// @brief Container type of ::rebind_container.
+template <class Container, class U>
+using rebind_container_t = typename rebind_container<Container, U>::type;
+} // namespace impl
+
 /// @brief la::Vector scatter pack/unpack function concept.
 template <class F, class Container, class ScatterContainer>
 concept VectorPackKernel = requires(F f, ScatterContainer idx, Container x) {
@@ -410,9 +434,12 @@ public:
   /// scatters must be issued in the same order on every rank.
   ///
   /// @tparam T1 Scalar type of the new vector.
-  /// @tparam Container1 Data container type of the new vector.
+  /// @tparam Container1 Data container type of the new vector. Defaults
+  /// to this vector's container rebound to `T1`, so a device vector
+  /// clones to a device vector.
   /// @return Vector over the same layout.
-  template <typename T1 = T, typename Container1 = std::vector<T1>>
+  template <typename T1 = T,
+            typename Container1 = impl::rebind_container_t<Container, T1>>
   Vector<T1, Container1, ScatterContainer> clone_layout() const
   {
     return Vector<T1, Container1, ScatterContainer>(_map, _bs, _scatterer);

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -398,15 +398,12 @@ public:
   /// @brief Create a vector over the same layout, entries
   /// value-initialised and not copied.
   ///
-  /// The index map and scatterer are shared, so no communication
-  /// pattern is rebuilt. The block size is inherited, a scatterer being
-  /// built for one block size only. Unlike the copy-converting
-  /// constructor, no data is copied, so `T1` need not represent the
-  /// values of this vector, e.g. an `std::int8_t` marker array
-  /// alongside floating-point weights.
+  /// The index map and scatterer are shared, so no communication pattern is
+  /// rebuilt. Unlike the copy-converting constructor, no vector data is
+  /// copied, so `T1` can be different to `T`.
   ///
-  /// @note Both vectors scatter on the same communicators. Each owns
-  /// its buffers and request, so sequential use is safe, but concurrent
+  /// @note Both vectors scatter on the same communicators. Each owns its
+  /// buffers and request, so sequential scatters is safe, but concurrent
   /// scatters must be issued in the same order on every rank.
   ///
   /// @tparam T1 Scalar type of the new vector.

--- a/cpp/test/vector.cpp
+++ b/cpp/test/vector.cpp
@@ -10,6 +10,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <complex>
+#include <cstdint>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/la/Vector.h>
@@ -17,53 +18,12 @@
 #include <iterator>
 #include <memory>
 #include <numeric>
-#include <span>
-#include <type_traits>
 #include <vector>
 
 using namespace dolfinx;
 
 namespace
 {
-// Stand-in for a device container: a distinct container template with
-// the same shape as std::vector.
-template <class T, class A = std::allocator<T>>
-struct FakeDeviceVector : std::vector<T, A>
-{
-  using std::vector<T, A>::vector;
-};
-
-// clone_layout must rebind this vector's container to the new scalar
-// type, not fall back to std::vector, or a device vector would clone to
-// host storage while sharing a device scatterer.
-void test_vector_clone_layout_container()
-{
-  using Host
-      = la::Vector<double, std::vector<double>, std::vector<std::int32_t>>;
-  static_assert(
-      std::is_same_v<
-          typename decltype(std::declval<Host>()
-                                .clone_layout<std::int8_t>())::container_type,
-          std::vector<std::int8_t>>);
-
-  using Device
-      = la::Vector<double, FakeDeviceVector<double>, std::vector<std::int32_t>>;
-  static_assert(
-      std::is_same_v<
-          typename decltype(std::declval<Device>()
-                                .clone_layout<std::int8_t>())::container_type,
-          FakeDeviceVector<std::int8_t>>);
-
-  // An explicit container is still honoured
-  static_assert(
-      std::is_same_v<
-          typename decltype(std::declval<Device>()
-                                .clone_layout<std::int8_t,
-                                              std::vector<std::int8_t>>())::
-              container_type,
-          std::vector<std::int8_t>>);
-}
-
 template <typename T>
 void test_vector()
 {
@@ -175,66 +135,6 @@ void test_vector_scatter_rev()
                                   std::next(v.array().begin(), size_local));
   CHECK(sum1 == 2 * sum0);
 }
-void test_vector_clone_layout()
-{
-  const int mpi_size = dolfinx::MPI::size(MPI_COMM_WORLD);
-  const int mpi_rank = dolfinx::MPI::rank(MPI_COMM_WORLD);
-  constexpr int size_local = 100;
-  constexpr int bs = 3;
-
-  // Create some ghost entries on next process
-  int num_ghosts = (mpi_size - 1) * 3;
-  std::vector<std::int64_t> ghosts(num_ghosts);
-  for (int i = 0; i < num_ghosts; ++i)
-    ghosts[i] = (mpi_rank + 1) % mpi_size * size_local + i;
-
-  std::vector<int> global_ghost_owner(ghosts.size(), (mpi_rank + 1) % mpi_size);
-
-  auto index_map = std::make_shared<common::IndexMap>(
-      MPI_COMM_WORLD, size_local, ghosts, global_ghost_owner);
-
-  la::Vector<double> v(index_map, bs);
-
-  // Out of range for std::int8_t: the copy-converting constructor would
-  // be undefined behaviour here
-  std::ranges::fill(v.array(), 1e30);
-
-  la::Vector<std::int8_t> marks = v.clone_layout<std::int8_t>();
-
-  // Layout is shared, and the block size is inherited
-  CHECK(marks.index_map() == v.index_map());
-  CHECK(marks.bs() == bs);
-  CHECK(marks.array().size() == v.array().size());
-
-  // Entries are value-initialised, not copied
-  CHECK(
-      std::ranges::all_of(marks.array(), [](std::int8_t x) { return x == 0; }));
-
-  // Storage is independent of the source
-  std::ranges::fill(marks.array(), 1);
-  CHECK(std::ranges::all_of(v.array(), [](double x) { return x == 1e30; }));
-
-  // The shared scatterer serves the new value type
-  std::ranges::fill(marks.array(), 0);
-  std::fill_n(marks.array().begin(), bs * size_local,
-              static_cast<std::int8_t>(mpi_rank + 1));
-  marks.scatter_fwd();
-
-  std::span<const std::int8_t> ghost_marks(
-      std::next(marks.array().begin(), bs * size_local), marks.array().end());
-  const std::int8_t expected
-      = static_cast<std::int8_t>((mpi_rank + 1) % mpi_size + 1);
-  CHECK(ghost_marks.size() == static_cast<std::size_t>(bs * num_ghosts));
-  CHECK(std::ranges::all_of(ghost_marks, [expected](std::int8_t x)
-                            { return x == expected; }));
-
-  // Without an explicit type, a zeroed vector of the same type
-  la::Vector<double> zeros = v.clone_layout();
-  CHECK(zeros.index_map() == v.index_map());
-  CHECK(zeros.bs() == bs);
-  CHECK(std::ranges::all_of(zeros.array(), [](double x) { return x == 0; }));
-}
-
 } // namespace
 
 TEMPLATE_TEST_CASE("Linear Algebra Vector", "[la_vector]", double,
@@ -251,10 +151,4 @@ TEST_CASE("Linear Algebra Vector", "[la_vector]")
 TEST_CASE("Linear Algebra Vector scatter reverse", "[la_vector]")
 {
   CHECK_NOTHROW(test_vector_scatter_rev());
-}
-
-TEST_CASE("Linear Algebra Vector clone_layout", "[la_vector]")
-{
-  CHECK_NOTHROW(test_vector_clone_layout());
-  CHECK_NOTHROW(test_vector_clone_layout_container());
 }

--- a/cpp/test/vector.cpp
+++ b/cpp/test/vector.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/MPI.h>
+#include <dolfinx/common/Scatterer.h>
 #include <dolfinx/la/Vector.h>
 #include <functional>
 #include <iterator>
@@ -135,6 +136,46 @@ void test_vector_scatter_rev()
                                   std::next(v.array().begin(), size_local));
   CHECK(sum1 == 2 * sum0);
 }
+void test_vector_shared_scatterer()
+{
+  const int mpi_size = dolfinx::MPI::size(MPI_COMM_WORLD);
+  const int mpi_rank = dolfinx::MPI::rank(MPI_COMM_WORLD);
+  constexpr int size_local = 100;
+  constexpr int bs = 3;
+
+  // Ghost entries owned by the next process
+  const int num_ghosts = (mpi_size - 1) * 3;
+  std::vector<std::int64_t> ghosts(num_ghosts);
+  for (int i = 0; i < num_ghosts; ++i)
+    ghosts[i] = (mpi_rank + 1) % mpi_size * size_local + i;
+  const std::vector<int> owners(ghosts.size(), (mpi_rank + 1) % mpi_size);
+  auto map = std::make_shared<const common::IndexMap>(
+      MPI_COMM_WORLD, size_local, ghosts, owners);
+
+  auto sct = std::make_shared<const common::Scatterer<>>(*map, bs);
+  CHECK(sct.use_count() == 1);
+  {
+    // One scatterer, two vectors, two scalar types
+    la::Vector<double> u(map, bs, sct);
+    la::Vector<std::int8_t> v(map, bs, sct);
+    CHECK(sct.use_count() == 3);
+    CHECK(u.index_map() == map);
+    CHECK(u.bs() == bs);
+
+    std::ranges::fill_n(u.array().begin(), bs * size_local,
+                        static_cast<double>(mpi_rank));
+    u.scatter_fwd();
+    const double owner = static_cast<double>((mpi_rank + 1) % mpi_size);
+    for (int i = 0; i < bs * num_ghosts; ++i)
+      CHECK(u.array()[bs * size_local + i] == owner);
+
+    std::ranges::fill_n(v.array().begin(), bs * size_local, std::int8_t(7));
+    v.scatter_fwd();
+    for (int i = 0; i < bs * num_ghosts; ++i)
+      CHECK(v.array()[bs * size_local + i] == std::int8_t(7));
+  }
+  CHECK(sct.use_count() == 1);
+}
 } // namespace
 
 TEMPLATE_TEST_CASE("Linear Algebra Vector", "[la_vector]", double,
@@ -151,4 +192,9 @@ TEST_CASE("Linear Algebra Vector", "[la_vector]")
 TEST_CASE("Linear Algebra Vector scatter reverse", "[la_vector]")
 {
   CHECK_NOTHROW(test_vector_scatter_rev());
+}
+
+TEST_CASE("Linear Algebra Vector shared scatterer", "[la_vector]")
+{
+  CHECK_NOTHROW(test_vector_shared_scatterer());
 }

--- a/cpp/test/vector.cpp
+++ b/cpp/test/vector.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Chris Richardson
+// Copyright (C) 2021-2026 Chris Richardson and Jack S. Hale
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -10,9 +10,14 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <complex>
+#include <cstdint>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/la/Vector.h>
+#include <iterator>
+#include <memory>
+#include <span>
+#include <vector>
 
 using namespace dolfinx;
 
@@ -91,6 +96,65 @@ void test_vector_cast()
   CHECK(la::inner_product(v1, v1) == sumn2);
   CHECK(la::norm(v1, la::Norm::linf) == static_cast<U>(mpi_size - 1));
 }
+void test_vector_clone_layout()
+{
+  const int mpi_size = dolfinx::MPI::size(MPI_COMM_WORLD);
+  const int mpi_rank = dolfinx::MPI::rank(MPI_COMM_WORLD);
+  constexpr int size_local = 100;
+  constexpr int bs = 3;
+
+  // Create some ghost entries on next process
+  int num_ghosts = (mpi_size - 1) * 3;
+  std::vector<std::int64_t> ghosts(num_ghosts);
+  for (int i = 0; i < num_ghosts; ++i)
+    ghosts[i] = (mpi_rank + 1) % mpi_size * size_local + i;
+
+  std::vector<int> global_ghost_owner(ghosts.size(), (mpi_rank + 1) % mpi_size);
+
+  auto index_map = std::make_shared<common::IndexMap>(
+      MPI_COMM_WORLD, size_local, ghosts, global_ghost_owner);
+
+  la::Vector<double> v(index_map, bs);
+
+  // Out of range for std::int8_t: the copy-converting constructor would
+  // be undefined behaviour here
+  std::ranges::fill(v.array(), 1e30);
+
+  la::Vector<std::int8_t> marks = v.clone_layout<std::int8_t>();
+
+  // Layout is shared, and the block size is inherited
+  CHECK(marks.index_map() == v.index_map());
+  CHECK(marks.bs() == bs);
+  CHECK(marks.array().size() == v.array().size());
+
+  // Entries are value-initialised, not copied
+  CHECK(
+      std::ranges::all_of(marks.array(), [](std::int8_t x) { return x == 0; }));
+
+  // Storage is independent of the source
+  std::ranges::fill(marks.array(), 1);
+  CHECK(std::ranges::all_of(v.array(), [](double x) { return x == 1e30; }));
+
+  // The shared scatterer serves the new value type
+  std::ranges::fill(marks.array(), 0);
+  std::fill_n(marks.array().begin(), bs * size_local,
+              static_cast<std::int8_t>(mpi_rank + 1));
+  marks.scatter_fwd();
+
+  std::span<const std::int8_t> ghost_marks(
+      std::next(marks.array().begin(), bs * size_local), marks.array().end());
+  const std::int8_t expected
+      = static_cast<std::int8_t>((mpi_rank + 1) % mpi_size + 1);
+  CHECK(ghost_marks.size() == static_cast<std::size_t>(bs * num_ghosts));
+  CHECK(std::ranges::all_of(ghost_marks, [expected](std::int8_t x)
+                            { return x == expected; }));
+
+  // Without an explicit type, a zeroed vector of the same type
+  la::Vector<double> zeros = v.clone_layout();
+  CHECK(zeros.index_map() == v.index_map());
+  CHECK(zeros.bs() == bs);
+  CHECK(std::ranges::all_of(zeros.array(), [](double x) { return x == 0; }));
+}
 } // namespace
 
 TEMPLATE_TEST_CASE("Linear Algebra Vector", "[la_vector]", double,
@@ -102,4 +166,9 @@ TEMPLATE_TEST_CASE("Linear Algebra Vector", "[la_vector]", double,
 TEST_CASE("Linear Algebra Vector", "[la_vector]")
 {
   CHECK_NOTHROW(test_vector_cast());
+}
+
+TEST_CASE("Linear Algebra Vector clone_layout", "[la_vector]")
+{
+  CHECK_NOTHROW(test_vector_clone_layout());
 }

--- a/cpp/test/vector.cpp
+++ b/cpp/test/vector.cpp
@@ -17,12 +17,52 @@
 #include <iterator>
 #include <memory>
 #include <span>
+#include <type_traits>
 #include <vector>
 
 using namespace dolfinx;
 
 namespace
 {
+// Stand-in for a device container: a distinct container template with
+// the same shape as std::vector.
+template <class T, class A = std::allocator<T>>
+struct FakeDeviceVector : std::vector<T, A>
+{
+  using std::vector<T, A>::vector;
+};
+
+// clone_layout must rebind this vector's container to the new scalar
+// type, not fall back to std::vector, or a device vector would clone to
+// host storage while sharing a device scatterer.
+void test_vector_clone_layout_container()
+{
+  using Host
+      = la::Vector<double, std::vector<double>, std::vector<std::int32_t>>;
+  static_assert(
+      std::is_same_v<
+          typename decltype(std::declval<Host>()
+                                .clone_layout<std::int8_t>())::container_type,
+          std::vector<std::int8_t>>);
+
+  using Device
+      = la::Vector<double, FakeDeviceVector<double>, std::vector<std::int32_t>>;
+  static_assert(
+      std::is_same_v<
+          typename decltype(std::declval<Device>()
+                                .clone_layout<std::int8_t>())::container_type,
+          FakeDeviceVector<std::int8_t>>);
+
+  // An explicit container is still honoured
+  static_assert(
+      std::is_same_v<
+          typename decltype(std::declval<Device>()
+                                .clone_layout<std::int8_t,
+                                              std::vector<std::int8_t>>())::
+              container_type,
+          std::vector<std::int8_t>>);
+}
+
 template <typename T>
 void test_vector()
 {
@@ -171,4 +211,5 @@ TEST_CASE("Linear Algebra Vector", "[la_vector]")
 TEST_CASE("Linear Algebra Vector clone_layout", "[la_vector]")
 {
   CHECK_NOTHROW(test_vector_clone_layout());
+  CHECK_NOTHROW(test_vector_clone_layout_container());
 }

--- a/cpp/test/vector.cpp
+++ b/cpp/test/vector.cpp
@@ -156,11 +156,13 @@ void test_vector_shared_scatterer()
   CHECK(sct.use_count() == 1);
   {
     // One scatterer, two vectors, two scalar types
-    la::Vector<double> u(map, bs, sct);
-    la::Vector<std::int8_t> v(map, bs, sct);
+    la::Vector<double> u(map, sct);
+    la::Vector<std::int8_t> v(map, sct);
     CHECK(sct.use_count() == 3);
     CHECK(u.index_map() == map);
+    // Block size comes from the scatterer, not a separate argument
     CHECK(u.bs() == bs);
+    CHECK(v.bs() == bs);
 
     std::ranges::fill_n(u.array().begin(), bs * size_local,
                         static_cast<double>(mpi_rank));


### PR DESCRIPTION
## Summary

Adds one constructor to `la::Vector`, taking a
`std::shared_ptr<const common::Scatterer<...>>` alongside the index map:

```cpp
Vector(std::shared_ptr<const common::IndexMap> map,
       std::shared_ptr<const common::Scatterer<ScatterContainer>> scatterer);
```

The `(map, bs)` constructor delegates to it. `common::Scatterer` gains a
`bs()` accessor so the block size can be taken from the scatterer rather than
passed again — see "Why the block size is not a parameter" below.

This is the "first simple step" @garth-wells asked for on #4293:

> First simple step would be for `Vector` to have a constructor that takes a
> shared pointer to a scatterer.

@chrisrichardson's constraint on #3065 — "We still would want to be able to
create a `Vector` just from an `IndexMap` too" — is preserved by the delegating
form.

## What this is for

The constructor lets a caller decide which `Scatterer` a `Vector` uses, rather
than having one built for it. Two things follow from that.

**A caller can give a `Vector` a scatterer built on its own communication
pattern.** In #4484, scatterers over one `IndexMap` share a cached pattern, and
therefore a pair of neighbourhood communicators. Concurrent scatters in the
same direction on shared communicators are matched in start order, so every
rank must start them in the same order. A caller that cannot guarantee that
opts out by building its own pattern — and this constructor is the only way to
hand the result to a `Vector`:

```cpp
auto pattern = std::make_shared<const common::ScatterPattern>(*map);
auto sct = std::make_shared<const common::Scatterer<>>(pattern, bs);
la::Vector<double> v(map, sct);  // its own communicators
```

**Several vectors can share one scatterer**, avoiding the per-`Vector` rebuild
of the block size-expanded scatter indices.

## What changed since this PR was opened

It originally also added `la::Vector::clone_layout`, and argued the
communicator cost of `Scatterer` as its motivation. Both have been dropped.

**The motivation moved.** The original argument was that every `la::Vector`
built from an `IndexMap` costs two neighbourhood communicators, and that
sharing a scatterer avoids them. #4484 fixes that at the source, by caching the
communication pattern on the `IndexMap`, so `Vector(map, bs)` no longer creates
communicators at all. Reviewing this PR on the communicator argument would be
reviewing it for a reason that no longer holds.

**`clone_layout` went with it.** Its purpose was a vector over the same layout
with a different scalar type and no data copied — the copy-converting
constructor copies, and narrowing a value that does not fit the target type is
undefined behaviour, which `1e30` into an `std::int8_t` is not a hypothetical
for. With the pattern cached, that is simply:

```cpp
la::Vector<std::int8_t> marks(v.index_map(), v.bs());
```

which value-initialises rather than copying, and creates no communicator.
Verified equivalent at np = 3: same index map by pointer, same block size, same
size, same contents, and it scatters correctly.

What `clone_layout` still offered was inferring `Container` and
`ScatterContainer` from the source vector, so a device vector clones to a
device vector, and saving the index-array rebuild — measured at 16.9 µs versus
11.5 µs for a 2000-ghost, `bs = 3` vector. Ergonomics and microseconds, not
correctness, and not enough to carry the API plus its `rebind_container`
machinery. It is gone, along with `impl::rebind_container` and its tests.

## Why the block size is not a parameter

`Scatterer` took `bs`, expanded its indices for it, and discarded it — no
member, no accessor. So a `Vector` sharing a scatterer had to be told the block
size separately, making `(map, bs, scatterer)` a triple the caller must keep
consistent. Passing a scatterer built for a different block size compiled,
allocated the wrong storage and corrupted every scatter, with nothing checking
it. That is the same hazard this PR originally cited as its reason *not* to
expose a `scatterer()` accessor:

> The accessor would only make the consistency of the (map, bs, scatterer)
> triple a caller obligation, where passing a scatterer built for a different
> block size compiles and silently corrupts every scatter.

The argument applies just as well to a three-argument constructor. `Scatterer`
now stores the block size and reports it through `bs()`, and the constructor
takes `(map, scatterer)`. There is no second block size to disagree with.

A `Scatterer` is a communication pattern plus a block size — that is exactly
what #4484's split makes explicit — so being able to report which block size it
was built for is a property it should have had.

The index map stays a parameter: `Scatterer` does not hold one, and it must
not. #4484 has `IndexMap` own the communication pattern, so a pointer back
would be an uncollectable cycle.

## Relationship to #4293, #3065 and #4484

#4293 proposed associating a `Scatterer` with `fem::FunctionSpace`, and did not
converge: @garth-wells noted the scatterer "is really a property of the
`Vector`", @chrisrichardson raised `DofMap` without being convinced it was
better, and @schnellerhase suggested splitting `Scatterer` into a
topology-level communication pattern and a dofmap-level layout.

#4484 implements that split and closes #3065. This PR is deliberately
independent of where a shared scatterer should live: it only lets a caller
supply one.

## Tests

`test_vector_shared_scatterer` in `cpp/test/vector.cpp` builds two vectors of
different scalar types on one `Scatterer` and checks that the scatterer is
shared by reference count rather than copied, that the index map is carried
through, that both vectors report the scatterer's block size, and that both
scatter correctly on it.

Verified the reference count check is not vacuous: expecting 2 references
instead of 3 fails at np = 2.

Passing at np = 1, 2 and 3, with zero failures in both suites:

| | C++ (Catch2) | Python (pytest) |
| --- | --- | --- |
| np = 1 | 83 cases | 3492 passed, 110 skipped, 21 xfailed |
| np = 2 | 83 cases | 2431 passed, 1089 skipped, 21 xfailed |
| np = 3 | 83 cases | 2432 passed, 1088 skipped, 21 xfailed |

`clang-format`, `ruff`, `ruff format` and `gersemi` clean; mypy unchanged
against its pre-existing baseline.

---

AI assistance: I used Claude Code (Opus) to draft parts of this PR. I reviewed,
edited, tested, and take responsibility for the final contribution.
