### PR TITLE
Cache the scatter communication pattern on IndexMap

### DIFF
--- a/cpp/dolfinx/common/CMakeLists.txt
+++ b/cpp/dolfinx/common/CMakeLists.txt
@@ -11,6 +11,7 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/math.h
   ${CMAKE_CURRENT_SOURCE_DIR}/MPI.h
   ${CMAKE_CURRENT_SOURCE_DIR}/petsc.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/ScatterPattern.h
   ${CMAKE_CURRENT_SOURCE_DIR}/Scatterer.h
   ${CMAKE_CURRENT_SOURCE_DIR}/Table.h
   ${CMAKE_CURRENT_SOURCE_DIR}/Timer.h
@@ -27,6 +28,7 @@ target_sources(
     log.cpp
     MPI.cpp
     petsc.cpp
+    ScatterPattern.cpp
     Table.cpp
     TimeLogger.cpp
     timing.cpp

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -1343,7 +1343,7 @@ std::span<const int> IndexMap::dest() const noexcept { return _dest; }
 std::shared_ptr<const ScatterPattern> IndexMap::scatter_pattern() const
 {
   if (!_scatter_pattern)
-    _scatter_pattern = std::make_shared<const ScatterPattern>(*this);
+    _scatter_pattern = create_scatter_pattern(*this);
   return _scatter_pattern;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -1343,7 +1343,8 @@ std::span<const int> IndexMap::dest() const noexcept { return _dest; }
 std::shared_ptr<const ScatterPattern> IndexMap::scatter_pattern() const
 {
   if (!_scatter_pattern)
-    _scatter_pattern = create_scatter_pattern(*this);
+    _scatter_pattern
+        = std::make_shared<const ScatterPattern>(create_scatter_pattern(*this));
   return _scatter_pattern;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -6,10 +6,12 @@
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include "IndexMap.h"
+#include "ScatterPattern.h"
 #include "sort.h"
 #include <algorithm>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <numeric>
 #include <ranges>
 #include <set>
@@ -1337,6 +1339,13 @@ std::vector<std::int32_t> IndexMap::shared_indices() const
 std::span<const int> IndexMap::src() const noexcept { return _src; }
 //-----------------------------------------------------------------------------
 std::span<const int> IndexMap::dest() const noexcept { return _dest; }
+//-----------------------------------------------------------------------------
+std::shared_ptr<const ScatterPattern> IndexMap::scatter_pattern() const
+{
+  if (!_scatter_pattern)
+    _scatter_pattern = std::make_shared<const ScatterPattern>(*this);
+  return _scatter_pattern;
+}
 //-----------------------------------------------------------------------------
 std::vector<std::int32_t> IndexMap::weights_src() const
 {

--- a/cpp/dolfinx/common/IndexMap.cpp
+++ b/cpp/dolfinx/common/IndexMap.cpp
@@ -1343,8 +1343,7 @@ std::span<const int> IndexMap::dest() const noexcept { return _dest; }
 std::shared_ptr<const ScatterPattern> IndexMap::scatter_pattern() const
 {
   if (!_scatter_pattern)
-    _scatter_pattern
-        = std::make_shared<const ScatterPattern>(create_scatter_pattern(*this));
+    _scatter_pattern = std::make_shared<const ScatterPattern>(*this);
   return _scatter_pattern;
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/IndexMap.h
+++ b/cpp/dolfinx/common/IndexMap.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MPI.h"
+#include "ScatterPattern.h"
 #include <cstdint>
 #include <memory>
 #include <span>
@@ -256,6 +257,30 @@ public:
   /// The ranks are unique and sorted.
   std::span<const int> dest() const noexcept;
 
+  /// @brief Communication pattern for scattering data laid out
+  /// according to this index map.
+  ///
+  /// The pattern owns the two neighbourhood communicators used by
+  /// common::Scatterer. It is built on the first call and shared by
+  /// every subsequent caller, so a code that creates many la::Vector or
+  /// fem::Function objects over one index map creates one pair of
+  /// communicators, not one pair per object.
+  ///
+  /// Built on demand rather than in the constructor because most index
+  /// maps are never scattered: a refinement and assembly run measured
+  /// 20 index maps but needed 3 patterns, so building eagerly would
+  /// cost more communicators than the per-Vector patterns this replaces.
+  ///
+  /// @note Collective on comm() on the first call. Every rank must
+  /// reach the first call for a given index map in the same order,
+  /// which is the requirement that constructing a common::Scatterer
+  /// already imposes.
+  ///
+  /// @note Not thread safe.
+  ///
+  /// @return Communication pattern of this index map.
+  std::shared_ptr<const ScatterPattern> scatter_pattern() const;
+
   /// @brief Compute the number of ghost indices owned by each rank in
   /// IndexMap::src.
   ///
@@ -328,6 +353,9 @@ private:
 
   // Set of ranks ghost owned indices
   std::vector<int> _dest;
+
+  // Communication pattern, built on the first call to scatter_pattern()
+  mutable std::shared_ptr<const ScatterPattern> _scatter_pattern;
 };
 
 } // namespace dolfinx::common

--- a/cpp/dolfinx/common/ScatterPattern.cpp
+++ b/cpp/dolfinx/common/ScatterPattern.cpp
@@ -57,7 +57,7 @@ common::ScatterPattern::ScatterPattern(const IndexMap& map)
   std::span owners = map.owners();
   _perm.resize(owners.size());
   std::iota(_perm.begin(), _perm.end(), 0);
-  dolfinx::radix_sort(_perm, [&owners](auto index) { return owners[index]; });
+  dolfinx::radix_sort(_perm, [&owners](std::int32_t i) { return owners[i]; });
 
   // Sort (i) ghost indices and (ii) ghost index owners by rank (using
   // the permutation array)
@@ -65,9 +65,9 @@ common::ScatterPattern::ScatterPattern(const IndexMap& map)
   std::vector<int> owners_sorted(owners.size());
   std::vector<std::int64_t> ghosts_sorted(owners.size());
   std::ranges::transform(_perm, owners_sorted.begin(),
-                         [&owners](auto idx) { return owners[idx]; });
+                         [&owners](std::int32_t i) { return owners[i]; });
   std::ranges::transform(_perm, ghosts_sorted.begin(),
-                         [&ghosts](auto idx) { return ghosts[idx]; });
+                         [&ghosts](std::int32_t i) { return ghosts[i]; });
 
   // For data associated with ghost indices, packed by owning
   // (neighbourhood) rank, compute sizes and displacements. I.e., when
@@ -119,13 +119,14 @@ common::ScatterPattern::ScatterPattern(const IndexMap& map)
   const std::array<std::int64_t, 2> range = map.local_range();
 #ifndef NDEBUG
   // Check that all received indices are within the owned range
-  std::ranges::for_each(recv_buffer, [range](auto idx)
+  std::ranges::for_each(recv_buffer, [&range](std::int64_t idx)
                         { assert(idx >= range[0] and idx < range[1]); });
 #endif
 
   // Convert the received indices from global to local numbering
   _local_inds.resize(recv_buffer.size());
-  std::ranges::transform(recv_buffer, _local_inds.begin(), [range](auto idx)
+  std::ranges::transform(recv_buffer, _local_inds.begin(),
+                         [&range](std::int64_t idx)
                          { return static_cast<std::int32_t>(idx - range[0]); });
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/ScatterPattern.cpp
+++ b/cpp/dolfinx/common/ScatterPattern.cpp
@@ -1,0 +1,131 @@
+// Copyright (C) 2022-2026 Igor Baratta, Garth N. Wells and Jack S. Hale
+//
+// This file is part of DOLFINx (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+
+#include "ScatterPattern.h"
+#include "IndexMap.h"
+#include "MPI.h"
+#include "sort.h"
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <iterator>
+#include <mpi.h>
+#include <numeric>
+#include <span>
+#include <vector>
+
+using namespace dolfinx;
+
+//-----------------------------------------------------------------------------
+common::ScatterPattern::ScatterPattern(const IndexMap& map)
+    : _src(map.src().begin(), map.src().end()),
+      _dest(map.dest().begin(), map.dest().end()),
+      _sizes_remote(_src.size(), 0), _displs_remote(_src.size() + 1),
+      _sizes_local(_dest.size()), _displs_local(_dest.size() + 1)
+{
+  if (dolfinx::MPI::size(map.comm()) == 1)
+    return;
+
+  int ierr;
+
+  // Check that src and dest ranks are unique and sorted
+  assert(std::ranges::is_sorted(_src));
+  assert(std::ranges::is_sorted(_dest));
+
+  // Create communicators with directed edges:
+  // (0) owner -> ghost,
+  // (1) ghost -> owner
+  MPI_Comm comm0;
+  ierr = MPI_Dist_graph_create_adjacent(
+      map.comm(), _src.size(), _src.data(), MPI_UNWEIGHTED, _dest.size(),
+      _dest.data(), MPI_UNWEIGHTED, MPI_INFO_NULL, false, &comm0);
+  _comm0 = dolfinx::MPI::Comm(comm0, false);
+  dolfinx::MPI::check_error(map.comm(), ierr);
+
+  MPI_Comm comm1;
+  ierr = MPI_Dist_graph_create_adjacent(
+      map.comm(), _dest.size(), _dest.data(), MPI_UNWEIGHTED, _src.size(),
+      _src.data(), MPI_UNWEIGHTED, MPI_INFO_NULL, false, &comm1);
+  _comm1 = dolfinx::MPI::Comm(comm1, false);
+  dolfinx::MPI::check_error(map.comm(), ierr);
+
+  // Build permutation array that sorts ghost indices by owning rank
+  std::span owners = map.owners();
+  _perm.resize(owners.size());
+  std::iota(_perm.begin(), _perm.end(), 0);
+  dolfinx::radix_sort(_perm, [&owners](auto index) { return owners[index]; });
+
+  // Sort (i) ghost indices and (ii) ghost index owners by rank (using
+  // the permutation array)
+  std::span ghosts = map.ghosts();
+  std::vector<int> owners_sorted(owners.size());
+  std::vector<std::int64_t> ghosts_sorted(owners.size());
+  std::ranges::transform(_perm, owners_sorted.begin(),
+                         [&owners](auto idx) { return owners[idx]; });
+  std::ranges::transform(_perm, ghosts_sorted.begin(),
+                         [&ghosts](auto idx) { return ghosts[idx]; });
+
+  // For data associated with ghost indices, packed by owning
+  // (neighbourhood) rank, compute sizes and displacements. I.e., when
+  // sending ghost index data from this rank to the owning ranks,
+  // disp[i] is the first entry in the buffer sent to neighbourhood rank
+  // i, and disp[i + 1] - disp[i] is the number of values sent to rank i.
+  assert(_sizes_remote.size() == _src.size());
+  assert(_displs_remote.size() == _src.size() + 1);
+  auto begin = owners_sorted.begin();
+  for (std::size_t i = 0; i < _src.size(); i++)
+  {
+    auto upper = std::upper_bound(begin, owners_sorted.end(), _src[i]);
+    std::size_t num_ind = std::ranges::distance(begin, upper);
+    _displs_remote[i + 1] = _displs_remote[i] + num_ind;
+    _sizes_remote[i] = num_ind;
+    begin = upper;
+  }
+
+  // For data associated with owned indices that are ghosted by other
+  // ranks, compute the size and displacement arrays. When sending data
+  // associated with ghost indices to the owner, these size and
+  // displacement arrays are for the receive buffer.
+
+  // Compute sizes and displacements of local data (how many local
+  // elements to be sent/received grouped by neighbours)
+  assert(_sizes_local.size() == _dest.size());
+  assert(_displs_local.size() == _dest.size() + 1);
+  _sizes_remote.reserve(1);
+  _sizes_local.reserve(1);
+  ierr = MPI_Neighbor_alltoall(_sizes_remote.data(), 1, MPI_INT32_T,
+                               _sizes_local.data(), 1, MPI_INT32_T,
+                               _comm1.comm());
+  dolfinx::MPI::check_error(_comm1.comm(), ierr);
+
+  std::partial_sum(_sizes_local.begin(), _sizes_local.end(),
+                   std::next(_displs_local.begin()));
+
+  assert(static_cast<int>(ghosts_sorted.size()) == _displs_remote.back());
+
+  // Send ghost global indices to owning rank, and receive owned indices
+  // that are ghosts on other ranks
+  std::vector<std::int64_t> recv_buffer(_displs_local.back(), 0);
+  ierr = MPI_Neighbor_alltoallv(
+      ghosts_sorted.data(), _sizes_remote.data(), _displs_remote.data(),
+      MPI_INT64_T, recv_buffer.data(), _sizes_local.data(),
+      _displs_local.data(), MPI_INT64_T, _comm1.comm());
+  dolfinx::MPI::check_error(_comm1.comm(), ierr);
+
+  const std::array<std::int64_t, 2> range = map.local_range();
+#ifndef NDEBUG
+  // Check that all received indices are within the owned range
+  std::ranges::for_each(recv_buffer, [range](auto idx)
+                        { assert(idx >= range[0] and idx < range[1]); });
+#endif
+
+  // Convert the received indices from global to local numbering
+  _local_inds.resize(recv_buffer.size());
+  std::ranges::transform(recv_buffer, _local_inds.begin(), [range](auto idx)
+                         { return static_cast<std::int32_t>(idx - range[0]); });
+}
+//-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/ScatterPattern.cpp
+++ b/cpp/dolfinx/common/ScatterPattern.cpp
@@ -13,7 +13,6 @@
 #include <cassert>
 #include <cstdint>
 #include <iterator>
-#include <memory>
 #include <mpi.h>
 #include <numeric>
 #include <span>
@@ -132,9 +131,8 @@ common::ScatterPattern::ScatterPattern(const IndexMap& map)
                          { return static_cast<std::int32_t>(idx - range[0]); });
 }
 //-----------------------------------------------------------------------------
-std::shared_ptr<const common::ScatterPattern>
-common::create_scatter_pattern(const IndexMap& map)
+common::ScatterPattern common::create_scatter_pattern(const IndexMap& map)
 {
-  return std::make_shared<const ScatterPattern>(map);
+  return ScatterPattern(map);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/ScatterPattern.cpp
+++ b/cpp/dolfinx/common/ScatterPattern.cpp
@@ -131,8 +131,3 @@ common::ScatterPattern::ScatterPattern(const IndexMap& map)
                          { return static_cast<std::int32_t>(idx - range[0]); });
 }
 //-----------------------------------------------------------------------------
