### PR TITLE
Add one-shot common::scatter_fwd/scatter_rev helpers

### DIFF
--- a/cpp/dolfinx/common/Scatterer.h
+++ b/cpp/dolfinx/common/Scatterer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2026 Igor Baratta and Garth N. Wells
+// Copyright (C) 2022-2026 Igor Baratta, Garth N. Wells and Jack S. Hale
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -12,6 +12,8 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <concepts>
+#include <cstddef>
 #include <cstdint>
 #include <mpi.h>
 #include <numeric>
@@ -597,4 +599,95 @@ private:
   // Displacements of local data for mpi scatter and gather
   std::vector<int> _displs_local;
 };
+
+/// @brief One-shot forward (owner -> ghost) scatter of host data.
+///
+/// Packs `local_data`, communicates, and unpacks into `remote_data`.
+/// The send and receive buffers are allocated for the duration of the
+/// call. For repeated scatters where the allocation matters, use
+/// Scatterer::scatter_fwd_begin and Scatterer::scatter_fwd_end
+/// directly, or la::Vector, which holds persistent buffers.
+///
+/// @note Collective MPI operation.
+/// @note For host data. `Container` is constrained to containers with
+/// raw pointer storage, which excludes the device containers used in
+/// GPU builds, but host residency of `local_data` and `remote_data` is
+/// a caller precondition that is not checked.
+///
+/// @param[in] sc Scatterer describing the communication pattern.
+/// @param[in] local_data Owned values, blocked by local index.
+/// @param[out] remote_data Ghost values, blocked by ghost index, i.e.
+/// indexed from the first ghost.
+/// @param[in] bs Number of values per index (the block size).
+template <typename T, class Container>
+  requires requires(Container c) {
+    { c.data() } -> std::same_as<typename Container::value_type*>;
+  }
+void scatter_fwd(const Scatterer<Container>& sc, std::span<const T> local_data,
+                 std::span<T> remote_data, int bs)
+{
+  const Container& local_inds = sc.local_indices_block();
+  std::vector<T> send_buffer(bs * local_inds.size());
+  for (std::size_t i = 0; i < local_inds.size(); ++i)
+    for (int j = 0; j < bs; ++j)
+      send_buffer[i * bs + j] = local_data[local_inds[i] * bs + j];
+
+  const Container& remote_inds = sc.remote_indices_block();
+  std::vector<T> recv_buffer(bs * remote_inds.size());
+  MPI_Request request = MPI_REQUEST_NULL;
+  sc.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), bs, request);
+  sc.scatter_fwd_end(request);
+
+  for (std::size_t i = 0; i < remote_inds.size(); ++i)
+    for (int j = 0; j < bs; ++j)
+      remote_data[remote_inds[i] * bs + j] = recv_buffer[i * bs + j];
+}
+
+/// @brief One-shot reverse (ghost -> owner) scatter of host data.
+///
+/// Packs `remote_data`, communicates, and accumulates into `local_data`
+/// using `op`. The send and receive buffers are allocated for the
+/// duration of the call. For repeated scatters where the allocation
+/// matters, use Scatterer::scatter_rev_begin and
+/// Scatterer::scatter_rev_end directly, or la::Vector, which holds
+/// persistent buffers.
+///
+/// @note Collective MPI operation.
+/// @note For host data, see ::scatter_fwd.
+///
+/// @param[in] sc Scatterer describing the communication pattern.
+/// @param[in,out] local_data Owned values, blocked by local index.
+/// @param[in] remote_data Ghost values, blocked by ghost index, i.e.
+/// indexed from the first ghost.
+/// @param[in] bs Number of values per index (the block size).
+/// @param[in] op Binary operation applied as `local_data[i] =
+/// op(received, local_data[i])`, e.g. `std::plus<T>()` to accumulate.
+template <typename T, class Container, typename BinaryOperation>
+  requires requires(Container c) {
+    { c.data() } -> std::same_as<typename Container::value_type*>;
+  }
+void scatter_rev(const Scatterer<Container>& sc, std::span<T> local_data,
+                 std::span<const T> remote_data, int bs, BinaryOperation op)
+{
+  const Container& remote_inds = sc.remote_indices_block();
+  std::vector<T> send_buffer(bs * remote_inds.size());
+  for (std::size_t i = 0; i < remote_inds.size(); ++i)
+    for (int j = 0; j < bs; ++j)
+      send_buffer[i * bs + j] = remote_data[remote_inds[i] * bs + j];
+
+  const Container& local_inds = sc.local_indices_block();
+  std::vector<T> recv_buffer(bs * local_inds.size());
+  MPI_Request request = MPI_REQUEST_NULL;
+  sc.scatter_rev_begin(send_buffer.data(), recv_buffer.data(), bs, request);
+  sc.scatter_rev_end(request);
+
+  for (std::size_t i = 0; i < local_inds.size(); ++i)
+  {
+    for (int j = 0; j < bs; ++j)
+    {
+      T& x = local_data[local_inds[i] * bs + j];
+      x = op(recv_buffer[i * bs + j], x);
+    }
+  }
+}
 } // namespace dolfinx::common

