### PR TITLE
Move the block size out of common::Scatterer

### DIFF
--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -70,45 +70,6 @@ dolfinx::MPI::Comm::operator=(dolfinx::MPI::Comm&& comm) noexcept
 //-----------------------------------------------------------------------------
 MPI_Comm dolfinx::MPI::Comm::comm() const noexcept { return _comm; }
 //-----------------------------------------------------------------------------
-dolfinx::MPI::Datatype::Datatype(int count, MPI_Datatype base) : _base(base)
-{
-  if (count > 1)
-  {
-    int err = MPI_Type_contiguous(count, base, &_type);
-    dolfinx::MPI::check_error(MPI_COMM_SELF, err);
-    err = MPI_Type_commit(&_type);
-    dolfinx::MPI::check_error(MPI_COMM_SELF, err);
-  }
-}
-//-----------------------------------------------------------------------------
-dolfinx::MPI::Datatype::Datatype(Datatype&& type) noexcept
-    : _type(type._type), _base(type._base)
-{
-  type._type = MPI_DATATYPE_NULL;
-}
-//-----------------------------------------------------------------------------
-dolfinx::MPI::Datatype::~Datatype()
-{
-  if (_type != MPI_DATATYPE_NULL)
-    MPI_Type_free(&_type);
-}
-//-----------------------------------------------------------------------------
-dolfinx::MPI::Datatype&
-dolfinx::MPI::Datatype::operator=(Datatype&& type) noexcept
-{
-  if (_type != MPI_DATATYPE_NULL)
-    MPI_Type_free(&_type);
-  _type = type._type;
-  _base = type._base;
-  type._type = MPI_DATATYPE_NULL;
-  return *this;
-}
-//-----------------------------------------------------------------------------
-MPI_Datatype dolfinx::MPI::Datatype::type() const noexcept
-{
-  return _type == MPI_DATATYPE_NULL ? _base : _type;
-}
-//-----------------------------------------------------------------------------
 int dolfinx::MPI::rank(const MPI_Comm comm)
 {
   int rank;

--- a/cpp/dolfinx/common/MPI.cpp
+++ b/cpp/dolfinx/common/MPI.cpp
@@ -70,6 +70,45 @@ dolfinx::MPI::Comm::operator=(dolfinx::MPI::Comm&& comm) noexcept
 //-----------------------------------------------------------------------------
 MPI_Comm dolfinx::MPI::Comm::comm() const noexcept { return _comm; }
 //-----------------------------------------------------------------------------
+dolfinx::MPI::Datatype::Datatype(int count, MPI_Datatype base) : _base(base)
+{
+  if (count > 1)
+  {
+    int err = MPI_Type_contiguous(count, base, &_type);
+    dolfinx::MPI::check_error(MPI_COMM_SELF, err);
+    err = MPI_Type_commit(&_type);
+    dolfinx::MPI::check_error(MPI_COMM_SELF, err);
+  }
+}
+//-----------------------------------------------------------------------------
+dolfinx::MPI::Datatype::Datatype(Datatype&& type) noexcept
+    : _type(type._type), _base(type._base)
+{
+  type._type = MPI_DATATYPE_NULL;
+}
+//-----------------------------------------------------------------------------
+dolfinx::MPI::Datatype::~Datatype()
+{
+  if (_type != MPI_DATATYPE_NULL)
+    MPI_Type_free(&_type);
+}
+//-----------------------------------------------------------------------------
+dolfinx::MPI::Datatype&
+dolfinx::MPI::Datatype::operator=(Datatype&& type) noexcept
+{
+  if (_type != MPI_DATATYPE_NULL)
+    MPI_Type_free(&_type);
+  _type = type._type;
+  _base = type._base;
+  type._type = MPI_DATATYPE_NULL;
+  return *this;
+}
+//-----------------------------------------------------------------------------
+MPI_Datatype dolfinx::MPI::Datatype::type() const noexcept
+{
+  return _type == MPI_DATATYPE_NULL ? _base : _type;
+}
+//-----------------------------------------------------------------------------
 int dolfinx::MPI::rank(const MPI_Comm comm)
 {
   int rank;

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -70,51 +70,6 @@ private:
   MPI_Comm _comm;
 };
 
-/// @brief An MPI datatype for a contiguous block of values, and manage
-/// its lifetime.
-///
-/// For a block of one value the base type is used directly and no
-/// datatype is created, so this is cheap to construct in that case.
-///
-/// @note MPI keeps a datatype alive until communication using it has
-/// completed, so this may be destroyed as soon as a non-blocking call
-/// using it has been started.
-class Datatype
-{
-public:
-  /// @brief Create a datatype for a contiguous block of values.
-  /// @param[in] count Number of values in a block.
-  /// @param[in] base Type of each value.
-  Datatype(int count, MPI_Datatype base);
-
-  // Copy constructor (deleted)
-  Datatype(const Datatype& type) = delete;
-
-  /// Move constructor
-  Datatype(Datatype&& type) noexcept;
-
-  /// Destructor (frees the datatype, if one was created)
-  ~Datatype();
-
-  // Copy assignment (deleted)
-  Datatype& operator=(const Datatype& type) = delete;
-
-  /// Move assignment
-  Datatype& operator=(Datatype&& type) noexcept;
-
-  /// @brief The datatype to pass to MPI.
-  /// @return Contiguous type, or the base type if the block holds one
-  /// value.
-  MPI_Datatype type() const noexcept;
-
-private:
-  // Created contiguous type, or MPI_DATATYPE_NULL if none was created
-  MPI_Datatype _type = MPI_DATATYPE_NULL;
-
-  // Type of each value in a block. Never owned.
-  MPI_Datatype _base;
-};
-
 /// Return process rank for the communicator
 int rank(MPI_Comm comm);
 
@@ -363,6 +318,75 @@ MPI_Datatype mpi_datatype()
 /// @tparam T cpp type to map
 template <typename T>
 MPI_Datatype mpi_t = mpi_datatype<T>();
+
+/// @brief An MPI datatype for a contiguous block of `T`, and manage its
+/// lifetime.
+///
+/// For a block of one value `mpi_t<T>` is used directly and no datatype
+/// is created, so this is cheap to construct in that case.
+///
+/// @note MPI keeps a datatype alive until communication using it has
+/// completed, so this may be destroyed as soon as a non-blocking call
+/// using it has been started.
+///
+/// @tparam T Type of each value in a block.
+template <typename T>
+class Datatype
+{
+public:
+  /// @brief Create a datatype for a contiguous block of values.
+  /// @param[in] count Number of values in a block.
+  explicit Datatype(int count)
+  {
+    if (count > 1)
+    {
+      int err = MPI_Type_contiguous(count, mpi_t<T>, &_type);
+      dolfinx::MPI::check_error(MPI_COMM_SELF, err);
+      err = MPI_Type_commit(&_type);
+      dolfinx::MPI::check_error(MPI_COMM_SELF, err);
+    }
+  }
+
+  // Copy constructor (deleted)
+  Datatype(const Datatype& type) = delete;
+
+  /// Move constructor
+  Datatype(Datatype&& type) noexcept : _type(type._type)
+  {
+    type._type = MPI_DATATYPE_NULL;
+  }
+
+  /// Destructor (frees the datatype, if one was created)
+  ~Datatype()
+  {
+    if (_type != MPI_DATATYPE_NULL)
+      MPI_Type_free(&_type);
+  }
+
+  // Copy assignment (deleted)
+  Datatype& operator=(const Datatype& type) = delete;
+
+  /// Move assignment
+  Datatype& operator=(Datatype&& type) noexcept
+  {
+    if (_type != MPI_DATATYPE_NULL)
+      MPI_Type_free(&_type);
+    _type = type._type;
+    type._type = MPI_DATATYPE_NULL;
+    return *this;
+  }
+
+  /// @brief The datatype to pass to MPI.
+  /// @return Contiguous type, or `mpi_t<T>` if the block holds one value.
+  MPI_Datatype type() const noexcept
+  {
+    return _type == MPI_DATATYPE_NULL ? mpi_t<T> : _type;
+  }
+
+private:
+  // Created contiguous type, or MPI_DATATYPE_NULL if none was created
+  MPI_Datatype _type = MPI_DATATYPE_NULL;
+};
 
 //---------------------------------------------------------------------------
 namespace impl

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -70,6 +70,51 @@ private:
   MPI_Comm _comm;
 };
 
+/// @brief An MPI datatype for a contiguous block of values, and manage
+/// its lifetime.
+///
+/// For a block of one value the base type is used directly and no
+/// datatype is created, so this is cheap to construct in that case.
+///
+/// @note MPI keeps a datatype alive until communication using it has
+/// completed, so this may be destroyed as soon as a non-blocking call
+/// using it has been started.
+class Datatype
+{
+public:
+  /// @brief Create a datatype for a contiguous block of values.
+  /// @param[in] count Number of values in a block.
+  /// @param[in] base Type of each value.
+  Datatype(int count, MPI_Datatype base);
+
+  // Copy constructor (deleted)
+  Datatype(const Datatype& type) = delete;
+
+  /// Move constructor
+  Datatype(Datatype&& type) noexcept;
+
+  /// Destructor (frees the datatype, if one was created)
+  ~Datatype();
+
+  // Copy assignment (deleted)
+  Datatype& operator=(const Datatype& type) = delete;
+
+  /// Move assignment
+  Datatype& operator=(Datatype&& type) noexcept;
+
+  /// @brief The datatype to pass to MPI.
+  /// @return Contiguous type, or the base type if the block holds one
+  /// value.
+  MPI_Datatype type() const noexcept;
+
+private:
+  // Created contiguous type, or MPI_DATATYPE_NULL if none was created
+  MPI_Datatype _type = MPI_DATATYPE_NULL;
+
+  // Type of each value in a block. Never owned.
+  MPI_Datatype _base;
+};
+
 /// Return process rank for the communicator
 int rank(MPI_Comm comm);
 

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -338,12 +338,15 @@ public:
   /// @param[in] count Number of values in a block.
   explicit Datatype(int count)
   {
+    // Not error checked, matching the other datatype creation sites in
+    // the library: these are local calls, and under the default
+    // MPI_ERRORS_ARE_FATAL handler a failure aborts before a return code
+    // is visible. There is also no communicator here to abort on --
+    // MPI_COMM_SELF would abort this rank alone and hang the rest.
     if (count > 1)
     {
-      int err = MPI_Type_contiguous(count, mpi_t<T>, &_type);
-      dolfinx::MPI::check_error(MPI_COMM_SELF, err);
-      err = MPI_Type_commit(&_type);
-      dolfinx::MPI::check_error(MPI_COMM_SELF, err);
+      MPI_Type_contiguous(count, mpi_t<T>, &_type);
+      MPI_Type_commit(&_type);
     }
   }
 

--- a/cpp/dolfinx/common/MPI.h
+++ b/cpp/dolfinx/common/MPI.h
@@ -319,23 +319,28 @@ MPI_Datatype mpi_datatype()
 template <typename T>
 MPI_Datatype mpi_t = mpi_datatype<T>();
 
-/// @brief An MPI datatype for a contiguous block of `T`, and manage its
-/// lifetime.
+/// @brief An MPI datatype for `count` contiguous values of type `T`, and
+/// manage its lifetime.
 ///
-/// For a block of one value `mpi_t<T>` is used directly and no datatype
-/// is created, so this is cheap to construct in that case.
+/// Lets a buffer be sent with counts and displacements measured in
+/// groups of `count` values rather than in single values. The group is
+/// an index map block size in common::Scatterer, and the row width of a
+/// row-major buffer elsewhere; it is not required to be either.
+///
+/// For `count == 1` no datatype is created and `mpi_t<T>` is used
+/// directly, so this is cheap to construct in that case.
 ///
 /// @note MPI keeps a datatype alive until communication using it has
 /// completed, so this may be destroyed as soon as a non-blocking call
 /// using it has been started.
 ///