-common::ScatterPattern common::create_scatter_pattern(const IndexMap& map)
-{
-  return ScatterPattern(map);
-}
-//-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/ScatterPattern.cpp
+++ b/cpp/dolfinx/common/ScatterPattern.cpp
@@ -95,11 +95,11 @@ common::ScatterPattern::ScatterPattern(const IndexMap& map)
   // elements to be sent/received grouped by neighbours)
   assert(_sizes_local.size() == _dest.size());
   assert(_displs_local.size() == _dest.size() + 1);
+  // Allocate so that data() is not null when a rank has no neighbours
   _sizes_remote.reserve(1);
   _sizes_local.reserve(1);
-  ierr = MPI_Neighbor_alltoall(_sizes_remote.data(), 1, MPI_INT32_T,
-                               _sizes_local.data(), 1, MPI_INT32_T,
-                               _comm1.comm());
+  ierr = MPI_Neighbor_alltoall(_sizes_remote.data(), 1, MPI_INT,
+                               _sizes_local.data(), 1, MPI_INT, _comm1.comm());
   dolfinx::MPI::check_error(_comm1.comm(), ierr);
 
   std::partial_sum(_sizes_local.begin(), _sizes_local.end(),

--- a/cpp/dolfinx/common/ScatterPattern.cpp
+++ b/cpp/dolfinx/common/ScatterPattern.cpp
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <cstdint>
 #include <iterator>
+#include <memory>
 #include <mpi.h>
 #include <numeric>
 #include <span>
@@ -129,5 +130,11 @@ common::ScatterPattern::ScatterPattern(const IndexMap& map)
   std::ranges::transform(recv_buffer, _local_inds.begin(),
                          [&range](std::int64_t idx)
                          { return static_cast<std::int32_t>(idx - range[0]); });
+}
+//-----------------------------------------------------------------------------
+std::shared_ptr<const common::ScatterPattern>
+common::create_scatter_pattern(const IndexMap& map)
+{
+  return std::make_shared<const ScatterPattern>(map);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/dolfinx/common/ScatterPattern.h
+++ b/cpp/dolfinx/common/ScatterPattern.h
@@ -8,6 +8,7 @@
 
 #include "MPI.h"
 #include <cstdint>
+#include <memory>
 #include <mpi.h>
 #include <span>
 #include <vector>
@@ -130,4 +131,22 @@ private:
   // Owned indices that are ghosted elsewhere, grouped by neighbour
   std::vector<std::int32_t> _local_inds;
 };
+
+/// @brief Build the communication pattern of an index map.
+///
+/// The returned pattern is owned by the caller, and is distinct from the
+/// one that IndexMap::scatter_pattern shares. Use this to give a
+/// common::Scatterer its own pair of neighbourhood communicators, so
+/// that its scatters carry no ordering requirement against scatters on
+/// other scatterers over the same map.
+///
+/// @note Collective on `map.comm()`. Creating a pattern creates two
+/// neighbourhood communicators, a limited resource; prefer
+/// IndexMap::scatter_pattern unless a private pattern is needed.
+///
+/// @param[in] map Index map that describes the parallel layout of data.
+/// @return Communication pattern of `map`.
+std::shared_ptr<const ScatterPattern>
+create_scatter_pattern(const IndexMap& map);
+
 } // namespace dolfinx::common

--- a/cpp/dolfinx/common/ScatterPattern.h
+++ b/cpp/dolfinx/common/ScatterPattern.h
@@ -32,7 +32,15 @@ class ScatterPattern
 public:
   /// @brief Build the communication pattern of an index map.
   ///
-  /// @note Collective on `map.comm()`.
+  /// The pattern is owned by the caller, and is distinct from the one
+  /// that IndexMap::scatter_pattern shares. Construct one directly to
+  /// give a common::Scatterer its own pair of neighbourhood
+  /// communicators, so that its scatters carry no ordering requirement
+  /// against scatters on other scatterers over the same index map.
+  ///
+  /// @note Collective on `map.comm()`. Each pattern creates two
+  /// neighbourhood communicators, a limited resource, so prefer
+  /// IndexMap::scatter_pattern unless a private pattern is needed.
   ///
   /// @param[in] map Index map that describes the parallel layout of
   /// data.
@@ -130,21 +138,5 @@ private:
   // Owned indices that are ghosted elsewhere, grouped by neighbour
   std::vector<std::int32_t> _local_inds;
 };