--- a/cpp/dolfinx/refinement/uniform.cpp
+++ b/cpp/dolfinx/refinement/uniform.cpp
@@ -12,6 +12,7 @@
 #include <dolfinx/mesh/utils.h>
 #include <format>
 #include <iterator>
+#include <span>
 #include <vector>
 
 using namespace dolfinx;
@@ -153,23 +154,9 @@ mesh::Mesh<T> refinement::uniform_refine(const mesh::Mesh<T>& mesh,
               local_range[0] + entity_offsets[j]);
 
     common::Scatterer sc(*index_maps[j]);
-    std::vector<std::int64_t> send_buffer(sc.local_indices_block().size());
-    {
-      auto& idx = sc.local_indices_block();
-      for (std::size_t i = 0; i < idx.size(); ++i)
-        send_buffer[i] = new_v[j][idx[i]];
-    }
-    std::vector<std::int64_t> recv_buffer(sc.remote_indices_block().size());
-    MPI_Request request = MPI_REQUEST_NULL;
-    sc.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), 1, request);
-    sc.scatter_fwd_end(request);
-    {
-      std::span ghosts(std::next(new_v[j].begin(), num_entities),
-                       new_v[j].end());
-      auto& idx = sc.remote_indices_block();
-      for (std::size_t i = 0; i < idx.size(); ++i)
-        ghosts[idx[i]] = recv_buffer[i];
-    }
+    std::span<std::int64_t> v(new_v[j]);
+    common::scatter_fwd<std::int64_t>(sc, v.first(num_entities),
+                                      v.subspan(num_entities), 1);
   }
 
   // Create new topology

--- a/cpp/test/common/index_map.cpp
+++ b/cpp/test/common/index_map.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <numeric>
 #include <set>
+#include <span>
 #include <utility>
 #include <vector>
 
@@ -387,6 +388,47 @@ void test_rank_weights()
     REQUIRE(weight_dest.empty());
   }
 }