-/// @tparam T Type of each value in a block.
+/// @tparam T Type of each value.
 template <typename T>
 class Datatype
 {
 public:
-  /// @brief Create a datatype for a contiguous block of values.
-  /// @param[in] count Number of values in a block.
+  /// @brief Create a datatype for `count` contiguous values.
+  /// @param[in] count Number of values MPI should treat as one unit.
   explicit Datatype(int count)
   {
     // Not error checked, matching the other datatype creation sites in
@@ -380,7 +385,7 @@ public:
   }
 
   /// @brief The datatype to pass to MPI.
-  /// @return Contiguous type, or `mpi_t<T>` if the block holds one value.
+  /// @return Contiguous type, or `mpi_t<T>` when `count` is one.
   MPI_Datatype type() const noexcept
   {
     return _type == MPI_DATATYPE_NULL ? mpi_t<T> : _type;

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -240,8 +240,8 @@ public:
     if (!has_neighbours())
       return;
 
-    const block_type<T> type(bs);
-    MPI_Datatype dt = type.get();
+    const dolfinx::MPI::Datatype type(bs, dolfinx::MPI::mpi_t<T>);
+    MPI_Datatype dt = type.type();
     int ierr = MPI_Ineighbor_alltoallv(
         send_buffer, _sizes_local.data(), _displs_local.data(), dt, recv_buffer,
         _sizes_remote.data(), _displs_remote.data(), dt, _comm0.comm(),
@@ -287,10 +287,10 @@ public:
     if (!has_neighbours())
       return;
 
-    block_type<T> type(bs);
+    dolfinx::MPI::Datatype type(bs, dolfinx::MPI::mpi_t<T>);
     int ierr = MPI_Ineighbor_alltoallv(
-        send_buffer, _sizes_remote.data(), _displs_remote.data(), type.get(),
-        recv_buffer, _sizes_local.data(), _displs_local.data(), type.get(),
+        send_buffer, _sizes_remote.data(), _displs_remote.data(), type.type(),
+        recv_buffer, _sizes_local.data(), _displs_local.data(), type.type(),
         _comm1.comm(), &request);
     dolfinx::MPI::check_error(_comm1.comm(), ierr);
   }
@@ -393,49 +393,6 @@ public:
   const container_type& remote_indices() const noexcept { return _remote_inds; }
 
 private:
-  // A contiguous block of `bs` values of type T, for sending sizes and
-  // displacements measured in blocks. For bs == 1 this is the scalar
-  // type itself and nothing is created or freed.
-  //
-  // MPI keeps a datatype alive until communication using it completes,
-  // so this may be destroyed as soon as the non-blocking call returns.
-  template <typename T>
-  class block_type
-  {
-  public:
-    explicit block_type(int bs)
-    {
-      if (bs > 1)
-      {
-        MPI_Type_contiguous(bs, dolfinx::MPI::mpi_t<T>, &_type);
-        MPI_Type_commit(&_type);
-      }
-    }
-
-    block_type(const block_type&) = delete;
-    block_type(block_type&&) = delete;
-
-    ~block_type()
-    {
-      if (_type != MPI_DATATYPE_NULL)
-        MPI_Type_free(&_type);
-    }
-
-    block_type& operator=(const block_type&) = delete;
-    block_type& operator=(block_type&&) = delete;
-
-    /// The contiguous type, or the scalar type when bs == 1.
-    MPI_Datatype get() const noexcept
-    {
-      return _type == MPI_DATATYPE_NULL ? dolfinx::MPI::mpi_t<T> : _type;
-    }
-
-  private:
-    // A committed contiguous type, or MPI_DATATYPE_NULL when bs == 1 and
-    // nothing was created
-    MPI_Datatype _type = MPI_DATATYPE_NULL;
-  };
-
   // False only on a single rank, where _comm0/_comm1 stay MPI_COMM_NULL
   bool has_neighbours() const noexcept
   {

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -397,13 +397,12 @@ private:
   class block_type
   {
   public:
-    explicit block_type(int bs) : _type(dolfinx::MPI::mpi_t<T>)
+    explicit block_type(int bs)
     {
       if (bs > 1)
       {
         MPI_Type_contiguous(bs, dolfinx::MPI::mpi_t<T>, &_type);
         MPI_Type_commit(&_type);
-        _owned = true;
       }
     }
 
@@ -412,18 +411,23 @@ private:
 
     ~block_type()
     {
-      if (_owned)
+      if (_type != MPI_DATATYPE_NULL)
         MPI_Type_free(&_type);
     }
 
     block_type& operator=(const block_type&) = delete;
     block_type& operator=(block_type&&) = delete;
 
-    MPI_Datatype get() const noexcept { return _type; }
+    /// The contiguous type, or the scalar type when bs == 1.
+    MPI_Datatype get() const noexcept
+    {
+      return _type == MPI_DATATYPE_NULL ? dolfinx::MPI::mpi_t<T> : _type;
+    }
 
   private:
-    MPI_Datatype _type;
-    bool _owned = false;
+    // A committed contiguous type, or MPI_DATATYPE_NULL when bs == 1 and
+    // nothing was created
+    MPI_Datatype _type = MPI_DATATYPE_NULL;
   };
 
   // False only on a single rank, where _comm0/_comm1 stay MPI_COMM_NULL

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -59,9 +59,7 @@ public:
   ///
   /// @param[in] map Index map that describes the parallel layout of
   /// data.
-  /// @param[in] bs Number of values associated with each `map` index
-  /// (the block size).
-  Scatterer(const IndexMap& map, int bs)
+  explicit Scatterer(const IndexMap& map)
       : _sizes_remote(map.src().size(), 0),
         _displs_remote(map.src().size() + 1), _sizes_local(map.dest().size()),
         _displs_local(map.dest().size() + 1)
@@ -165,36 +163,18 @@ public:
                           { assert(idx >= range[0] and idx < range[1]); });
 #endif
 
+    // Sizes, displacements and indices are all in blocks. The block
+    // size enters only through the MPI datatype used to send them, and
+    // through the caller's pack/unpack.
     {
-      // Scale sizes and displacements by block size
-      for (auto& x : {std::ref(_sizes_local), std::ref(_displs_local),
-                      std::ref(_sizes_remote), std::ref(_displs_remote)})
-      {
-        std::ranges::transform(x.get(), x.get().begin(),
-                               [bs](auto e) { return e * bs; });
-      }
-    }
-
-    {
-      // Expand local indices using block size and convert it from
-      // global to local numbering
-      std::vector<typename container_type::value_type> idx(recv_buffer.size()
-                                                           * bs);
-      std::int64_t offset = range[0] * bs;
-      for (std::size_t i = 0; i < recv_buffer.size(); i++)
-        for (int j = 0; j < bs; j++)
-          idx[i * bs + j] = (recv_buffer[i] * bs + j) - offset;
+      // Convert the received indices from global to local numbering
+      std::vector<typename container_type::value_type> idx(recv_buffer.size());
+      std::ranges::transform(recv_buffer, idx.begin(),
+                             [range](std::int64_t i) { return i - range[0]; });
       _local_inds = std::move(idx);
     }
 
-    {
-      // Expand remote indices using block size
-      std::vector<typename container_type::value_type> idx(perm.size() * bs);
-      for (std::size_t i = 0; i < perm.size(); i++)
-        for (int j = 0; j < bs; j++)
-          idx[i * bs + j] = perm[i] * bs + j;
-      _remote_inds = std::move(idx);
-    }
+    _remote_inds = container_type(perm.begin(), perm.end());
   }
 
   /// @brief Copy constructor
@@ -251,16 +231,18 @@ public:
   /// the non-blocking communication. The same request handle should be
   /// passed to Scatterer::scatter_fwd_end to complete the communication.
   template <typename T>
-  void scatter_fwd_begin(const T* send_buffer, T* recv_buffer,
+  void scatter_fwd_begin(const T* send_buffer, T* recv_buffer, int bs,
                          MPI_Request& request) const
   {
     if (!has_neighbours())
       return;
 
+    const block_type<T> type(bs);
+    MPI_Datatype dt = type.get();
     int ierr = MPI_Ineighbor_alltoallv(
-        send_buffer, _sizes_local.data(), _displs_local.data(),
-        dolfinx::MPI::mpi_t<T>, recv_buffer, _sizes_remote.data(),
-        _displs_remote.data(), dolfinx::MPI::mpi_t<T>, _comm0.comm(), &request);
+        send_buffer, _sizes_local.data(), _displs_local.data(), dt, recv_buffer,
+        _sizes_remote.data(), _displs_remote.data(), dt, _comm0.comm(),
+        &request);
     dolfinx::MPI::check_error(_comm0.comm(), ierr);
   }
 
@@ -293,16 +275,17 @@ public:
   /// the non-blocking communication. The same request handle should be
   /// passed to Scatterer::scatter_rev_end to complete the communication.
   template <typename T>
-  void scatter_rev_begin(const T* send_buffer, T* recv_buffer,
+  void scatter_rev_begin(const T* send_buffer, T* recv_buffer, int bs,
                          MPI_Request& request) const
   {
     if (!has_neighbours())
       return;
 
+    block_type<T> type(bs);
     int ierr = MPI_Ineighbor_alltoallv(
-        send_buffer, _sizes_remote.data(), _displs_remote.data(),
-        dolfinx::MPI::mpi_t<T>, recv_buffer, _sizes_local.data(),
-        _displs_local.data(), dolfinx::MPI::mpi_t<T>, _comm1.comm(), &request);
+        send_buffer, _sizes_remote.data(), _displs_remote.data(), type.get(),
+        recv_buffer, _sizes_local.data(), _displs_local.data(), type.get(),
+        _comm1.comm(), &request);
     dolfinx::MPI::check_error(_comm1.comm(), ierr);
   }
 
@@ -404,6 +387,45 @@ public:
   const container_type& remote_indices() const noexcept { return _remote_inds; }
 
 private:
+  // A contiguous block of `bs` values of type T, for sending sizes and
+  // displacements measured in blocks. For bs == 1 this is the scalar
+  // type itself and nothing is created or freed.
+  //
+  // MPI keeps a datatype alive until communication using it completes,
+  // so this may be destroyed as soon as the non-blocking call returns.
+  template <typename T>
+  class block_type
+  {
+  public:
+    explicit block_type(int bs) : _type(dolfinx::MPI::mpi_t<T>)
+    {
+      if (bs > 1)
+      {
+        MPI_Type_contiguous(bs, dolfinx::MPI::mpi_t<T>, &_type);
+        MPI_Type_commit(&_type);
+        _owned = true;
+      }
+    }
+
+    block_type(const block_type&) = delete;
+    block_type(block_type&&) = delete;
+
+    ~block_type()
+    {
+      if (_owned)
+        MPI_Type_free(&_type);
+    }
+
+    block_type& operator=(const block_type&) = delete;
+    block_type& operator=(block_type&&) = delete;
+
+    MPI_Datatype get() const noexcept { return _type; }
+
+  private:
+    MPI_Datatype _type;
+    bool _owned = false;
+  };
+
   // False only on a single rank, where _comm0/_comm1 stay MPI_COMM_NULL
   bool has_neighbours() const noexcept
   {

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -11,9 +11,8 @@
 #include "sort.h"
 #include <algorithm>
 #include <array>
-#include <concepts>
+#include <cassert>
 #include <cstdint>
-#include <functional>
 #include <mpi.h>
 #include <numeric>
 #include <span>
@@ -37,6 +36,11 @@ namespace dolfinx::common
 /// requests. Callers of a Scatterer's members are responsible for
 /// managing buffer and MPI request handles.
 ///
+/// Creating, copying and destroying a Scatterer are collective, since
+/// they create, duplicate and free MPI communicators. Move construction
+/// is not collective, but move assignment is, since it frees the
+/// communicators held by the assignment target.
+///
 /// @tparam Container Container type for storing the 'local' and
 /// 'remote' indices. On CPUs this is normally
 /// `std::vector<std::int32_t>`. For GPUs the container should store the
@@ -55,7 +59,9 @@ public:
   using container_type = Container;
 
   /// @brief Create a scatterer for data with a layout described by an
-  /// IndexMap and a block size.
+  /// IndexMap.
+  ///
+  /// @note Collective.
   ///
   /// @param[in] map Index map that describes the parallel layout of
   /// data.
@@ -119,7 +125,7 @@ public:
     auto begin = owners_sorted.begin();
     for (std::size_t i = 0; i < src.size(); i++)
     {
-      auto upper = std::upper_bound(begin, owners_sorted.end(), src[i]);
+      auto upper = std::ranges::upper_bound(begin, owners_sorted.end(), src[i]);
       std::size_t num_ind = std::ranges::distance(begin, upper);
       _displs_remote[i + 1] = _displs_remote[i] + num_ind;
       _sizes_remote[i] = num_ind;
@@ -135,15 +141,15 @@ public:
     // elements to be sent/received grouped by neighbors)
     assert(_sizes_local.size() == dest.size());
     assert(_displs_local.size() == dest.size() + 1);
-    _sizes_remote.reserve(1);
-    _sizes_local.reserve(1);
-    ierr = MPI_Neighbor_alltoall(_sizes_remote.data(), 1, MPI_INT32_T,
-                                 _sizes_local.data(), 1, MPI_INT32_T,
-                                 _comm1.comm());
+    _sizes_remote.reserve(1); // ensure data is not a nullptr
+    _sizes_local.reserve(1);  // ensure data is not a nullptr
+    ierr
+        = MPI_Neighbor_alltoall(_sizes_remote.data(), 1, MPI_INT,
+                                _sizes_local.data(), 1, MPI_INT, _comm1.comm());
     dolfinx::MPI::check_error(_comm1.comm(), ierr);
 
-    std::partial_sum(_sizes_local.begin(), _sizes_local.end(),
-                     std::next(_displs_local.begin()));
+    std::inclusive_scan(_sizes_local.begin(), _sizes_local.end(),
+                        std::next(_displs_local.begin()));
 
     assert(static_cast<int>(ghosts_sorted.size()) == _displs_remote.back());
 
@@ -170,15 +176,14 @@ public:
       // Convert the received indices from global to local numbering
       std::vector<typename container_type::value_type> idx(recv_buffer.size());
       std::ranges::transform(recv_buffer, idx.begin(),
-                             [range](std::int64_t i) { return i - range[0]; });
+                             [offset = range[0]](auto i) ->
+                             typename container_type::value_type
+                             { return i - offset; });
       _local_inds = std::move(idx);
     }
 
     _remote_inds = container_type(perm.begin(), perm.end());
   }
-
-  /// @brief Copy constructor
-  Scatterer(const Scatterer& scatterer) = default;
 
   /// @brief Cast-copy constructor.
   ///
@@ -192,6 +197,9 @@ public:
   /// parallel communication will usually be copied too with a different
   /// storage container.
   ///
+  /// @note Collective. The neighbourhood communicators are duplicated,
+  /// so all ranks must make the copy together.
+  ///
   /// @param s Scatterer to copy
   template <class U>
   Scatterer(const Scatterer<U>& s)
@@ -203,12 +211,46 @@ public:
   {
   }
 
-  /// @brief Start a non-blocking neighbourhood collective exchange of
-  /// owned data with ranks that ghost it.
+  /// Copy constructor
   ///
-  /// The communication is completed by calling Scatterer::scatter_fwd_end.
-  /// See ::local_block_indices for instructions on packing `send_buffer` and
-  /// ::remote_block_indices for instructions on unpacking `recv_buffer`.
+  /// @note Collective, as for the cast-copy constructor. Move instead
+  /// where the original is no longer required.
+  Scatterer(const Scatterer& scatterer) = default;
+
+  /// Move constructor
+  ///
+  /// @note Not collective, unlike the copy constructors: the
+  /// communicators are taken over rather than duplicated.
+  Scatterer(Scatterer&& scatterer) = default;
+
+  /// Destructor
+  ///
+  /// @note Collective, since the communicators are freed.
+  ~Scatterer() = default;
+
+  // Copy assignment (deleted). dolfinx::MPI::Comm cannot be copied into
+  // an existing object.
+  Scatterer& operator=(const Scatterer& scatterer) = delete;
+
+  /// Move assignment
+  ///
+  /// @note Collective if this Scatterer holds communicators, since
+  /// assigning to it frees them.
+  Scatterer& operator=(Scatterer&& scatterer) = default;
+
+  /// @brief Start a non-blocking neighbourhood collective exchange of
+  /// owned data with the ranks that ghost it.
+  ///
+  /// The communication is completed by calling
+  /// Scatterer::scatter_fwd_end. See ::local_indices_block for how to
+  /// pack `send_buffer` and ::remote_indices_block for how to unpack
+  /// `recv_buffer`.
+  ///
+  /// This is a differently named function rather than an overload of
+  /// ::scatter_fwd_begin because the underlying type of `MPI_Datatype`
+  /// is implementation-defined, and is an integer type in some MPI
+  /// implementations, so overloading on `int` and `MPI_Datatype` is not
+  /// portably unambiguous.
   ///
   /// @note Collective MPI operation. Every rank in the communicator
   /// must call this function, including ranks without neighbours.
@@ -223,39 +265,109 @@ public:
   ///
   /// @param[in] send_buffer Packed local data associated with each
   /// owned local index to be sent to processes where the data is
-  /// ghosted. See Scatterer::local_block_indices for the order of the buffer
-  /// and how to pack.
+  /// ghosted. See Scatterer::local_indices_block for the order of the
+  /// buffer and how to pack.
   /// @param[in,out] recv_buffer Buffer for storing received data. See
-  /// Scatterer::remote_block_indices for the order of the buffer and how to
-  /// unpack.
-  /// @param[in] bs Number of values per index map index (the block
-  /// size). The buffers hold `bs` values for each index in
-  /// ::local_block_indices and ::remote_block_indices respectively.
-  /// @param[in] request MPI request handle for tracking the status of
-  /// the non-blocking communication. The same request handle should be
-  /// passed to Scatterer::scatter_fwd_end to complete the communication.
+  /// Scatterer::remote_indices_block for the order of the buffer and
+  /// how to unpack.
+  /// @param[in] type MPI datatype for the data associated with one
+  /// index, e.g. `dolfinx::MPI::Datatype<T>(bs).type()`. Buffer counts
+  /// and displacements are in units of `type`, and the same type must
+  /// be used on all ranks. MPI keeps a datatype alive until
+  /// communication using it has completed, so `type` may be freed as
+  /// soon as this function returns.
+  /// @param[out] request Handle for tracking the status of the
+  /// non-blocking communication. Any value passed in is overwritten,
+  /// and `MPI_REQUEST_NULL` is returned when this rank has nothing to
+  /// communicate. The same handle must be passed to
+  /// Scatterer::scatter_fwd_end to complete the communication.
   template <typename T>
-  void scatter_fwd_begin(const T* send_buffer, T* recv_buffer, int bs,
-                         MPI_Request& request) const
+  void scatter_fwd_begin_dtype(const T* send_buffer, T* recv_buffer,
+                               MPI_Datatype type, MPI_Request& request) const
   {
     if (!has_neighbours())
+    {
+      request = MPI_REQUEST_NULL;
       return;
+    }
 
-    const dolfinx::MPI::Datatype<T> type(bs);
-    MPI_Datatype dt = type.type();
     int ierr = MPI_Ineighbor_alltoallv(
-        send_buffer, _sizes_local.data(), _displs_local.data(), dt, recv_buffer,
-        _sizes_remote.data(), _displs_remote.data(), dt, _comm0.comm(),
-        &request);
+        send_buffer, _sizes_local.data(), _displs_local.data(), type,
+        recv_buffer, _sizes_remote.data(), _displs_remote.data(), type,
+        _comm0.comm(), &request);
     dolfinx::MPI::check_error(_comm0.comm(), ierr);
   }
 
   /// @brief Start a non-blocking neighbourhood collective exchange of