-
-/// @brief Build the communication pattern of an index map.
-///
-/// The returned pattern is owned by the caller, and is distinct from the
-/// one that IndexMap::scatter_pattern shares. Use this to give a
-/// common::Scatterer its own pair of neighbourhood communicators, so
-/// that its scatters carry no ordering requirement against scatters on
-/// other scatterers over the same map.
-///
-/// @note Collective on `map.comm()`. Creating a pattern creates two
-/// neighbourhood communicators, a limited resource; prefer
-/// IndexMap::scatter_pattern unless a private pattern is needed.
-///
-/// @param[in] map Index map that describes the parallel layout of data.
-/// @return Communication pattern of `map`.
-ScatterPattern create_scatter_pattern(const IndexMap& map);
 
 } // namespace dolfinx::common

--- a/cpp/dolfinx/common/ScatterPattern.h
+++ b/cpp/dolfinx/common/ScatterPattern.h
@@ -8,7 +8,6 @@
 
 #include "MPI.h"
 #include <cstdint>
-#include <memory>
 #include <mpi.h>
 #include <span>
 #include <vector>
@@ -146,7 +145,6 @@ private:
 ///
 /// @param[in] map Index map that describes the parallel layout of data.
 /// @return Communication pattern of `map`.
-std::shared_ptr<const ScatterPattern>
-create_scatter_pattern(const IndexMap& map);
+ScatterPattern create_scatter_pattern(const IndexMap& map);
 
 } // namespace dolfinx::common

--- a/cpp/dolfinx/common/ScatterPattern.h
+++ b/cpp/dolfinx/common/ScatterPattern.h
@@ -1,0 +1,147 @@
+// Copyright (C) 2022-2026 Igor Baratta, Garth N. Wells and Jack S. Hale
+//
+// This file is part of DOLFINx (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+
+#pragma once
+
+#include "MPI.h"
+#include <cstdint>
+#include <mpi.h>
+#include <span>
+#include <vector>
+
+namespace dolfinx::common
+{
+class IndexMap;
+
+/// @brief The MPI communication pattern of a common::IndexMap.
+///
+/// A ScatterPattern owns the two neighbourhood communicators over which
+/// data associated with an IndexMap is scattered, together with the
+/// neighbourhood sizes, displacements and index permutations. All of
+/// this is a function of the IndexMap alone, so a pattern is built once
+/// per IndexMap (see IndexMap::scatter_pattern) and shared by every
+/// common::Scatterer built from that map, whatever the block size.
+///
+/// Sizes, displacements and indices are for a block size of one. A
+/// Scatterer scales and expands them for its own block size.
+class ScatterPattern
+{
+public:
+  /// @brief Build the communication pattern of an index map.
+  ///
+  /// @note Collective on `map.comm()`.
+  ///
+  /// @param[in] map Index map that describes the parallel layout of
+  /// data.
+  explicit ScatterPattern(const IndexMap& map);
+
+  // Copy constructor (deleted)
+  ScatterPattern(const ScatterPattern& pattern) = delete;
+
+  /// Move constructor
+  ScatterPattern(ScatterPattern&& pattern) = default;
+
+  /// Destructor
+  ~ScatterPattern() = default;
+
+  // Copy assignment (deleted)
+  ScatterPattern& operator=(const ScatterPattern& pattern) = delete;
+
+  /// Move assignment
+  ScatterPattern& operator=(ScatterPattern&& pattern) = default;
+
+  /// @brief Communicator on which owners send to the ranks that ghost
+  /// their indices.
+  /// @return Neighbourhood communicator, `MPI_COMM_NULL` on one rank.
+  MPI_Comm comm0() const noexcept { return _comm0.comm(); }
+
+  /// @brief Communicator on which ghosting ranks send to the owners of
+  /// the ghosted indices.
+  /// @return Neighbourhood communicator, `MPI_COMM_NULL` on one rank.
+  MPI_Comm comm1() const noexcept { return _comm1.comm(); }
+
+  /// @brief Ranks that own indices ghosted by the caller.
+  /// @return Sorted list of ranks on comm0()/comm1().
+  std::span<const int> src() const noexcept { return _src; }
+
+  /// @brief Ranks that ghost indices owned by the caller.
+  /// @return Sorted list of ranks on comm0()/comm1().
+  std::span<const int> dest() const noexcept { return _dest; }
+
+  /// @brief Number of owned indices shared with each rank in dest(),
+  /// for a block size of one.
+  /// @return Sizes, one per neighbour.
+  std::span<const int> sizes_local() const noexcept { return _sizes_local; }
+
+  /// @brief Displacements into the buffer of owned shared indices, for
+  /// a block size of one.
+  /// @return Displacements, of size `dest().size() + 1`.
+  std::span<const int> displs_local() const noexcept { return _displs_local; }
+
+  /// @brief Number of ghost indices owned by each rank in src(), for a
+  /// block size of one.
+  /// @return Sizes, one per neighbour.
+  std::span<const int> sizes_remote() const noexcept { return _sizes_remote; }
+
+  /// @brief Displacements into the buffer of ghost indices, for a block
+  /// size of one.
+  /// @return Displacements, of size `src().size() + 1`.
+  std::span<const int> displs_remote() const noexcept { return _displs_remote; }
+
+  /// @brief Permutation that sorts the index map's ghosts by owning
+  /// rank, for a block size of one.
+  /// @return Permutation of the ghost indices.
+  std::span<const std::int32_t> perm() const noexcept { return _perm; }
+
+  /// @brief Owned indices that are ghosted on other ranks, in local
+  /// numbering and grouped by neighbouring rank, for a block size of
+  /// one.
+  /// @return Local indices.
+  std::span<const std::int32_t> local_indices() const noexcept
+  {
+    return _local_inds;
+  }
+
+private:
+  // Communicator where the source ranks own the indices in the callers
+  // halo, and the destination ranks 'ghost' indices owned by the
+  // caller. I.e.,
+  // - in-edges (src) are from ranks that own my ghosts
+  // - out-edges (dest) go to ranks that 'ghost' my owned indices
+  dolfinx::MPI::Comm _comm0{MPI_COMM_NULL};
+
+  // Communicator where the source ranks have ghost indices that are
+  // owned by the caller, and the destination ranks are the owners of
+  // indices in the callers halo region. I.e.,
+  // - in-edges (src) are from ranks that 'ghost' my owned indices
+  // - out-edges (dest) are to the owning ranks of my ghost indices
+  dolfinx::MPI::Comm _comm1{MPI_COMM_NULL};
+
+  // Set of ranks that own ghosts
+  std::vector<int> _src;
+
+  // Set of ranks that ghost owned indices
+  std::vector<int> _dest;
+
+  // Number of remote indices (ghosts) for each neighbour process
+  std::vector<int> _sizes_remote;
+
+  // Displacements of remote data for MPI scatter and gather
+  std::vector<int> _displs_remote;
+
+  // Number of local shared indices per neighbour process
+  std::vector<int> _sizes_local;
+
+  // Displacements of local data for MPI scatter and gather
+  std::vector<int> _displs_local;
+
+  // Permutation that sorts the ghost indices by owning rank
+  std::vector<std::int32_t> _perm;
+
+  // Owned indices that are ghosted elsewhere, grouped by neighbour
+  std::vector<std::int32_t> _local_inds;
+};
+} // namespace dolfinx::common

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -51,7 +51,10 @@ namespace dolfinx::common
 /// communicators, concurrent scatters in the same direction are matched
 /// in the order they are started, so every rank must start them in the
 /// same order. Starting them in a rank-dependent order silently
-/// delivers one scatter's data to another.
+/// delivers one scatter's data to another. A caller that cannot meet
+/// that requirement can opt out by constructing its own ScatterPattern
+/// from the IndexMap and passing it here, giving it a private pair of
+/// communicators.
 ///
 /// @tparam Container Container type for storing the 'local' and
 /// 'remote' indices. On CPUs this is normally

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -120,7 +120,7 @@ public:
                     std::ref(_sizes_remote), std::ref(_displs_remote)})
     {
       std::ranges::transform(x.get(), x.get().begin(),
-                             [bs](auto e) { return e * bs; });
+                             [bs](int e) { return e * bs; });
     }
 
     // Expand the pattern's indices by the block size
@@ -143,8 +143,20 @@ public:
   {
   }
 
-  /// @brief Copy constructor
+  /// Copy constructor
   Scatterer(const Scatterer& scatterer) = default;
+
+  /// Move constructor
+  Scatterer(Scatterer&& scatterer) = default;
+
+  /// Destructor
+  ~Scatterer() = default;
+
+  /// Copy assignment
+  Scatterer& operator=(const Scatterer& scatterer) = default;
+
+  /// Move assignment
+  Scatterer& operator=(Scatterer&& scatterer) = default;
 
   /// @brief Cast-copy constructor.
   ///

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2025 Igor Baratta and Garth N. Wells
+// Copyright (C) 2022-2026 Igor Baratta, Garth N. Wells and Jack S. Hale
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -8,15 +8,17 @@
 
 #include "IndexMap.h"
 #include "MPI.h"
-#include "sort.h"
+#include "ScatterPattern.h"
 #include <algorithm>
-#include <concepts>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mpi.h>
-#include <numeric>
 #include <span>
+#include <stdexcept>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace dolfinx::common
@@ -38,6 +40,11 @@ namespace dolfinx::common
 /// requests. Callers of the a Scatterer's members are responsible for
 /// managing buffer and MPI request handles.
 ///
+/// A Scatterer is a block size-specific view onto a ScatterPattern that
+/// is owned by the IndexMap. Scatterers built from one IndexMap share
+/// that pattern, and with it the neighbourhood communicators, whatever
+/// their block size or index container type.
+///
 /// @tparam Container Container type for storing the 'local' and
 /// 'remote' indices. On CPUs this is normally
 /// `std::vector<std::int32_t>`. For GPUs the container should store the