+
+/// Check the one-shot common::scatter_fwd/scatter_rev helpers. Only
+/// std::int8_t is exercised here: the other host types are covered
+/// through the Python bindings, which delegate to these helpers, but are
+/// instantiated only for int64/float/double.
+void test_scatter_helpers_int8()
+{
+  const int mpi_size = dolfinx::MPI::size(MPI_COMM_WORLD);
+  const int mpi_rank = dolfinx::MPI::rank(MPI_COMM_WORLD);
+  constexpr int size_local = 100;
+  constexpr int bs = 2;
+
+  const common::IndexMap idx_map
+      = create_index_map(MPI_COMM_WORLD, size_local, (mpi_size - 1) * 3);
+  const std::int32_t num_ghosts = idx_map.num_ghosts();
+  const common::Scatterer sct(idx_map);
+
+  // Forward scatter the owning rank (+1, to keep zero distinguishable
+  // from an untouched buffer)
+  const std::vector<std::int8_t> data_local(
+      bs * size_local, static_cast<std::int8_t>(1 + mpi_rank % 5));
+  std::vector<std::int8_t> data_ghost(bs * num_ghosts, 0);
+  common::scatter_fwd<std::int8_t>(sct,
+                                   std::span<const std::int8_t>(data_local),
+                                   std::span<std::int8_t>(data_ghost), bs);
+  const std::int8_t expected
+      = static_cast<std::int8_t>(1 + (mpi_rank + 1) % mpi_size % 5);
+  CHECK(std::ranges::all_of(data_ghost, [expected](std::int8_t v)
+                            { return v == expected; }));
+
+  // Reverse scatter, accumulating each ghost value onto its owner. Every
+  // ghost index is ghosted by exactly one rank, so each contribution
+  // arrives once.
+  std::ranges::fill(data_ghost, std::int8_t(2));
+  std::vector<std::int8_t> data_owned(bs * size_local, 0);
+  common::scatter_rev<std::int8_t>(sct, std::span<std::int8_t>(data_owned),
+                                   std::span<const std::int8_t>(data_ghost), bs,
+                                   std::plus<std::int8_t>());
+  CHECK(std::accumulate(data_owned.begin(), data_owned.end(), std::int64_t(0))
+        == 2 * bs * num_ghosts);
+}
 } // namespace
 
 TEST_CASE("Scatter forward using IndexMap", "[index_map_scatter_fwd]")
@@ -432,4 +474,9 @@ TEST_CASE("Split IndexMap communicator by type", "[index_map_comm_split]")
 TEST_CASE("IndexMap stats", "[index_map_stats]")
 {
   CHECK_NOTHROW(test_rank_weights());
+}
+
+TEST_CASE("One-shot scatter helpers", "[index_map_scatter_helpers]")
+{
+  CHECK_NOTHROW(test_scatter_helpers_int8());
 }

--- a/python/dolfinx/wrappers/dolfinx_wrappers/common.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/common.h
@@ -7,11 +7,11 @@
 #pragma once
 
 #include <dolfinx/common/Scatterer.h>
-#include <mpi.h>
+#include <functional>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
+#include <span>
 #include <stdexcept>
-#include <vector>
 
 namespace dolfinx_wrappers
 {
@@ -39,26 +39,9 @@ void declare_scatter_functions(
               "Ghost data buffer too small in forward scatter.");
         }
 
-        std::vector<T> send_buffer(bs * self.local_indices_block().size());
-        {
-          auto _local_data = local_data.view();
-          auto& idx = self.local_indices_block();
-          for (std::size_t i = 0; i < idx.size(); ++i)
-            for (int j = 0; j < bs; ++j)
-              send_buffer[i * bs + j] = _local_data(idx[i] * bs + j);
-        }
-        std::vector<T> recv_buffer(bs * self.remote_indices_block().size());
-        MPI_Request request = MPI_REQUEST_NULL;
-        self.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), bs,
-                               request);
-        self.scatter_fwd_end(request);
-        {
-          auto _remote_data = remote_data.view();
-          auto& idx = self.remote_indices_block();
-          for (std::size_t i = 0; i < idx.size(); ++i)
-            for (int j = 0; j < bs; ++j)
-              _remote_data(idx[i] * bs + j) = recv_buffer[i * bs + j];
-        }
+        dolfinx::common::scatter_fwd<T>(
+            self, std::span<const T>(local_data.data(), local_data.size()),
+            std::span<T>(remote_data.data(), remote_data.size()), bs);
       },
       nb::arg("local_data"), nb::arg("remote_data"), nb::arg("bs"));
 
@@ -79,26 +62,10 @@ void declare_scatter_functions(
               "Ghost data buffer too small in reverse scatter.");
         }
 