-  /// ghost data with owning ranks.
+  /// owned data with the ranks that ghost it.
   ///
-  /// The communication is completed by calling Scatterer::scatter_rev_end.
-  /// See ::remote_block_indices for instructions on packing `send_buffer` and
-  /// ::local_block_indices  for instructions on unpacking `recv_buffer`.
+  /// As ::scatter_fwd_begin_dtype, but with the MPI datatype built from
+  /// a block size.
+  ///
+  /// @param[in] send_buffer Packed local data associated with each
+  /// owned local index to be sent to processes where the data is
+  /// ghosted. See Scatterer::local_indices_block for the order of the
+  /// buffer and how to pack.
+  /// @param[in,out] recv_buffer Buffer for storing received data. See
+  /// Scatterer::remote_indices_block for the order of the buffer and
+  /// how to unpack.
+  /// @param[in] bs Number of values per index map index (the block
+  /// size). The buffers hold `bs` values for each index in
+  /// ::local_indices_block and ::remote_indices_block respectively.
+  /// @param[out] request Handle for tracking the status of the
+  /// non-blocking communication. Any value passed in is overwritten,
+  /// and `MPI_REQUEST_NULL` is returned when this rank has nothing to
+  /// communicate. The same handle must be passed to
+  /// Scatterer::scatter_fwd_end to complete the communication.
+  template <typename T>
+  void scatter_fwd_begin(const T* send_buffer, T* recv_buffer, int bs,
+                         MPI_Request& request) const
+  {
+    // Checked here too, to avoid building a datatype that will not be
+    // used
+    if (!has_neighbours())
+    {
+      request = MPI_REQUEST_NULL;
+      return;
+    }
+
+    dolfinx::MPI::Datatype<T> type(bs);
+    scatter_fwd_begin_dtype(send_buffer, recv_buffer, type.type(), request);
+  }
+
+  /// @brief Complete a non-blocking MPI neighbourhood collective send.
+  ///
+  /// This function completes the communication started by
+  /// ::scatter_fwd_begin or ::scatter_fwd_begin_dtype.
+  ///
+  /// @note Local completion of the caller's own request, not itself
+  /// collective. Every rank that called ::scatter_fwd_begin must
+  /// still call this before reusing the buffers.
+  ///
+  /// @param[in,out] request Handle returned by the matching begin
+  /// call. Set to `MPI_REQUEST_NULL` once the communication has
+  /// completed.
+  void scatter_fwd_end(MPI_Request& request) const
+  {
+    if (!has_neighbours())
+      return;
+
+    wait(_comm0, request);
+  }
+
+  /// @brief Start a non-blocking neighbourhood collective exchange of
+  /// ghost data with the owning ranks.
+  ///
+  /// The communication is completed by calling
+  /// Scatterer::scatter_rev_end. See ::remote_indices_block for how to
+  /// pack `send_buffer` and ::local_indices_block for how to unpack
+  /// `recv_buffer`.
+  ///
+  /// This is a differently named function rather than an overload of
+  /// ::scatter_rev_begin because the underlying type of `MPI_Datatype`
+  /// is implementation-defined, and is an integer type in some MPI
+  /// implementations, so overloading on `int` and `MPI_Datatype` is not
+  /// portably unambiguous.
   ///
   /// @note Collective MPI operation. Every rank in the communicator
   /// must call this function, including ranks without neighbours.
@@ -270,62 +382,88 @@ public:
   ///
   /// @param[in] send_buffer Data associated with each ghost index. This
   /// data is sent to the process that owns the index. See
-  /// Scatterer::remote_block_indices for the order of the buffer and how to
-  /// pack.
+  /// Scatterer::remote_indices_block for the order of the buffer and
+  /// how to pack.
   /// @param[in,out] recv_buffer Buffer for storing received data. See
-  /// Scatterer::local_block_indices for the order of the buffer and how to
-  /// unpack.
-  /// @param[in] bs Number of values per index map index (the block
-  /// size). The buffers hold `bs` values for each index in
-  /// ::remote_block_indices and ::local_block_indices respectively.
-  /// @param[in] request MPI request handle for tracking the status of
-  /// the non-blocking communication. The same request handle should be
-  /// passed to Scatterer::scatter_rev_end to complete the communication.
+  /// Scatterer::local_indices_block for the order of the buffer and how
+  /// to unpack.
+  /// @param[in] type MPI datatype for the data associated with one
+  /// index, e.g. `dolfinx::MPI::Datatype<T>(bs).type()`. Buffer counts
+  /// and displacements are in units of `type`, and the same type must
+  /// be used on all ranks. MPI keeps a datatype alive until
+  /// communication using it has completed, so `type` may be freed as
+  /// soon as this function returns.
+  /// @param[out] request Handle for tracking the status of the
+  /// non-blocking communication. Any value passed in is overwritten,
+  /// and `MPI_REQUEST_NULL` is returned when this rank has nothing to
+  /// communicate. The same handle must be passed to
+  /// Scatterer::scatter_rev_end to complete the communication.
   template <typename T>
-  void scatter_rev_begin(const T* send_buffer, T* recv_buffer, int bs,
-                         MPI_Request& request) const
+  void scatter_rev_begin_dtype(const T* send_buffer, T* recv_buffer,
+                               MPI_Datatype type, MPI_Request& request) const
   {
     if (!has_neighbours())
+    {
+      request = MPI_REQUEST_NULL;
       return;
+    }
 
-    dolfinx::MPI::Datatype<T> type(bs);
     int ierr = MPI_Ineighbor_alltoallv(
-        send_buffer, _sizes_remote.data(), _displs_remote.data(), type.type(),
-        recv_buffer, _sizes_local.data(), _displs_local.data(), type.type(),
+        send_buffer, _sizes_remote.data(), _displs_remote.data(), type,
+        recv_buffer, _sizes_local.data(), _displs_local.data(), type,
         _comm1.comm(), &request);
     dolfinx::MPI::check_error(_comm1.comm(), ierr);
   }
 
-  /// @brief Complete a non-blocking MPI neighbourhood collective send.
+  /// @brief Start a non-blocking neighbourhood collective exchange of
+  /// ghost data with the owning ranks.
   ///
-  /// This function completes the communication started by
-  /// ::scatter_fwd_begin.
+  /// As ::scatter_rev_begin_dtype, but with the MPI datatype built from
+  /// a block size.
   ///
-  /// @note Local completion of the caller's own request, not itself
-  /// collective. Every rank that called ::scatter_fwd_begin must
-  /// still call this before reusing the buffers.
-  ///
-  /// @param[in] request MPI request handle for tracking the status of
-  /// communication.
-  void scatter_fwd_end(MPI_Request& request) const
+  /// @param[in] send_buffer Data associated with each ghost index. This
+  /// data is sent to the process that owns the index. See
+  /// Scatterer::remote_indices_block for the order of the buffer and
+  /// how to pack.
+  /// @param[in,out] recv_buffer Buffer for storing received data. See
+  /// Scatterer::local_indices_block for the order of the buffer and how
+  /// to unpack.
+  /// @param[in] bs Number of values per index map index (the block
+  /// size). The buffers hold `bs` values for each index in
+  /// ::remote_indices_block and ::local_indices_block respectively.
+  /// @param[out] request Handle for tracking the status of the
+  /// non-blocking communication. Any value passed in is overwritten,
+  /// and `MPI_REQUEST_NULL` is returned when this rank has nothing to
+  /// communicate. The same handle must be passed to
+  /// Scatterer::scatter_rev_end to complete the communication.
+  template <typename T>
+  void scatter_rev_begin(const T* send_buffer, T* recv_buffer, int bs,
+                         MPI_Request& request) const
   {
+    // Checked here too, to avoid building a datatype that will not be
+    // used
     if (!has_neighbours())
+    {
+      request = MPI_REQUEST_NULL;
       return;
+    }
 
-    wait(_comm0, request);
+    dolfinx::MPI::Datatype<T> type(bs);
+    scatter_rev_begin_dtype(send_buffer, recv_buffer, type.type(), request);
   }
 
   /// @brief Complete a non-blocking MPI neighbourhood collective send.
   ///
   /// This function completes the communication started by
-  /// ::scatter_rev_begin.
+  /// ::scatter_rev_begin or ::scatter_rev_begin_dtype.
   ///
   /// @note Local completion of the caller's own request, not itself
   /// collective. Every rank that called ::scatter_rev_begin must
   /// still call this before reusing the buffers.
   ///