@@ -55,146 +62,52 @@ public:
   /// Container type used to store local and remote indices.
   using container_type = Container;
 
+  /// @brief Create a scatterer for data with a layout described by a
+  /// communication pattern and a block size.
+  ///
+  /// No MPI communication is performed; the pattern holds everything
+  /// that requires it.
+  ///
+  /// @param[in] pattern Communication pattern of the index map that
+  /// describes the parallel layout of the data.
+  /// @param[in] bs Number of values associated with each index map
+  /// index (the block size).
+  Scatterer(std::shared_ptr<const ScatterPattern> pattern, int bs)
+      : _pattern(std::move(pattern)),
+        _sizes_remote(_pattern->sizes_remote().begin(),
+                      _pattern->sizes_remote().end()),
+        _displs_remote(_pattern->displs_remote().begin(),
+                       _pattern->displs_remote().end()),
+        _sizes_local(_pattern->sizes_local().begin(),
+                     _pattern->sizes_local().end()),
+        _displs_local(_pattern->displs_local().begin(),
+                      _pattern->displs_local().end())
+  {
+    // Scale sizes and displacements by the block size
+    for (auto& x : {std::ref(_sizes_local), std::ref(_displs_local),
+                    std::ref(_sizes_remote), std::ref(_displs_remote)})
+    {
+      std::ranges::transform(x.get(), x.get().begin(),
+                             [bs](auto e) { return e * bs; });
+    }
+
+    // Expand the pattern's indices by the block size
+    _local_inds = expand(_pattern->local_indices(), bs);
+    _remote_inds = expand(_pattern->perm(), bs);
+  }
+
   /// @brief Create a scatterer for data with a layout described by an
   /// IndexMap and a block size.
+  ///
+  /// @note Collective on `map.comm()` if `map` has not yet built its
+  /// communication pattern. See IndexMap::scatter_pattern.
   ///
   /// @param[in] map Index map that describes the parallel layout of
   /// data.
   /// @param[in] bs Number of values associated with each `map` index
   /// (the block size).
-  Scatterer(const IndexMap& map, int bs)
-      : _src(map.src().begin(), map.src().end()),
-        _dest(map.dest().begin(), map.dest().end()),
-        _sizes_remote(_src.size(), 0), _displs_remote(_src.size() + 1),
-        _sizes_local(_dest.size()), _displs_local(_dest.size() + 1)
+  Scatterer(const IndexMap& map, int bs) : Scatterer(map.scatter_pattern(), bs)
   {
-    if (dolfinx::MPI::size(map.comm()) == 1)
-      return;
-
-    int ierr;
-
-    // Check that src and dest ranks are unique and sorted
-    assert(std::ranges::is_sorted(_src));
-    assert(std::ranges::is_sorted(_dest));
-
-    // Create communicators with directed edges:
-    // (0) owner -> ghost,
-    // (1) ghost -> owner
-    MPI_Comm comm0;
-    ierr = MPI_Dist_graph_create_adjacent(
-        map.comm(), _src.size(), _src.data(), MPI_UNWEIGHTED, _dest.size(),
-        _dest.data(), MPI_UNWEIGHTED, MPI_INFO_NULL, false, &comm0);
-    _comm0 = dolfinx::MPI::Comm(comm0, false);
-    dolfinx::MPI::check_error(map.comm(), ierr);
-
-    MPI_Comm comm1;
-    ierr = MPI_Dist_graph_create_adjacent(
-        map.comm(), _dest.size(), _dest.data(), MPI_UNWEIGHTED, _src.size(),
-        _src.data(), MPI_UNWEIGHTED, MPI_INFO_NULL, false, &comm1);
-    _comm1 = dolfinx::MPI::Comm(comm1, false);
-    dolfinx::MPI::check_error(map.comm(), ierr);
-
-    // Build permutation array that sorts ghost indices by owning rank
-    std::span owners = map.owners();
-    std::vector<std::int32_t> perm(owners.size());
-    std::iota(perm.begin(), perm.end(), 0);
-    dolfinx::radix_sort(perm, [&owners](auto index) { return owners[index]; });
-
-    // Sort (i) ghost indices and (ii) ghost index owners by rank
-    // (using perm array)
-    std::span ghosts = map.ghosts();
-    std::vector<int> owners_sorted(owners.size());
-    std::vector<std::int64_t> ghosts_sorted(owners.size());
-    std::ranges::transform(perm, owners_sorted.begin(),
-                           [&owners](auto idx) { return owners[idx]; });
-    std::ranges::transform(perm, ghosts_sorted.begin(),
-                           [&ghosts](auto idx) { return ghosts[idx]; });
-
-    // For data associated with ghost indices, packed by owning
-    // (neighbourhood) rank, compute sizes and displacements. I.e., when
-    // sending ghost index data from this rank to the owning ranks,
-    // disp[i] is the first entry in the buffer sent to neighbourhood
-    // rank i, and disp[i + 1] - disp[i] is the number of values sent to
-    // rank i.
-    assert(_sizes_remote.size() == _src.size());
-    assert(_displs_remote.size() == _src.size() + 1);
-    auto begin = owners_sorted.begin();
-    for (std::size_t i = 0; i < _src.size(); i++)
-    {
-      auto upper = std::upper_bound(begin, owners_sorted.end(), _src[i]);
-      std::size_t num_ind = std::ranges::distance(begin, upper);
-      _displs_remote[i + 1] = _displs_remote[i] + num_ind;
-      _sizes_remote[i] = num_ind;
-      begin = upper;
-    }
-
-    // For data associated with owned indices that are ghosted by other
-    // ranks, compute the size and displacement arrays. When sending
-    // data associated with ghost indices to the owner, these size and
-    // displacement arrays are for the receive buffer.
-
-    // Compute sizes and displacements of local data (how many local
-    // elements to be sent/received grouped by neighbors)
-    assert(_sizes_local.size() == _dest.size());
-    assert(_displs_local.size() == _dest.size() + 1);
-    _sizes_remote.reserve(1);
-    _sizes_local.reserve(1);
-    ierr = MPI_Neighbor_alltoall(_sizes_remote.data(), 1, MPI_INT32_T,
-                                 _sizes_local.data(), 1, MPI_INT32_T,
-                                 _comm1.comm());
-    dolfinx::MPI::check_error(_comm1.comm(), ierr);
-
-    std::partial_sum(_sizes_local.begin(), _sizes_local.end(),
-                     std::next(_displs_local.begin()));
-
-    assert(static_cast<int>(ghosts_sorted.size()) == _displs_remote.back());
-
-    // Send ghost global indices to owning rank, and receive owned
-    // indices that are ghosts on other ranks
-    std::vector<std::int64_t> recv_buffer(_displs_local.back(), 0);
-    ierr = MPI_Neighbor_alltoallv(
-        ghosts_sorted.data(), _sizes_remote.data(), _displs_remote.data(),
-        MPI_INT64_T, recv_buffer.data(), _sizes_local.data(),
-        _displs_local.data(), MPI_INT64_T, _comm1.comm());
-    dolfinx::MPI::check_error(_comm1.comm(), ierr);
-
-    const std::array<std::int64_t, 2> range = map.local_range();
-#ifndef NDEBUG
-    // Check that all received indice are within the owned range
-    std::ranges::for_each(recv_buffer, [range](auto idx)
-                          { assert(idx >= range[0] and idx < range[1]); });
-#endif
-
-    {
-      // Scale sizes and displacements by block size
-      for (auto& x : {std::ref(_sizes_local), std::ref(_displs_local),
-                      std::ref(_sizes_remote), std::ref(_displs_remote)})
-      {
-        std::ranges::transform(x.get(), x.get().begin(),
-                               [bs](auto e) { return e * bs; });
-      }
-    }
-
-    {
-      // Expand local indices using block size and convert it from
-      // global to local numbering
-      std::vector<typename container_type::value_type> idx(recv_buffer.size()
-                                                           * bs);
-      std::int64_t offset = range[0] * bs;
-      for (std::size_t i = 0; i < recv_buffer.size(); i++)
-        for (int j = 0; j < bs; j++)
-          idx[i * bs + j] = (recv_buffer[i] * bs + j) - offset;
-      _local_inds = std::move(idx);
-    }
-
-    {
-      // Expand remote indices using block size
-      std::vector<typename container_type::value_type> idx(perm.size() * bs);
-      for (std::size_t i = 0; i < perm.size(); i++)
-        for (int j = 0; j < bs; j++)
-          idx[i * bs + j] = perm[i] * bs + j;
-      _remote_inds = std::move(idx);
-    }
   }
 
   /// @brief Copy constructor
@@ -215,7 +128,7 @@ public:
   /// @param s Scatterer to copy
   template <class U>
   Scatterer(const Scatterer<U>& s)
-      : _comm0(s._comm0), _comm1(s._comm1), _src(s._src), _dest(s._dest),
+      : _pattern(s._pattern),
         _remote_inds(s._remote_inds.begin(), s._remote_inds.end()),
         _sizes_remote(s._sizes_remote), _displs_remote(s._displs_remote),
         _local_inds(s._local_inds.begin(), s._local_inds.end()),
@@ -259,8 +172,9 @@ public:
     int ierr = MPI_Ineighbor_alltoallv(
         send_buffer, _sizes_local.data(), _displs_local.data(),
         dolfinx::MPI::mpi_t<T>, recv_buffer, _sizes_remote.data(),
-        _displs_remote.data(), dolfinx::MPI::mpi_t<T>, _comm0.comm(), &request);
-    dolfinx::MPI::check_error(_comm0.comm(), ierr);
+        _displs_remote.data(), dolfinx::MPI::mpi_t<T>, _pattern->comm0(),
+        &request);
+    dolfinx::MPI::check_error(_pattern->comm0(), ierr);
   }
 
   /// @brief Start a non-blocking send of owned data to ranks that ghost