-        std::vector<T> send_buffer(bs * self.remote_indices_block().size());
-        {
-          auto _remote_data = remote_data.view();
-          auto& idx = self.remote_indices_block();
-          for (std::size_t i = 0; i < idx.size(); ++i)
-            for (int j = 0; j < bs; ++j)
-              send_buffer[i * bs + j] = _remote_data(idx[i] * bs + j);
-        }
-        std::vector<T> recv_buffer(bs * self.local_indices_block().size());
-        MPI_Request request = MPI_REQUEST_NULL;
-        self.scatter_rev_begin<T>(send_buffer.data(), recv_buffer.data(), bs,
-                                  request);
-        self.scatter_rev_end(request);
-        {
-          auto _local_data = local_data.view();
-          auto& idx = self.local_indices_block();
-          for (std::size_t i = 0; i < idx.size(); ++i)
-            for (int j = 0; j < bs; ++j)
-              _local_data(idx[i] * bs + j) += recv_buffer[i * bs + j];
-        }
+        dolfinx::common::scatter_rev<T>(
+            self, std::span<T>(local_data.data(), local_data.size()),
+            std::span<const T>(remote_data.data(), remote_data.size()), bs,
+            std::plus<T>());
       },
       nb::arg("local_data"), nb::arg("remote_data"), nb::arg("bs"));
 }


### PR DESCRIPTION
## Summary

The pack → `scatter_fwd_begin` → `scatter_fwd_end` → unpack sequence around
`common::Scatterer` is written out by hand at every call site. This adds two
free functions in `dolfinx::common` that do it in one call for contiguous host
data, and uses them where the hand-rolled version bought nothing:

- `refinement/uniform.cpp` — fwd (`std::int64_t`), 18 lines → 3.
- `wrappers/dolfinx_wrappers/common.h` — fwd + rev (`int64`/`float`/`double`),
  both lambda bodies now delegate.

```cpp
template <typename T, class Container>
  requires requires(Container c) {
    { c.data() } -> std::same_as<typename Container::value_type*>;
  }
void scatter_fwd(const Scatterer<Container>& sc, std::span<const T> local_data,
                 std::span<T> remote_data, int bs);

template <typename T, class Container, typename BinaryOperation>
  requires requires(Container c) {
    { c.data() } -> std::same_as<typename Container::value_type*>;
  }
void scatter_rev(const Scatterer<Container>& sc, std::span<T> local_data,
                 std::span<const T> remote_data, int bs, BinaryOperation op);
```

This supersedes #4482, which was written before #4487 moved the block size out
of `common::Scatterer`.

## Design notes

- **Free functions, not members.** A one-shot member must allocate buffers
  internally, contradicting the documented contract that a `Scatterer` is
  stateless. A free function taking `const Scatterer&` leaves the caller owning
  the `Scatterer`, so its construction can still be amortised.
- **Two spans, not array + offset.** `Scatterer` stores no `IndexMap`, so an
  offset would have to be recomputed by every caller. This also matches the
  existing Python binding signature exactly, so `test_scatterer.py` passes
  unchanged. A caller with one contiguous array splits it with `x.first(n)` /
  `x.subspan(n)`.
- **The `Container` constraint** is the one `la::Vector` uses to select its CPU
  overloads: raw-pointer storage, which GPU device containers lack, so a
  `thrust::device_vector` is rejected at the constraint rather than deep in the
  body. It is a capability check, not a memory-space check — host residency of
  the spans stays a documented caller precondition.
- **`la::Vector` is untouched**, deliberately: it allocates its buffers once in
  the constructor (a per-call allocation would land on every solver iteration),
  exposes `begin`/`end` separately for comm/compute overlap, is generic over
  device storage that `std::span` cannot express, and unpacks at
  `_bs * size_local()`, which it knows and the helper does not.
- **No regression.** Both converted sites already allocated exactly these two
  buffers per call; the allocation moved rather than appeared.

## Tests

- `test_scatterer.py` passes unchanged — its calls now route through the
  helpers, covering `int64`/`float32`/`float64`, both directions, serial and
  parallel, with no new test code.
- One new `[index_map_scatter_helpers]` case in `cpp/test/common/index_map.cpp`
  for `std::int8_t` with `bs = 2` — a narrow signed type, and the only host type
  the bindings do not instantiate.

Verified: full C++ suite on 1, 2 and 3 ranks; `pytest -k "scatterer or refine"`
(81 tests) serial and on 3 ranks; `clang-format`, `ruff`, `ruff format`,
`gersemi` clean. mypy matches its pre-existing baseline — no Python source is
touched.

---

AI assistance: I used Claude Code to draft parts of this PR. I reviewed,
edited, tested, and take responsibility for the final contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