-  /// @param[in] request MPI request handle for tracking the status of
-  /// communication.
+  /// @param[in,out] request Handle returned by the matching begin
+  /// call. Set to `MPI_REQUEST_NULL` once the communication has
+  /// completed.
   void scatter_rev_end(MPI_Request& request) const
   {
     if (!has_neighbours())
@@ -343,28 +481,35 @@ public:
   /// for assigning (accumulating) the receive buffer values into
   /// the correct position in the owned part of the data array.
   ///
+  /// The indices are in blocks, so for a block size `bs` a buffer holds
+  /// `bs` values per index and must be `bs * local_indices_block().size()`
+  /// long.
+  ///
   /// For a forward scatter, if `x` is the owned part of an array and
   /// `send_buffer` is the send buffer, `send_buffer` is packed such
   /// that:
   ///
-  ///     auto& idx = scatterer.local_block_indices()
-  ///     std::vector<T> send_buffer(idx.size())
+  ///     auto& idx = scatterer.local_indices_block()
+  ///     std::vector<T> send_buffer(bs * idx.size())
   ///     for (std::size_t i = 0; i < idx.size(); ++i)
-  ///         send_buffer[i] = x[idx[i]];
+  ///         for (int j = 0; j < bs; ++j)
+  ///             send_buffer[i * bs + j] = x[idx[i] * bs + j];
   ///
   /// For a reverse scatter, if `recv_buffer` is the received buffer,
   /// then `x` is updated by
   ///
-  ///     auto& idx = scatterer.local_block_indices()
-  ///     std::vector<T> recv_buffer(idx.size())
+  ///     auto& idx = scatterer.local_indices_block()
+  ///     std::vector<T> recv_buffer(bs * idx.size())
   ///     for (std::size_t i = 0; i < idx.size(); ++i)
-  ///         x[idx[i]] = op(recv_buffer[i], x[idx[i]]);
+  ///         for (int j = 0; j < bs; ++j)
+  ///             x[idx[i] * bs + j]
+  ///                 = op(recv_buffer[i * bs + j], x[idx[i] * bs + j]);
   ///
-  /// where `op` is a binary operation, e.g. `x[idx[i]] = buffer[i]` or
-  /// `x[idx[i]] += buffer[i]`.
+  /// where `op` is a binary operation, e.g. `x[...] = buffer[...]` or
+  /// `x[...] += buffer[...]`.
   ///
   /// @return Indices container.
-  const container_type& local_block_indices() const noexcept
+  const container_type& local_indices_block() const noexcept
   {
     return _local_inds;
   }
@@ -373,17 +518,17 @@ public:
   /// send/receive buffer.
   ///
   /// For a forward scatter, the indices are used to unpack received data
-  /// into ghost entries. For a reverse scatter, indices are used for assigning
-  /// (accumulating) the receive buffer values to the correct position in
-  /// the owned array.
+  /// into ghost entries. For a reverse scatter, indices are used to pack
+  /// ghost entries into the send buffer.
   ///
   /// The indices are in blocks, so for a block size `bs` a buffer holds
-  /// `bs` values per index and must be `bs * size()` long.
+  /// `bs` values per index and must be
+  /// `bs * remote_indices_block().size()` long.
   ///
   /// For a forward scatter, if `xg` is the ghost part of the data array
   /// and `recv_buffer` is the receive buffer, `xg` is updated as
   ///
-  ///     auto& idx = scatterer.remote_block_indices()
+  ///     auto& idx = scatterer.remote_indices_block()
   ///     std::vector<T> recv_buffer(bs * idx.size())
   ///     for (std::size_t i = 0; i < idx.size(); ++i)
   ///         for (int j = 0; j < bs; ++j)
@@ -392,14 +537,14 @@ public:
   /// For a reverse scatter, if `send_buffer` is the send buffer, then
   /// `send_buffer` is packed such that:
   ///
-  ///     auto& idx = scatterer.remote_block_indices()
+  ///     auto& idx = scatterer.remote_indices_block()
   ///     std::vector<T> send_buffer(bs * idx.size())
   ///     for (std::size_t i = 0; i < idx.size(); ++i)
   ///         for (int j = 0; j < bs; ++j)
   ///             send_buffer[i * bs + j] = xg[idx[i] * bs + j];
   ///
   /// @return Block indices container.
-  const container_type& remote_block_indices() const noexcept
+  const container_type& remote_indices_block() const noexcept
   {
     return _remote_inds;
   }

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -227,6 +227,9 @@ public:
   /// and how to pack.
   /// @param[in,out] recv_buffer Buffer for storing received data. See
   /// Scatterer::remote_indices for the order of the buffer and how to unpack.
+  /// @param[in] bs Number of values per index map index (the block
+  /// size). The buffers hold `bs` values for each index in
+  /// ::local_indices and ::remote_indices respectively.
   /// @param[in] request MPI request handle for tracking the status of
   /// the non-blocking communication. The same request handle should be
   /// passed to Scatterer::scatter_fwd_end to complete the communication.
@@ -271,6 +274,9 @@ public:
   /// @param[in,out] recv_buffer Buffer for storing received data. See
   /// Scatterer::local_indices for the order of the buffer and how to
   /// unpack.
+  /// @param[in] bs Number of values per index map index (the block
+  /// size). The buffers hold `bs` values for each index in
+  /// ::remote_indices and ::local_indices respectively.
   /// @param[in] request MPI request handle for tracking the status of
   /// the non-blocking communication. The same request handle should be
   /// passed to Scatterer::scatter_rev_end to complete the communication.

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -207,8 +207,8 @@ public:
   /// owned data with ranks that ghost it.
   ///
   /// The communication is completed by calling Scatterer::scatter_fwd_end.
-  /// See ::local_indices for instructions on packing `send_buffer` and
-  /// ::remote_indices for instructions on unpacking `recv_buffer`.
+  /// See ::local_block_indices for instructions on packing `send_buffer` and
+  /// ::remote_block_indices for instructions on unpacking `recv_buffer`.
   ///
   /// @note Collective MPI operation. Every rank in the communicator
   /// must call this function, including ranks without neighbours.
@@ -223,13 +223,14 @@ public:
   ///
   /// @param[in] send_buffer Packed local data associated with each
   /// owned local index to be sent to processes where the data is
-  /// ghosted. See Scatterer::local_indices for the order of the buffer
+  /// ghosted. See Scatterer::local_block_indices for the order of the buffer
   /// and how to pack.
   /// @param[in,out] recv_buffer Buffer for storing received data. See
-  /// Scatterer::remote_indices for the order of the buffer and how to unpack.
+  /// Scatterer::remote_block_indices for the order of the buffer and how to
+  /// unpack.
   /// @param[in] bs Number of values per index map index (the block
   /// size). The buffers hold `bs` values for each index in
-  /// ::local_indices and ::remote_indices respectively.
+  /// ::local_block_indices and ::remote_block_indices respectively.
   /// @param[in] request MPI request handle for tracking the status of
   /// the non-blocking communication. The same request handle should be
   /// passed to Scatterer::scatter_fwd_end to complete the communication.
@@ -253,8 +254,8 @@ public:
   /// ghost data with owning ranks.
   ///
   /// The communication is completed by calling Scatterer::scatter_rev_end.
-  /// See ::remote_indices for instructions on packing `send_buffer` and
-  /// ::local_indices  for instructions on unpacking `recv_buffer`.
+  /// See ::remote_block_indices for instructions on packing `send_buffer` and
+  /// ::local_block_indices  for instructions on unpacking `recv_buffer`.
   ///
   /// @note Collective MPI operation. Every rank in the communicator
   /// must call this function, including ranks without neighbours.
@@ -269,14 +270,14 @@ public:
   ///
   /// @param[in] send_buffer Data associated with each ghost index. This
   /// data is sent to the process that owns the index. See
-  /// Scatterer::remote_indices for the order of the buffer and how to
+  /// Scatterer::remote_block_indices for the order of the buffer and how to
   /// pack.
   /// @param[in,out] recv_buffer Buffer for storing received data. See
-  /// Scatterer::local_indices for the order of the buffer and how to
+  /// Scatterer::local_block_indices for the order of the buffer and how to
   /// unpack.
   /// @param[in] bs Number of values per index map index (the block
   /// size). The buffers hold `bs` values for each index in
-  /// ::remote_indices and ::local_indices respectively.
+  /// ::remote_block_indices and ::local_block_indices respectively.
   /// @param[in] request MPI request handle for tracking the status of
   /// the non-blocking communication. The same request handle should be
   /// passed to Scatterer::scatter_rev_end to complete the communication.
@@ -346,7 +347,7 @@ public:
   /// `send_buffer` is the send buffer, `send_buffer` is packed such
   /// that:
   ///
-  ///     auto& idx = scatterer.local_indices()
+  ///     auto& idx = scatterer.local_block_indices()
   ///     std::vector<T> send_buffer(idx.size())
   ///     for (std::size_t i = 0; i < idx.size(); ++i)
   ///         send_buffer[i] = x[idx[i]];
@@ -354,7 +355,7 @@ public:
   /// For a reverse scatter, if `recv_buffer` is the received buffer,
   /// then `x` is updated by
   ///
-  ///     auto& idx = scatterer.local_indices()
+  ///     auto& idx = scatterer.local_block_indices()
   ///     std::vector<T> recv_buffer(idx.size())
   ///     for (std::size_t i = 0; i < idx.size(); ++i)
   ///         x[idx[i]] = op(recv_buffer[i], x[idx[i]]);
@@ -363,7 +364,10 @@ public:
   /// `x[idx[i]] += buffer[i]`.
   ///
   /// @return Indices container.
-  const container_type& local_indices() const noexcept { return _local_inds; }
+  const container_type& local_block_indices() const noexcept
+  {
+    return _local_inds;
+  }
 
   /// @brief Array of indices for packing/unpacking ghost data to/from a
   /// send/receive buffer.
@@ -373,24 +377,32 @@ public:
   /// (accumulating) the receive buffer values to the correct position in
   /// the owned array.
   ///
+  /// The indices are in blocks, so for a block size `bs` a buffer holds
+  /// `bs` values per index and must be `bs * size()` long.
+  ///
   /// For a forward scatter, if `xg` is the ghost part of the data array
   /// and `recv_buffer` is the receive buffer, `xg` is updated as
   ///
-  ///     auto& idx = scatterer.remote_indices()
-  ///     std::vector<T> recv_buffer(idx.size())
+  ///     auto& idx = scatterer.remote_block_indices()
+  ///     std::vector<T> recv_buffer(bs * idx.size())
   ///     for (std::size_t i = 0; i < idx.size(); ++i)
-  ///         xg[idx[i]] = recv_buffer[i];
+  ///         for (int j = 0; j < bs; ++j)
+  ///             xg[idx[i] * bs + j] = recv_buffer[i * bs + j];
   ///
   /// For a reverse scatter, if `send_buffer` is the send buffer, then
   /// `send_buffer` is packed such that:
   ///
-  ///     auto& idx = scatterer.remote_indices()
-  ///     std::vector<T> send_buffer(idx.size())
+  ///     auto& idx = scatterer.remote_block_indices()
+  ///     std::vector<T> send_buffer(bs * idx.size())
   ///     for (std::size_t i = 0; i < idx.size(); ++i)
-  ///         send_buffer[i] = xg[idx[i]];
+  ///         for (int j = 0; j < bs; ++j)
+  ///             send_buffer[i * bs + j] = xg[idx[i] * bs + j];
   ///
-  /// @return Indices container.
-  const container_type& remote_indices() const noexcept { return _remote_inds; }
+  /// @return Block indices container.
+  const container_type& remote_block_indices() const noexcept
+  {
+    return _remote_inds;
+  }
 
 private:
   // False only on a single rank, where _comm0/_comm1 stay MPI_COMM_NULL

--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -240,7 +240,7 @@ public:
     if (!has_neighbours())
       return;
 
-    const dolfinx::MPI::Datatype type(bs, dolfinx::MPI::mpi_t<T>);
+    const dolfinx::MPI::Datatype<T> type(bs);
     MPI_Datatype dt = type.type();
     int ierr = MPI_Ineighbor_alltoallv(
         send_buffer, _sizes_local.data(), _displs_local.data(), dt, recv_buffer,
@@ -287,7 +287,7 @@ public:
     if (!has_neighbours())
       return;
 
-    dolfinx::MPI::Datatype type(bs, dolfinx::MPI::mpi_t<T>);
+    dolfinx::MPI::Datatype<T> type(bs);
     int ierr = MPI_Ineighbor_alltoallv(
         send_buffer, _sizes_remote.data(), _displs_remote.data(), type.type(),
         recv_buffer, _sizes_local.data(), _displs_local.data(), type.type(),

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -102,29 +102,15 @@ private:
     };
   }
 
-  /// @brief Return an 'unpack' function for unpacking a receive buffer. Assigns
-  /// received values to entries.
+  /// @brief Return an 'unpack' function for unpacking a receive buffer.
+  /// Assigns received values to entries.
   ///
   /// Typically used to unpack into ghost entries on a CPU.
   auto get_unpack()
   {
-    return [bs = _bs](typename ScatterContainer::const_iterator idx_first,
-                      typename ScatterContainer::const_iterator idx_last,
-                      const auto in_first, auto out_first)
-    {
-      // out[idx[i] * bs + j] = in[i * bs + j]
-      dispatch_bs(bs,
-                  [&](auto B)
-                  {
-                    auto in = in_first;
-                    for (auto idx = idx_first; idx != idx_last; ++idx)
-                    {
-                      auto out = std::next(out_first, (*idx) * B);
-                      for (int j = 0; j < B; ++j, ++in, ++out)
-                        *out = *in;
-                    }
-                  });
-    };
+    // Assignment is accumulation with an operation that keeps the
+    // received value
+    return get_unpack_op([](auto, auto received) { return received; });
   }
 
   /// @brief Return an 'unpack' function for unpacking a receive buffer.

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -54,6 +54,41 @@ class Vector
   friend class Vector;
 
 private:
+  /// @brief Call `f` with the block size as a compile-time constant for
+  /// the common block sizes, and as a plain `int` otherwise.
+  ///
+  /// The pack/unpack inner loops run over the block size, so giving it
+  /// to the compiler as a constant lets them be unrolled. Without this
+  /// the scatter is several times slower. la::MatrixCSR::mult does the
+  /// same for spmv.
+  template <class F>
+  static void dispatch_bs(int bs, F&& f)
+  {
+    switch (bs)
+    {
+    case 1:
+      return f(std::integral_constant<int, 1>{});
+    case 2:
+      return f(std::integral_constant<int, 2>{});
+    case 3:
+      return f(std::integral_constant<int, 3>{});
+    case 4:
+      return f(std::integral_constant<int, 4>{});
+    case 5:
+      return f(std::integral_constant<int, 5>{});
+    case 6:
+      return f(std::integral_constant<int, 6>{});
+    case 7:
+      return f(std::integral_constant<int, 7>{});
+    case 8:
+      return f(std::integral_constant<int, 8>{});
+    case 9:
+      return f(std::integral_constant<int, 9>{});
+    default:
+      return f(bs);
+    }
+  }
+
   /// @brief Return a 'pack' function for packing a send buffer.
   ///
   /// Typically used for forward and reverse scatter operations on a
@@ -64,31 +99,15 @@ private:
                       typename ScatterContainer::const_iterator idx_last,
                       const auto in_first, auto out_first)
     {
-      // out[i * bs + j] = in[idx[i] * bs + j]. Dispatch on the common
-      // block sizes so the inner loop has a compile-time trip count, as
-      // la::MatrixCSR::mult does for spmv.
-      auto kernel = [&]<int B>(std::integral_constant<int, B>)
-      {
-        auto out = out_first;
-        for (auto idx = idx_first; idx != idx_last; ++idx)
-          for (int j = 0; j < B; ++j, ++out)
-            *out = *std::next(in_first, (*idx) * B + j);
-      };
-      switch (bs)
-      {
-      case 1:
-        return kernel(std::integral_constant<int, 1>{});
-      case 2:
-        return kernel(std::integral_constant<int, 2>{});
-      case 3:
-        return kernel(std::integral_constant<int, 3>{});
-      default:
-      {
-        auto out = out_first;
-        for (auto idx = idx_first; idx != idx_last; ++idx)
-          out = std::copy_n(std::next(in_first, (*idx) * bs), bs, out);
-      }
-      }
+      // out[i * bs + j] = in[idx[i] * bs + j]
+      dispatch_bs(bs,
+                  [&](auto B)
+                  {
+                    auto out = out_first;
+                    for (auto idx = idx_first; idx != idx_last; ++idx)
+                      for (int j = 0; j < B; ++j, ++out)
+                        *out = *std::next(in_first, (*idx) * B + j);
+                  });
     };
   }
 
@@ -103,31 +122,14 @@ private:
                       const auto in_first, auto out_first)
     {
       // out[idx[i] * bs + j] = in[i * bs + j]
-      auto kernel = [&]<int B>(std::integral_constant<int, B>)
-      {
-        auto in = in_first;
-        for (auto idx = idx_first; idx != idx_last; ++idx)
-          for (int j = 0; j < B; ++j, ++in)
-            *std::next(out_first, (*idx) * B + j) = *in;
-      };
-      switch (bs)
-      {
-      case 1:
-        return kernel(std::integral_constant<int, 1>{});
-      case 2:
-        return kernel(std::integral_constant<int, 2>{});
-      case 3:
-        return kernel(std::integral_constant<int, 3>{});
-      default:
-      {
-        auto in = in_first;
-        for (auto idx = idx_first; idx != idx_last; ++idx)
-        {
-          std::copy_n(in, bs, std::next(out_first, (*idx) * bs));
-          std::advance(in, bs);
-        }
-      }
-      }
+      dispatch_bs(bs,
+                  [&](auto B)
+                  {
+                    auto in = in_first;
+                    for (auto idx = idx_first; idx != idx_last; ++idx)
+                      for (int j = 0; j < B; ++j, ++in)
+                        *std::next(out_first, (*idx) * B + j) = *in;
+                  });
     };
   }
 
@@ -144,13 +146,17 @@ private:
                           const auto in_first, auto out_first)
     {
       // out[idx[i] * bs + j] = op(out[idx[i] * bs + j], in[i * bs + j])
-      auto in = in_first;
-      for (auto idx = idx_first; idx != idx_last; ++idx)
-      {
-        auto out = std::next(out_first, (*idx) * bs);
-        for (int j = 0; j < bs; ++j, ++in, ++out)
-          *out = op(*out, *in);
-      }
+      dispatch_bs(bs,
+                  [&](auto B)
+                  {
+                    auto in = in_first;
+                    for (auto idx = idx_first; idx != idx_last; ++idx)
+                    {
+                      auto out = std::next(out_first, (*idx) * B);
+                      for (int j = 0; j < B; ++j, ++in, ++out)
+                        *out = op(*out, *in);
+                    }
+                  });
     };
   }
 

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -159,8 +159,8 @@ public:
       : _map(map), _bs(bs), _x(bs * (map->size_local() + map->num_ghosts())),
         _scatterer(
             std::make_shared<common::Scatterer<ScatterContainer>>(*_map)),
-        _buffer_local(bs * _scatterer->local_block_indices().size()),
-        _buffer_remote(bs * _scatterer->remote_block_indices().size())
+        _buffer_local(bs * _scatterer->local_indices_block().size()),
+        _buffer_remote(bs * _scatterer->remote_indices_block().size())
   {
   }
 
@@ -208,8 +208,8 @@ public:
   explicit Vector(const Vector<T0, Container0, ScatterContainer0>& x)
       : _map(x.index_map()), _bs(x.bs()), _x(x._x.begin(), x._x.end()),
         _scatterer(scatter_ptr(x._scatterer)), _request(MPI_REQUEST_NULL),
-        _buffer_local(_bs * _scatterer->local_block_indices().size()),
-        _buffer_remote(_bs * _scatterer->remote_block_indices().size())
+        _buffer_local(_bs * _scatterer->local_indices_block().size()),
+        _buffer_remote(_bs * _scatterer->remote_indices_block().size())
   {
   }
 