@@ -280,7 +194,9 @@ public:
   void scatter_fwd_begin(const T* send_buffer, T* recv_buffer,
                          std::span<MPI_Request> requests) const
   {
-    if (requests.size() != _dest.size() + _src.size())
+    std::span<const int> src = _pattern->src();
+    std::span<const int> dest = _pattern->dest();
+    if (requests.size() != dest.size() + src.size())
     {
       throw std::runtime_error(
           "Point-to-point scatterer has wrong number of MPI_Requests.");
@@ -290,20 +206,21 @@ public:
     if (_sizes_local.empty() and _sizes_remote.empty())
       return;
 
-    for (std::size_t i = 0; i < _src.size(); ++i)
+    MPI_Comm comm = _pattern->comm0();
+    for (std::size_t i = 0; i < src.size(); ++i)
     {
       int ierr = MPI_Irecv(recv_buffer + _displs_remote[i], _sizes_remote[i],
-                           dolfinx::MPI::mpi_t<T>, _src[i], MPI_ANY_TAG,
-                           _comm0.comm(), &requests[i]);
-      dolfinx::MPI::check_error(_comm0.comm(), ierr);
+                           dolfinx::MPI::mpi_t<T>, src[i], MPI_ANY_TAG, comm,
+                           &requests[i]);
+      dolfinx::MPI::check_error(comm, ierr);
     }
 
-    for (std::size_t i = 0; i < _dest.size(); ++i)
+    for (std::size_t i = 0; i < dest.size(); ++i)
     {
       int ierr = MPI_Isend(send_buffer + _displs_local[i], _sizes_local[i],
-                           dolfinx::MPI::mpi_t<T>, _dest[i], 0, _comm0.comm(),
-                           &requests[i + _src.size()]);
-      dolfinx::MPI::check_error(_comm0.comm(), ierr);
+                           dolfinx::MPI::mpi_t<T>, dest[i], 0, comm,
+                           &requests[i + src.size()]);
+      dolfinx::MPI::check_error(comm, ierr);
     }
   }
 
@@ -344,8 +261,9 @@ public:
     int ierr = MPI_Ineighbor_alltoallv(
         send_buffer, _sizes_remote.data(), _displs_remote.data(),
         dolfinx::MPI::mpi_t<T>, recv_buffer, _sizes_local.data(),
-        _displs_local.data(), dolfinx::MPI::mpi_t<T>, _comm1.comm(), &request);
-    dolfinx::MPI::check_error(_comm1.comm(), ierr);
+        _displs_local.data(), dolfinx::MPI::mpi_t<T>, _pattern->comm1(),
+        &request);
+    dolfinx::MPI::check_error(_pattern->comm1(), ierr);
   }
 
   /// @brief Start a non-blocking send of ghost data to ranks that own
@@ -365,7 +283,9 @@ public:
   void scatter_rev_begin(const T* send_buffer, T* recv_buffer,
                          std::span<MPI_Request> requests) const
   {
-    if (requests.size() != _dest.size() + _src.size())
+    std::span<const int> src = _pattern->src();
+    std::span<const int> dest = _pattern->dest();
+    if (requests.size() != dest.size() + src.size())
     {
       throw std::runtime_error(
           "Point-to-point scatterer has wrong number of MPI_Requests.");
@@ -376,22 +296,23 @@ public:
       return;
 
     // Start non-blocking send from this process to ghost owners
-    for (std::size_t i = 0; i < _dest.size(); i++)
+    MPI_Comm comm = _pattern->comm0();
+    for (std::size_t i = 0; i < dest.size(); i++)
     {
       int ierr = MPI_Irecv(recv_buffer + _displs_local[i], _sizes_local[i],
-                           dolfinx::MPI::mpi_t<T>, _dest[i], MPI_ANY_TAG,
-                           _comm0.comm(), &requests[i]);
-      dolfinx::MPI::check_error(_comm0.comm(), ierr);
+                           dolfinx::MPI::mpi_t<T>, dest[i], MPI_ANY_TAG, comm,
+                           &requests[i]);
+      dolfinx::MPI::check_error(comm, ierr);
     }
 
     // Start non-blocking receive from neighbor process for which an
     // owned index is a ghost
-    for (std::size_t i = 0; i < _src.size(); i++)
+    for (std::size_t i = 0; i < src.size(); i++)
     {
       int ierr = MPI_Isend(send_buffer + _displs_remote[i], _sizes_remote[i],
-                           dolfinx::MPI::mpi_t<T>, _src[i], 0, _comm0.comm(),
-                           &requests[i + _dest.size()]);
-      dolfinx::MPI::check_error(_comm0.comm(), ierr);
+                           dolfinx::MPI::mpi_t<T>, src[i], 0, comm,
+                           &requests[i + dest.size()]);
+      dolfinx::MPI::check_error(comm, ierr);
     }
   }
 
@@ -490,31 +411,25 @@ public:
   /// @return Number of required MPI request handles.
   std::size_t num_p2p_requests() const noexcept
   {
-    return _dest.size() + _src.size();
+    return _pattern->dest().size() + _pattern->src().size();
   }
 
 private:
-  // Communicator where the source ranks own the indices in the callers
-  // halo, and the destination ranks 'ghost' indices owned by the
-  // caller. I.e.,
-  // - in-edges (src) are from ranks that own my ghosts
-  // - out-edges (dest) go to ranks that 'ghost' my owned indices
-  dolfinx::MPI::Comm _comm0{MPI_COMM_NULL};
+  // Expand indices by the block size, i.e. index i becomes the bs
+  // indices [i * bs, (i + 1) * bs)
+  static std::vector<typename container_type::value_type>
+  expand(std::span<const std::int32_t> indices, int bs)
+  {
+    std::vector<typename container_type::value_type> idx(indices.size() * bs);
+    for (std::size_t i = 0; i < indices.size(); i++)
+      for (int j = 0; j < bs; j++)
+        idx[i * bs + j] = indices[i] * bs + j;
+    return idx;
+  }
 
-  // Communicator where the source ranks have ghost indices that are
-  // owned by the caller, and the destination ranks are the owners of
-  // indices in the callers halo region. I.e.,
-  // - in-edges (src) are from ranks that 'ghost' my owned indices
-  // - out-edges (dest) are to the owning ranks of my ghost indices
-  dolfinx::MPI::Comm _comm1{MPI_COMM_NULL};
-
-  // Set of ranks that own ghosts
-  // FIXME: Should we store the index map instead?
-  std::vector<int> _src;
-
-  // Set of ranks ghost owned indices
-  // FIXME: Should we store the index map instead?
-  std::vector<int> _dest;
+  // Block size-independent communication pattern, shared with every
+  // other Scatterer built from the same IndexMap
+  std::shared_ptr<const ScatterPattern> _pattern;
 
   // Permutation indices used to pack and unpack ghost data (remote)
   container_type _remote_inds;

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -45,6 +45,14 @@ namespace dolfinx::common
 /// that pattern, and with it the neighbourhood communicators, whatever
 /// their block size or index container type.
 ///
+/// @note Scatters may overlap: each caller supplies its own buffers and
+/// MPI request, and forward and reverse scatters use separate
+/// communicators. Because scatterers over one IndexMap share those
+/// communicators, concurrent scatters in the same direction are matched
+/// in the order they are started, so every rank must start them in the
+/// same order. Starting them in a rank-dependent order silently
+/// delivers one scatter's data to another.
+///
 /// @tparam Container Container type for storing the 'local' and
 /// 'remote' indices. On CPUs this is normally
 /// `std::vector<std::int32_t>`. For GPUs the container should store the

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -10,6 +10,7 @@
 #include "MPI.h"
 #include "ScatterPattern.h"
 #include <algorithm>
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -23,6 +24,26 @@
 
 namespace dolfinx::common
 {
+namespace impl
+{
+/// @brief Expand indices by a block size, i.e. index `i` becomes the
+/// `bs` indices `[i * bs, (i + 1) * bs)`.
+///
+/// @tparam V Value type of the expanded indices.
+/// @param[in] indices Indices to expand.
+/// @param[in] bs Block size.
+/// @return Expanded indices.
+template <std::integral V>
+std::vector<V> expand_indices(std::span<const std::int32_t> indices, int bs)
+{
+  std::vector<V> idx(indices.size() * bs);
+  for (std::size_t i = 0; i < indices.size(); i++)
+    for (int j = 0; j < bs; j++)
+      idx[i * bs + j] = indices[i] * bs + j;
+  return idx;
+}
+} // namespace impl
+
 /// @brief A Scatterer supports the scattering and gathering of
 /// distributed data that is associated with a common::IndexMap, using
 /// MPI.
@@ -103,8 +124,9 @@ public:
     }
 
     // Expand the pattern's indices by the block size
-    _local_inds = expand(_pattern->local_indices(), bs);
-    _remote_inds = expand(_pattern->perm(), bs);
+    using V = typename container_type::value_type;
+    _local_inds = impl::expand_indices<V>(_pattern->local_indices(), bs);
+    _remote_inds = impl::expand_indices<V>(_pattern->perm(), bs);
   }
 
   /// @brief Create a scatterer for data with a layout described by an
@@ -426,18 +448,6 @@ public:
   }
 
 private:
