### PR TITLE
Nanobind layer wrapper review fixes

### DIFF
--- a/python/dolfinx/fem/assemble.py
+++ b/python/dolfinx/fem/assemble.py
@@ -486,7 +486,7 @@ def apply_lifting(
         ]
 
     if coeffs is None:
-        coeffs = [pack_coefficients(form) for form in a]
+        coeffs = [pack_coefficients(form) if form is not None else {} for form in a]
 
     _a = [None if form is None else form._cpp_object for form in a]
     _bcs = [[bc._cpp_object for bc in bcs0] for bcs0 in bcs]

--- a/python/dolfinx/fem/petsc.py
+++ b/python/dolfinx/fem/petsc.py
@@ -591,7 +591,7 @@ def _assemble_matrix_petsc(
         if coeffs is None:
             coeffs = pack_coefficients(a)
         _bcs = [bc._cpp_object for bc in bcs] if bcs is not None else []
-        _cpp.fem.petsc.assemble_matrix(A, a._cpp_object, constants, coeffs, _bcs)  # type: ignore
+        _cpp.fem.petsc.assemble_matrix(A, a._cpp_object, constants, coeffs, _bcs, False)  # type: ignore
         if a.function_spaces[0] is a.function_spaces[1]:
             A.assemblyBegin(PETSc.Mat.AssemblyType.FLUSH)  # type: ignore[arg-type]
             A.assemblyEnd(PETSc.Mat.AssemblyType.FLUSH)  # type: ignore[arg-type]

--- a/python/dolfinx/graph.py
+++ b/python/dolfinx/graph.py
@@ -236,7 +236,7 @@ def comm_graph(map: _cpp.common.IndexMap, root: int = 0) -> AdjacencyList:
     Returns:
         An adjacency list representing the communication graph.
     """
-    return AdjacencyList(_cpp.graph.comm_graph(map))
+    return AdjacencyList(_cpp.graph.comm_graph(map, root))
 
 
 def comm_graph_data(

--- a/python/dolfinx/wrappers/common.cpp
+++ b/python/dolfinx/wrappers/common.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2019 Chris Richardson and Garth N. Wells
+// Copyright (C) 2017-2026 Chris Richardson and Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -8,6 +8,10 @@
 #include "dolfinx_wrappers/MPICommWrapper.h"
 #include "dolfinx_wrappers/array.h"
 #include "dolfinx_wrappers/caster_mpi.h"
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstdint>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/Scatterer.h>
 #include <dolfinx/common/Table.h>
@@ -150,8 +154,8 @@ void common(nb::module_& m)
           [](const dolfinx::common::IndexMap& self)
           {
             std::span ghosts = self.ghosts();
-            return nb::ndarray<const std::int64_t, nb::numpy>(ghosts.data(),
-                                                              {ghosts.size()});
+            return nb::ndarray<const std::int64_t, nb::ndim<1>, nb::numpy>(
+                ghosts.data(), {ghosts.size()});
           },
           nb::rv_policy::reference_internal, "Return list of ghost indices")
       .def_prop_ro(
@@ -183,7 +187,7 @@ void common(nb::module_& m)
                                  local);
             return dolfinx_wrappers::as_nbarray(std::move(local));
           },
-          nb::arg("global_index"));
+          nb::arg("global"));
 
   // dolfinx::common::Timer
   nb::class_<dolfinx::common::Timer<std::chrono::high_resolution_clock>>(
@@ -208,7 +212,7 @@ void common(nb::module_& m)
            &dolfinx::common::Timer<std::chrono::high_resolution_clock>::flush,
            "Flush timer");
 
-  m.def("timing", &dolfinx::timing);
+  m.def("timing", &dolfinx::timing, nb::arg("task"));
   m.def("timings", &dolfinx::timings);
 
   m.def("hardware_concurrency",
@@ -252,7 +256,7 @@ void common(nb::module_& m)
         for (std::size_t i = 0; i < indices.size(); ++i)
         {
           if (indices.data()[i] < 0 or indices.data()[i] >= size)
-            throw std::runtime_error("Index out of range in indices array.");
+            throw std::out_of_range("Index out of range in indices array.");
         }
         auto [map, submap_to_map] = dolfinx::common::create_sub_index_map(
             imap, std::span(indices.data(), indices.size()),

--- a/python/dolfinx/wrappers/dolfinx_wrappers/array.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/array.h
@@ -16,10 +16,10 @@
 #include <span>
 #include <utility>
 
-namespace nb = nanobind;
-
 namespace dolfinx_wrappers
 {
+namespace nb = nanobind;
+
 /// @brief Create a multi-dimensional `nb::ndarray` that shares data
 /// with a `std::vector`.
 ///

--- a/python/dolfinx/wrappers/dolfinx_wrappers/assemble.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/assemble.h
@@ -47,6 +47,7 @@
 
 namespace dolfinx_wrappers
 {
+namespace nb = nanobind;
 
 namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
 
@@ -86,7 +87,6 @@ create_sparsity(const dolfinx::fem::FunctionSpace<U>& V0,
 template <typename T, typename U>
 void declare_discrete_operators(nanobind::module_& m)
 {
-  namespace nb = nanobind;
   m.def(
       "interpolation_matrix",
       [](const dolfinx::fem::FunctionSpace<U>& V0,
@@ -181,7 +181,6 @@ void declare_discrete_operators(nanobind::module_& m)
 template <typename T, typename U>
 void declare_assembly_functions(nanobind::module_& m)
 {
-  namespace nb = nanobind;
   // Coefficient/constant packing
   m.def(
       "pack_coefficients",

--- a/python/dolfinx/wrappers/dolfinx_wrappers/assemble.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/assemble.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2025 Chris Richardson and Garth N. Wells
+// Copyright (C) 2017-2026 Chris Richardson and Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -12,6 +12,7 @@
 #include <basix/mdspan.hpp>
 #include <cstdint>
 #include <dolfinx/fem/DirichletBC.h>
+#include <dolfinx/fem/DofMap.h>
 #include <dolfinx/fem/FiniteElement.h>
 #include <dolfinx/fem/Form.h>
 #include <dolfinx/fem/FunctionSpace.h>
@@ -22,6 +23,7 @@
 #include <dolfinx/la/MatrixCSR.h>
 #include <dolfinx/la/SparsityPattern.h>
 #include <dolfinx/mesh/Mesh.h>
+#include <format>
 #include <functional>
 #include <memory>
 #include <nanobind/nanobind.h>
@@ -38,8 +40,10 @@
 #include <nanobind/stl/vector.h>
 #include <ranges>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace dolfinx_wrappers
 {
@@ -51,20 +55,19 @@ dolfinx::la::SparsityPattern
 create_sparsity(const dolfinx::fem::FunctionSpace<U>& V0,
                 const dolfinx::fem::FunctionSpace<U>& V1)
 {
-  assert(V0.mesh());
-  auto mesh = V0.mesh();
-  assert(V1.mesh());
-  assert(mesh == V1.mesh());
+  std::shared_ptr<const dolfinx::mesh::Mesh<U>> mesh = V0.mesh();
+  if (!mesh or mesh != V1.mesh())
+    throw std::invalid_argument("V0 and V1 must share a mesh.");
   MPI_Comm comm = mesh->comm();
 
-  auto dofmap0 = V0.dofmap();
+  std::shared_ptr<const dolfinx::fem::DofMap> dofmap0 = V0.dofmap();
+  std::shared_ptr<const dolfinx::fem::DofMap> dofmap1 = V1.dofmap();
   assert(dofmap0);
-  auto dofmap1 = V1.dofmap();
   assert(dofmap1);
-
-  // Create and build  sparsity pattern
   assert(dofmap0->index_map);
   assert(dofmap1->index_map);
+
+  // Create and build sparsity pattern
   dolfinx::la::SparsityPattern sp(
       comm, {dofmap1->index_map, dofmap0->index_map},
       {dofmap1->index_map_bs(), dofmap0->index_map_bs()});
@@ -72,7 +75,7 @@ create_sparsity(const dolfinx::fem::FunctionSpace<U>& V0,
   int tdim = mesh->topology()->dim();
   auto map = mesh->topology()->index_map(tdim);
   assert(map);
-  auto c = std::ranges::views::iota(0, map->size_local());
+  auto c = std::views::iota(0, map->size_local());
   dolfinx::fem::sparsitybuild::cells(sp, std::pair{c, c}, {*dofmap1, *dofmap0});
   sp.finalize();
 
@@ -84,61 +87,64 @@ template <typename T, typename U>
 void declare_discrete_operators(nanobind::module_& m)
 {
   namespace nb = nanobind;
-  m.def("interpolation_matrix",
-        [](const dolfinx::fem::FunctionSpace<U>& V0,
-           const dolfinx::fem::FunctionSpace<U>& V1)
+  m.def(
+      "interpolation_matrix",
+      [](const dolfinx::fem::FunctionSpace<U>& V0,
+         const dolfinx::fem::FunctionSpace<U>& V1)
+      {
+        // Create sparsity
+        dolfinx::la::SparsityPattern sp = create_sparsity(V0, V1);
+
+        // Build operator
+        dolfinx::la::MatrixCSR<T> A(sp);
+
+        auto [bs0, bs1] = A.block_size();
+        if (bs0 == 1 and bs1 == 1)
         {
-          // Create sparsity
-          dolfinx::la::SparsityPattern sp = create_sparsity(V0, V1);
+          dolfinx::fem::interpolation_matrix<T, U>(
+              V0, V1, A.template mat_add_values<1, 1>());
+        }
+        else if (bs0 == 2 and bs1 == 1)
+        {
+          dolfinx::fem::interpolation_matrix<T, U>(
+              V0, V1, A.template mat_add_values<2, 1>());
+        }
+        else if (bs0 == 1 and bs1 == 2)
+        {
+          dolfinx::fem::interpolation_matrix<T, U>(
+              V0, V1, A.template mat_add_values<1, 2>());
+        }
+        else if (bs0 == 2 and bs1 == 2)
+        {
+          dolfinx::fem::interpolation_matrix<T, U>(
+              V0, V1, A.template mat_add_values<2, 2>());
+        }
+        else if (bs0 == 3 and bs1 == 1)
+        {
+          dolfinx::fem::interpolation_matrix<T, U>(
+              V0, V1, A.template mat_add_values<3, 1>());
+        }
+        else if (bs0 == 1 and bs1 == 3)
+        {
+          dolfinx::fem::interpolation_matrix<T, U>(
+              V0, V1, A.template mat_add_values<1, 3>());
+        }
+        else if (bs0 == 3 and bs1 == 3)
+        {
+          dolfinx::fem::interpolation_matrix<T, U>(
+              V0, V1, A.template mat_add_values<3, 3>());
+        }
+        else
+        {
+          throw std::invalid_argument(std::format(
+              "Interpolation matrix not supported between block sizes "
+              "{} and {}.",
+              bs0, bs1));
+        }
 
-          // Build operator
-          dolfinx::la::MatrixCSR<T> A(sp);
-
-          auto [bs0, bs1] = A.block_size();
-          if (bs0 == 1 and bs1 == 1)
-          {
-            dolfinx::fem::interpolation_matrix<T, U>(
-                V0, V1, A.template mat_add_values<1, 1>());
-          }
-          else if (bs0 == 2 and bs1 == 1)
-          {
-            dolfinx::fem::interpolation_matrix<T, U>(
-                V0, V1, A.template mat_add_values<2, 1>());
-          }
-          else if (bs0 == 1 and bs1 == 2)
-          {
-            dolfinx::fem::interpolation_matrix<T, U>(
-                V0, V1, A.template mat_add_values<1, 2>());
-          }
-          else if (bs0 == 2 and bs1 == 2)
-          {
-            dolfinx::fem::interpolation_matrix<T, U>(
-                V0, V1, A.template mat_add_values<2, 2>());
-          }
-          else if (bs0 == 3 and bs1 == 1)
-          {
-            dolfinx::fem::interpolation_matrix<T, U>(
-                V0, V1, A.template mat_add_values<3, 1>());
-          }
-          else if (bs0 == 1 and bs1 == 3)
-          {
-            dolfinx::fem::interpolation_matrix<T, U>(
-                V0, V1, A.template mat_add_values<1, 3>());
-          }
-          else if (bs0 == 3 and bs1 == 3)
-          {
-            dolfinx::fem::interpolation_matrix<T, U>(
-                V0, V1, A.template mat_add_values<3, 3>());
-          }
-          else
-          {
-            throw std::runtime_error(
-                "Interpolation matrix not supported between block sizes "
-                + std::to_string(bs0) + " and " + std::to_string(bs1));
-          }
-
-          return A;
-        });
+        return A;
+      },
+      nb::arg("V0"), nb::arg("V1"));
 
   m.def(
       "discrete_curl",
@@ -291,7 +297,12 @@ void declare_assembly_functions(nanobind::module_& m)
         }
         else if (entities.ndim() == 2)
         {
-          assert(entities.shape(1) == 2);
+          if (entities.shape(1) != 2)
+          {
+            throw std::invalid_argument(
+                std::format("2D entities array must have 2 columns, got {}.",
+                            entities.shape(1)));
+          }
           dolfinx::fem::tabulate_expression<T>(
               std::span<T>(values.data(), values.size()), e,
               md::mdspan(coeffs.data(), coeffs.shape(0), coeffs.shape(1)),
@@ -303,8 +314,8 @@ void declare_assembly_functions(nanobind::module_& m)
         }
         else
         {
-          throw std::runtime_error(
-              "Unsupported entities rank in tabulate_expression wrapper.");
+          throw std::invalid_argument(std::format(
+              "entities must have rank 1 or 2, got {}.", entities.ndim()));
         }
       },
       nb::arg("values"), nb::arg("expression"), nb::arg("constants"),
@@ -358,7 +369,8 @@ void declare_assembly_functions(nanobind::module_& m)
             _bcs;
         for (auto bc : bcs)
         {
-          assert(bc);
+          if (!bc)
+            throw std::invalid_argument("bcs contains None.");
           _bcs.push_back(*bc);
         }
 
@@ -370,8 +382,8 @@ void declare_assembly_functions(nanobind::module_& m)
 
         if (data_bs[0] != data_bs[1])
         {
-          throw std::runtime_error(
-              "Non-square blocksize unsupported in Python");
+          throw std::invalid_argument(
+              "Non-square blocksize unsupported in Python.");
         }
 
         if (data_bs[0] == 1)
@@ -438,7 +450,7 @@ void declare_assembly_functions(nanobind::module_& m)
               dolfinx_wrappers::py_to_cpp_coeffs(coefficients), _bcs);
         }
         else
-          throw std::runtime_error("Block size not supported in Python");
+          throw std::invalid_argument("Block size not supported in Python.");
       },
       nb::arg("A"), nb::arg("a"), nb::arg("constants"), nb::arg("coeffs"),
       nb::arg("bcs"), "Experimental.");
@@ -453,7 +465,8 @@ void declare_assembly_functions(nanobind::module_& m)
             _bcs;
         for (auto bc : bcs)
         {
-          assert(bc);
+          if (!bc)
+            throw std::invalid_argument("bcs contains None.");
           _bcs.push_back(*bc);
         }
 
@@ -489,7 +502,8 @@ void declare_assembly_functions(nanobind::module_& m)
             _bcs;
         for (auto bc : bcs)
         {
-          assert(bc);
+          if (!bc)
+            throw std::invalid_argument("bcs contains None.");
           _bcs.push_back(*bc);
         }
 
@@ -533,7 +547,8 @@ void declare_assembly_functions(nanobind::module_& m)
           auto& _bcs0 = _bcs.emplace_back();
           for (auto bc : bc1)
           {
-            assert(bc);
+            if (!bc)
+              throw std::invalid_argument("bcs1 contains None.");
             _bcs0.push_back(*bc);
           }
         }

--- a/python/dolfinx/wrappers/dolfinx_wrappers/caster_petsc.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/caster_petsc.h
@@ -18,8 +18,6 @@
 
 // nanobind casters for PETSc/petsc4py objects
 
-namespace nb = nanobind;
-
 // Import petsc4py on demand
 #define VERIFY_PETSC4PY_FROMPY(func)                                           \
   if (!func)                                                                   \
@@ -64,7 +62,7 @@ namespace nb = nanobind;
         dolfinx::common::petsc::check(                                         \
             PetscObjectDereference((PetscObject)src),                          \
             "PetscObjectDereference");                                         \
-        return nb::handle(obj);                                                \
+        return handle(obj);                                                    \
       }                                                                        \
       else if (policy == rv_policy::automatic                                  \
                or policy == rv_policy::automatic_reference                     \
@@ -72,7 +70,7 @@ namespace nb = nanobind;
                or policy == rv_policy::reference_internal)                     \
       {                                                                        \
         PyObject* obj = PyPetsc##P4PYTYPE##_New(src);                          \
-        return nb::handle(obj);                                                \
+        return handle(obj);                                                    \
       }                                                                        \
       else                                                                     \
       {                                                                        \

--- a/python/dolfinx/wrappers/dolfinx_wrappers/common.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/common.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2019 Chris Richardson and Garth N. Wells
+// Copyright (C) 2017-2026 Chris Richardson and Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -6,15 +6,45 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
 #include <dolfinx/common/Scatterer.h>
+#include <format>
 #include <mpi.h>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
+#include <span>
 #include <stdexcept>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 namespace dolfinx_wrappers
 {
+
+/// @brief Check that every entry of `idx` is a valid index into an array
+/// of `size` entries.
+///
+/// The scatter index arrays index *into* the data array, so the array
+/// must hold at least `max(idx) + 1` entries. `idx.size()` counts the
+/// entries taking part in the exchange and is unrelated to the required
+/// extent of the data array.
+///
+/// @param[in] idx Indices used to pack/unpack the data array.
+/// @param[in] size Number of entries in the data array.
+/// @param[in] name Name of the data array, used in the error message.
+inline void check_scatter_buffer(std::span<const std::int32_t> idx,
+                                 std::size_t size, std::string_view name)
+{
+  auto it = std::ranges::max_element(idx);
+  if (it != idx.end() and std::cmp_greater_equal(*it, size))
+  {
+    throw std::invalid_argument(
+        std::format("{} buffer is too small: it has {} entries, but index {} "
+                    "is accessed.",
+                    name, size, *it));
+  }
+}
 
 template <typename T>
 void declare_scatter_functions(
@@ -28,16 +58,10 @@ void declare_scatter_functions(
          nb::ndarray<const T, nb::ndim<1>, nb::c_contig> local_data,
          nb::ndarray<T, nb::ndim<1>, nb::c_contig> remote_data)
       {
-        if (local_data.size() < self.local_indices().size())
-        {
-          throw std::runtime_error(
-              "Local data buffer too small in forward scatter.");
-        }
-        if (remote_data.size() < self.remote_indices().size())
-        {
-          throw std::runtime_error(
-              "Ghost data buffer too small in forward scatter.");
-        }
+        check_scatter_buffer(self.local_indices(), local_data.size(),
+                             "Local data");
+        check_scatter_buffer(self.remote_indices(), remote_data.size(),
+                             "Ghost data");
 
         std::vector<T> send_buffer(self.local_indices().size());
         {
@@ -48,7 +72,8 @@ void declare_scatter_functions(
         }
         std::vector<T> recv_buffer(self.remote_indices().size());
         MPI_Request request = MPI_REQUEST_NULL;
-        self.scatter_fwd_begin(send_buffer.data(), recv_buffer.data(), request);
+        self.scatter_fwd_begin<T>(send_buffer.data(), recv_buffer.data(),
+                                  request);
         self.scatter_fwd_end(request);
         {
           auto _remote_data = remote_data.view();
@@ -65,16 +90,10 @@ void declare_scatter_functions(
          nb::ndarray<T, nb::ndim<1>, nb::c_contig> local_data,
          nb::ndarray<const T, nb::ndim<1>, nb::c_contig> remote_data)
       {
-        if (local_data.size() < self.local_indices().size())
-        {
-          throw std::runtime_error(
-              "Local data buffer too small in reverse scatter.");
-        }
-        if (remote_data.size() < self.remote_indices().size())
-        {
-          throw std::runtime_error(
-              "Ghost data buffer too small in reverse scatter.");
-        }
+        check_scatter_buffer(self.local_indices(), local_data.size(),
+                             "Local data");
+        check_scatter_buffer(self.remote_indices(), remote_data.size(),
+                             "Ghost data");
 
         std::vector<T> send_buffer(self.remote_indices().size());
         {

--- a/python/dolfinx/wrappers/dolfinx_wrappers/common.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/common.h
@@ -21,6 +21,7 @@
 
 namespace dolfinx_wrappers
 {
+namespace nb = nanobind;
 
 /// @brief Check that every entry of `idx` is a valid index into an array
 /// of `size` entries.
@@ -50,8 +51,6 @@ template <typename T>
 void declare_scatter_functions(
     nanobind::class_<dolfinx::common::Scatterer<>>& sc)
 {
-  namespace nb = nanobind;
-
   sc.def(
       "scatter_fwd",
       [](dolfinx::common::Scatterer<>& self,

--- a/python/dolfinx/wrappers/dolfinx_wrappers/fem.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/fem.h
@@ -8,6 +8,7 @@
 
 #include "array.h"
 #include "caster_mpi.h"
+#include "marker.h"
 #include "numpy_dtype.h"
 #include <array>
 #include <cstdint>
@@ -71,11 +72,12 @@ auto ptr_to_ref_wrapper_vec(auto& x)
   std::ranges::transform(x, std::back_inserter(y),
                          [](auto ptr)
                          {
-                           assert(ptr);
+                           if (!ptr)
+                             throw std::invalid_argument("List entry is None.");
                            return std::reference_wrapper<T>(*ptr);
                          });
   return y;
-};
+}
 
 template <typename T>
 void declare_function_space(nb::module_& m, std::string type)
@@ -441,7 +443,7 @@ void declare_objects(nb::module_& m, std::string type)
           },
           nb::arg("g").noconvert(), nb::arg("dofs").noconvert(),
           nb::arg("V").noconvert())
-      .def_prop_ro("dtype", [](const dolfinx::fem::Function<T, U>&)
+      .def_prop_ro("dtype", [](const dolfinx::fem::DirichletBC<T, U>&)
                    { return dolfinx_wrappers::numpy_dtype_v<T>; })
       .def(
           "dof_indices",
@@ -899,7 +901,7 @@ void declare_form(nb::module_& m, std::string type)
                   _d.data(), {_d.size() / 4, 2, 2});
             }
             default:
-              throw ::std::runtime_error("Integral type unsupported.");
+              throw std::invalid_argument("Integral type unsupported.");
             }
           },
           nb::rv_policy::reference_internal, nb::arg("type"), nb::arg("i"));
@@ -964,7 +966,7 @@ void declare_form(nb::module_& m, std::string type)
                  std::int32_t, nb::ndarray<const std::int32_t, nb::c_contig>>>>&
              subdomains,
          const std::vector<const dolfinx::mesh::EntityMap*>& entity_maps,
-         std::shared_ptr<const dolfinx::mesh::Mesh<U>> mesh = nullptr)
+         std::shared_ptr<const dolfinx::mesh::Mesh<U>> mesh)
       {
         std::map<
             dolfinx::fem::IntegralType,
@@ -1076,6 +1078,13 @@ void declare_coordinate_element(nb::module_& m, const std::string& type)
             std::size_t num_points = x.shape(0);
             std::size_t gdim = x.shape(1);
             std::size_t tdim = dolfinx::mesh::cell_dim(self.cell_shape());
+            if (cell_geometry.shape(1) > 3)
+            {
+              throw std::invalid_argument(
+                  std::format("cell_geometry must have at most 3 columns, "
+                              "got {}.",
+                              cell_geometry.shape(1)));
+            }
 
             using mdspan2_t = md::mdspan<T, md::dextents<std::size_t, 2>>;
             using cmdspan2_t
@@ -1121,7 +1130,7 @@ void declare_coordinate_element(nb::module_& m, const std::string& type)
               self.compute_jacobian_inverse(J, K);
               std::array<T, 3> x0{0, 0, 0};
               for (std::size_t i = 0; i < g.extent(1); ++i)
-                x0[i] += g(0, i);
+                x0[i] = g(0, i);
               self.pull_back_affine(X, K, x0, _x);
             }
             else
@@ -1198,7 +1207,7 @@ void declare_real_functions(nb::module_& m)
          bool remote)
       {
         if (V.size() != 2)
-          throw std::runtime_error("Expected two function spaces.");
+          throw std::invalid_argument("Expected two function spaces.");
         std::array<std::vector<std::int32_t>, 2> dofs
             = dolfinx::fem::locate_dofs_topological(
                 *V[0].get()->mesh()->topology_mutable(),
@@ -1208,8 +1217,7 @@ void declare_real_functions(nb::module_& m)
             {dolfinx_wrappers::as_nbarray(std::move(dofs[0])),
              dolfinx_wrappers::as_nbarray(std::move(dofs[1]))});
       },
-      nb::arg("V"), nb::arg("dim"), nb::arg("entities"),
-      nb::arg("remote") = true);
+      nb::arg("V"), nb::arg("dim"), nb::arg("entities"), nb::arg("remote"));
   m.def(
       "locate_dofs_topological",
       [](const dolfinx::fem::FunctionSpace<T>& V, int dim,
@@ -1221,30 +1229,19 @@ void declare_real_functions(nb::module_& m)
                 *V.mesh()->topology_mutable(), *V.dofmap(), dim,
                 std::span(entities.data(), entities.size()), remote));
       },
-      nb::arg("V"), nb::arg("dim"), nb::arg("entities"),
-      nb::arg("remote") = true);
+      nb::arg("V"), nb::arg("dim"), nb::arg("entities"), nb::arg("remote"));
   m.def(
       "locate_dofs_geometrical",
       [](const std::vector<
              std::shared_ptr<const dolfinx::fem::FunctionSpace<T>>>& V,
-         std::function<nb::ndarray<bool, nb::ndim<1>, nb::c_contig>(
-             nb::ndarray<const T, nb::ndim<2>, nb::numpy>)>
-             marker)
+         const PythonMarkerFunction<T>& marker)
       {
         if (V.size() != 2)
-          throw std::runtime_error("Expected two function spaces.");
-
-        auto _marker = [&marker](auto x)
-        {
-          nb::ndarray<const T, nb::ndim<2>, nb::numpy> x_view(
-              x.data_handle(), {x.extent(0), x.extent(1)});
-          auto marked = marker(x_view);
-          return std::vector<std::int8_t>(marked.data(),
-                                          marked.data() + marked.size());
-        };
+          throw std::invalid_argument("Expected two function spaces.");
 
         std::array<std::vector<std::int32_t>, 2> dofs
-            = dolfinx::fem::locate_dofs_geometrical<T>({*V[0], *V[1]}, _marker);
+            = dolfinx::fem::locate_dofs_geometrical<T>(
+                {*V[0], *V[1]}, to_cpp_marker<T>(marker));
         return std::array<nb::ndarray<std::int32_t, nb::numpy>, 2>(
             {dolfinx_wrappers::as_nbarray(std::move(dofs[0])),
              dolfinx_wrappers::as_nbarray(std::move(dofs[1]))});
@@ -1253,21 +1250,10 @@ void declare_real_functions(nb::module_& m)
   m.def(
       "locate_dofs_geometrical",
       [](const dolfinx::fem::FunctionSpace<T>& V,
-         std::function<nb::ndarray<bool, nb::ndim<1>, nb::c_contig>(
-             nb::ndarray<const T, nb::ndim<2>, nb::numpy>)>
-             marker)
+         const PythonMarkerFunction<T>& marker)
       {
-        auto _marker = [&marker](auto x)
-        {
-          nb::ndarray<const T, nb::ndim<2>, nb::numpy> x_view(
-              x.data_handle(), {x.extent(0), x.extent(1)});
-          auto marked = marker(x_view);
-          return std::vector<std::int8_t>(marked.data(),
-                                          marked.data() + marked.size());
-        };
-
         return dolfinx_wrappers::as_nbarray(
-            dolfinx::fem::locate_dofs_geometrical(V, _marker));
+            dolfinx::fem::locate_dofs_geometrical(V, to_cpp_marker<T>(marker)));
       },
       nb::arg("V"), nb::arg("marker"));
 

--- a/python/dolfinx/wrappers/dolfinx_wrappers/geometry.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/geometry.h
@@ -35,6 +35,7 @@
 
 namespace dolfinx_wrappers
 {
+namespace nb = nanobind;
 
 /// Number of points in an array assumed to hold 3D point coordinates,
 /// either as a single point (shape (3,)) or a list of points (shape

--- a/python/dolfinx/wrappers/dolfinx_wrappers/geometry.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/geometry.h
@@ -8,23 +8,30 @@
 
 #include "array.h"
 #include "caster_mpi.h"
+#include <algorithm>
 #include <array>
 #include <boost/multiprecision/cpp_bin_float.hpp>
+#include <cstdint>
 #include <dolfinx/geometry/BoundingBoxTree.h>
 #include <dolfinx/geometry/gjk.h>
 #include <dolfinx/geometry/utils.h>
 #include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/mesh/Mesh.h>
+#include <format>
+#include <iterator>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 #include <optional>
+#include <ranges>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <vector>
 
 namespace dolfinx_wrappers
 {
@@ -43,8 +50,8 @@ std::size_t num_points_3d(const nb::ndarray<const T, nb::c_contig>& x,
     return x.shape(0);
   else
   {
-    throw std::runtime_error(std::string(name)
-                             + " must have shape (3,) or (num_points, 3).");
+    throw std::invalid_argument(
+        std::format("{} must have shape (3,) or (num_points, 3).", name));
   }
 }
 
@@ -54,10 +61,10 @@ std::size_t num_points_3d(const nb::ndarray<const T, nb::c_contig>& x,
 /// @param type String representation of the scalar type (e.g., "float64",
 /// "float32")
 template <typename T>
-void declare_bbtree(nb::module_& m, const std::string& type)
+void declare_bbtree(nb::module_& m, std::string_view type)
 {
   // dolfinx::geometry::BoundingBoxTree
-  std::string pyclass_name = "BoundingBoxTree_" + type;
+  std::string pyclass_name = std::string("BoundingBoxTree_").append(type);
   nb::class_<dolfinx::geometry::BoundingBoxTree<T>>(m, pyclass_name.c_str())
       .def(
           "__init__",
@@ -94,8 +101,7 @@ void declare_bbtree(nb::module_& m, const std::string& type)
           "to the lower and upper corners of bounding box `ibbox`.")
       .def(
           "get_bbox",
-          [](const dolfinx::geometry::BoundingBoxTree<T>& self,
-             const std::size_t i)
+          [](const dolfinx::geometry::BoundingBoxTree<T>& self, std::size_t i)
           {
             std::array<T, 6> bbox = self.get_bbox(i);
             return nb::ndarray<T, nb::shape<2, 3>, nb::numpy>(bbox.data())
@@ -106,7 +112,7 @@ void declare_bbtree(nb::module_& m, const std::string& type)
       .def(
           "create_global_tree",
           [](const dolfinx::geometry::BoundingBoxTree<T>& self,
-             const dolfinx_wrappers::MPICommWrapper comm)
+             MPICommWrapper comm)
           { return self.create_global_tree(comm.get()); },
           nb::arg("comm"));
 
@@ -198,7 +204,7 @@ void declare_bbtree(nb::module_& m, const std::string& type)
       },
       nb::arg("mesh"), nb::arg("candidate_cells"), nb::arg("points"));
 
-  std::string gjk_name = "compute_distance_gjk_" + type;
+  std::string gjk_name = std::string("compute_distance_gjk_").append(type);
   m.def(
       gjk_name.c_str(),
       [](nb::ndarray<const T, nb::c_contig> p,
@@ -208,9 +214,9 @@ void declare_bbtree(nb::module_& m, const std::string& type)
         std::size_t q_s0 = num_points_3d(q, "q");
         std::span<const T> _p(p.data(), 3 * p_s0), _q(q.data(), 3 * q_s0);
         // Use double when T==float, and double_extended when T==double
-        using U = std::conditional<
+        using U = std::conditional_t<
             std::is_same_v<T, float>, double,
-            boost::multiprecision::cpp_bin_float_double_extended>::type;
+            boost::multiprecision::cpp_bin_float_double_extended>;
 
         std::array<T, 3> d
             = dolfinx::geometry::compute_distance_gjk<T, U>(_p, _q);
@@ -218,7 +224,7 @@ void declare_bbtree(nb::module_& m, const std::string& type)
       },
       nb::arg("p"), nb::arg("q"));
 
-  std::string gjks_name = "compute_distances_gjk_" + type;
+  std::string gjks_name = std::string("compute_distances_gjk_").append(type);
   m.def(
       gjks_name.c_str(),
       [](const std::vector<nb::ndarray<const T, nb::c_contig>>& bodies,
@@ -238,9 +244,9 @@ void declare_bbtree(nb::module_& m, const std::string& type)
               return std::span<const T>(body.data(), 3 * body_s0);
             });
 
-        using U = typename std::conditional<
+        using U = std::conditional_t<
             std::is_same_v<T, float>, double,
-            boost::multiprecision::cpp_bin_float_double_extended>::type;
+            boost::multiprecision::cpp_bin_float_double_extended>;
 
         std::vector<T> distances
             = dolfinx::geometry::compute_distances_gjk<T, U>(_bodies, _q,
@@ -266,7 +272,7 @@ void declare_bbtree(nb::module_& m, const std::string& type)
   m.def(
       "determine_point_ownership",
       [](const dolfinx::mesh::Mesh<T>& mesh,
-         nb::ndarray<const T, nb::c_contig> points, const T padding,
+         nb::ndarray<const T, nb::c_contig> points, T padding,
          std::optional<
              nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig>>
              cells,
@@ -290,7 +296,8 @@ void declare_bbtree(nb::module_& m, const std::string& type)
       nb::arg("cells").none(), nb::arg("find_closest_cell"),
       "Compute point ownership data for mesh-points pair.");
 
-  std::string pod_pyclass_name = "PointOwnershipData_" + type;
+  std::string pod_pyclass_name
+      = std::string("PointOwnershipData_").append(type);
   nb::class_<dolfinx::geometry::PointOwnershipData<T>>(m,
                                                        pod_pyclass_name.c_str())
       .def(
@@ -322,16 +329,16 @@ void declare_bbtree(nb::module_& m, const std::string& type)
           "src_owner",
           [](const dolfinx::geometry::PointOwnershipData<T>& self)
           {
-            return nb::ndarray<const int, nb::numpy>(self.src_owner.data(),
-                                                     {self.src_owner.size()});
+            return nb::ndarray<const std::int32_t, nb::ndim<1>, nb::numpy>(
+                self.src_owner.data(), {self.src_owner.size()});
           },
           nb::rv_policy::reference_internal)
       .def_prop_ro(
           "dest_owners",
           [](const dolfinx::geometry::PointOwnershipData<T>& self)
           {
-            return nb::ndarray<const int, nb::numpy>(self.dest_owners.data(),
-                                                     {self.dest_owners.size()});
+            return nb::ndarray<const std::int32_t, nb::ndim<1>, nb::numpy>(
+                self.dest_owners.data(), {self.dest_owners.size()});
           },
           nb::rv_policy::reference_internal)
       .def_prop_ro(

--- a/python/dolfinx/wrappers/dolfinx_wrappers/graph.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/graph.h
@@ -8,9 +8,11 @@
 
 #include "MPICommWrapper.h"
 #include "array.h"
+#include <cstdint>
 #include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/graph/ordering.h>
 #include <dolfinx/graph/partition.h>
+#include <format>
 #include <functional>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
@@ -21,6 +23,7 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace dolfinx_wrappers
@@ -114,7 +117,7 @@ void declare_adjacency_list_common(
          "offsets",
          [](const dolfinx::graph::AdjacencyList<T, U>& self)
          {
-           return nb::ndarray<const std::int32_t, nb::numpy>(
+           return nb::ndarray<const std::int32_t, nb::ndim<1>, nb::numpy>(
                self.offsets().data(), {self.offsets().size()});
          },
          nb::rv_policy::reference_internal)
@@ -135,11 +138,9 @@ void declare_adjacency_list_common(
 /// @param m The nanobind module
 /// @param type String representation of the type (e.g., "int32", "int64")
 template <typename T, typename U>
-void declare_adjacency_list_init(nanobind::module_& m, std::string type)
+void declare_adjacency_list_init(nanobind::module_& m, std::string_view type)
 {
-  namespace nb = nanobind;
-
-  std::string pyclass_name = std::string("AdjacencyList_") + type;
+  std::string pyclass_name = std::string("AdjacencyList_").append(type);
   nb::class_<dolfinx::graph::AdjacencyList<T, U>> cls(m, pyclass_name.c_str(),
                                                       "Adjacency List");
   cls.def(
@@ -171,20 +172,20 @@ void declare_adjacency_list_init(nanobind::module_& m, std::string type)
           {
             if (displ.size() == 0 or displ.data()[0] != 0)
             {
-              throw std::runtime_error(
+              throw std::invalid_argument(
                   "offsets must be non-empty and start at 0.");
             }
 
             for (std::size_t i = 1; i < displ.size(); ++i)
             {
               if (displ.data()[i] < displ.data()[i - 1])
-                throw std::runtime_error("offsets must be non-decreasing.");
+                throw std::invalid_argument("offsets must be non-decreasing.");
             }
 
             if (static_cast<std::size_t>(displ.data()[displ.size() - 1])
                 != array.size())
             {
-              throw std::runtime_error(
+              throw std::invalid_argument(
                   "Last entry in offsets must equal the length of data.");
             }
 
@@ -197,8 +198,15 @@ void declare_adjacency_list_init(nanobind::module_& m, std::string type)
           nb::arg("data").noconvert(), nb::arg("offsets"))
       .def(
           "links",
-          [](const dolfinx::graph::AdjacencyList<T, U>& self, int i)
+          [](const dolfinx::graph::AdjacencyList<T, U>& self, std::int32_t i)
           {
+            if (i < 0 or i >= self.num_nodes())
+            {
+              throw std::out_of_range(std::format(
+                  "Node index {} is out of range for an adjacency list with "
+                  "{} nodes.",
+                  i, self.num_nodes()));
+            }
             std::span<const T> link = self.links(i);
             return nb::ndarray<const T, nb::numpy>(link.data(), {link.size()});
           },
@@ -220,9 +228,9 @@ void declare_adjacency_list_init(nanobind::module_& m, std::string type)
 /// @param m The nanobind module
 /// @param type String representation of the type
 template <typename T, typename U>
-void declare_adjacency_list(nanobind::module_& m, std::string type)
+void declare_adjacency_list(nanobind::module_& m, std::string_view type)
 {
-  std::string pyclass_name = std::string("AdjacencyList_") + type;
+  std::string pyclass_name = std::string("AdjacencyList_").append(type);
   nb::class_<dolfinx::graph::AdjacencyList<T, U>> cls(m, pyclass_name.c_str(),
                                                       "Adjacency List");
   declare_adjacency_list_common(cls);

--- a/python/dolfinx/wrappers/dolfinx_wrappers/io.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/io.h
@@ -36,6 +36,7 @@
 
 namespace dolfinx_wrappers
 {
+namespace nb = nanobind;
 
 namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
 
@@ -46,8 +47,6 @@ using mdspan_t = md::mdspan<const T, md::dextents<std::size_t, ndim>>;
 template <typename T>
 void declare_xdmf_real_fn(auto&& m)
 {
-  namespace nb = nanobind;
-
   m.def(
       "write_mesh",
       [](dolfinx::io::XDMFFile& self, const dolfinx::mesh::Mesh<T>& mesh,
@@ -68,8 +67,6 @@ void declare_xdmf_real_fn(auto&& m)
 template <typename T, typename U>
 void declare_xdmf_scalar_fn(auto&& m)
 {
-  namespace nb = nanobind;
-
   m.def(
       "write_function",
       [](dolfinx::io::XDMFFile& self, const dolfinx::fem::Function<T, U>& u,
@@ -82,8 +79,6 @@ void declare_xdmf_scalar_fn(auto&& m)
 template <typename T>
 void declare_vtk_real_fn(auto&& m)
 {
-  namespace nb = nanobind;
-
   m.def(
       "write",
       [](dolfinx::io::VTKFile& self, const dolfinx::mesh::Mesh<T>& mesh,
@@ -95,8 +90,6 @@ void declare_vtk_real_fn(auto&& m)
 template <typename T, typename U>
 void declare_vtk_scalar_fn(auto&& m)
 {
-  namespace nb = nanobind;
-
   m.def(
       "write",
       [](dolfinx::io::VTKFile& self,
@@ -123,8 +116,6 @@ void declare_vtk_scalar_fn(auto&& m)
 template <typename T>
 void declare_vtx_writer(nanobind::module_& m, std::string_view type)
 {
-  namespace nb = nanobind;
-
   std::string pyclass_name = std::string("VTXWriter_").append(type);
   auto vtx_writer
       = nb::class_<dolfinx::io::VTXWriter<T>>(m, pyclass_name.c_str());
@@ -197,8 +188,6 @@ void declare_vtx_writer(nanobind::module_& m, std::string_view type)
 template <typename T>
 void declare_data_types(nanobind::module_& m)
 {
-  namespace nb = nanobind;
-
   m.def(
       "distribute_entity_data",
       [](const dolfinx::mesh::Topology& topology,

--- a/python/dolfinx/wrappers/dolfinx_wrappers/io.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/io.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2025 Chris N. Richardson and Garth N. Wells
+// Copyright (C) 2017-2026 Chris N. Richardson and Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -9,6 +9,7 @@
 #include "MPICommWrapper.h"
 #include "array.h"
 #include <basix/mdspan.hpp>
+#include <cstdint>
 #include <dolfinx/fem/ElementDofLayout.h>
 #include <dolfinx/fem/Function.h>
 #include <dolfinx/io/VTKFile.h>
@@ -17,12 +18,16 @@
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/MeshTags.h>
 #include <filesystem>
+#include <format>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/filesystem.h>
 #include <span>
+#include <stdexcept>
 #include <string>
+#include <string_view>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #ifdef HAS_ADIOS2
@@ -47,7 +52,7 @@ void declare_xdmf_real_fn(auto&& m)
       "write_mesh",
       [](dolfinx::io::XDMFFile& self, const dolfinx::mesh::Mesh<T>& mesh,
          const std::string& xpath) { self.write_mesh(mesh, xpath); },
-      nb::arg("mesh"), nb::arg("xpath") = "/Xdmf/Domain");
+      nb::arg("mesh"), nb::arg("xpath"));
   m.def(
       "write_meshtags",
       [](dolfinx::io::XDMFFile& self,
@@ -56,7 +61,7 @@ void declare_xdmf_real_fn(auto&& m)
          const std::string& xpath)
       { self.write_meshtags(meshtags, x, geometry_xpath, xpath); },
       nb::arg("meshtags"), nb::arg("x"), nb::arg("geometry_xpath"),
-      nb::arg("xpath") = "/Xdmf/Domain");
+      nb::arg("xpath"));
 }
 
 /// Add scalar function write methods to XDMFFile
@@ -70,8 +75,7 @@ void declare_xdmf_scalar_fn(auto&& m)
       [](dolfinx::io::XDMFFile& self, const dolfinx::fem::Function<T, U>& u,
          double t, const std::string& mesh_xpath)
       { self.write_function(u, t, mesh_xpath); },
-      nb::arg("u"), nb::arg("t"),
-      nb::arg("mesh_xpath") = "/Xdmf/Domain/Grid[@GridType='Uniform'][1]");
+      nb::arg("u"), nb::arg("t"), nb::arg("mesh_xpath"));
 }
 
 /// Add real-valued mesh write methods to VTKFile
@@ -84,7 +88,7 @@ void declare_vtk_real_fn(auto&& m)
       "write",
       [](dolfinx::io::VTKFile& self, const dolfinx::mesh::Mesh<T>& mesh,
          double t) { self.write(mesh, t); },
-      nb::arg("mesh"), nb::arg("t") = 0);
+      nb::arg("mesh"), nb::arg("t"));
 }
 
 /// Add scalar function write methods to VTKFile
@@ -108,7 +112,7 @@ void declare_vtk_scalar_fn(auto&& m)
 
         self.write(u, t);
       },
-      nb::arg("u"), nb::arg("t") = 0);
+      nb::arg("u"), nb::arg("t"));
 }
 
 #ifdef HAS_ADIOS2
@@ -117,11 +121,11 @@ void declare_vtk_scalar_fn(auto&& m)
 /// @param type String representation of the scalar type (e.g., "float64",
 /// "float32")
 template <typename T>
-void declare_vtx_writer(nanobind::module_& m, const std::string& type)
+void declare_vtx_writer(nanobind::module_& m, std::string_view type)
 {
   namespace nb = nanobind;
 
-  std::string pyclass_name = "VTXWriter_" + type;
+  std::string pyclass_name = std::string("VTXWriter_").append(type);
   auto vtx_writer
       = nb::class_<dolfinx::io::VTXWriter<T>>(m, pyclass_name.c_str());
   vtx_writer.def(
@@ -160,8 +164,7 @@ void declare_vtx_writer(nanobind::module_& m, const std::string& type)
   {
     vtx_writer.def(
         "__init__", init_u, nb::arg("comm"), nb::arg("filename"), nb::arg("u"),
-        nb::arg("engine") = "BPFile",
-        nb::arg("policy") = dolfinx::io::VTXMeshPolicy::update,
+        nb::arg("engine"), nb::arg("policy"),
         nb::sig("def __init__(self, comm: mpi4py.MPI.Comm, filename: str | "
                 "os.PathLike, u: collections.abc.Sequence["
                 "dolfinx.cpp.fem.Function_float32 | "
@@ -173,8 +176,7 @@ void declare_vtx_writer(nanobind::module_& m, const std::string& type)
   {
     vtx_writer.def(
         "__init__", init_u, nb::arg("comm"), nb::arg("filename"), nb::arg("u"),
-        nb::arg("engine") = "BPFile",
-        nb::arg("policy") = dolfinx::io::VTXMeshPolicy::update,
+        nb::arg("engine"), nb::arg("policy"),
         nb::sig("def __init__(self, comm: mpi4py.MPI.Comm, filename: str | "
                 "os.PathLike, u: collections.abc.Sequence["
                 "dolfinx.cpp.fem.Function_float64 | "
@@ -209,7 +211,12 @@ void declare_data_types(nanobind::module_& m)
          nb::ndarray<const std::int64_t, nb::ndim<2>, nb::c_contig> entities,
          nb::ndarray<const T, nb::ndim<1>, nb::c_contig> values)
       {
-        assert(entities.shape(0) == values.size());
+        if (entities.shape(0) != values.size())
+        {
+          throw std::invalid_argument(
+              std::format("entities has {} rows but values has {} entries.",
+                          entities.shape(0), values.size()));
+        }
         mdspan_t<const std::int64_t, 2> entities_span(
             entities.data(), entities.shape(0), entities.shape(1));
         mdspan_t<const std::int32_t, 2> xdofmap_span(

--- a/python/dolfinx/wrappers/dolfinx_wrappers/la.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/la.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2025 Chris Richardson and Garth N. Wells
+// Copyright (C) 2017-2026 Chris Richardson and Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -24,6 +24,7 @@
 #include <nanobind/stl/vector.h>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #if defined(HAS_SUPERLU_DIST)
@@ -45,13 +46,12 @@ enum class PyInsertMode : std::uint8_t
 /// @param type String representation of the scalar type (e.g., "float64",
 /// "complex128")
 template <typename T>
-void declare_la_objects(nanobind::module_& m, const std::string& type)
+void declare_la_objects(nanobind::module_& m, std::string_view type)
 {
   namespace nb = nanobind;
-  using namespace nb::literals;
 
   // dolfinx::la::Vector
-  std::string pyclass_vector_name = std::string("Vector_") + type;
+  std::string pyclass_vector_name = std::string("Vector_").append(type);
   nb::class_<dolfinx::la::Vector<T>>(m, pyclass_vector_name.c_str())
       .def(nb::init<std::shared_ptr<const dolfinx::common::IndexMap>, int>(),
            nb::arg("map"), nb::arg("bs"))
@@ -83,109 +83,126 @@ void declare_la_objects(nanobind::module_& m, const std::string& type)
               self.scatter_rev([](T /*a*/, T b) { return b; });
               break;
             default:
-              throw std::runtime_error("InsertMode not recognized.");
+              throw std::invalid_argument("InsertMode not recognized.");
               break;
             }
           },
           nb::arg("mode"));
 
   // dolfinx::la::MatrixCSR
-  std::string pyclass_matrix_name = std::string("MatrixCSR_") + type;
+  std::string pyclass_matrix_name = std::string("MatrixCSR_").append(type);
   nb::class_<dolfinx::la::MatrixCSR<
       T, std::vector<T>, std::vector<std::int32_t>, std::vector<std::int64_t>>>(
       m, pyclass_matrix_name.c_str())
       .def(nb::init<const dolfinx::la::SparsityPattern&,
                     dolfinx::la::BlockMode>(),
-           nb::arg("p"),
-           nb::arg("block_mode") = dolfinx::la::BlockMode::compact)
+           nb::arg("p"), nb::arg("block_mode"))
       .def_prop_ro("dtype", [](const dolfinx::la::MatrixCSR<T>&)
                    { return dolfinx_wrappers::numpy_dtype_v<T>; })
       .def_prop_ro("bs", &dolfinx::la::MatrixCSR<T>::block_size)
       .def("squared_norm", &dolfinx::la::MatrixCSR<T>::squared_norm)
-      .def("index_map", &dolfinx::la::MatrixCSR<T>::index_map)
-      .def("add",
-           [](dolfinx::la::MatrixCSR<T>& self,
-              nb::ndarray<const T, nb::ndim<1>, nb::c_contig> x,
-              nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> rows,
-              nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> cols,
-              int bs = 1)
-           {
-             if (x.size() != rows.size() * cols.size() * bs * bs)
-             {
-               throw std::runtime_error(
-                   "x size must equal rows size * cols size * bs * bs.");
-             }
+      .def("index_map", &dolfinx::la::MatrixCSR<T>::index_map, nb::arg("dim"))
+      .def(
+          "add",
+          [](dolfinx::la::MatrixCSR<T>& self,
+             nb::ndarray<const T, nb::ndim<1>, nb::c_contig> x,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> rows,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> cols,
+             int bs)
+          {
+            if (x.size() != rows.size() * cols.size() * bs * bs)
+            {
+              throw std::invalid_argument(
+                  "x size must equal rows size * cols size * bs * bs.");
+            }
 
-             const std::int32_t num_rows = self.num_all_rows();
-             const int mat_bs0 = self.block_size()[0];
-             const std::int32_t max_row
-                 = (mat_bs0 == bs) ? num_rows
-                                   : ((mat_bs0 == 1) ? (num_rows / bs)
-                                                     : (num_rows * mat_bs0));
-             for (std::size_t i = 0; i < rows.size(); ++i)
-             {
-               if (rows.data()[i] < 0 or rows.data()[i] >= max_row)
-                 throw std::runtime_error("Index out of range in rows array.");
-             }
-             std::span x_span = std::span(x.data(), x.size());
-             std::span rows_span = std::span(rows.data(), rows.size());
-             std::span cols_span = std::span(cols.data(), cols.size());
-             if (bs == 1)
-               self.template add<1, 1>(x_span, rows_span, cols_span);
-             else if (bs == 2)
-               self.template add<2, 2>(x_span, rows_span, cols_span);
-             else if (bs == 3)
-               self.template add<3, 3>(x_span, rows_span, cols_span);
-             else
-             {
-               throw std::runtime_error(
-                   "Block size not supported in this function");
-             }
-           })
-      .def("set",
-           [](dolfinx::la::MatrixCSR<T>& self,
-              nb::ndarray<const T, nb::ndim<1>, nb::c_contig> x,
-              nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> rows,
-              nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> cols,
-              int bs = 1)
-           {
-             if (x.size() != rows.size() * cols.size() * bs * bs)
-             {
-               throw std::runtime_error(
-                   "x size must equal rows size * cols size * bs * bs.");
-             }
-             const std::int32_t num_rows = self.num_all_rows();
-             const int mat_bs0 = self.block_size()[0];
-             const std::int32_t max_row
-                 = (mat_bs0 == bs) ? num_rows
-                                   : ((mat_bs0 == 1) ? (num_rows / bs)
-                                                     : (num_rows * mat_bs0));
-             for (std::size_t i = 0; i < rows.size(); ++i)
-             {
-               if (rows.data()[i] < 0 or rows.data()[i] >= max_row)
-                 throw std::runtime_error("Index out of range in rows array.");
-             }
-             std::span x_span = std::span(x.data(), x.size());
-             std::span rows_span = std::span(rows.data(), rows.size());
-             std::span cols_span = std::span(cols.data(), cols.size());
-             if (bs == 1)
-               self.template set<1, 1>(x_span, rows_span, cols_span);
-             else if (bs == 2)
-               self.template set<2, 2>(x_span, rows_span, cols_span);
-             else if (bs == 3)
-               self.template set<3, 3>(x_span, rows_span, cols_span);
-             else
-             {
-               throw std::runtime_error(
-                   "Block size not supported in this function");
-             }
-           })
+            const std::int32_t num_rows = self.num_all_rows();
+            const int mat_bs0 = self.block_size()[0];
+            const std::int32_t max_row
+                = (mat_bs0 == bs) ? num_rows
+                                  : ((mat_bs0 == 1) ? (num_rows / bs)
+                                                    : (num_rows * mat_bs0));
+            for (std::size_t i = 0; i < rows.size(); ++i)
+            {
+              if (rows.data()[i] < 0 or rows.data()[i] >= max_row)
+                throw std::out_of_range("Index out of range in rows array.");
+            }
+            for (std::size_t i = 0; i < cols.size(); ++i)
+            {
+              if (cols.data()[i] < 0)
+                throw std::out_of_range("Index out of range in cols array.");
+            }
+            std::span x_span = std::span(x.data(), x.size());
+            std::span rows_span = std::span(rows.data(), rows.size());
+            std::span cols_span = std::span(cols.data(), cols.size());
+            if (bs == 1)
+              self.template add<1, 1>(x_span, rows_span, cols_span);
+            else if (bs == 2)
+              self.template add<2, 2>(x_span, rows_span, cols_span);
+            else if (bs == 3)
+              self.template add<3, 3>(x_span, rows_span, cols_span);
+            else
+            {
+              throw std::invalid_argument(
+                  "Block size not supported in this function.");
+            }
+          },
+          nb::arg("x"), nb::arg("rows"), nb::arg("cols"), nb::arg("bs"))
+      .def(
+          "set",
+          [](dolfinx::la::MatrixCSR<T>& self,
+             nb::ndarray<const T, nb::ndim<1>, nb::c_contig> x,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> rows,
+             nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig> cols,
+             int bs)
+          {
+            if (x.size() != rows.size() * cols.size() * bs * bs)
+            {
+              throw std::invalid_argument(
+                  "x size must equal rows size * cols size * bs * bs.");
+            }
+            const std::int32_t num_rows = self.num_all_rows();
+            const int mat_bs0 = self.block_size()[0];
+            const std::int32_t max_row
+                = (mat_bs0 == bs) ? num_rows
+                                  : ((mat_bs0 == 1) ? (num_rows / bs)
+                                                    : (num_rows * mat_bs0));
+            for (std::size_t i = 0; i < rows.size(); ++i)
+            {
+              if (rows.data()[i] < 0 or rows.data()[i] >= max_row)
+                throw std::out_of_range("Index out of range in rows array.");
+            }
+            for (std::size_t i = 0; i < cols.size(); ++i)
+            {
+              if (cols.data()[i] < 0)
+                throw std::out_of_range("Index out of range in cols array.");
+            }
+            std::span x_span = std::span(x.data(), x.size());
+            std::span rows_span = std::span(rows.data(), rows.size());
+            std::span cols_span = std::span(cols.data(), cols.size());
+            if (bs == 1)
+              self.template set<1, 1>(x_span, rows_span, cols_span);
+            else if (bs == 2)
+              self.template set<2, 2>(x_span, rows_span, cols_span);
+            else if (bs == 3)
+              self.template set<3, 3>(x_span, rows_span, cols_span);
+            else
+            {
+              throw std::invalid_argument(
+                  "Block size not supported in this function.");
+            }
+          },
+          nb::arg("x"), nb::arg("rows"), nb::arg("cols"), nb::arg("bs"))
       .def("scatter_reverse", &dolfinx::la::MatrixCSR<T>::scatter_rev)
-      .def("mult", &dolfinx::la::MatrixCSR<T>::mult)
-      .def("mult", [](const dolfinx::la::MatrixCSR<T>& self,
-                      const dolfinx::la::MatrixCSR<T>& B)
-           { return dolfinx::la::matmul(self, B); })
-      .def("multT", &dolfinx::la::MatrixCSR<T>::multT)
+      .def("mult", &dolfinx::la::MatrixCSR<T>::mult, nb::arg("x"), nb::arg("y"))
+      .def(
+          "mult",
+          [](const dolfinx::la::MatrixCSR<T>& self,
+             const dolfinx::la::MatrixCSR<T>& B)
+          { return dolfinx::la::matmul(self, B); },
+          nb::arg("B"))
+      .def("multT", &dolfinx::la::MatrixCSR<T>::multT, nb::arg("x"),
+           nb::arg("y"))
       .def("transpose",
            [](const dolfinx::la::MatrixCSR<T>& self)
            {
@@ -199,7 +216,7 @@ void declare_la_objects(nanobind::module_& m, const std::string& type)
              return dolfinx::la::transpose(self);
            })
       .def("eliminate_zeros", &dolfinx::la::MatrixCSR<T>::eliminate_zeros,
-           nb::arg("tol") = T(0))
+           nb::arg("tol"))
       .def("to_dense",
            [](const dolfinx::la::MatrixCSR<T>& self)
            {
@@ -246,11 +263,11 @@ template <typename T>
 void declare_la_functions(nanobind::module_& m)
 {
   namespace nb = nanobind;
-  using namespace nb::literals;
 
   m.def(
       "norm", [](const dolfinx::la::Vector<T>& x, dolfinx::la::Norm type)
-      { return dolfinx::la::norm(x, type); }, "vector"_a, "type"_a);
+      { return dolfinx::la::norm(x, type); }, nb::arg("vector"),
+      nb::arg("type"));
   m.def(
       "inner_product",
       [](const dolfinx::la::Vector<T>& x, const dolfinx::la::Vector<T>& y)
@@ -261,8 +278,12 @@ void declare_la_functions(nanobind::module_& m)
       {
         std::vector<std::reference_wrapper<dolfinx::la::Vector<T>>> _basis;
         _basis.reserve(basis.size());
-        for (std::size_t i = 0; i < basis.size(); ++i)
-          _basis.push_back(*basis[i]);
+        for (dolfinx::la::Vector<T>* v : basis)
+        {
+          if (!v)
+            throw std::invalid_argument("basis contains None.");
+          _basis.push_back(*v);
+        }
         dolfinx::la::orthonormalize(_basis);
       },
       nb::arg("basis"));
@@ -274,8 +295,12 @@ void declare_la_functions(nanobind::module_& m)
         std::vector<std::reference_wrapper<const dolfinx::la::Vector<T>>>
             _basis;
         _basis.reserve(basis.size());
-        for (std::size_t i = 0; i < basis.size(); ++i)
-          _basis.push_back(*basis[i]);
+        for (const dolfinx::la::Vector<T>* v : basis)
+        {
+          if (!v)
+            throw std::invalid_argument("basis contains None.");
+          _basis.push_back(*v);
+        }
         return dolfinx::la::is_orthonormal(_basis, eps);
       },
       nb::arg("basis"), nb::arg("eps"));
@@ -287,13 +312,12 @@ void declare_la_functions(nanobind::module_& m)
 /// @param type String representation of the scalar type (e.g., "float64",
 /// "complex128")
 template <typename T>
-void declare_superlu_dist_matrix(nanobind::module_& m, const std::string& type)
+void declare_superlu_dist_matrix(nanobind::module_& m, std::string_view type)
 {
   namespace nb = nanobind;
-  using namespace nb::literals;
 
   // dolfinx::la::SuperLUDistMatrix
-  std::string name = std::string("SuperLUDistMatrix_") + type;
+  std::string name = std::string("SuperLUDistMatrix_").append(type);
   nb::class_<dolfinx::la::SuperLUDistMatrix<T>>(m, name.c_str())
       .def(
           "__init__",
@@ -303,7 +327,6 @@ void declare_superlu_dist_matrix(nanobind::module_& m, const std::string& type)
           nb::arg("A"))
       .def_prop_ro("dtype", [](const dolfinx::la::SuperLUDistMatrix<T>&)
                    { return dolfinx_wrappers::numpy_dtype_v<T>; });
-  ;
 }
 
 /// Declare SuperLU_DIST solver wrapper for a given scalar type
@@ -311,13 +334,12 @@ void declare_superlu_dist_matrix(nanobind::module_& m, const std::string& type)
 /// @param type String representation of the scalar type (e.g., "float64",
 /// "complex128")
 template <typename T>
-void declare_superlu_dist_solver(nanobind::module_& m, const std::string& type)
+void declare_superlu_dist_solver(nanobind::module_& m, std::string_view type)
 {
   namespace nb = nanobind;
-  using namespace nb::literals;
 
   // dolfinx::la::SuperLUDistSolver
-  std::string name = std::string("SuperLUDistSolver_") + type;
+  std::string name = std::string("SuperLUDistSolver_").append(type);
   nb::class_<dolfinx::la::SuperLUDistSolver<T>>(m, name.c_str())
       .def(
           "__init__",
@@ -329,9 +351,12 @@ void declare_superlu_dist_solver(nanobind::module_& m, const std::string& type)
                 dolfinx::la::SuperLUDistSolver<T>(std::move(Amat_superlu));
           },
           nb::arg("A"))
-      .def("set_option", &dolfinx::la::SuperLUDistSolver<T>::set_option)
-      .def("set_A", &dolfinx::la::SuperLUDistSolver<T>::set_A)
-      .def("solve", &dolfinx::la::SuperLUDistSolver<T>::solve);
+      .def("set_option", &dolfinx::la::SuperLUDistSolver<T>::set_option,
+           nb::arg("name"), nb::arg("value"))
+      .def("set_A", &dolfinx::la::SuperLUDistSolver<T>::set_A, nb::arg("A"),
+           nb::arg("fact"))
+      .def("solve", &dolfinx::la::SuperLUDistSolver<T>::solve, nb::arg("b"),
+           nb::arg("u"));
 }
 #endif // HAS_SUPERLU_DIST
 

--- a/python/dolfinx/wrappers/dolfinx_wrappers/la.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/la.h
@@ -33,6 +33,7 @@
 
 namespace dolfinx_wrappers
 {
+namespace nb = nanobind;
 
 // InsertMode types for Python bindings
 enum class PyInsertMode : std::uint8_t
@@ -48,8 +49,6 @@ enum class PyInsertMode : std::uint8_t
 template <typename T>
 void declare_la_objects(nanobind::module_& m, std::string_view type)
 {
-  namespace nb = nanobind;
-
   // dolfinx::la::Vector
   std::string pyclass_vector_name = std::string("Vector_").append(type);
   nb::class_<dolfinx::la::Vector<T>>(m, pyclass_vector_name.c_str())
@@ -262,8 +261,6 @@ void declare_la_objects(nanobind::module_& m, std::string_view type)
 template <typename T>
 void declare_la_functions(nanobind::module_& m)
 {
-  namespace nb = nanobind;
-
   m.def(
       "norm", [](const dolfinx::la::Vector<T>& x, dolfinx::la::Norm type)
       { return dolfinx::la::norm(x, type); }, nb::arg("vector"),
@@ -314,8 +311,6 @@ void declare_la_functions(nanobind::module_& m)
 template <typename T>
 void declare_superlu_dist_matrix(nanobind::module_& m, std::string_view type)
 {
-  namespace nb = nanobind;
-
   // dolfinx::la::SuperLUDistMatrix
   std::string name = std::string("SuperLUDistMatrix_").append(type);
   nb::class_<dolfinx::la::SuperLUDistMatrix<T>>(m, name.c_str())
@@ -336,8 +331,6 @@ void declare_superlu_dist_matrix(nanobind::module_& m, std::string_view type)
 template <typename T>
 void declare_superlu_dist_solver(nanobind::module_& m, std::string_view type)
 {
-  namespace nb = nanobind;
-
   // dolfinx::la::SuperLUDistSolver
   std::string name = std::string("SuperLUDistSolver_").append(type);
   nb::class_<dolfinx::la::SuperLUDistSolver<T>>(m, name.c_str())

--- a/python/dolfinx/wrappers/dolfinx_wrappers/marker.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/marker.h
@@ -1,0 +1,59 @@
+// Copyright (C) 2017-2026 Chris N. Richardson and Garth N. Wells
+//
+// This file is part of DOLFINx (https://www.fenicsproject.org)
+//
+// SPDX-License-Identifier:    LGPL-3.0-or-later
+
+#pragma once
+
+#include <cstdint>
+#include <format>
+#include <functional>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <stdexcept>
+#include <vector>
+
+namespace dolfinx_wrappers
+{
+
+namespace nb = nanobind;
+
+/// @brief Shape of a Python entity marker: candidate-entity coordinates
+/// (a `(3, num_points)` array) mapped to a per-point boolean array.
+template <typename T>
+using PythonMarkerFunction
+    = std::function<nb::ndarray<bool, nb::ndim<1>, nb::c_contig>(
+        nb::ndarray<const T, nb::ndim<2>, nb::numpy>)>;
+
+/// @brief Wrap a Python entity marker as the callable
+/// dolfinx::mesh::locate_entities, dolfinx::mesh::locate_entities_boundary
+/// and dolfinx::fem::locate_dofs_geometrical expect.
+///
+/// @note The returned closure holds a reference to `marker`, so it must
+/// not outlive it. It is only ever passed straight into a DOLFINx call
+/// that invokes it in place.
+///
+/// @param[in] marker Python marker function.
+/// @return Callable mapping an mdspan of point coordinates to a marker
+/// per point.
+template <typename T>
+auto to_cpp_marker(const PythonMarkerFunction<T>& marker)
+{
+  return [&marker](auto x)
+  {
+    nb::ndarray<const T, nb::ndim<2>, nb::numpy> x_view(
+        x.data_handle(), {x.extent(0), x.extent(1)});
+    auto marked = marker(x_view);
+    if (marked.size() != x.extent(1))
+    {
+      throw std::invalid_argument(
+          std::format("Marker function returned {} values for {} points.",
+                      marked.size(), x.extent(1)));
+    }
+    return std::vector<std::int8_t>(marked.data(),
+                                    marked.data() + marked.size());
+  };
+}
+
+} // namespace dolfinx_wrappers

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -43,7 +43,10 @@
 #include <variant>
 #include <vector>
 
+namespace dolfinx_wrappers
+{
 namespace nb = nanobind;
+}
 
 namespace dolfinx_wrappers::part::impl
 {

--- a/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/mesh.h
@@ -9,6 +9,7 @@
 #include "MPICommWrapper.h"
 #include "array.h"
 #include "graph.h"
+#include "marker.h"
 #include "numpy_dtype.h"
 #include <cstdint>
 #include <dolfinx/fem/CoordinateElement.h>
@@ -22,6 +23,7 @@
 #include <dolfinx/mesh/types.h>
 #include <dolfinx/mesh/utils.h>
 #include <functional>
+#include <memory>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/array.h>
@@ -33,8 +35,13 @@
 #include <optional>
 #include <ranges>
 #include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
 #include <type_traits>
+#include <utility>
 #include <variant>
+#include <vector>
 
 namespace nb = nanobind;
 
@@ -103,29 +110,10 @@ inline std::optional<std::span<const std::int32_t>> to_cell_weights_span(
                                        cell_weights->size());
 }
 
-/// Wrap a Python entity marker (candidate-entity coordinates -> a
-/// boolean array) as the callable dolfinx::mesh::locate_entities and
-/// dolfinx::mesh::locate_entities_boundary expect. The returned
-/// closure holds a reference to `marker`, so it must not outlive it.
 template <typename T>
-auto to_cpp_marker(
-    const std::function<nb::ndarray<bool, nb::ndim<1>, nb::c_contig>(
-        nb::ndarray<const T, nb::ndim<2>, nb::numpy>)>& marker)
+void declare_meshtags(nb::module_& m, std::string_view type)
 {
-  return [&marker](auto x)
-  {
-    nb::ndarray<const T, nb::ndim<2>, nb::numpy> x_view(
-        x.data_handle(), {x.extent(0), x.extent(1)});
-    auto marked = marker(x_view);
-    return std::vector<std::int8_t>(marked.data(),
-                                    marked.data() + marked.size());
-  };
-}
-
-template <typename T>
-void declare_meshtags(nb::module_& m, const std::string& type)
-{
-  std::string pyclass_name = std::string("MeshTags_") + type;
+  std::string pyclass_name = std::string("MeshTags_").append(type);
   nb::class_<dolfinx::mesh::MeshTags<T>>(m, pyclass_name.c_str(),
                                          "MeshTags object")
       .def(
@@ -143,14 +131,16 @@ void declare_meshtags(nb::module_& m, const std::string& type)
             new (self) dolfinx::mesh::MeshTags<T>(
                 topology, dim, std::move(indices_vec), std::move(values_vec),
                 std::move(name));
-          })
+          },
+          nb::arg("topology"), nb::arg("dim"), nb::arg("indices"),
+          nb::arg("values"), nb::arg("name"))
       .def_prop_ro("dtype", [](const dolfinx::mesh::MeshTags<T>&)
                    { return dolfinx_wrappers::numpy_dtype_v<T>; })
       .def_prop_rw(
           "name",
           [](const dolfinx::mesh::MeshTags<T>& self) { return self.name(); },
           [](dolfinx::mesh::MeshTags<T>& self, std::string name)
-          { self.name(name); })
+          { self.name(std::move(name)); })
       .def_prop_ro("dim", &dolfinx::mesh::MeshTags<T>::dim)
       .def_prop_ro("topology", &dolfinx::mesh::MeshTags<T>::topology)
       .def_prop_ro(
@@ -170,20 +160,25 @@ void declare_meshtags(nb::module_& m, const std::string& type)
                                                               {idx.size()});
           },
           nb::rv_policy::reference_internal)
-      .def("find", [](dolfinx::mesh::MeshTags<T>& self, T value)
-           { return as_nbarray(self.find(value)); });
+      .def(
+          "find", [](dolfinx::mesh::MeshTags<T>& self, T value)
+          { return as_nbarray(self.find(value)); }, nb::arg("value"));
 
-  m.def("create_meshtags",
-        [](std::shared_ptr<const dolfinx::mesh::Topology> topology, int dim,
-           const dolfinx::graph::AdjacencyList<std::int32_t>& entities,
-           nb::ndarray<const T, nb::ndim<1>, nb::c_contig> values,
-           std::string name)
-        {
-          return dolfinx::mesh::create_meshtags(
-              topology, dim, entities, std::span(values.data(), values.size()),
-              std::move(name));
-        });
-  std::string pyfunc_name = "transfer_meshtags_to_submesh_" + type;
+  m.def(
+      "create_meshtags",
+      [](std::shared_ptr<const dolfinx::mesh::Topology> topology, int dim,
+         const dolfinx::graph::AdjacencyList<std::int32_t>& entities,
+         nb::ndarray<const T, nb::ndim<1>, nb::c_contig> values,
+         std::string name)
+      {
+        return dolfinx::mesh::create_meshtags(
+            topology, dim, entities, std::span(values.data(), values.size()),
+            std::move(name));
+      },
+      nb::arg("topology"), nb::arg("dim"), nb::arg("entities"),
+      nb::arg("values"), nb::arg("name"));
+  std::string pyfunc_name
+      = std::string("transfer_meshtags_to_submesh_").append(type);
   m.def(
       pyfunc_name.c_str(),
       [](const dolfinx::mesh::MeshTags<T>& tags,
@@ -194,14 +189,14 @@ void declare_meshtags(nb::module_& m, const std::string& type)
         return dolfinx::mesh::transfer_meshtags_to_submesh<T>(
             tags, submesh_topology, vertex_map, cell_map);
       },
-      nanobind::arg("tags"), nanobind::arg("submesh_topology"),
-      nanobind::arg("vertex_map"), nanobind::arg("cell_map"));
+      nb::arg("tags"), nb::arg("submesh_topology"), nb::arg("vertex_map"),
+      nb::arg("cell_map"));
 }
 
 template <typename T>
-void declare_mesh(nb::module_& m, std::string type)
+void declare_mesh(nb::module_& m, std::string_view type)
 {
-  std::string pyclass_geometry_name = std::string("Geometry_") + type;
+  std::string pyclass_geometry_name = std::string("Geometry_").append(type);
   nb::class_<dolfinx::mesh::Geometry<T>>(m, pyclass_geometry_name.c_str(),
                                          "Geometry object")
       .def(
@@ -217,7 +212,7 @@ void declare_mesh(nb::module_& m, std::string type)
             std::size_t shape1 = x.shape(1);
             if (shape1 == 0 or shape1 > 3)
             {
-              throw std::runtime_error(
+              throw std::invalid_argument(
                   "Geometry point array must have shape (num_points, dim) "
                   "with 0 < dim <= 3.");
             }
@@ -290,7 +285,7 @@ void declare_mesh(nb::module_& m, std::string type)
           },
           nb::rv_policy::reference_internal);
 
-  std::string pyclass_mesh_name = std::string("Mesh_") + type;
+  std::string pyclass_mesh_name = std::string("Mesh_").append(type);
   nb::class_<dolfinx::mesh::Mesh<T>>(m, pyclass_mesh_name.c_str(),
                                      nb::dynamic_attr(), "Mesh object")
       .def(
@@ -314,7 +309,7 @@ void declare_mesh(nb::module_& m, std::string type)
           { return MPICommWrapper(self.comm()); }, nb::keep_alive<0, 1>())
       .def_rw("name", &dolfinx::mesh::Mesh<T>::name);
 
-  std::string create_interval("create_interval_" + type);
+  std::string create_interval = std::string("create_interval_").append(type);
   m.def(
       create_interval.c_str(),
       [](MPICommWrapper comm, std::int64_t n, std::array<T, 2> p,
@@ -328,7 +323,7 @@ void declare_mesh(nb::module_& m, std::string type)
       nb::arg("comm"), nb::arg("n"), nb::arg("p"), nb::arg("ghost_mode"),
       nb::arg("partitioner").none(), nb::arg("gdim"));
 
-  std::string create_rectangle("create_rectangle_" + type);
+  std::string create_rectangle = std::string("create_rectangle_").append(type);
   m.def(
       create_rectangle.c_str(),
       [](MPICommWrapper comm, std::array<std::array<T, 2>, 2> p,
@@ -346,7 +341,7 @@ void declare_mesh(nb::module_& m, std::string type)
       nb::arg("partitioner").none(), nb::arg("diagonal"), nb::arg("gdim"),
       nb::arg("ghost_mode"));
 
-  std::string create_box("create_box_" + type);
+  std::string create_box = std::string("create_box_").append(type);
   m.def(
       create_box.c_str(),
       [](MPICommWrapper comm, std::array<std::array<T, 3>, 2> p,
@@ -354,9 +349,9 @@ void declare_mesh(nb::module_& m, std::string type)
          const part::impl::PythonPartitionFn& part,
          dolfinx::mesh::GhostMode ghost_mode)
       {
-        MPI_Comm _comm = comm.get();
+        MPI_Comm mpi_comm = comm.get();
         return dolfinx::mesh::create_box<T>(
-            _comm, _comm, p, n, celltype,
+            mpi_comm, mpi_comm, p, n, celltype,
             part::impl::to_any_cell_partitioner(part), ghost_mode);
       },
       nb::arg("comm"), nb::arg("p"), nb::arg("n"), nb::arg("celltype"),
@@ -463,7 +458,7 @@ void declare_mesh(nb::module_& m, std::string type)
             mesh, std::span(entities.data(), entities.size()), dim));
       },
       nb::arg("mesh"), nb::arg("dim"), nb::arg("entities"),
-      "Compute maximum distsance between any two vertices.");
+      "Compute the maximum distance between any two vertices.");
   m.def(
       "compute_midpoints",
       [](const dolfinx::mesh::Mesh<T>& mesh, int dim,
@@ -478,9 +473,7 @@ void declare_mesh(nb::module_& m, std::string type)
   m.def(
       "locate_entities",
       [](const dolfinx::mesh::Mesh<T>& mesh, int dim,
-         std::function<nb::ndarray<bool, nb::ndim<1>, nb::c_contig>(
-             nb::ndarray<const T, nb::ndim<2>, nb::numpy>)>
-             marker)
+         const PythonMarkerFunction<T>& marker)
       {
         return as_nbarray(dolfinx::mesh::locate_entities(
             mesh, dim, to_cpp_marker<T>(marker)));
@@ -490,10 +483,7 @@ void declare_mesh(nb::module_& m, std::string type)
   m.def(
       "locate_entities",
       [](const dolfinx::mesh::Mesh<T>& mesh, int dim,
-         std::function<nb::ndarray<bool, nb::ndim<1>, nb::c_contig>(
-             nb::ndarray<const T, nb::ndim<2>, nb::numpy>)>
-             marker,
-         int entity_type_idx)
+         const PythonMarkerFunction<T>& marker, int entity_type_idx)
       {
         return as_nbarray(dolfinx::mesh::locate_entities(
             mesh, dim, to_cpp_marker<T>(marker), entity_type_idx));
@@ -504,9 +494,7 @@ void declare_mesh(nb::module_& m, std::string type)
   m.def(
       "locate_entities_boundary",
       [](const dolfinx::mesh::Mesh<T>& mesh, int dim,
-         std::function<nb::ndarray<bool, nb::ndim<1>, nb::c_contig>(
-             nb::ndarray<const T, nb::ndim<2>, nb::numpy>)>
-             marker)
+         const PythonMarkerFunction<T>& marker)
       {
         return as_nbarray(dolfinx::mesh::locate_entities_boundary(
             mesh, dim, to_cpp_marker<T>(marker)));
@@ -525,19 +513,22 @@ void declare_mesh(nb::module_& m, std::string type)
       },
       nb::arg("mesh"), nb::arg("dim"), nb::arg("entities"), nb::arg("permute"));
 
-  m.def("create_geometry",
-        [](const dolfinx::mesh::Topology& topology,
-           const std::vector<dolfinx::fem::CoordinateElement<T>>& elements,
-           nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig> nodes,
-           nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig> xdofs,
-           nb::ndarray<const T, nb::ndim<1>, nb::c_contig> x, int dim)
-        {
-          return dolfinx::mesh::create_geometry(
-              topology, elements,
-              std::span<const std::int64_t>(nodes.data(), nodes.size()),
-              std::span<const std::int64_t>(xdofs.data(), xdofs.size()),
-              std::span<const T>(x.data(), x.size()), dim);
-        });
+  m.def(
+      "create_geometry",
+      [](const dolfinx::mesh::Topology& topology,
+         const std::vector<dolfinx::fem::CoordinateElement<T>>& elements,
+         nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig> nodes,
+         nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig> xdofs,
+         nb::ndarray<const T, nb::ndim<1>, nb::c_contig> x, int dim)
+      {
+        return dolfinx::mesh::create_geometry(
+            topology, elements,
+            std::span<const std::int64_t>(nodes.data(), nodes.size()),
+            std::span<const std::int64_t>(xdofs.data(), xdofs.size()),
+            std::span<const T>(x.data(), x.size()), dim);
+      },
+      nb::arg("topology"), nb::arg("elements"), nb::arg("nodes"),
+      nb::arg("xdofs"), nb::arg("x"), nb::arg("dim"));
 }
 
 } // namespace dolfinx_wrappers

--- a/python/dolfinx/wrappers/dolfinx_wrappers/numpy_dtype.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/numpy_dtype.h
@@ -1,13 +1,13 @@
-// Copyright (C) 2024 Chris Richardson and Garth N. Wells
+// Copyright (C) 2024-2026 Chris Richardson and Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
+#pragma once
+
 #include <complex>
 #include <cstdint>
-
-#pragma once
 
 namespace dolfinx_wrappers
 {

--- a/python/dolfinx/wrappers/dolfinx_wrappers/petsc.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/petsc.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2025 Chris Richardson and Garth N. Wells
+// Copyright (C) 2017-2026 Chris Richardson and Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -9,6 +9,7 @@
 #if defined(HAS_PETSC) && defined(HAS_PETSC4PY)
 
 #include "array.h"
+#include "assemble.h"
 #include "caster_mpi.h"
 #include "caster_petsc.h"
 #include "pycoeff.h"
@@ -56,33 +57,10 @@ void declare_petsc_discrete_operators(nb::module_& m)
       [](const dolfinx::fem::FunctionSpace<U>& V0,
          const dolfinx::fem::FunctionSpace<U>& V1)
       {
-        assert(V0.mesh());
-        auto mesh = V0.mesh();
-        assert(V1.mesh());
-        assert(mesh == V1.mesh());
-
-        auto dofmap0 = V0.dofmap();
-        assert(dofmap0);
-        auto dofmap1 = V1.dofmap();
-        assert(dofmap1);
-
-        // Create and build  sparsity pattern
-        assert(dofmap0->index_map);
-        assert(dofmap1->index_map);
-        MPI_Comm comm = mesh->comm();
-        dolfinx::la::SparsityPattern sp(
-            comm, {dofmap1->index_map, dofmap0->index_map},
-            {dofmap1->index_map_bs(), dofmap0->index_map_bs()});
-
-        int tdim = mesh->topology()->dim();
-        auto map = mesh->topology()->index_map(tdim);
-        assert(map);
-        auto c = std::ranges::views::iota(0, map->size_local());
-        dolfinx::fem::sparsitybuild::cells(sp, std::pair{c, c},
-                                           {*dofmap1, *dofmap0});
-        sp.finalize();
+        dolfinx::la::SparsityPattern sp = create_sparsity(V0, V1);
 
         // Build operator
+        MPI_Comm comm = V0.mesh()->comm();
         Mat A = dolfinx::la::petsc::create_matrix(comm, sp);
         try
         {
@@ -94,9 +72,9 @@ void declare_petsc_discrete_operators(nb::module_& m)
         }
         catch (...)
         {
-          // Already unwinding, so a thrown error here calls
-          // std::terminate rather than propagating
-          dolfinx::common::petsc::check(MatDestroy(&A), "MatDestroy");
+          // Destroy A before rethrowing. MatDestroy is not allowed to
+          // throw here: it would replace the in-flight exception.
+          MatDestroy(&A);
           throw;
         }
         return A;
@@ -108,33 +86,10 @@ void declare_petsc_discrete_operators(nb::module_& m)
       [](const dolfinx::fem::FunctionSpace<U>& V0,
          const dolfinx::fem::FunctionSpace<U>& V1)
       {
-        assert(V0.mesh());
-        auto mesh = V0.mesh();
-        assert(V1.mesh());
-        assert(mesh == V1.mesh());
-
-        auto dofmap0 = V0.dofmap();
-        assert(dofmap0);
-        auto dofmap1 = V1.dofmap();
-        assert(dofmap1);
-
-        // Create and build  sparsity pattern
-        assert(dofmap0->index_map);
-        assert(dofmap1->index_map);
-        MPI_Comm comm = mesh->comm();
-        dolfinx::la::SparsityPattern sp(
-            comm, {dofmap1->index_map, dofmap0->index_map},
-            {dofmap1->index_map_bs(), dofmap0->index_map_bs()});
-
-        int tdim = mesh->topology()->dim();
-        auto map = mesh->topology()->index_map(tdim);
-        assert(map);
-        auto c = std::ranges::views::iota(0, map->size_local());
-        dolfinx::fem::sparsitybuild::cells(sp, std::pair{c, c},
-                                           {*dofmap1, *dofmap0});
-        sp.finalize();
+        dolfinx::la::SparsityPattern sp = create_sparsity(V0, V1);
 
         // Build operator
+        MPI_Comm comm = V0.mesh()->comm();
         Mat A = dolfinx::la::petsc::create_matrix(comm, sp);
         try
         {
@@ -148,9 +103,9 @@ void declare_petsc_discrete_operators(nb::module_& m)
         }
         catch (...)
         {
-          // Already unwinding, so a thrown error here calls
-          // std::terminate rather than propagating
-          dolfinx::common::petsc::check(MatDestroy(&A), "MatDestroy");
+          // Destroy A before rethrowing. MatDestroy is not allowed to
+          // throw here: it would replace the in-flight exception.
+          MatDestroy(&A);
           throw;
         }
         return A;
@@ -161,33 +116,10 @@ void declare_petsc_discrete_operators(nb::module_& m)
       [](const dolfinx::fem::FunctionSpace<U>& V0,
          const dolfinx::fem::FunctionSpace<U>& V1)
       {
-        assert(V0.mesh());
-        auto mesh = V0.mesh();
-        assert(V1.mesh());
-        assert(mesh == V1.mesh());
-
-        auto dofmap0 = V0.dofmap();
-        assert(dofmap0);
-        auto dofmap1 = V1.dofmap();
-        assert(dofmap1);
-
-        // Create and build  sparsity pattern
-        assert(dofmap0->index_map);
-        assert(dofmap1->index_map);
-        MPI_Comm comm = mesh->comm();
-        dolfinx::la::SparsityPattern sp(
-            comm, {dofmap1->index_map, dofmap0->index_map},
-            {dofmap1->index_map_bs(), dofmap0->index_map_bs()});
-
-        int tdim = mesh->topology()->dim();
-        auto map = mesh->topology()->index_map(tdim);
-        assert(map);
-        auto c = std::ranges::views::iota(0, map->size_local());
-        dolfinx::fem::sparsitybuild::cells(sp, std::pair{c, c},
-                                           {*dofmap1, *dofmap0});
-        sp.finalize();
+        dolfinx::la::SparsityPattern sp = create_sparsity(V0, V1);
 
         // Build operator
+        MPI_Comm comm = V0.mesh()->comm();
         Mat A = dolfinx::la::petsc::create_matrix(comm, sp);
         try
         {
@@ -199,9 +131,9 @@ void declare_petsc_discrete_operators(nb::module_& m)
         }
         catch (...)
         {
-          // Already unwinding, so a thrown error here calls
-          // std::terminate rather than propagating
-          dolfinx::common::petsc::check(MatDestroy(&A), "MatDestroy");
+          // Destroy A before rethrowing. MatDestroy is not allowed to
+          // throw here: it would replace the in-flight exception.
+          MatDestroy(&A);
           throw;
         }
         return A;

--- a/python/dolfinx/wrappers/dolfinx_wrappers/pycoeff.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/pycoeff.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2023 Chris Richardson and Garth N. Wells
+// Copyright (C) 2017-2026 Chris Richardson and Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -8,12 +8,18 @@
 
 #include <algorithm>
 #include <dolfinx/fem/Form.h>
+#include <iterator>
 #include <map>
+#include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <span>
+#include <type_traits>
+#include <utility>
 
 namespace dolfinx_wrappers
 {
+namespace nb = nanobind;
+
 template <typename T>
 std::map<std::pair<dolfinx::fem::IntegralType, int>,
          std::pair<std::span<const T>, int>>

--- a/python/dolfinx/wrappers/dolfinx_wrappers/refinement.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/refinement.h
@@ -76,7 +76,7 @@ void declare_refinement(nanobind::module_& m)
           auto index_map = mesh.topology()->index_map(1);
           if (!index_map)
           {
-            throw std::runtime_error(
+            throw std::invalid_argument(
                 "Edge entities have not been created on the mesh topology.");
           }
 
@@ -86,7 +86,7 @@ void declare_refinement(nanobind::module_& m)
           {
             std::int32_t e = edges.value().data()[i];
             if (e < 0 or e >= num_edges)
-              throw std::runtime_error("Index out of range in edges array.");
+              throw std::out_of_range("Index out of range in edges array.");
           }
           cpp_edges.emplace(
               std::span(edges.value().data(), edges.value().size()));

--- a/python/dolfinx/wrappers/dolfinx_wrappers/refinement.h
+++ b/python/dolfinx/wrappers/dolfinx_wrappers/refinement.h
@@ -32,12 +32,11 @@
 
 namespace dolfinx_wrappers
 {
+namespace nb = nanobind;
 
 template <std::floating_point T>
 void declare_refinement(nanobind::module_& m)
 {
-  namespace nb = nanobind;
-
   m.def(
       "uniform_refine",
       [](const dolfinx::mesh::Mesh<T>& mesh,

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -17,6 +17,7 @@
 #include <dolfinx/graph/ordering.h>
 #include <dolfinx/la/SparsityPattern.h>
 #include <dolfinx/mesh/Mesh.h>
+#include <format>
 #include <functional>
 #include <memory>
 #include <nanobind/nanobind.h>
@@ -34,9 +35,11 @@
 #include <nanobind/stl/variant.h>
 #include <nanobind/stl/vector.h>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 namespace nb = nanobind;
 namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
@@ -50,7 +53,8 @@ void fem(nb::module_& m)
       [](MPICommWrapper comm, const dolfinx::mesh::Topology& topology,
          const dolfinx::fem::ElementDofLayout& layout)
       {
-        assert(topology.entity_types(topology.dim()).size() == 1);
+        if (topology.entity_types(topology.dim()).size() != 1)
+          throw std::invalid_argument("Mixed topology unsupported.");
         auto [map, bs, dofmap] = dolfinx::fem::build_dofmap_data(
             comm.get(), topology, {layout}, nullptr);
         return std::tuple(std::move(map), bs, std::move(dofmap));
@@ -72,6 +76,7 @@ void fem(nb::module_& m)
             dofmap.data(), dofmap.shape(0), dofmap.shape(1));
         return dolfinx::fem::transpose_dofmap(_dofmap, num_cells);
       },
+      nb::arg("dofmap"), nb::arg("num_cells"),
       "Build the index to (cell, local index) map from a dofmap ((cell, local "
       "index) -> index).");
   m.def(
@@ -124,8 +129,14 @@ void fem(nb::module_& m)
       .def_prop_ro("dof_layout", &dolfinx::fem::DofMap::element_dof_layout)
       .def(
           "cell_dofs",
-          [](const dolfinx::fem::DofMap& self, int cell)
+          [](const dolfinx::fem::DofMap& self, std::int32_t cell)
           {
+            if (cell < 0 or std::cmp_greater_equal(cell, self.map().extent(0)))
+            {
+              throw std::out_of_range(std::format(
+                  "Cell index {} is out of range for a dofmap with {} cells.",
+                  cell, self.map().extent(0)));
+            }
             std::span<const std::int32_t> dofs = self.cell_dofs(cell);
             return nb::ndarray<const std::int32_t, nb::numpy>(dofs.data(),
                                                               {dofs.size()});
@@ -147,7 +158,7 @@ void fem(nb::module_& m)
       .value("exterior_facet", dolfinx::fem::IntegralType::exterior_facet,
              "exterior facet integral")
       .value("interior_facet", dolfinx::fem::IntegralType::interior_facet,
-             "exterior facet integral")
+             "interior facet integral")
       .value("vertex", dolfinx::fem::IntegralType::vertex, "vertex integral")
       .value("ridge", dolfinx::fem::IntegralType::ridge, "ridge integral");
 

--- a/python/dolfinx/wrappers/graph.cpp
+++ b/python/dolfinx/wrappers/graph.cpp
@@ -7,6 +7,8 @@
 #include "dolfinx_wrappers/graph.h"
 #include "dolfinx_wrappers/array.h"
 #include "dolfinx_wrappers/caster_mpi.h"
+#include <algorithm>
+#include <cstdint>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/graph/AdjacencyList.h>
 #include <dolfinx/graph/ordering.h>
@@ -15,6 +17,7 @@
 #include <dolfinx/graph/sfc.h>
 #include <dolfinx/graph/utils.h>
 #include <functional>
+#include <map>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/operators.h>
@@ -29,6 +32,9 @@
 #include <optional>
 #include <ranges>
 #include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace nb = nanobind;
@@ -179,8 +185,8 @@ void graph(nb::module_& m)
 #ifdef HAS_KAHIP
   m.def(
       "partitioner_kahip",
-      [](int mode = 1, int seed = 1, double imbalance = 0.03,
-         bool suppress_output = true) -> GraphPartitioner
+      [](int mode, int seed, double imbalance,
+         bool suppress_output) -> GraphPartitioner
       {
         return GraphPartitioner{dolfinx::graph::kahip::partitioner(
             mode, seed, imbalance, suppress_output)};
@@ -371,7 +377,7 @@ void graph(nb::module_& m)
   m.def(
       "comm_graph", [](const dolfinx::common::IndexMap& map, int root)
       { return dolfinx::graph::comm_graph(map, root); }, nb::arg("map"),
-      nb::arg("root") = 0,
+      nb::arg("root"),
       "Build a graph representing parallel communication patterns.");
 
   m.def(
@@ -392,13 +398,15 @@ void graph(nb::module_& m)
           }
         }
 
+        if (!g.node_data())
+          throw std::invalid_argument("Graph has no node data.");
+
         std::vector<
             std::pair<std::int32_t, std::map<std::string, std::int32_t>>>
             nodes;
         std::ranges::transform(
-            g.node_data().value(), std::ranges::views::iota(0),
-            std::back_inserter(nodes),
-            [](auto data, auto n)
+            *g.node_data(), std::views::iota(0), std::back_inserter(nodes),
+            [](std::pair<std::int32_t, std::int32_t> data, std::int32_t n)
             {
               return std::pair(
                   n, std::map<std::string, std::int32_t>{
@@ -407,8 +415,9 @@ void graph(nb::module_& m)
 
         return std::pair(std::move(adj), std::move(nodes));
       },
-      "Build a graph edge and node data representing parallel communication "
-      "patterns. Can be used to creat NetworkX graphs.");
+      nb::arg("g"),
+      "Build graph edge and node data representing parallel communication "
+      "patterns. Can be used to create NetworkX graphs.");
 
   m.def(
       "comm_to_json",
@@ -416,7 +425,8 @@ void graph(nb::module_& m)
           std::tuple<int, std::size_t, std::int8_t>,
           std::pair<std::int32_t, std::int32_t>>& g)
       { return dolfinx::graph::comm_to_json(g); },
+      nb::arg("g"),
       "Build a JSON string representation of a parallel communication "
-      "graph that can use used by build a NetworkX graph.");
+      "graph, which can be used to build a NetworkX graph.");
 }
 } // namespace dolfinx_wrappers

--- a/python/dolfinx/wrappers/io.cpp
+++ b/python/dolfinx/wrappers/io.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2021 Chris N. Richardson Garth N. Wells
+// Copyright (C) 2017-2026 Chris N. Richardson Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
@@ -8,6 +8,7 @@
 #include "dolfinx_wrappers/array.h"
 #include "dolfinx_wrappers/caster_mpi.h"
 #include <basix/mdspan.hpp>
+#include <cstdint>
 #include <dolfinx/io/ADIOS2Writers.h>
 #include <dolfinx/io/VTKFile.h>
 #include <dolfinx/io/VTKHDF.h>
@@ -28,6 +29,9 @@
 #include <nanobind/stl/string_view.h>
 #include <nanobind/stl/variant.h>
 #include <nanobind/stl/vector.h>
+#include <string>
+#include <utility>
+#include <variant>
 #include <vector>
 
 namespace nb = nanobind;
@@ -65,24 +69,36 @@ void io(nb::module_& m)
       "Extract the mesh topology with VTK ordering using "
       "geometry indices");
 
-  m.def("write_vtkhdf_mesh", &dolfinx::io::VTKHDF::write_mesh<double>)
-      .def("write_vtkhdf_mesh", &dolfinx::io::VTKHDF::write_mesh<float>);
-  m.def("write_vtkhdf_data", &dolfinx::io::VTKHDF::write_data<double>);
-  m.def("write_vtkhdf_data", &dolfinx::io::VTKHDF::write_data<float>);
-  m.def("read_vtkhdf_mesh_float64",
-        [](MPICommWrapper comm, const std::string& filename, std::size_t gdim,
-           std::optional<std::int32_t> max_facet_to_cell_links)
-        {
-          return dolfinx::io::VTKHDF::read_mesh<double>(
-              comm.get(), filename, gdim, max_facet_to_cell_links);
-        });
-  m.def("read_vtkhdf_mesh_float32",
-        [](MPICommWrapper comm, const std::string& filename, std::size_t gdim,
-           std::optional<std::int32_t> max_facet_to_cell_links)
-        {
-          return dolfinx::io::VTKHDF::read_mesh<float>(
-              comm.get(), filename, gdim, max_facet_to_cell_links);
-        });
+  m.def("write_vtkhdf_mesh", &dolfinx::io::VTKHDF::write_mesh<double>,
+        nb::arg("filename"), nb::arg("mesh"));
+  m.def("write_vtkhdf_mesh", &dolfinx::io::VTKHDF::write_mesh<float>,
+        nb::arg("filename"), nb::arg("mesh"));
+  m.def("write_vtkhdf_data", &dolfinx::io::VTKHDF::write_data<double>,
+        nb::arg("point_or_cell"), nb::arg("filename"), nb::arg("mesh"),
+        nb::arg("data"), nb::arg("time"));
+  m.def("write_vtkhdf_data", &dolfinx::io::VTKHDF::write_data<float>,
+        nb::arg("point_or_cell"), nb::arg("filename"), nb::arg("mesh"),
+        nb::arg("data"), nb::arg("time"));
+  m.def(
+      "read_vtkhdf_mesh_float64",
+      [](MPICommWrapper comm, const std::string& filename, std::size_t gdim,
+         std::optional<std::int32_t> max_facet_to_cell_links)
+      {
+        return dolfinx::io::VTKHDF::read_mesh<double>(
+            comm.get(), filename, gdim, max_facet_to_cell_links);
+      },
+      nb::arg("comm"), nb::arg("filename"), nb::arg("gdim"),
+      nb::arg("max_facet_to_cell_links").none());
+  m.def(
+      "read_vtkhdf_mesh_float32",
+      [](MPICommWrapper comm, const std::string& filename, std::size_t gdim,
+         std::optional<std::int32_t> max_facet_to_cell_links)
+      {
+        return dolfinx::io::VTKHDF::read_mesh<float>(comm.get(), filename, gdim,
+                                                     max_facet_to_cell_links);
+      },
+      nb::arg("comm"), nb::arg("filename"), nb::arg("gdim"),
+      nb::arg("max_facet_to_cell_links").none());
 
   // dolfinx::io::cell permutation functions
   m.def(
@@ -126,11 +142,10 @@ void io(nb::module_& m)
                                           encoding);
           },
           nb::arg("comm"), nb::arg("filename"), nb::arg("file_mode"),
-          nb::arg("encoding") = dolfinx::io::XDMFFile::Encoding::HDF5)
+          nb::arg("encoding"))
       .def("close", &dolfinx::io::XDMFFile::close)
       .def("write_geometry", &dolfinx::io::XDMFFile::write_geometry,
-           nb::arg("geometry"), nb::arg("name") = "geometry",
-           nb::arg("xpath") = "/Xdmf/Domain")
+           nb::arg("geometry"), nb::arg("name"), nb::arg("xpath"))
       .def(
           "read_topology_data",
           [](dolfinx::io::XDMFFile& self, const std::string& name,
@@ -139,26 +154,31 @@ void io(nb::module_& m)
             auto [cells, shape] = self.read_topology_data(name, xpath);
             return as_nbarray(std::move(cells), shape);
           },
-          nb::arg("name") = "mesh", nb::arg("xpath") = "/Xdmf/Domain")
+          nb::arg("name"), nb::arg("xpath"))
       .def(
           "read_geometry_data",
           [](dolfinx::io::XDMFFile& self, const std::string& name,
              const std::string& xpath)
           {
             auto [x, shape] = self.read_geometry_data(name, xpath);
-            std::vector<double>& _x = std::get<std::vector<double>>(x);
-            return as_nbarray(std::move(_x), shape);
+
+            // Geometry may be stored as float or double. Both are
+            // returned as a NumPy array of the matching dtype.
+            return std::visit(
+                [shape](auto&& _x)
+                { return nb::cast(as_nbarray(std::move(_x), shape)); },
+                std::move(x));
           },
-          nb::arg("name") = "mesh", nb::arg("xpath") = "/Xdmf/Domain")
+          nb::arg("name"), nb::arg("xpath"))
       .def("read_cell_type", &dolfinx::io::XDMFFile::read_cell_type,
-           nb::arg("name") = "mesh", nb::arg("xpath") = "/Xdmf/Domain")
+           nb::arg("name"), nb::arg("xpath"))
       .def("read_meshtags", &dolfinx::io::XDMFFile::read_meshtags,
            nb::arg("mesh"), nb::arg("name"), nb::arg("attribute_name").none(),
            nb::arg("xpath"))
       .def("write_information", &dolfinx::io::XDMFFile::write_information,
-           nb::arg("name"), nb::arg("value"), nb::arg("xpath") = "/Xdmf/Domain")
+           nb::arg("name"), nb::arg("value"), nb::arg("xpath"))
       .def("read_information", &dolfinx::io::XDMFFile::read_information,
-           nb::arg("name"), nb::arg("xpath") = "/Xdmf/Domain")
+           nb::arg("name"), nb::arg("xpath"))
       .def("flush", &dolfinx::io::XDMFFile::flush)
       .def_prop_ro(
           "comm", [](dolfinx::io::XDMFFile& self)

--- a/python/dolfinx/wrappers/log.cpp
+++ b/python/dolfinx/wrappers/log.cpp
@@ -1,16 +1,16 @@
-// Copyright (C) 2017 Chris Richardson and Garth N. Wells
+// Copyright (C) 2017-2026 Chris Richardson and Garth N. Wells
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //
 // SPDX-License-Identifier:    LGPL-3.0-or-later
 
 #include <dolfinx/common/log.h>
-#include <iostream>
+#include <format>
 #include <memory>
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
 #include <spdlog/sinks/basic_file_sink.h>
-
+#include <stdexcept>
 #include <string>
 
 namespace nb = nanobind;
@@ -35,12 +35,13 @@ void log(nb::module_& m)
       {
         try
         {
-          auto logger = spdlog::basic_logger_mt("dolfinx", filename.c_str());
-          spdlog::set_default_logger(logger);
+          spdlog::set_default_logger(
+              spdlog::basic_logger_mt("dolfinx", filename));
         }
         catch (const spdlog::spdlog_ex& ex)
         {
-          std::cout << "Log init failed: " << ex.what() << "\n";
+          throw std::runtime_error(
+              std::format("Log initialisation failed: {}", ex.what()));
         }
       },
       nb::arg("filename"));
@@ -49,9 +50,8 @@ void log(nb::module_& m)
       "set_thread_name",
       [](const std::string& thread_name)
       {
-        std::string fmt
-            = "[%Y-%m-%d %H:%M:%S.%e] [" + thread_name + "] [%l] %v";
-        spdlog::set_pattern(fmt);
+        spdlog::set_pattern(
+            std::format("[%Y-%m-%d %H:%M:%S.%e] [{}] [%l] %v", thread_name));
       },
       nb::arg("thread_name"));
 
@@ -66,28 +66,27 @@ void log(nb::module_& m)
         switch (level)
         {
         case (spdlog::level::level_enum::trace):
-          spdlog::trace(s.c_str());
+          spdlog::trace(s);
           break;
         case (spdlog::level::level_enum::debug):
-          spdlog::debug(s.c_str());
+          spdlog::debug(s);
           break;
         case (spdlog::level::level_enum::info):
-          spdlog::info(s.c_str());
+          spdlog::info(s);
           break;
         case (spdlog::level::level_enum::warn):
-          spdlog::warn(s.c_str());
+          spdlog::warn(s);
           break;
         case (spdlog::level::level_enum::err):
-          spdlog::error(s.c_str());
+          spdlog::error(s);
           break;
         case (spdlog::level::level_enum::critical):
-          spdlog::critical(s.c_str());
+          spdlog::critical(s);
           break;
         case (spdlog::level::level_enum::off):
           break;
         default:
-          throw std::runtime_error("Log level not supported");
-          break;
+          throw std::invalid_argument("Log level not supported.");
         }
       },
       nb::arg("level"), nb::arg("s"));

--- a/python/dolfinx/wrappers/mesh.cpp
+++ b/python/dolfinx/wrappers/mesh.cpp
@@ -11,6 +11,7 @@
 #include "dolfinx_wrappers/caster_mpi.h"
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/fem/ElementDofLayout.h>
 #include <dolfinx/mesh/EntityMap.h>
@@ -36,7 +37,9 @@
 #include <nanobind/stl/vector.h>
 #include <optional>
 #include <span>
+#include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace nb = nanobind;
 
@@ -150,7 +153,7 @@ void mesh(nb::module_& m)
                                                num_threads);
       },
       nb::arg("topology"), nb::arg("dim"), nb::arg("entity_type"),
-      nb::arg("num_threads") = 1);
+      nb::arg("num_threads"));
   m.def("compute_connectivity", &dolfinx::mesh::compute_connectivity,
         nb::arg("topology"), nb::arg("d0"), nb::arg("d1"));
 
@@ -218,7 +221,7 @@ void mesh(nb::module_& m)
           nb::arg("cell_type"), nb::arg("vertex_map"), nb::arg("cell_map"),
           nb::arg("cells"), nb::arg("original_index").none())
       .def("create_entities", &dolfinx::mesh::Topology::create_entities,
-           nb::arg("dim"), nb::arg("num_threads") = 1)
+           nb::arg("dim"), nb::arg("num_threads"))
       .def("create_entity_permutations",
            &dolfinx::mesh::Topology::create_entity_permutations,
            nb::arg("num_threads"))
@@ -250,10 +253,10 @@ void mesh(nb::module_& m)
           [](const dolfinx::mesh::Topology& self)
           {
             if (self.original_cell_index.size() != 1)
-              throw std::runtime_error("Mixed topology unsupported.");
+              throw std::invalid_argument("Mixed topology unsupported.");
             const std::vector<std::vector<std::int64_t>>& idx
                 = self.original_cell_index;
-            return nb::ndarray<const std::int64_t, nb::numpy>(
+            return nb::ndarray<const std::int64_t, nb::ndim<1>, nb::numpy>(
                 idx.front().data(), {idx.front().size()});
           },
           [](dolfinx::mesh::Topology& self,
@@ -261,13 +264,13 @@ void mesh(nb::module_& m)
                  original_cell_indices)
           {
             if (self.original_cell_index.size() > 1)
-              throw std::runtime_error("Mixed topology unsupported.");
+              throw std::invalid_argument("Mixed topology unsupported.");
             self.original_cell_index.resize(1);
             self.original_cell_index.front().assign(
                 original_cell_indices.data(),
                 original_cell_indices.data() + original_cell_indices.size());
           },
-          nb::arg("original_cell_indices"))
+          nb::rv_policy::reference_internal, nb::arg("original_cell_indices"))
       .def_prop_ro(
           "original_cell_indices",
           [](const dolfinx::mesh::Topology& self)
@@ -351,13 +354,15 @@ void mesh(nb::module_& m)
       nb::arg("boundary_vertices").noconvert(), nb::arg("num_threads"),
       "Create a Topology object.");
 
-  m.def("compute_mixed_cell_pairs", &dolfinx::mesh::compute_mixed_cell_pairs);
+  m.def("compute_mixed_cell_pairs", &dolfinx::mesh::compute_mixed_cell_pairs,
+        nb::arg("topology"), nb::arg("facet_type"));
 
   m.def(
       "compute_cell_centroids",
       [](MPICommWrapper comm,
          const std::vector<dolfinx::mesh::CellType>& cell_types,
-         std::vector<nb::ndarray<const std::int64_t, nb::numpy>> cells_nb,
+         const std::vector<nb::ndarray<const std::int64_t, nb::ndim<1>,
+                                       nb::c_contig>>& cells_nb,
          MPICommWrapper commg,
          nb::ndarray<const double, nb::ndim<2>, nb::c_contig> x)
       {
@@ -400,7 +405,7 @@ void mesh(nb::module_& m)
         return as_nbarray(dolfinx::mesh::compute_incident_entities(
             topology, std::span(entities.data(), entities.size()), d0, d1));
       },
-      nb::arg("mesh"), nb::arg("entities"), nb::arg("d0"), nb::arg("d1"));
+      nb::arg("topology"), nb::arg("entities"), nb::arg("d0"), nb::arg("d1"));
 
   // Mesh generation
   nb::enum_<dolfinx::mesh::DiagonalType>(m, "DiagonalType")

--- a/python/dolfinx/wrappers/petsc.cpp
+++ b/python/dolfinx/wrappers/petsc.cpp
@@ -9,6 +9,7 @@
 #include "dolfinx_wrappers/petsc.h"
 #include "dolfinx_wrappers/array.h"
 #include "dolfinx_wrappers/pycoeff.h"
+#include <algorithm>
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/common/petsc.h>
 #include <dolfinx/fem/DirichletBC.h>
@@ -20,6 +21,10 @@
 #include <dolfinx/fem/utils.h>
 #include <dolfinx/la/SparsityPattern.h>
 #include <dolfinx/la/petsc.h>
+#include <functional>
+#include <iterator>
+#include <map>
+#include <memory>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/complex.h>
@@ -32,7 +37,11 @@
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
 #include <petsc4py/petsc4py.h>
+#include <ranges>
+#include <span>
 #include <stdexcept>
+#include <utility>
+#include <vector>
 
 namespace
 {
@@ -66,7 +75,8 @@ bool unit_block_size(Mat A)
 
 void petsc_la_module(nb::module_& m)
 {
-  import_petsc4py();
+  if (import_petsc4py() != 0)
+    throw std::runtime_error("Could not import petsc4py.");
 
   m.def(
       "create_matrix",
@@ -75,8 +85,7 @@ void petsc_la_module(nb::module_& m)
          std::optional<std::string> type) -> Mat
       { return dolfinx::la::petsc::create_matrix(comm.get(), p, type); },
       nb::rv_policy::take_ownership, nb::arg("comm"), nb::arg("p"),
-      nb::arg("type") = nb::none(),
-      "Create a PETSc Mat from sparsity pattern.");
+      nb::arg("type").none(), "Create a PETSc Mat from sparsity pattern.");
 
   m.def(
       "create_index_sets",
@@ -149,7 +158,7 @@ void petsc_fem_module(nb::module_& m)
       },
       nb::rv_policy::take_ownership, nb::arg("maps"),
       "Create nested vector for multiple (stacked) linear forms.");
-  m.def("create_matrix", dolfinx::fem::petsc::create_matrix<PetscReal>,
+  m.def("create_matrix", &dolfinx::fem::petsc::create_matrix<PetscReal>,
         nb::rv_policy::take_ownership, nb::arg("a"), nb::arg("type").none(),
         "Create a PETSc Mat for bilinear form.");
   m.def("create_matrix_block",
@@ -179,7 +188,7 @@ void petsc_fem_module(nb::module_& m)
         for (auto bc : bcs)
         {
           if (!bc)
-            throw std::runtime_error("Null DirichletBC in bcs list.");
+            throw std::invalid_argument("bcs contains None.");
           _bcs.push_back(*bc);
         }
 
@@ -213,7 +222,7 @@ void petsc_fem_module(nb::module_& m)
         }
       },
       nb::arg("A"), nb::arg("a"), nb::arg("constants"), nb::arg("coeffs"),
-      nb::arg("bcs"), nb::arg("unrolled") = false,
+      nb::arg("bcs"), nb::arg("unrolled"),
       "Assemble bilinear form into an existing PETSc matrix");
   m.def(
       "assemble_matrix",
@@ -248,7 +257,7 @@ void petsc_fem_module(nb::module_& m)
             std::span(rows1.data(), rows1.size()));
       },
       nb::arg("A"), nb::arg("a"), nb::arg("constants"), nb::arg("coeffs"),
-      nb::arg("rows0"), nb::arg("rows1"), nb::arg("unrolled") = false);
+      nb::arg("rows0"), nb::arg("rows1"), nb::arg("unrolled"));
   m.def(
       "insert_diagonal",
       [](Mat A, const dolfinx::fem::FunctionSpace<PetscReal>& V,
@@ -262,7 +271,7 @@ void petsc_fem_module(nb::module_& m)
         for (auto bc : bcs)
         {
           if (!bc)
-            throw std::runtime_error("Null DirichletBC in bcs list.");
+            throw std::invalid_argument("bcs contains None.");
           _bcs.push_back(*bc);
         }
 

--- a/python/dolfinx/wrappers/refinement.cpp
+++ b/python/dolfinx/wrappers/refinement.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2024 Chris N. Richardson, Garth N. Wells and Paul T.
+// Copyright (C) 2018-2026 Chris N. Richardson, Garth N. Wells and Paul T.
 // Kühner
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
@@ -51,10 +51,10 @@ void refinement(nb::module_& m)
       {
         int tdim = parent_meshtag.topology()->dim();
         if (parent_meshtag.dim() != tdim - 1)
-          throw std::runtime_error("Input meshtag is not facet-based");
+          throw std::invalid_argument("Input meshtag is not facet-based.");
         if (parent_facet.size() != parent_cell.size() * (tdim + 1))
         {
-          throw std::runtime_error(
+          throw std::invalid_argument(
               "parent_facet size must equal parent_cell size * (tdim + 1).");
         }
 
@@ -66,7 +66,7 @@ void refinement(nb::module_& m)
           {
             if (parent_cell.data()[i] < 0 or parent_cell.data()[i] >= num_cells)
             {
-              throw std::runtime_error(
+              throw std::out_of_range(
                   "Index out of range in parent_cell array.");
             }
           }
@@ -80,8 +80,8 @@ void refinement(nb::module_& m)
             topology1, tdim - 1, std::move(entities), std::move(values),
             parent_meshtag.name());
       },
-      nb::arg("parent_meshtag"), nb::arg("refined_mesh"),
-      nb::arg("parent_cell"), nb::arg("parent_facet"));
+      nb::arg("parent_meshtag"), nb::arg("topology1"), nb::arg("parent_cell"),
+      nb::arg("parent_facet"));
   m.def(
       "transfer_cell_meshtag",
       [](const dolfinx::mesh::MeshTags<std::int32_t>& parent_meshtag,
@@ -90,10 +90,10 @@ void refinement(nb::module_& m)
       {
         int tdim = parent_meshtag.topology()->dim();
         if (parent_meshtag.dim() != tdim)
-          throw std::runtime_error("Input meshtag is not cell-based");
+          throw std::invalid_argument("Input meshtag is not cell-based.");
 
         if (parent_meshtag.topology()->index_map(tdim)->num_ghosts() > 0)
-          throw std::runtime_error("Ghosted meshes are not supported");
+          throw std::invalid_argument("Ghosted meshes are not supported.");
 
         {
           auto index_map = parent_meshtag.topology()->index_map(tdim);
@@ -103,7 +103,7 @@ void refinement(nb::module_& m)
           {
             if (parent_cell.data()[i] < 0 or parent_cell.data()[i] >= num_cells)
             {
-              throw std::runtime_error(
+              throw std::out_of_range(
                   "Index out of range in parent_cell array.");
             }
           }
@@ -115,8 +115,7 @@ void refinement(nb::module_& m)
             topology1, tdim, std::move(entities), std::move(values),
             parent_meshtag.name());
       },
-      nb::arg("parent_meshtag"), nb::arg("refined_mesh"),
-      nb::arg("parent_cell"));
+      nb::arg("parent_meshtag"), nb::arg("topology1"), nb::arg("parent_cell"));
 }
 
 } // namespace dolfinx_wrappers


### PR DESCRIPTION
A review pass over `python/dolfinx/wrappers/`, fixing correctness bugs found
there and bringing the layer into line with the conventions in `AGENTS.md`.

Two commits, kept separate because the second is a pure no-op refactor:

1. Correctness bugs and convention deviations.
2. Scoping the `nb` namespace alias to `dolfinx_wrappers`.

## Correctness bugs

These are the changes worth the most review attention.

**~~`Scatterer.scatter_fwd`/`scatter_rev` read and wrote out of bounds.~~**
*(Superseded — see note below.)* The buffer check compared the data array
against `local_indices().size()`, but those indices indexed *into* the array
and could reach `size_local*bs - 1`, while the index array itself only
counted the entries taking part in the exchange and was typically far
shorter. An index map with `size_local=100, bs=1` where only index 99 is
shared gave `local_indices() == {99}`, so a length-1 array passed the check
and was then read at index 99 in `scatter_fwd` and *written* at index 99 in
`scatter_rev`. Fixed at the time by checking against `max(idx)` instead.
>
> **Note added after review:** while this PR was open, `Scatterer`'s Python
> wrapping was redesigned from scratch in #4489 (merged to `main`, then
> merged into this branch): `scatter_fwd`/`scatter_rev` no longer exist, and
> the replacement `scatter_fwd_begin`/`scatter_rev_begin` methods take a
> caller-packed buffer sized by `bs * local_indices_block().size()` rather
> than indexing directly into the caller's own data array, so the
> `max(idx)`-based check no longer applies or exists. What survives from
> this bullet is only a `check_scatter_buffer()` helper that deduplicates
> the (already-correct, unrelated) size checks in the new `*_begin` methods
> and switches them from `std::runtime_error` to `std::invalid_argument`.

**`DirichletBC.dtype` always raised `TypeError`.** The getter was bound with a
`Function<T, U>` self parameter on the `DirichletBC` class. Latent: nothing in
`python/dolfinx/` reads it, which is why no test caught it.

**`AdjacencyList.links()` and `DofMap.cell_dofs()` segfaulted on a bad index.**
Neither wrapper bounds-checked, and neither `AdjacencyList::links` nor
`DofMap::cell_dofs` does either — `links(-1)` converts to a huge `size_t` and
walks off the offsets array.

**`None` in a list of bound pointers was a null dereference in Release.**
nanobind does not set `none_disallowed` for pointer types, so `None` inside a
`std::vector<const T*>` silently becomes `nullptr`. The `assert(bc)` guards
before dereferencing `bcs`, `basis` and `entity_maps` compile away in Release.
`petsc.cpp` already threw here; the rest now match.

**`CoordinateElement.pull_back()` wrote past a `std::array<T, 3>`** when
`cell_geometry` had more than three columns.

Smaller ones: `XDMFFile.read_geometry_data()` used
`std::get<std::vector<double>>` on the geometry variant, throwing
`bad_variant_access` for float32 files; `comm_graph_data()` called
`node_data().value()` unguarded; `compute_cell_centroids()`'s `cells` argument
was the only such parameter missing `nb::c_contig`, so a strided array was read
as contiguous; `Topology.original_cell_index` returned a copy while the
near-identically-named `original_cell_indices` returned a view.

Two bugs fell out of the Python side while removing C++-side argument defaults:

- `dolfinx.graph.comm_graph(map, root)` documented and accepted `root` but
  never forwarded it, so every call behaved as `root=0`.
- `apply_lifting()` packed coefficients for `None` blocks, unlike the
  `constants` branch three lines above it.

## Behaviour changes to agree with

**Exception types at the API boundary changed.** Per `AGENTS.md` the wrapper
layer now raises `std::invalid_argument` for bad arguments and
`std::out_of_range` for index failures instead of `std::runtime_error`
throughout. In Python that means **`ValueError`/`IndexError` where callers
previously saw `RuntimeError`.** Anything catching `RuntimeError` around these
calls will need updating.

**A precondition violated on one rank only will now hang instead of corrupting
memory.** The scatter check throws before the neighbourhood collective, so if
one rank's buffer is undersized and another's is not, that rank throws while
the others block. Previously it read out of bounds and carried on. A hang is
the better failure, but this is the same latent asymmetry as every other
per-rank precondition check in the wrapper layer (and `mark_maximum` in the
core library). Whether these should instead `Allreduce` an error flag is a
separate decision, not made here.

## Conventions (`AGENTS.md`)

- Removed Python-visible `nb::arg(...) =` defaults where the pure-Python layer
  already declares and forwards them, updating that layer where it relied on
  the C++ default.
- Added `nb::arg` names to bound functions that lacked them, and fixed three
  that did not match the C++ parameter (`compute_incident_entities`,
  `global_to_local`, `transfer_*_meshtag`).
- Promoted asserts guarding user-supplied preconditions to throws.
- Dropped dead C++ default arguments on bound lambdas (nanobind ignores them),
  took read-only type tags as `std::string_view`, added missing IWYU includes,
  and moved `numpy_dtype.h`'s includes after its `#pragma once`.
- `log.cpp` no longer swallows a logger-init failure into `std::cout`.
- Docstring fixes: `IntegralType.interior_facet` was documented as "exterior
  facet integral"; plus `creat`, `use used by build`, `distsance`.

## Deduplication

- `create_sparsity()` was repeated verbatim three times in `petsc.h` and
  already existed in `assemble.h`.
- `to_cpp_marker()` had two inline re-implementations in `fem.h` of `mesh.h`'s
  copy; moved to a new `marker.h`, which also validates the marker's result
  length.
- Corrected the comment on the PETSc `catch` blocks: catching ends the unwind,
  so a throw there propagates and replaces the in-flight exception rather than
  calling `std::terminate`.

## The namespace alias (second commit)

`array.h`, `mesh.h` and `caster_petsc.h` declared `namespace nb = nanobind;` at
global scope, so the alias landed in every translation unit that included them.
`geometry.h` is the evidence: it used `nb::` throughout without declaring the
alias and only compiled because `array.h` leaked one. The alias now lives inside
`namespace dolfinx_wrappers`, which also removes thirteen function-local
redeclarations that existed only to work around its absence at namespace scope.
`caster_petsc.h` needs none — its two uses are inside `namespace
nanobind::detail`, where `handle` is already visible.

The `.cpp` files keep their file-scope aliases: a `.cpp` is a leaf translation
unit so an alias there leaks nowhere, and `dolfinx.cpp` needs one at global
scope for `NB_MODULE`.

## Deliberately not done

- **The SCOTCH/ParMETIS/KaHIP partitioner factories keep their `nb::arg(...) =`
  defaults.** Unlike everything else they are re-exported to users as the raw
  C++ objects and called with no arguments, so removing the defaults needs a
  Python wrapper layer first — a user-facing API change that does not belong
  here.
- **The block-size dispatch ladders and the six `T_apply`/`Tt_apply`/
  `Tt_inv_apply` variants are untouched.** The 9-branch ladder in `assemble.h`,
  the 7-branch `interpolation_matrix` and the 3-branch `MatrixCSR::add`/`set`
  are clear candidates for a `constexpr` dispatch helper, but that is pure
  cleanup with real regression risk and belongs in its own PR.

## Follow-up CI fixes

Two more, caught by CI after the initial push:

- `read_geometry_data`'s new `std::visit`-based binding (see the float32
  `bad_variant_access` fix above) returns a nanobind `object`, not a
  concrete array type, so its Python wrapper's declared return type
  (`NDArray[float64]`) was no longer accurate and mypy caught it. Widened
  to `NDArray[float32] | NDArray[float64]`, and `read_mesh` now casts to
  float64 explicitly since it always builds a float64 `CoordinateElement`
  regardless of what dtype the file stores.
- `spdlog::error("...", ierr)` with `ierr: PetscErrorCode` failed to
  compile on the macOS Homebrew job: its `fmt` release refuses to format
  an opaque `PetscErrorCode` directly. `static_cast` to `int` first,
  matching the convention already used in `common::petsc::error`.

## Testing

C++ library and wrappers built in `Developer` mode with `-Werror`;
`clang-format`, `ruff check` and `ruff format --check` clean.

pytest, run from the repository root:

| | result |
|---|---|
| serial | 3530 passed |
| `mpirun -n 2` | 2445 passed |
| `mpirun -n 3` | 2446 passed |

The fixed bugs were also exercised directly: `bc.dtype` returns `d`;
`links(-1)`, `links(n)` and `cell_dofs(10**6)` raise `IndexError` naming the
valid range; and (post-redesign) an undersized `scatter_fwd_begin` packing
buffer raises `ValueError: Local packing buffer is too small: it has 1
entries, but needs 4.` while a correctly sized buffer still gives the right
answer. A compile check confirms `::nb` no longer exists after including the
headers.

---

AI assistance: I used Claude Code (Opus 5) to draft parts of this PR. I
reviewed, edited, tested, and take responsibility for the final contribution.