@@ -249,8 +249,8 @@ public:
              and GetPtrConcept<GetPtr, Container, T>
   void scatter_fwd_begin(U pack, GetPtr get_ptr)
   {
-    pack(_scatterer->local_block_indices().begin(),
-         _scatterer->local_block_indices().end(), _x.begin(),
+    pack(_scatterer->local_indices_block().begin(),
+         _scatterer->local_indices_block().end(), _x.begin(),
          _buffer_local.begin());
     _scatterer->scatter_fwd_begin(get_ptr(_buffer_local),
                                   get_ptr(_buffer_remote), _bs, _request);
@@ -292,8 +292,8 @@ public:
   void scatter_fwd_end(U unpack)
   {
     _scatterer->scatter_fwd_end(_request);
-    unpack(_scatterer->remote_block_indices().begin(),
-           _scatterer->remote_block_indices().end(), _buffer_remote.begin(),
+    unpack(_scatterer->remote_indices_block().begin(),
+           _scatterer->remote_indices_block().end(), _buffer_remote.begin(),
            std::next(_x.begin(), _bs * _map->size_local()));
   }
 
@@ -354,8 +354,8 @@ public:
   void scatter_rev_begin(U pack, GetPtr get_ptr)
   {
     std::int32_t local_size = _bs * _map->size_local();
-    pack(_scatterer->remote_block_indices().begin(),
-         _scatterer->remote_block_indices().end(),
+    pack(_scatterer->remote_indices_block().begin(),
+         _scatterer->remote_indices_block().end(),
          std::next(_x.begin(), local_size), _buffer_remote.begin());
     _scatterer->scatter_rev_begin(get_ptr(_buffer_remote),
                                   get_ptr(_buffer_local), _bs, _request);
@@ -394,8 +394,8 @@ public:
   void scatter_rev_end(U unpack)
   {
     _scatterer->scatter_rev_end(_request);
-    unpack(_scatterer->local_block_indices().begin(),
-           _scatterer->local_block_indices().end(), _buffer_local.begin(),
+    unpack(_scatterer->local_indices_block().begin(),
+           _scatterer->local_indices_block().end(), _buffer_local.begin(),
            _x.begin());
   }
 

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -159,8 +159,8 @@ public:
       : _map(map), _bs(bs), _x(bs * (map->size_local() + map->num_ghosts())),
         _scatterer(
             std::make_shared<common::Scatterer<ScatterContainer>>(*_map)),
-        _buffer_local(bs * _scatterer->local_indices().size()),
-        _buffer_remote(bs * _scatterer->remote_indices().size())
+        _buffer_local(bs * _scatterer->local_block_indices().size()),
+        _buffer_remote(bs * _scatterer->remote_block_indices().size())
   {
   }
 
@@ -208,8 +208,8 @@ public:
   explicit Vector(const Vector<T0, Container0, ScatterContainer0>& x)
       : _map(x.index_map()), _bs(x.bs()), _x(x._x.begin(), x._x.end()),
         _scatterer(scatter_ptr(x._scatterer)), _request(MPI_REQUEST_NULL),
-        _buffer_local(_bs * _scatterer->local_indices().size()),
-        _buffer_remote(_bs * _scatterer->remote_indices().size())
+        _buffer_local(_bs * _scatterer->local_block_indices().size()),
+        _buffer_remote(_bs * _scatterer->remote_block_indices().size())
   {
   }
 
@@ -249,8 +249,9 @@ public:
              and GetPtrConcept<GetPtr, Container, T>
   void scatter_fwd_begin(U pack, GetPtr get_ptr)
   {
-    pack(_scatterer->local_indices().begin(), _scatterer->local_indices().end(),
-         _x.begin(), _buffer_local.begin());
+    pack(_scatterer->local_block_indices().begin(),
+         _scatterer->local_block_indices().end(), _x.begin(),
+         _buffer_local.begin());
     _scatterer->scatter_fwd_begin(get_ptr(_buffer_local),
                                   get_ptr(_buffer_remote), _bs, _request);
   }
@@ -291,8 +292,8 @@ public:
   void scatter_fwd_end(U unpack)
   {
     _scatterer->scatter_fwd_end(_request);
-    unpack(_scatterer->remote_indices().begin(),
-           _scatterer->remote_indices().end(), _buffer_remote.begin(),
+    unpack(_scatterer->remote_block_indices().begin(),
+           _scatterer->remote_block_indices().end(), _buffer_remote.begin(),
            std::next(_x.begin(), _bs * _map->size_local()));
   }
 
@@ -353,9 +354,9 @@ public:
   void scatter_rev_begin(U pack, GetPtr get_ptr)
   {
     std::int32_t local_size = _bs * _map->size_local();
-    pack(_scatterer->remote_indices().begin(),
-         _scatterer->remote_indices().end(), std::next(_x.begin(), local_size),
-         _buffer_remote.begin());
+    pack(_scatterer->remote_block_indices().begin(),
+         _scatterer->remote_block_indices().end(),
+         std::next(_x.begin(), local_size), _buffer_remote.begin());
     _scatterer->scatter_rev_begin(get_ptr(_buffer_remote),
                                   get_ptr(_buffer_local), _bs, _request);
   }
@@ -393,8 +394,8 @@ public:
   void scatter_rev_end(U unpack)
   {
     _scatterer->scatter_rev_end(_request);
-    unpack(_scatterer->local_indices().begin(),
-           _scatterer->local_indices().end(), _buffer_local.begin(),
+    unpack(_scatterer->local_block_indices().begin(),
+           _scatterer->local_block_indices().end(), _buffer_local.begin(),
            _x.begin());
   }
 

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -60,13 +60,35 @@ private:
   /// CPU.
   auto get_pack()
   {
-    return [](typename ScatterContainer::const_iterator idx_first,
-              typename ScatterContainer::const_iterator idx_last,
-              const auto in_first, auto out_first)
+    return [bs = _bs](typename ScatterContainer::const_iterator idx_first,
+                      typename ScatterContainer::const_iterator idx_last,
+                      const auto in_first, auto out_first)
     {
-      // out[i] = in[idx[i]]
-      std::transform(idx_first, idx_last, out_first,
-                     [in_first](auto p) { return *std::next(in_first, p); });
+      // out[i * bs + j] = in[idx[i] * bs + j]. Dispatch on the common
+      // block sizes so the inner loop has a compile-time trip count, as
+      // la::MatrixCSR::mult does for spmv.
+      auto kernel = [&]<int B>(std::integral_constant<int, B>)
+      {
+        auto out = out_first;
+        for (auto idx = idx_first; idx != idx_last; ++idx)
+          for (int j = 0; j < B; ++j, ++out)
+            *out = *std::next(in_first, (*idx) * B + j);
+      };
+      switch (bs)
+      {
+      case 1:
+        return kernel(std::integral_constant<int, 1>{});
+      case 2:
+        return kernel(std::integral_constant<int, 2>{});
+      case 3:
+        return kernel(std::integral_constant<int, 3>{});
+      default:
+      {
+        auto out = out_first;
+        for (auto idx = idx_first; idx != idx_last; ++idx)
+          out = std::copy_n(std::next(in_first, (*idx) * bs), bs, out);
+      }
+      }
     };
   }
 
@@ -76,16 +98,35 @@ private:
   /// Typically used to unpack into ghost entries on a CPU.
   auto get_unpack()
   {
-    return [](typename ScatterContainer::const_iterator idx_first,
-              typename ScatterContainer::const_iterator idx_last,
-              const auto in_first, auto out_first)
+    return [bs = _bs](typename ScatterContainer::const_iterator idx_first,
+                      typename ScatterContainer::const_iterator idx_last,
+                      const auto in_first, auto out_first)
     {
-      // out[idx[i]] = in[i]
-      auto in = in_first;
-      for (typename ScatterContainer::const_iterator idx = idx_first;
-           idx != idx_last; ++idx, ++in)
+      // out[idx[i] * bs + j] = in[i * bs + j]
+      auto kernel = [&]<int B>(std::integral_constant<int, B>)
       {
-        *std::next(out_first, *idx) = *in;
+        auto in = in_first;
+        for (auto idx = idx_first; idx != idx_last; ++idx)
+          for (int j = 0; j < B; ++j, ++in)
+            *std::next(out_first, (*idx) * B + j) = *in;
+      };
+      switch (bs)
+      {
+      case 1:
+        return kernel(std::integral_constant<int, 1>{});
+      case 2:
+        return kernel(std::integral_constant<int, 2>{});
+      case 3:
+        return kernel(std::integral_constant<int, 3>{});
+      default:
+      {
+        auto in = in_first;
+        for (auto idx = idx_first; idx != idx_last; ++idx)
+        {
+          std::copy_n(in, bs, std::next(out_first, (*idx) * bs));
+          std::advance(in, bs);
+        }
+      }
       }
     };
   }
@@ -98,17 +139,17 @@ private:
   template <typename BinaryOp>
   auto get_unpack_op(BinaryOp op)
   {
-    return [op](typename ScatterContainer::const_iterator idx_first,
-                typename ScatterContainer::const_iterator idx_last,
-                const auto in_first, auto out_first)
+    return [op, bs = _bs](typename ScatterContainer::const_iterator idx_first,
+                          typename ScatterContainer::const_iterator idx_last,
+                          const auto in_first, auto out_first)
     {
-      // out[idx[i]] = op(out[idx[i]], in[i])
+      // out[idx[i] * bs + j] = op(out[idx[i] * bs + j], in[i * bs + j])
       auto in = in_first;
-      for (typename ScatterContainer::const_iterator idx = idx_first;
-           idx != idx_last; ++idx, ++in)
+      for (auto idx = idx_first; idx != idx_last; ++idx)
       {
-        auto& out = *std::next(out_first, *idx);
-        out = op(out, *in);
+        auto out = std::next(out_first, (*idx) * bs);
+        for (int j = 0; j < bs; ++j, ++in, ++out)
+          *out = op(*out, *in);
       }
     };
   }
@@ -131,9 +172,9 @@ public:
   Vector(std::shared_ptr<const common::IndexMap> map, int bs)
       : _map(map), _bs(bs), _x(bs * (map->size_local() + map->num_ghosts())),
         _scatterer(
-            std::make_shared<common::Scatterer<ScatterContainer>>(*_map, bs)),
-        _buffer_local(_scatterer->local_indices().size()),
-        _buffer_remote(_scatterer->remote_indices().size())
+            std::make_shared<common::Scatterer<ScatterContainer>>(*_map)),
+        _buffer_local(bs * _scatterer->local_indices().size()),
+        _buffer_remote(bs * _scatterer->remote_indices().size())
   {
   }
 
@@ -181,8 +222,8 @@ public:
   explicit Vector(const Vector<T0, Container0, ScatterContainer0>& x)
       : _map(x.index_map()), _bs(x.bs()), _x(x._x.begin(), x._x.end()),
         _scatterer(scatter_ptr(x._scatterer)), _request(MPI_REQUEST_NULL),
-        _buffer_local(_scatterer->local_indices().size()),
-        _buffer_remote(_scatterer->remote_indices().size())
+        _buffer_local(_bs * _scatterer->local_indices().size()),
+        _buffer_remote(_bs * _scatterer->remote_indices().size())
   {
   }
 
@@ -225,7 +266,7 @@ public:
     pack(_scatterer->local_indices().begin(), _scatterer->local_indices().end(),
          _x.begin(), _buffer_local.begin());
     _scatterer->scatter_fwd_begin(get_ptr(_buffer_local),
-                                  get_ptr(_buffer_remote), _request);
+                                  get_ptr(_buffer_remote), _bs, _request);
   }
 
   /// @brief Begin scatter (send) of local data that is ghosted on other
@@ -330,7 +371,7 @@ public:
          _scatterer->remote_indices().end(), std::next(_x.begin(), local_size),
          _buffer_remote.begin());
     _scatterer->scatter_rev_begin(get_ptr(_buffer_remote),
-                                  get_ptr(_buffer_local), _request);
+                                  get_ptr(_buffer_local), _bs, _request);
   }
 
   /// @brief Start scatter (send) of ghost entry data to the owning

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -72,18 +72,6 @@ private:
       return f(std::integral_constant<int, 2>{});
     case 3:
       return f(std::integral_constant<int, 3>{});
-    case 4:
-      return f(std::integral_constant<int, 4>{});
-    case 5:
-      return f(std::integral_constant<int, 5>{});
-    case 6:
-      return f(std::integral_constant<int, 6>{});
-    case 7:
-      return f(std::integral_constant<int, 7>{});
-    case 8:
-      return f(std::integral_constant<int, 8>{});
-    case 9:
-      return f(std::integral_constant<int, 9>{});
     default:
       return f(bs);
     }
@@ -105,8 +93,11 @@ private:
                   {
                     auto out = out_first;
                     for (auto idx = idx_first; idx != idx_last; ++idx)
-                      for (int j = 0; j < B; ++j, ++out)
-                        *out = *std::next(in_first, (*idx) * B + j);
+                    {
+                      auto in = std::next(in_first, (*idx) * B);
+                      for (int j = 0; j < B; ++j, ++in, ++out)
+                        *out = *in;
+                    }
                   });
     };
   }
@@ -127,8 +118,11 @@ private:
                   {
                     auto in = in_first;
                     for (auto idx = idx_first; idx != idx_last; ++idx)
-                      for (int j = 0; j < B; ++j, ++in)
-                        *std::next(out_first, (*idx) * B + j) = *in;
+                    {
+                      auto out = std::next(out_first, (*idx) * B);
+                      for (int j = 0; j < B; ++j, ++in, ++out)
+                        *out = *in;
+                    }
                   });
     };
   }

--- a/cpp/dolfinx/la/mattrans.h
+++ b/cpp/dolfinx/la/mattrans.h
@@ -271,14 +271,8 @@ dolfinx::la::MatrixCSR<T> transpose(const dolfinx::la::MatrixCSR<T>& A)
   std::vector<T> recv_vals(total_recv * bs[0] * bs[1]);
 
   MPI_Request data_reqs[3];
-  MPI_Datatype mpi_T;
-  if (bs[0] * bs[1] == 1)
-    mpi_T = dolfinx::MPI::mpi_t<T>;
-  else
-  {
-    MPI_Type_contiguous(bs[0] * bs[1], dolfinx::MPI::mpi_t<T>, &mpi_T);
-    MPI_Type_commit(&mpi_T);
-  }
+  const dolfinx::MPI::Datatype block(bs[0] * bs[1], dolfinx::MPI::mpi_t<T>);
+  MPI_Datatype mpi_T = block.type();
 
   MPI_Ineighbor_alltoallv(send_row_gidx.data(), send_count.data(),
                           send_disp.data(), MPI_INT64_T, recv_row_gidx.data(),
@@ -299,8 +293,6 @@ dolfinx::la::MatrixCSR<T> transpose(const dolfinx::la::MatrixCSR<T>& A)
   // Wait for all data exchanges to complete.
   // -----------------------------------------------------------------------
   MPI_Waitall(3, data_reqs, MPI_STATUSES_IGNORE);
-  if (bs[0] * bs[1] != 1)
-    MPI_Type_free(&mpi_T);
   MPI_Comm_free(&neigh_comm);
 
   // -----------------------------------------------------------------------

--- a/cpp/dolfinx/la/mattrans.h
+++ b/cpp/dolfinx/la/mattrans.h
@@ -271,7 +271,7 @@ dolfinx::la::MatrixCSR<T> transpose(const dolfinx::la::MatrixCSR<T>& A)
   std::vector<T> recv_vals(total_recv * bs[0] * bs[1]);
 
   MPI_Request data_reqs[3];
-  const dolfinx::MPI::Datatype block(bs[0] * bs[1], dolfinx::MPI::mpi_t<T>);
+  const dolfinx::MPI::Datatype<T> block(bs[0] * bs[1]);
   MPI_Datatype mpi_T = block.type();
 
   MPI_Ineighbor_alltoallv(send_row_gidx.data(), send_count.data(),

--- a/cpp/dolfinx/refinement/uniform.cpp
+++ b/cpp/dolfinx/refinement/uniform.cpp
@@ -153,20 +153,20 @@ mesh::Mesh<T> refinement::uniform_refine(const mesh::Mesh<T>& mesh,
               local_range[0] + entity_offsets[j]);
 
     common::Scatterer sc(*index_maps[j]);
-    std::vector<std::int64_t> send_buffer(sc.local_indices().size());
+    std::vector<std::int64_t> send_buffer(sc.local_block_indices().size());
     {
-      auto& idx = sc.local_indices();
+      auto& idx = sc.local_block_indices();
       for (std::size_t i = 0; i < idx.size(); ++i)
         send_buffer[i] = new_v[j][idx[i]];
     }
-    std::vector<std::int64_t> recv_buffer(sc.remote_indices().size());
+    std::vector<std::int64_t> recv_buffer(sc.remote_block_indices().size());
     MPI_Request request = MPI_REQUEST_NULL;
     sc.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), 1, request);
     sc.scatter_fwd_end(request);
     {
       std::span ghosts(std::next(new_v[j].begin(), num_entities),
                        new_v[j].end());
-      auto& idx = sc.remote_indices();
+      auto& idx = sc.remote_block_indices();
       for (std::size_t i = 0; i < idx.size(); ++i)
         ghosts[idx[i]] = recv_buffer[i];
     }

--- a/cpp/dolfinx/refinement/uniform.cpp
+++ b/cpp/dolfinx/refinement/uniform.cpp
@@ -152,7 +152,7 @@ mesh::Mesh<T> refinement::uniform_refine(const mesh::Mesh<T>& mesh,
     std::iota(new_v[j].begin(), std::next(new_v[j].begin(), num_entities),
               local_range[0] + entity_offsets[j]);
 
-    common::Scatterer sc(*index_maps[j], 1);
+    common::Scatterer sc(*index_maps[j]);
     std::vector<std::int64_t> send_buffer(sc.local_indices().size());
     {
       auto& idx = sc.local_indices();
@@ -161,7 +161,7 @@ mesh::Mesh<T> refinement::uniform_refine(const mesh::Mesh<T>& mesh,
     }
     std::vector<std::int64_t> recv_buffer(sc.remote_indices().size());
     MPI_Request request = MPI_REQUEST_NULL;
-    sc.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), request);
+    sc.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), 1, request);
     sc.scatter_fwd_end(request);
     {
       std::span ghosts(std::next(new_v[j].begin(), num_entities),

--- a/cpp/dolfinx/refinement/uniform.cpp
+++ b/cpp/dolfinx/refinement/uniform.cpp
@@ -153,20 +153,20 @@ mesh::Mesh<T> refinement::uniform_refine(const mesh::Mesh<T>& mesh,
               local_range[0] + entity_offsets[j]);
 
     common::Scatterer sc(*index_maps[j]);
-    std::vector<std::int64_t> send_buffer(sc.local_block_indices().size());
+    std::vector<std::int64_t> send_buffer(sc.local_indices_block().size());
     {
-      auto& idx = sc.local_block_indices();
+      auto& idx = sc.local_indices_block();
       for (std::size_t i = 0; i < idx.size(); ++i)
         send_buffer[i] = new_v[j][idx[i]];
     }
-    std::vector<std::int64_t> recv_buffer(sc.remote_block_indices().size());
+    std::vector<std::int64_t> recv_buffer(sc.remote_indices_block().size());
     MPI_Request request = MPI_REQUEST_NULL;
     sc.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), 1, request);
     sc.scatter_fwd_end(request);
     {
       std::span ghosts(std::next(new_v[j].begin(), num_entities),
                        new_v[j].end());
-      auto& idx = sc.remote_block_indices();
+      auto& idx = sc.remote_indices_block();
       for (std::size_t i = 0; i < idx.size(); ++i)
         ghosts[idx[i]] = recv_buffer[i];
     }

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -49,7 +49,7 @@ void test_scatter_fwd(int n)
   const common::IndexMap idx_map
       = create_index_map(MPI_COMM_WORLD, size_local, (mpi_size - 1) * 3);
   std::int32_t num_ghosts = idx_map.num_ghosts();