-  // Expand indices by the block size, i.e. index i becomes the bs
-  // indices [i * bs, (i + 1) * bs)
-  static std::vector<typename container_type::value_type>
-  expand(std::span<const std::int32_t> indices, int bs)
-  {
-    std::vector<typename container_type::value_type> idx(indices.size() * bs);
-    for (std::size_t i = 0; i < indices.size(); i++)
-      for (int j = 0; j < bs; j++)
-        idx[i * bs + j] = indices[i] * bs + j;
-    return idx;
-  }
-
   // Block size-independent communication pattern, shared with every
   // other Scatterer built from the same IndexMap
   std::shared_ptr<const ScatterPattern> _pattern;

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -13,7 +13,6 @@
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <memory>
 #include <mpi.h>
 #include <span>
@@ -26,20 +25,38 @@ namespace dolfinx::common
 {
 namespace impl
 {
+/// @brief Scale MPI counts or displacements by a block size.
+///
+/// @param[in] x Counts or displacements for a block size of one.
+/// @param[in] bs Block size.
+/// @return Scaled counts or displacements.
+inline std::vector<int> scale(std::span<const int> x, int bs)
+{
+  std::vector<int> y(x.size());
+  std::ranges::transform(x, y.begin(), [bs](int e) { return e * bs; });
+  return y;
+}
+
 /// @brief Expand indices by a block size, i.e. index `i` becomes the
 /// `bs` indices `[i * bs, (i + 1) * bs)`.
 ///
+/// The expansion is computed in `V`, so a `std::int64_t` expansion of a
+/// large index does not overflow before it is widened.
+///
 /// @tparam V Value type of the expanded indices.
 /// @param[in] indices Indices to expand.
-/// @param[in] bs Block size.
+/// @param[in] bs Block size, greater than zero.
 /// @return Expanded indices.
 template <std::integral V>
 std::vector<V> expand_indices(std::span<const std::int32_t> indices, int bs)
 {
   std::vector<V> idx(indices.size() * bs);
   for (std::size_t i = 0; i < indices.size(); i++)
+  {
+    const V base = static_cast<V>(indices[i]) * bs;
     for (int j = 0; j < bs; j++)
-      idx[i * bs + j] = indices[i] * bs + j;
+      idx[i * bs + j] = base + j;
+  }
   return idx;
 }
 } // namespace impl
@@ -101,29 +118,25 @@ public:
   /// that requires it.
   ///
   /// @param[in] pattern Communication pattern of the index map that
-  /// describes the parallel layout of the data.
+  /// describes the parallel layout of the data. Must not be null.
   /// @param[in] bs Number of values associated with each index map
-  /// index (the block size).
+  /// index (the block size). Must be greater than zero.
   Scatterer(std::shared_ptr<const ScatterPattern> pattern, int bs)
-      : _pattern(std::move(pattern)),
-        _sizes_remote(_pattern->sizes_remote().begin(),
-                      _pattern->sizes_remote().end()),
-        _displs_remote(_pattern->displs_remote().begin(),
-                       _pattern->displs_remote().end()),
-        _sizes_local(_pattern->sizes_local().begin(),
-                     _pattern->sizes_local().end()),
-        _displs_local(_pattern->displs_local().begin(),
-                      _pattern->displs_local().end())
+      : _pattern(std::move(pattern))
   {
-    // Scale sizes and displacements by the block size
-    for (auto& x : {std::ref(_sizes_local), std::ref(_displs_local),
-                    std::ref(_sizes_remote), std::ref(_displs_remote)})
+    if (!_pattern)
+      throw std::invalid_argument("Scatterer requires a communication pattern");
+    if (bs < 1)
     {
-      std::ranges::transform(x.get(), x.get().begin(),
-                             [bs](int e) { return e * bs; });
+      throw std::invalid_argument("Scatterer block size must be greater than "
+                                  "zero");
     }
 
-    // Expand the pattern's indices by the block size
+    _sizes_remote = impl::scale(_pattern->sizes_remote(), bs);
+    _displs_remote = impl::scale(_pattern->displs_remote(), bs);
+    _sizes_local = impl::scale(_pattern->sizes_local(), bs);
+    _displs_local = impl::scale(_pattern->displs_local(), bs);
+
     using V = typename container_type::value_type;
     _local_inds = impl::expand_indices<V>(_pattern->local_indices(), bs);
     _remote_inds = impl::expand_indices<V>(_pattern->perm(), bs);

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -9,9 +9,12 @@
 #include <catch2/generators/catch_generators.hpp>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/MPI.h>
+#include <dolfinx/common/ScatterPattern.h>
 #include <dolfinx/common/Scatterer.h>
 #include <dolfinx/common/utils.h>
+#include <dolfinx/la/Vector.h>
 #include <iostream>
+#include <memory>
 #include <numeric>
 #include <set>
 #include <vector>
@@ -231,6 +234,52 @@ void test_rank_weights()
     REQUIRE(weight_dest.empty());
   }
 }
+void test_scatter_pattern_shared()
+{
+  const int mpi_size = dolfinx::MPI::size(MPI_COMM_WORLD);
+  constexpr int size_local = 100;
+  auto map = std::make_shared<const common::IndexMap>(
+      create_index_map(MPI_COMM_WORLD, size_local, (mpi_size - 1) * 3));
+
+  // The pattern is built once and returned to every subsequent caller
+  std::shared_ptr<const common::ScatterPattern> pattern
+      = map->scatter_pattern();
+  CHECK(pattern.get() == map->scatter_pattern().get());
+  CHECK(pattern.use_count() == 2);
+
+  // Scatterers share the pattern, whatever their block size or index
+  // container type. Two neighbourhood communicators are created for the
+  // index map, not two per Scatterer.
+  {
+    common::Scatterer<std::vector<std::int32_t>> sct0(*map, 1);
+    common::Scatterer<std::vector<std::int32_t>> sct1(*map, 3);
+    CHECK(pattern.use_count() == 4);
+
+    // The cast-copy constructor shares the pattern rather than
+    // duplicating the communicators
+    common::Scatterer<std::vector<std::int64_t>> sct2(sct0);
+    CHECK(pattern.use_count() == 5);
+  }
+  CHECK(pattern.use_count() == 2);
+
+  // A code that creates many vectors over one index map creates no
+  // extra communicators. This is the regression test for
+  // https://github.com/FEniCS/dolfinx/issues/3065.
+  {
+    constexpr int num_vectors = 16;
+    std::vector<la::Vector<double>> vectors;
+    vectors.reserve(num_vectors);
+    for (int i = 0; i < num_vectors; ++i)
+      vectors.emplace_back(map, 2);
+    CHECK(pattern.use_count() == 2 + num_vectors);
+
+    // Cloning a layout shares the scatterer, so does not add a
+    // reference to the pattern
+    la::Vector<std::int8_t> marks = vectors.front().clone_layout<std::int8_t>();
+    CHECK(pattern.use_count() == 2 + num_vectors);
+  }
+  CHECK(pattern.use_count() == 2);
+}
 } // namespace
 
 TEST_CASE("Scatter forward using IndexMap", "[index_map_scatter_fwd]")
@@ -259,4 +308,9 @@ TEST_CASE("Split IndexMap communicator by type", "[index_map_comm_split]")
 TEST_CASE("IndexMap stats", "[index_map_stats]")
 {
   CHECK_NOTHROW(test_rank_weights());
+}
+
+TEST_CASE("IndexMap scatter pattern is shared", "[index_map_scatter_pattern]")
+{
+  CHECK_NOTHROW(test_scatter_pattern_shared());
 }

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Chris Richardson
+// Copyright (C) 2018-2026 Chris Richardson and Jack S. Hale
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -414,7 +414,8 @@ void test_private_scatter_pattern()
   // A caller that wants its scatters unordered with respect to every
   // other scatter on this map can build a private pattern, and with it
   // a private pair of communicators.
-  auto priv = std::make_shared<const common::ScatterPattern>(*map);
+  std::shared_ptr<const common::ScatterPattern> priv
+      = common::create_scatter_pattern(*map);
   CHECK(priv.get() != shared.get());
   if (mpi_size > 1)
     CHECK(priv->comm0() != shared->comm0());

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -122,6 +122,21 @@ void test_scatter_rev()
     common::Scatterer<std::vector<std::int64_t>> sct2(sct);
   }
 
+  // A scatterer built directly on a wider index container expands the
+  // pattern indices itself, rather than converting an expanded copy
+  {
+    common::Scatterer<std::vector<std::int64_t>> sct2(idx_map, n);
+    CHECK(std::ranges::equal(sct2.local_indices(), sct.local_indices()));
+    CHECK(std::ranges::equal(sct2.remote_indices(), sct.remote_indices()));
+  }
+
+  // Preconditions on the block size and the pattern
+  CHECK_THROWS_AS(common::Scatterer<>(idx_map.scatter_pattern(), 0),
+                  std::invalid_argument);
+  CHECK_THROWS_AS(common::Scatterer<>(idx_map.scatter_pattern(), -1),
+                  std::invalid_argument);
+  CHECK_THROWS_AS(common::Scatterer<>(nullptr, 1), std::invalid_argument);
+
   auto pack_fn = [](auto&& in, auto&& idx, auto&& out)
   {
     for (std::size_t i = 0; i < idx.size(); ++i)

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -414,8 +414,7 @@ void test_private_scatter_pattern()
   // A caller that wants its scatters unordered with respect to every
   // other scatter on this map can build a private pattern, and with it
   // a private pair of communicators.
-  auto priv = std::make_shared<const common::ScatterPattern>(
-      common::create_scatter_pattern(*map));
+  auto priv = std::make_shared<const common::ScatterPattern>(*map);
   CHECK(priv.get() != shared.get());
   if (mpi_size > 1)
     CHECK(priv->comm0() != shared->comm0());

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -13,6 +13,7 @@
 #include <dolfinx/common/Scatterer.h>
 #include <dolfinx/common/utils.h>
 #include <dolfinx/la/Vector.h>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <numeric>
@@ -280,6 +281,80 @@ void test_scatter_pattern_shared()
   }
   CHECK(pattern.use_count() == 2);
 }
