### PR TITLE
Fix doc toc navigation

### DIFF
--- a/python/doc/source/demos.rst
+++ b/python/doc/source/demos.rst
@@ -10,7 +10,76 @@ equation <demos/demo_poisson>` is recommended.
 PDEs (introductory)
 -------------------
 
+* :doc:`demos/demo_poisson`
+* :doc:`demos/demo_helmholtz`
+* :doc:`demos/demo_scattering-boundary-conditions`
+* :doc:`demos/demo_pml`
+* :doc:`demos/demo_half-loaded-waveguide`
+* :doc:`demos/demo_axis`
+
+PDEs (advanced)
+---------------
+
+* :doc:`demos/demo_mixed-poisson`
+* :doc:`demos/demo_stokes`
+* :doc:`demos/demo_navier-stokes`
+* :doc:`demos/demo_elasticity`
+* :doc:`demos/demo_cahn-hilliard`
+* :doc:`demos/demo_static-condensation`
+* :doc:`demos/demo_biharmonic`
+* :doc:`demos/demo_types`
+* :doc:`demos/demo_poisson-matrix-free`
+* :doc:`demos/demo_pyamg`
+* :doc:`demos/demo_hdg`
+* :doc:`demos/demo_mixed-topology`
+* :doc:`demos/demo_matrix-free-petsc`
+
+Nonlinear problems
+------------------
+
+* :doc:`demos/demo_cahn-hilliard`
+
+
+Mesh generation
+---------------
+
+* :doc:`demos/demo_gmsh`
+
+
+Interpolation, IO and visualisation
+-----------------------------------
+
+* :doc:`demos/demo_pyvista`
+* :doc:`demos/demo_interpolation-io`
+
+
+Advanced iterative solvers
+--------------------------
+
+* :doc:`demos/demo_stokes`
+* :doc:`demos/demo_elasticity`
+
+
+User-defined and advanced finite elements
+-----------------------------------------
+
+* :doc:`demos/demo_lagrange-variants`
+* :doc:`demos/demo_tnt-elements`
+
+
+Mesh partitioning and parallel communication analysis
+-----------------------------------------------------
+
+* :doc:`demos/demo_partition`
+* :doc:`demos/demo_comm-pattern`
+
+
+.. 
+   The following hidden toctree serves as the master site map for Sphinx. 
+   It ensures the left sidebar populates cleanly without duplicating items.
+
 .. toctree::
+   :hidden:
    :maxdepth: 1
 
    demos/demo_poisson.md
@@ -19,13 +88,6 @@ PDEs (introductory)
    demos/demo_pml.md
    demos/demo_half-loaded-waveguide.md
    demos/demo_axis.md
-
-PDEs (advanced)
----------------
-
-.. toctree::
-   :maxdepth: 1
-
    demos/demo_mixed-poisson.md
    demos/demo_stokes.md
    demos/demo_navier-stokes.md
@@ -39,94 +101,10 @@ PDEs (advanced)
    demos/demo_hdg.md
    demos/demo_mixed-topology.md
    demos/demo_matrix-free-petsc.md
-
-
-
-Nonlinear problems
-------------------
-
-.. toctree::
-   :maxdepth: 1
-
-   demos/demo_cahn-hilliard.md
-
-
-Mesh generation
----------------
-
-.. toctree::
-   :maxdepth: 1
-
    demos/demo_gmsh.md
-
-
-Interpolation, IO and visualisation
------------------------------------
-
-.. toctree::
-   :maxdepth: 1
-
    demos/demo_pyvista.md
    demos/demo_interpolation-io.md
-
-
-Advanced iterative solvers
---------------------------
-
-.. toctree::
-   :maxdepth: 1
-
-   demos/demo_stokes.md
-   demos/demo_elasticity.md
-
-
-User-defined and advanced finite elements
------------------------------------------
-
-.. toctree::
-   :maxdepth: 1
-
    demos/demo_lagrange-variants.md
    demos/demo_tnt-elements.md
-
-
-Mesh partitioning and parallel communication analysis
------------------------------------------------------
-
-.. toctree::
-   :maxdepth: 1
-
-   demos/demo_partition.md
-   demos/demo_comm-pattern.md
-
-
-List of all demos
------------------
-
-.. toctree::
-   :maxdepth: 1
-
-   demos/demo_poisson.md
-   demos/demo_biharmonic.md
-   demos/demo_cahn-hilliard.md
-   demos/demo_stokes.md
-   demos/demo_elasticity.md
-   demos/demo_gmsh.md
-   demos/demo_helmholtz.md
-   demos/demo_static-condensation.md
-   demos/demo_pyvista.md
-   demos/demo_interpolation-io.md
-   demos/demo_types.md
-   demos/demo_lagrange-variants.md
-   demos/demo_tnt-elements.md
-   demos/demo_scattering-boundary-conditions.md
-   demos/demo_pml.md
-   demos/demo_half-loaded-waveguide.md
-   demos/demo_axis.md
-   demos/demo_navier-stokes.md
-   demos/demo_mixed-poisson.md
-   demos/demo_pyamg.md
-   demos/demo_hdg.md
-   demos/demo_mixed-topology.md
    demos/demo_partition.md
    demos/demo_comm-pattern.md


### PR DESCRIPTION
The current documentation navigation tool is utterly cluttered:
<img width="4286" height="3278" alt="image" src="https://github.com/user-attachments/assets/793cc11e-ea26-47a4-b6cc-9029618c1ecd" />
Reported by @edvardak
Fix created with the help of Google Gemini (Sept 2026).
New docs built locally and looks like
<img width="4286" height="3278" alt="image" src="https://github.com/user-attachments/assets/e2bdeb5b-70b9-49c6-8ce6-9586b36bc12e" />