-  common::Scatterer sct(idx_map, n);
+  common::Scatterer sct(idx_map);
 
   // Create some data to scatter
   const std::int64_t val = 11;
@@ -58,20 +58,22 @@ void test_scatter_fwd(int n)
 
   // Scatter values to ghost and check value is correctly received
   {
-    std::vector<std::int64_t> send_buffer(sct.local_indices().size());
+    std::vector<std::int64_t> send_buffer(n * sct.local_indices().size());
     {
       auto& idx = sct.local_indices();
       for (std::size_t i = 0; i < idx.size(); ++i)
-        send_buffer[i] = data_local[idx[i]];
+        for (int j = 0; j < n; ++j)
+          send_buffer[i * n + j] = data_local[idx[i] * n + j];
     }
-    std::vector<std::int64_t> recv_buffer(sct.remote_indices().size());
+    std::vector<std::int64_t> recv_buffer(n * sct.remote_indices().size());
     MPI_Request request = MPI_REQUEST_NULL;
-    sct.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), request);
+    sct.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), n, request);
     sct.scatter_fwd_end(request);
     {
       auto& idx = sct.remote_indices();
       for (std::size_t i = 0; i < idx.size(); ++i)
-        data_ghost[idx[i]] = recv_buffer[i];
+        for (int j = 0; j < n; ++j)
+          data_ghost[idx[i] * n + j] = recv_buffer[i * n + j];
     }
     CHECK((int)data_ghost.size() == n * num_ghosts);
     CHECK(std::ranges::all_of(
@@ -93,20 +95,25 @@ void test_scatter_rev()
       = create_index_map(MPI_COMM_WORLD, size_local, (mpi_size - 1) * 3);
   std::int32_t num_ghosts = idx_map.num_ghosts();
 
-  common::Scatterer<std::vector<std::int32_t>> sct(idx_map, n);
+  common::Scatterer<std::vector<std::int32_t>> sct(idx_map);
   {
     common::Scatterer<std::vector<std::int64_t>> sct2(sct);
   }
 
-  auto pack_fn = [](auto&& in, auto&& idx, auto&& out)
+  auto pack_fn = [n](auto&& in, auto&& idx, auto&& out)
   {
     for (std::size_t i = 0; i < idx.size(); ++i)
-      out[i] = in[idx[i]];
+      for (int j = 0; j < n; ++j)
+        out[i * n + j] = in[idx[i] * n + j];
   };
-  auto unpack_fn = [](auto&& in, auto&& idx, auto&& out, auto op)
+  auto unpack_fn = [n](auto&& in, auto&& idx, auto&& out, auto op)
   {
     for (std::size_t i = 0; i < idx.size(); ++i)
-      out[idx[i]] = op(out[idx[i]], in[i]);
+      for (int j = 0; j < n; ++j)
+      {
+        auto& o = out[idx[i] * n + j];
+        o = op(o, in[i * n + j]);
+      }
   };
 
   // Create some data, setting ghost values
@@ -115,10 +122,10 @@ void test_scatter_rev()
   std::vector<std::int64_t> data_ghost(n * num_ghosts, value);
   {
     MPI_Request request = MPI_REQUEST_NULL;
-    std::vector<std::int64_t> send_buffer(sct.remote_indices().size(), 0);
+    std::vector<std::int64_t> send_buffer(n * sct.remote_indices().size(), 0);
     pack_fn(data_ghost, sct.remote_indices(), send_buffer);
-    std::vector<std::int64_t> recv_buffer(sct.local_indices().size(), 0);
-    sct.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), request);
+    std::vector<std::int64_t> recv_buffer(n * sct.local_indices().size(), 0);
+    sct.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), n, request);
     sct.scatter_rev_end(request);
     unpack_fn(recv_buffer, sct.local_indices(), data_local, std::plus<>{});
 
@@ -132,10 +139,10 @@ void test_scatter_rev()
   // data_local rather than overwriting it
   {
     MPI_Request request = MPI_REQUEST_NULL;
-    std::vector<std::int64_t> send_buffer(sct.remote_indices().size(), 0);
+    std::vector<std::int64_t> send_buffer(n * sct.remote_indices().size(), 0);
     pack_fn(data_ghost, sct.remote_indices(), send_buffer);
-    std::vector<std::int64_t> recv_buffer(sct.local_indices().size(), 0);
-    sct.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), request);
+    std::vector<std::int64_t> recv_buffer(n * sct.local_indices().size(), 0);
+    sct.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), n, request);
     sct.scatter_rev_end(request);
     unpack_fn(recv_buffer, sct.local_indices(), data_local, std::plus<>{});
 
@@ -164,13 +171,13 @@ void test_scatter_with_isolated_rank()
   }
 
   const common::IndexMap map(MPI_COMM_WORLD, 1, src_dest, ghosts, owners);
-  const common::Scatterer scatterer(map, 1);
+  const common::Scatterer scatterer(map);
 
   {
     std::vector<std::int64_t> send_buffer(scatterer.local_indices().size(), 17);
     std::vector<std::int64_t> recv_buffer(scatterer.remote_indices().size());
     MPI_Request request = MPI_REQUEST_NULL;
-    scatterer.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(),
+    scatterer.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), 1,
                                 request);
     CHECK(request != MPI_REQUEST_NULL);
     scatterer.scatter_fwd_end(request);
@@ -183,7 +190,7 @@ void test_scatter_with_isolated_rank()
                                           29);
     std::vector<std::int64_t> recv_buffer(scatterer.local_indices().size());
     MPI_Request request = MPI_REQUEST_NULL;
-    scatterer.scatter_rev_begin(send_buffer.data(), recv_buffer.data(),
+    scatterer.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), 1,
                                 request);
     CHECK(request != MPI_REQUEST_NULL);
     scatterer.scatter_rev_end(request);

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -58,19 +58,20 @@ void test_scatter_fwd(int n)
 
   // Scatter values to ghost and check value is correctly received
   {
-    std::vector<std::int64_t> send_buffer(n * sct.local_indices().size());
+    std::vector<std::int64_t> send_buffer(n * sct.local_block_indices().size());
     {
-      auto& idx = sct.local_indices();
+      auto& idx = sct.local_block_indices();
       for (std::size_t i = 0; i < idx.size(); ++i)
         for (int j = 0; j < n; ++j)
           send_buffer[i * n + j] = data_local[idx[i] * n + j];
     }
-    std::vector<std::int64_t> recv_buffer(n * sct.remote_indices().size());
+    std::vector<std::int64_t> recv_buffer(n
+                                          * sct.remote_block_indices().size());
     MPI_Request request = MPI_REQUEST_NULL;
     sct.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), n, request);
     sct.scatter_fwd_end(request);
     {
-      auto& idx = sct.remote_indices();
+      auto& idx = sct.remote_block_indices();
       for (std::size_t i = 0; i < idx.size(); ++i)
         for (int j = 0; j < n; ++j)
           data_ghost[idx[i] * n + j] = recv_buffer[i * n + j];
@@ -122,12 +123,15 @@ void test_scatter_rev()
   std::vector<std::int64_t> data_ghost(n * num_ghosts, value);
   {
     MPI_Request request = MPI_REQUEST_NULL;
-    std::vector<std::int64_t> send_buffer(n * sct.remote_indices().size(), 0);
-    pack_fn(data_ghost, sct.remote_indices(), send_buffer);
-    std::vector<std::int64_t> recv_buffer(n * sct.local_indices().size(), 0);
+    std::vector<std::int64_t> send_buffer(n * sct.remote_block_indices().size(),
+                                          0);
+    pack_fn(data_ghost, sct.remote_block_indices(), send_buffer);
+    std::vector<std::int64_t> recv_buffer(n * sct.local_block_indices().size(),
+                                          0);
     sct.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), n, request);
     sct.scatter_rev_end(request);
-    unpack_fn(recv_buffer, sct.local_indices(), data_local, std::plus<>{});
+    unpack_fn(recv_buffer, sct.local_block_indices(), data_local,
+              std::plus<>{});
 
     std::int64_t sum;
     CHECK((int)data_local.size() == n * size_local);
@@ -139,12 +143,15 @@ void test_scatter_rev()
   // data_local rather than overwriting it
   {
     MPI_Request request = MPI_REQUEST_NULL;
-    std::vector<std::int64_t> send_buffer(n * sct.remote_indices().size(), 0);
-    pack_fn(data_ghost, sct.remote_indices(), send_buffer);
-    std::vector<std::int64_t> recv_buffer(n * sct.local_indices().size(), 0);
+    std::vector<std::int64_t> send_buffer(n * sct.remote_block_indices().size(),
+                                          0);
+    pack_fn(data_ghost, sct.remote_block_indices(), send_buffer);
+    std::vector<std::int64_t> recv_buffer(n * sct.local_block_indices().size(),
+                                          0);
     sct.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), n, request);
     sct.scatter_rev_end(request);
-    unpack_fn(recv_buffer, sct.local_indices(), data_local, std::plus<>{});
+    unpack_fn(recv_buffer, sct.local_block_indices(), data_local,
+              std::plus<>{});
 
     std::int64_t sum = std::reduce(data_local.begin(), data_local.end(), 0);
     CHECK(sum == 2 * n * value * num_ghosts);
@@ -174,8 +181,10 @@ void test_scatter_with_isolated_rank()
   const common::Scatterer scatterer(map);
 
   {
-    std::vector<std::int64_t> send_buffer(scatterer.local_indices().size(), 17);
-    std::vector<std::int64_t> recv_buffer(scatterer.remote_indices().size());
+    std::vector<std::int64_t> send_buffer(
+        scatterer.local_block_indices().size(), 17);
+    std::vector<std::int64_t> recv_buffer(
+        scatterer.remote_block_indices().size());
     MPI_Request request = MPI_REQUEST_NULL;
     scatterer.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), 1,
                                 request);
@@ -186,9 +195,10 @@ void test_scatter_with_isolated_rank()
   }
 
   {
-    std::vector<std::int64_t> send_buffer(scatterer.remote_indices().size(),
-                                          29);
-    std::vector<std::int64_t> recv_buffer(scatterer.local_indices().size());
+    std::vector<std::int64_t> send_buffer(
+        scatterer.remote_block_indices().size(), 29);
+    std::vector<std::int64_t> recv_buffer(
+        scatterer.local_block_indices().size());
     MPI_Request request = MPI_REQUEST_NULL;
     scatterer.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), 1,
                                 request);

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -13,9 +13,11 @@
 #include <dolfinx/common/MPI.h>
 #include <dolfinx/common/Scatterer.h>
 #include <dolfinx/common/utils.h>
+#include <functional>
 #include <iostream>
 #include <numeric>
 #include <set>
+#include <utility>
 #include <vector>
 
 using namespace dolfinx;
@@ -39,7 +41,7 @@ common::IndexMap create_index_map(MPI_Comm comm, int size_local, int num_ghosts)
                           global_ghost_owner);
 }
 
-void test_scatter_fwd(int n)
+void test_scatter_fwd(int n, bool use_dtype)
 {
   const int mpi_size = dolfinx::MPI::size(MPI_COMM_WORLD);
   const int mpi_rank = dolfinx::MPI::rank(MPI_COMM_WORLD);
@@ -49,7 +51,11 @@ void test_scatter_fwd(int n)
   const common::IndexMap idx_map
       = create_index_map(MPI_COMM_WORLD, size_local, (mpi_size - 1) * 3);
   std::int32_t num_ghosts = idx_map.num_ghosts();
-  common::Scatterer sct(idx_map);
+
+  // Move, rather than copy, the Scatterer: a copy would duplicate the
+  // communicators, which is collective
+  common::Scatterer sct0(idx_map);
+  common::Scatterer sct = std::move(sct0);
 
   // Create some data to scatter
   const std::int64_t val = 11;
@@ -58,20 +64,29 @@ void test_scatter_fwd(int n)
 
   // Scatter values to ghost and check value is correctly received
   {
-    std::vector<std::int64_t> send_buffer(n * sct.local_block_indices().size());
+    std::vector<std::int64_t> send_buffer(n * sct.local_indices_block().size());
     {
-      auto& idx = sct.local_block_indices();
+      auto& idx = sct.local_indices_block();
       for (std::size_t i = 0; i < idx.size(); ++i)
         for (int j = 0; j < n; ++j)
           send_buffer[i * n + j] = data_local[idx[i] * n + j];
     }
     std::vector<std::int64_t> recv_buffer(n
-                                          * sct.remote_block_indices().size());
+                                          * sct.remote_indices_block().size());
     MPI_Request request = MPI_REQUEST_NULL;
-    sct.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), n, request);
+    if (use_dtype)
+    {
+      // Destroyed before scatter_fwd_end, since MPI keeps a datatype
+      // alive until communication using it has completed
+      const dolfinx::MPI::Datatype<std::int64_t> type(n);
+      sct.scatter_fwd_begin_dtype(send_buffer.data(), recv_buffer.data(),
+                                  type.type(), request);
+    }
+    else
+      sct.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), n, request);
     sct.scatter_fwd_end(request);
     {
-      auto& idx = sct.remote_block_indices();
+      auto& idx = sct.remote_indices_block();
       for (std::size_t i = 0; i < idx.size(); ++i)
         for (int j = 0; j < n; ++j)
           data_ghost[idx[i] * n + j] = recv_buffer[i * n + j];
@@ -83,7 +98,7 @@ void test_scatter_fwd(int n)
   }
 }
 