+void test_scatter_overlap()
+{
+  const int mpi_size = dolfinx::MPI::size(MPI_COMM_WORLD);
+  const int mpi_rank = dolfinx::MPI::rank(MPI_COMM_WORLD);
+  constexpr int size_local = 100;
+  auto map = std::make_shared<const common::IndexMap>(
+      create_index_map(MPI_COMM_WORLD, size_local, (mpi_size - 1) * 3));
+  std::int32_t num_ghosts = map->num_ghosts();
+
+  // Vectors over one index map, and so over one pair of neighbourhood
+  // communicators. Each holds its own buffers and MPI_Request.
+  constexpr int num_vectors = 4;
+  std::vector<la::Vector<double>> v;
+  v.reserve(num_vectors);
+  for (int k = 0; k < num_vectors; ++k)
+  {
+    v.emplace_back(map, 1);
+    std::ranges::fill_n(v.back().array().begin(), size_local,
+                        100.0 * mpi_rank + k);
+  }
+
+  // Every forward scatter in flight at once on the shared communicator.
+  // Nonblocking collectives on one communicator are matched in issue
+  // order, which is identical on every rank here.
+  for (auto& x : v)
+    x.scatter_fwd_begin();
+  for (auto& x : v)
+    x.scatter_fwd_end();
+
+  // Each vector must receive its own data, not another's
+  const double owner = 100.0 * ((mpi_rank + 1) % mpi_size);
+  for (int k = 0; k < num_vectors; ++k)
+  {
+    const std::vector<double>& x = v[k].array();
+    for (std::int32_t i = 0; i < num_ghosts; ++i)
+      CHECK(x[size_local + i] == owner + k);
+  }
+
+  // A forward and a reverse scatter overlap without an ordering
+  // constraint between them: they use different communicators.
+  std::ranges::fill(v[0].array(), 0.0);
+  std::ranges::fill_n(v[0].array().begin(), size_local, 7.0);
+  std::ranges::fill(v[1].array(), 0.0);
+  std::ranges::fill_n(std::next(v[1].array().begin(), size_local), num_ghosts,
+                      1.0);
+  // out[idx[i]] = out[idx[i]] + in[i]
+  auto unpack_add = [](std::vector<std::int32_t>::const_iterator idx_first,
+                       std::vector<std::int32_t>::const_iterator idx_last,
+                       const auto in_first, auto out_first)
+  {
+    for (auto idx = idx_first; idx != idx_last; ++idx)
+    {
+      std::size_t d = std::ranges::distance(idx_first, idx);
+      auto& out = *std::next(out_first, *idx);
+      out = out + *std::next(in_first, d);
+    }
+  };
+
+  v[0].scatter_fwd_begin();
+  v[1].scatter_rev_begin();
+  v[0].scatter_fwd_end();
+  v[1].scatter_rev_end(unpack_add);
+  for (std::int32_t i = 0; i < num_ghosts; ++i)
+    CHECK(v[0].array()[size_local + i] == 7.0);
+  if (mpi_size > 1)
+  {
+    // Rank r owns the indices ghosted by rank r - 1, three per rank
+    const std::vector<double>& x = v[1].array();
+    double received = 0;
+    for (std::int32_t i = 0; i < size_local; ++i)
+      received += x[i];
+    CHECK(received == static_cast<double>(num_ghosts));
+  }
+}
 } // namespace
 
 TEST_CASE("Scatter forward using IndexMap", "[index_map_scatter_fwd]")
@@ -313,4 +388,10 @@ TEST_CASE("IndexMap stats", "[index_map_stats]")
 TEST_CASE("IndexMap scatter pattern is shared", "[index_map_scatter_pattern]")
 {
   CHECK_NOTHROW(test_scatter_pattern_shared());
+}
+
+TEST_CASE("Overlapping scatters share a communicator",
+          "[index_map_scatter_overlap]")
+{
+  CHECK_NOTHROW(test_scatter_overlap());
 }

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -355,6 +355,38 @@ void test_scatter_overlap()
     CHECK(received == static_cast<double>(num_ghosts));
   }
 }
+void test_private_scatter_pattern()
+{
+  const int mpi_size = dolfinx::MPI::size(MPI_COMM_WORLD);
+  const int mpi_rank = dolfinx::MPI::rank(MPI_COMM_WORLD);
+  constexpr int size_local = 100;
+  auto map = std::make_shared<const common::IndexMap>(
+      create_index_map(MPI_COMM_WORLD, size_local, (mpi_size - 1) * 3));
+  std::int32_t num_ghosts = map->num_ghosts();
+
+  std::shared_ptr<const common::ScatterPattern> shared = map->scatter_pattern();
+
+  // A caller that wants its scatters unordered with respect to every
+  // other scatter on this map can build a private pattern, and with it
+  // a private pair of communicators.
+  auto priv = std::make_shared<const common::ScatterPattern>(*map);
+  CHECK(priv.get() != shared.get());
+  if (mpi_size > 1)
+    CHECK(priv->comm0() != shared->comm0());
+
+  auto sct = std::make_shared<const common::Scatterer<>>(priv, 1);
+  la::Vector<double> v(map, 1, sct);
+
+  // The vector did not take the map's shared pattern
+  CHECK(shared.use_count() == 2);
+
+  // ... and scatters correctly on its own communicators
+  std::ranges::fill_n(v.array().begin(), size_local, 1.0 * mpi_rank);
+  v.scatter_fwd();
+  const double owner = static_cast<double>((mpi_rank + 1) % mpi_size);
+  for (std::int32_t i = 0; i < num_ghosts; ++i)
+    CHECK(v.array()[size_local + i] == owner);
+}
 } // namespace
 
 TEST_CASE("Scatter forward using IndexMap", "[index_map_scatter_fwd]")
@@ -394,4 +426,10 @@ TEST_CASE("Overlapping scatters share a communicator",
           "[index_map_scatter_overlap]")
 {
   CHECK_NOTHROW(test_scatter_overlap());
+}
+
+TEST_CASE("Opt out of the shared scatter pattern",
+          "[index_map_private_pattern]")
+{
+  CHECK_NOTHROW(test_private_scatter_pattern());
 }

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -316,13 +316,16 @@ void test_scatter_pattern_shared()
       vectors.emplace_back(map, 2);
     CHECK(pattern.use_count() == 2 + num_vectors);
 
-    // Cloning a layout shares the scatterer, so does not add a
-    // reference to the pattern
-    la::Vector<std::int8_t> marks = vectors.front().clone_layout<std::int8_t>();
-    CHECK(pattern.use_count() == 2 + num_vectors);
+    // A vector of a different scalar type over the same layout builds
+    // its own Scatterer from the shared pattern: one more reference to
+    // the pattern, and still no new communicators
+    la::Vector<std::int8_t> marks(vectors.front().index_map(),
+                                  vectors.front().bs());
+    CHECK(pattern.use_count() == 3 + num_vectors);
   }
   CHECK(pattern.use_count() == 2);
 }