-void test_scatter_rev()
+void test_scatter_rev(bool use_dtype)
 {
   // Block size
   auto n = GENERATE(1, 5, 10);
@@ -100,6 +115,22 @@ void test_scatter_rev()
   {
     common::Scatterer<std::vector<std::int64_t>> sct2(sct);
   }
+
+  // Start a reverse scatter through either the block size or the MPI
+  // datatype interface
+  auto rev_begin_fn
+      = [&sct, n, use_dtype](const std::int64_t* send_buffer,
+                             std::int64_t* recv_buffer, MPI_Request& request)
+  {
+    if (use_dtype)
+    {
+      const dolfinx::MPI::Datatype<std::int64_t> type(n);
+      sct.scatter_rev_begin_dtype(send_buffer, recv_buffer, type.type(),
+                                  request);
+    }
+    else
+      sct.scatter_rev_begin(send_buffer, recv_buffer, n, request);
+  };
 
   auto pack_fn = [n](auto&& in, auto&& idx, auto&& out)
   {
@@ -123,14 +154,14 @@ void test_scatter_rev()
   std::vector<std::int64_t> data_ghost(n * num_ghosts, value);
   {
     MPI_Request request = MPI_REQUEST_NULL;
-    std::vector<std::int64_t> send_buffer(n * sct.remote_block_indices().size(),
+    std::vector<std::int64_t> send_buffer(n * sct.remote_indices_block().size(),
                                           0);
-    pack_fn(data_ghost, sct.remote_block_indices(), send_buffer);
-    std::vector<std::int64_t> recv_buffer(n * sct.local_block_indices().size(),
+    pack_fn(data_ghost, sct.remote_indices_block(), send_buffer);
+    std::vector<std::int64_t> recv_buffer(n * sct.local_indices_block().size(),
                                           0);
-    sct.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), n, request);
+    rev_begin_fn(send_buffer.data(), recv_buffer.data(), request);
     sct.scatter_rev_end(request);
-    unpack_fn(recv_buffer, sct.local_block_indices(), data_local,
+    unpack_fn(recv_buffer, sct.local_indices_block(), data_local,
               std::plus<>{});
 
     std::int64_t sum;
@@ -143,14 +174,14 @@ void test_scatter_rev()
   // data_local rather than overwriting it
   {
     MPI_Request request = MPI_REQUEST_NULL;
-    std::vector<std::int64_t> send_buffer(n * sct.remote_block_indices().size(),
+    std::vector<std::int64_t> send_buffer(n * sct.remote_indices_block().size(),
                                           0);
-    pack_fn(data_ghost, sct.remote_block_indices(), send_buffer);
-    std::vector<std::int64_t> recv_buffer(n * sct.local_block_indices().size(),
+    pack_fn(data_ghost, sct.remote_indices_block(), send_buffer);
+    std::vector<std::int64_t> recv_buffer(n * sct.local_indices_block().size(),
                                           0);
-    sct.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), n, request);
+    rev_begin_fn(send_buffer.data(), recv_buffer.data(), request);
     sct.scatter_rev_end(request);
-    unpack_fn(recv_buffer, sct.local_block_indices(), data_local,
+    unpack_fn(recv_buffer, sct.local_indices_block(), data_local,
               std::plus<>{});
 
     std::int64_t sum = std::reduce(data_local.begin(), data_local.end(), 0);
@@ -182,9 +213,9 @@ void test_scatter_with_isolated_rank()
 
   {
     std::vector<std::int64_t> send_buffer(
-        scatterer.local_block_indices().size(), 17);
+        scatterer.local_indices_block().size(), 17);
     std::vector<std::int64_t> recv_buffer(
-        scatterer.remote_block_indices().size());
+        scatterer.remote_indices_block().size());
     MPI_Request request = MPI_REQUEST_NULL;
     scatterer.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), 1,
                                 request);
@@ -196,9 +227,9 @@ void test_scatter_with_isolated_rank()
 
   {
     std::vector<std::int64_t> send_buffer(
-        scatterer.remote_block_indices().size(), 29);
+        scatterer.remote_indices_block().size(), 29);
     std::vector<std::int64_t> recv_buffer(
-        scatterer.local_block_indices().size());
+        scatterer.local_indices_block().size());
     MPI_Request request = MPI_REQUEST_NULL;
     scatterer.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), 1,
                                 request);
@@ -207,6 +238,88 @@ void test_scatter_with_isolated_rank()
     if (mpi_rank == 0)
       CHECK(recv_buffer == std::vector<std::int64_t>{29});
   }
+}
+
+// A copy of a Scatterer duplicates the communicators, so the copy must
+// describe the same communication pattern as the original. A move takes
+// the communicators over.
+void test_scatter_copy_move()
+{
+  const int mpi_size = dolfinx::MPI::size(MPI_COMM_WORLD);
+  const int mpi_rank = dolfinx::MPI::rank(MPI_COMM_WORLD);
+  // Must be at least the ghost count, so that every ghost index is in
+  // the owning rank's range
+  constexpr int size_local = 100;
+  const common::IndexMap idx_map
+      = create_index_map(MPI_COMM_WORLD, size_local, (mpi_size - 1) * 3);
+
+  const std::int64_t val = 11;
+  const std::vector<std::int64_t> data_local(size_local, val * mpi_rank);
+
+  // Forward scatter data_local through `s`, returning the ghost values
+  // received
+  auto fwd = [&data_local](auto&& s)
+  {
+    const auto& idx_local = s.local_indices_block();
+    std::vector<std::int64_t> send_buffer(idx_local.size());
+    for (std::size_t i = 0; i < idx_local.size(); ++i)
+      send_buffer[i] = data_local[idx_local[i]];
+
+    std::vector<std::int64_t> recv_buffer(s.remote_indices_block().size(), -1);
+    MPI_Request request = MPI_REQUEST_NULL;
+    s.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), 1, request);
+    s.scatter_fwd_end(request);
+    return recv_buffer;
+  };
+
+  common::Scatterer sct(idx_map);
+  const std::vector<std::int64_t> expected = fwd(sct);
+  // `val` is a constant expression, so it needs no capture
+  CHECK(
+      std::ranges::all_of(expected, [mpi_rank, mpi_size](std::int64_t i)
+                          { return i == val * ((mpi_rank + 1) % mpi_size); }));
+
+  // Copy, and copy to a different index container type
+  {
+    const common::Scatterer sct_copy(sct);
+    CHECK(sct_copy.local_indices_block() == sct.local_indices_block());
+    CHECK(sct_copy.remote_indices_block() == sct.remote_indices_block());
+    CHECK(fwd(sct_copy) == expected);
+
+    const common::Scatterer<std::vector<std::int64_t>> sct_cast(sct);
+    CHECK(fwd(sct_cast) == expected);
+  }
+
+  // Move construction, then move assignment onto a Scatterer that
+  // already holds communicators
+  {
+    common::Scatterer sct_move(std::move(sct));
+    CHECK(fwd(sct_move) == expected);
+
+    common::Scatterer sct_target(idx_map);
+    sct_target = std::move(sct_move);
+    CHECK(fwd(sct_target) == expected);
+  }
+}
+
+// On a single-rank communicator there are no neighbours, so a scatter
+// performs no communication and leaves the request as MPI_REQUEST_NULL
+void test_scatter_single_rank()
+{
+  const common::IndexMap map(MPI_COMM_SELF, 4);
+  const common::Scatterer sct(map);
+  CHECK(sct.local_indices_block().empty());
+  CHECK(sct.remote_indices_block().empty());
+
+  std::vector<std::int64_t> send_buffer(4, 0), recv_buffer(4, 0);
+  MPI_Request request = MPI_REQUEST_NULL;
+  sct.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), 1, request);
+  CHECK(request == MPI_REQUEST_NULL);
+  sct.scatter_fwd_end(request);
+
+  sct.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), 1, request);
+  CHECK(request == MPI_REQUEST_NULL);
+  sct.scatter_rev_end(request);
 }
 
 void test_consensus_exchange()
@@ -279,12 +392,24 @@ void test_rank_weights()
 TEST_CASE("Scatter forward using IndexMap", "[index_map_scatter_fwd]")
 {
   auto n = GENERATE(1, 5, 10);
-  CHECK_NOTHROW(test_scatter_fwd(n));
+  auto use_dtype = GENERATE(false, true);
+  CHECK_NOTHROW(test_scatter_fwd(n, use_dtype));
 }
 
 TEST_CASE("Scatter reverse using IndexMap", "[index_map_scatter_rev]")
 {
-  CHECK_NOTHROW(test_scatter_rev());
+  auto use_dtype = GENERATE(false, true);
+  CHECK_NOTHROW(test_scatter_rev(use_dtype));
+}
+
+TEST_CASE("Scatter with a copied and a moved Scatterer", "[index_map_scatter]")
+{
+  CHECK_NOTHROW(test_scatter_copy_move());
+}
+
+TEST_CASE("Scatter on a single rank", "[index_map_scatter]")
+{
+  CHECK_NOTHROW(test_scatter_single_rank());
 }
 
 TEST_CASE("Scatter with an isolated rank", "[index_map_scatter]")

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -72,9 +72,9 @@ void common(nb::module_& m)
       .value("min", dolfinx::Table::Reduction::min)
       .value("average", dolfinx::Table::Reduction::average);
 
-  auto sc = nb::class_<dolfinx::common::Scatterer<>>(m, "Scatterer")
-                .def(nb::init<dolfinx::common::IndexMap&, int>(),
-                     nb::arg("index_map"), nb::arg("block_size"));
+  auto sc
+      = nb::class_<dolfinx::common::Scatterer<>>(m, "Scatterer")
+            .def(nb::init<dolfinx::common::IndexMap&>(), nb::arg("index_map"));
   declare_scatter_functions<std::int64_t>(sc);
   declare_scatter_functions<double>(sc);
   declare_scatter_functions<float>(sc);

--- a/python/dolfinx/wrappers/dolfinx_wrappers/common.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/common.h
@@ -26,76 +26,81 @@ void declare_scatter_functions(
       "scatter_fwd",
       [](dolfinx::common::Scatterer<>& self,
          nb::ndarray<const T, nb::ndim<1>, nb::c_contig> local_data,
-         nb::ndarray<T, nb::ndim<1>, nb::c_contig> remote_data)
+         nb::ndarray<T, nb::ndim<1>, nb::c_contig> remote_data, int bs)
       {
-        if (local_data.size() < self.local_indices().size())
+        if (local_data.size() < bs * self.local_indices().size())
         {
           throw std::runtime_error(
               "Local data buffer too small in forward scatter.");
         }
-        if (remote_data.size() < self.remote_indices().size())
+        if (remote_data.size() < bs * self.remote_indices().size())
         {
           throw std::runtime_error(
               "Ghost data buffer too small in forward scatter.");
         }
 
-        std::vector<T> send_buffer(self.local_indices().size());
+        std::vector<T> send_buffer(bs * self.local_indices().size());
         {
           auto _local_data = local_data.view();
           auto& idx = self.local_indices();
           for (std::size_t i = 0; i < idx.size(); ++i)
-            send_buffer[i] = _local_data(idx[i]);
+            for (int j = 0; j < bs; ++j)
+              send_buffer[i * bs + j] = _local_data(idx[i] * bs + j);
         }
-        std::vector<T> recv_buffer(self.remote_indices().size());
+        std::vector<T> recv_buffer(bs * self.remote_indices().size());
         MPI_Request request = MPI_REQUEST_NULL;
-        self.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), request);
+        self.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), bs,
+                               request);
         self.scatter_fwd_end(request);
         {
           auto _remote_data = remote_data.view();
           auto& idx = self.remote_indices();
           for (std::size_t i = 0; i < idx.size(); ++i)
-            _remote_data(idx[i]) = recv_buffer[i];
+            for (int j = 0; j < bs; ++j)
+              _remote_data(idx[i] * bs + j) = recv_buffer[i * bs + j];
         }
       },
-      nb::arg("local_data"), nb::arg("remote_data"));
+      nb::arg("local_data"), nb::arg("remote_data"), nb::arg("bs"));
 
   sc.def(
       "scatter_rev",
       [](dolfinx::common::Scatterer<>& self,
          nb::ndarray<T, nb::ndim<1>, nb::c_contig> local_data,
-         nb::ndarray<const T, nb::ndim<1>, nb::c_contig> remote_data)
+         nb::ndarray<const T, nb::ndim<1>, nb::c_contig> remote_data, int bs)
       {
-        if (local_data.size() < self.local_indices().size())
+        if (local_data.size() < bs * self.local_indices().size())
         {
           throw std::runtime_error(
               "Local data buffer too small in reverse scatter.");
         }
-        if (remote_data.size() < self.remote_indices().size())
+        if (remote_data.size() < bs * self.remote_indices().size())
         {
           throw std::runtime_error(
               "Ghost data buffer too small in reverse scatter.");
         }
 
-        std::vector<T> send_buffer(self.remote_indices().size());
+        std::vector<T> send_buffer(bs * self.remote_indices().size());
         {
           auto _remote_data = remote_data.view();
           auto& idx = self.remote_indices();
           for (std::size_t i = 0; i < idx.size(); ++i)
-            send_buffer[i] = _remote_data(idx[i]);
+            for (int j = 0; j < bs; ++j)
+              send_buffer[i * bs + j] = _remote_data(idx[i] * bs + j);
         }
-        std::vector<T> recv_buffer(self.local_indices().size());
+        std::vector<T> recv_buffer(bs * self.local_indices().size());
         MPI_Request request = MPI_REQUEST_NULL;
-        self.scatter_rev_begin<T>(send_buffer.data(), recv_buffer.data(),
+        self.scatter_rev_begin<T>(send_buffer.data(), recv_buffer.data(), bs,
                                   request);
         self.scatter_rev_end(request);
         {
           auto _local_data = local_data.view();
           auto& idx = self.local_indices();
           for (std::size_t i = 0; i < idx.size(); ++i)
-            _local_data(idx[i]) += recv_buffer[i];
+            for (int j = 0; j < bs; ++j)
+              _local_data(idx[i] * bs + j) += recv_buffer[i * bs + j];
         }
       },
-      nb::arg("local_data"), nb::arg("remote_data"));
+      nb::arg("local_data"), nb::arg("remote_data"), nb::arg("bs"));
 }
 
 } // namespace dolfinx_wrappers

--- a/python/dolfinx/wrappers/dolfinx_wrappers/common.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/common.h
@@ -28,33 +28,33 @@ void declare_scatter_functions(
          nb::ndarray<const T, nb::ndim<1>, nb::c_contig> local_data,
          nb::ndarray<T, nb::ndim<1>, nb::c_contig> remote_data, int bs)
       {
-        if (local_data.size() < bs * self.local_indices().size())
+        if (local_data.size() < bs * self.local_block_indices().size())
         {
           throw std::runtime_error(
               "Local data buffer too small in forward scatter.");
         }
-        if (remote_data.size() < bs * self.remote_indices().size())
+        if (remote_data.size() < bs * self.remote_block_indices().size())
         {
           throw std::runtime_error(
               "Ghost data buffer too small in forward scatter.");
         }
 
-        std::vector<T> send_buffer(bs * self.local_indices().size());
+        std::vector<T> send_buffer(bs * self.local_block_indices().size());
         {
           auto _local_data = local_data.view();
-          auto& idx = self.local_indices();
+          auto& idx = self.local_block_indices();
           for (std::size_t i = 0; i < idx.size(); ++i)
             for (int j = 0; j < bs; ++j)
               send_buffer[i * bs + j] = _local_data(idx[i] * bs + j);
         }
-        std::vector<T> recv_buffer(bs * self.remote_indices().size());
+        std::vector<T> recv_buffer(bs * self.remote_block_indices().size());
         MPI_Request request = MPI_REQUEST_NULL;
         self.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), bs,
                                request);
         self.scatter_fwd_end(request);
         {
           auto _remote_data = remote_data.view();
-          auto& idx = self.remote_indices();
+          auto& idx = self.remote_block_indices();
           for (std::size_t i = 0; i < idx.size(); ++i)
             for (int j = 0; j < bs; ++j)
               _remote_data(idx[i] * bs + j) = recv_buffer[i * bs + j];
@@ -68,33 +68,33 @@ void declare_scatter_functions(
          nb::ndarray<T, nb::ndim<1>, nb::c_contig> local_data,
          nb::ndarray<const T, nb::ndim<1>, nb::c_contig> remote_data, int bs)
       {
-        if (local_data.size() < bs * self.local_indices().size())
+        if (local_data.size() < bs * self.local_block_indices().size())
         {
           throw std::runtime_error(
               "Local data buffer too small in reverse scatter.");
         }
-        if (remote_data.size() < bs * self.remote_indices().size())
+        if (remote_data.size() < bs * self.remote_block_indices().size())
         {
           throw std::runtime_error(
               "Ghost data buffer too small in reverse scatter.");
         }
 
-        std::vector<T> send_buffer(bs * self.remote_indices().size());
+        std::vector<T> send_buffer(bs * self.remote_block_indices().size());
         {
           auto _remote_data = remote_data.view();
-          auto& idx = self.remote_indices();
+          auto& idx = self.remote_block_indices();
           for (std::size_t i = 0; i < idx.size(); ++i)
             for (int j = 0; j < bs; ++j)
               send_buffer[i * bs + j] = _remote_data(idx[i] * bs + j);
         }
-        std::vector<T> recv_buffer(bs * self.local_indices().size());
+        std::vector<T> recv_buffer(bs * self.local_block_indices().size());
         MPI_Request request = MPI_REQUEST_NULL;
         self.scatter_rev_begin<T>(send_buffer.data(), recv_buffer.data(), bs,
                                   request);
         self.scatter_rev_end(request);
         {
           auto _local_data = local_data.view();
-          auto& idx = self.local_indices();
+          auto& idx = self.local_block_indices();
           for (std::size_t i = 0; i < idx.size(); ++i)
             for (int j = 0; j < bs; ++j)
               _local_data(idx[i] * bs + j) += recv_buffer[i * bs + j];

--- a/python/dolfinx/wrappers/dolfinx_wrappers/common.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/common.h
@@ -28,33 +28,33 @@ void declare_scatter_functions(
          nb::ndarray<const T, nb::ndim<1>, nb::c_contig> local_data,
          nb::ndarray<T, nb::ndim<1>, nb::c_contig> remote_data, int bs)
       {
-        if (local_data.size() < bs * self.local_block_indices().size())
+        if (local_data.size() < bs * self.local_indices_block().size())
         {
           throw std::runtime_error(
               "Local data buffer too small in forward scatter.");
         }
-        if (remote_data.size() < bs * self.remote_block_indices().size())
+        if (remote_data.size() < bs * self.remote_indices_block().size())
         {
           throw std::runtime_error(
               "Ghost data buffer too small in forward scatter.");
         }
 
-        std::vector<T> send_buffer(bs * self.local_block_indices().size());
+        std::vector<T> send_buffer(bs * self.local_indices_block().size());
         {
           auto _local_data = local_data.view();
-          auto& idx = self.local_block_indices();
+          auto& idx = self.local_indices_block();
           for (std::size_t i = 0; i < idx.size(); ++i)
             for (int j = 0; j < bs; ++j)
               send_buffer[i * bs + j] = _local_data(idx[i] * bs + j);
         }
-        std::vector<T> recv_buffer(bs * self.remote_block_indices().size());
+        std::vector<T> recv_buffer(bs * self.remote_indices_block().size());
         MPI_Request request = MPI_REQUEST_NULL;
         self.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), bs,
                                request);
         self.scatter_fwd_end(request);
         {
           auto _remote_data = remote_data.view();
-          auto& idx = self.remote_block_indices();
+          auto& idx = self.remote_indices_block();
           for (std::size_t i = 0; i < idx.size(); ++i)
             for (int j = 0; j < bs; ++j)
               _remote_data(idx[i] * bs + j) = recv_buffer[i * bs + j];
@@ -68,33 +68,33 @@ void declare_scatter_functions(
          nb::ndarray<T, nb::ndim<1>, nb::c_contig> local_data,
          nb::ndarray<const T, nb::ndim<1>, nb::c_contig> remote_data, int bs)
       {
-        if (local_data.size() < bs * self.local_block_indices().size())
+        if (local_data.size() < bs * self.local_indices_block().size())
         {
           throw std::runtime_error(
               "Local data buffer too small in reverse scatter.");
         }
-        if (remote_data.size() < bs * self.remote_block_indices().size())
+        if (remote_data.size() < bs * self.remote_indices_block().size())
         {
           throw std::runtime_error(
               "Ghost data buffer too small in reverse scatter.");
         }
 
-        std::vector<T> send_buffer(bs * self.remote_block_indices().size());
+        std::vector<T> send_buffer(bs * self.remote_indices_block().size());
         {
           auto _remote_data = remote_data.view();
-          auto& idx = self.remote_block_indices();
+          auto& idx = self.remote_indices_block();
           for (std::size_t i = 0; i < idx.size(); ++i)
             for (int j = 0; j < bs; ++j)
               send_buffer[i * bs + j] = _remote_data(idx[i] * bs + j);
         }
-        std::vector<T> recv_buffer(bs * self.local_block_indices().size());
+        std::vector<T> recv_buffer(bs * self.local_indices_block().size());
         MPI_Request request = MPI_REQUEST_NULL;
         self.scatter_rev_begin<T>(send_buffer.data(), recv_buffer.data(), bs,
                                   request);
         self.scatter_rev_end(request);
         {
           auto _local_data = local_data.view();
-          auto& idx = self.local_block_indices();
+          auto& idx = self.local_indices_block();
           for (std::size_t i = 0; i < idx.size(); ++i)
             for (int j = 0; j < bs; ++j)
               _local_data(idx[i] * bs + j) += recv_buffer[i * bs + j];

--- a/python/test/unit/common/test_scatterer.py
+++ b/python/test/unit/common/test_scatterer.py
@@ -22,13 +22,13 @@ def test_scatter_forward(dtype):
     map = IndexMap(comm, local_size, [dest, src], map_ghosts, src)
     assert map.size_global == local_size * comm.size
 
-    sc = _cpp.common.Scatterer(map, 1)
+    sc = _cpp.common.Scatterer(map)
     v = np.zeros((map.size_local + map.num_ghosts), dtype=dtype)
 
     # Fill local part with rank of this process and scatter
     v[: map.size_local] = comm.rank
     assert np.all(v[map.size_local :] == 0)
-    sc.scatter_fwd(v, v[map.size_local :])
+    sc.scatter_fwd(v, v[map.size_local :], 1)
     # Received values should match the owners in the index map
     assert np.all(v[map.size_local :] == map.owners)
 
@@ -47,9 +47,9 @@ def test_scatter_reverse(dtype):
     assert map.size_global == local_size * comm.size
 
     # Fill ghost part with ones and reverse scatter
-    sc = _cpp.common.Scatterer(map, 1)
+    sc = _cpp.common.Scatterer(map)
     v = np.zeros((local_size + map.num_ghosts), dtype=dtype)
     v[local_size:] = 1
 
-    sc.scatter_rev(v, v[local_size:])
+    sc.scatter_rev(v, v[local_size:], 1)
     assert sum(v[:local_size]) == comm.size - 1


### PR DESCRIPTION
## Summary

Takes the block size out of `common::Scatterer`. A `Scatterer` currently
expands its indices, sizes and displacements for a block size fixed at
construction, so it can serve exactly one block size. Send blocks rather than
scalars, using a contiguous derived datatype, and that dependence goes away:

- The constructor takes only an `IndexMap`. Sizes, displacements, the ghost
  permutation and the owned shared indices are all in blocks.
- `scatter_fwd_begin` / `scatter_rev_begin` take a block size and build an
  `MPI_Type_contiguous` for the transfer. For `bs == 1` no type is created.
- `la::Vector` does the blocking in its pack/unpack, and sizes its buffers as
  `bs * blocks`.

This is @garth-wells' suggestion from review of #4484:

> I think the Scatterer PRs are getting too elaborate by overlooking a core
> issue: the scatter depends on the block size. If we use `MPI_Type_contiguous`
> the Scatterer becomes independent of the block size and simplifications
> follow.

## Why

A block size-free `Scatterer` is reusable across every `la::Vector` over an
index map, whatever their block sizes. That is the property #3065 and #3061
need — they are about a code creating many `Function`s and exhausting the
neighbourhood communicators, two of which every `Scatterer` creates.

This PR deliberately stops at making the `Scatterer` reusable. **It does not
decide who should reuse it**, and adds no cache or sharing of its own, so it
is independent of the open question on #4293 and #4484. `la::Vector` still
builds its own `Scatterer` per construction, exactly as on `main`.

## The datatype costs nothing

Measured at np = 3, 5000 blocks of 3 doubles:

| | derived type | scalar type |
| --- | --- | --- |
| `MPI_Neighbor_alltoallv` | 11.29 us | 11.56 us |
| `MPI_Ineighbor_alltoallv` (what `Scatterer` uses) | 12.12 us | 12.93 us |
| `MPI_Type_contiguous` + commit + free | 0.153 us | — |

The derived type is marginally faster in both, and creation is noise against a
~20 us scatter, so the type is built per call under RAII rather than cached. A
cached `static MPI_Datatype` was tried and rejected: it is never freed before
`MPI_Finalize` and is not thread safe, and it measured no faster.

## The pack/unpack dispatch is not optional

With block indices, the pack/unpack inner loop runs over the block size. Left
as a runtime value the compiler cannot unroll it, and that alone makes this
change a 2x regression. On the pack kernel in isolation, 5000 blocks:

| | |
| --- | --- |
| blocked, block size a compile-time constant | 3.57 us |
| blocked, block size a runtime value | 17.41 us |
| flat, pre-expanded indices (what this replaces) | 3.72 us |

`Vector::dispatch_bs` therefore calls the kernels with the block size as an
`std::integral_constant` for sizes 1, 2 and 3, and as a plain `int` otherwise.
That range matches the rest of the library — `la::MatrixCSR::mult` and
`fem/pack.h` dispatch 1, 2 and 3, and the assemblers dispatch 1 and 3. The
kernels are written once and take the block size as a value, so the same source
serves both paths.

Reviewers should know this is load-bearing: it looks like an optimisation and
is actually what makes the approach viable.

## Performance

Release build, np = 3, 100k owned and 5000 ghost indices, microseconds per
scatter:

| bs | fwd, this branch | fwd, main | rev, this branch | rev, main |
| --- | --- | --- | --- | --- |
| 1 | 10.4 | 10.1 | 10.7 | 10.2 |
| 2 | **15.0** | 15.9 | 17.1 | 17.4 |
| 3 | **20.1** | 22.4 | **22.7** | 24.5 |
| 4 | 32.1 | 28.3 | 34.0 | 32.5 |
| 9 | **52.4** | 64.5 | **56.0** | 71.5 |

`bs = 1` is a wash within run-to-run variation. Block sizes 2 and 3 are faster,
because one blocked index replaces `bs` expanded ones in the pack/unpack
gather.

**Block sizes 4 to 8 are the cost of this change**: they fall outside the
dispatched range, and `bs = 4` is about 14% slower on a forward scatter.
Extending the dispatch to 9 removes it entirely (`bs = 4` becomes 23.5 us,
faster than main), but no other dispatch site in the library goes past 3, so I
have kept the convention rather than the microseconds. Say if you would rather
have it the other way round. Note that `bs = 9` is already well ahead without
dispatch, because at large block sizes main's gather over `bs * N` expanded
indices is itself the bottleneck — so the regression window is only 4 to 8.

Benchmarking found two defects before these numbers were reached, both fixed
here: `scatter_rev` was slower than `main` at every block size, because
`get_unpack_op` had been left with a runtime trip count while the forward
kernels were dispatched; and block sizes outside the dispatched set fell off a
cliff (`bs = 4` at 38 us against main's 28 us) because the fallback used a
per-index `std::copy_n`, i.e. a `memmove` call per index.

## API changes

```cpp
// common::Scatterer
Scatterer(const IndexMap& map);                     // was (map, bs)
void scatter_fwd_begin(const T*, T*, int bs, MPI_Request&) const;
void scatter_rev_begin(const T*, T*, int bs, MPI_Request&) const;
const container_type& local_block_indices() const;  // was local_indices()
const container_type& remote_block_indices() const; // was remote_indices()
```

**The buffer size contract changes**, and the rename is there to enforce it.
The accessors return block indices now, so a buffer is `bs * size()` long
rather than `size()`. Adding the `bs` argument makes stale *calls* fail to
compile, but it would not have caught stale *sizing*:

```cpp
std::vector<T> send_buffer(sct.local_indices().size());   // bs times too small
```

That compiles, and MPI writes past the end of it — and the sizing usually sits
several lines from the call the compiler does flag. Renaming turns that silent
heap overflow into a compile error. No runtime check is possible: the scatter
functions take raw pointers so that device pointers work, so there is no size
to assert against.

Python-facing: `_cpp.common.Scatterer(index_map)`, and `scatter_fwd` /
`scatter_rev` take a block size.

`la::Vector`'s public interface is unchanged. It is also, on this branch, not
possible to give a `Vector` a scatterer whose block size disagrees with its
own: the `Scatterer` has no block size, `Vector` has no scatterer-taking
constructor and no `scatterer()` accessor, and the one `_bs` is used both to
size the buffers and to make the scatter call. On `main` the `Scatterer`
carries a block size that has to match the `Vector`'s, with nothing enforcing
it.

## Tests

`cpp/test/common/index_map.cpp` and `python/test/unit/common/test_scatterer.py`
are updated for the block indices and the block size argument; their coverage
is otherwise unchanged, including `GENERATE(1, 5, 10)` block sizes — note that
5 and 10 exercise the dispatched and fallback paths respectively.

Passing at np = 1, 2 and 3 in both Developer and Release builds, with zero
failures:

| | C++ (Catch2) | Python (pytest) |
| --- | --- | --- |
| np = 1 | 82 cases | 3492 passed, 110 skipped, 21 xfailed |
| np = 2 | 82 cases | — |
| np = 3 | 82 cases | 2432 passed, 1088 skipped, 21 xfailed |

The Doxygen build is also clean (`cpp/doc/Doxyfile`, which treats warnings as
errors).
`clang-format`, `ruff`, `ruff format` and `gersemi` clean; mypy unchanged
against its pre-existing baseline.

## Relationship to #4483 and #4484

#4484 caches a communication pattern on `IndexMap`, splitting `Scatterer` in
two along the block size boundary. If this lands, that split is unnecessary:
there is nothing left to separate, and the thing to cache is simply the
`Scatterer`. I would close #4484 in favour of a much smaller follow-up.

#4483 adds a constructor letting a caller supply a `Vector`'s `Scatterer`. It
survives, but its `Scatterer::bs()` accessor does not, and its constructor
reverts to `(map, bs, scatterer)` since the scatterer no longer knows the
block size.

One thing this PR does **not** address: a block size-free `Scatterer` is still
templated on the index container, so a GPU `Scatterer<device_vector>` cannot
share a CPU one and still duplicates the communicators. The block size axis and
the container axis are separate problems.

## Incidental cleanups

Two things this change made possible, in separate commits:

- **`dolfinx::MPI::Datatype<T>`.** The contiguous-datatype wrapper this PR
  needs already existed hand-rolled in `la/mattrans.h`: a raw `MPI_Datatype`, a
  conditional create and commit, and a conditional free 25 lines later, each
  guarded by its own copy of the `bs[0] * bs[1] == 1` test. Promoting the
  wrapper to `common/MPI.h`, beside `MPI::Comm` and following the same
  handle-owner pattern, lets `mattrans.h` drop both guards and the raw handle.
  It is templated on the value type rather than taking a base datatype,
  because every site that builds one builds it over something `mpi_t` already
  names. Like every other datatype creation in the library it is not error
  checked: these are local calls, there is no communicator to abort on, and
  under the default `MPI_ERRORS_ARE_FATAL` handler a failure aborts before a
  return code is visible. Four further sites create contiguous types by hand
  and could adopt it (`graph/partition.cpp` twice, `mesh/graphbuild.cpp`,
  `io/utils.h`, `common/MPI.h`); they are unconditional so they gain less, and
  are left alone.
- **`get_unpack` is now `get_unpack_op`** with an operation that keeps the
  received value. After the block size dispatch the two kernels were identical
  apart from that, so one of three near-identical kernels goes.

---

AI assistance: I used Claude Code (Opus) to draft parts of this PR. I reviewed,
edited, tested, and take responsibility for the final contribution.