+
 void test_scatter_overlap()
 {
   const int mpi_size = dolfinx::MPI::size(MPI_COMM_WORLD);

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -414,8 +414,8 @@ void test_private_scatter_pattern()
   // A caller that wants its scatters unordered with respect to every
   // other scatter on this map can build a private pattern, and with it
   // a private pair of communicators.
-  std::shared_ptr<const common::ScatterPattern> priv
-      = common::create_scatter_pattern(*map);
+  auto priv = std::make_shared<const common::ScatterPattern>(
+      common::create_scatter_pattern(*map));
   CHECK(priv.get() != shared.get());
   if (mpi_size > 1)
     CHECK(priv->comm0() != shared->comm0());


### PR DESCRIPTION
# Cache the scatter communication pattern on `IndexMap`

## Summary

Splits `common::Scatterer` at the block size boundary. Everything that needs
MPI — the two neighbourhood communicators, the source/destination ranks, the
neighbourhood sizes and displacements, the ghost permutation — moves into a new
`common::ScatterPattern`, which is built once per `IndexMap` and shared. What
remains in `Scatterer` is the block size-dependent part: two scaled size arrays
and two expanded index arrays, all cheap and none of it an MPI resource.

Result: **one communicator pair per distinct `IndexMap`**, however many
`Function`s, `Vector`s, block sizes or scatter container types exist.

Stacked on #4483, and targeted at its branch so the diff shows only this
change; retarget to `main` once #4483 merges. Merged with `main` after #4478
landed — see "Relationship to #4478" below.

Closes #3065, and addresses the neighbourhood-communicator half of #3061.

## Why

Every `Scatterer` constructor calls `MPI_Dist_graph_create_adjacent` twice, so
every `la::Vector` — and hence every `fem::Function` — costs two neighbourhood
communicators. As #3065 puts it, a code that creates a lot of `Function`s "can
create a lot of (neighbourhood) communicators, and exhaust the available
communicators". #3061 is a user hitting exactly that from hIPPYlib.

## What is split, and why here

`Scatterer`'s constructor on `main` spans 140 lines, and `bs` first appears in
the last 30 of them. Everything before that is a pure function of `map.comm()`, `map.src()`,
`map.dest()`, `map.owners()` and `map.ghosts()`:

- both `MPI_Dist_graph_create_adjacent` calls,
- the ghost permutation (radix sort by owning rank),
- the `MPI_Neighbor_alltoall`/`alltoallv` that fill the size and displacement
  arrays.

`bs` appears only in the tail, scaling sizes/displacements and expanding two
index arrays. So the scarce resource is determined entirely by the `IndexMap`,
and the `bs`-dependent remainder costs nothing scarce.

One small change makes the split clean: `ScatterPattern` stores the owned
shared indices as `recv_buffer[i] - range[0]`, i.e. local numbering at `bs = 1`.
The block size expansion of *both* index arrays is then the same
`idx[i] * bs + j`, and the pattern needs no index map after construction.

## Relationship to #4478

#4478 ("`common::Scatterer`: use neighbourhood collectives only") landed on
`main` while this was in review, and the two overlap heavily. They compose
cleanly, and the merge made this change *smaller*:

- `Scatterer` keeps everything #4478 gave it — no point-to-point path, separate
  `scatter_fwd_end`/`scatter_rev_end`, the `has_neighbours()` and `wait()`
  helpers. Only the constructor is replaced, and `has_neighbours()` now tests
  the pattern's communicator.
- #4478 removed `Scatterer`'s `_src`/`_dest` members, which were the only
  consumers of `ScatterPattern::src()`/`dest()`. Those accessors and members
  are gone here too, and the ranks are taken as local spans in the
  constructor — exactly what #4478 did to `Scatterer`. `ScatterPattern`'s
  public surface is smaller than first proposed as a result.

## Why the `IndexMap` and not the `FunctionSpace`, `DofMap` or `Vector`

This is the question #4293 stalled on. @garth-wells noted the scatterer "is
really a property of the `Vector`"; @chrisrichardson raised `DofMap` without
being convinced; @schnellerhase suggested splitting `Scatterer` into a
communication pattern and a layout. This PR is that suggestion, and it lets the
ownership question go unanswered: the pattern is a function of the `IndexMap`
alone, so the `IndexMap` is the only object that can own it without a
convention anyone has to enforce.

`IndexMap` deletes both copy operations, so a cache on it has no
copy-duplication or invalidation problem.

## Why the pattern is built on demand and not in the constructor

DOLFINx prefers fully-constructed objects, and this is the one piece of lazy
state in the library, so it needs justifying. I instrumented `IndexMap`'s and
`ScatterPattern`'s constructors and counted, at np = 3:

| Workload | `IndexMap`s built | patterns needed |
| --- | --- | --- |
| Poisson solve, 21 `Function`s, 20 forward scatters | 7 | 1 |
| 3x refinement, 3 spaces, 15 `Function`s, 1 matrix | 20 | 3 |

Most index maps are mesh and topology maps that are never scattered. Since
every `IndexMap` already dups its own communicator in its constructor
(`_comm(comm, true)`), the live communicator count for the second workload
works out as (measured map and pattern counts, arithmetic at 2 communicators
per `Scatterer` or per pattern):

| | live communicators |
| --- | --- |
| `main` | 20 + 2 x 15 = 50 |
| this PR | 20 + 2 x 3 = **26** |
| eager in the `IndexMap` constructor | 20 + 2 x 20 = 60 |

Building eagerly would consume *more* communicators than the code it is meant
to fix, on exactly the mesh-heavy codes that have the most index maps. So the
pattern is built on the first call to `IndexMap::scatter_pattern()`.

Laziness adds no collective-ordering requirement that does not already exist.
The collective fires at `Scatterer` construction, which is where one fires on
`main`; ranks that build scatterers for different maps in different orders
already deadlock today. The rationale is recorded in the header so it does not
have to be rediscovered.

The cache is not thread safe. There is no `std::mutex`, `once_flag` or
`MPI_THREAD` anywhere in `cpp/` or `python/`, so this matches existing practice;
a `once_flag` member would also break `IndexMap`'s defaulted move operations,
which `create_sub_index_map` (returns `IndexMap` by value) relies on.

## What this does not fix

The remaining 20 communicators above are the `MPI_Comm_dup` that each
`IndexMap` performs on its own communicator. That is the other half of #3061
and a separate axis; deliberately out of scope here.

Stripping the point-to-point scatter path was listed as out of scope here; it
landed independently as #4478 and this branch is merged with it.

## Overlapping non-blocking communication

#3065 records that each `Vector` having its own `Scatterer` "allows overlapping
non-blocking communication". Sharing the communicators keeps that, with one
documented constraint.

What still holds: every `Vector` owns its buffers and its `MPI_Request`, so
there is no shared state to corrupt, and forward and reverse scatters use
different communicators (`comm0` and `comm1`), so a forward and a reverse
scatter overlap with no ordering constraint between them.

What changes: concurrent scatters *in the same direction* now share a
communicator, and MPI matches nonblocking collectives on a communicator in the
order they are started. Every rank must therefore start them in the same order.
Previously the per-`Vector` communicators made the order irrelevant.

`test_scatter_overlap` puts four forward scatters in flight at once over one
index map and checks each vector receives its own data, then overlaps a forward
with a reverse scatter. Verified that issuing the four in a rank-dependent
order makes the test fail — the mismatch corrupts silently rather than
deadlocking, which is why the constraint is a `@note` on `Scatterer` rather
than left to be discovered.

In DOLFINx this order is fixed by the code path, which is identical on every
rank; the pattern that would break is issuing scatters in a data-dependent
order that varies by rank. No code in the library has two scatters in flight on
one index map: `MatrixCSR::mult` overlaps a *single* vector's scatter with
computation, which is unaffected. So the constraint is only reachable from user
code. It is the same constraint #4293 would introduce, and
`la::Vector::clone_layout` already carries a note to this effect.

### Opting out

A caller that cannot guarantee a rank-consistent order can take a private pair
of communicators back, recovering the pre-PR behaviour. This needs no new API —
`ScatterPattern`'s constructor is public, and #4483's `(map, scatterer)`
constructor accepts the result:

```cpp
auto pattern = std::make_shared<const common::ScatterPattern>(*map);
auto sct = std::make_shared<const common::Scatterer<>>(pattern, bs);
la::Vector<double> v(map, sct);  // its own communicators
```

`test_private_scatter_pattern` checks that the private pattern is a distinct
object on distinct communicators, that the vector takes no reference to the
map's shared pattern, and that it scatters correctly. So sharing is the
default, not the only option.

## Incidental fix

`MPI::Comm`'s copy constructor duplicates the communicator, so `Scatterer`'s
copy and cast-copy constructors each cost two `MPI_Comm_dup`s on `main`. They
now copy a `shared_ptr` instead. This is on the CPU to GPU path used by
`la::Vector::scatter_ptr`, where a copy-converted vector was paying for a
second pair of communicators describing the same graph.

## API

```cpp
// common::IndexMap — the shared pattern, built on first call
std::shared_ptr<const ScatterPattern> scatter_pattern() const;

// common::Scatterer, new primary constructor; performs no MPI.
// Throws std::invalid_argument on a null pattern or a block size < 1.
Scatterer(std::shared_ptr<const ScatterPattern> pattern, int bs);
Scatterer(const IndexMap& map, int bs);  // unchanged, now delegates
int bs() const noexcept;                 // added on #4483
```

`la::Vector` and the nanobind wrappers are unchanged, which was the check on
the design: if preserving the `Scatterer` interface had required touching
`Vector`, the split would have been in the wrong place. `ScatterPattern` is not
bound to Python. No `nb::keep_alive` is needed on the existing
`Scatterer(index_map, block_size)` binding, because the pattern is
heap-allocated and co-owned by the `Scatterer`, so a Python-owned `IndexMap`
collected first cannot dangle it.

## Tests

`test_scatter_pattern_shared` in `cpp/test/common/index_map.cpp` checks that
the pattern is returned by pointer identity rather than rebuilt, that
scatterers of different block size and different index container type share one
pattern, that the cast-copy constructor shares it rather than duplicating
communicators, and that 16 `la::Vector`s over one index map add exactly 16
references and no communicators — the last being the regression test for #3065,
expressed through `use_count()` so it needs no non-portable live-communicator
count.

Verified that the test fails if the implementation is wrong: making
`scatter_pattern()` rebuild on every call produces 10 failed assertions at
np = 2.

`test_scatter_rev` additionally covers `expand_indices` on a wider index
container directly, rather than only through the cast-copy constructor, and
covers the new block size and null pattern preconditions.

The existing coverage is otherwise unmodified and must stay that way —
`test_scatter_fwd`/`test_scatter_rev` (`GENERATE(1, 5, 10)` block sizes and the
`Scatterer<int32> -> Scatterer<int64>` cast-copy),
`test_scatter_with_isolated_rank` and `test_vector_scatter_rev` from #4478,
`test_vector_cast`, `test_vector_clone_layout`, and
`python/test/unit/common/test_scatterer.py`.

Passing at np = 1, 2 and 3, with zero failures in both suites:

| | C++ (Catch2) | Python (pytest) |
| --- | --- | --- |
| np = 1 | 86 cases | 3492 passed, 110 skipped, 21 xfailed |
| np = 2 | 86 cases | 2431 passed, 1089 skipped, 21 xfailed |
| np = 3 | 86 cases | 2432 passed, 1088 skipped, 21 xfailed |

`clang-format`, `ruff`, `ruff format` and `gersemi` clean; mypy unchanged
against its pre-existing baseline.

## Cost

Constructing a `Scatterer` on an index map, np = 3, through the Python binding:

| | per construct |
| --- | --- |
| first, builds the pattern | 67.5 us |
| subsequent, shares it | 0.5 us |

The communicator count, not the microseconds, is the point.

---

AI assistance: I used Claude Code (Opus) to draft parts of this PR. I reviewed,
edited, tested, and take responsibility for the final contribution.
